### PR TITLE
feat: Add Ant Design 5 Theme 

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -122,6 +122,7 @@
     "abortcontroller-polyfill": "^1.1.9",
     "ace-builds": "^1.4.14",
     "antd": "4.10.3",
+    "antd-v5": "npm:antd@^5.18.0",
     "babel-plugin-typescript-to-proptypes": "^2.0.0",
     "bootstrap": "^3.4.1",
     "brace": "^0.11.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -160,6 +160,7 @@
     "polished": "^4.3.1",
     "prop-types": "^15.7.2",
     "query-string": "^6.13.7",
+    "rc-trigger": "^5.3.4",
     "re-resizable": "^6.9.11",
     "react": "^16.13.1",
     "react-ace": "^10.1.0",

--- a/superset-frontend/src/components/AntdThemeProvider/index.tsx
+++ b/superset-frontend/src/components/AntdThemeProvider/index.tsx
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { ConfigProvider, type ConfigProviderProps } from 'antd-v5';
 import { getTheme, ThemeType } from 'src/theme/index';
 

--- a/superset-frontend/src/components/AntdThemeProvider/index.tsx
+++ b/superset-frontend/src/components/AntdThemeProvider/index.tsx
@@ -1,0 +1,8 @@
+import { ConfigProvider, type ConfigProviderProps } from 'antd-v5';
+import { getTheme, ThemeType } from 'src/theme/index';
+
+export const AntdThemeProvider = ({ theme, children }: ConfigProviderProps) => (
+  <ConfigProvider theme={theme || getTheme(ThemeType.LIGHT)} prefixCls="antd5">
+    {children}
+  </ConfigProvider>
+);

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { type ThemeConfig } from 'antd-v5';
 import { theme as supersetTheme } from 'src/preamble';
 import { lightAlgorithm } from './light';

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -1,0 +1,50 @@
+import { type ThemeConfig } from 'antd-v5';
+import { theme as supersetTheme } from 'src/preamble';
+import { lightAlgorithm } from './light';
+
+export enum ThemeType {
+  LIGHT = 'light',
+}
+
+const themes = {
+  [ThemeType.LIGHT]: lightAlgorithm,
+};
+
+const baseConfig: ThemeConfig = {
+  token: {
+    borderRadius: supersetTheme.borderRadius,
+    colorBgBase: supersetTheme.colors.primary.light4,
+    colorError: supersetTheme.colors.error.base,
+    colorInfo: supersetTheme.colors.info.base,
+    colorLink: supersetTheme.colors.grayscale.dark1,
+    colorPrimary: supersetTheme.colors.primary.base,
+    colorSuccess: supersetTheme.colors.success.base,
+    colorTextBase: supersetTheme.colors.grayscale.dark2,
+    colorWarning: supersetTheme.colors.warning.base,
+    controlHeight: supersetTheme.gridUnit * 32,
+    fontFamily: supersetTheme.typography.families.sansSerif,
+    fontFamilyCode: supersetTheme.typography.families.monospace,
+    fontSize: supersetTheme.typography.sizes.m,
+    lineType: 'solid',
+    lineWidth: 1,
+    sizeStep: supersetTheme.gridUnit,
+    sizeUnit: supersetTheme.gridUnit,
+    zIndexBase: 0,
+    zIndexPopupBase: supersetTheme.zIndex.max,
+  },
+  components: {
+    Badge: {
+      paddingXS: supersetTheme.gridUnit * 2,
+    },
+    Card: {
+      colorBgContainer: supersetTheme.colors.grayscale.light4,
+      paddingLG: supersetTheme.gridUnit * 6,
+      fontWeightStrong: supersetTheme.typography.weights.medium,
+    },
+  },
+};
+
+export const getTheme = (themeType?: ThemeType) => ({
+  ...baseConfig,
+  algorithm: themes[themeType || ThemeType.LIGHT],
+});

--- a/superset-frontend/src/theme/light.ts
+++ b/superset-frontend/src/theme/light.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { type MappingAlgorithm, theme } from 'antd-v5';
 import { theme as supersetTheme } from 'src/preamble';
 

--- a/superset-frontend/src/theme/light.ts
+++ b/superset-frontend/src/theme/light.ts
@@ -1,0 +1,100 @@
+import { type MappingAlgorithm, theme } from 'antd-v5';
+import { theme as supersetTheme } from 'src/preamble';
+
+export const lightAlgorithm: MappingAlgorithm = seedToken => {
+  const defaultTokens = theme.defaultAlgorithm(seedToken);
+  return {
+    // Map Tokens
+    ...defaultTokens,
+    borderRadiusLG: supersetTheme.borderRadius,
+    borderRadiusOuter: supersetTheme.borderRadius,
+    borderRadiusSM: supersetTheme.borderRadius,
+    borderRadiusXS: supersetTheme.borderRadius,
+
+    colorBgContainer: supersetTheme.colors.primary.light4,
+    colorBgElevated: supersetTheme.colors.primary.base,
+    colorBgLayout: supersetTheme.colors.grayscale.light4,
+    colorBgMask: supersetTheme.colors.grayscale.light2,
+    colorBgSpotlight: supersetTheme.colors.grayscale.dark1,
+
+    colorBorder: supersetTheme.colors.grayscale.light2,
+    colorBorderSecondary: supersetTheme.colors.grayscale.light3,
+
+    colorErrorActive: supersetTheme.colors.error.dark1,
+    colorErrorBg: supersetTheme.colors.error.light2,
+    colorErrorBgActive: supersetTheme.colors.error.light1,
+    colorErrorBgHover: supersetTheme.colors.error.light2,
+    colorErrorBorder: supersetTheme.colors.error.light1,
+    colorErrorBorderHover: supersetTheme.colors.error.light1,
+    colorErrorHover: supersetTheme.colors.error.base,
+    colorErrorText: supersetTheme.colors.error.base,
+    colorErrorTextActive: supersetTheme.colors.error.dark1,
+    colorErrorTextHover: supersetTheme.colors.error.base,
+
+    colorFill: supersetTheme.colors.grayscale.light4,
+    colorFillSecondary: supersetTheme.colors.grayscale.light2,
+    colorFillTertiary: supersetTheme.colors.grayscale.light3,
+
+    colorInfoActive: supersetTheme.colors.info.dark1,
+    colorInfoBg: supersetTheme.colors.info.light2,
+    colorInfoBgHover: supersetTheme.colors.info.light1,
+    colorInfoBorder: supersetTheme.colors.info.light1,
+    colorInfoBorderHover: supersetTheme.colors.info.dark1,
+    colorInfoHover: supersetTheme.colors.info.dark1,
+    colorInfoText: supersetTheme.colors.info.dark1,
+    colorInfoTextActive: supersetTheme.colors.info.dark2,
+    colorInfoTextHover: supersetTheme.colors.info.dark1,
+
+    colorLinkActive: supersetTheme.colors.info.dark2,
+    colorLinkHover: supersetTheme.colors.info.dark1,
+
+    colorPrimaryActive: supersetTheme.colors.primary.dark2,
+    colorPrimaryBg: supersetTheme.colors.primary.light4,
+    colorPrimaryBgHover: supersetTheme.colors.primary.light3,
+    colorPrimaryBorder: supersetTheme.colors.primary.light2,
+    colorPrimaryBorderHover: supersetTheme.colors.primary.light1,
+    colorPrimaryHover: supersetTheme.colors.primary.dark1,
+    colorPrimaryText: supersetTheme.colors.primary.dark1,
+    colorPrimaryTextActive: supersetTheme.colors.primary.dark2,
+    colorPrimaryTextHover: supersetTheme.colors.primary.dark1,
+
+    colorSuccessActive: supersetTheme.colors.success.dark1,
+    colorSuccessBg: supersetTheme.colors.success.light2,
+    colorSuccessBgHover: supersetTheme.colors.success.light1,
+    colorSuccessBorder: supersetTheme.colors.success.light1,
+    colorSuccessBorderHover: supersetTheme.colors.success.dark1,
+    colorSuccessHover: supersetTheme.colors.success.dark1,
+    colorSuccessText: supersetTheme.colors.success.dark1,
+    colorSuccessTextActive: supersetTheme.colors.success.dark2,
+    colorSuccessTextHover: supersetTheme.colors.success.dark1,
+
+    colorText: supersetTheme.colors.grayscale.dark2,
+    colorTextQuaternary: supersetTheme.colors.grayscale.light1,
+    colorTextSecondary: supersetTheme.colors.text.label,
+    colorTextTertiary: supersetTheme.colors.text.help,
+
+    colorWarningActive: supersetTheme.colors.warning.dark1,
+    colorWarningBg: supersetTheme.colors.warning.light2,
+    colorWarningBgHover: supersetTheme.colors.warning.light1,
+    colorWarningBorder: supersetTheme.colors.warning.light1,
+    colorWarningBorderHover: supersetTheme.colors.warning.dark1,
+    colorWarningHover: supersetTheme.colors.warning.dark1,
+    colorWarningText: supersetTheme.colors.warning.dark1,
+    colorWarningTextActive: supersetTheme.colors.warning.dark2,
+    colorWarningTextHover: supersetTheme.colors.warning.dark1,
+
+    colorWhite: supersetTheme.colors.grayscale.light5,
+
+    fontSizeHeading1: supersetTheme.typography.sizes.xxl,
+    fontSizeHeading2: supersetTheme.typography.sizes.xl,
+    fontSizeHeading3: supersetTheme.typography.sizes.l,
+    fontSizeHeading4: supersetTheme.typography.sizes.m,
+    fontSizeHeading5: supersetTheme.typography.sizes.s,
+
+    fontSizeLG: supersetTheme.typography.sizes.l,
+    fontSizeSM: supersetTheme.typography.sizes.s,
+    fontSizeXL: supersetTheme.typography.sizes.xl,
+
+    lineWidthBold: supersetTheme.gridUnit / 2,
+  };
+};

--- a/superset-frontend/src/views/RootContextProviders.tsx
+++ b/superset-frontend/src/views/RootContextProviders.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { FC } from 'react';
 import { Route } from 'react-router-dom';
 import { getExtensionsRegistry, ThemeProvider } from '@superset-ui/core';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -25,6 +24,7 @@ import { QueryParamProvider } from 'use-query-params';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { AntdThemeProvider } from '../components/AntdThemeProvider';
 import { store } from './store';
 import FlashProvider from '../components/FlashProvider';
 import { theme } from '../preamble';
@@ -35,35 +35,37 @@ const { common } = getBootstrapData();
 
 const extensionsRegistry = getExtensionsRegistry();
 
-export const RootContextProviders: FC = ({ children }) => {
+export const RootContextProviders: React.FC = ({ children }) => {
   const RootContextProviderExtension = extensionsRegistry.get(
     'root.context.provider',
   );
 
   return (
     <ThemeProvider theme={theme}>
-      <ReduxProvider store={store}>
-        <DndProvider backend={HTML5Backend}>
-          <FlashProvider messages={common.flash_messages}>
-            <EmbeddedUiConfigProvider>
-              <DynamicPluginProvider>
-                <QueryParamProvider
-                  ReactRouterRoute={Route}
-                  stringifyOptions={{ encode: false }}
-                >
-                  {RootContextProviderExtension ? (
-                    <RootContextProviderExtension>
-                      {children}
-                    </RootContextProviderExtension>
-                  ) : (
-                    children
-                  )}
-                </QueryParamProvider>
-              </DynamicPluginProvider>
-            </EmbeddedUiConfigProvider>
-          </FlashProvider>
-        </DndProvider>
-      </ReduxProvider>
+      <AntdThemeProvider>
+        <ReduxProvider store={store}>
+          <DndProvider backend={HTML5Backend}>
+            <FlashProvider messages={common.flash_messages}>
+              <EmbeddedUiConfigProvider>
+                <DynamicPluginProvider>
+                  <QueryParamProvider
+                    ReactRouterRoute={Route}
+                    stringifyOptions={{ encode: false }}
+                  >
+                    {RootContextProviderExtension ? (
+                      <RootContextProviderExtension>
+                        {children}
+                      </RootContextProviderExtension>
+                    ) : (
+                      children
+                    )}
+                  </QueryParamProvider>
+                </DynamicPluginProvider>
+              </EmbeddedUiConfigProvider>
+            </FlashProvider>
+          </DndProvider>
+        </ReduxProvider>
+      </AntdThemeProvider>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This work is part of SIP 139 https://github.com/apache/superset/issues/29268.
This PR introduces Ant Design 5 in the repo and adds the initial Ant Design mapping with the original Superset theme to allow overrides through preamble. This should serve as the base for the Ant Design upgrade. As new components are upgraded, this initial mapping will be adjusted accordingly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
