### PR TITLE
fix(Mixed Chart Filter Control): Allow delete condition for `adhoc_filters_b`

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -485,7 +485,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         ? baseDescription(exploreState, controls[name], chart)
         : baseDescription;
 
-    if (name.startsWith('adhoc_filters')) {
+    if (name.includes('adhoc_filters')) {
       restProps.canDelete = (
         valueToBeDeleted: Record<string, any>,
         values: Record<string, any>[],

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -485,7 +485,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
         ? baseDescription(exploreState, controls[name], chart)
         : baseDescription;
 
-    if (name === 'adhoc_filters') {
+    if (name.startsWith('adhoc_filters')) {
       restProps.canDelete = (
         valueToBeDeleted: Record<string, any>,
         values: Record<string, any>[],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is meant to fix a bug that would prevent the deletion of filters from `Query B` in the control panel of a mixed chart.
The condition to run the `canDelete` function for a filter previously only allowed for `adhoc_filters` as a valid value but the mixed chart uses `adhoc_filters_b` for the `Query B` group. This change should allow any string starting with `adhoc_filters` to be checked for deletion conditions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
B:
![filters_old-ezgif com-optimize](https://github.com/apache/superset/assets/92495987/cfa9c76e-e516-4e5b-bd9a-f365ebf65cce)
A:
![filters_new-ezgif com-optimize](https://github.com/apache/superset/assets/92495987/8472c0eb-64a3-4a01-a2e3-c9da0a204ea6)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a Mixed Chart
2. Add a filter to Query B
3. Delete filter
4. Delete last remaining temporal filter to test warning if is displayed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
