### PR TITLE
feat(reports): adding flag for removing the index on the report CSV

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -21,6 +21,7 @@ from uuid import UUID
 
 import pandas as pd
 from celery.exceptions import SoftTimeLimitExceeded
+from flask import current_app
 
 from superset import app, db, security_manager
 from superset.commands.base import BaseCommand
@@ -44,6 +45,7 @@ from superset.commands.report.exceptions import (
     ReportScheduleUnexpectedError,
     ReportScheduleWorkingTimeoutError,
 )
+from superset.commands.report.utils import remove_post_processed
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.daos.report import (
     REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER,
@@ -251,6 +253,8 @@ class BaseReportState:
 
     def _get_csv_data(self) -> bytes:
         url = self._get_url(result_format=ChartDataResultFormat.CSV)
+        if not current_app.config["CSV_INDEX"]:
+            url = remove_post_processed(url)
         _, username = get_executor(
             executor_types=app.config["ALERT_REPORTS_EXECUTE_AS"],
             model=self._report_schedule,

--- a/superset/commands/report/utils.py
+++ b/superset/commands/report/utils.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+def remove_post_processed(url: str) -> str:
+    """Remove the type=post_processed parameter from the URL query string.
+
+    Args:
+        url (str): The URL to process.
+    Returns:
+        str: The URL with the type=post_processed parameter removed."""
+    if "?" not in url:
+        return url
+    base_url, query_string = url.split("?", 1)
+    params = query_string.split("&")
+    filtered_params = [param for param in params if param != "type=post_processed"]
+    filtered_query_string = "&".join(filtered_params)
+    filtered_url = f"{base_url}?{filtered_query_string}"
+    return filtered_url

--- a/superset/config.py
+++ b/superset/config.py
@@ -826,6 +826,9 @@ CSV_UPLOAD_MAX_SIZE = None
 # note: index option should not be overridden
 CSV_EXPORT = {"encoding": "utf-8"}
 
+# Include the CSV index when sending reports
+CSV_INDEX = True
+
 # Excel Options: key/value pairs that will be passed as argument to DataFrame.to_excel
 # method.
 # note: index option should not be overridden

--- a/tests/unit_tests/commands/report/test_report_utils.py
+++ b/tests/unit_tests/commands/report/test_report_utils.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from superset.commands.report.utils import remove_post_processed
+
+
+def test_remove_post_processed():
+    url = "https://superset.com/?param1=value1&type=post_processed&param2=value2"
+    expected = "https://superset.com/?param1=value1&param2=value2"
+    assert remove_post_processed(url) == expected
+
+
+def test_retain_other_parameters():
+    url = "https://superset.com/?param1=value1&param2=value2"
+    expected = "https://superset.com/?param1=value1&param2=value2"
+    assert remove_post_processed(url) == expected
+
+
+def test_no_post_processed_present():
+    url = "https://superset.com/?param1=value1&param2=value2"
+    expected = "https://superset.com/?param1=value1&param2=value2"
+    assert remove_post_processed(url) == expected
+
+
+def test_empty_query_string():
+    url = "https://superset.com/?"
+    expected = "https://superset.com/?"
+    assert remove_post_processed(url) == expected
+
+
+def test_no_query_string():
+    url = "https://superset.com"
+    expected = "https://superset.com"
+    assert remove_post_processed(url) == expected


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Some of our account managers send their reports in CSV format. Currently, the index is shown in the CSV due to the `POST_PROCESSED` value being set in the call to the API. This is causing a few complaints from our clients due to the need for them to remove the column when working with the report data.

There is a current PR that has been ongoing for over a year and appears to have stalled. I have linked this below. Since this is unlikely to be completed, I am opening this in the hopes that we can resolve it sooner. As opposed to their approach, I reformat the `url` used to call the API based on the `CSV_INDEX`, leaving it as-is for its default behaviour.

Issue #[22981](https://github.com/apache/superset/issues/22981) 
[Current PR](https://github.com/apache/superset/pull/23155)
Fixes https://github.com/apache/superset/issues/32113

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Superset Index](https://github.com/apache/superset/assets/18397189/faf75d54-866a-4f4f-8f1d-d9449516a9bc)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
