### PR TITLE
fix(mixed-timeseries-plugin): Second query stacks stacked on top of first query series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -392,6 +392,7 @@ export default function transformProps(
         seriesType,
         showValue,
         stack: Boolean(stack),
+        stackIdSuffix: '_a',
         yAxisIndex,
         filterState,
         seriesKey: entry.name,
@@ -438,6 +439,7 @@ export default function transformProps(
         seriesType: seriesTypeB,
         showValue: showValueB,
         stack: Boolean(stackB),
+        stackIdSuffix: '_b',
         yAxisIndex: yAxisIndexB,
         filterState,
         seriesKey: primarySeries.has(entry.name as string)

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -392,7 +392,7 @@ export default function transformProps(
         seriesType,
         showValue,
         stack: Boolean(stack),
-        stackIdSuffix: '_a',
+        stackIdSuffix: '\na',
         yAxisIndex,
         filterState,
         seriesKey: entry.name,
@@ -439,7 +439,7 @@ export default function transformProps(
         seriesType: seriesTypeB,
         showValue: showValueB,
         stack: Boolean(stackB),
-        stackIdSuffix: '_b',
+        stackIdSuffix: '\nb',
         yAxisIndex: yAxisIndexB,
         filterState,
         seriesKey: primarySeries.has(entry.name as string)

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -151,6 +151,7 @@ export function transformSeries(
     areaOpacity?: number;
     seriesType?: EchartsTimeseriesSeriesType;
     stack?: StackType;
+    stackIdSuffix?: string;
     yAxisIndex?: number;
     showValue?: boolean;
     onlyTotal?: boolean;
@@ -179,6 +180,7 @@ export function transformSeries(
     areaOpacity = 1,
     seriesType,
     stack,
+    stackIdSuffix,
     yAxisIndex = 0,
     showValue,
     onlyTotal,
@@ -224,6 +226,9 @@ export function transformSeries(
     stackId = getTimeCompareStackId('obs', timeCompare, name);
   } else if (stack && isTrend) {
     stackId = getTimeCompareStackId(forecastSeries.type, timeCompare, name);
+  }
+  if (stackId && stackIdSuffix) {
+    stackId += stackIdSuffix;
   }
   let plotType;
   if (

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps, supersetTheme } from '@superset-ui/core';
+import {
+  LegendOrientation,
+  LegendType,
+  EchartsTimeseriesSeriesType,
+} from '@superset-ui/plugin-chart-echarts';
+import transformProps from '../../src/MixedTimeseries/transformProps';
+import {
+  EchartsMixedTimeseriesFormData,
+  EchartsMixedTimeseriesProps,
+} from '../../src/MixedTimeseries/types';
+
+const formData: EchartsMixedTimeseriesFormData = {
+  annotationLayers: [],
+  area: false,
+  areaB: false,
+  legendMargin: null,
+  logAxis: false,
+  logAxisSecondary: false,
+  markerEnabled: false,
+  markerEnabledB: false,
+  markerSize: 0,
+  markerSizeB: 0,
+  minorSplitLine: false,
+  minorTicks: false,
+  opacity: 0,
+  opacityB: 0,
+  orderDesc: false,
+  orderDescB: false,
+  richTooltip: false,
+  rowLimit: 0,
+  rowLimitB: 0,
+  legendOrientation: LegendOrientation.Top,
+  legendType: LegendType.Scroll,
+  showLegend: false,
+  showValue: false,
+  showValueB: false,
+  stack: true,
+  stackB: true,
+  truncateYAxis: false,
+  truncateYAxisSecondary: false,
+  xAxisLabelRotation: 0,
+  xAxisTitle: '',
+  xAxisTitleMargin: 0,
+  yAxisBounds: [undefined, undefined],
+  yAxisBoundsSecondary: [undefined, undefined],
+  yAxisTitle: '',
+  yAxisTitleMargin: 0,
+  yAxisTitlePosition: '',
+  yAxisTitleSecondary: '',
+  zoomable: false,
+  colorScheme: 'bnbColors',
+  datasource: '3__table',
+  x_axis: 'ds',
+  metrics: ['sum__num'],
+  metricsB: ['sum__num'],
+  groupby: ['gender'],
+  groupbyB: ['gender'],
+  seriesType: EchartsTimeseriesSeriesType.Line,
+  seriesTypeB: EchartsTimeseriesSeriesType.Bar,
+  viz_type: 'mixed_timeseries',
+  forecastEnabled: false,
+  forecastPeriods: [],
+  forecastInterval: 0,
+  forecastSeasonalityDaily: 0,
+};
+
+const queriesData = [
+  {
+    data: [
+      { boy: 1, girl: 2, ds: 599616000000 },
+      { boy: 3, girl: 4, ds: 599916000000 },
+    ],
+    label_map: {
+      ds: ['ds'],
+      boy: ['boy'],
+      girl: ['girl'],
+    },
+  },
+  {
+    data: [
+      { boy: 1, girl: 2, ds: 599616000000 },
+      { boy: 3, girl: 4, ds: 599916000000 },
+    ],
+    label_map: {
+      ds: ['ds'],
+      boy: ['boy'],
+      girl: ['girl'],
+    },
+  },
+];
+
+const chartPropsConfig = {
+  formData,
+  width: 800,
+  height: 600,
+  queriesData,
+  theme: supersetTheme,
+};
+
+it('should transform chart props for viz', () => {
+  const chartProps = new ChartProps(chartPropsConfig);
+  expect(transformProps(chartProps as EchartsMixedTimeseriesProps)).toEqual(
+    expect.objectContaining({
+      echartOptions: expect.objectContaining({
+        series: expect.arrayContaining([
+          expect.objectContaining({
+            data: [
+              [599616000000, 1],
+              [599916000000, 3],
+            ],
+            id: 'boy',
+            stack: 'obs_a',
+          }),
+          expect.objectContaining({
+            data: [
+              [599616000000, 2],
+              [599916000000, 4],
+            ],
+            id: 'girl',
+            stack: 'obs_a',
+          }),
+          expect.objectContaining({
+            data: [
+              [599616000000, 1],
+              [599916000000, 3],
+            ],
+            id: 'boy (1)',
+            stack: 'obs_b',
+          }),
+          expect.objectContaining({
+            data: [
+              [599616000000, 2],
+              [599916000000, 4],
+            ],
+            id: 'girl (1)',
+            stack: 'obs_b',
+          }),
+        ]),
+      }),
+    }),
+  );
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -128,7 +128,7 @@ it('should transform chart props for viz', () => {
               [599916000000, 3],
             ],
             id: 'boy',
-            stack: 'obs_a',
+            stack: 'obs\na',
           }),
           expect.objectContaining({
             data: [
@@ -136,7 +136,7 @@ it('should transform chart props for viz', () => {
               [599916000000, 4],
             ],
             id: 'girl',
-            stack: 'obs_a',
+            stack: 'obs\na',
           }),
           expect.objectContaining({
             data: [
@@ -144,7 +144,7 @@ it('should transform chart props for viz', () => {
               [599916000000, 3],
             ],
             id: 'boy (1)',
-            stack: 'obs_b',
+            stack: 'obs\nb',
           }),
           expect.objectContaining({
             data: [
@@ -152,7 +152,7 @@ it('should transform chart props for viz', () => {
               [599916000000, 4],
             ],
             id: 'girl (1)',
-            stack: 'obs_b',
+            stack: 'obs\nb',
           }),
         ]),
       }),


### PR DESCRIPTION
### SUMMARY
In Mixed Series chart, when user sets "Stack" option to true for both queries, the series of the second query are stacked on top of the series of the first query. The reason for that is that both queries could have the same stack ids.
This PR introduces `stackIdSuffix`, which adds `_a` and `_b` suffixes to stack ids of queries A and B to ensure that they're unique.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
In the screenshots - the bars represent the second query. Before, they were stacked on top of the series from 1st query.

Before:

<img width="1727" alt="image" src="https://github.com/apache/superset/assets/15073128/bc273c4d-89f4-4142-b8d0-14db324f27a0">

After:

<img width="1725" alt="image" src="https://github.com/apache/superset/assets/15073128/e2e649e2-43fe-464e-9dff-064aa5f874a4">

### TESTING INSTRUCTIONS
1. Create Mixed Series chart
2. Set Stack to true for both queries
3. Make sure that the series of both queries are stacked separately

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
