### PR TITLE
fix(Dashboard): Prevent scroll when hovering filters

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -73,6 +73,9 @@ const StyledFilterCount = styled.div`
     .incompatible-count {
       font-size: ${theme.typography.sizes.s}px;
     }
+    &:focus-visible {
+      outline: 2px solid ${theme.colors.primary.dark2};
+    }
   `}
 `;
 
@@ -160,7 +163,7 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
   useEffect(() => {
     if (popoverVisible) {
       setTimeout(() => {
-        popoverContentRef?.current?.focus();
+        popoverContentRef?.current?.focus({ preventScroll: true });
       });
     }
   }, [popoverVisible]);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Recent changes for accessibility have introduced an issue that was scrolling the Dashboard page at the top when hovering filters. This fixes it.

### BEFORE

https://github.com/apache/superset/assets/60598000/286fa712-6038-4372-97b0-e11da1d724d7

### AFTER

https://github.com/apache/superset/assets/60598000/ce3d603b-10a2-45bf-a487-d8c3c80c643c

### TESTING INSTRUCTIONS
1. Enter a Dashboard
2. Apply filters
3. Scroll to the bottom charts
4. Hover a filter
5. Dashboard should not scroll

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
