### PR TITLE
feat: Support a dynamic minimum interval for alerts and reports

### DIFF
--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -207,7 +207,7 @@ REPORT_MINIMUM_INTERVAL = int(timedelta(minutes=5).total_seconds())
 Alternatively, you can assign a function to `ALERT_MINIMUM_INTERVAL` and/or `REPORT_MINIMUM_INTERVAL`. This is useful to dynamically retrieve a value as needed:
 
 ``` python
-def alert_dynamic_minimal_interval() -> int:
+def alert_dynamic_minimal_interval(**kwargs) -> int:
     """
     Define logic here to retrieve the value dynamically
     """

--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -204,6 +204,17 @@ ALERT_MINIMUM_INTERVAL = int(timedelta(minutes=10).total_seconds())
 REPORT_MINIMUM_INTERVAL = int(timedelta(minutes=5).total_seconds())
 ```
 
+Alternatively, you can assign a function to `ALERT_MINIMUM_INTERVAL` and/or `REPORT_MINIMUM_INTERVAL`. This is useful to dynamically retrieve a value as needed:
+
+``` python
+def alert_dynamic_minimal_interval() -> int:
+    """
+    Define logic here to retrieve the value dynamically
+    """
+
+ALERT_MINIMUM_INTERVAL = alert_dynamic_minimal_interval
+```
+
 ## Custom Dockerfile
 
 If you're running the dev version of a released Superset image, like `apache/superset:3.1.0-dev`, you should be set with the above.

--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -98,6 +98,8 @@ class BaseReportScheduleCommand(BaseCommand):
             else "REPORT_MINIMUM_INTERVAL"
         )
         minimum_interval = current_app.config.get(config_key, 0)
+        if callable(minimum_interval):
+            minimum_interval = minimum_interval()
 
         if not isinstance(minimum_interval, int):
             logger.error(

--- a/superset/config.py
+++ b/superset/config.py
@@ -1375,6 +1375,7 @@ ALERT_REPORTS_MIN_CUSTOM_SCREENSHOT_WIDTH = 600
 ALERT_REPORTS_MAX_CUSTOM_SCREENSHOT_WIDTH = 2400
 # Set a minimum interval threshold between executions (for each Alert/Report)
 # Value should be an integer i.e. int(timedelta(minutes=5).total_seconds())
+# You can also assign a function to the config that returns the expected integer
 ALERT_MINIMUM_INTERVAL = int(timedelta(minutes=0).total_seconds())
 REPORT_MINIMUM_INTERVAL = int(timedelta(minutes=0).total_seconds())
 

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -52,9 +52,17 @@ TEST_SCHEDULES_SINGLE_MINUTES = {
 TEST_SCHEDULES = TEST_SCHEDULES_EVERY_MINUTE.union(TEST_SCHEDULES_SINGLE_MINUTES)
 
 
+def dynamic_alert_minimum_interval() -> int:
+    return int(timedelta(minutes=10).total_seconds())
+
+
+def dynamic_report_minimum_interval() -> int:
+    return int(timedelta(minutes=5).total_seconds())
+
+
 def app_custom_config(
-    alert_minimum_interval: int | str = 0,
-    report_minimum_interval: int | str = 0,
+    alert_minimum_interval: int | str | Callable[[], int] = 0,
+    report_minimum_interval: int | str | Callable[[], int] = 0,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Decorator to mock the current_app.config values dynamically for each test.
@@ -253,3 +261,25 @@ def test_validate_report_frequency_invalid_config(
         f"invalid value for {report_type}_MINIMUM_INTERVAL: 10 minutes"
     )
     assert expected_error_message.lower() in caplog.text.lower()
+
+
+@app_custom_config(
+    alert_minimum_interval=dynamic_alert_minimum_interval,
+    report_minimum_interval=dynamic_report_minimum_interval,
+)
+def test_validate_report_frequency_using_callable() -> None:
+    """
+    Test the ``validate_report_frequency`` method when the config
+    values are set to a function.
+    """
+    with pytest.raises(ReportScheduleFrequencyNotAllowed):
+        BaseReportScheduleCommand().validate_report_frequency(
+            "1,10 * * * *",
+            ReportScheduleType.ALERT,
+        )
+
+    with pytest.raises(ReportScheduleFrequencyNotAllowed):
+        BaseReportScheduleCommand().validate_report_frequency(
+            "1,5 * * * *",
+            ReportScheduleType.REPORT,
+        )

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -272,14 +272,26 @@ def test_validate_report_frequency_using_callable() -> None:
     Test the ``validate_report_frequency`` method when the config
     values are set to a function.
     """
+    # Should fail with a 9 minutes interval, and work with 10
     with pytest.raises(ReportScheduleFrequencyNotAllowed):
         BaseReportScheduleCommand().validate_report_frequency(
             "1,10 * * * *",
             ReportScheduleType.ALERT,
         )
 
+    BaseReportScheduleCommand().validate_report_frequency(
+        "1,11 * * * *",
+        ReportScheduleType.ALERT,
+    )
+
+    # Should fail with a 4 minutes interval, and work with 5
     with pytest.raises(ReportScheduleFrequencyNotAllowed):
         BaseReportScheduleCommand().validate_report_frequency(
             "1,5 * * * *",
             ReportScheduleType.REPORT,
         )
+
+    BaseReportScheduleCommand().validate_report_frequency(
+        "1,6 * * * *",
+        ReportScheduleType.REPORT,
+    )

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -52,11 +52,11 @@ TEST_SCHEDULES_SINGLE_MINUTES = {
 TEST_SCHEDULES = TEST_SCHEDULES_EVERY_MINUTE.union(TEST_SCHEDULES_SINGLE_MINUTES)
 
 
-def dynamic_alert_minimum_interval() -> int:
+def dynamic_alert_minimum_interval(**kwargs) -> int:
     return int(timedelta(minutes=10).total_seconds())
 
 
-def dynamic_report_minimum_interval() -> int:
+def dynamic_report_minimum_interval(**kwargs) -> int:
     return int(timedelta(minutes=5).total_seconds())
 
 


### PR DESCRIPTION
### SUMMARY
This PR adds the ability to control the `ALERT_MINIMUM_INTERVAL` and/or `REPORT_MINIMUM_INTERVAL` configs dynamically (rather than having it statically defined during runtime). This is useful in case the value should be dynamically changed/evaluated on demand (you might want to control it externally).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added unit tests to make sure the config supports both an `integer` and a `callable`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
