### PR TITLE
fix(ci): restrict issue comments to members or owners

### DIFF
--- a/.github/workflows/update-monorepo-lockfiles.yml
+++ b/.github/workflows/update-monorepo-lockfiles.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@supersetbot trigger-dependabot-lockfile') && github.event.issue.pull_request)
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@supersetbot trigger-dependabot-lockfile') && github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'))
     defaults:
       run:
         working-directory: superset-frontend


### PR DESCRIPTION
### SUMMARY
`issue_comment` has access to secrets and doing a fresh checkout of the repo could open the possibility to execute malicious code on CI. Although we are not executing any script from the repo, it does seem safer to restrict this functionality to members and owners of the repo.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
