### PR TITLE
fix(dashboard): Remove 308 redirect when creating new dashboards

### DIFF
--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -241,7 +241,7 @@ test('handles create dashboard button click', async () => {
 
   const createButton = screen.getByRole('button', { name: /dashboard$/i });
   await userEvent.click(createButton);
-  expect(assignMock).toHaveBeenCalledWith('/dashboard/new');
+  expect(assignMock).toHaveBeenCalledWith('/dashboard/new/');
 });
 
 test('switches to Other tab when available', async () => {

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -200,7 +200,7 @@ function DashboardTable({
             name: t('Dashboard'),
             buttonStyle: 'secondary',
             onClick: () => {
-              navigateTo('/dashboard/new', { assign: true });
+              navigateTo('/dashboard/new/', { assign: true });
             },
           },
           {

--- a/superset-frontend/src/features/home/EmptyState.tsx
+++ b/superset-frontend/src/features/home/EmptyState.tsx
@@ -58,7 +58,7 @@ const LABELS = {
 const REDIRECTS = {
   create: {
     [WelcomeTable.Charts]: '/chart/add',
-    [WelcomeTable.Dashboards]: '/dashboard/new',
+    [WelcomeTable.Dashboards]: '/dashboard/new/',
     [WelcomeTable.SavedQueries]: makeUrl('/sqllab?new=true'),
   },
   viewAll: {

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -74,7 +74,7 @@ const dropdownItems = [
   },
   {
     label: 'Dashboard',
-    url: '/dashboard/new',
+    url: '/dashboard/new/',
     icon: 'fa-fw fa-dashboard',
     perm: 'can_write',
     view: 'Dashboard',

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -88,7 +88,7 @@ const dropdownItems = [
   },
   {
     label: 'Dashboard',
-    url: '/dashboard/new',
+    url: '/dashboard/new/',
     icon: 'fa-fw fa-dashboard',
     perm: 'can_write',
     view: 'Dashboard',

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -217,7 +217,7 @@ const RightMenu = ({
     },
     {
       label: t('Dashboard'),
-      url: '/dashboard/new',
+      url: '/dashboard/new/',
       icon: (
         <Icons.DashboardOutlined data-test={`menu-item-${t('Dashboard')}`} />
       ),

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -722,7 +722,7 @@ function DashboardList(props: DashboardListProps) {
       name: t('Dashboard'),
       buttonStyle: 'primary',
       onClick: () => {
-        navigateTo('/dashboard/new', { assign: true });
+        navigateTo('/dashboard/new/', { assign: true });
       },
     });
   }


### PR DESCRIPTION
## **User description**
### SUMMARY
Currently, a request for a new dashboard (hitting /dashboard/new) will respond with a 308 permanent redirect because the UI hits `/dashboard/new` even though the backend exposes `/dashboard/new/` https://github.com/apache/superset/blob/6575cacc5d1cc59c7cacd9e186a1d05e76259183/superset/views/dashboard/views.py#L117
Flask handles this case by responding with a 308 to the exposed version https://flask-cn.readthedocs.io/en/stable/api/#flask.Flask.route. 

This PR changes routes in the frontend from `/dashboard/new` to `/dashboard/new/` so that requests can be made without a 308 redirect.

In our infrastructure setup, there's a problem with the 308 redirect and it points to an invalid address. I believe others have seen this problem as well in this issue https://github.com/apache/superset/issues/20577. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Reproduction Steps
1. Hard refresh to remove cached response to `/dashboard/new` redirection
2. Create a new dashboard

Before
<img width="1507" alt="Screenshot 2024-05-28 at 9 05 32 PM" src="https://github.com/apache/superset/assets/2770197/d9ce52a4-c60e-4012-89d3-40fd662d9db6">


After
<img width="1501" alt="Screenshot 2024-05-28 at 9 20 03 PM" src="https://github.com/apache/superset/assets/2770197/86b87916-1351-4fce-8f72-d2348c049d2e">


### TESTING INSTRUCTIONS
See Reproduction Steps in section above

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Use /dashboard/new/ for creating dashboards to avoid 308 redirects

### What Changed
- Dashboard creation links and buttons now navigate directly to /dashboard/new/ instead of /dashboard/new, so the browser goes straight to the backend endpoint without a 308 redirect
- Welcome/empty-state, right-hand menu, dashboard table, and dashboard list UI paths were updated so all "Create Dashboard" entry points use the trailing-slash URL
- Frontend tests were updated to expect /dashboard/new/ so test behavior matches the live navigation

### Impact
`✅ No 308 redirects when creating a new dashboard`
`✅ Fewer broken dashboard creation flows in redirect-sensitive environments`
`✅ Tests validate the correct create-dashboard URL`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
