### PR TITLE
feat(dashboard): update tab drag and drop reordering with positional placement and indicators for UI

### DIFF
--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -90,6 +90,10 @@ const DragDroppableStyles = styled.div`
       opacity: 0.2;
     }
 
+    &.dragdroppable--dragging .dragdroppable-tab {
+      display: none;
+    }
+
     &.dragdroppable-row {
       width: 100%;
     }

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -182,20 +182,16 @@ export class UnwrappedDragDroppable extends PureComponent {
       isDraggingOver,
       style,
       editMode,
-      // dropIndicatorStyles,
     } = this.props;
 
     const { dropIndicator } = this.state;
     const dropIndicatorProps =
-      // dropIndicator && !disableDragDrop
       isDraggingOver && dropIndicator && !disableDragDrop
         ? {
             className: cx(
               'drop-indicator',
               dropIndicator === DROP_FORBIDDEN && 'drop-indicator--forbidden',
             ),
-            // css: !!dropIndicatorStyles && dropIndicatorStyles,
-            dropIndicator,
           }
         : null;
 

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -155,16 +155,19 @@ export class UnwrappedDragDroppable extends PureComponent {
       isDraggingOver,
       style,
       editMode,
+      // dropIndicatorStyles,
     } = this.props;
 
     const { dropIndicator } = this.state;
     const dropIndicatorProps =
-      isDraggingOver && dropIndicator && !disableDragDrop
+      // isDraggingOver && dropIndicator && !disableDragDrop
+      dropIndicator && !disableDragDrop
         ? {
             className: cx(
               'drop-indicator',
               dropIndicator === DROP_FORBIDDEN && 'drop-indicator--forbidden',
             ),
+            // css: !!dropIndicatorStyles && dropIndicatorStyles,
           }
         : null;
 

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -141,16 +141,7 @@ export class UnwrappedDragDroppable extends PureComponent {
       dropIndicator !== prevState.dropIndicator ||
       isDraggingOver !== prevProps.isDraggingOver ||
       index !== prevProps.index;
-    // console.log(
-    //   'index',
-    //   index,
-    //   'isTabsType:',
-    //   isTabsType,
-    //   'component:',
-    //   component,
-    //   'validStateChange:',
-    //   validStateChange,
-    // );
+
     if (onDropIndicatorChange && isTabsType && validStateChange) {
       onDropIndicatorChange({ dropIndicator, isDraggingOver, index });
     }

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.jsx
@@ -19,6 +19,7 @@
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
 import { DragSource, DropTarget } from 'react-dnd';
 import cx from 'classnames';
 import { css, styled } from '@superset-ui/core';
@@ -40,6 +41,7 @@ const propTypes = {
   style: PropTypes.object,
   onDrop: PropTypes.func,
   onHover: PropTypes.func,
+  onDropIndicatorChange: PropTypes.func,
   editMode: PropTypes.bool,
   useEmptyDragPreview: PropTypes.bool,
 
@@ -61,6 +63,7 @@ const defaultProps = {
   children() {},
   onDrop() {},
   onHover() {},
+  onDropIndicatorChange() {},
   orientation: 'row',
   useEmptyDragPreview: false,
   isDragging: false,
@@ -129,6 +132,30 @@ export class UnwrappedDragDroppable extends PureComponent {
     this.mounted = false;
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { onDropIndicatorChange, isDraggingOver, component, index } =
+      this.props;
+    const { dropIndicator } = this.state;
+    const isTabsType = component.type === TAB_TYPE;
+    const validStateChange =
+      dropIndicator !== prevState.dropIndicator ||
+      isDraggingOver !== prevProps.isDraggingOver ||
+      index !== prevProps.index;
+    // console.log(
+    //   'index',
+    //   index,
+    //   'isTabsType:',
+    //   isTabsType,
+    //   'component:',
+    //   component,
+    //   'validStateChange:',
+    //   validStateChange,
+    // );
+    if (onDropIndicatorChange && isTabsType && validStateChange) {
+      onDropIndicatorChange({ dropIndicator, isDraggingOver, index });
+    }
+  }
+
   setRef(ref) {
     this.ref = ref;
     // this is needed for a custom drag preview
@@ -160,14 +187,15 @@ export class UnwrappedDragDroppable extends PureComponent {
 
     const { dropIndicator } = this.state;
     const dropIndicatorProps =
-      // isDraggingOver && dropIndicator && !disableDragDrop
-      dropIndicator && !disableDragDrop
+      // dropIndicator && !disableDragDrop
+      isDraggingOver && dropIndicator && !disableDragDrop
         ? {
             className: cx(
               'drop-indicator',
               dropIndicator === DROP_FORBIDDEN && 'drop-indicator--forbidden',
             ),
             // css: !!dropIndicatorStyles && dropIndicatorStyles,
+            dropIndicator,
           }
         : null;
 

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
@@ -23,7 +23,11 @@ import {
 import sinon from 'sinon';
 
 import newComponentFactory from 'src/dashboard/util/newComponentFactory';
-import { CHART_TYPE, ROW_TYPE } from 'src/dashboard/util/componentTypes';
+import {
+  CHART_TYPE,
+  ROW_TYPE,
+  TAB_TYPE,
+} from 'src/dashboard/util/componentTypes';
 import { UnwrappedDragDroppable as DragDroppable } from 'src/dashboard/components/dnd/DragDroppable';
 
 describe('DragDroppable', () => {
@@ -61,6 +65,16 @@ describe('DragDroppable', () => {
     const childrenSpy = sinon.spy();
     setup({ children: childrenSpy });
     expect(childrenSpy.callCount).toBe(1);
+  });
+
+  it('should call onDropIndicatorChange when isDraggingOver changes', () => {
+    const onDropIndicatorChange = sinon.spy();
+    const wrapper = setup({
+      onDropIndicatorChange,
+      component: newComponentFactory(TAB_TYPE),
+    });
+    wrapper.setProps({ isDraggingOver: true });
+    expect(onDropIndicatorChange.callCount).toBe(1);
   });
 
   it('should call its child function with "dragSourceRef" if editMode=true', () => {

--- a/superset-frontend/src/dashboard/components/dnd/dragDroppableConfig.js
+++ b/superset-frontend/src/dashboard/components/dnd/dragDroppableConfig.js
@@ -47,6 +47,8 @@ export const dragConfig = [
       dragSourceRef: connect.dragSource(),
       dragPreviewRef: connect.dragPreview(),
       isDragging: monitor.isDragging(),
+      dragComponentType: monitor.getItem()?.type,
+      dragComponentId: monitor.getItem()?.id,
     };
   },
 ];

--- a/superset-frontend/src/dashboard/components/dnd/handleDrop.js
+++ b/superset-frontend/src/dashboard/components/dnd/handleDrop.js
@@ -53,6 +53,7 @@ export default function handleDrop(props, monitor, Component) {
       type: draggingItem.type,
       meta: draggingItem.meta,
     },
+    position: dropPosition,
   };
 
   const shouldAppendToChildren =

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -89,19 +89,6 @@ const TabTitleContainer = styled.div`
   `}
 `;
 
-// .drop-indicator {
-//         display: block;
-//         background-color: ${theme.colors.primary.base};
-//         position: absolute;
-//         z-index: 10;
-//         opacity: 0.3;
-//         width: 100%;
-//         height: 100%;
-//         &.drop-indicator--forbidden {
-//           background-color: ${theme.colors.error.light1};
-//         }
-//       }
-
 const TitleDropIndicator = styled.div`
   &.drop-indicator {
     position: absolute;
@@ -121,7 +108,6 @@ class Tab extends PureComponent {
     this.handleOnHover = this.handleOnHover.bind(this);
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
     this.handleChangeTab = this.handleChangeTab.bind(this);
-    this.logDropIndicator = this.logDropIndicator.bind(this);
     // this.handleGetDropPosition = this.handleGetDropPosition.bind(this);
   }
 
@@ -150,21 +136,8 @@ class Tab extends PureComponent {
   }
 
   handleOnHover() {
-    // this.logDropIndicator(dropIndicatorProps);
     this.props.onHoverTab();
   }
-
-  logDropIndicator(dropIndicatorProps) {
-    if (dropIndicatorProps?.dropIndicator) {
-      // eslint-disable-next-line no-console
-      console.log('dropIndicatorProps:', dropIndicatorProps);
-      // this.setState({ dropPosition: dropIndicatorProps.dropIndicator});
-    }
-  }
-
-  // handleGetDropPosition(dropIndicator, isDraggingOver) {
-  //   this.props.onDropPositionChange(dropIndicator, isDraggingOver);
-  // }
 
   handleTopDropTargetDrop(dropResult) {
     if (dropResult) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -104,10 +104,8 @@ const TabTitleContainer = styled.div`
 
 const TitleDropIndicator = styled.div`
   &.drop-indicator {
-    // width: 5px;
     position: absolute;
     top: 0;
-    // left: -12px;
     border-radius: 4px;
   }
 `;
@@ -328,7 +326,7 @@ class Tab extends PureComponent {
         {({ dropIndicatorProps, dragSourceRef }) => (
           <TabTitleContainer
             isHighlighted={isHighlighted}
-            className="dragdroppable-tab empty-droptarget"
+            className="dragdroppable-tab"
             ref={dragSourceRef}
           >
             <EditableTitle

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -78,7 +78,6 @@ const defaultProps = {
 };
 
 const TabTitleContainer = styled.div`
-  // TODO remove tab title container from visible if dragging it in edit mode
   ${({ isHighlighted, theme: { gridUnit, colors } }) => `
     padding: ${gridUnit}px ${gridUnit * 2}px;
     margin: ${-gridUnit}px ${gridUnit * -2}px;
@@ -108,7 +107,6 @@ class Tab extends PureComponent {
     this.handleOnHover = this.handleOnHover.bind(this);
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
     this.handleChangeTab = this.handleChangeTab.bind(this);
-    // this.handleGetDropPosition = this.handleGetDropPosition.bind(this);
   }
 
   handleChangeTab({ pathToTabIndex }) {
@@ -319,7 +317,10 @@ class Tab extends PureComponent {
               />
             )}
             {dropIndicatorProps && (
-              <TitleDropIndicator className={dropIndicatorProps.className} />
+              <TitleDropIndicator
+                className={dropIndicatorProps.className}
+                data-test="title-drop-indicator"
+              />
             )}
           </TabTitleContainer>
         )}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { styled, css, t } from '@superset-ui/core';
+import { styled, t } from '@superset-ui/core';
 
 import { EmptyStateMedium } from 'src/components/EmptyState';
 import EditableTitle from 'src/components/EditableTitle';
@@ -47,6 +47,7 @@ const propTypes = {
   depth: PropTypes.number.isRequired,
   renderType: PropTypes.oneOf([RENDER_TAB, RENDER_TAB_CONTENT]).isRequired,
   onDropOnTab: PropTypes.func,
+  onDropPositionChange: PropTypes.func,
   onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool.isRequired,
@@ -69,6 +70,7 @@ const defaultProps = {
   availableColumnCount: 0,
   columnWidth: 0,
   onDropOnTab() {},
+  onDropPositionChange() {},
   onHoverTab() {},
   onResizeStart() {},
   onResize() {},
@@ -76,6 +78,7 @@ const defaultProps = {
 };
 
 const TabTitleContainer = styled.div`
+  // TODO remove tab title container from visible if dragging it in edit mode
   ${({ isHighlighted, theme: { gridUnit, colors } }) => `
     padding: ${gridUnit}px ${gridUnit * 2}px;
     margin: ${-gridUnit}px ${gridUnit * -2}px;
@@ -86,11 +89,25 @@ const TabTitleContainer = styled.div`
   `}
 `;
 
-const TabDropIndicator = styled.div`
+// .drop-indicator {
+//         display: block;
+//         background-color: ${theme.colors.primary.base};
+//         position: absolute;
+//         z-index: 10;
+//         opacity: 0.3;
+//         width: 100%;
+//         height: 100%;
+//         &.drop-indicator--forbidden {
+//           background-color: ${theme.colors.error.light1};
+//         }
+//       }
+
+const TitleDropIndicator = styled.div`
   &.drop-indicator {
-    display: inline;
-    width: 5px;
-    margin-left: 4px;
+    // width: 5px;
+    position: absolute;
+    top: 0;
+    // left: -12px;
     border-radius: 4px;
   }
 `;
@@ -106,6 +123,8 @@ class Tab extends PureComponent {
     this.handleOnHover = this.handleOnHover.bind(this);
     this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
     this.handleChangeTab = this.handleChangeTab.bind(this);
+    this.logDropIndicator = this.logDropIndicator.bind(this);
+    // this.handleGetDropPosition = this.handleGetDropPosition.bind(this);
   }
 
   handleChangeTab({ pathToTabIndex }) {
@@ -133,8 +152,21 @@ class Tab extends PureComponent {
   }
 
   handleOnHover() {
+    // this.logDropIndicator(dropIndicatorProps);
     this.props.onHoverTab();
   }
+
+  logDropIndicator(dropIndicatorProps) {
+    if (dropIndicatorProps?.dropIndicator) {
+      // eslint-disable-next-line no-console
+      console.log('dropIndicatorProps:', dropIndicatorProps);
+      // this.setState({ dropPosition: dropIndicatorProps.dropIndicator});
+    }
+  }
+
+  // handleGetDropPosition(dropIndicator, isDraggingOver) {
+  //   this.props.onDropPositionChange(dropIndicator, isDraggingOver);
+  // }
 
   handleTopDropTargetDrop(dropResult) {
     if (dropResult) {
@@ -277,6 +309,7 @@ class Tab extends PureComponent {
       editMode,
       isFocused,
       isHighlighted,
+      onDropPositionChange,
     } = this.props;
 
     return (
@@ -288,6 +321,7 @@ class Tab extends PureComponent {
         depth={depth}
         onDrop={this.handleDrop}
         onHover={this.handleOnHover}
+        onDropIndicatorChange={onDropPositionChange}
         editMode={editMode}
         dropToChild={this.shouldDropToChild}
       >
@@ -313,9 +347,8 @@ class Tab extends PureComponent {
                 placement={index >= 5 ? 'left' : 'right'}
               />
             )}
-
             {dropIndicatorProps && (
-              <TabDropIndicator className={dropIndicatorProps.className} />
+              <TitleDropIndicator className={dropIndicatorProps.className} />
             )}
           </TabTitleContainer>
         )}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { styled, t } from '@superset-ui/core';
+import { styled, css, t } from '@superset-ui/core';
 
 import { EmptyStateMedium } from 'src/components/EmptyState';
 import EditableTitle from 'src/components/EditableTitle';
@@ -84,6 +84,15 @@ const TabTitleContainer = styled.div`
       isHighlighted && `box-shadow: 0 0 ${gridUnit}px ${colors.primary.light1};`
     }
   `}
+`;
+
+const TabDropIndicator = styled.div`
+  &.drop-indicator {
+    display: inline;
+    width: 5px;
+    margin-left: 4px;
+    border-radius: 4px;
+  }
 `;
 
 const renderDraggableContent = dropProps =>
@@ -285,7 +294,7 @@ class Tab extends PureComponent {
         {({ dropIndicatorProps, dragSourceRef }) => (
           <TabTitleContainer
             isHighlighted={isHighlighted}
-            className="dragdroppable-tab"
+            className="dragdroppable-tab empty-droptarget"
             ref={dragSourceRef}
           >
             <EditableTitle
@@ -305,7 +314,9 @@ class Tab extends PureComponent {
               />
             )}
 
-            {dropIndicatorProps && <div {...dropIndicatorProps} />}
+            {dropIndicatorProps && (
+              <TabDropIndicator className={dropIndicatorProps.className} />
+            )}
           </TabTitleContainer>
         )}
       </DragDroppable>

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -48,6 +48,7 @@ const propTypes = {
   renderType: PropTypes.oneOf([RENDER_TAB, RENDER_TAB_CONTENT]).isRequired,
   onDropOnTab: PropTypes.func,
   onDropPositionChange: PropTypes.func,
+  onDragTab: PropTypes.func,
   onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool.isRequired,
@@ -71,6 +72,7 @@ const defaultProps = {
   columnWidth: 0,
   onDropOnTab() {},
   onDropPositionChange() {},
+  onDragTab() {},
   onHoverTab() {},
   onResizeStart() {},
   onResize() {},
@@ -279,6 +281,7 @@ class Tab extends PureComponent {
       isFocused,
       isHighlighted,
       onDropPositionChange,
+      onDragTab,
     } = this.props;
 
     return (
@@ -291,10 +294,11 @@ class Tab extends PureComponent {
         onDrop={this.handleDrop}
         onHover={this.handleOnHover}
         onDropIndicatorChange={onDropPositionChange}
+        onDragTab={onDragTab}
         editMode={editMode}
         dropToChild={this.shouldDropToChild}
       >
-        {({ dropIndicatorProps, dragSourceRef }) => (
+        {({ dropIndicatorProps, dragSourceRef, draggingTabOnTab }) => (
           <TabTitleContainer
             isHighlighted={isHighlighted}
             className="dragdroppable-tab"
@@ -316,7 +320,7 @@ class Tab extends PureComponent {
                 placement={index >= 5 ? 'left' : 'right'}
               />
             )}
-            {dropIndicatorProps && (
+            {dropIndicatorProps && !draggingTabOnTab && (
               <TitleDropIndicator
                 className={dropIndicatorProps.className}
                 data-test="title-drop-indicator"

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
@@ -196,6 +196,10 @@ test('Drop on a tab', async () => {
   );
 
   fireEvent.dragStart(screen.getByText('Dashboard Component'));
+  fireEvent.dragOver(screen.getByText('Next Tab'));
+  await waitFor(() =>
+    expect(screen.getByTestId('title-drop-indicator')).toBeVisible(),
+  );
   fireEvent.drop(screen.getByText('Next Tab'));
   await waitFor(() => expect(mockOnDropOnTab).toHaveBeenCalledTimes(2));
   expect(mockOnDropOnTab).toHaveBeenLastCalledWith(

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -105,12 +105,6 @@ const StyledTabsContainer = styled.div`
     }
   }
 
-  .ant-tabs-tab {
-    &:has(.dragdroppable--dragging) {
-      display: none;
-    }
-  }
-
   div .ant-tabs-tab-btn {
     text-transform: none;
   }
@@ -127,7 +121,7 @@ const RightDropIndicator = styled.div`
   position: absolute;
   top: 0;
   right: -4px;
-  border-radius: 4px;
+  border-radius: 2px;
 `;
 const LeftDropIndicator = styled.div`
   border: 2px solid ${({ theme }) => theme.colors.primary.base};
@@ -136,7 +130,7 @@ const LeftDropIndicator = styled.div`
   position: absolute;
   top: 0;
   left: -4px;
-  border-radius: 4px;
+  border-radius: 2px;
 `;
 
 const CloseIconWithDropIndicator = props => (
@@ -329,17 +323,8 @@ export class Tabs extends PureComponent {
 
   handleGetDropPosition(dragObject) {
     const { dropIndicator, isDraggingOver, index } = dragObject;
-    const { dragOverTabIndex } = this.state;
 
     if (isDraggingOver) {
-      console.log(
-        'dropIndicator',
-        dropIndicator,
-        'dragOverTabIndex',
-        dragOverTabIndex,
-        'index',
-        index,
-      );
       this.setState(() => ({
         dropPosition: dropIndicator,
         dragOverTabIndex: index,
@@ -445,7 +430,6 @@ export class Tabs extends PureComponent {
               type={editMode ? 'editable-card' : 'card'}
             >
               {tabIds.map((tabId, tabIndex) => (
-                // Add droppable component to each tab
                 <LineEditableTabs.TabPane
                   key={tabId}
                   tab={

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -157,6 +157,7 @@ export class Tabs extends PureComponent {
     this.handleDropOnTab = this.handleDropOnTab.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
     this.handleGetDropPosition = this.handleGetDropPosition.bind(this);
+    this.handleDragggingTab = this.handleDragggingTab.bind(this);
   }
 
   componentDidMount() {
@@ -359,6 +360,14 @@ export class Tabs extends PureComponent {
     }
   }
 
+  handleDragggingTab(tabId) {
+    if (tabId) {
+      this.setState(() => ({ draggingTabId: tabId }));
+    } else {
+      this.setState(() => ({ draggingTabId: null }));
+    }
+  }
+
   render() {
     const {
       depth,
@@ -390,6 +399,8 @@ export class Tabs extends PureComponent {
         left: editMode && dropPosition === DROP_LEFT,
         right: editMode && dropPosition === DROP_RIGHT,
       };
+
+    const removeDraggedTab = tabID => this.state.draggingTabId === tabID;
 
     let tabsToHighlight;
     const highlightedFilterId =
@@ -433,35 +444,44 @@ export class Tabs extends PureComponent {
                 <LineEditableTabs.TabPane
                   key={tabId}
                   tab={
-                    <>
-                      {showDropIndicators(tabIndex).left && (
-                        <LeftDropIndicator className="drop-indicator-left" />
-                      )}
-                      <DashboardComponent
-                        id={tabId}
-                        parentId={tabsComponent.id}
-                        depth={depth}
-                        index={tabIndex}
-                        renderType={RENDER_TAB}
-                        availableColumnCount={availableColumnCount}
-                        columnWidth={columnWidth}
-                        onDropOnTab={this.handleDropOnTab}
-                        onDropPositionChange={this.handleGetDropPosition}
-                        onHoverTab={() => this.handleClickTab(tabIndex)}
-                        isFocused={activeKey === tabId}
-                        isHighlighted={
-                          activeKey !== tabId &&
-                          tabsToHighlight?.includes(tabId)
-                        }
-                      />
-                    </>
+                    removeDraggedTab(tabId) ? (
+                      <></>
+                    ) : (
+                      <>
+                        {showDropIndicators(tabIndex).left && (
+                          <LeftDropIndicator className="drop-indicator-left" />
+                        )}
+                        <DashboardComponent
+                          id={tabId}
+                          parentId={tabsComponent.id}
+                          depth={depth}
+                          index={tabIndex}
+                          renderType={RENDER_TAB}
+                          availableColumnCount={availableColumnCount}
+                          columnWidth={columnWidth}
+                          onDropOnTab={this.handleDropOnTab}
+                          onDropPositionChange={this.handleGetDropPosition}
+                          onDragTab={this.handleDragggingTab}
+                          onHoverTab={() => this.handleClickTab(tabIndex)}
+                          isFocused={activeKey === tabId}
+                          isHighlighted={
+                            activeKey !== tabId &&
+                            tabsToHighlight?.includes(tabId)
+                          }
+                        />
+                      </>
+                    )
                   }
                   closeIcon={
-                    <CloseIconWithDropIndicator
-                      role="button"
-                      tabIndex={tabIndex}
-                      showDropIndicators={showDropIndicators(tabIndex)}
-                    />
+                    removeDraggedTab(tabId) ? (
+                      <></>
+                    ) : (
+                      <CloseIconWithDropIndicator
+                        role="button"
+                        tabIndex={tabIndex}
+                        showDropIndicators={showDropIndicators(tabIndex)}
+                      />
+                    )
                   }
                 >
                   {renderTabContent && (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -114,22 +114,13 @@ const StyledCancelXIcon = styled(Icons.CancelX)`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
 
-const RightDropIndicator = styled.div`
+const DropIndicator = styled.div`
   border: 2px solid ${({ theme }) => theme.colors.primary.base};
   width: 5px;
   height: 100%;
   position: absolute;
   top: 0;
-  right: -4px;
-  border-radius: 2px;
-`;
-const LeftDropIndicator = styled.div`
-  border: 2px solid ${({ theme }) => theme.colors.primary.base};
-  width: 5px;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: -4px;
+  ${({ pos }) => (pos === 'left' ? 'left: -4px' : 'right: -4px')};
   border-radius: 2px;
 `;
 
@@ -137,7 +128,7 @@ const CloseIconWithDropIndicator = props => (
   <>
     <StyledCancelXIcon />
     {props.showDropIndicators.right && (
-      <RightDropIndicator className="drop-indicator-right" />
+      <DropIndicator className="drop-indicator-right" pos="right" />
     )}
   </>
 );
@@ -449,7 +440,10 @@ export class Tabs extends PureComponent {
                     ) : (
                       <>
                         {showDropIndicators(tabIndex).left && (
-                          <LeftDropIndicator className="drop-indicator-left" />
+                          <DropIndicator
+                            className="drop-indicator-left"
+                            pos="left"
+                          />
                         )}
                         <DashboardComponent
                           id={tabId}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.jsx
@@ -105,6 +105,12 @@ const StyledTabsContainer = styled.div`
     }
   }
 
+  .ant-tabs-tab {
+    &:has(.dragdroppable--dragging) {
+      display: none;
+    }
+  }
+
   div .ant-tabs-tab-btn {
     text-transform: none;
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
@@ -122,21 +122,24 @@ test('Should render editMode:true', () => {
   const props = createProps();
   render(<Tabs {...props} />, { useRedux: true, useDnd: true });
   expect(screen.getAllByRole('tab')).toHaveLength(3);
-  expect(Draggable).toBeCalledTimes(1);
-  expect(DashboardComponent).toBeCalledTimes(4);
-  expect(DeleteComponentButton).toBeCalledTimes(1);
   expect(screen.getAllByRole('button', { name: 'remove' })).toHaveLength(3);
   expect(screen.getAllByRole('button', { name: 'Add tab' })).toHaveLength(2);
+  expect(Draggable).toHaveBeenCalledTimes(1);
+  expect(DashboardComponent).toHaveBeenCalledTimes(4);
+  expect(DeleteComponentButton).toHaveBeenCalledTimes(1);
 });
 
 test('Should render editMode:false', () => {
   const props = createProps();
   props.editMode = false;
-  render(<Tabs {...props} />, { useRedux: true, useDnd: true });
+  render(<Tabs {...props} />, {
+    useRedux: true,
+    useDnd: true,
+  });
   expect(screen.getAllByRole('tab')).toHaveLength(3);
-  expect(Draggable).toBeCalledTimes(1);
-  expect(DashboardComponent).toBeCalledTimes(4);
-  expect(DeleteComponentButton).not.toBeCalled();
+  expect(Draggable).toHaveBeenCalledTimes(1);
+  expect(DashboardComponent).toHaveBeenCalledTimes(4);
+  expect(DeleteComponentButton).not.toHaveBeenCalled();
   expect(
     screen.queryByRole('button', { name: 'remove' }),
   ).not.toBeInTheDocument();
@@ -153,11 +156,11 @@ test('Update component props', () => {
     useRedux: true,
     useDnd: true,
   });
-  expect(DeleteComponentButton).not.toBeCalled();
+  expect(DeleteComponentButton).not.toHaveBeenCalled();
 
   props.editMode = true;
   rerender(<Tabs {...props} />);
-  expect(DeleteComponentButton).toBeCalledTimes(1);
+  expect(DeleteComponentButton).toHaveBeenCalledTimes(1);
 });
 
 test('Clicking on "DeleteComponentButton"', () => {
@@ -167,9 +170,12 @@ test('Clicking on "DeleteComponentButton"', () => {
     useDnd: true,
   });
 
-  expect(props.deleteComponent).not.toBeCalled();
+  expect(props.deleteComponent).not.toHaveBeenCalled();
   userEvent.click(screen.getByTestId('DeleteComponentButton'));
-  expect(props.deleteComponent).toBeCalledWith('TABS-L-d9eyOE-b', 'GRID_ID');
+  expect(props.deleteComponent).toHaveBeenCalledWith(
+    'TABS-L-d9eyOE-b',
+    'GRID_ID',
+  );
 });
 
 test('Add new tab', () => {
@@ -179,9 +185,9 @@ test('Add new tab', () => {
     useDnd: true,
   });
 
-  expect(props.createComponent).not.toBeCalled();
+  expect(props.createComponent).not.toHaveBeenCalled();
   userEvent.click(screen.getAllByRole('button', { name: 'Add tab' })[0]);
-  expect(props.createComponent).toBeCalled();
+  expect(props.createComponent).toHaveBeenCalled();
 });
 
 test('Removing a tab', async () => {
@@ -191,16 +197,16 @@ test('Removing a tab', async () => {
     useDnd: true,
   });
 
-  expect(props.deleteComponent).not.toBeCalled();
+  expect(props.deleteComponent).not.toHaveBeenCalled();
   expect(screen.queryByText('Delete dashboard tab?')).not.toBeInTheDocument();
   userEvent.click(screen.getAllByRole('button', { name: 'remove' })[0]);
-  expect(props.deleteComponent).not.toBeCalled();
+  expect(props.deleteComponent).not.toHaveBeenCalled();
 
   expect(await screen.findByText('Delete dashboard tab?')).toBeInTheDocument();
 
-  expect(props.deleteComponent).not.toBeCalled();
+  expect(props.deleteComponent).not.toHaveBeenCalled();
   userEvent.click(screen.getByRole('button', { name: 'DELETE' }));
-  expect(props.deleteComponent).toBeCalled();
+  expect(props.deleteComponent).toHaveBeenCalled();
 });
 
 test('Switching tabs', () => {
@@ -210,11 +216,11 @@ test('Switching tabs', () => {
     useDnd: true,
   });
 
-  expect(props.logEvent).not.toBeCalled();
-  expect(props.onChangeTab).not.toBeCalled();
+  expect(props.logEvent).not.toHaveBeenCalled();
+  expect(props.onChangeTab).not.toHaveBeenCalled();
   userEvent.click(screen.getAllByRole('tab')[2]);
-  expect(props.logEvent).toBeCalled();
-  expect(props.onChangeTab).toBeCalled();
+  expect(props.logEvent).toHaveBeenCalled();
+  expect(props.onChangeTab).toHaveBeenCalled();
 });
 
 test('Call "DashboardComponent.onDropOnTab"', async () => {
@@ -224,12 +230,12 @@ test('Call "DashboardComponent.onDropOnTab"', async () => {
     useDnd: true,
   });
 
-  expect(props.logEvent).not.toBeCalled();
-  expect(props.onChangeTab).not.toBeCalled();
+  expect(props.logEvent).not.toHaveBeenCalled();
+  expect(props.onChangeTab).not.toHaveBeenCalled();
   userEvent.click(screen.getAllByText('DashboardComponent')[0]);
 
   await waitFor(() => {
-    expect(props.logEvent).toBeCalled();
-    expect(props.onChangeTab).toBeCalled();
+    expect(props.logEvent).toHaveBeenCalled();
+    expect(props.onChangeTab).toHaveBeenCalled();
   });
 });

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.js
@@ -134,7 +134,7 @@ const actionHandlers = {
     const {
       payload: { dropResult },
     } = action;
-    const { source, destination, dragging } = dropResult;
+    const { source, destination, dragging, position } = dropResult;
 
     if (!source || !destination || !dragging) return state;
 
@@ -142,6 +142,7 @@ const actionHandlers = {
       entitiesMap: state,
       source,
       destination,
+      position,
     });
 
     if (componentIsResizable(nextEntities[dragging.id])) {

--- a/superset-frontend/src/dashboard/util/dnd-reorder.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.js
@@ -16,6 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+// import { TABS_TYPE } from './componentTypes';
+// import { DROP_LEFT } from './getDropPosition';
+
 export function reorder(list, startIndex, endIndex) {
   const result = [...list];
   const [removed] = result.splice(startIndex, 1);
@@ -28,6 +32,28 @@ export default function reorderItem({ entitiesMap, source, destination }) {
   const current = [...entitiesMap[source.id].children];
   const next = [...entitiesMap[destination.id].children];
   const target = current[source.index];
+  // const { dropPosition } = destination;
+
+  // reorder tabs with positional drop
+  /*
+  if (source.type && destination.type === TABS_TYPE && dropPosition) {
+    const reordered = reorder(
+      current,
+      source.index,
+      dropPosition === DROP_LEFT ? destination.index : destination.index + 1,
+    );
+
+    const result = {
+      ...entitiesMap,
+      [source.id]: {
+        ...entitiesMap[source.id],
+        children: reordered,
+      },
+    };
+
+    return result;
+  }
+  */
 
   // moving to same list
   if (source.id === destination.id) {

--- a/superset-frontend/src/dashboard/util/dnd-reorder.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.js
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-// import { TABS_TYPE } from './componentTypes';
-// import { DROP_LEFT } from './getDropPosition';
+import { TABS_TYPE } from './componentTypes';
+import { DROP_LEFT, DROP_RIGHT } from './getDropPosition';
 
 export function reorder(list, startIndex, endIndex) {
   const result = [...list];
@@ -28,20 +28,49 @@ export function reorder(list, startIndex, endIndex) {
   return result;
 }
 
-export default function reorderItem({ entitiesMap, source, destination }) {
+export default function reorderItem({
+  entitiesMap,
+  source,
+  destination,
+  position,
+}) {
   const current = [...entitiesMap[source.id].children];
   const next = [...entitiesMap[destination.id].children];
   const target = current[source.index];
-  // const { dropPosition } = destination;
 
-  // reorder tabs with positional drop
-  /*
-  if (source.type && destination.type === TABS_TYPE && dropPosition) {
-    const reordered = reorder(
-      current,
-      source.index,
-      dropPosition === DROP_LEFT ? destination.index : destination.index + 1,
-    );
+  const isSameSource = source.id === destination.id;
+  const isTabsType = source.type && destination.type === TABS_TYPE;
+
+  // moving to same list
+  let dropIndex = destination.index;
+
+  if (isSameSource) {
+    if (isTabsType) {
+      if (position === DROP_LEFT) {
+        dropIndex = Math.max(dropIndex, 0);
+      } else if (position === DROP_RIGHT) {
+        dropIndex += 1;
+      }
+
+      const isRightPosition =
+        position === DROP_RIGHT && source.index === destination.index + 1;
+      const isLeftPosition =
+        position === DROP_LEFT && source.index === destination.index - 1;
+
+      const sameTabSourceIndex = isRightPosition || isLeftPosition;
+
+      if (sameTabSourceIndex) {
+        // If the source tab is dropped to be the same index as the source
+        // tab, no change is needed in entitiesMap
+        return entitiesMap;
+      }
+
+      // Adjust dropIndex to account for the source tab being removed
+      if (dropIndex > source.index) {
+        dropIndex -= 1;
+      }
+    }
+    const reordered = reorder(current, source.index, dropIndex);
 
     const result = {
       ...entitiesMap,
@@ -53,26 +82,19 @@ export default function reorderItem({ entitiesMap, source, destination }) {
 
     return result;
   }
-  */
 
-  // moving to same list
-  if (source.id === destination.id) {
-    const reordered = reorder(current, source.index, destination.index);
-
-    const result = {
-      ...entitiesMap,
-      [source.id]: {
-        ...entitiesMap[source.id],
-        children: reordered,
-      },
-    };
-
-    return result;
+  if (isTabsType) {
+    // Ensure the dropIndex is within the bounds of the destination children
+    if (position === DROP_LEFT) {
+      dropIndex = Math.max(dropIndex, 0);
+    } else if (position === DROP_RIGHT) {
+      dropIndex = Math.min(dropIndex + 1, current.length - 1);
+    }
   }
 
   // moving to different list
   current.splice(source.index, 1); // remove from original
-  next.splice(destination.index, 0, target); // insert into next
+  next.splice(dropIndex, 0, target); // insert into next
 
   const result = {
     ...entitiesMap,

--- a/superset-frontend/src/dashboard/util/dnd-reorder.test.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.test.js
@@ -17,6 +17,8 @@
  * under the License.
  */
 import reorderItem from 'src/dashboard/util/dnd-reorder';
+import { TABS_TYPE } from './componentTypes';
+import { DROP_LEFT, DROP_RIGHT } from './getDropPosition';
 
 describe('dnd-reorderItem', () => {
   it('should remove the item from its source entity and add it to its destination entity', () => {
@@ -72,6 +74,121 @@ describe('dnd-reorderItem', () => {
       destination: { id: 'b', index: 1 },
     });
 
-    expect(result.iAmExtra === extraEntity).toBe(true);
+    expect(result.iAmExtra).toBe(extraEntity);
+  });
+
+  it('should handle out of bounds destination index gracefully', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          children: ['x', 'y', 'z'],
+        },
+        b: {
+          id: 'b',
+          children: ['banana'],
+        },
+      },
+      source: { id: 'a', index: 1 },
+      destination: { id: 'b', index: 5 },
+    });
+
+    expect(result.a.children).toEqual(['x', 'z']);
+    expect(result.b.children).toEqual(['banana', 'y']);
+  });
+
+  it('should do nothing if source and destination are the same and indices are the same', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          children: ['x', 'y', 'z'],
+        },
+      },
+      source: { id: 'a', index: 1 },
+      destination: { id: 'a', index: 1 },
+    });
+
+    expect(result.a.children).toEqual(['x', 'y', 'z']);
+  });
+
+  it('should handle DROP_LEFT in the same TABS_TYPE list correctly', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          type: TABS_TYPE,
+          children: ['x', 'y', 'z'],
+        },
+      },
+      source: { id: 'a', type: TABS_TYPE, index: 2 },
+      destination: { id: 'a', type: TABS_TYPE, index: 1 },
+      position: DROP_LEFT,
+    });
+
+    expect(result.a.children).toEqual(['x', 'z', 'y']);
+  });
+
+  it('should handle DROP_RIGHT in the same TABS_TYPE list correctly', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          type: TABS_TYPE,
+          children: ['x', 'y', 'z'],
+        },
+      },
+      source: { id: 'a', type: TABS_TYPE, index: 0 },
+      destination: { id: 'a', type: TABS_TYPE, index: 1 },
+      position: DROP_RIGHT,
+    });
+
+    expect(result.a.children).toEqual(['y', 'x', 'z']);
+  });
+
+  it('should handle DROP_LEFT when moving between different TABS_TYPE lists', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          type: TABS_TYPE,
+          children: ['x', 'y'],
+        },
+        b: {
+          id: 'b',
+          type: TABS_TYPE,
+          children: ['banana'],
+        },
+      },
+      source: { id: 'a', type: TABS_TYPE, index: 1 },
+      destination: { id: 'b', type: TABS_TYPE, index: 0 },
+      position: DROP_LEFT,
+    });
+
+    expect(result.a.children).toEqual(['x']);
+    expect(result.b.children).toEqual(['y', 'banana']);
+  });
+
+  it('should handle DROP_RIGHT when moving between different TABS_TYPE lists', () => {
+    const result = reorderItem({
+      entitiesMap: {
+        a: {
+          id: 'a',
+          type: TABS_TYPE,
+          children: ['x', 'y'],
+        },
+        b: {
+          id: 'b',
+          type: TABS_TYPE,
+          children: ['banana'],
+        },
+      },
+      source: { id: 'a', type: TABS_TYPE, index: 0 },
+      destination: { id: 'b', type: TABS_TYPE, index: 0 },
+      position: DROP_RIGHT,
+    });
+
+    expect(result.a.children).toEqual(['y']);
+    expect(result.b.children).toEqual(['banana', 'x']);
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change reordering and UI specifically for `Tab` components within `Tabs` parent components across the codebase.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
B:

https://github.com/user-attachments/assets/c9029ae0-8db5-4f9b-88ed-264da4cda784


A:

https://github.com/user-attachments/assets/3a4767a3-23ba-485f-91eb-8325dc6cc4bf


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Create or navigate to a dashboard with tabs
- Drag tabs over other tabs to reorder

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
