### PR TITLE
chore: Set isolation level to READ COMMITTED for testing et al. 

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -196,6 +196,13 @@ SQLALCHEMY_DATABASE_URI = (
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
+# The default MySQL isolation level is REPEATABLE READ whereas the default PostgreSQL
+# isolation level is READ COMMITTED. All backends should use READ COMMITTED (or similar)
+# to help ensure consistent behavior.
+SQLALCHEMY_ENGINE_OPTIONS = {
+    "isolation_level": "SERIALIZABLE",  # SQLite does not support READ COMMITTED.
+}
+
 # In order to hook up a custom password store for all SQLALCHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',
 # returns a password and set SQLALCHEMY_CUSTOM_PASSWORD_STORE.

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -20,6 +20,8 @@ import math
 from copy import copy
 from datetime import timedelta
 
+from sqlalchemy.engine import make_url
+
 from superset.config import *  # noqa: F403
 from superset.config import DATA_DIR
 from tests.integration_tests.superset_test_custom_template_processors import (
@@ -52,11 +54,14 @@ if "SUPERSET__SQLALCHEMY_EXAMPLES_URI" in os.environ:  # noqa: F405
 if "UPLOAD_FOLDER" in os.environ:  # noqa: F405
     UPLOAD_FOLDER = os.environ["UPLOAD_FOLDER"]  # noqa: F405
 
-if "sqlite" in SQLALCHEMY_DATABASE_URI:
+if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() == "sqlite":
     logger.warning(  # noqa: F405
         "SQLite Database support for metadata databases will be "
         "removed in a future version of Superset."
     )
+
+if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() in ("postgresql", "mysql"):
+    SQLALCHEMY_ENGINE_OPTIONS["isolation_level"] = "READ COMMITTED"  # noqa: F405
 
 # Speeding up the tests.integration_tests.
 PRESTO_POLL_INTERVAL = 0.1

--- a/tests/integration_tests/superset_test_config_thumbnails.py
+++ b/tests/integration_tests/superset_test_config_thumbnails.py
@@ -17,6 +17,8 @@
 # type: ignore
 from copy import copy
 
+from sqlalchemy.engine import make_url
+
 from superset.config import *  # noqa: F403
 from superset.config import DATA_DIR
 
@@ -33,11 +35,14 @@ DEBUG = True
 if "SUPERSET__SQLALCHEMY_DATABASE_URI" in os.environ:  # noqa: F405
     SQLALCHEMY_DATABASE_URI = os.environ["SUPERSET__SQLALCHEMY_DATABASE_URI"]  # noqa: F405
 
-if "sqlite" in SQLALCHEMY_DATABASE_URI:
+if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() == "sqlite":
     logger.warning(  # noqa: F405
         "SQLite Database support for metadata databases will be removed \
         in a future version of Superset."
     )
+
+if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() in ("postgresql", "mysql"):
+    SQLALCHEMY_ENGINE_OPTIONS["isolation_level"] = "READ COMMITTED"  # noqa: F405
 
 SQL_SELECT_AS_CTA = True
 SQL_MAX_ROW = 666


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The default isolation level for PostgreSQL is `READ COMMITTED` whereas for MySQL it is `REPEATABLE READ`. Ideally we would strive to have these the same (for consistency reasons) and the former is likely preferred given the async nature of Superset (especially SQL Lab) where the backend is polling to determine whether a query has been cancelled from another Flask-SQLAlchemy session.

This PR:

1. Adds a comment in `config.py` to try to persuade institutions to set the isolation level. It's actually hard/difficult to impose this given that the default config is configured for SQLite which doesn't support `READ COMMITTED`.
2. Updates the test configs to ensure that—for MySQL and PostgreSQL—the isolation level is `READ COMMITTED`. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
