### PR TITLE
chore(distributed-lock): refactor tests

### DIFF
--- a/superset/commands/key_value/get.py
+++ b/superset/commands/key_value/get.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import logging
-from datetime import datetime
 from typing import Any, Optional, Union
 from uuid import UUID
 
@@ -67,6 +66,6 @@ class GetKeyValueCommand(BaseCommand):
     def get(self) -> Optional[Any]:
         filter_ = get_filter(self.resource, self.key)
         entry = db.session.query(KeyValueEntry).filter_by(**filter_).first()
-        if entry and (entry.expires_on is None or entry.expires_on > datetime.now()):
+        if entry and not entry.is_expired():
             return self.codec.decode(entry.value)
         return None

--- a/superset/key_value/models.py
+++ b/superset/key_value/models.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime
+
 from flask_appbuilder import Model
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, LargeBinary, String
 from sqlalchemy.orm import relationship
@@ -38,3 +40,6 @@ class KeyValueEntry(AuditMixinNullable, ImportExportMixin, Model):
     changed_by_fk = Column(Integer, ForeignKey("ab_user.id"), nullable=True)
     created_by = relationship(security_manager.user_model, foreign_keys=[created_by_fk])
     changed_by = relationship(security_manager.user_model, foreign_keys=[changed_by_fk])
+
+    def is_expired(self) -> bool:
+        return self.expires_on is not None and self.expires_on <= datetime.now()

--- a/superset/utils/lock.py
+++ b/superset/utils/lock.py
@@ -53,6 +53,10 @@ def serialize(params: dict[str, Any]) -> str:
     return json.dumps(params)
 
 
+def get_key(namespace: str, **kwargs: Any) -> uuid.UUID:
+    return uuid.uuid5(uuid.uuid5(uuid.NAMESPACE_DNS, namespace), serialize(kwargs))
+
+
 @contextmanager
 def KeyValueDistributedLock(  # pylint: disable=invalid-name
     namespace: str,
@@ -77,7 +81,7 @@ def KeyValueDistributedLock(  # pylint: disable=invalid-name
     from superset.commands.key_value.delete import DeleteKeyValueCommand
     from superset.commands.key_value.delete_expired import DeleteExpiredKeyValueCommand
 
-    key = uuid.uuid5(uuid.uuid5(uuid.NAMESPACE_DNS, namespace), serialize(kwargs))
+    key = get_key(namespace, **kwargs)
     logger.debug("Acquiring lock on namespace %s for key %s", namespace, key)
     try:
         DeleteExpiredKeyValueCommand(resource=KeyValueResource.LOCK).run()


### PR DESCRIPTION
### SUMMARY
This PR refactors the distributed lock tests in the following way:
1. Replace assertions of mocked internals with assertions of the functional aspects of the lock
2. Assert that the lock state is committed to the metastore during the locking process

This will make it safer to refactor SQLAlchemy session logic in accordance with [SIP-99A](#25107), as the test will ensure that commits happen at the critical moments (lock is taken, lock is released). In addition, it makes the test immune to refactoring of internals of the lock.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
