### PR TITLE
chore: move all GHAs to ubuntu-22.04

### DIFF
--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   bump-python-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/cancel_duplicates.yml
+++ b/.github/workflows/cancel_duplicates.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cancel-duplicate-runs:
     name: Cancel duplicate workflow runs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/check_db_migration_confict.yml
+++ b/.github/workflows/check_db_migration_confict.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   check_db_migration_conflict:
     name: Check DB migration conflict
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   setup_matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix_config: ${{ steps.set_matrix.outputs.matrix_config }}
     steps:
@@ -28,7 +28,7 @@ jobs:
   docker-build:
     name: docker-build
     needs: setup_matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build_preset: ${{fromJson(needs.setup_matrix.outputs.matrix_config)}}

--- a/.github/workflows/embedded-sdk-release.yml
+++ b/.github/workflows/embedded-sdk-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   build:
     needs: config
     if: needs.config.outputs.has-secrets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: superset-embedded-sdk

--- a/.github/workflows/embedded-sdk-test.yml
+++ b/.github/workflows/embedded-sdk-test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   embedded-sdk-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: superset-embedded-sdk

--- a/.github/workflows/ephemeral-env-pr-close.yml
+++ b/.github/workflows/ephemeral-env-pr-close.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -22,7 +22,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: Cleanup ephemeral envs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     if: github.event.issue.pull_request
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
@@ -26,7 +26,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: Evaluate ephemeral env comment trigger (/testenv)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     outputs:
@@ -88,7 +88,7 @@ jobs:
       cancel-in-progress: true
     needs: ephemeral-env-comment
     name: ephemeral-docker-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Get Info from comment
         uses: actions/github-script@v7
@@ -153,7 +153,7 @@ jobs:
     needs: [ephemeral-env-comment, ephemeral-docker-build]
     if: needs.ephemeral-env-comment.outputs.slash-command == 'up'
     name: Spin up an ephemeral environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/generate-FOSSA-report.yml
+++ b/.github/workflows/generate-FOSSA-report.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -24,7 +24,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: Generate Report
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/github-action-validator.yml
+++ b/.github/workflows/github-action-validator.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   validate-all-ghas:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   superbot-orglabel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   latest-release:
     name: Add/update tag to new release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   license_check:
     name: License Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/no-hold-label.yml
+++ b/.github/workflows/no-hold-label.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check-hold-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check for 'hold' label
       uses: actions/github-script@v7

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/prefer-typescript.yml
+++ b/.github/workflows/prefer-typescript.yml
@@ -21,7 +21,7 @@ jobs:
   prefer_typescript:
     if: github.ref == 'ref/heads/master' && github.event_name == 'pull_request'
     name: Prefer TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -25,7 +25,7 @@ jobs:
     if: needs.config.outputs.has-secrets
     name: Bump version and publish package(s)
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -21,7 +21,7 @@ jobs:
   cypress-applitools:
     needs: config
     if: needs.config.outputs.has-secrets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/superset-applitools-storybook.yml
+++ b/.github/workflows/superset-applitools-storybook.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -27,7 +27,7 @@ jobs:
   cron:
     needs: config
     if: needs.config.outputs.has-secrets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node: [18]

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-load-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -28,7 +28,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: Build & Deploy
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-deploy:
     name: Build & Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cypress-matrix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   frontend-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
 

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test-mysql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -74,7 +74,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
   test-postgres:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["current", "next", "previous"]
@@ -136,7 +136,7 @@ jobs:
           verbose: true
 
   test-sqlite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-misc.yml
+++ b/.github/workflows/superset-python-misc.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   python-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
         if: steps.check.outputs.python
 
   babel-extract:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-postgres-presto:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -84,7 +84,7 @@ jobs:
           verbose: true
 
   test-postgres-hive:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONPATH: ${{ github.workspace }}
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["current", "next"]

--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   frontend-check-translations:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           npm run build-translation
 
   babel-extract:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/superset-websocket.yml
+++ b/.github/workflows/superset-websocket.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   app-checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   supersetbot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@supersetbot'))

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -23,7 +23,7 @@ on:
           - 'false'
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     name: docker-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         build_preset: ["dev", "lean", "py310", "websocket", "dockerize"]

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   config:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   process-and-upload:
     needs: config
     if: needs.config.outputs.has-secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Generate Reports
     steps:
       - name: Checkout Repository

--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   welcome:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
GHA doesn't really offer a great way to make this DRY, but that doesn't mean we can't be consistent and deterministic. Ideally we'd set our preferred ubuntu version centrally and change it all at once, but it's really not hard to mass update this.

I got GPT to write a quick script to replace in files for reference:

```python
import os

def replace_strings_in_file(file_path, old_string, new_string):
    with open(file_path, 'r') as file:
        content = file.read()

    content = content.replace(old_string, new_string)

    with open(file_path, 'w') as file:
        file.write(content)

def update_github_workflows(directory='.github/workflows', old_string1='ubuntu-20.04', old_string2='ubuntu-latest', new_string='ubuntu-22.04'):
    for subdir, _, files in os.walk(directory):
        for file in files:
            file_path = os.path.join(subdir, file)
            if file_path.endswith('.yml') or file_path.endswith('.yaml'):
                replace_strings_in_file(file_path, old_string1, new_string)
                replace_strings_in_file(file_path, old_string2, new_string)
                print(f"Updated {file_path}")

if __name__ == "__main__":
    update_github_workflows()
```

