### PR TITLE
chore(deps): Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -394,21 +394,33 @@ couchbase://{username}:{password}@{hostname}:{port}?truststorepath={certificate 
 
 #### CrateDB
 
-The recommended connector library for CrateDB is
-[crate](https://pypi.org/project/crate/).
-You need to install the extras as well for this library.
-We recommend adding something like the following
-text to your requirements file:
-
+The connector library for CrateDB is [sqlalchemy-cratedb].
+We recommend to add the following item to your `requirements.txt` file:
 ```
 sqlalchemy-cratedb>=0.40.1,<1
 ```
 
-The expected connection string is formatted as follows:
-
+An SQLAlchemy connection string for [CrateDB Self-Managed] on localhost,
+for evaluation purposes, looks like this:
 ```
 crate://crate@127.0.0.1:4200
 ```
+An SQLAlchemy connection string for connecting to [CrateDB Cloud] looks like
+this:
+```
+crate://<username>:<password>@<clustername>.cratedb.net:4200/?ssl=true
+```
+
+Follow the steps [here](/docs/configuration/databases#installing-database-drivers)
+to install the CrateDB connector package when setting up Superset locally using
+Docker Compose.
+```
+echo "sqlalchemy-cratedb" >> ./docker/requirements-local.txt
+```
+
+[CrateDB Cloud]: https://cratedb.com/product/cloud
+[CrateDB Self-Managed]: https://cratedb.com/product/self-managed
+[sqlalchemy-cratedb]: https://pypi.org/project/sqlalchemy-cratedb/
 
 
 #### Databend

--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -401,7 +401,7 @@ We recommend adding something like the following
 text to your requirements file:
 
 ```
-crate[sqlalchemy]==0.26.0
+sqlalchemy-cratedb>=0.40.1,<1
 ```
 
 The expected connection string is formatted as follows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ bigquery = [
 clickhouse = ["clickhouse-connect>=0.5.14, <1.0"]
 cockroachdb = ["cockroachdb>=0.3.5, <0.4"]
 cors = ["flask-cors>=2.0.0"]
-crate = ["crate[sqlalchemy]>=0.26.0, <0.27"]
+crate = ["sqlalchemy-cratedb>=0.40.1, <1"]
 databend = ["databend-sqlalchemy>=0.3.2, <1.0"]
 databricks = [
     "databricks-sql-connector>=2.0.2, <3",


### PR DESCRIPTION
### SUMMARY
- The CrateDB SQLAlchemy dialect needs more love, so it was separated from the DBAPI HTTP driver.
- This patch concludes the update to the new designated CrateDB SQLAlchemy dialect package, [`sqlalchemy-cratedb`](https://pypi.org/project/sqlalchemy-cratedb/), which has been validated on a few other downstream packages already.
- The patch also updates the documentation section about configuring the CrateDB connector driver ([preview](https://github.com/apache/superset/blob/aef7f2dd1ff8853642eda2fdd3e5bbae4277f142/docs/docs/configuration/databases.mdx#cratedb)).

### Personal Message
Dear Superset maintainers, first things first: Thanks a stack for conceiving and maintaining Apache Superset, you know who you are. Hereby, we are submitting a little update about the database adapter of CrateDB. With kind regards, Andreas.

May we ask you to approve running the software tests on this draft PR, so we can get an impression if anything breaks?


/cc @hammerhead, @hlcianfagna, @surister