### PR TITLE
chore: Don't mark Helm releases as latest

### DIFF
--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -36,7 +36,7 @@ jobs:
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: ./.github/actions/chart-releaser-action
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: helm
           mark_as_latest: false


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/26753 set [mark_as_latest: false](https://github.com/apache/superset/blob/920f2f437ea62688d39c76d6596ed02b82e3a6f4/.github/workflows/superset-helm-release.yml#L42) in our Helm release workflow in an attempt to stop Helm releases from being tagged as `latest`. The problem is that our version of [chart-releaser-action](https://github.com/helm/chart-releaser-action) is 1.2.0 which does not support that configuration. `mark_as_latest` was introduced in version 1.6.0 and this PR bumps that dependency to match this version.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
