### PR TITLE
fix: permission issue with SElinux

### DIFF
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -27,7 +27,7 @@ x-superset-depends-on: &superset-depends-on
   - redis
 x-superset-volumes:
   &superset-volumes # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
-  - ./docker:/app/docker
+  - ./docker:/app/docker:z
   - superset_home:/app/superset_home
 
 version: "3.7"
@@ -50,7 +50,7 @@ services:
     restart: unless-stopped
     volumes:
       - db_home:/var/lib/postgresql/data
-      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
 
   superset:
     env_file:

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -26,7 +26,7 @@ x-superset-depends-on: &superset-depends-on
   - redis
 x-superset-volumes:
   &superset-volumes # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
-  - ./docker:/app/docker
+  - ./docker:/app/docker:z
   - superset_home:/app/superset_home
 
 x-common-build: &common-build
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
     volumes:
       - db_home:/var/lib/postgresql/data
-      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
 
   superset:
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ x-superset-depends-on: &superset-depends-on
   - redis
 x-superset-volumes: &superset-volumes
   # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
-  - ./docker:/app/docker
+  - ./docker:/app/docker:z
   - ./superset:/app/superset
   - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
@@ -72,7 +72,7 @@ services:
       - "127.0.0.1:5432:5432"
     volumes:
       - db_home:/var/lib/postgresql/data
-      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
 
   superset:
     env_file:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While installing `superset` on RedHat I got a bunch of `Permission denied`. Looking a bit around (e.g. [1](https://prefetch.net/blog/2017/09/30/using-docker-volumes-on-selinux-enabled-servers/), [2](https://www.redhat.com/sysadmin/container-permission-denied-errors), or [3](https://stackoverflow.com/questions/60680394/docker-compose-using-with-selinux)), it seems it is a known issue between `docker-compose` and SELinux. The suggested solution (add `:z`) worked for me.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Install `superset` with `docker compose` on Redhat.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
