### PR TITLE
fix: jwt extended broken by flask bump

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -117,7 +117,7 @@ flask-caching==2.1.0
     # via apache-superset
 flask-compress==1.14
     # via apache-superset
-flask-jwt-extended==4.3.1
+flask-jwt-extended==4.5.3
     # via flask-appbuilder
 flask-limiter==3.3.1
     # via flask-appbuilder

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -67,6 +67,18 @@ class TestSecurityCsrfApi(SupersetTestCase):
         response = self.client.get(uri)
         self.assert401(response)
 
+    def test_login(self):
+        """
+        Security API: Test get login
+        """
+        uri = f"api/v1/{self.resource_name}/login"
+        response = self.client.post(
+            uri,
+            json={"username": ADMIN_USERNAME, "password": "general", "provider": "db"},
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.json
+
 
 class TestSecurityGuestTokenApi(SupersetTestCase):
     uri = "api/v1/security/guest_token/"  # noqa: F541


### PR DESCRIPTION
### SUMMARY
Flask 2.3.0 removed `app.json_encoder` 

https://github.com/pallets/flask/blob/255c8d66af6daff3eaa063ea0819e185d4d1e214/CHANGES.rst#version-230

This property was being used by flask-jwt-extended, fixed here: https://github.com/vimalloc/flask-jwt-extended/pull/493
and released on version 4.4.4 

This fixes `/api/v1/security/login` on Superset

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
