### PR TITLE
fix: Color scheme control crashing when dashboardId present

### DIFF
--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/ColorSchemeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/ColorSchemeControl.test.tsx
@@ -127,3 +127,11 @@ test('displays color scheme options', async () => {
     expect(screen.getByText('Other color palettes')).toBeInTheDocument();
   });
 });
+
+test('Renders control with dashboard id', () => {
+  setup({ dashboardId: 1 });
+  expect(screen.getByText('Dashboard scheme')).toBeInTheDocument();
+  expect(
+    screen.getByLabelText('Select color scheme', { selector: 'input' }),
+  ).toBeDisabled();
+});

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
@@ -125,13 +125,9 @@ const ColorSchemeControl = ({
   const options = useMemo(() => {
     if (dashboardId) {
       return [
-        {
-          value: 'dashboard',
-          label: t('dashboard'),
-          customLabel: (
-            <Tooltip title={DASHBOARD_ALERT}>{t('Dashboard scheme')}</Tooltip>
-          ),
-        },
+        <Option value="dashboard" label={t('dashboard')} key="dashboard">
+          <Tooltip title={DASHBOARD_ALERT}>{t('Dashboard scheme')}</Tooltip>
+        </Option>,
       ];
     }
     const schemesObject = isFunction(schemes) ? schemes() : schemes;


### PR DESCRIPTION

### SUMMARY
Fix a bug introduced in https://github.com/apache/superset/pull/27995. When user opens a chart from dashboard, the color scheme control would crash.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="322" alt="image" src="https://github.com/apache/superset/assets/15073128/f74ad7ff-ffe5-45b4-9392-b0910fb42455">

After:

<img width="329" alt="image" src="https://github.com/apache/superset/assets/15073128/7c033e0a-f77e-4c0e-b718-01321946bdf2">


### TESTING INSTRUCTIONS
1. Go to a dashboard
2. Open in Explore a chart that has categorical color scheme control
3. Verify that the control works, has value "Dashboard scheme" and is disabled

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
