### PR TITLE
fix(sqllab): excessive API calls for schemas

### DIFF
--- a/superset-frontend/src/hooks/apiResources/catalogs.ts
+++ b/superset-frontend/src/hooks/apiResources/catalogs.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import useEffectEvent from 'src/hooks/useEffectEvent';
 import { api, JsonResponse } from './queryApi';
 
@@ -68,7 +68,6 @@ export const {
 export const EMPTY_CATALOGS = [] as CatalogOption[];
 
 export function useCatalogs(options: Params) {
-  const isMountedRef = useRef(false);
   const { dbId, onSuccess, onError } = options || {};
   const [trigger] = useLazyCatalogsQuery();
   const result = useCatalogsQuery(
@@ -88,6 +87,10 @@ export function useCatalogs(options: Params) {
     onError?.();
   });
 
+  const resolver = useEffectEvent(() =>
+    result.currentData ? undefined : trigger({ dbId, forceRefresh: false }),
+  );
+
   const refetch = useCallback(() => {
     if (dbId) {
       trigger({ dbId, forceRefresh: true }).then(
@@ -104,21 +107,17 @@ export function useCatalogs(options: Params) {
   }, [dbId, handleOnError, handleOnSuccess, trigger]);
 
   useEffect(() => {
-    if (isMountedRef.current) {
-      const { requestId, isSuccess, isError, isFetching, data, originalArgs } =
-        result;
-      if (!originalArgs?.forceRefresh && requestId && !isFetching) {
+    if (dbId) {
+      resolver()?.then(({ isSuccess, isError, data }) => {
         if (isSuccess) {
           handleOnSuccess(data || EMPTY_CATALOGS, false);
         }
         if (isError) {
           handleOnError();
         }
-      }
-    } else {
-      isMountedRef.current = true;
+      });
     }
-  }, [result, handleOnSuccess, handleOnError]);
+  }, [dbId, result, handleOnSuccess, handleOnError, resolver]);
 
   return {
     ...result,

--- a/superset-frontend/src/hooks/apiResources/schemas.test.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.test.ts
@@ -88,7 +88,7 @@ describe('useSchemas hook', () => {
         })}`,
       ).length,
     ).toBe(1);
-    expect(onSuccess).toHaveBeenCalledTimes(2);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
     act(() => {
       result.current.refetch();
     });
@@ -100,7 +100,7 @@ describe('useSchemas hook', () => {
         })}`,
       ).length,
     ).toBe(1);
-    expect(onSuccess).toHaveBeenCalledTimes(3);
+    expect(onSuccess).toHaveBeenCalledTimes(2);
     expect(result.current.data).toEqual(expectedResult);
   });
 
@@ -149,28 +149,36 @@ describe('useSchemas hook', () => {
       },
     );
 
-    await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+    await waitFor(() =>
+      expect(result.current.currentData).toEqual(expectedResult),
+    );
     expect(fetchMock.calls(schemaApiRoute).length).toBe(1);
-    expect(onSuccess).toHaveBeenCalledTimes(2);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
 
     rerender({ dbId: 'db2' });
-    await waitFor(() => expect(result.current.data).toEqual(expectedResult2));
+    await waitFor(() =>
+      expect(result.current.currentData).toEqual(expectedResult2),
+    );
     expect(fetchMock.calls(schemaApiRoute).length).toBe(2);
-    expect(onSuccess).toHaveBeenCalledTimes(4);
+    expect(onSuccess).toHaveBeenCalledTimes(2);
 
     rerender({ dbId: expectDbId });
-    await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+    await waitFor(() =>
+      expect(result.current.currentData).toEqual(expectedResult),
+    );
     expect(fetchMock.calls(schemaApiRoute).length).toBe(2);
-    expect(onSuccess).toHaveBeenCalledTimes(5);
+    expect(onSuccess).toHaveBeenCalledTimes(2);
 
     // clean up cache
     act(() => {
       store.dispatch(api.util.invalidateTags(['Schemas']));
     });
 
-    await waitFor(() => expect(fetchMock.calls(schemaApiRoute).length).toBe(3));
+    await waitFor(() => expect(fetchMock.calls(schemaApiRoute).length).toBe(4));
     expect(fetchMock.calls(schemaApiRoute)[2][0]).toContain(expectDbId);
-    await waitFor(() => expect(result.current.data).toEqual(expectedResult));
+    await waitFor(() =>
+      expect(result.current.currentData).toEqual(expectedResult),
+    );
   });
 
   test('returns correct schema list by a catalog', async () => {
@@ -201,7 +209,7 @@ describe('useSchemas hook', () => {
 
     await waitFor(() => expect(fetchMock.calls(schemaApiRoute).length).toBe(1));
     expect(result.current.data).toEqual(expectedResult3);
-    expect(onSuccess).toHaveBeenCalledTimes(2);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
 
     rerender({ dbId, catalog: 'catalog2' });
     await waitFor(() => expect(fetchMock.calls(schemaApiRoute).length).toBe(2));


### PR DESCRIPTION
### SUMMARY
Currently, the refresh logic for schemas is being triggered excessively due to unnecessary dependencies, causing it to be called every time a tab is switched.

This commit addresses the issue by modifying the logic to execute only when a trigger is needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/b0ba7b17-1c7a-4d0e-aa9b-1e2fcaa5604b

After:

https://github.com/apache/superset/assets/1392866/a785f3fe-3d04-4c1b-a574-34783d6c496c

### TESTING INSTRUCTIONS

Switch the tabs between the same db selected tabs
Check the network tab and then only schemas called once

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
