### PR TITLE
fix(explore): Drill to detail truncates int64 IDs

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -609,6 +609,7 @@ export const getDatasourceSamples = async (
       endpoint: '/datasource/samples',
       jsonPayload,
       searchParams,
+      parseMethod: 'json-bigint',
     });
 
     return response.json.result;


### PR DESCRIPTION
### SUMMARY
This commit fixes the missing `json-bigint` parseMethod on dril-to-detail view request.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

![Screenshot 2024-06-04 at 5 18 24 PM](https://github.com/apache/superset/assets/1392866/02632d15-734c-4725-95fe-17f1eb19621c)

After:

![Screenshot 2024-06-04 at 5 18 00 PM](https://github.com/apache/superset/assets/1392866/883564f1-e8d8-479d-a90d-d346528a201f)


### TESTING INSTRUCTIONS
Create a chart including int64 value and then click "drill to detail" in the dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
