### PR TITLE
chore: make docker-compose use less memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,8 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    environment:
+      CELERYD_CONCURRENCY: 2
     restart: unless-stopped
     depends_on: *superset-depends-on
     user: *superset-user
@@ -211,12 +213,15 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
+    profiles:
+      - optional
     environment:
       DATABASE_HOST: localhost
       DATABASE_DB: test
       REDIS_CELERY_DB: 2
       REDIS_RESULTS_DB: 3
       REDIS_HOST: localhost
+      CELERYD_CONCURRENCY: 8
     network_mode: host
     depends_on: *superset-depends-on
     user: *superset-user

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -38,7 +38,8 @@ fi
 case "${1}" in
   worker)
     echo "Starting Celery worker..."
-    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO
+    # setting up only 2 workers by default to contain memory usage
+    celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2}
     ;;
   beat)
     echo "Starting Celery beat..."

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -38,7 +38,7 @@ fi
 case "${1}" in
   worker)
     echo "Starting Celery worker..."
-    # setting up only 2 workers by default to contain memory usage
+    # setting up only 2 workers by default to contain memory usage in dev environments
     celery --app=superset.tasks.celery_app:app worker -O fair -l INFO --concurrency=${CELERYD_CONCURRENCY:-2}
     ;;
   beat)


### PR DESCRIPTION
Playing a few tricks to make docker-compose use less memory:

- not starting the `superset-tests-worker` service on a normal `docker-compose up` by using `profile`. From my understanding this service is used only by `scripts/tests/run.sh`, and it starts/stops it on its own - doesn't assume its already running. This saves ~900MB, while maintaining 8 workers to run tests by default, but makes it confiurable if you wanted more you could more easily change it now
- starting only 2 workers by default for `superset-worker` as opposed to the default of 8, which is not necessary for dev workflows. This saves maybe ~500MB

### before
<img width="1326" alt="Screenshot 2024-05-29 at 4 16 17 PM" src="https://github.com/apache/superset/assets/487433/9e8a3609-b1df-403b-8d45-50c10b75e0c5">

### after
<img width="1306" alt="Screenshot 2024-05-29 at 4 59 49 PM" src="https://github.com/apache/superset/assets/487433/00795dcc-3e4c-4b96-947c-0c9a2b4904e6">



