### PR TITLE
chore(Table): Add aria-label to Table page size selector

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/SelectPageSize.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/SelectPageSize.tsx
@@ -37,7 +37,6 @@ function DefaultSelectRenderer({
     <span className="dt-select-page-size form-inline">
       {t('Show')}{' '}
       <select
-        aria-label={t('Show %s entries', current)}
         className="form-control input-sm"
         value={current}
         onBlur={() => {}}
@@ -49,8 +48,13 @@ function DefaultSelectRenderer({
           const [size, text] = Array.isArray(option)
             ? option
             : [option, option];
+          const sizeLabel = size === 0 ? t('all') : size;
           return (
-            <option key={size} value={size}>
+            <option
+              aria-label={t('Show %s entries', sizeLabel)}
+              key={size}
+              value={size}
+            >
               {text}
             </option>
           );

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/SelectPageSize.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/components/SelectPageSize.tsx
@@ -37,6 +37,7 @@ function DefaultSelectRenderer({
     <span className="dt-select-page-size form-inline">
       {t('Show')}{' '}
       <select
+        aria-label={t('Show %s entries', current)}
         className="form-control input-sm"
         value={current}
         onBlur={() => {}}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -181,10 +181,10 @@ function SearchInput({ count, value, onChange }: SearchInputProps) {
     <span className="dt-global-filter">
       {t('Search')}{' '}
       <input
+        aria-label={t('Search %s records', count)}
         className="form-control input-sm"
         placeholder={tn('search.num_records', count)}
         value={value}
-        aria-label={t('Search %s records', count)}
         onChange={onChange}
       />
     </span>
@@ -200,9 +200,6 @@ function SelectPageSize({
     <span className="dt-select-page-size form-inline">
       {t('page_size.show')}{' '}
       <select
-        aria-label={`${t('page_size.show %s', current)} ${t(
-          'page_size.entries',
-        )}`}
         className="form-control input-sm"
         value={current}
         onBlur={() => {}}
@@ -214,8 +211,13 @@ function SelectPageSize({
           const [size, text] = Array.isArray(option)
             ? option
             : [option, option];
+          const sizeLabel = size === 0 ? t('all') : size;
           return (
-            <option key={size} value={size}>
+            <option
+              aria-label={t('Show %s entries', sizeLabel)}
+              key={size}
+              value={size}
+            >
               {text}
             </option>
           );

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -200,7 +200,7 @@ function SelectPageSize({
     <span className="dt-select-page-size form-inline">
       {t('page_size.show')}{' '}
       <select
-        aria-label={`${t('page_size.show')} ${current} ${t(
+        aria-label={`${t('page_size.show %s', current)} ${t(
           'page_size.entries',
         )}`}
         className="form-control input-sm"

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -200,6 +200,9 @@ function SelectPageSize({
     <span className="dt-select-page-size form-inline">
       {t('page_size.show')}{' '}
       <select
+        aria-label={`${t('page_size.show')} ${current} ${t(
+          'page_size.entries',
+        )}`}
         className="form-control input-sm"
         value={current}
         onBlur={() => {}}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Makes the page size selector for the table accessible to screen readers

### BEFORE/AFTER

![image](https://github.com/apache/superset/assets/60598000/5ce3f425-d4d8-4c81-bf49-cec4b61399cb)

### TESTING INSTRUCTIONS
1. Interact with a page size selector of a table via screen reader
2. The screen reader should be able to read the size selector

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
