### PR TITLE
feat(alert/report): Added optional CC and BCC fields for email notifi…

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1028,12 +1028,12 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       return emails
         .split(/[,;]/)
         .every(email => EMAIL_REGEX.test(email.trim()));
-     };
+    };
 
     for (const setting of notificationSettings) {
       if (!!setting.method && setting.method === 'Email') {
         if (setting.recipients?.length && !validateEmails(setting.recipients))
-            return false;
+          return false;
         if (setting.cc && !validateEmails(setting.cc)) return false;
         if (setting.bcc && !validateEmails(setting.bcc)) return false;
       }
@@ -1098,7 +1098,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   const validateNotificationSection = () => {
     const errors = [];
     const hasErrors = !checkNotificationSettings();
-    
+
     if (hasErrors) {
       errors.push(TRANSLATIONS.RECIPIENTS_ERROR_TEXT);
     } else {

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1028,16 +1028,16 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       return emails
         .split(/[,;]/)
         .every(email => EMAIL_REGEX.test(email.trim()));
-   };
+     };
 
-   for (const setting of notificationSettings) {
-      if (!!setting.method && setting.method==='Email') {
-          if (setting.recipients?.length && !validateEmails(setting.recipients))
+    for (const setting of notificationSettings) {
+      if (!!setting.method && setting.method === 'Email') {
+        if (setting.recipients?.length && !validateEmails(setting.recipients))
             return false;
-          if (setting.cc && !validateEmails(setting.cc)) return false;
-          if (setting.bcc && !validateEmails(setting.bcc)) return false;
-        }
+        if (setting.cc && !validateEmails(setting.cc)) return false;
+        if (setting.bcc && !validateEmails(setting.bcc)) return false;
       }
+    }
     return true;
   };
 
@@ -1104,9 +1104,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     } else {
       // Check for email format errors
       const hasValidationErrors = !checkEmailFormat();
-        if (hasValidationErrors) {
-            errors.push(TRANSLATIONS.EMAIL_VALIDATION_ERROR_TEXT);
-        }
+      if (hasValidationErrors) {
+        errors.push(TRANSLATIONS.EMAIL_VALIDATION_ERROR_TEXT);
+      }
     }
 
     if (emailError) {

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1025,17 +1025,19 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
 
     const validateEmails = (emails: string): boolean => {
       if (!emails) return true; // No emails to validate
-      return emails.split(/[,;]/).every(email => EMAIL_REGEX.test(email.trim()));
+      return emails
+        .split(/[,;]/)
+        .every(email => EMAIL_REGEX.test(email.trim()));
    };
 
    for (const setting of notificationSettings) {
       if (!!setting.method && setting.method==='Email') {
-          if(setting.recipients?.length && !validateEmails(setting.recipients))return false;
-          if(setting.cc && !validateEmails(setting.cc))return false;
-          if(setting.bcc && !validateEmails(setting.bcc))return false;
+          if (setting.recipients?.length && !validateEmails(setting.recipients))
+            return false;
+          if (setting.cc && !validateEmails(setting.cc)) return false;
+          if (setting.bcc && !validateEmails(setting.bcc)) return false;
         }
-      };
-
+      }
     return true;
   };
 
@@ -1099,10 +1101,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     
     if (hasErrors) {
       errors.push(TRANSLATIONS.RECIPIENTS_ERROR_TEXT);
-    } 
-    else {
-        // Check for email format errors
-        const hasValidationErrors = !checkEmailFormat();
+    } else {
+      // Check for email format errors
+      const hasValidationErrors = !checkEmailFormat();
         if (hasValidationErrors) {
             errors.push(TRANSLATIONS.EMAIL_VALIDATION_ERROR_TEXT);
         }
@@ -1169,8 +1170,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       setNotificationSettings([
         {
           recipients: '',
-          cc:'',
-          bcc:'',
+          cc: '',
+          bcc: '',
           options: allowedNotificationMethods,
           method: NotificationMethodOption.Email,
         },

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1030,15 +1030,17 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
         .every(email => EMAIL_REGEX.test(email.trim()));
     };
 
-    for (const setting of notificationSettings) {
+    // Use array method to check conditions
+    return notificationSettings.every(setting => {
       if (!!setting.method && setting.method === 'Email') {
-        if (setting.recipients?.length && !validateEmails(setting.recipients))
-          return false;
-        if (setting.cc && !validateEmails(setting.cc)) return false;
-        if (setting.bcc && !validateEmails(setting.bcc)) return false;
+        return (
+          (!setting.recipients?.length || validateEmails(setting.recipients)) &&
+          (!setting.cc || validateEmails(setting.cc)) &&
+          (!setting.bcc || validateEmails(setting.bcc))
+        );
       }
-    }
-    return true;
+      return true; // Non-Email methods are considered valid
+    });
   };
 
   const validateGeneralSection = () => {

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -80,7 +80,7 @@ describe('NotificationMethod', () => {
       />,
     );
 
-    const deleteButton = screen.getByRole('button');
+    const deleteButton = screen.getByRole('delbutton');
     userEvent.click(deleteButton);
 
     expect(mockOnRemove).toHaveBeenCalledWith(1);

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -80,8 +80,8 @@ describe('NotificationMethod', () => {
       />,
     );
 
-    const deleteButton = screen.getByRole('delbutton');
-    userEvent.click(deleteButton);
+    const deleteButton = document.querySelector('.delete-button');
+    if (deleteButton) userEvent.click(deleteButton);
 
     expect(mockOnRemove).toHaveBeenCalledWith(1);
   });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -35,7 +35,6 @@ import {
   useTheme,
 } from '@superset-ui/core';
 import { Select } from 'src/components';
-import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import {
   NotificationMethodOption,
@@ -78,35 +77,28 @@ const StyledNotificationMethod = styled.div`
     }
   }
 
-  /* New style for buttons container */
-  .buttons-container {
-    display: flex;
+  .ghost-button {
+    color: ${({ theme }) => theme.colors.primary.dark1};
+    display: inline-flex;
     align-items: center;
-    margin-top: 8px; /* Adjust as needed */
+    font-size: 12px;
+    cursor: pointer;
+    margin-top: 4px;
+
+    .icon {
+      width: 12px;
+      height: 12px;
+      font-size: 12px;
+      margin-right: 4px;
+    }
   }
 
-  .buttons-container .control-label {
-    margin-right: 16px;
-  }
-`;
-
-const InlineButton = styled(Button)`
-  font-size: 12px;
-  display: inline-flex;
-  align-items: center;
-  padding: 0;
-  margin-right: 16px;
-  background: none;
-  font-weight: normal;
-  text-transform: none;
-
-  .anticon {
-    margin-right: 4px;
+  .ghost-button + .ghost-button {
+    margin-left: 16px;
   }
 
-  &:hover,
-  &:focus {
-    background: none;
+  .ghost-button:first-child[style*='none'] + .ghost-button {
+    margin-left: 0; /* Remove margin when the first button is hidden */
   }
 `;
 

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -44,62 +44,66 @@ import {
 import { StyledInputContainer } from '../AlertReportModal';
 
 const StyledNotificationMethod = styled.div`
-  margin-bottom: 10px;
+  ${({ theme }) => `
+    margin-bottom: ${theme.gridUnit * 2.5}px;
 
-  .input-container {
-    textarea {
-      height: auto;
-    }
+    .input-container {
+      textarea {
+        height: auto;
+      }
 
-    &.error {
-      input {
-        border-color: ${({ theme }) => theme.colors.error.base};
+      &.error {
+        input {
+          border-color: ${theme.colors.error.base};
+        }
+      }
+
+      .helper {
+        margin-top: ${theme.gridUnit * 2}px;
+        font-size: ${theme.typography.sizes.s}px;
+        color: ${theme.colors.grayscale.base};
       }
     }
 
-    .helper {
-      margin-top: 5px;
-      font-size: 12px;
-      color: ${({ theme }) => theme.colors.grayscale.base};
+    .inline-container {
+      margin-bottom: ${theme.gridUnit * 2.5}px;
+
+      > div {
+        margin: ${theme.gridUnit * 0}px;
+      }
+
+      .delete-button {
+        margin-left: ${theme.gridUnit * 2.5}px;
+        padding-top: ${theme.gridUnit * 0.75}px;
+      }
     }
-  }
 
-  .inline-container {
-    margin-bottom: 10px;
+    .ghost-button {
+      color: ${theme.colors.primary.dark1};
+      display: inline-flex;
+      align-items: center;
+      font-size: ${theme.typography.sizes.s}px;
+      cursor: pointer;
+      margin-top: ${theme.gridUnit}px;
 
-    > div {
-      margin: 0;
+      .icon {
+        width: ${theme.gridUnit * 3}px;
+        height: ${theme.gridUnit * 3}px;
+        font-size: ${theme.typography.sizes.s}px;
+        margin-right: ${theme.gridUnit}px;
+      }
     }
 
-    .delete-button {
-      margin-left: 10px;
-      padding-top: 3px;
+    .ghost-button + .ghost-button {
+      margin-left: ${theme.gridUnit * 4}px;
     }
-  }
 
-  .ghost-button {
-    color: ${({ theme }) => theme.colors.primary.dark1};
-    display: inline-flex;
-    align-items: center;
-    font-size: 12px;
-    cursor: pointer;
-    margin-top: 4px;
-
-    .icon {
-      width: 12px;
-      height: 12px;
-      font-size: 12px;
-      margin-right: 4px;
+    .ghost-button:first-child[style*='none'] + .ghost-button {
+      margin-left: ${
+        theme.gridUnit * 0
+      }px; /* Remove margin when the first button is hidden */
     }
-  }
-
-  .ghost-button + .ghost-button {
-    margin-left: 16px;
-  }
-
-  .ghost-button:first-child[style*='none'] + .ghost-button {
-    margin-left: 0; /* Remove margin when the first button is hidden */
-  }
+  `}
 `;
 
 const TRANSLATIONS = {
@@ -554,7 +558,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               <div
                 style={{
                   color: theme.colors.error.base,
-                  fontSize: theme.gridUnit * 3,
+                  fontSize: theme.typography.sizes.s,
                 }}
               >
                 {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -437,7 +437,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
             />
             {index !== 0 && !!onRemove ? (
               <span
-                role="button"
+                role="delbutton"
                 tabIndex={0}
                 className="delete-button"
                 onClick={() => onRemove(index)}
@@ -577,7 +577,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               <div className="ghost-button">
                 <span
                   className="ghost-button"
-                  role="button"
+                  role="ccbutton"
                   tabIndex={0}
                   onClick={() => setCcVisible(true)}
                   style={{ display: ccVisible ? 'none' : 'inline-flex' }}
@@ -587,7 +587,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 </span>
                 <span
                   className="ghost-button"
-                  role="button"
+                  role="bccbutton"
                   tabIndex={0}
                   onClick={() => setBccVisible(true)}
                   style={{ display: bccVisible ? 'none' : 'inline-flex' }}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -45,7 +45,7 @@ import { StyledInputContainer } from '../AlertReportModal';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
-    margin-bottom: ${theme.gridUnit * 2.5}px;
+    margin-bottom: ${theme.gridUnit * 3}px;
 
     .input-container {
       textarea {
@@ -69,7 +69,7 @@ const StyledNotificationMethod = styled.div`
       margin-bottom: ${theme.gridUnit * 2}px;
 
       > div {
-        margin: ${theme.gridUnit * 0}px;
+        margin: 0px;
       }
 
       .delete-button {
@@ -99,17 +99,15 @@ const StyledNotificationMethod = styled.div`
     }
 
     .ghost-button:first-child[style*='none'] + .ghost-button {
-      margin-left: ${
-        theme.gridUnit * 0
-      }px; /* Remove margin when the first button is hidden */
+      margin-left: 0px; /* Remove margin when the first button is hidden */
     }
   `}
 `;
 
 const TRANSLATIONS = {
-  EMAIL_CC_NAME: t('CC'),
-  EMAIL_BCC_NAME: t('BCC'),
-  EMAIL_SUBJECT_NAME: t('Subject'),
+  EMAIL_CC_NAME: t('CC recipients'),
+  EMAIL_BCC_NAME: t('BCC recipients'),
+  EMAIL_SUBJECT_NAME: t('Email subject name (optional)'),
   EMAIL_SUBJECT_ERROR_TEXT: t(
     'Please enter valid text. Spaces alone are not permitted.',
   ),
@@ -127,15 +125,6 @@ interface NotificationMethodProps {
   defaultSubject: string;
   setErrorSubject: (hasError: boolean) => void;
 }
-
-const TRANSLATIONS = {
-  EMAIL_CC_NAME: t('CC (optional)'),
-  EMAIL_BCC_NAME: t('BCC (optional)'),
-  EMAIL_SUBJECT_NAME: t('Subject (optional)'),
-  EMAIL_SUBJECT_ERROR_TEXT: t(
-    'Please enter valid text. Spaces alone are not permitted.',
-  ),
-};
 
 export const mapSlackValues = ({
   method,
@@ -237,6 +226,9 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   }) => {
     // Since we're swapping the method, reset the recipients
     setRecipientValue('');
+    setCcValue('');
+    setBccValue('');
+
     if (onUpdate && setting) {
       const updatedSetting = {
         ...setting,
@@ -488,106 +480,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               ) : null}
             </StyledInputContainer>
           </div>
-          <div className="input-container">
-          <textarea
-              name="To"
-              data-test="recipients"
-              value={recipientValue}
-              onChange={onRecipientsChange}
-          />
-          </div>
-          <div className="control-label">
-            {TRANSLATIONS.EMAIL_CC_NAME}
-          </div>
-          <div className="input-container">
-          <textarea
-              name="CC"
-              data-test="cc"
-              value={ccValue}
-              onChange={onCcChange}
-          />
-          </div>
-          <div className="control-label">
-            {TRANSLATIONS.EMAIL_BCC_NAME}
-          </div>
-          <div className="input-container">
-          <textarea
-
-      {method !== undefined ? (
-        method === 'Email' ? (
-          <StyledInputContainer>
-            <div className="control-label">
-              {t('To')}
-              <span className="required">*</span>
-            </div>
-            <div className="input-container">
-              <textarea
-                name="To"
-                data-test="recipients"
-                value={recipientValue}
-                onChange={onRecipientsChange}
-              />
-            </div>
-            <div className="input-container">
-              <div className="helper">
-                {t('Recipients are separated by "," or ";"')}
-              </div>
-            </div>
-            <div className="control-label">{TRANSLATIONS.EMAIL_BCC_NAME}</div>
-            <div className="input-container">
-            <textarea
-                name="BCC"
-                data-test="bcc"
-                value={bccValue}
-                onChange={onBccChange}
-              />
-            </div>
-            <div className="control-label">
-              {TRANSLATIONS.EMAIL_SUBJECT_NAME}
-            </div>
-            <div className={`input-container ${error ? 'error' : ''}`}>
-              <input
-                type="text"
-                name="email_subject"
-                value={email_subject}
-                placeholder={defaultSubject}
-                onChange={onSubjectChange}
-              />
-            </div>
-            {error && (
-              <div
-                style={{
-                  color: theme.colors.error.base,
-                  fontSize: theme.typography.sizes.s,
-                }}
-              >
-                {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
-              </div>
-            )}
-          </StyledInputContainer>
-        ) : (
-          <StyledInputContainer>
-            <div className="control-label">
-              {t('%s recipients', method)}
-              <span className="required">*</span>
-            </div>
-            <div className="input-container">
-              <textarea
-                name="recipients"
-                data-test="recipients"
-                value={recipientValue}
-                onChange={onRecipientsChange}
-              />
-            </div>
-            <div className="input-container">
-              <div className="helper">
-                {t('Recipients are separated by "," or ";"')}
-              </div>
-            </div>
-          </StyledInputContainer>
-        )
-          :
-        (
+          <div className="inline-container">
             <StyledInputContainer>
               <div className="control-label">
                 {t(
@@ -606,14 +499,16 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                   <>
                     <div className="input-container">
                       <textarea
-                        name="recipients"
+                        name="To"
                         data-test="recipients"
                         value={recipientValue}
                         onChange={onRecipientsChange}
                       />
                     </div>
-                    <div className="helper">
-                      {t('Recipients are separated by "," or ";"')}
+                    <div className="input-container">
+                      <div className="helper">
+                        {t('Recipients are separated by "," or ";"')}
+                      </div>
                     </div>
                   </>
                 ) : (
@@ -633,9 +528,78 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 )}
               </div>
             </StyledInputContainer>
-        )
-      )
-      :null}
+          </div>
+          {method === NotificationMethodOption.Email && (
+            <StyledInputContainer>
+              {/* Render "CC" input field if ccVisible is true */}
+              {ccVisible && (
+                <>
+                  <div className="control-label">
+                    {TRANSLATIONS.EMAIL_CC_NAME}
+                  </div>
+                  <div className="input-container">
+                    <textarea
+                      name="CC"
+                      data-test="cc"
+                      value={ccValue}
+                      onChange={onCcChange}
+                    />
+                  </div>
+                  <div className="input-container">
+                    <div className="helper">
+                      {t('Recipients are separated by "," or ";"')}
+                    </div>
+                  </div>
+                </>
+              )}
+              {/* Render "BCC" input field if bccVisible is true */}
+              {bccVisible && (
+                <>
+                  <div className="control-label">
+                    {TRANSLATIONS.EMAIL_BCC_NAME}
+                  </div>
+                  <div className="input-container">
+                    <textarea
+                      name="BCC"
+                      data-test="bcc"
+                      value={bccValue}
+                      onChange={onBccChange}
+                    />
+                  </div>
+                  <div className="input-container">
+                    <div className="helper">
+                      {t('Recipients are separated by "," or ";"')}
+                    </div>
+                  </div>
+                </>
+              )}
+              {/* New buttons container */}
+              <div className="ghost-button">
+                <span
+                  className="ghost-button"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setCcVisible(true)}
+                  style={{ display: ccVisible ? 'none' : 'inline-flex' }}
+                >
+                  <Icons.Email className="icon" />
+                  {t('Add CC Recipients')}
+                </span>
+                <span
+                  className="ghost-button"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setBccVisible(true)}
+                  style={{ display: bccVisible ? 'none' : 'inline-flex' }}
+                >
+                  <Icons.Email className="icon" />
+                  {t('Add BCC Recipients')}
+                </span>
+              </div>
+            </StyledInputContainer>
+          )}
+        </>
+      ) : null}
     </StyledNotificationMethod>
   );
 };

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -437,7 +437,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
             />
             {index !== 0 && !!onRemove ? (
               <span
-                role="delbutton"
+                role="button"
                 tabIndex={0}
                 className="delete-button"
                 onClick={() => onRemove(index)}
@@ -577,7 +577,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               <div className="ghost-button">
                 <span
                   className="ghost-button"
-                  role="ccbutton"
+                  role="button"
                   tabIndex={0}
                   onClick={() => setCcVisible(true)}
                   style={{ display: ccVisible ? 'none' : 'inline-flex' }}
@@ -587,7 +587,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 </span>
                 <span
                   className="ghost-button"
-                  role="bccbutton"
+                  role="button"
                   tabIndex={0}
                   onClick={() => setBccVisible(true)}
                   style={{ display: bccVisible ? 'none' : 'inline-flex' }}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -412,6 +412,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
           </div>
         </StyledInputContainer>
       </div>
+<<<<<<< HEAD
       {method !== undefined ? (
         <>
           <div className="inline-container">
@@ -468,6 +469,35 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
           </div>
           <div className="input-container">
           <textarea
+=======
+      {method !== undefined ? (            
+        method === 'Email' ? (
+          <StyledInputContainer>
+            <div className="control-label">
+              {t('To')}
+              <span className="required">*</span>
+            </div>
+            <div className="input-container">
+              <textarea
+                name="To"
+                data-test="recipients"
+                value={recipientValue}
+                onChange={onRecipientsChange}
+              />
+            </div>
+            <div className="control-label">{TRANSLATIONS.EMAIL_CC_NAME}</div>
+            <div className="input-container">
+              <textarea
+                name="CC"
+                data-test="cc"
+                value={ccValue}
+                onChange={onCcChange}
+              />
+            </div>
+            <div className="control-label">{TRANSLATIONS.EMAIL_BCC_NAME}</div>
+            <div className="input-container">
+            <textarea
+>>>>>>> 261b54a89 (handle build failure and prettify)
               name="BCC"
               data-test="bcc"
               value={bccValue}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -35,6 +35,7 @@ import {
   useTheme,
 } from '@superset-ui/core';
 import { Select } from 'src/components';
+import Button from 'src/components/Button';
 import Icons from 'src/components/Icons';
 import {
   NotificationMethodOption,
@@ -56,6 +57,12 @@ const StyledNotificationMethod = styled.div`
         border-color: ${({ theme }) => theme.colors.error.base};
       }
     }
+
+    .helper {
+      margin-top: 5px;
+      font-size: 12px;
+      color: ${({ theme }) => theme.colors.grayscale.base};
+    }
   }
 
   .inline-container {
@@ -70,7 +77,47 @@ const StyledNotificationMethod = styled.div`
       padding-top: 3px;
     }
   }
+
+  /* New style for buttons container */
+  .buttons-container {
+    display: flex;
+    align-items: center;
+    margin-top: 8px; /* Adjust as needed */
+  }
+
+  .buttons-container .control-label {
+    margin-right: 16px;
+  }
 `;
+
+const InlineButton = styled(Button)`
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  margin-right: 16px;
+  background: none;
+  font-weight: normal;
+  text-transform: none;
+
+  .anticon {
+    margin-right: 4px;
+  }
+
+  &:hover,
+  &:focus {
+    background: none;
+  }
+`;
+
+const TRANSLATIONS = {
+  EMAIL_CC_NAME: t('CC'),
+  EMAIL_BCC_NAME: t('BCC'),
+  EMAIL_SUBJECT_NAME: t('Subject'),
+  EMAIL_SUBJECT_ERROR_TEXT: t(
+    'Please enter valid text. Spaces alone are not permitted.',
+  ),
+};
 
 interface NotificationMethodProps {
   setting?: NotificationSetting | null;
@@ -174,6 +221,8 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     { label: string; value: string }[]
   >([]);
   const [error, setError] = useState(false);
+  const [ccVisible, setCcVisible] = useState<boolean>(!!cc);
+  const [bccVisible, setBccVisible] = useState<boolean>(!!bcc);
   const [ccValue, setCcValue] = useState<string>(cc || '');
   const [bccValue, setBccValue] = useState<string>(bcc || '');
   const theme = useTheme();
@@ -469,7 +518,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
           <textarea
 
       {method !== undefined ? (
->>>>>>> 4f823a140 (pytest and pre-commit validated)
         method === 'Email' ? (
           <StyledInputContainer>
             <div className="control-label">
@@ -484,14 +532,10 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 onChange={onRecipientsChange}
               />
             </div>
-            <div className="control-label">{TRANSLATIONS.EMAIL_CC_NAME}</div>
             <div className="input-container">
-              <textarea
-                name="CC"
-                data-test="cc"
-                value={ccValue}
-                onChange={onCcChange}
-              />
+              <div className="helper">
+                {t('Recipients are separated by "," or ";"')}
+              </div>
             </div>
             <div className="control-label">{TRANSLATIONS.EMAIL_BCC_NAME}</div>
             <div className="input-container">
@@ -524,9 +568,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
               </div>
             )}
-            <div className="helper">
-              {t('Recipients are separated by "," or ";"')}
-            </div>
           </StyledInputContainer>
         ) : (
           <StyledInputContainer>
@@ -542,8 +583,10 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 onChange={onRecipientsChange}
               />
             </div>
-            <div className="helper">
-              {t('Recipients are separated by "," or ";"')}
+            <div className="input-container">
+              <div className="helper">
+                {t('Recipients are separated by "," or ";"')}
+              </div>
             </div>
           </StyledInputContainer>
         )

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -369,7 +369,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-
   // Set recipients
   if (!!recipients && recipientValue !== recipients) {
     setRecipientValue(recipients);
@@ -412,7 +411,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
           </div>
         </StyledInputContainer>
       </div>
-<<<<<<< HEAD
       {method !== undefined ? (
         <>
           <div className="inline-container">
@@ -469,8 +467,9 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
           </div>
           <div className="input-container">
           <textarea
-=======
-      {method !== undefined ? (            
+
+      {method !== undefined ? (
+>>>>>>> 4f823a140 (pytest and pre-commit validated)
         method === 'Email' ? (
           <StyledInputContainer>
             <div className="control-label">
@@ -497,14 +496,15 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
             <div className="control-label">{TRANSLATIONS.EMAIL_BCC_NAME}</div>
             <div className="input-container">
             <textarea
->>>>>>> 261b54a89 (handle build failure and prettify)
-              name="BCC"
-              data-test="bcc"
-              value={bccValue}
-              onChange={onBccChange}
-            />
+                name="BCC"
+                data-test="bcc"
+                value={bccValue}
+                onChange={onBccChange}
+              />
             </div>
-            <div className="control-label">{TRANSLATIONS.EMAIL_SUBJECT_NAME}</div>
+            <div className="control-label">
+              {TRANSLATIONS.EMAIL_SUBJECT_NAME}
+            </div>
             <div className={`input-container ${error ? 'error' : ''}`}>
               <input
                 type="text"
@@ -515,13 +515,19 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               />
             </div>
             {error && (
-            <div style={{color: theme.colors.error.base, fontSize: theme.gridUnit * 3,}}>
-                      {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
-            </div>)}
+              <div
+                style={{
+                  color: theme.colors.error.base,
+                  fontSize: theme.gridUnit * 3,
+                }}
+              >
+                {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
+              </div>
+            )}
             <div className="helper">
               {t('Recipients are separated by "," or ";"')}
             </div>
-          </StyledInputContainer>       
+          </StyledInputContainer>
         ) : (
           <StyledInputContainer>
             <div className="control-label">

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -66,15 +66,15 @@ const StyledNotificationMethod = styled.div`
     }
 
     .inline-container {
-      margin-bottom: ${theme.gridUnit * 2.5}px;
+      margin-bottom: ${theme.gridUnit * 2}px;
 
       > div {
         margin: ${theme.gridUnit * 0}px;
       }
 
       .delete-button {
-        margin-left: ${theme.gridUnit * 2.5}px;
-        padding-top: ${theme.gridUnit * 0.75}px;
+        margin-left: ${theme.gridUnit * 2}px;
+        padding-top: ${theme.gridUnit}px;
       }
     }
 

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -174,12 +174,8 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     { label: string; value: string }[]
   >([]);
   const [error, setError] = useState(false);
-  const [ccValue, setCcValue] = useState<string>(
-    cc || '',
-  );
-  const [bccValue, setBccValue] = useState<string>(
-    bcc || '',
-  );
+  const [ccValue, setCcValue] = useState<string>(cc || '');
+  const [bccValue, setBccValue] = useState<string>(bcc || '');
   const theme = useTheme();
   const [slackOptions, setSlackOptions] = useState<SlackOptionsType>([
     {
@@ -343,9 +339,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const onCcChange = (
-    event: React.ChangeEvent<HTMLTextAreaElement>,
-  ) => {
+  const onCcChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { target } = event;
 
     setCcValue(target.value);
@@ -360,9 +354,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const onBccChange = (
-    event: React.ChangeEvent<HTMLTextAreaElement>,
-  ) => {
+  const onBccChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { target } = event;
 
     setBccValue(target.value);
@@ -480,11 +472,9 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               data-test="bcc"
               value={bccValue}
               onChange={onBccChange}
-          />
-          </div>
-          <div className="control-label">
-                    {TRANSLATIONS.EMAIL_SUBJECT_NAME}
-          </div>
+            />
+            </div>
+            <div className="control-label">{TRANSLATIONS.EMAIL_SUBJECT_NAME}</div>
             <div className={`input-container ${error ? 'error' : ''}`}>
               <input
                 type="text"
@@ -498,11 +488,28 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
             <div style={{color: theme.colors.error.base, fontSize: theme.gridUnit * 3,}}>
                       {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
             </div>)}
-
-          <div className="helper">
-          {t('Recipients are separated by "," or ";"')}
-        </div>
-        </StyledInputContainer>       
+            <div className="helper">
+              {t('Recipients are separated by "," or ";"')}
+            </div>
+          </StyledInputContainer>       
+        ) : (
+          <StyledInputContainer>
+            <div className="control-label">
+              {t('%s recipients', method)}
+              <span className="required">*</span>
+            </div>
+            <div className="input-container">
+              <textarea
+                name="recipients"
+                data-test="recipients"
+                value={recipientValue}
+                onChange={onRecipientsChange}
+              />
+            </div>
+            <div className="helper">
+              {t('Recipients are separated by "," or ";"')}
+            </div>
+          </StyledInputContainer>
         )
           :
         (

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -86,7 +86,9 @@ interface NotificationMethodProps {
 }
 
 const TRANSLATIONS = {
-  EMAIL_SUBJECT_NAME: t('Email subject name (optional)'),
+  EMAIL_CC_NAME: t('CC (optional)'),
+  EMAIL_BCC_NAME: t('BCC (optional)'),
+  EMAIL_SUBJECT_NAME: t('Subject (optional)'),
   EMAIL_SUBJECT_ERROR_TEXT: t(
     'Please enter valid text. Spaces alone are not permitted.',
   ),
@@ -164,7 +166,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   defaultSubject,
   setErrorSubject,
 }) => {
-  const { method, recipients, options } = setting || {};
+  const { method, recipients, cc, bcc, options } = setting || {};
   const [recipientValue, setRecipientValue] = useState<string>(
     recipients || '',
   );
@@ -172,6 +174,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     { label: string; value: string }[]
   >([]);
   const [error, setError] = useState(false);
+  const [ccValue, setCcValue] = useState<string>(
+    cc || '',
+  );
+  const [bccValue, setBccValue] = useState<string>(
+    bcc || '',
+  );
   const theme = useTheme();
   const [slackOptions, setSlackOptions] = useState<SlackOptionsType>([
     {
@@ -193,6 +201,8 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
         ...setting,
         method: selected.value,
         recipients: '',
+        cc: '',
+        bcc: '',
       };
 
       onUpdate(index, updatedSetting);
@@ -333,9 +343,52 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
+  const onCcChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const { target } = event;
+
+    setCcValue(target.value);
+
+    if (onUpdate) {
+      const updatedSetting = {
+        ...setting,
+        cc: target.value,
+      };
+
+      onUpdate(index, updatedSetting);
+    }
+  };
+
+  const onBccChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const { target } = event;
+
+    setBccValue(target.value);
+
+    if (onUpdate) {
+      const updatedSetting = {
+        ...setting,
+        bcc: target.value,
+      };
+
+      onUpdate(index, updatedSetting);
+    }
+  };
+
+
   // Set recipients
   if (!!recipients && recipientValue !== recipients) {
     setRecipientValue(recipients);
+  }
+
+  if (!!cc && ccValue !== cc) {
+    setCcValue(cc);
+  }
+
+  if (!!bcc && bccValue !== bcc) {
+    setBccValue(bcc);
   }
 
   return (
@@ -399,7 +452,60 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               ) : null}
             </StyledInputContainer>
           </div>
-          <div className="inline-container">
+          <div className="input-container">
+          <textarea
+              name="To"
+              data-test="recipients"
+              value={recipientValue}
+              onChange={onRecipientsChange}
+          />
+          </div>
+          <div className="control-label">
+            {TRANSLATIONS.EMAIL_CC_NAME}
+          </div>
+          <div className="input-container">
+          <textarea
+              name="CC"
+              data-test="cc"
+              value={ccValue}
+              onChange={onCcChange}
+          />
+          </div>
+          <div className="control-label">
+            {TRANSLATIONS.EMAIL_BCC_NAME}
+          </div>
+          <div className="input-container">
+          <textarea
+              name="BCC"
+              data-test="bcc"
+              value={bccValue}
+              onChange={onBccChange}
+          />
+          </div>
+          <div className="control-label">
+                    {TRANSLATIONS.EMAIL_SUBJECT_NAME}
+          </div>
+            <div className={`input-container ${error ? 'error' : ''}`}>
+              <input
+                type="text"
+                name="email_subject"
+                value={email_subject}
+                placeholder={defaultSubject}
+                onChange={onSubjectChange}
+              />
+            </div>
+            {error && (
+            <div style={{color: theme.colors.error.base, fontSize: theme.gridUnit * 3,}}>
+                      {TRANSLATIONS.EMAIL_SUBJECT_ERROR_TEXT}
+            </div>)}
+
+          <div className="helper">
+          {t('Recipients are separated by "," or ";"')}
+        </div>
+        </StyledInputContainer>       
+        )
+          :
+        (
             <StyledInputContainer>
               <div className="control-label">
                 {t(
@@ -445,9 +551,9 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 )}
               </div>
             </StyledInputContainer>
-          </div>
-        </>
-      ) : null}
+        )
+      )
+      :null}
     </StyledNotificationMethod>
   );
 };

--- a/superset-frontend/src/features/alerts/types.ts
+++ b/superset-frontend/src/features/alerts/types.ts
@@ -50,6 +50,8 @@ export enum NotificationMethodOption {
 export type NotificationSetting = {
   method?: NotificationMethodOption;
   recipients: string;
+  cc?: string;
+  bcc?: string;
   options: NotificationMethodOption[];
 };
 
@@ -63,6 +65,8 @@ export type SlackChannel = {
 export type Recipient = {
   recipient_config_json: {
     target: string;
+    ccTarget?: string;
+    bccTarget?: string;
   };
   type: NotificationMethodOption;
 };

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -73,6 +73,8 @@ interface ReportProps {
   show: boolean;
   userId: number;
   userEmail: string;
+  ccEmail: string;
+  bccEmail: string;
   chart?: ChartState;
   chartName?: string;
   dashboardId?: number;
@@ -109,6 +111,8 @@ function ReportModal({
   chart,
   userId,
   userEmail,
+  ccEmail,
+  bccEmail,
   creationMethod,
   dashboardName,
   chartName,
@@ -184,7 +188,7 @@ function ReportModal({
       owners: [userId],
       recipients: [
         {
-          recipient_config_json: { target: userEmail },
+          recipient_config_json: { target: userEmail, ccTarget: ccEmail, bccTarget: bccEmail },
           type: 'Email',
         },
       ],

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -188,7 +188,11 @@ function ReportModal({
       owners: [userId],
       recipients: [
         {
-          recipient_config_json: { target: userEmail, ccTarget: ccEmail, bccTarget: bccEmail },
+          recipient_config_json: { 
+            target: userEmail,
+            ccTarget: ccEmail,
+            bccTarget: bccEmail
+          },
           type: 'Email',
         },
       ],

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -188,7 +188,7 @@ function ReportModal({
       owners: [userId],
       recipients: [
         {
-          recipient_config_json: { 
+          recipient_config_json: {
             target: userEmail,
             ccTarget: ccEmail,
             bccTarget: bccEmail,

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -191,7 +191,7 @@ function ReportModal({
           recipient_config_json: { 
             target: userEmail,
             ccTarget: ccEmail,
-            bccTarget: bccEmail
+            bccTarget: bccEmail,
           },
           type: 'Email',
         },

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -46,7 +46,7 @@ export interface ReportObject {
   name: string;
   owners: number[];
   recipients: [
-    { recipient_config_json: { target: string }; type: ReportRecipientType },
+    { recipient_config_json: { target: string, ccTarget: string, bccTarget:string }; type: ReportRecipientType },
   ];
   report_format: string;
   timezone: string;

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -46,7 +46,7 @@ export interface ReportObject {
   name: string;
   owners: number[];
   recipients: [
-    { 
+    {
       recipient_config_json: {
         target: string;
         ccTarget: string;

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -46,7 +46,14 @@ export interface ReportObject {
   name: string;
   owners: number[];
   recipients: [
-    { recipient_config_json: { target: string, ccTarget: string, bccTarget:string }; type: ReportRecipientType },
+    { 
+      recipient_config_json: {
+        target: string,
+        ccTarget: string,
+        bccTarget:string
+      };
+      type: ReportRecipientType;
+    },
   ];
   report_format: string;
   timezone: string;

--- a/superset-frontend/src/features/reports/types.ts
+++ b/superset-frontend/src/features/reports/types.ts
@@ -48,9 +48,9 @@ export interface ReportObject {
   recipients: [
     { 
       recipient_config_json: {
-        target: string,
-        ccTarget: string,
-        bccTarget:string
+        target: string;
+        ccTarget: string;
+        bccTarget: string;
       };
       type: ReportRecipientType;
     },

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -192,11 +192,11 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
-    
+
     def _get_cc(self) -> str:
         # To accomadate backward compatability
         return json.loads(self._recipient.recipient_config_json).get("ccTarget", "")
-    
+
     def _get_bcc(self) -> str:
         # To accomadate backward compatability
         return json.loads(self._recipient.recipient_config_json).get("bccTarget", "")

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -192,15 +192,28 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
 
     def _get_to(self) -> str:
         return json.loads(self._recipient.recipient_config_json)["target"]
+    
+    def _get_cc(self) -> str:
+        # To accomadate backward compatability
+        return json.loads(self._recipient.recipient_config_json).get("ccTarget", "")
+    
+    def _get_bcc(self) -> str:
+        # To accomadate backward compatability
+        return json.loads(self._recipient.recipient_config_json).get("bccTarget", "")
 
     @statsd_gauge("reports.email.send")
     def send(self) -> None:
         subject = self._get_subject()
         content = self._get_content()
         to = self._get_to()
+        cc = self._get_cc()
+        bcc = self._get_bcc()
+
         try:
             send_email_smtp(
                 to,
+                cc,
+                bcc,
                 subject,
                 content.body,
                 app.config,

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -212,8 +212,6 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
         try:
             send_email_smtp(
                 to,
-                cc,
-                bcc,
                 subject,
                 content.body,
                 app.config,
@@ -221,9 +219,10 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 data=content.data,
                 pdf=content.pdf,
                 images=content.images,
-                bcc="",
                 mime_subtype="related",
                 dryrun=False,
+                cc=cc,
+                bcc=bcc,
                 header_data=content.header_data,
             )
             logger.info(

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -123,6 +123,8 @@ class ValidatorConfigJSONSchema(Schema):
 class ReportRecipientConfigJSONSchema(Schema):
     # TODO if email check validity
     target = fields.String()
+    ccTarget = fields.String()
+    bccTarget = fields.String()
 
 
 class ReportRecipientSchema(Schema):

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -711,7 +711,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
     recipients = smtp_mail_to
     if cc:
         smtp_mail_cc = get_email_address_list(cc)
-        msg["CC"] = ", ".join(smtp_mail_cc)
+        msg["Cc"] = ", ".join(smtp_mail_cc)
         recipients = recipients + smtp_mail_cc
 
     smtp_mail_bcc = []

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -107,6 +107,19 @@ def get_target_from_report_schedule(report_schedule: ReportSchedule) -> list[str
         for recipient in report_schedule.recipients
     ]
 
+def get_cctarget_from_report_schedule(report_schedule: ReportSchedule) -> list[str]:
+    return [
+        json.loads(recipient.recipient_config_json).get("ccTarget", "")
+        for recipient in report_schedule.recipients
+    ]
+
+
+def get_bcctarget_from_report_schedule(report_schedule: ReportSchedule) -> list[str]:
+    return [
+        json.loads(recipient.recipient_config_json).get("bccTarget", "")
+        for recipient in report_schedule.recipients
+    ]
+    
 
 def get_error_logs_query(report_schedule: ReportSchedule) -> BaseQuery:
     return (
@@ -615,6 +628,65 @@ def create_invalid_sql_alert_email_chart(request, app_context: AppContext):
         yield report_schedule
 
         cleanup_report_schedule(report_schedule)
+
+@pytest.mark.usefixtures(
+    "load_birth_names_dashboard_with_slices", "create_report_email_chart"
+)
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
+def test_email_chart_report_schedule_withccbcc(
+    screenshot_mock,
+    email_mock,
+    create_report_email_chart,
+):
+    """
+    ExecuteReport Command: Test chart email report schedule with screenshot and email cc, bcc options
+    """
+    # setup screenshot mock
+    screenshot_mock.return_value = SCREENSHOT_FILE
+
+    with freeze_time("2020-01-01T00:00:00Z"):
+        AsyncExecuteReportScheduleCommand(
+            TEST_ID, create_report_email_chart.id, datetime.utcnow()
+        ).run()
+
+        notification_targets = get_target_from_report_schedule(
+            create_report_email_chart
+        )
+
+        notification_cctargets = get_cctarget_from_report_schedule(
+            create_report_email_chart
+        )
+
+        notification_bcctargets = get_bcctarget_from_report_schedule(
+            create_report_email_chart
+        )
+
+        # assert that the link sent is correct
+        assert (
+            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            f"{create_report_email_chart.chart.id}"
+            '%7D&force=false">Explore in Superset</a>' in email_mock.call_args[0][2]
+        )
+        # Assert the email smtp address
+        if notification_targets:
+            expected_targets = [target.strip() for target in notification_targets.split(",")]
+            assert email_mock.call_args[1].get("to", "").split(",") == expected_targets
+
+        # Assert the cc recipients if provided
+        if notification_cctargets:
+            expected_cc_targets = [target.strip() for target in notification_cctargets.split(",")]
+            assert email_mock.call_args[1].get("cc", "").split(",") == expected_cc_targets
+
+        if notification_bcctargets:
+            expected_bcc_targets = [target.strip() for target in notification_bcctargets.split(",")]
+            assert email_mock.call_args[1].get("bcc", "").split(",") == expected_bcc_targets
+
+        # Assert the email inline screenshot
+        smtp_images = email_mock.call_args[1]["images"]
+        assert smtp_images[list(smtp_images.keys())[0]] == SCREENSHOT_FILE
+        # Assert logs are correct
+        assert_log(ReportState.SUCCESS)
 
 
 @pytest.mark.usefixtures(

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -107,6 +107,7 @@ def get_target_from_report_schedule(report_schedule: ReportSchedule) -> list[str
         for recipient in report_schedule.recipients
     ]
 
+
 def get_cctarget_from_report_schedule(report_schedule: ReportSchedule) -> list[str]:
     return [
         json.loads(recipient.recipient_config_json).get("ccTarget", "")
@@ -119,7 +120,7 @@ def get_bcctarget_from_report_schedule(report_schedule: ReportSchedule) -> list[
         json.loads(recipient.recipient_config_json).get("bccTarget", "")
         for recipient in report_schedule.recipients
     ]
-    
+
 
 def get_error_logs_query(report_schedule: ReportSchedule) -> BaseQuery:
     return (
@@ -189,7 +190,10 @@ def create_report_email_chart():
 def create_report_email_chart_with_cc_and_bcc():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", ccTarget="cc@email.com", bccTarget="bcc@email.com", chart=chart
+        email_target="target@email.com",
+        ccTarget="cc@email.com",
+        bccTarget="bcc@email.com",
+        chart=chart,
     )
     yield report_schedule
 
@@ -640,8 +644,10 @@ def create_invalid_sql_alert_email_chart(request, app_context: AppContext):
 
         cleanup_report_schedule(report_schedule)
 
+
 @pytest.mark.usefixtures(
-    "load_birth_names_dashboard_with_slices", "create_report_email_chart_with_cc_and_bcc"
+    "load_birth_names_dashboard_with_slices",
+    "create_report_email_chart_with_cc_and_bcc",
 )
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -685,9 +691,7 @@ def test_email_chart_report_schedule_with_cc_bcc(
 
         # Assert the cc recipients if provided
         if notification_cctargets:
-            expected_cc_targets = [
-                target.strip() for target in notification_cctargets
-            ]
+            expected_cc_targets = [target.strip() for target in notification_cctargets]
             assert (
                 email_mock.call_args[1].get("cc", "").split(",") == expected_cc_targets
             )
@@ -697,7 +701,8 @@ def test_email_chart_report_schedule_with_cc_bcc(
                 target.strip() for target in notification_bcctargets
             ]
             assert (
-                email_mock.call_args[1].get("bcc", "").split(",") == expected_bcc_targets
+                email_mock.call_args[1].get("bcc", "").split(",")
+                == expected_bcc_targets
             )
 
         # Assert the email inline screenshot

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -140,7 +140,9 @@ def create_report_notification(
     else:
         recipient = ReportRecipients(
             type=ReportRecipientType.EMAIL,
-            recipient_config_json=json.dumps({"target": email_target,"ccTarget": ccTarget,"bccTarget": bccTarget}),
+            recipient_config_json=json.dumps(
+                {"target": email_target, "ccTarget": ccTarget, "bccTarget": bccTarget}
+            ),
         )
 
     if name is None:

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -116,6 +116,8 @@ def create_report_notification(
     extra: Optional[dict[str, Any]] = None,
     force_screenshot: bool = False,
     owners: Optional[list[User]] = None,
+    ccTarget: Optional[str] = None,
+    bccTarget: Optional[str] = None,
 ) -> ReportSchedule:
     if not owners:
         owners = [
@@ -138,7 +140,7 @@ def create_report_notification(
     else:
         recipient = ReportRecipients(
             type=ReportRecipientType.EMAIL,
-            recipient_config_json=json.dumps({"target": email_target}),
+            recipient_config_json=json.dumps({"target": email_target,"ccTarget": ccTarget,"bccTarget": bccTarget}),
         )
 
     if name is None:


### PR DESCRIPTION
### SUMMARY
Addition of an option to provide **cc and bcc list** for email notifications along with email validation under Alerts and Reports.

### SAMPLE SCREENSHOT

<img width="382" alt="image" src="https://github.com/apache/superset/assets/117266407/7ea6c02a-ec05-4a46-a887-2d7b25ee0322">


### TESTING INSTRUCTIONS

- Open Superset in browser > Click on the "Settings" menu on top right > Click on "Alerts & Reports"
- Create a new alert/report or edit an existing alert/report. Enter the required details.
- Select "Email" as the preferred notification method.
- Enter valid/invalid email ids in the To field, CC and BCC fields and hit add/save to test the feature.

### CONTRIBUTORS
nsivarajan, episkey24

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
