### PR TITLE
fix(explore): restored hidden field values has discarded

### DIFF
--- a/superset-frontend/src/explore/actions/exploreActions.test.js
+++ b/superset-frontend/src/explore/actions/exploreActions.test.js
@@ -231,9 +231,7 @@ describe('reducers', () => {
       newState,
       actions.setStashFormData(false, ['y_axis_format']),
     );
-    expect(updatedState.hiddenFormData).toEqual({
-      y_axis_format: defaultState.form_data.y_axis_format,
-    });
+    expect(updatedState.hiddenFormData.y_axis_format).toBeFalsy();
     expect(updatedState.form_data.y_axis_format).toEqual(
       defaultState.form_data.y_axis_format,
     );

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -267,7 +267,7 @@ export default function exploreReducer(state = {}, action) {
           ...form_data,
           ...restoredField,
         },
-        hiddenFormData,
+        hiddenFormData: omit(hiddenFormData, fieldNames),
       };
     },
     [actions.SLICE_UPDATED]() {

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.js
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import exploreReducer from './exploreReducer';
+import { setStashFormData } from '../actions/exploreActions';
+
+test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
+  const initialState = {
+    form_data: { a: 3, c: 4 },
+  };
+  const action = setStashFormData(true, ['a', 'c']);
+  const newState = exploreReducer(initialState, action);
+  expect(newState.form_data).toEqual({});
+  expect(newState.hiddenFormData).toEqual({ a: 3, c: 4 });
+  const restoreAction = setStashFormData(false, ['c']);
+  const newState2 = exploreReducer(newState, restoreAction);
+  expect(newState2.form_data).toEqual({ c: 4 });
+  expect(newState2.hiddenFormData).toEqual({ a: 3 });
+});


### PR DESCRIPTION
### SUMMARY
When the x-axis was changed back to a time item from a non-time control item, the values of hidden fields were not properly restored to their original state, causing them to be consistently recognized as hidden items and preventing form_data from being sent.
This commit fixes the issue and includes test code to prevent regression.

Fixes #29331 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/bc0afdcc-fa5c-4183-b7e2-99bcea5d4283

After:

https://github.com/apache/superset/assets/1392866/ccff9bb4-496b-4253-a6e1-8bca4fc4754b

### TESTING INSTRUCTIONS
1. Create line chart with temporal x-axis column and COUNT(*) metric and a specific time grain like Month
2. Switch the x-axis variable to categorical or numeric variable instead and click Update Chart
3. Switch the x-axis variable back to the original variable.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
