### PR TITLE
fix(websocket): add error handling

### DIFF
--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -465,6 +465,9 @@ export const cleanChannel = (channel: string) => {
 
 if (startServer) {
   // init server event listeners
+  wss.on('connection', function(ws) {
+    ws.on('error', console.error);
+  });
   wss.on('connection', wsConnection);
   httpServer.on('request', httpRequest);
   httpServer.on('upgrade', httpUpgrade);

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -465,7 +465,7 @@ export const cleanChannel = (channel: string) => {
 
 if (startServer) {
   // init server event listeners
-  wss.on('connection', function(ws) {
+  wss.on('connection', function (ws) {
     ws.on('error', console.error);
   });
   wss.on('connection', wsConnection);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding Error handling in websocket to avoid crashing whole service due to a faulty socket etc

Certain Browsers (i.e Safari) don't play nicely with WS Protocol, they can end up crashing the whole service. [ref](https://github.com/websockets/ws/issues/1354#issuecomment-1288007531)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

