### PR TITLE
fix: Dashboard hangs when initial filters cannot be loaded

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/BasicErrorAlert.tsx
@@ -45,7 +45,7 @@ const StyledTitle = styled.span`
 interface BasicErrorAlertProps {
   title: string;
   body: string;
-  level: ErrorLevel;
+  level?: ErrorLevel;
 }
 
 export default function BasicErrorAlert({

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -76,6 +76,7 @@ import {
   OPEN_FILTER_BAR_WIDTH,
   EMPTY_CONTAINER_Z_INDEX,
 } from 'src/dashboard/constants';
+import BasicErrorAlert from 'src/components/ErrorMessage/BasicErrorAlert';
 import { getRootLevelTabsComponent, shouldFocusTabs } from './utils';
 import DashboardContainer from './DashboardContainer';
 import { useNativeFilters } from './state';
@@ -462,6 +463,7 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
 
   const {
     showDashboard,
+    missingInitialFilters,
     dashboardFiltersOpen,
     toggleDashboardFiltersOpen,
     nativeFiltersEnabled,
@@ -673,7 +675,30 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
             editMode={editMode}
             marginLeft={dashboardContentMarginLeft}
           >
-            {showDashboard ? (
+            {missingInitialFilters.length > 0 ? (
+              <div
+                css={css`
+                  display: flex;
+                  flex-direction: row;
+                  align-items: center;
+                  justify-content: center;
+                  flex: 1;
+                  & div {
+                    width: 500px;
+                  }
+                `}
+              >
+                <BasicErrorAlert
+                  title={t('Unable to load dashboard')}
+                  body={t(
+                    `The following filters have the 'Select first filter value by default'
+                    option checked and could not be loaded, which is preventing the dashboard
+                    from rendering: %s`,
+                    missingInitialFilters.join(', '),
+                  )}
+                />
+              </div>
+            ) : showDashboard ? (
               <DashboardContainer topLevelTabs={topLevelTabs} />
             ) : (
               <Loading />

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/state.ts
@@ -47,17 +47,14 @@ export const useNativeFilters = () => {
     filter => filter.requiredFirst,
   );
   const dataMask = useNativeFiltersDataMask();
+
+  const missingInitialFilters = requiredFirstFilter
+    .filter(({ id }) => dataMask[id]?.filterState?.value === undefined)
+    .map(({ name }) => name);
   const showDashboard =
     isInitialized ||
     !nativeFiltersEnabled ||
-    !(
-      nativeFiltersEnabled &&
-      requiredFirstFilter.length &&
-      requiredFirstFilter.find(
-        ({ id }) => dataMask[id]?.filterState?.value === undefined,
-      )
-    );
-
+    missingInitialFilters.length === 0;
   const toggleDashboardFiltersOpen = useCallback(
     (visible?: boolean) => {
       setDashboardFiltersOpen(visible ?? !dashboardFiltersOpen);
@@ -84,6 +81,7 @@ export const useNativeFilters = () => {
 
   return {
     showDashboard,
+    missingInitialFilters,
     dashboardFiltersOpen,
     toggleDashboardFiltersOpen,
     nativeFiltersEnabled,


### PR DESCRIPTION
### SUMMARY
The filter option "Select first filter value by default" is generally used when users want the dashboard to load with initial filters set. This is important when charts have a lot of data or they don't make sense without an initial filter. This PR fixes a bug were the dashboard could not leave the loading state when these initial filters could not be loaded. Now it will correctly display a message to the user informing which filters are failing and preventing the dashboard from rendering.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1771" alt="Screenshot 2024-07-02 at 11 36 29" src="https://github.com/apache/superset/assets/70410625/92f9d473-7070-4b41-b4d1-eaee78f49e87">
<img width="1771" alt="Screenshot 2024-07-02 at 11 35 45" src="https://github.com/apache/superset/assets/70410625/57790b6a-0d72-4f52-90fb-5b4e6fdd3694">

### TESTING INSTRUCTIONS
1 - Create a filter with the "Select first filter value by default" option checked
2 - Simulate a failure when loading the filter
3 - Check that the dashboard presents a message indicating which filter is preventing the dashboard from rendering

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
