### PR TITLE
fix: Handling of column types for Presto, Trino, et al.

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -14,9 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 # pylint: disable=too-many-lines
-
 from __future__ import annotations
 
 import contextlib
@@ -118,7 +116,7 @@ def get_children(column: ResultSetColumnType) -> list[ResultSetColumnType]:
     pattern = re.compile(r"(?P<type>\w+)\((?P<children>.*)\)")
     if not column["type"]:
         raise ValueError
-    match = pattern.match(column["type"])
+    match = pattern.match(cast(str, column["type"]))
     if not match:
         raise Exception(  # pylint: disable=broad-exception-raised
             f"Unable to parse column type {column['type']}"
@@ -537,6 +535,10 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
 
         for col_name, value in zip(col_names, values):
             col_type = column_type_by_name.get(col_name)
+
+            if isinstance(col_type, str):
+                col_type_class = getattr(types, col_type, None)
+                col_type = col_type_class() if col_type_class else None
 
             if isinstance(col_type, types.DATE):
                 col_type = Date()

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -18,11 +18,14 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Literal, Optional, TYPE_CHECKING, TypedDict, Union
 
+from sqlalchemy.sql.type_api import TypeEngine
 from typing_extensions import NotRequired
 from werkzeug.wrappers import Response
 
 if TYPE_CHECKING:
     from superset.utils.core import GenericDataType
+
+SQLType = Union[TypeEngine, type[TypeEngine]]
 
 
 class LegacyMetric(TypedDict):
@@ -73,7 +76,7 @@ class ResultSetColumnType(TypedDict):
 
     name: str  # legacy naming convention keeping this for backwards compatibility
     column_name: str
-    type: Optional[str]
+    type: Optional[Union[SQLType, str]]
     is_dttm: Optional[bool]
     type_generic: NotRequired[Optional["GenericDataType"]]
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This is a rehash of @brouberol's https://github.com/apache/superset/pull/26782 which was later reverted in https://github.com/apache/superset/pull/28613 as it was problematic with Trino, given both the `PrestoEngineSpec` and `TrinoEngineSpec` derive from the `PrestoBaseEngineSpec`.  

The TL;DR is typically most SQLAlchemy dialects (including Trino) use native SQLAlchemy types for encoding column types, whereas PyHive is unconventional and uses `str`. I asked a similar question [years ago](https://github.com/dropbox/PyHive/issues/121) and you can see [here](https://github.com/dropbox/PyHive/blob/d4ae481675ac5588ba9101596fa26f22ef0e77c4/pyhive/tests/test_presto.py#L52-L81) how these types are materialized.

I hypothesize that part of the confusion when @brouberol's was authoring their PR was that the `ResultSetColumnType` `TypedDict` was incorrect, alluding to the fact that the `type` field was `Optional[str]` as opposed to `Optional[Union[str, TypeEngine, type[TypeEngine]]`. This PR simply ensures that in the `PrestoBaseEngineSpec` class—which handles Hive, Presto, and Trino—that we only try to coerce `str` types to a SQLAlchemy type (if available).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
  - Fixes https://github.com/apache/superset/issues/25636
  - Fixes https://github.com/apache/superset/issues/25962
  - Fixes https://github.com/apache/superset/issues/26740
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
