### PR TITLE
fix: Cypress CI process while opening PR from a fork

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -68,7 +68,6 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
           persist-credentials: false
           submodules: recursive
       - name: Checkout using ref (workflow_dispatch)

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Package's main module!"""
-
 from flask import current_app, Flask
 from werkzeug.local import LocalProxy
 


### PR DESCRIPTION
As observed in https://github.com/apache/superset/pull/28774 (thanks for catching this @rusackas), I broke the PR-from-fork in my recently merged PR here https://github.com/apache/superset/pull/29077 .

This PR removes special handling of `ref:` on github_event in (pull_request, push)