### PR TITLE
fix: Improving handling for tag relationship when deleting assets v2

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -155,7 +155,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         primaryjoin="and_(Dashboard.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'dashboard')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
-        viewonly=True,
+        viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )
     published = Column(Boolean, default=False)
     is_managed_externally = Column(Boolean, nullable=False, default=False)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -154,8 +154,8 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         secondary="tagged_object",
         primaryjoin="and_(Dashboard.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'dashboard')",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
-        passive_deletes=True,
+        secondaryjoin="TaggedObject.tag_id == Tag.id",
+        viewonly=True,
     )
     published = Column(Boolean, default=False)
     is_managed_externally = Column(Boolean, nullable=False, default=False)

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -107,7 +107,7 @@ class Slice(  # pylint: disable=too-many-public-methods
         primaryjoin="and_(Slice.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'chart')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
-        viewonly=True,
+        viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )
     table = relationship(
         "SqlaTable",

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -106,8 +106,8 @@ class Slice(  # pylint: disable=too-many-public-methods
         overlaps="objects,tag,tags",
         primaryjoin="and_(Slice.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'chart')",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
-        passive_deletes=True,
+        secondaryjoin="TaggedObject.tag_id == Tag.id",
+        viewonly=True,
     )
     table = relationship(
         "SqlaTable",

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -418,8 +418,8 @@ class SavedQuery(
         overlaps="objects,tag,tags",
         primaryjoin="and_(SavedQuery.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'query')",
-        secondaryjoin="and_(TaggedObject.tag_id == Tag.id)",
-        passive_deletes=True,
+        secondaryjoin="TaggedObject.tag_id == Tag.id",
+        viewonly=True,
     )
 
     export_parent = "database"

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -419,7 +419,7 @@ class SavedQuery(
         primaryjoin="and_(SavedQuery.id == TaggedObject.object_id, "
         "TaggedObject.object_type == 'query')",
         secondaryjoin="TaggedObject.tag_id == Tag.id",
-        viewonly=True,
+        viewonly=True,  # cascading deletion already handled by superset.tags.models.ObjectUpdater.after_delete
     )
 
     export_parent = "database"


### PR DESCRIPTION
### SUMMARY
This is a follow up for https://github.com/apache/superset/pull/29117, since it was confirmed on [this comment](https://github.com/apache/superset/pull/26654#issuecomment-2162050230) that the issue still persists.

I'm updating these relationships to `viewonly=True`, since there's already an `after_delete` hook in place to delete tag association after an asset is deleted - [reference](https://github.com/apache/superset/blob/master/superset/tags/models.py#L276-L290). With that in mind, handling the cascade deletion in the relationship is redundant.

Long-term, we could delete this hook and fix the relationships for a proper cascading deletion -- I'll look into that in a following PR (need to make sure that removing this hook won't impact any other logic in the application).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Make sure you have a dashboard and a chart with the same ID.
2. Assign a tag for both assets. Also add owners to both assets.
3. Validate that you're able to delete one of the assets.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
