### PR TITLE
feat (datasets): allowing control over certification datasets

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -352,6 +352,14 @@ AUTH_TYPE = AUTH_DB
 PUBLIC_ROLE_LIKE: str | None = None
 
 # ---------------------------------------------------
+# Certification config
+# ---------------------------------------------------
+# Allows the limiting of users who can certify datasets based on the role.
+# Requires the creation of a role within Superset with the matching name
+# and the setting of the LIMIT_CERTIFICATION feature flag to True.
+# ROLE_CERTIFIER: str = "certifier"
+
+# ---------------------------------------------------
 # Babel config for translations
 # ---------------------------------------------------
 # Setup default language
@@ -496,6 +504,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "PLAYWRIGHT_REPORTS_AND_THUMBNAILS": False,
     # Set to True to enable experimental chart plugins
     "CHART_PLUGINS_EXPERIMENTAL": False,
+    # Set to True to limit the number of users who can certify datasets
+    "LIMIT_CERTIFICATION": False,
 }
 
 # ------------------------------

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -27,7 +27,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
 
-from superset import event_logger
+from superset import event_logger, is_feature_enabled, security_manager
 from superset.commands.dataset.create import CreateDatasetCommand
 from superset.commands.dataset.delete import DeleteDatasetCommand
 from superset.commands.dataset.duplicate import DuplicateDatasetCommand
@@ -327,6 +327,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         """
         try:
             item = self.add_model_schema.load(request.json)
+            if (
+                "extra" in item
+                and "certification" in item["extra"]
+                and is_feature_enabled("LIMIT_CERTIFICATION")
+                and not security_manager.is_certifier()
+            ):
+                item["extra"].pop("certification")
         # This validates custom Schema with custom validations
         except ValidationError as error:
             return self.response_400(message=error.messages)
@@ -406,6 +413,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         )
         try:
             item = self.edit_model_schema.load(request.json)
+            if (
+                "extra" in item
+                and "certification" in item["extra"]
+                and is_feature_enabled("LIMIT_CERTIFICATION")
+                and not security_manager.is_certifier()
+            ):
+                item["extra"].pop("certification")
         # This validates custom Schema with custom validations
         except ValidationError as error:
             return self.response_400(message=error.messages)
@@ -598,6 +612,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         """
         try:
             item = self.duplicate_model_schema.load(request.json)
+            if (
+                "extra" in item
+                and "certification" in item["extra"]
+                and is_feature_enabled("LIMIT_CERTIFICATION")
+                and not security_manager.is_certifier()
+            ):
+                item["extra"].pop("certification")
         # This validates custom Schema with custom validations
         except ValidationError as error:
             return self.response_400(message=error.messages)

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2718,3 +2718,16 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         return current_app.config["AUTH_ROLE_ADMIN"] in [
             role.name for role in self.get_user_roles()
         ]
+
+    def is_certifier(self) -> bool:
+        """
+        Returns True if the current user is a certifier, False otherwise.
+
+        :returns: Whether the current user is a certifier
+        """
+
+        if not current_app.config.get("ROLE_CERTIFIER"):
+            return False
+        return current_app.config["ROLE_CERTIFIER"] in [
+            role.name for role in self.get_user_roles()
+        ]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We are interested in controlling who can certify datasets. We have a central analytics engineering team who are the single-source of truth regarding datasets. We would like them to be the only team that can certify their datasets.

This introduces the ability to create a new type of role ('certifier') that we can grant to members of that team. There is an additional feature flag that would enable this feature. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
