### PR TITLE
feat: skip `npm run build` in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ x-common-build: &common-build
   target: dev
   cache_from:
     - apache/superset-cache:3.10-slim-bookworm
+  args:
+    INCLUDE_NODE: false
 
 services:
   nginx:
@@ -147,7 +149,11 @@ services:
       disable: true
 
   superset-node:
-    image: node:18
+    build:
+      context: .
+      target: superset-node-base
+      cache_from:
+        - type=registry,ref=apache/superset-cache:3.10-slim-bookworm
     environment:
       # set this to false if you have perf issues running the npm i; npm run dev in-docker
       # if you do so, you have to run this manually on the host, which should perform better!

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -25,10 +25,9 @@ fi
 
 if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     cd /app/superset-frontend
-    npm install -f --no-optional --global webpack webpack-cli
-    npm install -f --no-optional
+    RUN if [ ! -d "node_modules" ]; then npm install; fi
 
-    echo "Running frontend"
+    echo "Running webpack in watch mode..."
     npm run dev
 else
     echo "Skipping frontend build steps - YOU RUN IT MANUALLY ON THE HOST!"

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -496,7 +496,7 @@ const config = {
     'react/lib/ReactContext': true,
   },
   plugins,
-  devtool: 'source-map',
+  devtool: isDevMode ? 'source-map' : false,
 };
 
 // find all the symlinked plugins and use their source code for imports

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -496,7 +496,7 @@ const config = {
     'react/lib/ReactContext': true,
   },
   plugins,
-  devtool: isDevMode ? 'source-map' : false,
+  devtool: 'source-map',
 };
 
 // find all the symlinked plugins and use their source code for imports


### PR DESCRIPTION
When using docker-compose, we mount the local drive and fire up a `npm run dev` which is effectively webpack in --watch mode, so that it looks for changes in frontend files and compiles-as-you-change interactively.

`npm run build` is in the Dockerfile, specifically in the superset-node layer which is used to compile and later COPY the static assets into a python-based layer, `lean`.

But in the context of docker-compose, we don't need all of it, and that `npm run build` has gotten expensive in terms of memory usage and takes a while to build. In recent build memory monitoring I've seen the docker container peak at like 13GB memory during this phase.

So in this PR I'm:
- making `npm run build` optional with a dockerfile ARG (default is current behavior, but docker-compose skips it)
- adding a `superset-node-base` layer for that superset-node service in docker-compose that runs `npm run dev`, ensuring the same base for both processes, but stopping/diverging prior to `npm ci`
- making `npm install` run only if node_module is not present in the superset-node service. The user can simply `npm i` locally if/when they alter package.json. That speeds up firing up `docker-compose up` as unless you nuke node_modules/ it'll skip that step
