### PR TITLE
fix(sqllab): Sort db selector options by the API order

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -16,8 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode, useState, useMemo, useEffect, useRef } from 'react';
+import React, {
+  ReactNode,
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 import { styled, SupersetClient, t } from '@superset-ui/core';
+import type { LabeledValue as AntdLabeledValue } from 'antd/lib/select';
 import rison from 'rison';
 import { AsyncSelect, Select } from 'src/components';
 import Label from 'src/components/Label';
@@ -150,9 +158,15 @@ export default function DatabaseSelector({
   const [currentSchema, setCurrentSchema] = useState<SchemaOption | undefined>(
     schema ? { label: schema, value: schema, title: schema } : undefined,
   );
+  const dbIdSeqMap = useRef<Record<number, number>>();
   const schemaRef = useRef(schema);
   schemaRef.current = schema;
   const { addSuccessToast } = useToasts();
+  const sortComparator = useCallback(
+    (itemA: AntdLabeledValue, itemB: AntdLabeledValue) =>
+      dbIdSeqMap.current?.[itemA.value] - dbIdSeqMap.current?.[itemB.value],
+    [],
+  );
 
   const loadDatabases = useMemo(
     () =>
@@ -165,7 +179,7 @@ export default function DatabaseSelector({
         totalCount: number;
       }> => {
         const queryParams = rison.encode({
-          order_columns: 'database_name',
+          order_column: 'database_name',
           order_direction: 'asc',
           page,
           page_size: pageSize,
@@ -191,6 +205,10 @@ export default function DatabaseSelector({
           if (result.length === 0) {
             if (onEmptyResults) onEmptyResults(search);
           }
+
+          dbIdSeqMap.current = Object.fromEntries<number>(
+            result.map(({ id }: DatabaseObject, seq: number) => [id, seq]),
+          );
           const options = result.map((row: DatabaseObject) => ({
             label: (
               <SelectLabel
@@ -346,6 +364,7 @@ export default function DatabaseSelector({
         placeholder={t('Select database or type to search databases')}
         disabled={!isDatabaseSelectEnabled || readOnly}
         options={loadDatabases}
+        sortComparator={sortComparator}
       />,
       null,
     );

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -132,6 +132,10 @@ const SelectLabel = ({
 const EMPTY_CATALOG_OPTIONS: CatalogOption[] = [];
 const EMPTY_SCHEMA_OPTIONS: SchemaOption[] = [];
 
+interface AntdLabeledValueWithOrder extends AntdLabeledValue {
+  order: number;
+}
+
 export default function DatabaseSelector({
   db,
   formMode = false,
@@ -158,13 +162,12 @@ export default function DatabaseSelector({
   const [currentSchema, setCurrentSchema] = useState<SchemaOption | undefined>(
     schema ? { label: schema, value: schema, title: schema } : undefined,
   );
-  const dbIdSeqMap = useRef<Record<number, number>>();
   const schemaRef = useRef(schema);
   schemaRef.current = schema;
   const { addSuccessToast } = useToasts();
   const sortComparator = useCallback(
-    (itemA: AntdLabeledValue, itemB: AntdLabeledValue) =>
-      dbIdSeqMap.current?.[itemA.value] - dbIdSeqMap.current?.[itemB.value],
+    (itemA: AntdLabeledValueWithOrder, itemB: AntdLabeledValueWithOrder) =>
+      itemA.order - itemB.order,
     [],
   );
 
@@ -206,10 +209,7 @@ export default function DatabaseSelector({
             if (onEmptyResults) onEmptyResults(search);
           }
 
-          dbIdSeqMap.current = Object.fromEntries<number>(
-            result.map(({ id }: DatabaseObject, seq: number) => [id, seq]),
-          );
-          const options = result.map((row: DatabaseObject) => ({
+          const options = result.map((row: DatabaseObject, order: number) => ({
             label: (
               <SelectLabel
                 backend={row.backend}
@@ -221,6 +221,7 @@ export default function DatabaseSelector({
             database_name: row.database_name,
             backend: row.backend,
             allow_multi_catalog: row.allow_multi_catalog,
+            order,
           }));
 
           return {


### PR DESCRIPTION
### SUMMARY
Currently, the order of the db selector dropdown in SQL Lab is always sorted by record ID, regardless of the intended sort order.
This issue arises due to two reasons: 
1. an incorrect order_column name is being passed
2. AsyncSelect component's [default sortComparator](https://github.com/apache/superset/blob/07b2449bd777cf04a266f1de3d72af6874b9c305/superset-frontend/src/components/Select/AsyncSelect.tsx#L138) is sorting by ID (Since label is not a string, the next ordering will be by id).

This commit fixes these issues, ensuring that the db selector is sorted by the API order as intended.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
