### PR TITLE
chore: only use cypress.io when triggered manually

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -130,7 +130,7 @@ cypress-install() {
 }
 
 cypress-run-all() {
-  local use_dashboard=$1
+  local USE_DASHBOARD=$1
   cd "$GITHUB_WORKSPACE/superset-frontend/cypress-base"
 
   # Start Flask and run it in background
@@ -143,16 +143,21 @@ cypress-run-all() {
   nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
   local flaskProcessId=$!
 
-  #cypress-run "*/**/*" "Default" "$use_dashboard"
-  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID
+  USE_DASHBOARD_FLAG=''
+  if [ "$USE_DASHBOARD" = "true" ]; then
+    USE_DASHBOARD_FLAG='--use-dashboard'
+  fi
+
+  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID $USE_DASHBOARD_FLAG
 
   # After job is done, print out Flask log for debugging
-  say "::group::Flask log for default run"
+  echo "::group::Flask log for default run"
   cat "$flasklog"
-  say "::endgroup::"
+  echo "::endgroup::"
   # make sure the program exits
   kill $flaskProcessId
 }
+
 eyes-storybook-dependencies() {
   say "::group::install eyes-storyook dependencies"
   sudo apt-get update -y && sudo apt-get -y install gconf-service ca-certificates libxshmfence-dev fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libglib2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libnspr4 libnss3 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release xdg-utils libappindicator1

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -131,6 +131,7 @@ cypress-install() {
 
 cypress-run-all() {
   local use_dashboard=$1
+  cd "$GITHUB_WORKSPACE/superset-frontend/cypress-base"
 
   # Start Flask and run it in background
   # --no-debugger means disable the interactive debugger on the 500 page
@@ -143,7 +144,7 @@ cypress-run-all() {
   local flaskProcessId=$!
 
   #cypress-run "*/**/*" "Default" "$use_dashboard"
-  python scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID
+  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID
 
   # After job is done, print out Flask log for debugging
   say "::group::Flask log for default run"
@@ -158,7 +159,7 @@ cypress-run-all() {
   nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
   local flaskProcessId=$!
 
-  python scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group "Backend persist" --filter "cypress/e2e/sqllab/**/*"
+  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group "Backend persist" --filter "sqllab"
 
   say "::group::Flask log for backend persist"
   cat "$flasklog"

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -150,21 +150,6 @@ cypress-run-all() {
   say "::group::Flask log for default run"
   cat "$flasklog"
   say "::endgroup::"
-
-  # Rerun SQL Lab tests with backend persist disabled
-  export SUPERSET_CONFIG=tests.integration_tests.superset_test_config_sqllab_backend_persist_off
-
-  # Restart Flask with new configs
-  kill $flaskProcessId
-  nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
-  local flaskProcessId=$!
-
-  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group "Backend persist" --filter "sqllab"
-
-  say "::group::Flask log for backend persist"
-  cat "$flasklog"
-  say "::endgroup::"
-
   # make sure the program exits
   kill $flaskProcessId
 }

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -129,37 +129,6 @@ cypress-install() {
   cache-save cypress
 }
 
-cypress-run() {
-  cd "$GITHUB_WORKSPACE/superset-frontend/cypress-base"
-
-  local page=$1
-  local group=${2:-Default}
-  local cypress="./node_modules/.bin/cypress run"
-  local browser=${CYPRESS_BROWSER:-chrome}
-  local use_dashboard=$3
-
-  export TERM="xterm"
-  export ELECTRON_DISABLE_GPU=true # Attempt to disable GPU for Electron-based Cypress
-
-  say "::group::Run Cypress for [$page]"
-  if [[ "$use_dashboard" == "true" && -n $CYPRESS_KEY ]]; then
-
-    export CYPRESS_RECORD_KEY=$(echo $CYPRESS_KEY | base64 --decode)
-    echo "Running using the paid Cypress service and API key"
-    # additional flags for Cypress dashboard recording
-    xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' $cypress --spec "cypress/e2e/$page" --browser "$browser" \
-      --record --group "$group" --tag "${GITHUB_REPOSITORY},${GITHUB_EVENT_NAME}" \
-      --parallel --ci-build-id "${GITHUB_SHA:0:8}-${NONCE}"
-  else
-    echo "Running locally"
-    unset CYPRESS_KEY
-    xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' $cypress --spec "cypress/e2e/$page" --browser "$browser" \
-      --parallel --group "$group"
-  fi
-
-  say "::endgroup::"
-}
-
 cypress-run-all() {
   local use_dashboard=$1
 
@@ -173,7 +142,8 @@ cypress-run-all() {
   nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
   local flaskProcessId=$!
 
-  cypress-run "*/**/*" "Default" "$use_dashboard"
+  #cypress-run "*/**/*" "Default" "$use_dashboard"
+  python scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID
 
   # After job is done, print out Flask log for debugging
   say "::group::Flask log for default run"
@@ -188,7 +158,7 @@ cypress-run-all() {
   nohup flask run --no-debugger -p $port >"$flasklog" 2>&1 </dev/null &
   local flaskProcessId=$!
 
-  cypress-run "sqllab/*" "Backend persist" "$use_dashboard"
+  python scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group "Backend persist" --filter "cypress/e2e/sqllab/**/*"
 
   say "::group::Flask log for backend persist"
   cat "$flasklog"

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -13,6 +13,14 @@ on:
         description: 'Use Cypress Dashboard (true/false) [paid service - trigger manually when needed]'
         required: false
         default: 'false'
+      ref:
+        description: 'The branch or tag to checkout'
+        required: false
+        default: ''
+      pr_id:
+        description: 'The pull request ID to checkout'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -31,7 +39,7 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        parallel_id: [0, 1, 2, 3, 4]
+        parallel_id: [0, 1, 2, 3, 4, 5]
         browser: ["chrome"]
     env:
       SUPERSET_ENV: development
@@ -54,11 +62,28 @@ jobs:
         ports:
           - 16379:6379
     steps:
-      - name: "Checkout (pull) ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4
+      # -------------------------------------------------------
+      # Conditional checkout based on context
+      - name: Checkout for push or pull_request event
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
           persist-credentials: false
           submodules: recursive
+      - name: Checkout using ref (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.ref != ''
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.inputs.ref }}
+      - name: Checkout using PR ID (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_id != ''
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          ref: refs/pull/${{ github.event.inputs.pr_id }}/merge
+      # -------------------------------------------------------
       - name: Check for file changes
         id: check
         uses: ./.github/actions/change-detector/
@@ -103,7 +128,7 @@ jobs:
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
           PARALLEL_ID: ${{ matrix.parallel_id }}
-          PARALLELISM: 5
+          PARALLELISM: 6
           CYPRESS_KEY: YjljODE2MzAtODcwOC00NTA3LWE4NmMtMTU3YmFmMjIzOTRhCg==
         with:
           run: cypress-run-all ${{ env.USE_DASHBOARD }}

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -56,15 +56,7 @@ jobs:
     steps:
       - name: "Checkout (pull) ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
-        if: github.event_name == 'push'
         with:
-          persist-credentials: false
-          submodules: recursive
-      - name: "Checkout (pull_request) ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v4
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
           persist-credentials: false
           submodules: recursive
       - name: Check for file changes

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -26,12 +26,12 @@ jobs:
       pull-requests: read
     strategy:
       # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
+      # parallel_id, because this will kill Cypress processes
       # leaving the Dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        containers: [1, 2, 3]
+        parallel_id: [0, 1, 2, 3, 4]
         browser: ["chrome"]
     env:
       SUPERSET_ENV: development
@@ -110,6 +110,8 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
+          PARALLEL_ID: ${{ matrix.parallel_id }}
+          PARALLELISM: 5
           CYPRESS_KEY: YjljODE2MzAtODcwOC00NTA3LWE4NmMtMTU3YmFmMjIzOTRhCg==
         with:
           run: cypress-run-all ${{ env.USE_DASHBOARD }}

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -7,6 +7,12 @@ on:
       - "[0-9].[0-9]"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      use_dashboard:
+        description: 'Use Cypress Dashboard (true/false) [paid service - trigger manually when needed]'
+        required: false
+        default: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -34,6 +40,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
+      USE_DASHBOARD: ${{ github.event.inputs.use_dashboard || 'false' }}
     services:
       postgres:
         image: postgres:15-alpine
@@ -105,7 +112,7 @@ jobs:
           CYPRESS_BROWSER: ${{ matrix.browser }}
           CYPRESS_KEY: YjljODE2MzAtODcwOC00NTA3LWE4NmMtMTU3YmFmMjIzOTRhCg==
         with:
-          run: cypress-run-all
+          run: cypress-run-all ${{ env.USE_DASHBOARD }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: steps.check.outputs.python || steps.check.outputs.frontend

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -134,7 +134,7 @@ jobs:
           run: cypress-run-all ${{ env.USE_DASHBOARD }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        if: steps.check.outputs.python || steps.check.outputs.frontend
+        if: github.event_name == 'workflow_dispatch' && (steps.check.outputs.python || steps.check.outputs.frontend)
         with:
           name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -77,12 +77,14 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
+          submodules: recursive
       - name: Checkout using PR ID (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_id != ''
         uses: actions/checkout@v2
         with:
           persist-credentials: false
           ref: refs/pull/${{ github.event.inputs.pr_id }}/merge
+          submodules: recursive
       # -------------------------------------------------------
       - name: Check for file changes
         id: check

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -98,6 +98,7 @@ def print_files(files: List[str]) -> None:
 def main(event_type: str, sha: str, repo: str) -> None:
     """Main function to check for file changes based on event context."""
     print("SHA:", sha)
+    print("EVENT_TYPE", event_type)
     if event_type == "pull_request":
         pr_number = os.getenv("GITHUB_REF", "").split("/")[-2]
         files = fetch_changed_files_pr(repo, pr_number)

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -108,13 +108,19 @@ def main(event_type: str, sha: str, repo: str) -> None:
         files = fetch_changed_files_push(repo, sha)
         print("Files touched since previous commit:")
         print_files(files)
+
+    elif event_type == "workflow_dispatch":
+        print("Workflow dispatched, assuming all changed")
+
     else:
         raise ValueError("Unsupported event type")
 
     changes_detected = {}
     for group, regex_patterns in PATTERNS.items():
         patterns_compiled = [re.compile(p) for p in regex_patterns]
-        changes_detected[group] = detect_changes(files, patterns_compiled)
+        changes_detected[group] = event_type == "workflow_dispatch" or detect_changes(
+            files, patterns_compiled
+        )
 
     # Output results
     output_path = os.getenv("GITHUB_OUTPUT") or "/tmp/GITHUB_OUTPUT.txt"

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -64,9 +64,6 @@ def get_cypress_cmd(
         )
         os.environ["CYPRESS_RECORD_KEY"] = cypress_record_key
         spec: str = "*/**/*"
-        if _filter and "sqllab" in _filter:
-            spec = "cypress/e2e/sqllab/**/*"
-
         cmd = (
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{spec}" --browser {browser} '

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import argparse
 import hashlib
 import os

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -65,7 +65,6 @@ def get_cypress_cmd(
         cmd = (
             f"{XVFB_PRE_CMD} "
             f"{cypress_cmd} --browser {browser} "
-            f"--parallel --group {group} "
             f'--spec "{spec_list_str}" '
         )
     return cmd

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -132,7 +132,6 @@ def main() -> None:
 
     group_id = args.parallelism_id
     spec_list = groups[group_id]
-
     cmd = get_cypress_cmd(spec_list, args.filter, args.group, args.use_dashboard)
     print(f"RUN: {cmd}")
     if not args.dry_run:

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -46,7 +46,9 @@ def get_cypress_cmd(
             .strip()
         )
         os.environ["CYPRESS_RECORD_KEY"] = cypress_record_key
-        spec: str = "*/**/*" if not _filter else _filter
+        spec: str = "*/**/*"
+        if _filter and "sqllab" in _filter:
+            spec = "cypress/e2e/sqllab/**/*"
 
         cmd = (
             f"{XVFB_PRE_CMD} "
@@ -95,14 +97,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Determine the base directory relative to the script location
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    base_dir = os.path.join(
-        script_dir, "..", "superset-frontend", "cypress-base", "cypress", "e2e"
-    )
+    cypress_base_path = "superset-frontend/cypress-base/"
+    cypress_tests_path = os.path.join(cypress_base_path, "cypress/e2e")
 
     test_files = []
-    for root, _, files in os.walk(base_dir):
+    for root, _, files in os.walk(cypress_tests_path):
         for file in files:
             if file.endswith("test.ts") or file.endswith("test.js"):
                 test_files.append(os.path.join(root, file))

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -120,9 +120,8 @@ def main() -> None:
     spec_list = groups[group_id]
 
     cmd = get_cypress_cmd(spec_list, args.filter, args.group, args.use_dashboard)
-    if args.dry_run:
-        print(cmd)
-    else:
+    print(f"RUN: {cmd}")
+    if not args.dry_run:
         subprocess.run(cmd, shell=True, check=True, stdout=None, stderr=None)
 
 

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -55,12 +55,10 @@ def get_cypress_cmd(
 
     if use_dashboard:
         # Run using cypress.io service
+        cypress_key = os.getenv("CYPRESS_KEY")
+        command = f"echo {cypress_key} | base64 --decode"
         cypress_record_key = (
-            subprocess.check_output(
-                ["echo", os.getenv("CYPRESS_KEY") or "DUMMY", "|", "base64", "--decode"]
-            )
-            .decode("utf-8")
-            .strip()
+            subprocess.check_output(command, shell=True).decode("utf-8").strip()
         )
         os.environ["CYPRESS_RECORD_KEY"] = cypress_record_key
         spec: str = "*/**/*"

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -123,11 +123,15 @@ def main() -> None:
                     os.path.join(root, file).replace(cypress_base_full_path, "")
                 )
 
+    # Initialize groups
     groups: dict[int, list[str]] = {i: [] for i in range(args.parallelism)}
 
-    for test_file in test_files:
-        hash_value = compute_hash(test_file)
-        group_index = compute_group_index(hash_value, args.parallelism)
+    # Sort test files to ensure deterministic distribution
+    sorted_test_files = sorted(test_files)
+
+    # Distribute test files in a round-robin manner
+    for index, test_file in enumerate(sorted_test_files):
+        group_index = index % args.parallelism
         groups[group_index].append(test_file)
 
     group_id = args.parallelism_id

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -97,14 +97,18 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    script_dir = os.path.dirname(os.path.abspath(__file__))
     cypress_base_path = "superset-frontend/cypress-base/"
-    cypress_tests_path = os.path.join(cypress_base_path, "cypress/e2e")
+    cypress_base_full_path = os.path.join(script_dir, "../", cypress_base_path)
+    cypress_tests_path = os.path.join(cypress_base_full_path, "cypress/e2e")
 
     test_files = []
     for root, _, files in os.walk(cypress_tests_path):
         for file in files:
             if file.endswith("test.ts") or file.endswith("test.js"):
-                test_files.append(os.path.join(root, file))
+                test_files.append(
+                    os.path.join(root, file).replace(cypress_base_full_path, "")
+                )
 
     groups: dict[int, list[str]] = {i: [] for i in range(args.parallelism)}
 

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -33,10 +33,10 @@ from superset.extensions import (
 )
 from superset.security import SupersetSecurityManager  # noqa: F401
 
-#  All of the fields located here should be considered legacy. The correct way
-#  to declare "global" dependencies is to define it in extensions.py,
-#  then initialize it in app.create_app(). These fields will be removed
-#  in subsequent PRs as things are migrated towards the factory pattern
+# All of the fields located here should be considered legacy. The correct way
+# to declare "global" dependencies is to define it in extensions.py,
+# then initialize it in app.create_app(). These fields will be removed
+# in subsequent PRs as things are migrated towards the factory pattern
 app: Flask = current_app
 cache = cache_manager.cache
 conf = LocalProxy(lambda: current_app.config)


### PR DESCRIPTION
Preset is picking up the bill for Cypress.io and it's getting pricey for the usage we have for it. In this PR, I'm moving normal pull_request and push events to run in local GHA mode without the `--record` flag. This means we can't use the `--parallel` feature, but I wrote a little python script that segments the jobs and make them run in parallel.

I'm also providing a `workflow_dispatch` option where you can trigger a cypress.io run in dashboard mode, so you can still go use their stuff on a given branch if/where needed. 