### PR TITLE
feat: Adds chart IDs option to migrate-viz

### DIFF
--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -99,7 +99,7 @@ def migrate_viz() -> None:
     type=str,
 )
 @optgroup.option(
-    "-ids",
+    "--ids",
     help="A comma separated list of chart IDs to upgrade",
     type=str,
 )
@@ -123,7 +123,7 @@ def upgrade(viz_type: str, ids: str | None = None) -> None:
     type=str,
 )
 @optgroup.option(
-    "-ids",
+    "--ids",
     help="A comma separated list of chart IDs to downgrade",
     type=str,
 )

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -17,11 +17,32 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Type
 
 import click
+from click_option_group import optgroup, RequiredAnyOptionGroup
 from flask.cli import with_appcontext
 
 from superset import db
+from superset.migrations.shared.migrate_viz.base import (
+    MigrateViz,
+    Slice,
+)
+from superset.migrations.shared.migrate_viz.processors import (
+    MigrateAreaChart,
+    MigrateBarChart,
+    MigrateBubbleChart,
+    MigrateDistBarChart,
+    MigrateDualLine,
+    MigrateHeatmapChart,
+    MigrateHistogramChart,
+    MigrateLineChart,
+    MigratePivotTable,
+    MigrateSankey,
+    MigrateSunburst,
+    MigrateTreeMap,
+)
+from superset.migrations.shared.utils import paginated_update
 
 
 class VizType(str, Enum):
@@ -39,6 +60,26 @@ class VizType(str, Enum):
     TREEMAP = "treemap"
 
 
+MIGRATIONS: dict[VizType, Type[MigrateViz]] = {
+    VizType.AREA: MigrateAreaChart,
+    VizType.BAR: MigrateBarChart,
+    VizType.BUBBLE: MigrateBubbleChart,
+    VizType.DIST_BAR: MigrateDistBarChart,
+    VizType.DUAL_LINE: MigrateDualLine,
+    VizType.HEATMAP: MigrateHeatmapChart,
+    VizType.HISTOGRAM: MigrateHistogramChart,
+    VizType.LINE: MigrateLineChart,
+    VizType.PIVOT_TABLE: MigratePivotTable,
+    VizType.SANKEY: MigrateSankey,
+    VizType.SUNBURST: MigrateSunburst,
+    VizType.TREEMAP: MigrateTreeMap,
+}
+
+PREVIOUS_VERSION = {
+    migration.target_viz_type: migration for migration in MIGRATIONS.values()
+}
+
+
 @click.group()
 def migrate_viz() -> None:
     """
@@ -48,75 +89,82 @@ def migrate_viz() -> None:
 
 @migrate_viz.command()
 @with_appcontext
-@click.option(
+@optgroup.group(
+    cls=RequiredAnyOptionGroup,
+)
+@optgroup.option(
     "--viz_type",
     "-t",
     help=f"The viz type to upgrade: {', '.join(list(VizType))}",
-    required=True,
+    type=str,
 )
-@click.option(
-    "--chart_id",
-    help="The chart ID to upgrade",
-    type=int,
+@optgroup.option(
+    "-ids",
+    help="A comma separated list of chart IDs to upgrade",
+    type=str,
 )
-def upgrade(viz_type: str, chart_id: int | None = None) -> None:
+def upgrade(viz_type: str, ids: str | None = None) -> None:
     """Upgrade a viz to the latest version."""
-    migrate(VizType(viz_type), chart_id)
+    if ids is None:
+        migrate_by_viz_type(VizType(viz_type))
+    else:
+        migrate_by_ids(ids)
 
 
 @migrate_viz.command()
 @with_appcontext
-@click.option(
+@optgroup.group(
+    cls=RequiredAnyOptionGroup,
+)
+@optgroup.option(
     "--viz_type",
     "-t",
     help=f"The viz type to downgrade: {', '.join(list(VizType))}",
-    required=True,
+    type=str,
 )
-@click.option(
-    "--chart_id",
-    help="The chart ID to downgrade",
-    type=int,
+@optgroup.option(
+    "-ids",
+    help="A comma separated list of chart IDs to downgrade",
+    type=str,
 )
-def downgrade(viz_type: str, chart_id: int | None = None) -> None:
+def downgrade(viz_type: str, ids: str | None = None) -> None:
     """Downgrade a viz to the previous version."""
-    migrate(VizType(viz_type), chart_id, is_downgrade=True)
-
-
-def migrate(
-    viz_type: VizType, chart_id: int | None = None, is_downgrade: bool = False
-) -> None:
-    """Migrate a viz from one type to another."""
-    # pylint: disable=import-outside-toplevel
-    from superset.migrations.shared.migrate_viz.processors import (
-        MigrateAreaChart,
-        MigrateBarChart,
-        MigrateBubbleChart,
-        MigrateDistBarChart,
-        MigrateDualLine,
-        MigrateHeatmapChart,
-        MigrateHistogramChart,
-        MigrateLineChart,
-        MigratePivotTable,
-        MigrateSankey,
-        MigrateSunburst,
-        MigrateTreeMap,
-    )
-
-    migrations = {
-        VizType.AREA: MigrateAreaChart,
-        VizType.BAR: MigrateBarChart,
-        VizType.BUBBLE: MigrateBubbleChart,
-        VizType.DIST_BAR: MigrateDistBarChart,
-        VizType.DUAL_LINE: MigrateDualLine,
-        VizType.HEATMAP: MigrateHeatmapChart,
-        VizType.HISTOGRAM: MigrateHistogramChart,
-        VizType.LINE: MigrateLineChart,
-        VizType.PIVOT_TABLE: MigratePivotTable,
-        VizType.SANKEY: MigrateSankey,
-        VizType.SUNBURST: MigrateSunburst,
-        VizType.TREEMAP: MigrateTreeMap,
-    }
-    if is_downgrade:
-        migrations[viz_type].downgrade(db.session, chart_id)
+    if ids is None:
+        migrate_by_viz_type(VizType(viz_type), is_downgrade=True)
     else:
-        migrations[viz_type].upgrade(db.session, chart_id)
+        migrate_by_ids(ids, is_downgrade=True)
+
+
+def migrate_by_viz_type(viz_type: VizType, is_downgrade: bool = False) -> None:
+    """
+    Migrate all charts of a viz type.
+
+    :param viz_type: The viz type to migrate
+    :param is_downgrade: Whether to downgrade the charts. Default is upgrade.
+    """
+    migration: Type[MigrateViz] = MIGRATIONS[viz_type]
+    if is_downgrade:
+        migration.downgrade(db.session)
+    else:
+        migration.upgrade(db.session)
+
+
+def migrate_by_ids(ids: str, is_downgrade: bool = False) -> None:
+    """
+    Migrate a subset of charts by a list of IDs.
+
+    :param ids: List of chart IDs to migrate
+    :param is_downgrade: Whether to downgrade the charts. Default is upgrade.
+    """
+    id_list = [int(i) for i in ids.split(",")]
+    slices = db.session.query(Slice).filter(Slice.id.in_(id_list))
+    for slc in paginated_update(
+        slices,
+        lambda current, total: print(
+            f"{('Downgraded' if is_downgrade else 'Upgraded')} {current}/{total} charts"
+        ),
+    ):
+        if is_downgrade:
+            PREVIOUS_VERSION[slc.viz_type].downgrade_slice(slc)
+        else:
+            MIGRATIONS[slc.viz_type].upgrade_slice(slc)

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
 import copy
 from typing import Any
 
@@ -153,13 +151,8 @@ class MigrateViz:
                 slc.query_context = json.dumps(query_context)
 
     @classmethod
-    def upgrade(cls, session: Session, chart_id: int | None = None) -> None:
-        slices = session.query(Slice).filter(
-            and_(
-                Slice.viz_type == cls.source_viz_type,
-                Slice.id == chart_id if chart_id is not None else True,
-            )
-        )
+    def upgrade(cls, session: Session) -> None:
+        slices = session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
         for slc in paginated_update(
             slices,
             lambda current, total: print(f"Upgraded {current}/{total} charts"),
@@ -167,12 +160,11 @@ class MigrateViz:
             cls.upgrade_slice(slc)
 
     @classmethod
-    def downgrade(cls, session: Session, chart_id: int | None = None) -> None:
+    def downgrade(cls, session: Session) -> None:
         slices = session.query(Slice).filter(
             and_(
                 Slice.viz_type == cls.target_viz_type,
                 Slice.params.like(f"%{FORM_DATA_BAK_FIELD_NAME}%"),
-                Slice.id == chart_id if chart_id is not None else True,
             )
         )
         for slc in paginated_update(

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -153,8 +153,13 @@ class MigrateViz:
                 slc.query_context = json.dumps(query_context)
 
     @classmethod
-    def upgrade(cls, session: Session) -> None:
-        slices = session.query(Slice).filter(Slice.viz_type == cls.source_viz_type)
+    def upgrade(cls, session: Session, chart_id: int | None = None) -> None:
+        slices = session.query(Slice).filter(
+            and_(
+                Slice.viz_type == cls.source_viz_type,
+                Slice.id == chart_id if chart_id is not None else True,
+            )
+        )
         for slc in paginated_update(
             slices,
             lambda current, total: print(f"Upgraded {current}/{total} charts"),
@@ -162,11 +167,12 @@ class MigrateViz:
             cls.upgrade_slice(slc)
 
     @classmethod
-    def downgrade(cls, session: Session) -> None:
+    def downgrade(cls, session: Session, chart_id: int | None = None) -> None:
         slices = session.query(Slice).filter(
             and_(
                 Slice.viz_type == cls.target_viz_type,
                 Slice.params.like(f"%{FORM_DATA_BAK_FIELD_NAME}%"),
+                Slice.id == chart_id if chart_id is not None else True,
             )
         )
         for slc in paginated_update(


### PR DESCRIPTION
### SUMMARY
Adds the optional `chart_id` parameter to the `migrate-viz` command to allow upgrading/downgrading a specific chart.

```
Usage: superset migrate-viz upgrade [OPTIONS]

  Upgrade a viz to the latest version.

Options:
  -t, --viz_type TEXT  The viz type to upgrade: area, bar, bubble, dist_bar,
                       dual_line, heatmap, histogram, line, pivot_table,
                       sunburst, treemap  [required]
  --id INTEGER         The chart ID to upgrade. It can set set multiple times.
  --help               Show this message and exit.
```

```
Usage: superset migrate-viz downgrade [OPTIONS]

  Downgrade a viz to the previous version.

Options:
  -t, --viz_type TEXT  The viz type to upgrade: area, bar, bubble, dist_bar,
                       dual_line, heatmap, histogram, line, pivot_table,
                       sunburst, treemap  [required]
  --id INTEGER         The chart ID to downgrade. It can set set multiple times.
  --help               Show this message and exit.
```


### TESTING INSTRUCTIONS
Check that you can upgrade/downgrade a specific chart using the `-id` option.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
