### PR TITLE
chore: add canvas repaint for explore

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -23,6 +23,8 @@ import { isFeatureEnabled, t, FeatureFlag } from '@superset-ui/core';
 import { PluginContext } from 'src/components/DynamicPlugins';
 import Loading from 'src/components/Loading';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import handleCanvasChange from 'src/utils/canvasRepaint';
+
 import getChartIdsFromLayout from '../util/getChartIdsFromLayout';
 import getLayoutComponentFromChartId from '../util/getLayoutComponentFromChartId';
 
@@ -90,8 +92,6 @@ class Dashboard extends React.PureComponent {
     this.appliedFilters = props.activeFilters ?? {};
     this.appliedOwnDataCharts = props.ownDataCharts ?? {};
     this.onVisibilityChange = this.onVisibilityChange.bind(this);
-    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
-    this.repaintCanvas = this.repaintCanvas.bind(this);
   }
 
   componentDidMount() {
@@ -194,24 +194,6 @@ class Dashboard extends React.PureComponent {
     this.props.actions.clearDataMaskState();
   }
 
-  repaintCanvas(canvas, ctx, imageBitmap) {
-    // Clear the canvas
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    // Draw the copied content
-    ctx.drawImage(imageBitmap, 0, 0);
-  }
-
-  handleVisibilityChange() {
-    this.canvases.forEach(canvas => {
-      const ctx = canvas.getContext('2d');
-      createImageBitmap(canvas).then(imageBitmap => {
-        // Call the repaintCanvas function with canvas, ctx, and imageBitmap
-        this.repaintCanvas(canvas, ctx, imageBitmap);
-      });
-    });
-  }
-
   onVisibilityChange() {
     if (document.visibilityState === 'hidden') {
       // from visible to hidden
@@ -228,7 +210,7 @@ class Dashboard extends React.PureComponent {
         duration: Logger.getTimestamp() - logStart,
       });
       // for chrome to ensure that the canvas doesn't disappear
-      this.handleVisibilityChange();
+      handleCanvasChange(this.canvases);
     }
   }
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -260,6 +260,7 @@ function ExploreViewContainer(props) {
   const [width, setWidth] = useState(
     getSidebarWidths(LocalStorageKeys.DatasourceWidth),
   );
+  const [canvases, setCanvases] = useState(null);
   const tabId = useTabId();
 
   const theme = useTheme();
@@ -354,8 +355,21 @@ function ExploreViewContainer(props) {
     setIsCollapsed(!isCollapsed);
   }
 
+  function onVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      setCanvases(document.querySelectorAll('canvas'));
+    } else if (document.visibilityState === 'visible' && canvases) {
+      handleCanvasChange(canvases);
+    }
+  }
+
   useComponentDidMount(() => {
     props.actions.logEvent(LOG_ACTIONS_MOUNT_EXPLORER);
+    window.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      // on unmount
+      window.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   });
 
   useChangeEffect(tabId, (previous, current) => {

--- a/superset-frontend/src/utils/canvasRepaint.test.ts
+++ b/superset-frontend/src/utils/canvasRepaint.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import handleCanvasChange, { repaintCanvas, Canvas } from './canvasRepaint';
+import * as canvasRepaint from './canvasRepaint';
+
+const canvases: Canvas[] = [
+  {
+    width: 100,
+    height: 100,
+    getContext: jest.fn().mockReturnValue({
+      clearRect: jest.fn(),
+      drawImage: jest.fn(),
+    }),
+  },
+  {
+    width: 200,
+    height: 200,
+    getContext: jest.fn().mockReturnValue({
+      clearRect: jest.fn(),
+      drawImage: jest.fn(),
+    }),
+  },
+];
+describe('repaintCanvas', () => {
+  afterEach(() => {
+    jest.clearAllMocks(); // Clears all mock functions' usage data
+  });
+
+  it('should clear the canvas and draw the copied content', () => {
+    const canvas = {
+      width: 100,
+      height: 100,
+      getContext: jest.fn().mockReturnValue({
+        clearRect: jest.fn(),
+        drawImage: jest.fn(),
+      }),
+    };
+    const ctx = canvas.getContext('2d');
+    const imageBitmap = {} as ImageBitmap;
+
+    repaintCanvas(canvas, ctx, imageBitmap);
+
+    expect(ctx.clearRect).toHaveBeenCalledWith(
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
+    expect(ctx.drawImage).toHaveBeenCalledWith(imageBitmap, 0, 0);
+  });
+
+  it('should call createImageBitmap for each canvas with the copied content', () => {
+    const imageBitmapMock = {
+      width: 100, // Example width property
+      height: 100, // Example height property
+      close: jest.fn(), // Example close method
+    };
+
+    // Mock createImageBitmap
+    global.createImageBitmap = jest
+      .fn()
+      .mockResolvedValue(() => Promise.resolve(imageBitmapMock));
+
+    handleCanvasChange(canvases);
+
+    expect(canvases[0].getContext).toHaveBeenCalledWith('2d');
+    expect(canvases[1].getContext).toHaveBeenCalledWith('2d');
+    expect(createImageBitmap).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call repaintCanvas when canvases are provided', () => {
+    const repaintCanvasMock = jest.spyOn(canvasRepaint, 'repaintCanvas');
+
+    handleCanvasChange(canvases);
+
+    expect(repaintCanvasMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call repaintCanvas when no canvases are provided', () => {
+    const canvases: Canvas[] = [];
+    const repaintCanvasMock = jest.spyOn(canvasRepaint, 'repaintCanvas');
+
+    handleCanvasChange(canvases);
+
+    expect(repaintCanvasMock).not.toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/src/utils/canvasRepaint.ts
+++ b/superset-frontend/src/utils/canvasRepaint.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface Canvas {
+  width: number;
+  height: number;
+  getContext(contextId: '2d'): CanvasRenderingContext2D | null;
+}
+
+export interface CanvasRenderingContext2D {
+  clearRect(x: number, y: number, w: number, h: number): void;
+  drawImage(image: CanvasImageSource, dx: number, dy: number): void;
+}
+
+export const repaintCanvas = (
+  canvas: Canvas,
+  ctx: CanvasRenderingContext2D,
+  imageBitmap: ImageBitmap,
+) => {
+  // Clear the canvas
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // Draw the copied content
+  ctx.drawImage(imageBitmap, 0, 0);
+};
+
+const handleCanvasChange = (canvases: Canvas[]) => {
+  canvases.forEach((canvas: Canvas) => {
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      createImageBitmap(canvas as ImageBitmapSource).then(
+        (imageBitmap: ImageBitmap) => {
+          // Call the repaintCanvas function with canvas, ctx, and imageBitmap
+          repaintCanvas(canvas, ctx, imageBitmap);
+        },
+      );
+    }
+  });
+};
+
+export default handleCanvasChange;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Follow up to https://github.com/apache/superset/pull/28568 I'm also adding the fix to explore so that if you change browser tabs in Chrome on ~125.0 the chart/canvas won't disappear. 


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
