### PR TITLE
fix: Improving handling for tag relationship when deleting assets

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -150,11 +150,12 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
     )
     tags = relationship(
         "Tag",
-        overlaps="objects,tag,tags,tags",
+        overlaps="objects,tag,tags",
         secondary="tagged_object",
-        primaryjoin="and_(Dashboard.id == TaggedObject.object_id)",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id, "
+        primaryjoin="and_(Dashboard.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'dashboard')",
+        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
+        passive_deletes=True,
     )
     published = Column(Boolean, default=False)
     is_managed_externally = Column(Boolean, nullable=False, default=False)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -104,9 +104,10 @@ class Slice(  # pylint: disable=too-many-public-methods
         "Tag",
         secondary="tagged_object",
         overlaps="objects,tag,tags",
-        primaryjoin="and_(Slice.id == TaggedObject.object_id)",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id, "
+        primaryjoin="and_(Slice.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'chart')",
+        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
+        passive_deletes=True,
     )
     table = relationship(
         "SqlaTable",

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -415,10 +415,11 @@ class SavedQuery(
     tags = relationship(
         "Tag",
         secondary="tagged_object",
-        overlaps="tags",
-        primaryjoin="and_(SavedQuery.id == TaggedObject.object_id)",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id, "
+        overlaps="objects,tag,tags",
+        primaryjoin="and_(SavedQuery.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'query')",
+        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
+        passive_deletes=True,
     )
 
     export_parent = "database"


### PR DESCRIPTION
### SUMMARY
The relationship between the `tagged_objects` table and the asset table (for example, `dashboard`) is a combination of the `object_id` and `object_type`. While this relationship works properly when displaying tags/etc, when deleting an asset SQLAlchemy was trying to run `DELETE FROM tagged_object WHERE tagged_object.tag_id = ? AND tagged_object.object_id = ?` which would delete more rows then it should (it's missing another filter for `object_type`), causing the operation to fail with an error: 
```
sqlalchemy.orm.exc.StaleDataError: DELETE statement on table 'tagged_object' expected to delete 3 row(s); Only 10 were matched.
```

This PR adds the `passive_deletes=True` argument to the `relationship`, so that the cascade delete is handled by the DB (based on the constraints).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Make sure you have a dashboard and a chart with the same ID.
2. Assign a tag for both assets. Also add `owners` to both assets.
3. Validate that you're able to delete one of the assets.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
