### PR TITLE
fix: revert fix(presto preview): re-enable schema previsualization for Trino/Presto table/schemas"

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -536,10 +536,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         }
 
         for col_name, value in zip(col_names, values):
-            col_type = None
-            if col_type_name := column_type_by_name.get(col_name):
-                if col_type_class := getattr(types, col_type_name, None):
-                    col_type = col_type_class()
+            col_type = column_type_by_name.get(col_name)
 
             if isinstance(col_type, types.DATE):
                 col_type = Date()

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -116,10 +116,10 @@ def test_get_schema_from_engine_params() -> None:
 @pytest.mark.parametrize(
     ["column_type", "column_value", "expected_value"],
     [
-        ("DATE", "2023-05-01", "DATE '2023-05-01'"),
-        ("TIMESTAMP", "2023-05-01", "TIMESTAMP '2023-05-01'"),
-        ("VARCHAR", "2023-05-01", "'2023-05-01'"),
-        ("INT", 1234, "1234"),
+        (types.DATE(), "2023-05-01", "DATE '2023-05-01'"),
+        (types.TIMESTAMP(), "2023-05-01", "TIMESTAMP '2023-05-01'"),
+        (types.VARCHAR(), "2023-05-01", "'2023-05-01'"),
+        (types.INT(), 1234, "1234"),
     ],
 )
 def test_where_latest_partition(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR reverts apache/superset#26782 which was merged last week. Regrettably said logic seems to be problematic and throws a error:

```
Traceback (most recent call last):
  ...
  File "superset/db_engine_specs/presto.py", line 512, in where_latest_partition
    if col_type_class := getattr(types, col_type_name, None):
TypeError: getattr(): attribute name must be string
```

given that `col_type_name` isn't a string but rather a SQLAlchemy SQL type representing the column type—as denoted by the `column_type_by_name` mapping.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc: @brouberol  
