### PR TITLE
chore(tests): Cleanup Celery tests

### DIFF
--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -24,7 +24,6 @@ import time
 import unittest.mock as mock
 from typing import Optional
 from tests.integration_tests.fixtures.birth_names_dashboard import (
-    load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
 )
 
@@ -188,7 +187,7 @@ def test_run_sync_query_dont_exist(test_client, ctas_method):
         }
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_sync_query_cta(test_client, ctas_method):
     tmp_table_name = f"{TEST_SYNC}_{ctas_method.lower()}"
@@ -207,7 +206,7 @@ def test_run_sync_query_cta(test_client, ctas_method):
     delete_tmp_view_or_table(tmp_table_name, ctas_method)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 def test_run_sync_query_cta_no_data(test_client):
     sql_empty_result = "SELECT * FROM birth_names WHERE name='random'"
     result = run_sql(test_client, sql_empty_result)
@@ -218,7 +217,7 @@ def test_run_sync_query_cta_no_data(test_client):
     assert QueryStatus.SUCCESS == query.status
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 @mock.patch(
     "superset.sqllab.sqllab_execution_context.get_cta_schema_name",
@@ -249,7 +248,7 @@ def test_run_sync_query_cta_config(test_client, ctas_method):
     delete_tmp_view_or_table(f"{CTAS_SCHEMA_NAME}.{tmp_table_name}", ctas_method)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 @mock.patch(
     "superset.sqllab.sqllab_execution_context.get_cta_schema_name",
@@ -284,7 +283,7 @@ def test_run_async_query_cta_config(test_client, ctas_method):
     delete_tmp_view_or_table(f"{CTAS_SCHEMA_NAME}.{tmp_table_name}", ctas_method)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query(test_client, ctas_method):
     if backend() == "mysql":
@@ -315,7 +314,7 @@ def test_run_async_cta_query(test_client, ctas_method):
     delete_tmp_view_or_table(table_name, ctas_method)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
+@pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query_with_lower_limit(test_client, ctas_method):
     if backend() == "mysql":
@@ -385,7 +384,7 @@ def test_new_data_serialization():
     assert isinstance(data[0], bytes)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@pytest.mark.usefixtures("load_birth_names_data")
 def test_default_payload_serialization():
     use_new_deserialization = False
     db_engine_spec = BaseEngineSpec()
@@ -418,7 +417,7 @@ def test_default_payload_serialization():
     assert isinstance(serialized, str)
 
 
-@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@pytest.mark.usefixtures("load_birth_names_data")
 def test_msgpack_payload_serialization():
     use_new_deserialization = True
     db_engine_spec = BaseEngineSpec()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst spelunking through the tests, I realized that the Celery tests only require the data which backs the "Birth Names Dashboard" as opposed to the actual dashboard and associated charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
