### PR TITLE
chore(e2e): simplify Cypress record key usage

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,9 +63,12 @@ github:
         # combination here.
         contexts:
           - lint-check
+          - cypress-matrix (0, chrome)
           - cypress-matrix (1, chrome)
           - cypress-matrix (2, chrome)
           - cypress-matrix (3, chrome)
+          - cypress-matrix (4, chrome)
+          - cypress-matrix (5, chrome)
           - frontend-build
           - pre-commit
           - python-lint

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -130,7 +130,7 @@ jobs:
           CYPRESS_BROWSER: ${{ matrix.browser }}
           PARALLEL_ID: ${{ matrix.parallel_id }}
           PARALLELISM: 6
-          CYPRESS_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
           run: cypress-run-all ${{ env.USE_DASHBOARD }}
       - name: Upload Artifacts

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -137,5 +137,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'workflow_dispatch' && (steps.check.outputs.python || steps.check.outputs.frontend)
         with:
-          name: screenshots
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
+          name: cypress-artifact-${{ github.run_id }}-${{ github.job }}

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -55,7 +55,6 @@ def get_cypress_cmd(
 
     if use_dashboard:
         # Run using cypress.io service
-        os.environ["CYPRESS_RECORD_KEY"] = os.getenv("CYPRESS_RECORD_KEY", "")
         spec: str = "*/**/*"
         cmd = (
             f"{XVFB_PRE_CMD} "

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -66,7 +66,7 @@ def get_cypress_cmd(
         )
     else:
         # Run local, but split the execution
-        os.environ.pop("CYPRESS_KEY", None)
+        os.environ.pop("CYPRESS_RECORD_KEY", None)
         spec_list_str = ",".join(sorted(spec_list))
         if _filter:
             spec_list_str = ",".join(sorted([s for s in spec_list if _filter in s]))

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -24,7 +24,7 @@ from datetime import datetime
 XVFB_PRE_CMD = "xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' "
 REPO = os.getenv("GITHUB_REPOSITORY") or "apache/superset"
 GITHUB_EVENT_NAME = os.getenv("GITHUB_REPOSITORY") or "push"
-CYPRESS_RECORD_KEY = os.getenv("CYPRESS_RECORD_KEY") or "push"
+CYPRESS_RECORD_KEY = os.getenv("CYPRESS_RECORD_KEY") or ""
 
 
 def compute_hash(file_path: str) -> str:

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -66,6 +66,7 @@ def get_cypress_cmd(
         )
     else:
         # Run local, but split the execution
+        os.environ.pop("CYPRESS_KEY", None)
         spec_list_str = ",".join(sorted(spec_list))
         if _filter:
             spec_list_str = ",".join(sorted([s for s in spec_list if _filter in s]))

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -61,7 +61,7 @@ def get_cypress_cmd(
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{spec}" --browser {browser} '
             f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
-            f"--parallel --ci-build-id {build_id}"
+            f"--parallel --ci-build-id {build_id} "
             f"--key {CYPRESS_RECORD_KEY}"
         )
     else:

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -24,6 +24,7 @@ from datetime import datetime
 XVFB_PRE_CMD = "xvfb-run --auto-servernum --server-args='-screen 0, 1024x768x24' "
 REPO = os.getenv("GITHUB_REPOSITORY") or "apache/superset"
 GITHUB_EVENT_NAME = os.getenv("GITHUB_REPOSITORY") or "push"
+CYPRESS_RECORD_KEY = os.getenv("CYPRESS_RECORD_KEY") or "push"
 
 
 def compute_hash(file_path: str) -> str:
@@ -61,6 +62,7 @@ def get_cypress_cmd(
             f'{cypress_cmd} --spec "{spec}" --browser {browser} '
             f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
             f"--parallel --ci-build-id {build_id}"
+            f"--key {CYPRESS_RECORD_KEY}"
         )
     else:
         # Run local, but split the execution

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -64,7 +64,6 @@ def get_cypress_cmd(
         )
     else:
         # Run local, but split the execution
-        os.environ.pop("CYPRESS_RECORD_KEY", None)
         spec_list_str = ",".join(sorted(spec_list))
         if _filter:
             spec_list_str = ",".join(sorted([s for s in spec_list if _filter in s]))

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -56,13 +56,12 @@ def get_cypress_cmd(
 
     if use_dashboard:
         # Run using cypress.io service
-        spec: str = "*/**/*"
+        spec: str = "cypress/e2e/*/**/*"
         cmd = (
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{spec}" --browser {browser} '
             f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
-            f"--parallel --ci-build-id {build_id} "
-            f"--key {CYPRESS_RECORD_KEY}"
+            f"--parallel --ci-build-id {build_id}"
         )
     else:
         # Run local, but split the execution

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -55,12 +55,7 @@ def get_cypress_cmd(
 
     if use_dashboard:
         # Run using cypress.io service
-        cypress_key = os.getenv("CYPRESS_KEY")
-        command = f"echo {cypress_key} | base64 --decode"
-        cypress_record_key = (
-            subprocess.check_output(command, shell=True).decode("utf-8").strip()
-        )
-        os.environ["CYPRESS_RECORD_KEY"] = cypress_record_key
+        os.environ["CYPRESS_RECORD_KEY"] = os.getenv("CYPRESS_RECORD_KEY", "")
         spec: str = "*/**/*"
         cmd = (
             f"{XVFB_PRE_CMD} "
@@ -70,7 +65,7 @@ def get_cypress_cmd(
         )
     else:
         # Run local, but split the execution
-        os.environ.pop("CYPRESS_KEY", None)
+        os.environ.pop("CYPRESS_RECORD_KEY", None)
         spec_list_str = ",".join(sorted(spec_list))
         if _filter:
             spec_list_str = ",".join(sorted([s for s in spec_list if _filter in s]))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Cypress Record Key on the repo secrets is no longer base-64 encoded, so there's no need for this decoding. We also might as well just _call it_ the CYPRESS_RECORD_KEY everywhere to match the name of the repo secret, for sanity's sake.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
