### PR TITLE
refactor: Upgrade Badge component to Ant Design 5

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -355,7 +355,7 @@ describe('Horizontal FilterBar', () => {
     applyNativeFilterValueWithIndex(8, testItems.filterDefaultValue);
     cy.get(nativeFilters.applyFilter).click({ force: true });
     cy.wait('@chart');
-    cy.get('.ant-scroll-number.ant-badge-count').should(
+    cy.get('.antd5-scroll-number.antd5-badge-count').should(
       'have.attr',
       'title',
       '1',

--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -48,7 +48,7 @@ export const profile = {
   favoritesSpace: '#rc-tabs-0-panel-2',
 };
 export const securityAccess = {
-  rolesBubble: '.ant-badge-count',
+  rolesBubble: '.antd5-badge-count',
 };
 export const homePage = {
   homeSection: {

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -1,3 +1,4 @@
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,3 @@
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -120,29 +120,7 @@ export const BadgeGallery = () => (
   </>
 );
 
-export const BadgeTextGallery = () => (
-  <AntdThemeProvider>
-    {COLORS.options.map(color => (
-      <Badge
-        text="Hello"
-        color={color}
-        key={color}
-        style={{ marginRight: '15px' }}
-      />
-    ))}
-  </AntdThemeProvider>
-);
-
 BadgeGallery.parameters = {
-  actions: {
-    disable: true,
-  },
-  controls: {
-    disable: true,
-  },
-};
-
-BadgeTextGallery.parameters = {
   actions: {
     disable: true,
   },

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -66,11 +66,13 @@ export const InteractiveBadge = (args: BadgeProps) => (
 );
 
 InteractiveBadge.args = {
-  count: null,
-  color: null,
+  count: undefined,
+  color: undefined,
   text: 'Text',
   status: 'success',
   size: 'default',
+  showZero: false,
+  overflowCount: 99,
 };
 
 InteractiveBadge.argTypes = {
@@ -79,6 +81,8 @@ InteractiveBadge.argTypes = {
       type: 'select',
     },
     options: [undefined, ...STATUSES],
+    description:
+      'only works if `count` is `undefined` (or is set to 0) and `color` is set to `undefined`',
   },
   size: {
     control: {
@@ -95,8 +99,19 @@ InteractiveBadge.argTypes = {
   count: {
     control: {
       type: 'select',
+      defaultValue: undefined,
     },
     options: [undefined, ...Array(100).keys()],
+    defaultValue: undefined,
+  },
+  showZero: {
+    control: 'boolean',
+    defaultValue: false,
+  },
+  overflowCount: {
+    control: 'number',
+    description:
+      'The threshold at which the number overflows with a `+` e.g if you set this to 10, and the value is 11, you get `11+`',
   },
 };
 
@@ -112,6 +127,7 @@ export const BadgeGallery = () => (
               size={size}
               key={`${color}_${size}`}
               style={{ marginRight: '15px' }}
+              showZero={showZero}
             />
           ))}
         </AntdThemeProvider>

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -127,7 +127,6 @@ export const BadgeGallery = () => (
               size={size}
               key={`${color}_${size}`}
               style={{ marginRight: '15px' }}
-              showZero={showZero}
             />
           ))}
         </AntdThemeProvider>

--- a/superset-frontend/src/components/Badge/Badge.stories.tsx
+++ b/superset-frontend/src/components/Badge/Badge.stories.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { AntdThemeProvider } from 'src/components/AntdThemeProvider';
 import Badge, { BadgeProps } from '.';
 
 export default {
@@ -58,13 +59,16 @@ const SIZES = {
   defaultValue: undefined,
 };
 
-export const InteractiveBadge = (args: BadgeProps) => <Badge {...args} />;
+export const InteractiveBadge = (args: BadgeProps) => (
+  <AntdThemeProvider>
+    <Badge {...args} />
+  </AntdThemeProvider>
+);
 
 InteractiveBadge.args = {
   count: null,
   color: null,
   text: 'Text',
-  textColor: null,
   status: 'success',
   size: 'default',
 };
@@ -88,12 +92,6 @@ InteractiveBadge.argTypes = {
     },
     options: [undefined, ...COLORS.options],
   },
-  textColor: {
-    control: {
-      type: 'select',
-    },
-    options: [undefined, ...COLORS.options],
-  },
   count: {
     control: {
       type: 'select',
@@ -107,22 +105,23 @@ export const BadgeGallery = () => (
     {SIZES.options.map(size => (
       <div key={size} style={{ marginBottom: 40 }}>
         <h4>{size}</h4>
-        {COLORS.options.map(color => (
-          <Badge
-            count={9}
-            textColor={color}
-            size={size}
-            key={`${color}_${size}`}
-            style={{ marginRight: '15px' }}
-          />
-        ))}
+        <AntdThemeProvider>
+          {COLORS.options.map(color => (
+            <Badge
+              count={9}
+              size={size}
+              key={`${color}_${size}`}
+              style={{ marginRight: '15px' }}
+            />
+          ))}
+        </AntdThemeProvider>
       </div>
     ))}
   </>
 );
 
 export const BadgeTextGallery = () => (
-  <>
+  <AntdThemeProvider>
     {COLORS.options.map(color => (
       <Badge
         text="Hello"
@@ -131,7 +130,7 @@ export const BadgeTextGallery = () => (
         style={{ marginRight: '15px' }}
       />
     ))}
-  </>
+  </AntdThemeProvider>
 );
 
 BadgeGallery.parameters = {

--- a/superset-frontend/src/components/Badge/Badge.test.tsx
+++ b/superset-frontend/src/components/Badge/Badge.test.tsx
@@ -22,7 +22,6 @@ import Badge from '.';
 const mockedProps = {
   count: 9,
   text: 'Text',
-  textColor: 'orange',
 };
 
 test('should render', () => {
@@ -38,12 +37,4 @@ test('should render the count', () => {
 test('should render the text', () => {
   render(<Badge {...mockedProps} />);
   expect(screen.getByText('Text')).toBeInTheDocument();
-});
-
-test('should render with the chosen textColor', () => {
-  render(<Badge {...mockedProps} />);
-  const badge = screen.getAllByText('9')[0];
-  expect(badge).toHaveStyle(`
-    color: 'orange';
-  `);
 });

--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -20,11 +20,9 @@ import { styled } from '@superset-ui/core';
 import { Badge as AntdBadge } from 'antd-v5';
 import { BadgeProps as AntdBadgeProps } from 'antd-v5/lib/badge';
 
-export interface BadgeProps extends AntdBadgeProps {
-  textColor?: string;
-}
+export type { AntdBadgeProps as BadgeProps };
 
-const Badge = styled((props: BadgeProps) => <AntdBadge {...props} />)`
+const Badge = styled((props: AntdBadgeProps) => <AntdBadge {...props} />)`
   ${({ theme, color, count }) => `
     & > sup,
     & > sup.antd5-badge-count {

--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -1,4 +1,3 @@
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -1,3 +1,4 @@
+
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -24,22 +25,10 @@ export interface BadgeProps extends AntdBadgeProps {
   textColor?: string;
 }
 
-const Badge = styled(
-  (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { textColor, color, text, ...props }: BadgeProps,
-  ) => (
-    <AntdBadge
-      text={text}
-      color={text ? color : undefined}
-      status={props.status || 'default'}
-      {...props}
-    />
-  ),
-)`
+const Badge = styled((props: BadgeProps) => <AntdBadge {...props} />)`
   ${({ theme, color, count }) => `
     & > sup,
-    & > sup.ant-badge-count {
+    & > sup.antd5-badge-count {
       ${
         count !== undefined
           ? `background: ${color || theme.colors.primary.base};`

--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -32,19 +32,21 @@ const Badge = styled(
     <AntdBadge
       text={text}
       color={text ? color : undefined}
-      classNames={{
-        root: 'superset-badge',
-      }}
+      status={props.status || 'default'}
       {...props}
     />
   ),
 )`
-  & > sup {
-    padding: 0 ${({ theme }) => theme.gridUnit * 2}px;
-    background: ${({ theme, color }) => color || theme.colors.primary.base};
-    color: ${({ theme, textColor }) =>
-      textColor || theme.colors.grayscale.light5};
-  }
+  ${({ theme, color, count }) => `
+    & > sup,
+    & > sup.ant-badge-count {
+      ${
+        count !== undefined
+          ? `background: ${color || theme.colors.primary.base};`
+          : ''
+      }
+    }
+  `}
 `;
 
 export default Badge;

--- a/superset-frontend/src/components/Badge/index.tsx
+++ b/superset-frontend/src/components/Badge/index.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import { styled } from '@superset-ui/core';
-import { Badge as AntdBadge } from 'antd';
-import { BadgeProps as AntdBadgeProps } from 'antd/lib/badge';
+import { Badge as AntdBadge } from 'antd-v5';
+import { BadgeProps as AntdBadgeProps } from 'antd-v5/lib/badge';
 
 export interface BadgeProps extends AntdBadgeProps {
   textColor?: string;
@@ -28,7 +28,16 @@ const Badge = styled(
   (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     { textColor, color, text, ...props }: BadgeProps,
-  ) => <AntdBadge text={text} color={text ? color : undefined} {...props} />,
+  ) => (
+    <AntdBadge
+      text={text}
+      color={text ? color : undefined}
+      classNames={{
+        root: 'superset-badge',
+      }}
+      {...props}
+    />
+  ),
 )`
   & > sup {
     padding: 0 ${({ theme }) => theme.gridUnit * 2}px;

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -94,7 +94,7 @@ const StyledTableTabs = styled(Tabs)`
 `;
 
 const StyledBadge = styled(Badge)`
-  .ant-badge-count {
+  .antd5-badge-count {
     line-height: ${({ theme }) => theme.gridUnit * 4}px;
     height: ${({ theme }) => theme.gridUnit * 4}px;
     margin-left: ${({ theme }) => theme.gridUnit}px;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -85,7 +85,12 @@ const StyledFilterCount = styled.div`
 const StyledBadge = styled(Badge)`
   ${({ theme }) => `
     margin-left: ${theme.gridUnit * 2}px;
+<<<<<<< Updated upstream
     &>sup.ant-badge-count {
+=======
+    &>sup.antd5-badge-count {
+      padding: 0 ${theme.gridUnit}px;
+>>>>>>> Stashed changes
       min-width: ${theme.gridUnit * 4}px;
       height: ${theme.gridUnit * 4}px;
       line-height: 1.5;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -84,16 +84,15 @@ const StyledFilterCount = styled.div`
 
 const StyledBadge = styled(Badge)`
   ${({ theme }) => `
-    vertical-align: middle;
     margin-left: ${theme.gridUnit * 2}px;
-    &>sup {
-      padding: 0 ${theme.gridUnit}px;
+    &>sup.ant-badge-count {
       min-width: ${theme.gridUnit * 4}px;
       height: ${theme.gridUnit * 4}px;
       line-height: 1.5;
       font-weight: ${theme.typography.weights.medium};
       font-size: ${theme.typography.sizes.s - 1}px;
       box-shadow: none;
+      padding: 0 ${theme.gridUnit}px;
     }
   `}
 `;

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -85,12 +85,8 @@ const StyledFilterCount = styled.div`
 const StyledBadge = styled(Badge)`
   ${({ theme }) => `
     margin-left: ${theme.gridUnit * 2}px;
-<<<<<<< Updated upstream
-    &>sup.ant-badge-count {
-=======
     &>sup.antd5-badge-count {
       padding: 0 ${theme.gridUnit}px;
->>>>>>> Stashed changes
       min-width: ${theme.gridUnit * 4}px;
       height: ${theme.gridUnit * 4}px;
       line-height: 1.5;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This was a Proof of Concept (POC) aiming to demonstrate the capability to upgrade Ant Design components to the latest version in isolation, facilitating incremental upgrades.

Two versions of Ant Design will be maintained until all components are upgraded to the latest version.

Please refer to the inline comments in this PR and the Superset Improvement Proposal https://github.com/apache/superset/issues/29268

This PR is dependent on PR https://github.com/apache/superset/pull/29328

Promoting this PR to a mergiable state.

### BEFORE
![340085271-92a84b90-7d3b-47cc-8895-fadaf673b3e4](https://github.com/apache/superset/assets/60598000/6b5b5a96-f732-496f-a5b0-d892fe1b7c53)

![340429169-6c6264ec-6780-48d9-bb40-8edab2ae2e92](https://github.com/apache/superset/assets/60598000/df34aaab-d796-42a2-b7bf-0c7fc84dc96e)


### AFTER
Note that the prop `textColor` has been removed as it was unused. 

![340085221-236370b1-69f9-46e4-97bf-37ce2842e06c](https://github.com/apache/superset/assets/60598000/ac8a953a-c3bb-4f45-845f-1b61ec2f6bd6)

![340429536-8910c99e-db52-428d-9a17-daece5d5e3ac](https://github.com/apache/superset/assets/60598000/3d62f6da-88fa-45e2-a0ca-cf32d9659e03)

### TESTING INSTRUCTIONS
1. Verify the usage of the Badge throughout the application.
2. Ensure no visual or behavioral changes have been introduced.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
