### PR TITLE
chore: use json codec for key value lock

### DIFF
--- a/superset/utils/lock.py
+++ b/superset/utils/lock.py
@@ -26,7 +26,7 @@ from typing import Any, cast, TypeVar, Union
 
 from superset.exceptions import CreateKeyValueDistributedLockFailedException
 from superset.key_value.exceptions import KeyValueCreateFailedError
-from superset.key_value.types import KeyValueResource, PickleKeyValueCodec
+from superset.key_value.types import JsonKeyValueCodec, KeyValueResource
 from superset.utils import json
 
 LOCK_EXPIRATION = timedelta(seconds=30)
@@ -83,7 +83,7 @@ def KeyValueDistributedLock(  # pylint: disable=invalid-name
         DeleteExpiredKeyValueCommand(resource=KeyValueResource.LOCK).run()
         CreateKeyValueCommand(
             resource=KeyValueResource.LOCK,
-            codec=PickleKeyValueCodec(),
+            codec=JsonKeyValueCodec(),
             key=key,
             value=True,
             expires_on=datetime.now() + LOCK_EXPIRATION,

--- a/tests/unit_tests/utils/lock_tests.py
+++ b/tests/unit_tests/utils/lock_tests.py
@@ -42,7 +42,7 @@ def test_KeyValueDistributedLock_happy_path(mocker: MockerFixture) -> None:
     DeleteExpiredKeyValueCommand = mocker.patch(
         "superset.commands.key_value.delete_expired.DeleteExpiredKeyValueCommand"
     )
-    PickleKeyValueCodec = mocker.patch("superset.utils.lock.PickleKeyValueCodec")
+    JsonKeyValueCodec = mocker.patch("superset.utils.lock.JsonKeyValueCodec")
 
     with freeze_time("2024-01-01"):
         with KeyValueDistributedLock("ns", a=1, b=2) as key:
@@ -51,7 +51,7 @@ def test_KeyValueDistributedLock_happy_path(mocker: MockerFixture) -> None:
             )
             CreateKeyValueCommand.assert_called_with(
                 resource=KeyValueResource.LOCK,
-                codec=PickleKeyValueCodec(),
+                codec=JsonKeyValueCodec(),
                 key=key,
                 value=True,
                 expires_on=datetime(2024, 1, 1, 0, 0, 30),


### PR DESCRIPTION
### SUMMARY
When working on something unrelated I noticed that we're unnecessarily using the `PickleKeyValueCodec` for the key value distributed lock feature. This replaces it with `JsonKeyValueCodec`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
