### PR TITLE
fix: enable importing datasource with multi catalog support

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -180,6 +180,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         "encrypted_extra",
         "impersonate_user",
         "allow_multi_catalog",
+        "disable_drill_to_detail",
     ]
     export_children = ["tables"]
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -179,6 +179,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         "external_url",
         "encrypted_extra",
         "impersonate_user",
+        "allow_multi_catalog",
     ]
     export_children = ["tables"]
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I wanted to import trino connections using the new `allow_multi_catalog` param but I discovered that the param can only be set through the UI? So I wanted to try and address that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
