### PR TITLE
feat: unpack payload into log function

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -79,6 +79,8 @@ STATS_LOGGER = DummyStatsLogger()
 
 # By default will log events to the metadata database with `DBEventLogger`
 # Note that you can use `StdOutEventLogger` for debugging
+# Note that you can write your own event logger by extending `AbstractEventLogger`
+# https://github.com/apache/superset/blob/master/superset/utils/log.py
 EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -101,6 +101,20 @@ class AbstractEventLogger(ABC):
         "queryLimit",
         "select_as_cta",
     }
+    # Similarly, parameters that are passed under the `curated_form_data` arg
+    curated_form_data_params = {
+        "dashboardId",
+        "sliceId",
+        "viz_type",
+        "force",
+        "compare_lag",
+        "forecastPeriods",
+        "granularity_sqla",
+        "legendType",
+        "legendOrientation",
+        "show_legend",
+        "time_grain_sqla",
+    }
 
     def __call__(
         self,
@@ -133,7 +147,13 @@ class AbstractEventLogger(ABC):
 
     @classmethod
     def curate_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        """Curate payload to only include relevant keys/safe keys"""
         return {k: v for k, v in payload.items() if k in cls.curated_payload_params}
+
+    @classmethod
+    def curate_form_data(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        """Curate form_data to only include relevant keys/safe keys"""
+        return {k: v for k, v in payload.items() if k in cls.curated_form_data_params}
 
     @abstractmethod
     def log(  # pylint: disable=too-many-arguments
@@ -145,6 +165,7 @@ class AbstractEventLogger(ABC):
         slice_id: int | None,
         referrer: str | None,
         curated_payload: dict[str, Any] | None,
+        curated_form_data: dict[str, Any] | None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -224,6 +245,7 @@ class AbstractEventLogger(ABC):
             duration_ms=duration_ms,
             referrer=referrer,
             curated_payload=self.curate_payload(payload),
+            curated_form_data=self.curate_form_data(payload),
             **database_params,
         )
 
@@ -398,6 +420,7 @@ class StdOutEventLogger(AbstractEventLogger):
         slice_id: int | None,
         referrer: str | None,
         curated_payload: dict[str, Any] | None,
+        curated_form_data: dict[str, Any] | None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -409,6 +432,7 @@ class StdOutEventLogger(AbstractEventLogger):
             slice_id=slice_id,
             referrer=referrer,
             curated_payload=curated_payload,
+            curated_form_data=curated_form_data,
             **kwargs,
         )
         print("StdOutEventLogger: ", data)

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -217,6 +217,7 @@ class AbstractEventLogger(ABC):
                 "database_driver": database.driver,
             }
 
+        form_data: dict[str, Any] = {}
         if "form_data" in payload:
             form_data, _ = get_form_data()
             payload["form_data"] = form_data
@@ -245,7 +246,7 @@ class AbstractEventLogger(ABC):
             duration_ms=duration_ms,
             referrer=referrer,
             curated_payload=self.curate_payload(payload),
-            curated_form_data=self.curate_form_data(payload),
+            curated_form_data=self.curate_form_data(form_data),
             **database_params,
         )
 

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -207,6 +207,7 @@ class AbstractEventLogger(ABC):
             slice_id=slice_id,
             duration_ms=duration_ms,
             referrer=referrer,
+            payload=payload,
             **database_params,
         )
 

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -141,15 +141,18 @@ class TestEventLogger(unittest.TestCase):
             with logger(action="foo", engine="bar"):
                 pass
 
-        assert logger.records == [
-            {
-                "records": [{"path": "/", "engine": "bar"}],
-                "database_id": None,
-                "user_id": 2,
-                "payload": {"engine": "bar", "path": "/"},
-                "duration": 15000,
-            }
-        ]
+        self.assertEquals(
+            logger.records,
+            [
+                {
+                    "records": [{"path": "/", "engine": "bar"}],
+                    "database_id": None,
+                    "user_id": 2,
+                    "duration": 15000,
+                    "curated_payload": {},
+                }
+            ],
+        )
 
     @patch("superset.utils.core.g", spec={})
     def test_context_manager_log_with_context(self, mock_g):
@@ -184,25 +187,24 @@ class TestEventLogger(unittest.TestCase):
                 payload_override={"engine": "sqlite"},
             )
 
-        assert logger.records == [
-            {
-                "records": [
-                    {
-                        "path": "/",
-                        "object_ref": {"baz": "food"},
-                        "payload_override": {"engine": "sqlite"},
-                    }
-                ],
-                "database_id": None,
-                "user_id": 2,
-                "payload": {
-                    "path": "/",
-                    "object_ref": {"baz": "food"},
-                    "payload_override": {"engine": "sqlite"},
-                },
-                "duration": 5558756000,
-            }
-        ]
+        self.assertEquals(
+            logger.records,
+            [
+                {
+                    "records": [
+                        {
+                            "path": "/",
+                            "object_ref": {"baz": "food"},
+                            "payload_override": {"engine": "sqlite"},
+                        }
+                    ],
+                    "database_id": None,
+                    "user_id": 2,
+                    "duration": 5558756000,
+                    "curated_payload": {},
+                }
+            ],
+        )
 
     @patch("superset.utils.core.g", spec={})
     def test_log_with_context_user_null(self, mock_g):

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -146,6 +146,7 @@ class TestEventLogger(unittest.TestCase):
                 "records": [{"path": "/", "engine": "bar"}],
                 "database_id": None,
                 "user_id": 2,
+                "payload": {"engine": "bar", "path": "/"},
                 "duration": 15000,
             }
         ]
@@ -194,6 +195,11 @@ class TestEventLogger(unittest.TestCase):
                 ],
                 "database_id": None,
                 "user_id": 2,
+                "payload": {
+                    "path": "/",
+                    "object_ref": {"baz": "food"},
+                    "payload_override": {"engine": "sqlite"},
+                },
                 "duration": 5558756000,
             }
         ]

--- a/tests/integration_tests/event_logger_tests.py
+++ b/tests/integration_tests/event_logger_tests.py
@@ -150,6 +150,7 @@ class TestEventLogger(unittest.TestCase):
                     "user_id": 2,
                     "duration": 15000,
                     "curated_payload": {},
+                    "curated_form_data": {},
                 }
             ],
         )
@@ -202,6 +203,7 @@ class TestEventLogger(unittest.TestCase):
                     "user_id": 2,
                     "duration": 5558756000,
                     "curated_payload": {},
+                    "curated_form_data": {},
                 }
             ],
         )


### PR DESCRIPTION
Unpack the payload (merged from the ? querystring and POST data, depending on context) and pass it to the log function. In my specific case, I was looking to do analysis on around how much of the calls to `ChartDataRestApi.data` are using "force=true", and realize while this is in context, it doesn't flow through my current logger. By adding this one line of code, it should allow for many more (in fact ALL querystring and POST payload) parameters to flow through the logger. From there custom loggers can have access to much more context. Note that by default, the loggers we have won't do anything with the new arguments passed, and essentially flush it.
