### PR TITLE
fix: Remove recursive repr call

### DIFF
--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -28,7 +28,7 @@ class CommandException(SupersetException):
     def __repr__(self) -> str:
         if self._exception:
             return repr(self._exception)
-        return repr(self)
+        return repr(super())
 
 
 class ObjectNotFoundError(CommandException):

--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -28,7 +28,7 @@ class CommandException(SupersetException):
     def __repr__(self) -> str:
         if self._exception:
             return repr(self._exception)
-        return repr(super())
+        return super().__repr__()
 
 
 class ObjectNotFoundError(CommandException):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This repr call is recursive:
```
  File \"/opt/superset/lib/python3.11/site-packages/superset/commands/exceptions.py\", line 31, in __repr__
    return repr(self)
           ^^^^^^^^^^
  File \"/opt/superset/lib/python3.11/site-packages/superset/commands/exceptions.py\", line 31, in __repr__
    return repr(self)
           ^^^^^^^^^^
  File \"/opt/superset/lib/python3.11/site-packages/superset/commands/exceptions.py\", line 31, in __repr__
    return repr(self)
           ^^^^^^^^^^
  [Previous line repeated 321 more times]"}
```

Causing the error not to be printed.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Demonstration:
```
>>> class Parent():
...     def __init__(self, x):
...         self.x = x
...     def __repr__(self):
...         return 'Parent: ' + self.x
>>> Parent('0')
Parent: 0

>>> class Child(Parent):
...     def __repr__(self):
...         return repr(self)
>>> Child('1')
Traceback (most recent call last):
  File "<stdin>", line 3, in __repr__
  File "<stdin>", line 3, in __repr__
  File "<stdin>", line 3, in __repr__
  [Previous line repeated 2495 more times]
RecursionError: maximum recursion depth exceeded


>>> class Child(Parent):
...     def __repr__(self):
...         return super().__repr__()
>>> Child('2')
Parent: 2
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
