### PR TITLE
feat: Enable configuring redis in docker setup

### DIFF
--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -58,6 +58,15 @@ REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = os.getenv("REDIS_PORT", "6379")
 REDIS_CELERY_DB = os.getenv("REDIS_CELERY_DB", "0")
 REDIS_RESULTS_DB = os.getenv("REDIS_RESULTS_DB", "1")
+REDIS_PROTO = os.getenv("REDIS_PROTO", "redis")
+REDIS_USER = os.getenv("REDIS_USER", "")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD", "")
+
+REDIS_BASE_URL = (
+    f"{REDIS_PROTO}://{REDIS_USER}:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}"
+    if REDIS_PASSWORD
+    else f"{REDIS_PROTO}://{REDIS_HOST}:{REDIS_PORT}"
+)
 
 RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
@@ -65,17 +74,15 @@ CACHE_CONFIG = {
     "CACHE_TYPE": "RedisCache",
     "CACHE_DEFAULT_TIMEOUT": 300,
     "CACHE_KEY_PREFIX": "superset_",
-    "CACHE_REDIS_HOST": REDIS_HOST,
-    "CACHE_REDIS_PORT": REDIS_PORT,
-    "CACHE_REDIS_DB": REDIS_RESULTS_DB,
+    "CACHE_REDIS_URL": f"{REDIS_BASE_URL}/{REDIS_RESULTS_DB}",
 }
 DATA_CACHE_CONFIG = CACHE_CONFIG
 
 
 class CeleryConfig:
-    broker_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
+    broker_url = f"{REDIS_BASE_URL}/{REDIS_CELERY_DB}"
     imports = ("superset.sql_lab",)
-    result_backend = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
+    result_backend = f"{REDIS_BASE_URL}/{REDIS_RESULTS_DB}"
     worker_prefetch_multiplier = 1
     task_acks_late = False
     beat_schedule = {

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -25,6 +25,7 @@ import os
 
 from celery.schedules import crontab
 from flask_caching.backends.filesystemcache import FileSystemCache
+from flask_caching.backends.rediscache import RedisCache
 
 logger = logging.getLogger()
 
@@ -68,7 +69,17 @@ REDIS_BASE_URL = (
     else f"{REDIS_PROTO}://{REDIS_HOST}:{REDIS_PORT}"
 )
 
-RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
+if os.getenv("RESULTS_BACKEND_CACHE_TYPE") == "RedisCache":
+    RESULTS_BACKEND = RedisCache(
+        key_prefix="superset_results",
+        ssl=REDIS_PROTO == "rediss",
+        password=REDIS_PASSWORD or None,
+        host=REDIS_HOST,
+        port=REDIS_PORT,
+        db=REDIS_RESULTS_DB,
+    )
+else:
+    RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
 CACHE_CONFIG = {
     "CACHE_TYPE": "RedisCache",


### PR DESCRIPTION
### SUMMARY

This PR adds some configuration options for the docker-compose setup:

1. Enable using a password when connecting to redis
2. Enable using redis as the results backend

These changes are useful in scenarios where we want to use the docker-compose setup together with an existing redis instance and when we potentially want to run the superset UI on a different node from the superset workers without going all the way to using the k8s setup.

### TESTING INSTRUCTIONS

For testing the redis password support, apply the following patch:

```diff
diff --git a/docker-compose-image-tag.yml b/docker-compose-image-tag.yml
index 9309c6d619..b8c5aad55d 100644
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -38,6 +38,11 @@ services:
     restart: unless-stopped
     volumes:
       - redis:/data
+    entrypoint:
+      - sh
+    command:
+      - -c
+      - printf "requirepass supersecret\n" | exec redis-server -
 
   db:
     env_file:
diff --git a/docker/.env b/docker/.env
index 57575da76e..e5749aa3b3 100644
--- a/docker/.env
+++ b/docker/.env
@@ -49,6 +49,7 @@ POSTGRES_PASSWORD=superset
 PYTHONPATH=/app/pythonpath:/app/docker/pythonpath_dev
 REDIS_HOST=redis
 REDIS_PORT=6379
+REDIS_PASSWORD=supersecret
 
 FLASK_DEBUG=true
 SUPERSET_ENV=development
```

Now start the stack via `TAG=4.0.2 docker compose -f docker-compose-image-tag.yml up` and verify that Redis operations work.

For testing the redis results backend support, toggle the feature via `echo RESULTS_BACKEND_CACHE_TYPE=RedisCache > docker/.env-local`, restart the stack, and verify that Redis operations work.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
