### PR TITLE
fix(sqllab): Do not strip comments when executing SQL statements

### DIFF
--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -60,7 +60,6 @@ class SqlQueryRenderImpl(SqlQueryRender):
 
             parsed_query = ParsedQuery(
                 query_model.sql,
-                strip_comments=True,
                 engine=query_model.database.db_engine_spec.engine,
             )
             rendered_query = sql_template_processor.process_template(

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -573,9 +573,9 @@ class TestSqlLab(SupersetTestCase):
         assert data["status"] == "success"
 
         data = self.run_sql(
-            "SELECT * FROM birth_names WHERE state = '{{ state }}' -- blabblah {{ extra1 }} {{fake.fn()}}\nLIMIT 10",
+            "SELECT * FROM birth_names WHERE state = '{{ state }}' -- blabblah {{ extra1 }}\nLIMIT 10",
             "3",
-            template_params=json.dumps({"state": "CA"}),
+            template_params=json.dumps({"state": "CA", "extra1": "comment"}),
         )
         assert data["status"] == "success"
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Man, the SQL Lab execution/parsing logic is a real rabbit warren—so many methods and diversions to execute SQL.

https://github.com/apache/superset/pull/27725 _attempted_ to remove stripping comments when executing queries in SQL Lab, however it likely wasn't suffice. https://github.com/apache/superset/pull/28363 (which also preventing stripping of comments in Explore) remedied this, however it was later reverted in https://github.com/apache/superset/pull/28567.

The original issue with https://github.com/apache/superset/pull/27725 is it seems like the SQL is pre-processed/rendered in the command prior to the typical SQL Lab execution logic via Celery et al. This PR simply ensures that comments are never stripped within the context of SQL Lab. This change shouldn't cause the issue surfaced in https://github.com/apache/superset/pull/28567.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. The relevant tests were updated using logic from https://github.com/apache/superset/pull/28363.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
