### PR TITLE
fix(reports): Update the element class to wait for when taking a screenshot

### DIFF
--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -211,7 +211,7 @@ def dumps(  # pylint: disable=too-many-arguments
             cls=cls,
         )
     except UnicodeDecodeError:
-        results_string = simplejson.dumps(  # type: ignore[call-overload]
+        results_string = simplejson.dumps(
             obj,
             default=default,
             allow_nan=allow_nan,

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -211,7 +211,7 @@ def dumps(  # pylint: disable=too-many-arguments
             cls=cls,
         )
     except UnicodeDecodeError:
-        results_string = simplejson.dumps(
+        results_string = simplejson.dumps(  # type: ignore[call-overload]
             obj,
             default=default,
             allow_nan=allow_nan,

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -187,7 +187,7 @@ class WebDriverPlaywright(WebDriverProxy):
                 try:
                     # chart containers didn't render
                     logger.debug("Wait for chart containers to draw at url: %s", url)
-                    slice_container_locator = page.locator(".slice_container")
+                    slice_container_locator = page.locator(".chart-container")
                     slice_container_locator.first.wait_for()
                     for slice_container_elem in slice_container_locator.all():
                         slice_container_elem.wait_for()
@@ -375,7 +375,7 @@ class WebDriverSelenium(WebDriverProxy):
                 logger.debug("Wait for chart containers to draw at url: %s", url)
                 WebDriverWait(driver, self._screenshot_locate_wait).until(
                     EC.visibility_of_all_elements_located(
-                        (By.CLASS_NAME, "slice_container")
+                        (By.CLASS_NAME, "chart-container")
                     )
                 )
             except TimeoutException as ex:


### PR DESCRIPTION
### SUMMARY
In the process of taking screenshots for an alert/report, Selenium/Playwright is configured to wait a certain time (controlled via `superset_config.py`) until all chart elements are drawn. The logic was configured to monitor the `slice_container` class, however with https://github.com/apache/superset/pull/27255 this class is only used once the chart data is retrieved.

This PR changes the class to be monitored to the `chart-container` wrapper.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Configure `SCREENSHOT_LOCATE_WAIT` to be 30 seconds, and `SCREENSHOT_LOAD_WAIT` to be 200 seconds.
2. Create a chart that takes longer than 30 seconds to load. You can use `pg_sleep()` with Postgres for example. 
3. Configure a report with this chart. 

Before this PR the report would fail, as the chart wouldn't load within 30 seconds.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
