### PR TITLE
fix(list/chart views): Chart Properties modal now has transitions

### DIFF
--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -68,7 +68,7 @@ function PropertiesModal({
   const [submitting, setSubmitting] = useState(false);
   const [form] = AntdForm.useForm();
   // values of form inputs
-  const [name, setName] = useState(slice.slice_name || '');
+  const [name, setName] = useState(slice?.slice_name || '');
   const [selectedOwners, setSelectedOwners] = useState<SelectValue | null>(
     null,
   );
@@ -97,23 +97,25 @@ function PropertiesModal({
 
   const fetchChartOwners = useCallback(
     async function fetchChartOwners() {
-      try {
-        const response = await SupersetClient.get({
-          endpoint: `/api/v1/chart/${slice.slice_id}`,
-        });
-        const chart = response.json.result;
-        setSelectedOwners(
-          chart?.owners?.map((owner: any) => ({
-            value: owner.id,
-            label: `${owner.first_name} ${owner.last_name}`,
-          })),
-        );
-      } catch (response) {
-        const clientError = await getClientErrorObject(response);
-        showError(clientError);
+      if (slice?.slice_id) {
+        try {
+          const response = await SupersetClient.get({
+            endpoint: `/api/v1/chart/${slice?.slice_id}`,
+          });
+          const chart = response.json.result;
+          setSelectedOwners(
+            chart?.owners?.map((owner: any) => ({
+              value: owner.id,
+              label: `${owner.first_name} ${owner.last_name}`,
+            })),
+          );
+        } catch (response) {
+          const clientError = await getClientErrorObject(response);
+          showError(clientError);
+        }
       }
     },
-    [slice.slice_id],
+    [slice?.slice_id],
   );
 
   const loadOptions = useMemo(
@@ -174,7 +176,7 @@ function PropertiesModal({
 
     try {
       const res = await SupersetClient.put({
-        endpoint: `/api/v1/chart/${slice.slice_id}`,
+        endpoint: `/api/v1/chart/${slice?.slice_id}`,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
@@ -183,7 +185,7 @@ function PropertiesModal({
         ...payload,
         ...res.json.result,
         tags,
-        id: slice.slice_id,
+        id: slice?.slice_id,
         owners: selectedOwners,
       };
       onSave(updatedChart);
@@ -205,8 +207,8 @@ function PropertiesModal({
 
   // update name after it's changed in another modal
   useEffect(() => {
-    setName(slice.slice_name || '');
-  }, [slice.slice_name]);
+    setName(slice?.slice_name || '');
+  }, [slice?.slice_name]);
 
   useEffect(() => {
     if (!isFeatureEnabled(FeatureFlag.TaggingSystem)) return;
@@ -214,7 +216,7 @@ function PropertiesModal({
       fetchTags(
         {
           objectType: OBJECT_TYPES.CHART,
-          objectId: slice.slice_id,
+          objectId: slice?.slice_id,
           includeTypes: false,
         },
         (tags: TagType[]) => setTags(tags),
@@ -225,7 +227,7 @@ function PropertiesModal({
     } catch (error) {
       showError(error);
     }
-  }, [slice.slice_id]);
+  }, [slice?.slice_id]);
 
   const handleChangeTags = (tags: { label: string; value: number }[]) => {
     const parsedTags: TagType[] = ensureIsArray(tags).map(r => ({
@@ -261,9 +263,9 @@ function PropertiesModal({
             buttonSize="small"
             buttonStyle="primary"
             onClick={form.submit}
-            disabled={submitting || !name || slice.is_managed_externally}
+            disabled={submitting || !name || slice?.is_managed_externally}
             tooltip={
-              slice.is_managed_externally
+              slice?.is_managed_externally
                 ? t(
                     "This chart is managed externally, and can't be edited in Superset",
                   )
@@ -283,12 +285,13 @@ function PropertiesModal({
         onFinish={onSubmit}
         layout="vertical"
         initialValues={{
-          name: slice.slice_name || '',
-          description: slice.description || '',
-          cache_timeout: slice.cache_timeout != null ? slice.cache_timeout : '',
-          certified_by: slice.certified_by || '',
+          name: slice?.slice_name || '',
+          description: slice?.description || '',
+          cache_timeout:
+            slice?.cache_timeout != null ? slice.cache_timeout : '',
+          certified_by: slice?.certified_by || '',
           certification_details:
-            slice.certified_by && slice.certification_details
+            slice?.certified_by && slice?.certification_details
               ? slice.certification_details
               : '',
         }}

--- a/superset-frontend/src/features/home/ChartTable.tsx
+++ b/superset-frontend/src/features/home/ChartTable.tsx
@@ -171,15 +171,12 @@ function ChartTable({
   if (loading) return <LoadingCards cover={showThumbnails} />;
   return (
     <ErrorBoundary>
-      {sliceCurrentlyEditing && (
-        <PropertiesModal
-          onHide={closeChartEditModal}
-          onSave={handleChartUpdated}
-          show
-          slice={sliceCurrentlyEditing}
-        />
-      )}
-
+      <PropertiesModal
+        onHide={closeChartEditModal}
+        onSave={handleChartUpdated}
+        show
+        slice={sliceCurrentlyEditing}
+      />
       <SubMenu
         activeChild={activeTab}
         tabs={menuTabs}

--- a/superset-frontend/src/features/home/ChartTable.tsx
+++ b/superset-frontend/src/features/home/ChartTable.tsx
@@ -174,7 +174,7 @@ function ChartTable({
       <PropertiesModal
         onHide={closeChartEditModal}
         onSave={handleChartUpdated}
-        show
+        show={sliceCurrentlyEditing}
         slice={sliceCurrentlyEditing}
       />
       <SubMenu

--- a/superset-frontend/src/pages/ChartList/ChartList.test.jsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.test.jsx
@@ -153,6 +153,11 @@ describe('ChartList', () => {
     expect(wrapper.find(ChartList)).toExist();
   });
 
+  it('renders, but PropertiesModal initially hidden', () => {
+    expect(wrapper.find(PropertiesModal).exists()).toBe(true);
+    expect(wrapper.find(PropertiesModal).prop('show')).toBe(false);
+  });
+
   it('renders a ListView', () => {
     expect(wrapper.find(ListView)).toExist();
   });
@@ -182,10 +187,10 @@ describe('ChartList', () => {
   });
 
   it('edits', async () => {
-    expect(wrapper.find(PropertiesModal)).not.toExist();
+    expect(wrapper.find(PropertiesModal).prop('show')).toBe(false);
     wrapper.find('[data-test="edit-alt"]').first().simulate('click');
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find(PropertiesModal)).toExist();
+    expect(wrapper.find(PropertiesModal).prop('show')).toBe(true);
   });
 
   it('delete', async () => {

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -786,7 +786,7 @@ function ChartList(props: ChartListProps) {
       <PropertiesModal
         onHide={closeChartEditModal}
         onSave={handleChartUpdated}
-        show={sliceCurrentlyEditing ? true : false}
+        show={!!sliceCurrentlyEditing}
         slice={sliceCurrentlyEditing}
       />
       <ConfirmStatusChange

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -783,14 +783,12 @@ function ChartList(props: ChartListProps) {
   return (
     <>
       <SubMenu name={t('Charts')} buttons={subMenuButtons} />
-      {sliceCurrentlyEditing && (
-        <PropertiesModal
-          onHide={closeChartEditModal}
-          onSave={handleChartUpdated}
-          show
-          slice={sliceCurrentlyEditing}
-        />
-      )}
+      <PropertiesModal
+        onHide={closeChartEditModal}
+        onSave={handleChartUpdated}
+        show={sliceCurrentlyEditing ? true : false}
+        slice={sliceCurrentlyEditing}
+      />
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t('Are you sure you want to delete the selected charts?')}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes: https://github.com/apache/superset/issues/11520

The properties modal was previously conditionally rendered, rather than using the visibility prop. This fixes it, and adds a bunch of safe navigation operators to handle the default (null) slice scenario.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
