### PR TITLE
fix: remove info from datasource access error

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -580,7 +580,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         """
 
         return (
-            f"This endpoint requires the datasource {datasource.name}, "
+            f"This endpoint requires the datasource {datasource.id}, "
             "database or `all_datasource_access` permission"
         )
 
@@ -612,7 +612,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             level=ErrorLevel.WARNING,
             extra={
                 "link": self.get_datasource_access_link(datasource),
-                "datasource": datasource.name,
+                "datasource": datasource.id,
             },
         )
 

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -129,7 +129,7 @@ class TestDatasourceApi(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(
             response["message"],
-            "This endpoint requires the datasource virtual_dataset, "
+            f"This endpoint requires the datasource {table.id}, "
             "database or `all_datasource_access` permission",
         )
 


### PR DESCRIPTION
### SUMMARY
Remove information about the datasource name from the access error message.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
