### PR TITLE
fix: Revert "fix: don't strip SQL comments in Explore (#28363)"

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1134,8 +1134,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cte = None
         sql_remainder = None
         sql = sql.strip(" \t\n;")
+        sql_statement = sqlparse.format(sql, strip_comments=True)
         query_limit: int | None = sql_parse.extract_top_from_query(
-            sql, cls.top_keywords
+            sql_statement, cls.top_keywords
         )
         if not limit:
             final_limit = query_limit
@@ -1144,7 +1145,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         else:
             final_limit = limit
         if not cls.allows_cte_in_subquery:
-            cte, sql_remainder = sql_parse.get_cte_remainder_query(sql)
+            cte, sql_remainder = sql_parse.get_cte_remainder_query(sql_statement)
         if cte:
             str_statement = str(sql_remainder)
             cte = cte + "\n"

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1088,7 +1088,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 _("Virtual dataset query cannot consist of multiple statements")
             )
 
-        sql = script.statements[0].format()
+        sql = script.statements[0].format(comments=False)
         if not sql:
             raise QueryObjectValidationError(_("Virtual dataset query cannot be empty"))
         return sql

--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -60,6 +60,7 @@ class SqlQueryRenderImpl(SqlQueryRender):
 
             parsed_query = ParsedQuery(
                 query_model.sql,
+                strip_comments=True,
                 engine=query_model.database.db_engine_spec.engine,
             )
             rendered_query = sql_template_processor.process_template(

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -304,7 +304,6 @@ def virtual_dataset():
             "SELECT 3 as col1, 'd' as col2, 1.3, NULL, '2000-01-04 00:00:00', 4 "
             "UNION ALL "
             "SELECT 4 as col1, 'e' as col2, 1.4, NULL, '2000-01-05 00:00:00', 5 "
-            "\n /* CONTAINS A RANDOM COMMENT */ \n"
             "UNION ALL "
             "SELECT 5 as col1, 'f' as col2, 1.5, NULL, '2000-01-06 00:00:00', 6 "
             "UNION ALL "

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -540,9 +540,7 @@ class TestCore(SupersetTestCase):
             database=get_example_database(),
         )
         rendered_query = str(table.get_from_clause()[0])
-        assert "comment 1" in rendered_query
-        assert "comment 2" in rendered_query
-        assert "FROM tbl" in rendered_query
+        self.assertEqual(clean_query, rendered_query)
 
     def test_slice_payload_no_datasource(self):
         form_data = {

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -538,12 +538,10 @@ def test_get_samples(test_client, login_as_admin, virtual_dataset):
     assert "coltypes" in rv2.json["result"]
     assert "data" in rv2.json["result"]
 
-    sql = (
-        f"select * from ({virtual_dataset.sql}) as tbl "
-        f'limit {app.config["SAMPLES_ROW_LIMIT"]}'
+    eager_samples = virtual_dataset.database.get_df(
+        f"select * from ({virtual_dataset.sql}) as tbl"
+        f' limit {app.config["SAMPLES_ROW_LIMIT"]}'
     )
-    eager_samples = virtual_dataset.database.get_df(sql)
-
     # the col3 is Decimal
     eager_samples["col3"] = eager_samples["col3"].apply(float)
     eager_samples = eager_samples.to_dict(orient="records")

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -575,9 +575,9 @@ class TestSqlLab(SupersetTestCase):
         assert data["status"] == "success"
 
         data = self.run_sql(
-            "SELECT * FROM birth_names WHERE state = '{{ state }}' -- blabblah {{ extra1 }}\nLIMIT 10",
+            "SELECT * FROM birth_names WHERE state = '{{ state }}' -- blabblah {{ extra1 }} {{fake.fn()}}\nLIMIT 10",
             "3",
-            template_params=json.dumps({"state": "CA", "extra1": "comment"}),
+            template_params=json.dumps({"state": "CA"}),
         )
         assert data["status"] == "success"
 


### PR DESCRIPTION
### SUMMARY
This reverts commit c618767c6b4b7c1c921807e4f942586353110114.

After deploying Superset 4.0 to production a number of users reported issues where the rendered SQL statements were invalid if the underlying virtual dataset contained comments—likely trailing comments. Specifically the subquery lacked the trailing `)`.

We were able to determine that #28363 was the problematic PR and reverting it remedied the issue.

### TESTING INSTRUCTIONS

CI and confirmed that the issue was mitigated after reverting.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
