### PR TITLE
fix: Cannot delete empty column inside a tab using the dashboard editor

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/HoverMenu.tsx
@@ -33,7 +33,7 @@ const HoverStyleOverrides = styled.div`
   .hover-menu {
     opacity: 0;
     position: absolute;
-    z-index: 10;
+    z-index: 11; // one more than DragDroppable
     font-size: ${({ theme }) => theme.typography.sizes.m};
   }
 


### PR DESCRIPTION
### SUMMARY
Fixes a `z-index` problem that prevented an user from deleting an empty column inside a tab using the dashboard editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1395" alt="Screenshot 2024-06-24 at 11 38 31" src="https://github.com/apache/superset/assets/70410625/0a699668-d4ab-4644-a6c5-ca5251a48219">
<img width="1390" alt="Screenshot 2024-06-24 at 11 38 07" src="https://github.com/apache/superset/assets/70410625/1814944e-53b1-4367-be4b-96035391dcc1">

### TESTING INSTRUCTIONS
Check that you can delete an empty column inside a tab.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
