### PR TITLE
chore(utils): Support select_columns with getUserOwnedObjects and split recentActivityObjs

### DIFF
--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -185,23 +185,6 @@ export const getUserOwnedObjects = (
     endpoint: `/api/v1/${resource}/?q=${getParams(filters, selectColumns)}`,
   }).then(res => res.json?.result);
 
-export const getRecentActivityObjs = (
-  userId: string | number,
-  recent: string,
-  addDangerToast: (arg1: string, arg2: any) => any,
-  filters: Filter[],
-) =>
-  SupersetClient.get({ endpoint: recent }).then(recentsRes => {
-    const res: any = {};
-    return getFilteredChartsandDashboards(addDangerToast, filters).then(
-      ({ other }) => {
-        res.other = other;
-        res.viewed = recentsRes.json.result;
-        return res;
-      },
-    );
-  });
-
 export const getFilteredChartsandDashboards = (
   addDangerToast: (arg1: string, arg2: any) => any,
   filters: Filter[],
@@ -231,6 +214,23 @@ export const getFilteredChartsandDashboards = (
       return { other: [] };
     });
 };
+
+export const getRecentActivityObjs = (
+  userId: string | number,
+  recent: string,
+  addDangerToast: (arg1: string, arg2: any) => any,
+  filters: Filter[],
+) =>
+  SupersetClient.get({ endpoint: recent }).then(recentsRes => {
+    const res: any = {};
+    return getFilteredChartsandDashboards(addDangerToast, filters).then(
+      ({ other }) => {
+        res.other = other;
+        res.viewed = recentsRes.json.result;
+        return res;
+      },
+    );
+  });
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -126,15 +126,17 @@ const createFetchResourceMethod =
   };
 
 export const PAGE_SIZE = 5;
-const getParams = (filters?: Filter[]) => {
+const getParams = (filters?: Filter[], select_columns?: string[]) => {
   const params = {
     order_column: 'changed_on_delta_humanized',
     order_direction: 'desc',
     page: 0,
     page_size: PAGE_SIZE,
     filters,
+    select_columns,
   };
   if (!filters) delete params.filters;
+  if (!select_columns) delete params.select_columns;
   return rison.encode(params);
 };
 
@@ -177,9 +179,10 @@ export const getUserOwnedObjects = (
       value: `${userId}`,
     },
   ],
+  select_columns?: string[],
 ) =>
   SupersetClient.get({
-    endpoint: `/api/v1/${resource}/?q=${getParams(filters)}`,
+    endpoint: `/api/v1/${resource}/?q=${getParams(filters, select_columns)}`,
   }).then(res => res.json?.result);
 
 export const getRecentActivityObjs = (
@@ -190,27 +193,39 @@ export const getRecentActivityObjs = (
 ) =>
   SupersetClient.get({ endpoint: recent }).then(recentsRes => {
     const res: any = {};
-    const newBatch = [
-      SupersetClient.get({
-        endpoint: `/api/v1/chart/?q=${getParams(filters)}`,
-      }),
-      SupersetClient.get({
-        endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,
-      }),
-    ];
-    return Promise.all(newBatch)
-      .then(([chartRes, dashboardRes]) => {
-        res.other = [...chartRes.json.result, ...dashboardRes.json.result];
+    return getFilteredChartsandDashboards(addDangerToast, filters).then(
+      ({ other }) => {
+        res.other = other;
         res.viewed = recentsRes.json.result;
         return res;
-      })
-      .catch(errMsg =>
-        addDangerToast(
-          t('There was an error fetching your recent activity:'),
-          errMsg,
-        ),
-      );
+      },
+    );
   });
+
+export const getFilteredChartsandDashboards = (
+  addDangerToast: (arg1: string, arg2: any) => any,
+  filters: Filter[],
+) => {
+  const newBatch = [
+    SupersetClient.get({
+      endpoint: `/api/v1/chart/?q=${getParams(filters)}`,
+    }),
+    SupersetClient.get({
+      endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,
+    }),
+  ];
+  return Promise.all(newBatch)
+    .then(([chartRes, dashboardRes]) => ({
+      other: [...chartRes.json.result, ...dashboardRes.json.result],
+    }))
+    .catch(errMsg => {
+      addDangerToast(
+        t('There was an error fetching the filtered charts and dashboards:'),
+        errMsg,
+      );
+      return { other: [] };
+    });
+};
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -126,17 +126,17 @@ const createFetchResourceMethod =
   };
 
 export const PAGE_SIZE = 5;
-const getParams = (filters?: Filter[], select_columns?: string[]) => {
+const getParams = (filters?: Filter[], selectColumns?: string[]) => {
   const params = {
     order_column: 'changed_on_delta_humanized',
     order_direction: 'desc',
     page: 0,
     page_size: PAGE_SIZE,
     filters,
-    select_columns,
+    select_columns: selectColumns,
   };
   if (!filters) delete params.filters;
-  if (!select_columns) delete params.select_columns;
+  if (!selectColumns) delete params.select_columns;
   return rison.encode(params);
 };
 
@@ -179,10 +179,10 @@ export const getUserOwnedObjects = (
       value: `${userId}`,
     },
   ],
-  select_columns?: string[],
+  selectColumns?: string[],
 ) =>
   SupersetClient.get({
-    endpoint: `/api/v1/${resource}/?q=${getParams(filters, select_columns)}`,
+    endpoint: `/api/v1/${resource}/?q=${getParams(filters, selectColumns)}`,
   }).then(res => res.json?.result);
 
 export const getRecentActivityObjs = (
@@ -205,13 +205,18 @@ export const getRecentActivityObjs = (
 export const getFilteredChartsandDashboards = (
   addDangerToast: (arg1: string, arg2: any) => any,
   filters: Filter[],
+  dashboardSelectColumns?: string[],
+  chartSelectColumns?: string[],
 ) => {
   const newBatch = [
     SupersetClient.get({
-      endpoint: `/api/v1/chart/?q=${getParams(filters)}`,
+      endpoint: `/api/v1/chart/?q=${getParams(filters, chartSelectColumns)}`,
     }),
     SupersetClient.get({
-      endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,
+      endpoint: `/api/v1/dashboard/?q=${getParams(
+        filters,
+        dashboardSelectColumns,
+      )}`,
     }),
   ];
   return Promise.all(newBatch)


### PR DESCRIPTION
### SUMMARY
This PR adds support for specifying a list of columns to be used in the `select_columns` parameter with the `getUserOwnedObjects` helper. 

It also splits the `getRecentActivityObjs` so that the logic to fetch dashboards and charts is handled by a separate helper: `getFilteredChartsandDashboards`. This new helper also supports specifying values for the `select_columns` parameters (both for the chart and dashboard requests).

These parameters are all optional, so it shouldn't impact any existing call/implementation. Please refer to https://github.com/apache/superset/pull/28609 for additional context on the `select_columns` parameter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
