### PR TITLE
fix(dataset): Obscure error message on creation

### DIFF
--- a/superset/commands/dataset/exceptions.py
+++ b/superset/commands/dataset/exceptions.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
+
 from flask_babel import lazy_gettext as _
 from marshmallow.validate import ValidationError
 
@@ -26,6 +28,7 @@ from superset.commands.exceptions import (
     ImportFailedError,
     UpdateFailedError,
 )
+from superset.exceptions import SupersetSecurityException
 from superset.sql.parse import Table
 
 
@@ -162,11 +165,21 @@ class DatasetInvalidError(CommandInvalidError):
     message = _("Dataset parameters are invalid.")
 
 
-class DatasetCreateFailedError(CreateFailedError):
+class DatasetSQLStatementErrorMixin(CommandException):
+    def __init__(
+        self,
+        ex: Optional[Exception] = None,
+    ) -> None:
+        if isinstance(ex, SupersetSecurityException):
+            self.message = ex
+        super().__init__()
+
+
+class DatasetCreateFailedError(CreateFailedError, DatasetSQLStatementErrorMixin):
     message = _("Dataset could not be created.")
 
 
-class DatasetUpdateFailedError(UpdateFailedError):
+class DatasetUpdateFailedError(UpdateFailedError, DatasetSQLStatementErrorMixin):
     message = _("Dataset could not be updated.")
 
 

--- a/superset/commands/dataset/exceptions.py
+++ b/superset/commands/dataset/exceptions.py
@@ -171,7 +171,7 @@ class DatasetSQLStatementErrorMixin(CommandException):
         ex: Optional[Exception] = None,
     ) -> None:
         if isinstance(ex, SupersetSecurityException):
-            self.message = ex
+            self.message = str(ex)
         super().__init__()
 
 

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -86,6 +86,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             catches=(
                 SQLAlchemyError,
                 ValueError,
+                SupersetSecurityException,
             ),
             reraise=DatasetUpdateFailedError,
         )

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -227,7 +227,7 @@ def on_error(
             logger.exception(ex.exception)
 
         if reraise:
-            raise reraise() from ex
+            raise reraise(ex) from ex
     else:
         raise ex
 

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -27,6 +27,7 @@ from uuid import UUID
 from flask import current_app as app, g, Response
 from sqlalchemy.exc import SQLAlchemyError
 
+from superset.exceptions import SupersetSecurityException
 from superset.utils import core as utils
 from superset.utils.dates import now_as_float
 
@@ -227,7 +228,14 @@ def on_error(
             logger.exception(ex.exception)
 
         if reraise:
-            raise reraise(ex) from ex
+            # Only forward the source exception to the reraised exception for
+            # security exceptions, so that callers can surface validation errors
+            # (e.g. dataset SQL validation). For all other cases keep the default
+            # behavior of raising the reraise type with its own message, to avoid
+            # overriding callers' exception messages.
+            if isinstance(ex, SupersetSecurityException):
+                raise reraise(ex) from ex
+            raise reraise() from ex
     else:
         raise ex
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -887,6 +887,28 @@ class TestDatasetApi(SupersetTestCase):
         assert model.currency_code_column == "currency"
         self.items_to_delete = [model]
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_create_dataset_with_sql_validate_select_sql(self):
+        """
+        Dataset API: Test create dataset with invalid select sql statement
+        """
+        if backend() == "sqlite":
+            return
+
+        energy_usage_ds = self.get_energy_usage_dataset()
+        self.login(username="admin")
+        table_data = {
+            "database": energy_usage_ds.database_id,
+            "table_name": "energy_usage_virtual",
+            "sql": "insert into energy_usage select * from energy_usage",
+        }
+        if schema := get_example_default_schema():
+            table_data["schema"] = schema
+        rv = self.post_assert_metric("/api/v1/dataset/", table_data, "post")
+        assert rv.status_code == 422
+        data = json.loads(rv.data.decode("utf-8"))
+        assert data == {"message": "Only `SELECT` statements are allowed"}
+
     @unittest.skip("test is failing stochastically")
     def test_create_dataset_same_name_different_schema(self):
         if backend() == "sqlite":


### PR DESCRIPTION
### SUMMARY
Following up #25669 and #24969
This commit adds the SupersetSecurityException case that displays the error message from the statement validation error.
(When a SupersetSecurityException error is thrown while creating a dataset, it only shows "Fater Error" error message.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="806" alt="Screenshot 2023-10-16 at 4 32 05 PM" src="https://github.com/apache/superset/assets/1392866/09a8f225-02c8-450e-9b08-0425d86520e1">

After:
<img width="829" alt="Screenshot 2023-10-16 at 4 41 52 PM" src="https://github.com/apache/superset/assets/1392866/90386841-f966-4969-928d-1c575c16957b">

### TESTING INSTRUCTIONS
Go to SQL Lab and create an invalid select statement (`(SELECT 1)` with parentheses)
Create a dataset and see the error message

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
