### PR TITLE
fix(docs): fix broken indexed link from Google search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -188,7 +188,7 @@ const config = {
             from: '/docs/installation/event-logging/',
           },
           {
-            to: '/contributing/howtos/#contribute-translations',
+            to: '/docs/contributing/howtos/#contribute-translations',
             from: '/docs/contributing/translations/',
           },
         ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -188,7 +188,7 @@ const config = {
             from: '/docs/installation/event-logging/',
           },
           {
-            to: '/docs/contributing/howtos/#contribute-translations',
+            to: '/docs/contributing/howtos',
             from: '/docs/contributing/translations/',
           },
         ],

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -187,6 +187,10 @@ const config = {
             to: '/docs/configuration/event-logging',
             from: '/docs/installation/event-logging/',
           },
+          {
+            to: '/contributing/howtos/#contribute-translations',
+            from: '/docs/contributing/translations/',
+          },
         ],
       },
     ],


### PR DESCRIPTION
https://superset.apache.org/docs/contributing/translations/ is the first Kagi search hit for "superset translations contribute", but it's broken.  Here's a redirect.