### PR TITLE
chore(models): Adding encrypted field checks

### DIFF
--- a/superset/databases/ssh_tunnel/models.py
+++ b/superset/databases/ssh_tunnel/models.py
@@ -21,9 +21,10 @@ import sqlalchemy as sa
 from flask import current_app
 from flask_appbuilder import Model
 from sqlalchemy.orm import backref, relationship
-from sqlalchemy_utils import EncryptedType
+from sqlalchemy.types import LargeBinary
 
 from superset.constants import PASSWORD_MASK
+from superset.extensions import encrypted_field_factory
 from superset.models.core import Database
 from superset.models.helpers import (
     AuditMixinNullable,
@@ -53,19 +54,15 @@ class SSHTunnel(AuditMixinNullable, ExtraJSONMixin, ImportExportMixin, Model):
 
     server_address = sa.Column(sa.Text)
     server_port = sa.Column(sa.Integer)
-    username = sa.Column(EncryptedType(sa.String, app_config["SECRET_KEY"]))
+    username = sa.Column(encrypted_field_factory.create(LargeBinary))
 
     # basic authentication
-    password = sa.Column(
-        EncryptedType(sa.String, app_config["SECRET_KEY"]), nullable=True
-    )
+    password = sa.Column(encrypted_field_factory.create(LargeBinary), nullable=True)
 
     # password protected pkey authentication
-    private_key = sa.Column(
-        EncryptedType(sa.String, app_config["SECRET_KEY"]), nullable=True
-    )
+    private_key = sa.Column(encrypted_field_factory.create(LargeBinary), nullable=True)
     private_key_password = sa.Column(
-        EncryptedType(sa.String, app_config["SECRET_KEY"]), nullable=True
+        encrypted_field_factory.create(LargeBinary), nullable=True
     )
 
     export_fields = [

--- a/superset/databases/ssh_tunnel/models.py
+++ b/superset/databases/ssh_tunnel/models.py
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 from flask import current_app
 from flask_appbuilder import Model
 from sqlalchemy.orm import backref, relationship
-from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import Text
 
 from superset.constants import PASSWORD_MASK
 from superset.extensions import encrypted_field_factory
@@ -54,15 +54,15 @@ class SSHTunnel(AuditMixinNullable, ExtraJSONMixin, ImportExportMixin, Model):
 
     server_address = sa.Column(sa.Text)
     server_port = sa.Column(sa.Integer)
-    username = sa.Column(encrypted_field_factory.create(LargeBinary))
+    username = sa.Column(encrypted_field_factory.create(Text))
 
     # basic authentication
-    password = sa.Column(encrypted_field_factory.create(LargeBinary), nullable=True)
+    password = sa.Column(encrypted_field_factory.create(Text), nullable=True)
 
     # password protected pkey authentication
-    private_key = sa.Column(encrypted_field_factory.create(LargeBinary), nullable=True)
+    private_key = sa.Column(encrypted_field_factory.create(Text), nullable=True)
     private_key_password = sa.Column(
-        encrypted_field_factory.create(LargeBinary), nullable=True
+        encrypted_field_factory.create(Text), nullable=True
     )
 
     export_fields = [


### PR DESCRIPTION
### SUMMARY
It was recently discovered that the `SSHTunnel` model class was using the `EncryptedField` type decorator directly as opposed to leveraging the `EncryptedFieldFactory`. Although the current impl would allow for the proper encryption of fields in the `SSHTunnel` model, anyone that's implemented a custom field via `EncryptedFieldFactory.create()` would have been broken as of the addition of `SSHTunnel`

* Fixes `SSHTunnel`
* Adds additional unit test that verifies all `EncryptedType` fields were created via `EncryptedFieldFactory.create()`