### PR TITLE
fix: Unsupported Slack API calls

### DIFF
--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -210,7 +210,7 @@ Error: %(text)s
         for channel in recipients:
             if len(files) > 0:
                 for file in files:
-                    client.files_upload(
+                    client.files_upload_v2(
                         channels=channel,
                         file=file,
                         initial_comment=body,

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -246,7 +246,7 @@ Error: %(text)s
 
             files = self._get_inline_files()
 
-            # files_upload returns SlackResponse as we run it in sync mode.
+            # files_upload_v2 returns SlackResponse as we run it in sync mode.
             for channel in channels:
                 if len(files) > 0:
                     for file in files:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1172,11 +1172,11 @@ def test_slack_chart_report_schedule_deprecated(
             ).run()
 
             assert (
-                slack_client_mock.return_value.files_upload.call_args[1]["channels"]
+                slack_client_mock.return_value.files_upload_v2.call_args[1]["channels"]
                 == channel_name
             )
             assert (
-                slack_client_mock.return_value.files_upload.call_args[1]["file"]
+                slack_client_mock.return_value.files_upload_v2.call_args[1]["file"]
                 == SCREENSHOT_FILE
             )
 
@@ -1332,11 +1332,11 @@ def test_slack_chart_report_schedule_with_csv_deprecated_api(
         ).run()
 
         assert (
-            slack_client_mock_class.return_value.files_upload.call_args[1]["channels"]
+            slack_client_mock_class.return_value.files_upload_v2.call_args[1]["channels"]
             == channel_name
         )
         assert (
-            slack_client_mock_class.return_value.files_upload.call_args[1]["file"]
+            slack_client_mock_class.return_value.files_upload_v2.call_args[1]["file"]
             == CSV_FILE
         )
 
@@ -1577,7 +1577,7 @@ def test_report_schedule_success_grace(create_alert_slack_chart_success):
 
 
 @pytest.mark.usefixtures("create_alert_slack_chart_grace")
-@patch("superset.utils.slack.WebClient.files_upload")
+@patch("superset.utils.slack.WebClient.files_upload_v2")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 @patch("superset.reports.notifications.slack.get_slack_client")
 def test_report_schedule_success_grace_end(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
[Issue/29480 invalid slack operation](https://github.com/apache/superset/issues/29480)

I've used very naive approach of simply replacing method calls for 'files_upload', since the method using it has already been marked for deprecation inside Superset.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Setup Slack Token API-based notification using dashboard.
Actually send the notification, instead of receiving API deprecation response from Slack.

### ADDITIONAL INFORMATION
- [x] Has associated issue: fixes https://github.com/apache/superset/issues/29480
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
