### PR TITLE
fix: filters not updating with force update when caching is enabled

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -175,7 +175,7 @@ const FilterValue: FC<FilterControlProps> = ({
       setIsRefreshing(true);
       getChartDataRequest({
         formData: newFormData,
-        force: false,
+        force: shouldRefresh,
         ownState: filterOwnState,
       })
         .then(({ response, json }) => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Currently, when you have caching enabled and you click "refresh dashboard" it only updates the charts but not the filters. This is despite the filters having a loading spinner next to them.

### TESTING INSTRUCTIONS
1. Setup Superset with caching
2. Create a dataset with a simple table and create any chart and add it to a dashboard. Add a filter to the dashboard - could be the values of one of the columns. Insert a new row to the table with a new value for the column you have created a filter for.
3. Force refresh the dashboard using "refresh dashboard" in the upper right hand corner. 

You will see your chart updating, but not the filter. 

### ADDITIONAL INFORMATION

- [x] Has associated issue:
https://github.com/apache/superset/issues/25893
https://github.com/apache/superset/issues/21234
