### PR TITLE
fix(explore): don't respect y-axis formatting

### DIFF
--- a/superset-frontend/src/explore/components/StashFormDataContainer/StashFormDataContainer.test.tsx
+++ b/superset-frontend/src/explore/components/StashFormDataContainer/StashFormDataContainer.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { defaultState } from 'src/explore/store';
-import { render } from 'spec/helpers/testing-library';
+import { render, waitFor } from 'spec/helpers/testing-library';
 import { useSelector } from 'react-redux';
 import { ExplorePageState } from 'src/explore/types';
 import StashFormDataContainer from '.';
@@ -52,5 +52,33 @@ test('should stash form data from fieldNames', () => {
   );
   expect(container.querySelector('div')).not.toHaveTextContent(
     'granularity_sqla',
+  );
+});
+
+test('should restore form data from fieldNames', async () => {
+  const { granularity_sqla, ...formData } = defaultState.form_data;
+  const { container } = render(
+    <StashFormDataContainer
+      shouldStash={false}
+      fieldNames={['granularity_sqla']}
+    >
+      <FormDataMock />
+    </StashFormDataContainer>,
+    {
+      useRedux: true,
+      initialState: {
+        explore: {
+          form_data: formData,
+          hiddenFormData: {
+            granularity_sqla,
+          },
+        },
+      },
+    },
+  );
+  await waitFor(() =>
+    expect(container.querySelector('div')).toHaveTextContent(
+      'granularity_sqla',
+    ),
   );
 });

--- a/superset-frontend/src/explore/components/StashFormDataContainer/index.tsx
+++ b/superset-frontend/src/explore/components/StashFormDataContainer/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useRef, FC } from 'react';
+import { useEffect, FC } from 'react';
 
 import { useDispatch } from 'react-redux';
 import { setStashFormData } from 'src/explore/actions/exploreActions';
@@ -33,16 +33,11 @@ const StashFormDataContainer: FC<Props> = ({
   children,
 }) => {
   const dispatch = useDispatch();
-  const isMounted = useRef(false);
   const onVisibleUpdate = useEffectEvent((shouldStash: boolean) =>
     dispatch(setStashFormData(shouldStash, fieldNames)),
   );
   useEffect(() => {
-    if (!isMounted.current && !shouldStash) {
-      isMounted.current = true;
-    } else {
-      onVisibleUpdate(shouldStash);
-    }
+    onVisibleUpdate(shouldStash);
   }, [shouldStash, onVisibleUpdate]);
 
   return <>{children}</>;

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -261,14 +261,16 @@ export default function exploreReducer(state = {}, action) {
       }
 
       const restoredField = pick(hiddenFormData, fieldNames);
-      return {
-        ...state,
-        form_data: {
-          ...form_data,
-          ...restoredField,
-        },
-        hiddenFormData: omit(hiddenFormData, fieldNames),
-      };
+      return Object.keys(restoredField).length === 0
+        ? state
+        : {
+            ...state,
+            form_data: {
+              ...form_data,
+              ...restoredField,
+            },
+            hiddenFormData: omit(hiddenFormData, fieldNames),
+          };
     },
     [actions.SLICE_UPDATED]() {
       return {

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.js
@@ -33,3 +33,13 @@ test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   expect(newState2.form_data).toEqual({ c: 4 });
   expect(newState2.hiddenFormData).toEqual({ a: 3 });
 });
+
+test('skips updates when the field is already updated on SET_STASH_FORM_DATA', () => {
+  const initialState = {
+    form_data: { a: 3, c: 4 },
+    hiddenFormData: { b: 2 },
+  };
+  const restoreAction = setStashFormData(false, ['c', 'd']);
+  const newState = exploreReducer(initialState, restoreAction);
+  expect(newState).toBe(initialState);
+});


### PR DESCRIPTION
### SUMMARY
When StashFormData is initially loaded, the process of restoring hiddenFormData during the stash state update was missing, causing the y-axis format to not change properly after the first change.

This code fixes the process to always update hiddenFormData whenever the shouldStash state changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/apache/superset/assets/1392866/24804656-7348-47e6-8525-b591debc0238

After:

https://github.com/apache/superset/assets/1392866/84071f1a-02ec-4410-a187-80278e365af7


### TESTING INSTRUCTIONS
Create a bar chart
Set y-axis format with an option
Update the format with a different option
Y-axis format should update respectfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/29331
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
