### PR TITLE
fix: babel_update script crash

### DIFF
--- a/superset/translations/requirements.txt
+++ b/superset/translations/requirements.txt
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 Babel==2.9.1
+jinja2==3.1.4


### PR DESCRIPTION
This update adds the Jinja2 package to the translation requirements. When following the instructions mentioned in [Superset's contributing documentation](https://superset.apache.org/docs/contributing/howtos/#creating-a-new-language-dictionary) and running the `babel_update.sh` script, it currently fails due to a missing extraction method, which requires Jinja2.