### PR TITLE
fix(revert 27883): Excess padding in horizontal Bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -518,7 +518,6 @@ export default function transformProps(
   if (isHorizontal) {
     [xAxis, yAxis] = [yAxis, xAxis];
     [padding.bottom, padding.left] = [padding.left, padding.bottom];
-    yAxis.inverse = true;
   }
 
   const echartOptions: EChartsCoreOption = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -571,10 +571,6 @@ export function getPadding(
     ? TIMESERIES_CONSTANTS.yAxisLabelTopOffset
     : 0;
   const xAxisOffset = addXAxisTitleOffset ? Number(xAxisTitleMargin) || 0 : 0;
-  const showLegendTopOffset =
-    isHorizontal && showLegend && legendOrientation === LegendOrientation.Top
-      ? 100
-      : 0;
 
   return getChartPadding(
     showLegend,
@@ -583,12 +579,8 @@ export function getPadding(
     {
       top:
         yAxisTitlePosition && yAxisTitlePosition === 'Top'
-          ? TIMESERIES_CONSTANTS.gridOffsetTop +
-            showLegendTopOffset +
-            (Number(yAxisTitleMargin) || 0)
-          : TIMESERIES_CONSTANTS.gridOffsetTop +
-            showLegendTopOffset +
-            yAxisOffset,
+          ? TIMESERIES_CONSTANTS.gridOffsetTop + (Number(yAxisTitleMargin) || 0)
+          : TIMESERIES_CONSTANTS.gridOffsetTop + yAxisOffset,
       bottom:
         zoomable && !isHorizontal
           ? TIMESERIES_CONSTANTS.gridOffsetBottomZoomable + xAxisOffset

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -119,7 +119,6 @@ describe('EchartsTimeseries transformProps', () => {
               name: 'New York',
             }),
           ]),
-          yAxis: expect.objectContaining({ inverse: true }),
         }),
       }),
     );


### PR DESCRIPTION
### SUMMARY
This PR reverts https://github.com/apache/superset/pull/27883 which incorrectly calculated the chart's padding and introduced https://github.com/apache/superset/issues/29342.

There's a [bug](https://github.com/apache/echarts/issues/20068) with `yAxis.inverse` in ECharts and we don't know when a fix will be provided. To fix this issue, this PR partially reverts https://github.com/apache/superset/pull/23273 which introduced said configuration. I'm purposefully not adding a migration to this PR, as https://github.com/apache/superset/pull/23273 did, so it can be cherry-picked as it's affecting all 4.0.x versions. This will change the default y-axis order of horizontal bar charts. @yousoph 

An alternative solution, would be to fix the ECharts bug. @villebro 

Fixes https://github.com/apache/superset/issues/29342

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1125" alt="Screenshot 2024-06-24 at 11 16 37" src="https://github.com/apache/superset/assets/70410625/61cbcca9-056b-4b68-88eb-3b04010973ec">
<img width="1130" alt="Screenshot 2024-06-24 at 11 16 02" src="https://github.com/apache/superset/assets/70410625/81979ea0-60df-412c-b009-18db55a31854">
<img width="1116" alt="Screenshot 2024-06-24 at 10 51 52" src="https://github.com/apache/superset/assets/70410625/3d6d22e5-74b8-4875-a234-62156db6276b">
<img width="1106" alt="Screenshot 2024-06-24 at 10 51 27" src="https://github.com/apache/superset/assets/70410625/31873bee-93e9-410b-8e73-a88f0b09133e">

### TESTING INSTRUCTIONS
1 - Create an horizontal bar chart using a time column in the x-axis
2 - Check that the chart is displayed correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
