### PR TITLE
feat: Enable customizing the docker admin password

### DIFF
--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -37,7 +37,7 @@ Init Step ${1}/${STEP_CNT} [${2}] -- ${3}
 
 EOF
 }
-ADMIN_PASSWORD="admin"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
 # If Cypress run – overwrite the password for admin and export env variables
 if [ "$CYPRESS_CONFIG" == "true" ]; then
     ADMIN_PASSWORD="general"
@@ -57,7 +57,7 @@ superset fab create-admin \
               --firstname Superset \
               --lastname Admin \
               --email admin@superset.com \
-              --password $ADMIN_PASSWORD
+              --password "$ADMIN_PASSWORD"
 echo_step "2" "Complete" "Setting up admin user"
 # Create default roles and permissions
 echo_step "3" "Starting" "Setting up roles and perms"


### PR DESCRIPTION
### SUMMARY

This PR modifies the docker-compose setup to enable customizing the password used for the admin user. This is useful in scenarios where we want to use the docker-compose setup to spin up a self-contained superset instance but when we don't want to risk someone being able to log in as an admin with the known default credentials.

### TESTING INSTRUCTIONS

1. Configure password override: `echo 'ADMIN_PASSWORD=supersecret' > docker/.env-local`
2. Run the stack: `TAG=4.0.2 docker compose -f docker-compose-image-tag.yml up`
3. Go to http://localhost:8088 and log in using username admin and the password from step 1

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
