### PR TITLE
chore(Home): Avoid firing API requests when a custom Home is used

### DIFF
--- a/superset-frontend/src/pages/Home/Home.test.tsx
+++ b/superset-frontend/src/pages/Home/Home.test.tsx
@@ -234,6 +234,8 @@ test('Should not make data fetch calls if `welcome.main.replacement` is defined'
 
   // Clean up
   extensionsRegistry.set('welcome.banner', () => null);
+
+  // Set up
   extensionsRegistry.set('welcome.main.replacement', () => (
     <>welcome.main.replacement extension component</>
   ));

--- a/superset-frontend/src/pages/Home/Home.test.tsx
+++ b/superset-frontend/src/pages/Home/Home.test.tsx
@@ -228,3 +228,26 @@ test('Should render a submenu extension component if one is supplied', async () 
 
   expect(screen.getByText('submenu extension')).toBeInTheDocument();
 });
+
+test('Should not make data fetch calls if `welcome.main.replacement` is defined', async () => {
+  const extensionsRegistry = getExtensionsRegistry();
+
+  // Clean up
+  extensionsRegistry.set('welcome.banner', () => null);
+  extensionsRegistry.set('welcome.main.replacement', () => (
+    <>welcome.main.replacement extension component</>
+  ));
+
+  setupExtensions();
+
+  await renderWelcome();
+
+  expect(
+    screen.getByText('welcome.main.replacement extension component'),
+  ).toBeInTheDocument();
+
+  expect(fetchMock.calls(chartsEndpoint)).toHaveLength(0);
+  expect(fetchMock.calls(dashboardsEndpoint)).toHaveLength(0);
+  expect(fetchMock.calls(recentActivityEndpoint)).toHaveLength(0);
+  expect(fetchMock.calls(savedQueryEndpoint)).toHaveLength(0);
+});

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -218,7 +218,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   }, []);
 
   useEffect(() => {
-    if (!otherTabFilters || (WelcomeTopExtension && WelcomeMainExtension)) {
+    if (!otherTabFilters || WelcomeMainExtension) {
       return;
     }
     const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -217,89 +217,100 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ];
   }, []);
 
-  useEffect(() => {
-    if (!otherTabFilters) {
-      return;
-    }
-    const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);
-    setActiveState(collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR);
-    getRecentActivityObjs(user.userId!, recent, addDangerToast, otherTabFilters)
-      .then(res => {
-        const data: ActivityData | null = {};
-        data[TableTab.Other] = res.other;
-        if (res.viewed) {
-          const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
-          data[TableTab.Viewed] = filtered;
-          if (!activeTab && data[TableTab.Viewed]) {
-            setActiveChild(TableTab.Viewed);
-          } else if (!activeTab && !data[TableTab.Viewed]) {
-            setActiveChild(TableTab.Created);
-          } else setActiveChild(activeTab || TableTab.Created);
-        } else if (!activeTab) setActiveChild(TableTab.Created);
-        else setActiveChild(activeTab);
-        setActivityData(activityData => ({ ...activityData, ...data }));
-      })
-      .catch(
-        createErrorHandler((errMsg: unknown) => {
-          setActivityData(activityData => ({
-            ...activityData,
-            [TableTab.Viewed]: [],
-          }));
-          addDangerToast(
-            t('There was an issue fetching your recent activity: %s', errMsg),
-          );
-        }),
+  if (!WelcomeTopExtension && !WelcomeMainExtension) {
+    useEffect(() => {
+      if (!otherTabFilters) {
+        return;
+      }
+      const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);
+      setActiveState(
+        collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR,
       );
+      getRecentActivityObjs(
+        user.userId!,
+        recent,
+        addDangerToast,
+        otherTabFilters,
+      )
+        .then(res => {
+          const data: ActivityData | null = {};
+          data[TableTab.Other] = res.other;
+          if (res.viewed) {
+            const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
+            data[TableTab.Viewed] = filtered;
+            if (!activeTab && data[TableTab.Viewed]) {
+              setActiveChild(TableTab.Viewed);
+            } else if (!activeTab && !data[TableTab.Viewed]) {
+              setActiveChild(TableTab.Created);
+            } else setActiveChild(activeTab || TableTab.Created);
+          } else if (!activeTab) setActiveChild(TableTab.Created);
+          else setActiveChild(activeTab);
+          setActivityData(activityData => ({ ...activityData, ...data }));
+        })
+        .catch(
+          createErrorHandler((errMsg: unknown) => {
+            setActivityData(activityData => ({
+              ...activityData,
+              [TableTab.Viewed]: [],
+            }));
+            addDangerToast(
+              t('There was an issue fetching your recent activity: %s', errMsg),
+            );
+          }),
+        );
 
-    // Sets other activity data in parallel with recents api call
-    const ownSavedQueryFilters = [
-      {
-        col: 'created_by',
-        opr: 'rel_o_m',
-        value: `${id}`,
-      },
-    ];
-    Promise.all([
-      getUserOwnedObjects(id, 'dashboard')
-        .then(r => {
-          setDashboardData(r);
-          return Promise.resolve();
-        })
-        .catch((err: unknown) => {
-          setDashboardData([]);
-          addDangerToast(
-            t('There was an issue fetching your dashboards: %s', err),
-          );
-          return Promise.resolve();
-        }),
-      getUserOwnedObjects(id, 'chart')
-        .then(r => {
-          setChartData(r);
-          return Promise.resolve();
-        })
-        .catch((err: unknown) => {
-          setChartData([]);
-          addDangerToast(t('There was an issue fetching your chart: %s', err));
-          return Promise.resolve();
-        }),
-      canReadSavedQueries
-        ? getUserOwnedObjects(id, 'saved_query', ownSavedQueryFilters)
-            .then(r => {
-              setQueryData(r);
-              return Promise.resolve();
-            })
-            .catch((err: unknown) => {
-              setQueryData([]);
-              addDangerToast(
-                t('There was an issue fetching your saved queries: %s', err),
-              );
-              return Promise.resolve();
-            })
-        : Promise.resolve(),
-    ]).then(() => {
-      setIsFetchingActivityData(false);
-    });
-  }, [otherTabFilters]);
+      // Sets other activity data in parallel with recents api call
+      const ownSavedQueryFilters = [
+        {
+          col: 'created_by',
+          opr: 'rel_o_m',
+          value: `${id}`,
+        },
+      ];
+      Promise.all([
+        getUserOwnedObjects(id, 'dashboard')
+          .then(r => {
+            setDashboardData(r);
+            return Promise.resolve();
+          })
+          .catch((err: unknown) => {
+            setDashboardData([]);
+            addDangerToast(
+              t('There was an issue fetching your dashboards: %s', err),
+            );
+            return Promise.resolve();
+          }),
+        getUserOwnedObjects(id, 'chart')
+          .then(r => {
+            setChartData(r);
+            return Promise.resolve();
+          })
+          .catch((err: unknown) => {
+            setChartData([]);
+            addDangerToast(
+              t('There was an issue fetching your chart: %s', err),
+            );
+            return Promise.resolve();
+          }),
+        canReadSavedQueries
+          ? getUserOwnedObjects(id, 'saved_query', ownSavedQueryFilters)
+              .then(r => {
+                setQueryData(r);
+                return Promise.resolve();
+              })
+              .catch((err: unknown) => {
+                setQueryData([]);
+                addDangerToast(
+                  t('There was an issue fetching your saved queries: %s', err),
+                );
+                return Promise.resolve();
+              })
+          : Promise.resolve(),
+      ]).then(() => {
+        setIsFetchingActivityData(false);
+      });
+    }, [otherTabFilters]);
+  }
 
   const handleToggle = () => {
     setChecked(!checked);

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -217,100 +217,89 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ];
   }, []);
 
-  if (!WelcomeTopExtension && !WelcomeMainExtension) {
-    useEffect(() => {
-      if (!otherTabFilters) {
-        return;
-      }
-      const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);
-      setActiveState(
-        collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR,
+  useEffect(() => {
+    if (!otherTabFilters || (WelcomeTopExtension && WelcomeMainExtension)) {
+      return;
+    }
+    const activeTab = getItem(LocalStorageKeys.HomepageActivityFilter, null);
+    setActiveState(collapseState.length > 0 ? collapseState : DEFAULT_TAB_ARR);
+    getRecentActivityObjs(user.userId!, recent, addDangerToast, otherTabFilters)
+      .then(res => {
+        const data: ActivityData | null = {};
+        data[TableTab.Other] = res.other;
+        if (res.viewed) {
+          const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
+          data[TableTab.Viewed] = filtered;
+          if (!activeTab && data[TableTab.Viewed]) {
+            setActiveChild(TableTab.Viewed);
+          } else if (!activeTab && !data[TableTab.Viewed]) {
+            setActiveChild(TableTab.Created);
+          } else setActiveChild(activeTab || TableTab.Created);
+        } else if (!activeTab) setActiveChild(TableTab.Created);
+        else setActiveChild(activeTab);
+        setActivityData(activityData => ({ ...activityData, ...data }));
+      })
+      .catch(
+        createErrorHandler((errMsg: unknown) => {
+          setActivityData(activityData => ({
+            ...activityData,
+            [TableTab.Viewed]: [],
+          }));
+          addDangerToast(
+            t('There was an issue fetching your recent activity: %s', errMsg),
+          );
+        }),
       );
-      getRecentActivityObjs(
-        user.userId!,
-        recent,
-        addDangerToast,
-        otherTabFilters,
-      )
-        .then(res => {
-          const data: ActivityData | null = {};
-          data[TableTab.Other] = res.other;
-          if (res.viewed) {
-            const filtered = reject(res.viewed, ['item_url', null]).map(r => r);
-            data[TableTab.Viewed] = filtered;
-            if (!activeTab && data[TableTab.Viewed]) {
-              setActiveChild(TableTab.Viewed);
-            } else if (!activeTab && !data[TableTab.Viewed]) {
-              setActiveChild(TableTab.Created);
-            } else setActiveChild(activeTab || TableTab.Created);
-          } else if (!activeTab) setActiveChild(TableTab.Created);
-          else setActiveChild(activeTab);
-          setActivityData(activityData => ({ ...activityData, ...data }));
-        })
-        .catch(
-          createErrorHandler((errMsg: unknown) => {
-            setActivityData(activityData => ({
-              ...activityData,
-              [TableTab.Viewed]: [],
-            }));
-            addDangerToast(
-              t('There was an issue fetching your recent activity: %s', errMsg),
-            );
-          }),
-        );
 
-      // Sets other activity data in parallel with recents api call
-      const ownSavedQueryFilters = [
-        {
-          col: 'created_by',
-          opr: 'rel_o_m',
-          value: `${id}`,
-        },
-      ];
-      Promise.all([
-        getUserOwnedObjects(id, 'dashboard')
-          .then(r => {
-            setDashboardData(r);
-            return Promise.resolve();
-          })
-          .catch((err: unknown) => {
-            setDashboardData([]);
-            addDangerToast(
-              t('There was an issue fetching your dashboards: %s', err),
-            );
-            return Promise.resolve();
-          }),
-        getUserOwnedObjects(id, 'chart')
-          .then(r => {
-            setChartData(r);
-            return Promise.resolve();
-          })
-          .catch((err: unknown) => {
-            setChartData([]);
-            addDangerToast(
-              t('There was an issue fetching your chart: %s', err),
-            );
-            return Promise.resolve();
-          }),
-        canReadSavedQueries
-          ? getUserOwnedObjects(id, 'saved_query', ownSavedQueryFilters)
-              .then(r => {
-                setQueryData(r);
-                return Promise.resolve();
-              })
-              .catch((err: unknown) => {
-                setQueryData([]);
-                addDangerToast(
-                  t('There was an issue fetching your saved queries: %s', err),
-                );
-                return Promise.resolve();
-              })
-          : Promise.resolve(),
-      ]).then(() => {
-        setIsFetchingActivityData(false);
-      });
-    }, [otherTabFilters]);
-  }
+    // Sets other activity data in parallel with recents api call
+    const ownSavedQueryFilters = [
+      {
+        col: 'created_by',
+        opr: 'rel_o_m',
+        value: `${id}`,
+      },
+    ];
+    Promise.all([
+      getUserOwnedObjects(id, 'dashboard')
+        .then(r => {
+          setDashboardData(r);
+          return Promise.resolve();
+        })
+        .catch((err: unknown) => {
+          setDashboardData([]);
+          addDangerToast(
+            t('There was an issue fetching your dashboards: %s', err),
+          );
+          return Promise.resolve();
+        }),
+      getUserOwnedObjects(id, 'chart')
+        .then(r => {
+          setChartData(r);
+          return Promise.resolve();
+        })
+        .catch((err: unknown) => {
+          setChartData([]);
+          addDangerToast(t('There was an issue fetching your chart: %s', err));
+          return Promise.resolve();
+        }),
+      canReadSavedQueries
+        ? getUserOwnedObjects(id, 'saved_query', ownSavedQueryFilters)
+            .then(r => {
+              setQueryData(r);
+              return Promise.resolve();
+            })
+            .catch((err: unknown) => {
+              setQueryData([]);
+              addDangerToast(
+                t('There was an issue fetching your saved queries: %s', err),
+              );
+              return Promise.resolve();
+            })
+        : Promise.resolve(),
+    ]).then(() => {
+      setIsFetchingActivityData(false);
+    });
+  }, [otherTabFilters]);
 
   const handleToggle = () => {
     setChecked(!checked);


### PR DESCRIPTION
### SUMMARY
It's possible to override the content for the Homepage through the `extensionRegistry` (available options include `welcome.banner`, `welcome.main.replacement` and `welcome.message`).

Currently, regardless if a custom Homepage is set the React hook responsible for fetching the data is always called, resulting in additional/un-necessary API calls for Organizations with a custom home component implemented.

This PR avoids the data fetching process in case a custom Home is defined (through `welcome.main.replacement`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
