### PR TITLE
chore(tests): Fix MySQL logic

### DIFF
--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -256,8 +256,8 @@ def test_run_sync_query_cta_config(test_client, ctas_method):
     lambda d, u, s, sql: CTAS_SCHEMA_NAME,
 )
 def test_run_async_query_cta_config(test_client, ctas_method):
-    if backend() in {"sqlite", "mysql"}:
-        # sqlite doesn't support schemas, mysql is flaky
+    if backend() == "sqlite":
+        # sqlite doesn't support schemas
         return
     tmp_table_name = f"{TEST_ASYNC_CTA_CONFIG}_{ctas_method.lower()}"
     result = run_sql(
@@ -287,10 +287,6 @@ def test_run_async_query_cta_config(test_client, ctas_method):
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query(test_client, ctas_method):
-    if backend() == "mysql":
-        # failing
-        return
-
     table_name = f"{TEST_ASYNC_CTA}_{ctas_method.lower()}"
     result = run_sql(
         test_client,
@@ -318,10 +314,6 @@ def test_run_async_cta_query(test_client, ctas_method):
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "login_as_admin")
 @pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
 def test_run_async_cta_query_with_lower_limit(test_client, ctas_method):
-    if backend() == "mysql":
-        # failing
-        return
-
     tmp_table = f"{TEST_ASYNC_LOWER_LIMIT}_{ctas_method.lower()}"
     result = run_sql(
         test_client,

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1548,8 +1548,6 @@ def test_report_schedule_working_timeout(create_report_slack_chart_working):
                 datetime.utcnow(),
             ).run()
 
-    # Only needed for MySQL, understand why
-    db.session.commit()
     logs = db.session.query(ReportExecutionLog).all()
     # Two logs, first is created by fixture
     assert len(logs) == 2
@@ -2075,9 +2073,6 @@ def test_grace_period_error(email_mock, create_invalid_sql_alert_email_chart):
                 create_invalid_sql_alert_email_chart.id,
                 datetime.utcnow(),
             ).run()
-
-        # Only needed for MySQL, understand why
-        db.session.commit()
 
         # Assert the email smtp address, asserts a notification was sent with the error
         assert email_mock.call_args[0][0] == DEFAULT_OWNER_EMAIL


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Whilst spelunking through the tests, I realized that there was quirky logic for handle some atypical MySQL behavior. This seems to no longer be required, most probably as a byproduct of https://github.com/apache/superset/pull/28628.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
