### PR TITLE
chore: Adds setActiveTabs back

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -603,6 +603,13 @@ export function setActiveTab(tabId, prevTabId) {
   return { type: SET_ACTIVE_TAB, tabId, prevTabId };
 }
 
+// Even though SET_ACTIVE_TABS is not being called from Superset's codebase,
+// it is being used by Preset extensions.
+export const SET_ACTIVE_TABS = 'SET_ACTIVE_TABS';
+export function setActiveTabs(activeTabs) {
+  return { type: SET_ACTIVE_TABS, activeTabs };
+}
+
 export const SET_FOCUSED_FILTER_FIELD = 'SET_FOCUSED_FILTER_FIELD';
 export function setFocusedFilterField(chartId, column) {
   return { type: SET_FOCUSED_FILTER_FIELD, chartId, column };

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -38,6 +38,7 @@ import {
   SET_FOCUSED_FILTER_FIELD,
   UNSET_FOCUSED_FILTER_FIELD,
   SET_ACTIVE_TAB,
+  SET_ACTIVE_TABS,
   SET_FULL_SIZE_CHART_ID,
   ON_FILTERS_REFRESH,
   ON_FILTERS_REFRESH_SUCCESS,
@@ -186,6 +187,12 @@ export default function dashboardStateReducer(state = {}, action) {
       return {
         ...state,
         activeTabs: Array.from(newActiveTabs),
+      };
+    },
+    [SET_ACTIVE_TABS]() {
+      return {
+        ...state,
+        activeTabs: action.activeTabs,
       };
     },
     [SET_OVERRIDE_CONFIRM]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -18,7 +18,7 @@
  */
 
 import dashboardStateReducer from './dashboardState';
-import { setActiveTab } from '../actions/dashboardState';
+import { setActiveTab, setActiveTabs } from '../actions/dashboardState';
 
 describe('DashboardState reducer', () => {
   it('SET_ACTIVE_TAB', () => {
@@ -34,5 +34,16 @@ describe('DashboardState reducer', () => {
         setActiveTab('tab2', 'tab1'),
       ),
     ).toEqual({ activeTabs: ['tab2'] });
+  });
+  it('SET_ACTIVE_TABS', () => {
+    expect(
+      dashboardStateReducer({ activeTabs: [] }, setActiveTabs(['tab1'])),
+    ).toEqual({ activeTabs: ['tab1'] });
+    expect(
+      dashboardStateReducer(
+        { activeTabs: ['tab1', 'tab2'] },
+        setActiveTabs(['tab3', 'tab4']),
+      ),
+    ).toEqual({ activeTabs: ['tab3', 'tab4'] });
   });
 });


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/28386 removed `setActiveTabs` related code because it was not being called from anywhere in Superset's code base. It turns out that this is being used by Preset extensions and currently there's no way to override redux reducers in our extensions. I added a comment to the function to provide this context.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
