### PR TITLE
fix(plugins): Fix dashboard filter for Table and Big Number with Time Comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -81,6 +81,7 @@ export default function PopKPI(props: PopKPIProps) {
     currentTimeRangeFilter,
     startDateOffset,
     shift,
+    dashboardTimeRange,
   } = props;
 
   const [comparisonRange, setComparisonRange] = useState<string>('');
@@ -90,12 +91,16 @@ export default function PopKPI(props: PopKPIProps) {
       setComparisonRange('');
     } else if (!isEmpty(shift) || startDateOffset) {
       const newShift = getTimeOffset({
-        timeRangeFilter: currentTimeRangeFilter,
+        timeRangeFilter: {
+          ...currentTimeRangeFilter,
+          comparator:
+            dashboardTimeRange ?? (currentTimeRangeFilter as any).comparator,
+        },
         shifts: ensureIsArray(shift),
         startDate: startDateOffset || '',
       });
       const promise: any = fetchTimeRange(
-        (currentTimeRangeFilter as any).comparator,
+        dashboardTimeRange ?? (currentTimeRangeFilter as any).comparator,
         currentTimeRangeFilter.subject,
         newShift || [],
       );
@@ -108,7 +113,7 @@ export default function PopKPI(props: PopKPIProps) {
         );
       });
     }
-  }, [currentTimeRangeFilter, shift, startDateOffset]);
+  }, [currentTimeRangeFilter, shift, startDateOffset, dashboardTimeRange]);
 
   const theme = useTheme();
   const flexGap = theme.gridUnit * 5;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -60,7 +60,12 @@ export default function buildQuery(formData: QueryFormData) {
     const timeOffsets = ensureIsArray(
       isTimeComparison(formData, baseQueryObject)
         ? getTimeOffset({
-            timeRangeFilter: TimeRangeFilters[0],
+            timeRangeFilter: {
+              ...TimeRangeFilters[0],
+              comparator:
+                baseQueryObject?.time_range ??
+                (TimeRangeFilters[0] as any)?.comparator,
+            },
             shifts: formData.time_compare,
             startDate:
               previousCustomStartDate && !formData.start_date_offset

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -118,7 +118,12 @@ export default function transformProps(chartProps: ChartProps) {
   let dataOffset: string[] = [];
   if (isCustomOrInherit) {
     dataOffset = getTimeOffset({
-      timeRangeFilter: currentTimeRangeFilter,
+      timeRangeFilter: {
+        ...currentTimeRangeFilter,
+        comparator:
+          formData?.extra_form_data?.time_range ??
+          (currentTimeRangeFilter as any)?.comparator,
+      },
       shifts: ensureIsArray(timeComparison),
       startDate:
         previousCustomStartDate && !startDateOffset
@@ -207,5 +212,6 @@ export default function transformProps(chartProps: ChartProps) {
     currentTimeRangeFilter,
     startDateOffset,
     shift: timeComparison,
+    dashboardTimeRange: formData?.extraFormData?.time_range,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/types.ts
@@ -65,6 +65,7 @@ export type PopKPIProps = PopKPIStylesProps &
     currentTimeRangeFilter?: SimpleAdhocFilter;
     startDateOffset?: string;
     shift: string;
+    dashboardTimeRange?: string;
   };
 
 export enum ColorSchemeEnum {

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -110,7 +110,12 @@ const buildQuery: BuildQuery<TableChartFormData> = (
     const timeOffsets = ensureIsArray(
       isTimeComparison(formData, baseQueryObject)
         ? getTimeOffset({
-            timeRangeFilter: TimeRangeFilters[0],
+            timeRangeFilter: {
+              ...TimeRangeFilters[0],
+              comparator:
+                baseQueryObject?.time_range ??
+                (TimeRangeFilters[0] as any)?.comparator,
+            },
             shifts: formData.time_compare,
             startDate:
               previousCustomStartDate && !formData.start_date_offset

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -542,7 +542,12 @@ const transformProps = (
   }
 
   const timeOffsets = getTimeOffset({
-    timeRangeFilter: TimeRangeFilters[0],
+    timeRangeFilter: {
+      ...TimeRangeFilters[0],
+      comparator:
+        formData?.extra_form_data?.time_range ??
+        (TimeRangeFilters[0] as any)?.comparator,
+    },
     shifts: formData.time_compare,
     startDate:
       previousCustomStartDate && !formData.start_date_offset

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -592,8 +592,9 @@ class QueryContextProcessor:
 
             if time_grain:
                 # move the temporal column to the first column in df
-                col = df.pop(join_keys[0])
-                df.insert(0, col.name, col)
+                if join_keys:
+                    col = df.pop(join_keys[0])
+                    df.insert(0, col.name, col)
 
                 # removes columns created only for join purposes
                 df.drop(


### PR DESCRIPTION
### SUMMARY
When a dashboard is using the Table viz or the BigNumber viz with Time comparison, any time filter used in the dashboard is ignored by the charts. This PR address that fix and prevent an index out of range too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/apache/superset/assets/38889534/fe2aebb7-d61c-4ee5-9313-76e583305ec6



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
