### PR TITLE
fix(Query): Parse html string error responses to avoid displaying raw HTML as error message

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
@@ -136,7 +136,7 @@ export function parseErrorJson(responseJson: JsonObject): ClientErrorObject {
     }
     if (typeof error.message === 'string') {
       if (checkForHtml(error.message)) {
-        error.error = t(retrieveErrorMessage(error.message, error));
+        error.error = retrieveErrorMessage(error.message, error);
       } else {
         error.error = error.message;
       }
@@ -246,7 +246,7 @@ export function getClientErrorObject(
             resolve({
               // Destructuring not necessary here
               ...responseObject,
-              error: t(retrieveErrorMessage(errorText, responseObject)),
+              error: retrieveErrorMessage(errorText, responseObject),
             });
           });
         });
@@ -262,7 +262,7 @@ export function getClientErrorObject(
     }
     resolve({
       ...responseObject,
-      error: t(parseStringResponse(error)),
+      error: parseStringResponse(error),
     });
   });
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
@@ -61,7 +61,7 @@ export function parseErrorString(response: string): string {
     if (/404|not found/i.test(response)) {
       return t('Not found');
     }
-    return t('Server error');
+    return t('Internal error');
   }
   return response;
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
@@ -193,7 +193,7 @@ export function getClientErrorObject(
         });
       return;
     }
-    // check response http status code for generic error return
+    // check response http status code and return a generic error message
     if ((response as any).status) {
       const { status } = response as any;
       const error = ERROR_CODE_LOOKUP[status];

--- a/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
@@ -193,24 +193,18 @@ export function getClientErrorObject(
         });
       return;
     }
-    // check response http status code and return a generic error message
-    if ((response as any).status) {
-      const { status } = response as any;
-      const error = ERROR_CODE_LOOKUP[status];
-      if (error) {
-        resolve({
-          error,
-        });
-        return;
-      }
-    }
 
     // fall back to Response.statusText or generic error of we cannot read the response
     let error = (response as any).statusText || (response as any).message;
     if (!error) {
-      // eslint-disable-next-line no-console
-      console.error('non-standard error:', response);
-      error = t('An error occurred');
+      // check response http status code and return a generic error message
+      const { status } = response as any;
+      error = ERROR_CODE_LOOKUP[status];
+      if (!error) {
+        // eslint-disable-next-line no-console
+        console.error('non-standard error:', response);
+        error = t('An error occurred');
+      }
     }
     resolve({
       ...responseObject,

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -22,6 +22,8 @@ import {
   sanitizeHtmlIfNeeded,
   safeHtmlSpan,
   removeHTMLTags,
+  isJsonString,
+  getParagraphContents,
 } from './html';
 
 describe('sanitizeHtml', () => {
@@ -111,5 +113,79 @@ describe('removeHTMLTags', () => {
     const input = '<div><h1>Unclosed tag';
     const output = removeHTMLTags(input);
     expect(output).toBe('Unclosed tag');
+  });
+});
+
+describe('isJsonString', () => {
+  test('valid JSON object', () => {
+    const jsonString = '{"name": "John", "age": 30, "city": "New York"}';
+    expect(isJsonString(jsonString)).toBe(true);
+  });
+
+  test('valid JSON array', () => {
+    const jsonString = '[1, 2, 3, 4, 5]';
+    expect(isJsonString(jsonString)).toBe(true);
+  });
+
+  test('valid JSON string', () => {
+    const jsonString = '"Hello, world!"';
+    expect(isJsonString(jsonString)).toBe(true);
+  });
+
+  test('invalid JSON with syntax error', () => {
+    const jsonString = '{"name": "John", "age": 30, "city": "New York"';
+    expect(isJsonString(jsonString)).toBe(false);
+  });
+
+  test('empty string', () => {
+    const jsonString = '';
+    expect(isJsonString(jsonString)).toBe(false);
+  });
+
+  test('non-JSON string', () => {
+    const jsonString = '<p>Hello, <strong>World!</strong></p>';
+    expect(isJsonString(jsonString)).toBe(false);
+  });
+
+  test('non-JSON formatted number', () => {
+    const jsonString = '12345abc';
+    expect(isJsonString(jsonString)).toBe(false);
+  });
+});
+
+describe('getParagraphContents', () => {
+  test('should return an object with keys for each paragraph tag', () => {
+    const htmlString =
+      '<div><p>First paragraph.</p><p>Second paragraph.</p></div>';
+    const result = getParagraphContents(htmlString);
+    expect(result).toEqual({
+      p1: 'First paragraph.',
+      p2: 'Second paragraph.',
+    });
+  });
+
+  test('should return null if the string is not HTML', () => {
+    const nonHtmlString = 'Just a plain text string.';
+    expect(getParagraphContents(nonHtmlString)).toBeNull();
+  });
+
+  test('should return null if there are no <p> tags in the HTML string', () => {
+    const htmlStringWithoutP = '<div><span>No paragraph here.</span></div>';
+    expect(getParagraphContents(htmlStringWithoutP)).toBeNull();
+  });
+
+  test('should return an object with empty string for empty <p> tag', () => {
+    const htmlStringWithEmptyP = '<div><p></p></div>';
+    const result = getParagraphContents(htmlStringWithEmptyP);
+    expect(result).toEqual({ p1: '' });
+  });
+
+  test('should handle HTML strings with nested <p> tags correctly', () => {
+    const htmlStringWithNestedP =
+      '<div><p>First paragraph <span>with nested</span> content.</p></div>';
+    const result = getParagraphContents(htmlStringWithNestedP);
+    expect(result).toEqual({
+      p1: 'First paragraph with nested content.',
+    });
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -44,10 +44,26 @@ export function sanitizeHtml(htmlString: string) {
   return xssFilter.process(htmlString);
 }
 
+export function hasHtmlTagPattern(str: string): boolean {
+  const htmlTagPattern =
+    /<(html|head|body|div|span|a|p|h[1-6]|title|meta|link|script|style)/i;
+
+  return htmlTagPattern.test(str);
+}
+
 export function isProbablyHTML(text: string) {
-  return Array.from(
-    new DOMParser().parseFromString(text, 'text/html').body.childNodes,
-  ).some(({ nodeType }) => nodeType === 1);
+  const cleanedStr = text.trim().toLowerCase();
+
+  if (
+    cleanedStr.startsWith('<!doctype html>') &&
+    hasHtmlTagPattern(cleanedStr)
+  ) {
+    return true;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(cleanedStr, 'text/html');
+  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {
@@ -69,4 +85,37 @@ export function safeHtmlSpan(possiblyHtmlString: string) {
 
 export function removeHTMLTags(str: string): string {
   return str.replace(/<[^>]*>/g, '');
+}
+
+export function isJsonString(str: string): boolean {
+  try {
+    JSON.parse(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function getParagraphContents(
+  str: string,
+): { [key: string]: string } | null {
+  if (!isProbablyHTML(str)) {
+    return null;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(str, 'text/html');
+  const pTags = doc.querySelectorAll('p');
+
+  if (pTags.length === 0) {
+    return null;
+  }
+
+  const paragraphContents: { [key: string]: string } = {};
+
+  pTags.forEach((pTag, index) => {
+    paragraphContents[`p${index + 1}`] = pTag.textContent || '';
+  });
+
+  return paragraphContents;
 }

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -25,19 +25,59 @@ import {
   ErrorTypeEnum,
 } from '@superset-ui/core';
 
-it('Returns a Promise', () => {
+test('Returns a Promise', () => {
   const response = getClientErrorObject('error');
   expect(response instanceof Promise).toBe(true);
 });
 
-it('Returns a Promise that resolves to an object with an error key', async () => {
+test('Returns a Promise that resolves to an object with an error key', async () => {
   const error = 'error';
 
   const errorObj = await getClientErrorObject(error);
   expect(errorObj).toMatchObject({ error });
 });
 
-it('Handles Response that can be parsed as json', async () => {
+test('should handle HTML response with "500" or "server error"', async () => {
+  const htmlString500 = '<div>500: Internal Server Error</div>';
+  const clientErrorObject500 = await getClientErrorObject(htmlString500);
+  expect(clientErrorObject500).toEqual({ error: 'Server error' });
+
+  const htmlStringServerError = '<div>Server error message</div>';
+  const clientErrorObjectServerError = await getClientErrorObject(
+    htmlStringServerError,
+  );
+  expect(clientErrorObjectServerError).toEqual({
+    error: 'Server error',
+  });
+});
+
+test('should handle HTML response with "404" or "not found"', async () => {
+  const htmlString404 = '<div>404: Page not found</div>';
+  const clientErrorObject404 = await getClientErrorObject(htmlString404);
+  expect(clientErrorObject404).toEqual({ error: 'Page not found' });
+
+  const htmlStringNotFoundError = '<div>Not found message</div>';
+  const clientErrorObjectNotFoundError = await getClientErrorObject(
+    htmlStringNotFoundError,
+  );
+  expect(clientErrorObjectNotFoundError).toEqual({
+    error: 'Page not found',
+  });
+});
+
+test('should handle HTML response without common error code', async () => {
+  const htmlString = '<!doctype html><div>Foo bar Lorem Ipsum</div>';
+  const clientErrorObject = await getClientErrorObject(htmlString);
+  expect(clientErrorObject).toEqual({ error: 'Server error' });
+
+  const htmlString2 = '<div><p>An error occurred</p></div>';
+  const clientErrorObject2 = await getClientErrorObject(htmlString2);
+  expect(clientErrorObject2).toEqual({
+    error: 'Server error',
+  });
+});
+
+test('Handles Response that can be parsed as json', async () => {
   const jsonError = { something: 'something', error: 'Error message' };
   const jsonErrorString = JSON.stringify(jsonError);
 
@@ -45,7 +85,7 @@ it('Handles Response that can be parsed as json', async () => {
   expect(errorObj).toMatchObject(jsonError);
 });
 
-it('Handles backwards compatibility between old error messages and the new SIP-40 errors format', async () => {
+test('Handles backwards compatibility between old error messages and the new SIP-40 errors format', async () => {
   const jsonError = {
     errors: [
       {
@@ -63,14 +103,14 @@ it('Handles backwards compatibility between old error messages and the new SIP-4
   expect(errorObj.link).toEqual(jsonError.errors[0].extra.link);
 });
 
-it('Handles Response that can be parsed as text', async () => {
+test('Handles Response that can be parsed as text', async () => {
   const textError = 'Hello I am a text error';
 
   const errorObj = await getClientErrorObject(new Response(textError));
   expect(errorObj).toMatchObject({ error: textError });
 });
 
-it('Handles TypeError Response', async () => {
+test('Handles TypeError Response', async () => {
   const error = new TypeError('Failed to fetch');
 
   // @ts-ignore
@@ -78,7 +118,7 @@ it('Handles TypeError Response', async () => {
   expect(errorObj).toMatchObject({ error: 'Network error' });
 });
 
-it('Handles timeout error', async () => {
+test('Handles timeout error', async () => {
   const errorObj = await getClientErrorObject({
     timeout: 1000,
     statusText: 'timeout',
@@ -110,14 +150,14 @@ it('Handles timeout error', async () => {
   });
 });
 
-it('Handles plain text as input', async () => {
+test('Handles plain text as input', async () => {
   const error = 'error';
 
   const errorObj = await getClientErrorObject(error);
   expect(errorObj).toMatchObject({ error });
 });
 
-it('Handles error with status text and message', async () => {
+test('Handles error with status text and message', async () => {
   const statusText = 'status';
   const message = 'message';
 
@@ -135,7 +175,7 @@ it('Handles error with status text and message', async () => {
   });
 });
 
-it('getClientErrorMessage', () => {
+test('getClientErrorMessage', () => {
   expect(getClientErrorMessage('error')).toEqual('error');
   expect(
     getClientErrorMessage('error', {
@@ -150,7 +190,7 @@ it('getClientErrorMessage', () => {
   ).toEqual('error:\nclient error');
 });
 
-it('parseErrorJson with message', () => {
+test('parseErrorJson with message', () => {
   expect(parseErrorJson({ message: 'error message' })).toEqual({
     message: 'error message',
     error: 'error message',
@@ -181,7 +221,7 @@ it('parseErrorJson with message', () => {
   });
 });
 
-it('parseErrorJson with stacktrace', () => {
+test('parseErrorJson with stacktrace', () => {
   expect(
     parseErrorJson({ error: 'error message', stack: 'stacktrace' }),
   ).toEqual({
@@ -204,7 +244,7 @@ it('parseErrorJson with stacktrace', () => {
   });
 });
 
-it('parseErrorJson with CSRF', () => {
+test('parseErrorJson with CSRF', () => {
   expect(
     parseErrorJson({
       responseText: 'CSRF',
@@ -215,7 +255,7 @@ it('parseErrorJson with CSRF', () => {
   });
 });
 
-it('getErrorText', async () => {
+test('getErrorText', async () => {
   expect(await getErrorText('error', 'dashboard')).toEqual(
     'Sorry, there was an error saving this dashboard: error',
   );

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -164,6 +164,15 @@ test('Handles plain text as input', async () => {
   expect(errorObj).toMatchObject({ error });
 });
 
+test('Handles error with status code', async () => {
+  const status = 500;
+
+  // @ts-ignore
+  expect(await getClientErrorObject({ status })).toMatchObject({
+    error: 'Server error',
+  });
+});
+
 test('Handles error with status text and message', async () => {
   const statusText = 'status';
   const message = 'message';

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -263,6 +263,29 @@ test('parseErrorJson with HTML message', () => {
   });
 });
 
+test('parseErrorJson with HTML message and status code', () => {
+  expect(
+    parseErrorJson({
+      status: 502,
+      message: '<div>error message</div>',
+    }),
+  ).toEqual({
+    status: 502,
+    message: '<div>error message</div>',
+    error: 'Bad gateway',
+  });
+  expect(
+    parseErrorJson({
+      status: 999,
+      message: '<div>Server error</div>',
+    }),
+  ).toEqual({
+    status: 999,
+    message: '<div>Server error</div>',
+    error: 'Server error',
+  });
+});
+
 test('parseErrorJson with stacktrace', () => {
   expect(
     parseErrorJson({ error: 'error message', stack: 'stacktrace' }),

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -54,14 +54,14 @@ test('should handle HTML response with "500" or "server error"', async () => {
 test('should handle HTML response with "404" or "not found"', async () => {
   const htmlString404 = '<div>404: Page not found</div>';
   const clientErrorObject404 = await getClientErrorObject(htmlString404);
-  expect(clientErrorObject404).toEqual({ error: 'Page not found' });
+  expect(clientErrorObject404).toEqual({ error: 'Not found' });
 
   const htmlStringNotFoundError = '<div>Not found message</div>';
   const clientErrorObjectNotFoundError = await getClientErrorObject(
     htmlStringNotFoundError,
   );
   expect(clientErrorObjectNotFoundError).toEqual({
-    error: 'Page not found',
+    error: 'Not found',
   });
 });
 
@@ -104,6 +104,13 @@ test('Handles backwards compatibility between old error messages and the new SIP
 });
 
 test('Handles Response that can be parsed as text', async () => {
+  const textError = 'Hello I am a text error';
+
+  const errorObj = await getClientErrorObject(new Response(textError));
+  expect(errorObj).toMatchObject({ error: textError });
+});
+
+test('Handles Response that contains raw html be parsed as text', async () => {
   const textError = 'Hello I am a text error';
 
   const errorObj = await getClientErrorObject(new Response(textError));
@@ -218,6 +225,17 @@ test('parseErrorJson with message', () => {
   ).toEqual({
     message: {},
     error: 'Invalid input',
+  });
+});
+
+test('parseErrorJson with HTML message', () => {
+  expect(
+    parseErrorJson({
+      message: '<div>error message</div>',
+    }),
+  ).toEqual({
+    message: '<div>error message</div>',
+    error: 'Server error',
   });
 });
 

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -68,12 +68,12 @@ test('should handle HTML response with "404" or "not found"', async () => {
 test('should handle HTML response without common error code', async () => {
   const htmlString = '<!doctype html><div>Foo bar Lorem Ipsum</div>';
   const clientErrorObject = await getClientErrorObject(htmlString);
-  expect(clientErrorObject).toEqual({ error: 'Server error' });
+  expect(clientErrorObject).toEqual({ error: 'Internal error' });
 
   const htmlString2 = '<div><p>An error occurred</p></div>';
   const clientErrorObject2 = await getClientErrorObject(htmlString2);
   expect(clientErrorObject2).toEqual({
-    error: 'Server error',
+    error: 'Internal error',
   });
 });
 
@@ -235,7 +235,7 @@ test('parseErrorJson with HTML message', () => {
     }),
   ).toEqual({
     message: '<div>error message</div>',
-    error: 'Server error',
+    error: 'Internal error',
   });
 });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a function to check if a string is HTML and not capable of JSON parsing to ensure the client does not show raw HTML where there should be an error message.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Change the return of the `ChartDataRestApi` response for a `POST` method to be an error with the `message` `kwarg ` containing raw html in string form. e.g. `self.response_500(message='<html><div>Error</div></html>')`
2. Load a dashboard, and click `See more` on the unexpected error alert produced by charts.
3. The message displayed should be `Server error` or, in the case of a detected 404, `Not found`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
