### PR TITLE
fix(dashboard): unable to resize due to the overlapped droptarget

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardWrapper.tsx
@@ -47,6 +47,12 @@ const StyledDiv = styled.div`
       & .grid-row:after {
         border-style: hidden;
       }
+      & .droptarget-side:last-child {
+        inset-inline-end: 0;
+      }
+      & .droptarget-edge:last-child {
+        inset-block-end: 0;
+      }
     }
 
     /* A row within a column has inset hover menu */

--- a/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Column.jsx
@@ -98,9 +98,6 @@ const ColumnStyles = styled.div`
         &:first-child {
           inset-block-start: 0;
         }
-        &:last-child {
-          inset-block-end: 0;
-        }
       }
       &:first-child:not(.droptarget-edge) {
         position: absolute;
@@ -295,7 +292,7 @@ class Column extends React.PureComponent {
                           className={cx(
                             'empty-droptarget',
                             itemIndex === columnItems.length - 1 &&
-                              'droptarget-edge-last',
+                              'droptarget-edge',
                           )}
                           editMode
                         >

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -107,9 +107,6 @@ const GridRow = styled.div`
         &:first-child {
           inset-inline-start: 0;
         }
-        &:last-child {
-          inset-inline-end: 0;
-        }
       }
     }
 


### PR DESCRIPTION
### SUMMARY
This commit fixes the resizing issues on last item in #28746 and #28395 by applying the inset location only while dragging.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![ChartResize-ezgif com-optimize (1)](https://github.com/apache/superset/assets/92495987/dcc4b1ce-d6b6-4a27-aa7f-1c0671a3dbdd)

After:

https://github.com/apache/superset/assets/1392866/47128359-f69b-4cf9-a2f3-db4b3d2e6f21


### TESTING INSTRUCTIONS
Extend a widget to the entire width, then resize it again to narrow it down.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
