### PR TITLE
fix(metastore-cache): import dao in methods

### DIFF
--- a/superset/extensions/metastore_cache.py
+++ b/superset/extensions/metastore_cache.py
@@ -24,7 +24,6 @@ from flask_caching import BaseCache
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset import db
-from superset.daos.key_value import KeyValueDAO
 from superset.key_value.exceptions import KeyValueCreateFailedError
 from superset.key_value.types import (
     KeyValueCodec,
@@ -79,6 +78,9 @@ class SupersetMetastoreCache(BaseCache):
         return None
 
     def set(self, key: str, value: Any, timeout: Optional[int] = None) -> bool:
+        # pylint: disable=import-outside-toplevel
+        from superset.daos.key_value import KeyValueDAO
+
         KeyValueDAO.upsert_entry(
             resource=RESOURCE,
             key=self.get_key(key),
@@ -90,6 +92,9 @@ class SupersetMetastoreCache(BaseCache):
         return True
 
     def add(self, key: str, value: Any, timeout: Optional[int] = None) -> bool:
+        # pylint: disable=import-outside-toplevel
+        from superset.daos.key_value import KeyValueDAO
+
         try:
             KeyValueDAO.delete_expired_entries(RESOURCE)
             KeyValueDAO.create_entry(
@@ -106,6 +111,9 @@ class SupersetMetastoreCache(BaseCache):
             return False
 
     def get(self, key: str) -> Any:
+        # pylint: disable=import-outside-toplevel
+        from superset.daos.key_value import KeyValueDAO
+
         return KeyValueDAO.get_value(RESOURCE, self.get_key(key), self.codec)
 
     def has(self, key: str) -> bool:
@@ -116,4 +124,7 @@ class SupersetMetastoreCache(BaseCache):
 
     @transaction()
     def delete(self, key: str) -> Any:
+        # pylint: disable=import-outside-toplevel
+        from superset.daos.key_value import KeyValueDAO
+
         return KeyValueDAO.delete_entry(RESOURCE, self.get_key(key))

--- a/tests/integration_tests/extensions/metastore_cache_test.py
+++ b/tests/integration_tests/extensions/metastore_cache_test.py
@@ -18,22 +18,20 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from datetime import datetime, timedelta
-from typing import Any, TYPE_CHECKING
+from typing import Any
 from uuid import UUID
 
 import pytest
 from flask.ctx import AppContext
 from freezegun import freeze_time
 
+from superset.extensions.metastore_cache import SupersetMetastoreCache
 from superset.key_value.exceptions import KeyValueCodecEncodeException
 from superset.key_value.types import (
     JsonKeyValueCodec,
     KeyValueCodec,
     PickleKeyValueCodec,
 )
-
-if TYPE_CHECKING:
-    from superset.extensions.metastore_cache import SupersetMetastoreCache
 
 NAMESPACE = UUID("ee173d1b-ccf3-40aa-941c-985c15224496")
 
@@ -47,17 +45,11 @@ SECOND_VALUE = "qwerty"
 
 @pytest.fixture
 def cache() -> SupersetMetastoreCache:
-    from superset.extensions.metastore_cache import SupersetMetastoreCache
-
     return SupersetMetastoreCache(
         namespace=NAMESPACE,
         default_timeout=600,
         codec=PickleKeyValueCodec(),
     )
-
-
-def test_instantiation(cache: SupersetMetastoreCache) -> None:
-    assert cache
 
 
 def test_caching_flow(app_context: AppContext, cache: SupersetMetastoreCache) -> None:

--- a/tests/integration_tests/extensions/metastore_cache_test.py
+++ b/tests/integration_tests/extensions/metastore_cache_test.py
@@ -56,6 +56,10 @@ def cache() -> SupersetMetastoreCache:
     )
 
 
+def test_instantiation(cache: SupersetMetastoreCache) -> None:
+    assert cache
+
+
 def test_caching_flow(app_context: AppContext, cache: SupersetMetastoreCache) -> None:
     assert cache.has(FIRST_KEY) is False
     assert cache.add(FIRST_KEY, FIRST_KEY_INITIAL_VALUE) is True


### PR DESCRIPTION
### SUMMARY
The recent PR #29344 caused a regression causing importing of the Metastore cache outside the app context to fail. This moves the DAO import into the relevant methods to avoid needing the app context during import time and also changes the imports in the test to ensure they work without an app context.

### AFTER
```python
python
Python 3.10.6+ (heads/3.10:57f4472, Aug 30 2022, 12:15:19) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from superset.extensions.metastore_cache import SupersetMetastoreCache
>>>
```

### BEFORE
```python
$ python
Python 3.10.6+ (heads/3.10:57f4472, Aug 30 2022, 12:15:19) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from superset.extensions.metastore_cache import SupersetMetastoreCache
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ville/apple/apache-superset/superset/extensions/metastore_cache.py", line 27, in <module>
    from superset.daos.key_value import KeyValueDAO
  File "/Users/ville/apple/apache-superset/superset/daos/key_value.py", line 32, in <module>
    from superset.key_value.models import KeyValueEntry
  File "/Users/ville/apple/apache-superset/superset/key_value/models.py", line 24, in <module>
    from superset.models.helpers import AuditMixinNullable, ImportExportMixin
  File "/Users/ville/apple/apache-superset/superset/models/__init__.py", line 17, in <module>
    from . import core, dynamic_plugins, sql_lab, user_attributes  # noqa: F401
  File "/Users/ville/apple/apache-superset/superset/models/core.py", line 74, in <module>
    from superset.models.helpers import AuditMixinNullable, ImportExportMixin
  File "/Users/ville/apple/apache-superset/superset/models/helpers.py", line 107, in <module>
    config = app.config
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/werkzeug/local.py", line 318, in __get__
    obj = instance._get_current_object()
  File "/Users/ville/apple/apache-superset/venv/lib/python3.10/site-packages/werkzeug/local.py", line 519, in _get_current_object
    raise RuntimeError(unbound_message) from None
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
the current application. To solve this, set up an application context
with app.app_context(). See the documentation for more information.
>>>
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
