### PR TITLE
chore: Add query_context to ChartRestApi.list_columns

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -198,6 +198,7 @@ class ChartRestApi(BaseSupersetModelRestApi):
         "tags.id",
         "tags.name",
         "tags.type",
+        "query_context",
     ]
     list_select_columns = list_columns + ["changed_by_fk", "changed_on"]
     order_columns = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

As titled. This is helpful when using the HTTP RESTful API to process the chart parameters offline—specifically to extract the columns and metrics.

Currently only `params` is included in `ChartRestApi.list_columns`, however this  isn't suffice given that either the `params` or `query_context` column is used to encode the chart parameters depending on the visualization type.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
