### PR TITLE
chore: document upper bound for python lib 'holidays' >= 0.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "geopy",
     "gunicorn>=22.0.0; sys_platform != 'win32'",
     "hashids>=1.3.1, <2",
+    # known issue with holidays 0.26.0 and above related to prophet lib #25017
     "holidays>=0.25, <0.26",
     "humanize",
     "importlib_metadata",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,7 +80,7 @@ cron-descriptor==1.4.3
     # via apache-superset
 croniter==2.0.5
     # via apache-superset
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   apache-superset
     #   paramiko
@@ -93,7 +93,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via flask-appbuilder
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via cattrs
 flask==2.3.3
     # via
@@ -153,7 +153,7 @@ gunicorn==22.0.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-holidays==0.49
+holidays==0.25
     # via apache-superset
 humanize==4.9.0
     # via apache-superset
@@ -175,10 +175,14 @@ jinja2==3.1.4
     # via
     #   flask
     #   flask-babel
+jsonpath-ng==1.6.1
+    # via apache-superset
 jsonschema==4.17.3
     # via flask-appbuilder
 kombu==5.3.7
     # via celery
+korean-lunar-calendar==0.3.1
+    # via holidays
 limits==3.12.0
     # via flask-limiter
 llvmlite==0.42.0
@@ -249,6 +253,8 @@ pgsanity==0.2.9
     # via apache-superset
 platformdirs==3.8.1
     # via requests-cache
+ply==3.11
+    # via jsonpath-ng
 polyline==2.0.2
     # via apache-superset
 prison==0.2.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -80,7 +80,7 @@ cron-descriptor==1.4.3
     # via apache-superset
 croniter==2.0.5
     # via apache-superset
-cryptography==42.0.8
+cryptography==42.0.7
     # via
     #   apache-superset
     #   paramiko
@@ -93,7 +93,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via flask-appbuilder
-exceptiongroup==1.2.2
+exceptiongroup==1.2.1
     # via cattrs
 flask==2.3.3
     # via
@@ -153,7 +153,7 @@ gunicorn==22.0.0
     # via apache-superset
 hashids==1.3.1
     # via apache-superset
-holidays==0.25
+holidays==0.49
     # via apache-superset
 humanize==4.9.0
     # via apache-superset
@@ -175,14 +175,10 @@ jinja2==3.1.4
     # via
     #   flask
     #   flask-babel
-jsonpath-ng==1.6.1
-    # via apache-superset
 jsonschema==4.17.3
     # via flask-appbuilder
 kombu==5.3.7
     # via celery
-korean-lunar-calendar==0.3.1
-    # via holidays
 limits==3.12.0
     # via flask-limiter
 llvmlite==0.42.0
@@ -253,8 +249,6 @@ pgsanity==0.2.9
     # via apache-superset
 platformdirs==3.8.1
     # via requests-cache
-ply==3.11
-    # via jsonpath-ng
 polyline==2.0.2
     # via apache-superset
 prison==0.2.1


### PR DESCRIPTION
Change of plans, adding a note documenting the upper bound

~~I simply removed the upper bound for the holidays lib and ran `pip-compile-multi -P holidays`. Note that `pip-compile-multi` isn't as' deterministic as we'd like for it to be, but things should be fine as "# vias" are just informational here.~~

~~For the record: https://github.com/vacanza/python-holidays/blob/dev/CHANGES~~