### PR TITLE
chore(ci): Start Celery worker as a background process

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -117,6 +117,20 @@ testdata() {
   say "::endgroup::"
 }
 
+celery-worker() {
+  cd "$GITHUB_WORKSPACE"
+  say "::group::Start Celery worker"
+  # must specify PYTHONPATH to make `tests.superset_test_config` importable
+  export PYTHONPATH="$GITHUB_WORKSPACE"
+  celery \
+    --app=superset.tasks.celery_app:app \
+    worker \
+      --concurrency=2 \
+      --detach \
+      --optimization=fair
+  say "::endgroup::"
+}
+
 cypress-install() {
   cd "$GITHUB_WORKSPACE/superset-frontend/cypress-base"
 

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -58,9 +58,11 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-mysql
-      - name: Run celery
+      - name: Start Celery worker
         if: steps.check.outputs.python
-        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: celery-worker
       - name: Python integration tests (MySQL)
         if: steps.check.outputs.python
         run: |
@@ -117,9 +119,11 @@ jobs:
         with:
           run: |
             setup-postgres
-      - name: Run celery
+      - name: Start Celery worker
         if: steps.check.outputs.python
-        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: celery-worker
       - name: Python integration tests (PostgreSQL)
         if: steps.check.outputs.python
         run: |
@@ -167,9 +171,11 @@ jobs:
           run: |
             # sqlite needs this working directory
             mkdir ${{ github.workspace }}/.temp
-      - name: Run celery
+      - name: Start Celery worker
         if: steps.check.outputs.python
-        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: celery-worker
       - name: Python integration tests (SQLite)
         if: steps.check.outputs.python
         run: |

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -67,9 +67,11 @@ jobs:
           run: |
             echo "${{ steps.check.outputs.python }}"
             setup-postgres
-      - name: Run celery
+      - name: Start Celery worker
         if: steps.check.outputs.python
-        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: celery-worker
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outputs.python
         run: |
@@ -132,9 +134,11 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
-      - name: Run celery
+      - name: Start Celery worker
         if: steps.check.outputs.python
-        run: celery --app=superset.tasks.celery_app:app worker -Ofair -c 2 &
+        uses: ./.github/actions/cached-dependencies
+        with:
+          run: celery-worker
       - name: Python unit tests (PostgreSQL)
         if: steps.check.outputs.python
         run: |


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

I've been fighting with inconsistencies between running CI locally and remote. Whilst working on a specific PR the Celery tests would always succeed locally whereas they would fail in a remote setting. The errors were always suppressed, but my hunch was that maybe the Celery worker(s) weren't responsive as queries remained in the pending state.

If I mangled the `python_tests.sh` script to only run the `tests/integration_tests/celery_tests.py` tests everything seemed to be fine which indicated that maybe there was a temporal facet to the flakiness of the tests. Reading through the GitHub actions/workflows it seems like we manually background the task (via the `&`) yet one can actually run Celery in a detached state, which seems more robust.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

CI. Also verified that the tests on my other PR successfully ran.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
