### PR TITLE
feat: add Current time-range options for time filter

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -299,7 +299,10 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         <CalendarFrame value={timeRangeValue} onChange={setTimeRangeValue} />
       )}
       {frame === 'Current' && (
-        <CurrentCalendarFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+        <CurrentCalendarFrame
+          value={timeRangeValue}
+          onChange={setTimeRangeValue}
+        />
       )}
       {frame === 'Advanced' && (
         <AdvancedFrame value={timeRangeValue} onChange={setTimeRangeValue} />

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -53,6 +53,7 @@ import {
   AdvancedFrame,
   DateLabel,
 } from './components';
+import { CurrentCalendarFrame } from './components/CurrentCalendarFrame';
 
 const StyledRangeType = styled(Select)`
   width: 272px;
@@ -282,9 +283,9 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
 
   const overlayContent = (
     <ContentStyleWrapper>
-      <div className="control-label">{t('RANGE TYPE')}</div>
+      <div className="control-label">{t('RANGE TYPE TIME DEMO')}</div>
       <StyledRangeType
-        ariaLabel={t('RANGE TYPE')}
+        ariaLabel={t('RANGE TYPE DEMO TIME')}
         options={FRAME_OPTIONS}
         value={frame}
         onChange={onChangeFrame}
@@ -295,6 +296,9 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       )}
       {frame === 'Calendar' && (
         <CalendarFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+      )}
+      {frame === 'Current' && (
+        <CurrentCalendarFrame value={timeRangeValue} onChange={setTimeRangeValue} />
       )}
       {frame === 'Advanced' && (
         <AdvancedFrame value={timeRangeValue} onChange={setTimeRangeValue} />

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -283,9 +283,9 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
 
   const overlayContent = (
     <ContentStyleWrapper>
-      <div className="control-label">{t('RANGE TYPE TIME DEMO')}</div>
+      <div className="control-label">{t('RANGE TYPE')}</div>
       <StyledRangeType
-        ariaLabel={t('RANGE TYPE DEMO TIME')}
+        ariaLabel={t('RANGE TYPE')}
         options={FRAME_OPTIONS}
         value={frame}
         onChange={onChangeFrame}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -202,6 +202,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         if (
           guessedFrame === 'Common' ||
           guessedFrame === 'Calendar' ||
+          guessedFrame === 'Current' ||
           guessedFrame === 'No filter'
         ) {
           setActualTimeRange(value);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CurrentCalendarFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CurrentCalendarFrame.tsx
@@ -20,23 +20,19 @@ import React, { useEffect } from 'react';
 import { t } from '@superset-ui/core';
 import { Radio } from 'src/components/Radio';
 import {
-  CURRENT_CALENDAR_RANGE_OPTIONS,
+  CURRENT_RANGE_OPTIONS,
   CURRENT_CALENDAR_RANGE_SET,
 } from 'src/explore/components/controls/DateFilterControl/utils';
-import {
-  CurrentCalendarRangeType,
-  CurrentCalendarWeek,
-  FrameComponentProps,
-} from '../types';
+import { CurrentRangeType, CurrentWeek, FrameComponentProps } from '../types';
 
 export function CurrentCalendarFrame({ onChange, value }: FrameComponentProps) {
   useEffect(() => {
-    if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentCalendarRangeType)) {
-      onChange(CurrentCalendarWeek);
+    if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentRangeType)) {
+      onChange(CurrentWeek);
     }
-  }, [onChange, value]);
+  }, [value]);
 
-  if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentCalendarRangeType)) {
+  if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentRangeType)) {
     return null;
   }
 
@@ -47,9 +43,18 @@ export function CurrentCalendarFrame({ onChange, value }: FrameComponentProps) {
       </div>
       <Radio.Group
         value={value}
-        onChange={(e: any) => onChange(e.target.value)}
+        onChange={(e: any) => {
+          let newValue = e.target.value;
+          // Sanitization: Trim whitespace
+          newValue = newValue.trim();
+          // Validation: Check if the value is non-empty
+          if (newValue === '') {
+            return;
+          }
+          onChange(newValue);
+        }}
       >
-        {CURRENT_CALENDAR_RANGE_OPTIONS.map(({ value, label }) => (
+        {CURRENT_RANGE_OPTIONS.map(({ value, label }) => (
           <Radio key={value} value={value} className="vertical-radio">
             {label}
           </Radio>

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CurrentCalendarFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CurrentCalendarFrame.tsx
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useEffect } from 'react';
+import { t } from '@superset-ui/core';
+import { Radio } from 'src/components/Radio';
+import {
+  CURRENT_CALENDAR_RANGE_OPTIONS,
+  CURRENT_CALENDAR_RANGE_SET,
+} from 'src/explore/components/controls/DateFilterControl/utils';
+import {
+  CurrentCalendarRangeType,
+  CurrentCalendarWeek,
+  FrameComponentProps,
+} from '../types';
+
+export function CurrentCalendarFrame({ onChange, value }: FrameComponentProps) {
+  useEffect(() => {
+    if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentCalendarRangeType)) {
+      onChange(CurrentCalendarWeek);
+    }
+  }, [onChange, value]);
+
+  if (!CURRENT_CALENDAR_RANGE_SET.has(value as CurrentCalendarRangeType)) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="section-title">
+        {t('Configure Time Range: Current...')}
+      </div>
+      <Radio.Group
+        value={value}
+        onChange={(e: any) => onChange(e.target.value)}
+      >
+        {CURRENT_CALENDAR_RANGE_OPTIONS.map(({ value, label }) => (
+          <Radio key={value} value={value} className="vertical-radio">
+            {label}
+          </Radio>
+        ))}
+      </Radio.Group>
+    </>
+  );
+}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
@@ -18,7 +18,7 @@
  */
 export { CommonFrame } from './CommonFrame';
 export { CalendarFrame } from './CalendarFrame';
-export {CurrentCalendarFrame} from './CurrentCalendarFrame'
+export { CurrentCalendarFrame } from './CurrentCalendarFrame';
 export { CustomFrame } from './CustomFrame';
 export { AdvancedFrame } from './AdvancedFrame';
 export { DateLabel } from './DateLabel';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/index.ts
@@ -18,6 +18,7 @@
  */
 export { CommonFrame } from './CommonFrame';
 export { CalendarFrame } from './CalendarFrame';
+export {CurrentCalendarFrame} from './CurrentCalendarFrame'
 export { CustomFrame } from './CustomFrame';
 export { AdvancedFrame } from './AdvancedFrame';
 export { DateLabel } from './DateLabel';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect'; // For advanced DOM assertions
+import { CurrentCalendarFrame } from '../components/CurrentCalendarFrame';
+import { CurrentWeek } from '../types';
+
+const mockOnChange = jest.fn();
+
+test('calls onChange(CurrentWeek) when value is invalid', () => {
+  render(<CurrentCalendarFrame onChange={mockOnChange} value="InvalidValue" />);
+  expect(mockOnChange).toHaveBeenCalledWith(CurrentWeek);
+});
+
+test('returns null if value is not a valid CurrentRangeType', () => {
+  const { container } = render(
+    <CurrentCalendarFrame onChange={mockOnChange} value="InvalidValue" />,
+  );
+  expect(container.firstChild).toBeNull();
+});

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'; // For advanced DOM assertions

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
@@ -33,5 +33,5 @@ test('returns null if value is not a valid CurrentRangeType', () => {
   const { container } = render(
     <CurrentCalendarFrame onChange={mockOnChange} value="InvalidValue" />,
   );
-  expect(container.firstChild).toBeNull();
+  expect(container.firstChild).toBeEmptyDOMElement();
 });

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CurrentCalendarFrame.test.tsx
@@ -33,5 +33,5 @@ test('returns null if value is not a valid CurrentRangeType', () => {
   const { container } = render(
     <CurrentCalendarFrame onChange={mockOnChange} value="InvalidValue" />,
   );
-  expect(container.firstChild).toBeEmptyDOMElement();
+  expect(container.childNodes.length).toBe(0);
 });

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -86,14 +86,18 @@ export type CalendarRangeType =
   | typeof PreviousCalendarMonth
   | typeof PreviousCalendarYear;
 
-export const CurrentCalendarWeek = 'current calendar week';
-export const CurrentCalendarMonth = 'current calendar month';
-export const CurrentCalendarYear = 'current calendar year';
-export type CurrentCalendarRangeType =
-  | typeof CurrentCalendarWeek
-  | typeof CurrentCalendarMonth
-  | typeof CurrentCalendarYear;
-  
+export const CurrentDay = 'Current day';
+export const CurrentWeek = 'Current week';
+export const CurrentMonth = 'Current month';
+export const CurrentYear = 'Current year';
+export const CurrentQuarter = 'Current quarter';
+export type CurrentRangeType =
+  | typeof CurrentDay
+  | typeof CurrentWeek
+  | typeof CurrentMonth
+  | typeof CurrentQuarter
+  | typeof CurrentYear;
+
 export type FrameComponentProps = {
   onChange: (timeRange: string) => void;
   value: string;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -24,6 +24,7 @@ export type SelectOptionType = {
 export type FrameType =
   | 'Common'
   | 'Calendar'
+  | 'Current'
   | 'Custom'
   | 'Advanced'
   | 'No filter';
@@ -85,6 +86,14 @@ export type CalendarRangeType =
   | typeof PreviousCalendarMonth
   | typeof PreviousCalendarYear;
 
+export const CurrentCalendarWeek = 'current calendar week';
+export const CurrentCalendarMonth = 'current calendar month';
+export const CurrentCalendarYear = 'current calendar year';
+export type CurrentCalendarRangeType =
+  | typeof CurrentCalendarWeek
+  | typeof CurrentCalendarMonth
+  | typeof CurrentCalendarYear;
+  
 export type FrameComponentProps = {
   onChange: (timeRange: string) => void;
   value: string;

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
@@ -25,10 +25,12 @@ import {
   PreviousCalendarYear,
   CommonRangeType,
   CalendarRangeType,
-  CurrentCalendarRangeType,
-  CurrentCalendarWeek,
-  CurrentCalendarMonth,
-  CurrentCalendarYear,
+  CurrentRangeType,
+  CurrentWeek,
+  CurrentMonth,
+  CurrentYear,
+  CurrentQuarter,
+  CurrentDay,
 } from 'src/explore/components/controls/DateFilterControl/types';
 
 export const FRAME_OPTIONS: SelectOptionType[] = [
@@ -63,16 +65,18 @@ export const CALENDAR_RANGE_VALUES_SET = new Set(
   CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
 );
 
-export const CURRENT_CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
-  { value: CurrentCalendarWeek, label: t('current calendar week') },
+export const CURRENT_RANGE_OPTIONS: SelectOptionType[] = [
+  { value: CurrentDay, label: t('Current day') },
+  { value: CurrentWeek, label: t('Current week') },
   {
-    value: CurrentCalendarMonth,
-    label: t('current calendar month'),
+    value: CurrentMonth,
+    label: t('Current month'),
   },
-  { value: CurrentCalendarYear, label: t('current calendar year') },
+  { value: CurrentQuarter, label: t('Current quarter') },
+  { value: CurrentYear, label: t('Current year') },
 ];
-export const CURRENT_CALENDAR_RANGE_VALUES_SET = new Set(
-  CURRENT_CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
+export const CURRENT_RANGE_VALUES_SET = new Set(
+  CURRENT_RANGE_OPTIONS.map(({ value }) => value),
 );
 
 const GRAIN_OPTIONS = [
@@ -124,10 +128,12 @@ export const CALENDAR_RANGE_SET: Set<CalendarRangeType> = new Set([
   PreviousCalendarYear,
 ]);
 
-export const CURRENT_CALENDAR_RANGE_SET: Set<CurrentCalendarRangeType> = new Set([
-  CurrentCalendarWeek,
-  CurrentCalendarMonth,
-  CurrentCalendarYear,
+export const CURRENT_CALENDAR_RANGE_SET: Set<CurrentRangeType> = new Set([
+  CurrentDay,
+  CurrentWeek,
+  CurrentMonth,
+  CurrentQuarter,
+  CurrentYear,
 ]);
 
 export const MOMENT_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
@@ -25,11 +25,16 @@ import {
   PreviousCalendarYear,
   CommonRangeType,
   CalendarRangeType,
+  CurrentCalendarRangeType,
+  CurrentCalendarWeek,
+  CurrentCalendarMonth,
+  CurrentCalendarYear,
 } from 'src/explore/components/controls/DateFilterControl/types';
 
 export const FRAME_OPTIONS: SelectOptionType[] = [
   { value: 'Common', label: t('Last') },
   { value: 'Calendar', label: t('Previous') },
+  { value: 'Current', label: t('Current') },
   { value: 'Custom', label: t('Custom') },
   { value: 'Advanced', label: t('Advanced') },
   { value: 'No filter', label: t('No filter') },
@@ -55,6 +60,18 @@ export const CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
   { value: PreviousCalendarYear, label: t('previous calendar year') },
 ];
 export const CALENDAR_RANGE_VALUES_SET = new Set(
+  CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
+);
+
+export const CURRENT_CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
+  { value: CurrentCalendarWeek, label: t('current calendar week') },
+  {
+    value: CurrentCalendarMonth,
+    label: t('current calendar month'),
+  },
+  { value: CurrentCalendarYear, label: t('current calendar year') },
+];
+export const CURRENT_CALENDAR_RANGE_VALUES_SET = new Set(
   CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
 );
 
@@ -105,6 +122,12 @@ export const CALENDAR_RANGE_SET: Set<CalendarRangeType> = new Set([
   PreviousCalendarWeek,
   PreviousCalendarMonth,
   PreviousCalendarYear,
+]);
+
+export const CURRENT_CALENDAR_RANGE_SET: Set<CurrentCalendarRangeType> = new Set([
+  CurrentCalendarWeek,
+  CurrentCalendarMonth,
+  CurrentCalendarYear,
 ]);
 
 export const MOMENT_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
@@ -72,7 +72,7 @@ export const CURRENT_CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
   { value: CurrentCalendarYear, label: t('current calendar year') },
 ];
 export const CURRENT_CALENDAR_RANGE_VALUES_SET = new Set(
-  CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
+  CURRENT_CALENDAR_RANGE_OPTIONS.map(({ value }) => value),
 );
 
 const GRAIN_OPTIONS = [

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/constants.ts
@@ -55,10 +55,7 @@ export const COMMON_RANGE_VALUES_SET = new Set(
 
 export const CALENDAR_RANGE_OPTIONS: SelectOptionType[] = [
   { value: PreviousCalendarWeek, label: t('previous calendar week') },
-  {
-    value: PreviousCalendarMonth,
-    label: t('previous calendar month'),
-  },
+  { value: PreviousCalendarMonth, label: t('previous calendar month') },
   { value: PreviousCalendarYear, label: t('previous calendar year') },
 ];
 export const CALENDAR_RANGE_VALUES_SET = new Set(
@@ -68,10 +65,7 @@ export const CALENDAR_RANGE_VALUES_SET = new Set(
 export const CURRENT_RANGE_OPTIONS: SelectOptionType[] = [
   { value: CurrentDay, label: t('Current day') },
   { value: CurrentWeek, label: t('Current week') },
-  {
-    value: CurrentMonth,
-    label: t('Current month'),
-  },
+  { value: CurrentMonth, label: t('Current month') },
   { value: CurrentQuarter, label: t('Current quarter') },
   { value: CurrentYear, label: t('Current year') },
 ];

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
@@ -21,6 +21,7 @@ import { useSelector } from 'react-redux';
 import {
   COMMON_RANGE_VALUES_SET,
   CALENDAR_RANGE_VALUES_SET,
+  CURRENT_CALENDAR_RANGE_VALUES_SET,
   customTimeRangeDecode,
 } from '.';
 import { FrameType } from '../types';
@@ -31,6 +32,9 @@ export const guessFrame = (timeRange: string): FrameType => {
   }
   if (CALENDAR_RANGE_VALUES_SET.has(timeRange)) {
     return 'Calendar';
+  }
+  if (CURRENT_CALENDAR_RANGE_VALUES_SET.has(timeRange)) {
+    return 'Current';
   }
   if (timeRange === NO_TIME_RANGE) {
     return 'No filter';

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/utils/dateFilterUtils.ts
@@ -21,7 +21,7 @@ import { useSelector } from 'react-redux';
 import {
   COMMON_RANGE_VALUES_SET,
   CALENDAR_RANGE_VALUES_SET,
-  CURRENT_CALENDAR_RANGE_VALUES_SET,
+  CURRENT_RANGE_VALUES_SET,
   customTimeRangeDecode,
 } from '.';
 import { FrameType } from '../types';
@@ -33,7 +33,7 @@ export const guessFrame = (timeRange: string): FrameType => {
   if (CALENDAR_RANGE_VALUES_SET.has(timeRange)) {
     return 'Calendar';
   }
-  if (CURRENT_CALENDAR_RANGE_VALUES_SET.has(timeRange)) {
+  if (CURRENT_RANGE_VALUES_SET.has(timeRange)) {
     return 'Current';
   }
   if (timeRange === NO_TIME_RANGE) {

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -207,6 +207,24 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
         and separator not in time_range
     ):
         time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, YEAR), YEAR) : DATETRUNC(DATETIME('today'), YEAR)"  # pylint: disable=line-too-long,useless-suppression
+    if (
+        time_range
+        and time_range.startswith("current calendar week")
+        and separator not in time_range
+    ):
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, WEEK), WEEK) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
+    if (
+        time_range
+        and time_range.startswith("current calendar month")
+        and separator not in time_range
+    ):
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, MONTH), MONTH) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
+    if (
+        time_range
+        and time_range.startswith("current calendar year")
+        and separator not in time_range
+    ):
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, YEAR), YEAR) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
 
     if time_range and separator in time_range:
         time_range_lookup = [

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -209,22 +209,34 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
         time_range = "DATETRUNC(DATEADD(DATETIME('today'), -1, YEAR), YEAR) : DATETRUNC(DATETIME('today'), YEAR)"  # pylint: disable=line-too-long,useless-suppression
     if (
         time_range
-        and time_range.startswith("current calendar week")
+        and time_range.startswith("Current day")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, WEEK), WEEK) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, DAY), DAY) : DATETRUNC(DATEADD(DATETIME('today'), 1, DAY), DAY)"  # pylint: disable=line-too-long,useless-suppression
     if (
         time_range
-        and time_range.startswith("current calendar month")
+        and time_range.startswith("Current week")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, MONTH), MONTH) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, WEEK), WEEK) : DATETRUNC(DATEADD(DATETIME('today'), 1, WEEK), WEEK)"  # pylint: disable=line-too-long,useless-suppression
     if (
         time_range
-        and time_range.startswith("current calendar year")
+        and time_range.startswith("Current month")
         and separator not in time_range
     ):
-        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, YEAR), YEAR) : DATETRUNC(DATETIME('today'), DAY)"  # pylint: disable=line-too-long,useless-suppression
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, MONTH), MONTH) : DATETRUNC(DATEADD(DATETIME('today'), 1, MONTH), MONTH)"  # pylint: disable=line-too-long,useless-suppression
+    if (
+        time_range
+        and time_range.startswith("Current quarter")
+        and separator not in time_range
+    ):
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, QUARTER), QUARTER) : DATETRUNC(DATEADD(DATETIME('today'), 1, QUARTER), QUARTER)"  # pylint: disable=line-too-long,useless-suppression
+    if (
+        time_range
+        and time_range.startswith("Current year")
+        and separator not in time_range
+    ):
+        time_range = "DATETRUNC(DATEADD(DATETIME('today'), 0, YEAR), YEAR) : DATETRUNC(DATEADD(DATETIME('today'), 1, YEAR), YEAR)"  # pylint: disable=line-too-long,useless-suppression
 
     if time_range and separator in time_range:
         time_range_lookup = [

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -160,6 +160,26 @@ def test_get_since_until() -> None:
     expected = datetime(2015, 1, 1, 0, 0, 0), datetime(2016, 1, 1, 0, 0, 0)
     assert result == expected
 
+    result = get_since_until("Current day")
+    expected = datetime(2016, 11, 7, 0, 0, 0), datetime(2016, 11, 8, 0, 0, 0)
+    assert result == expected
+
+    result = get_since_until("Current week")
+    expected = datetime(2016, 11, 7, 0, 0, 0), datetime(2016, 11, 14, 0, 0, 0)
+    assert result == expected
+
+    result = get_since_until("Current month")
+    expected = datetime(2016, 11, 1, 0, 0, 0), datetime(2016, 12, 1, 0, 0, 0)
+    assert result == expected
+
+    result = get_since_until("Current quarter")
+    expected = datetime(2016, 10, 1, 0, 0, 0), datetime(2017, 1, 1, 0, 0, 0)
+    assert result == expected
+
+    result = get_since_until("Current year")
+    expected = expected = datetime(2016, 1, 1, 0, 0, 0), datetime(2017, 1, 1, 0, 0, 0)
+    assert result == expected
+
     # Tests for our new instant_time_comparison logic and Feature Flag off
     result = get_since_until(
         time_range="2000-01-01T00:00:00 : 2018-01-01T00:00:00",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This pull request introduces a new "Current" option to the time filter component. The "Current" option allows users to select and view data for the current week, current month, and current year.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/apache/superset/assets/86850478/0e0fb01a-af20-4448-82a3-fb24198c856f)

After :
![image](https://github.com/apache/superset/assets/86850478/056ba2ea-e7ff-4341-bd54-71e7feaa06a4)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/28489
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
