### PR TITLE
fix(plugins): Big Number with Time Comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -121,7 +121,7 @@ export default function transformProps(chartProps: ChartProps) {
       timeRangeFilter: {
         ...currentTimeRangeFilter,
         comparator:
-          formData?.extra_form_data?.time_range ??
+          formData?.extraFormData?.time_range ??
           (currentTimeRangeFilter as any)?.comparator,
       },
       shifts: ensureIsArray(timeComparison),


### PR DESCRIPTION
### SUMMARY
Use correct name to access dashboard filter in Big Number with Time Comparison plugin so the values are not combined but properly separated into bigNumber and the comparison one.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BN combining both values into one error:
<img width="1179" alt="Screenshot 2024-07-09 at 1 25 52 AM" src="https://github.com/apache/superset/assets/38889534/89df57a3-eff7-41f1-887d-ecaf5fa41ab9">

Fix
<img width="1179" alt="Screenshot 2024-07-09 at 1 26 07 AM" src="https://github.com/apache/superset/assets/38889534/6e0928f8-4f40-47dd-a5ae-d82468175554">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
