### PR TITLE
fix(tags): tags api change tag_get_objects method to be aligned with api documentation

### DIFF
--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -560,9 +560,8 @@ class TagRestApi(BaseSupersetModelRestApi):
             name: types
             schema:
               type: array
-              schema:
-                items:
-                  type: string
+              items:
+                type: string
 
           responses:
             200:

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -542,27 +542,29 @@ class TagRestApi(BaseSupersetModelRestApi):
         """Get all objects associated with a tag.
         ---
         get:
-          summary: Get all objects associated with a tag. If tagIds is set tags will be ignored.
+          summary: Get all objects associated with a tag
+          description: >-
+            Get all objects associated with a tag.
+            If tagIds is set, tags will be ignored.
           parameters:
-          - in: path
+          - in: query
             name: tagIds
             schema:
               type: array
               items:
                 type: integer
-          - in: path
+          - in: query
             name: tags
             schema:
               type: array
               items:
                 type: string
-          - in: path
+          - in: query
             name: types
             schema:
               type: array
               items:
                 type: string
-
           responses:
             200:
               description: List of tagged objects associated with a Tag

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -542,12 +542,28 @@ class TagRestApi(BaseSupersetModelRestApi):
         """Get all objects associated with a tag.
         ---
         get:
-          summary: Get all objects associated with a tag
+          summary: Get all objects associated with a tag. If tagIds is set tags will be ignored.
           parameters:
           - in: path
+            name: tagIds
             schema:
-              type: integer
-            name: tag_id
+              type: array
+              items:
+                type: integer
+          - in: path
+            name: tags
+            schema:
+              type: array
+              items:
+                type: string
+          - in: path
+            name: types
+            schema:
+              type: array
+              schema:
+                items:
+                  type: string
+
           responses:
             200:
               description: List of tagged objects associated with a Tag


### PR DESCRIPTION
### SUMMARY
I just came across an issue where the implemented logic was not aligned with the API documentation on OpenAPI. As a result, the method was not usable. I modified the method to align with the documentation, although I saw a benefit in the initial implementation of a better filter mechanism and bulk requests. I think a breaking change should be discussed first; therefore, I removed the non-functional code here, so that we have a fixed api soon.




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Start up superset and use the `tags/get_objects/<tag_id>` method it now should return the charts that belong to a tag.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
