### PR TITLE
docs: Add frontend dependency installation steps

### DIFF
--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -579,6 +579,9 @@ a collection of JSON files. To convert all PO files to formatted JSON files you 
 the build-translation script
 
 ```bash
+# Install dependencies if you haven't already
+cd superset-frontend/ && npm ci
+# Compile translations for the frontend
 npm run build-translation
 ```
 


### PR DESCRIPTION
This PR adds explicit instructions for installing frontend dependencies and compiling translations to our setup documentation. These steps were previously omitted, which could confuse new contributors.

## Changes Made
- Added instructions to navigate to the `superset-frontend/` directory
- Included a step to run `npm ci` for installing dependencies
- Added a comment for compiling frontend translations