### PR TITLE
fix: Update migration logic in #27119

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -84,6 +84,7 @@ assists people when migrating to a new version.
 ### Potential Downtime
 
 - [26416](https://github.com/apache/superset/pull/26416): Adds two database indexes to the `report_execution_log` table and one database index to the `report_recipient` to improve performance. Scheduled downtime may be required for large deployments.
+- [28482](https://github.com/apache/superset/pull/28482): Potentially augments the `query.executed_sql` and `query.select_sql` columns for MySQL from `MEDIUMTEXT` to `LONGTEXT`. Potential downtime may be required for large deployments which previously ran [27119](https://github.com/apache/superset/pull/27119).
 
 ## 3.1.0
 

--- a/superset/migrations/versions/2024-05-09_19-19_f7b6750b67e8_change_mediumtext_to_longtext.py
+++ b/superset/migrations/versions/2024-05-09_19-19_f7b6750b67e8_change_mediumtext_to_longtext.py
@@ -16,13 +16,13 @@
 # under the License.
 """change_mediumtext_to_longtext
 Revision ID: f7b6750b67e8
-Revises: 4081be5b6b74
+Revises: f84fde59123a
 Create Date: 2024-05-09 19:19:46.630140
 """
 
 # revision identifiers, used by Alembic.
 revision = "f7b6750b67e8"
-down_revision = "4081be5b6b74"
+down_revision = "f84fde59123a"
 
 from alembic import op  # noqa: E402
 from sqlalchemy.dialects.mysql import MEDIUMTEXT  # noqa: E402

--- a/superset/migrations/versions/2024-05-09_19-19_f7b6750b67e8_change_mediumtext_to_longtext.py
+++ b/superset/migrations/versions/2024-05-09_19-19_f7b6750b67e8_change_mediumtext_to_longtext.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""change_mediumtext_to_longtext
+Revision ID: f7b6750b67e8
+Revises: 4081be5b6b74
+Create Date: 2024-05-09 19:19:46.630140
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f7b6750b67e8"
+down_revision = "4081be5b6b74"
+
+from alembic import op  # noqa: E402
+from sqlalchemy.dialects.mysql import MEDIUMTEXT  # noqa: E402
+from sqlalchemy.dialects.mysql.base import MySQLDialect  # noqa: E402
+
+from superset.migrations.shared.utils import get_table_column  # noqa: E402
+from superset.utils.core import LongText, MediumText  # noqa: E402
+
+
+def upgrade():
+    if isinstance(op.get_bind().dialect, MySQLDialect):
+        for item in ["query.executed_sql", "query.select_sql"]:
+            table_name, column_name = item.split(".")
+
+            if (column := get_table_column(table_name, column_name)) and isinstance(
+                column["type"],
+                MEDIUMTEXT,
+            ):
+                with op.batch_alter_table(table_name) as batch_op:
+                    batch_op.alter_column(
+                        column_name,
+                        existing_type=MediumText(),
+                        type_=LongText(),
+                        existing_nullable=True,
+                    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR is a follow up https://github.com/apache/superset/pull/28422 (which needs to be cherry-picked to remedy an issue, but can't include a migration). Specifically it also adds a new migration to resize specific columns back to `LONGTEXT` if the previous migration has already been run. If not, the migration is a no-op.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
