### PR TITLE
fix(tox): Address issue with generative environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,9 +251,8 @@ setenv =
     SUPERSET_HOME = {envtmpdir}
     mysql: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     postgres: SUPERSET__SQLALCHEMY_DATABASE_URI = postgresql+psycopg2://superset:superset@localhost/test
-    sqlite:
-        SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
-        SUPERSET__SQLALCHEMY_EXAMPLES_URI = sqlite:////{envtmpdir}/examples.db
+    sqlite: SUPERSET__SQLALCHEMY_DATABASE_URI = sqlite:////{envtmpdir}/superset.db
+    sqlite: SUPERSET__SQLALCHEMY_EXAMPLES_URI = sqlite:////{envtmpdir}/examples.db
     mysql-presto: SUPERSET__SQLALCHEMY_DATABASE_URI = mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
     # docker run -p 8080:8080 --name presto starburstdata/presto
     mysql-presto: SUPERSET__SQLALCHEMY_EXAMPLES_URI = presto://localhost:8080/memory/default


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

The way the SQLite environment variables were specified were incorrect meaning that the `SUPERSET__SQLALCHEMY_DATABASE_URI` and `SUPERSET__SQLALCHEMY_EXAMPLES_URI` environment variables never adhered to the specified environment.

### TESTING INSTRUCTIONS


#### BEFORE

```
$ tox -e py310-mysql --showconfig | grep SUPERSET__SQLALCHEMY
  SUPERSET__SQLALCHEMY_DATABASE_URI=sqlite:///<redacted>/superset/.tox/py310-mysql/tmp/superset.db
  SUPERSET__SQLALCHEMY_EXAMPLES_URI=sqlite:///<redacted>/superset/.tox/py310-mysql/tmp/examples.db
```

```
$ tox -e py310-sqlite --showconfig | grep SUPERSET__SQLALCHEMY
  SUPERSET__SQLALCHEMY_DATABASE_URI=sqlite:///<redacted>/superset/.tox/py310-sqlite/tmp/superset.db
  SUPERSET__SQLALCHEMY_EXAMPLES_URI=sqlite:///<redacted>/superset/.tox/py310-sqlite/tmp/examples.db
```

#### AFTER 

```
$ tox -e py310-mysql --showconfig | grep SUPERSET__SQLALCHEMY
  SUPERSET__SQLALCHEMY_DATABASE_URI=mysql://mysqluser:mysqluserpassword@localhost/superset?charset=utf8
```

```
$ tox -e py310-sqlite --showconfig | grep SUPERSET__SQLALCHEMY
  SUPERSET__SQLALCHEMY_DATABASE_URI=sqlite:///<redacted>/superset/.tox/py310-sqlite/tmp/superset.db
  SUPERSET__SQLALCHEMY_EXAMPLES_URI=sqlite:///<redacted>/superset/.tox/py310-sqlite/tmp/examples.db
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
