### PR TITLE
fix(metastore-cache): prune before add

### DIFF
--- a/superset/extensions/metastore_cache.py
+++ b/superset/extensions/metastore_cache.py
@@ -101,6 +101,7 @@ class SupersetMetastoreCache(BaseCache):
         from superset.commands.key_value.create import CreateKeyValueCommand
 
         try:
+            self._prune()
             CreateKeyValueCommand(
                 resource=RESOURCE,
                 value=value,
@@ -108,7 +109,6 @@ class SupersetMetastoreCache(BaseCache):
                 key=self.get_key(key),
                 expires_on=self._get_expiry(timeout),
             ).run()
-            self._prune()
             return True
         except KeyValueCreateFailedError:
             return False


### PR DESCRIPTION
### SUMMARY
Currently the Metastore cache deletes expired entries _after_ trying to add a new entry. If an expired entry exists with the same key, this will cause the operation to fail. This PR fixes the issue, and adds a new test that would previously have failed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
