### PR TITLE
fix(explore): hide a control wrapped with StashFormDataContainer correctly

### DIFF
--- a/superset-frontend/src/explore/components/ControlRow.test.tsx
+++ b/superset-frontend/src/explore/components/ControlRow.test.tsx
@@ -19,49 +19,73 @@
 import React from 'react';
 import { render, screen } from 'spec/helpers/testing-library';
 import ControlSetRow from 'src/explore/components/ControlRow';
+import StashFormDataContainer from './StashFormDataContainer';
 
 const MockControl = (props: {
   children: React.ReactElement;
   type?: string;
   isVisible?: boolean;
 }) => <div>{props.children}</div>;
-describe('ControlSetRow', () => {
-  it('renders a single row with one element', () => {
-    render(<ControlSetRow controls={[<p>My Control 1</p>]} />);
-    expect(screen.getAllByText('My Control 1').length).toBe(1);
-  });
-  it('renders a single row with two elements', () => {
-    render(
-      <ControlSetRow controls={[<p>My Control 1</p>, <p>My Control 2</p>]} />,
-    );
-    expect(screen.getAllByText(/My Control/)).toHaveLength(2);
-  });
+test('renders a single row with one element', () => {
+  render(<ControlSetRow controls={[<p>My Control 1</p>]} />);
+  expect(screen.getAllByText('My Control 1').length).toBe(1);
+});
+test('renders a single row with two elements', () => {
+  render(
+    <ControlSetRow controls={[<p>My Control 1</p>, <p>My Control 2</p>]} />,
+  );
+  expect(screen.getAllByText(/My Control/)).toHaveLength(2);
+  expect(screen.getAllByText(/My Control/)[0]).toBeVisible();
+  expect(screen.getAllByText(/My Control/)[1]).toBeVisible();
+});
 
-  it('renders a single row with one elements if is HiddenControl', () => {
-    render(
-      <ControlSetRow
-        controls={[
-          <p>My Control 1</p>,
-          <MockControl type="HiddenControl">
-            <p>My Control 2</p>
-          </MockControl>,
-        ]}
-      />,
-    );
-    expect(screen.getAllByText(/My Control/)).toHaveLength(2);
-  });
+test('renders a single row with one elements if is HiddenControl', () => {
+  render(
+    <ControlSetRow
+      controls={[
+        <p>My Control 1</p>,
+        <MockControl type="HiddenControl">
+          <p>My Control 2</p>
+        </MockControl>,
+      ]}
+    />,
+  );
+  expect(screen.getAllByText(/My Control/)).toHaveLength(2);
+  expect(screen.getAllByText(/My Control/)[0]).toBeVisible();
+  expect(screen.getAllByText(/My Control/)[1]).not.toBeVisible();
+});
 
-  it('renders a single row with one elements if is invisible', () => {
-    render(
-      <ControlSetRow
-        controls={[
-          <p>My Control 1</p>,
+test('renders a single row with one elements if is invisible', () => {
+  render(
+    <ControlSetRow
+      controls={[
+        <p>My Control 1</p>,
+        <MockControl isVisible={false}>
+          <p>My Control 2</p>
+        </MockControl>,
+      ]}
+    />,
+  );
+  expect(screen.getAllByText(/My Control/)).toHaveLength(2);
+  expect(screen.getAllByText(/My Control/)[0]).toBeVisible();
+  expect(screen.getAllByText(/My Control/)[1]).not.toBeVisible();
+});
+
+test('renders a single row with one element wrapping with StashContainer if is invisible', () => {
+  render(
+    <ControlSetRow
+      controls={[
+        <p>My Control 1</p>,
+        <StashFormDataContainer shouldStash fieldNames={['field1']}>
           <MockControl isVisible={false}>
             <p>My Control 2</p>
-          </MockControl>,
-        ]}
-      />,
-    );
-    expect(screen.getAllByText(/My Control/)).toHaveLength(2);
-  });
+          </MockControl>
+        </StashFormDataContainer>,
+      ]}
+    />,
+    { useRedux: true },
+  );
+  expect(screen.getAllByText(/My Control/)).toHaveLength(2);
+  expect(screen.getAllByText(/My Control/)[0]).toBeVisible();
+  expect(screen.getAllByText(/My Control/)[1]).not.toBeVisible();
 });

--- a/superset-frontend/src/explore/components/ControlRow.tsx
+++ b/superset-frontend/src/explore/components/ControlRow.tsx
@@ -23,12 +23,13 @@ const NUM_COLUMNS = 12;
 type Control = React.ReactElement | null;
 
 export default function ControlRow({ controls }: { controls: Control[] }) {
-  const isHiddenControl = useCallback(
-    (control: Control) =>
-      control?.props.type === 'HiddenControl' ||
-      control?.props.isVisible === false,
-    [],
-  );
+  const isHiddenControl = useCallback((control: Control) => {
+    const props =
+      control && 'shouldStash' in control.props
+        ? control.props.children.props
+        : control?.props;
+    return props?.type === 'HiddenControl' || props?.isVisible === false;
+  }, []);
   // Invisible control should not be counted
   // in the columns number
   const countableControls = controls.filter(
@@ -41,6 +42,7 @@ export default function ControlRow({ controls }: { controls: Control[] }) {
     <div className="row">
       {controls.map((control, i) => (
         <div
+          data-test="control-item"
           className={`col-lg-${colSize} col-xs-12`}
           style={{
             display: isHiddenControl(control) ? 'none' : 'block',


### PR DESCRIPTION
### SUMMARY
With the introduction of StashFormDataContainer to stash form data while hidden, the control row visibility logic has been affected. This is because it currently only checks the direct element properties.
This commit fixes the logic to check with the correct Control component

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/23d43710-26d7-4efc-b413-14934780c1b7

After:

https://github.com/apache/superset/assets/1392866/b01997cc-bc40-4cd2-bcd0-3217a2250672

### TESTING INSTRUCTIONS
Open a explore to create a table chart
Resize the window over 1200px and then check the control panel

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
