### PR TITLE
docs: remove comment header in README.md

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -35,6 +35,7 @@ apache_superset.egg-info
 # Generated doc files
 env/*
 docs/.htaccess*
+docs/src/intro_header.txt
 .nojekyll
 _build/*
 _static/*

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -35,7 +35,6 @@ apache_superset.egg-info
 # Generated doc files
 env/*
 docs/.htaccess*
-docs/src/intro_header.txt
 .nojekyll
 _build/*
 _static/*
@@ -72,3 +71,4 @@ snowflake.svg
 # docs-related
 erd.puml
 erd.svg
+intro_header.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-hide_title: true
-sidebar_position: 1
----
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,13 +5,13 @@
   "license": "Apache-2.0",
   "scripts": {
     "docusaurus": "docusaurus",
-    "_init": "cp ../README.md docs/intro.md",
+    "_init": "cat src/intro_header.txt ../README.md > docs/intro.md",
     "start": "npm run _init && docusaurus start",
     "build": "npm run _init && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "npm run _init && docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"

--- a/docs/src/intro_header.txt
+++ b/docs/src/intro_header.txt
@@ -1,0 +1,4 @@
+---
+hide_title: true
+sidebar_position: 1
+---


### PR DESCRIPTION
### SUMMARY

In https://github.com/apache/superset/pull/28285 I muddied the README with markdown metadata header. The goal was to re-use the README.md in the Documentation, and on that side the header is needed, but adds artifacts on the GitHub side. This fixes it.
