### PR TITLE
feat(ParsedQuery): Improve peformance when check is_read_only_query

### DIFF
--- a/superset/commands/report/base.py
+++ b/superset/commands/report/base.py
@@ -114,11 +114,11 @@ class BaseReportScheduleCommand(BaseCommand):
 
         iterations = 60 if minimum_interval <= 3660 else 24
         schedule = croniter(cron_schedule)
-        current_exec = next(schedule)
+        current_exec: float = next(schedule)
 
         for _ in range(iterations):
-            next_exec = next(schedule)
-            diff, current_exec = next_exec - current_exec, next_exec
+            next_exec: float = next(schedule)
+            diff, current_exec = (next_exec - current_exec), next_exec
             if int(diff) < minimum_interval:
                 raise ReportScheduleFrequencyNotAllowed(
                     report_type=report_type, minimum_interval=minimum_interval

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -208,6 +208,8 @@ class ParsedQuery:
         strip_comments: bool = False,
         engine: str = "base",
     ):
+        self.strip_comments_sql: str | None = None
+        self.stripped_sql: str | None = None
         if strip_comments:
             sql_statement = sqlparse.format(sql_statement, strip_comments=True)
 
@@ -394,38 +396,33 @@ class ParsedQuery:
         return len(parsed) == 1 and parsed[0].get_type() == "SELECT"
 
     def is_explain(self) -> bool:
-        # Remove comments
-        statements_without_comments = sqlparse.format(
-            self.stripped(), strip_comments=True
-        )
-
         # Explain statements will only be the first statement
-        return statements_without_comments.upper().startswith("EXPLAIN")
+        return self.strip_comments().upper().startswith("EXPLAIN")
 
     def is_show(self) -> bool:
-        # Remove comments
-        statements_without_comments = sqlparse.format(
-            self.stripped(), strip_comments=True
-        )
         # Show statements will only be the first statement
-        return statements_without_comments.upper().startswith("SHOW")
+        return self.strip_comments().upper().startswith("SHOW")
 
     def is_set(self) -> bool:
-        # Remove comments
-        statements_without_comments = sqlparse.format(
-            self.stripped(), strip_comments=True
-        )
         # Set statements will only be the first statement
-        return statements_without_comments.upper().startswith("SET")
+        return self.strip_comments().upper().startswith("SET")
 
     def is_unknown(self) -> bool:
         return self._parsed[0].get_type() == "UNKNOWN"
 
     def stripped(self) -> str:
-        return self.sql.strip(" \t\r\n;")
+        if self.stripped_sql is None:
+            self.stripped_sql = self.sql.strip(" \t\r\n;")
+
+        return self.stripped_sql
 
     def strip_comments(self) -> str:
-        return sqlparse.format(self.stripped(), strip_comments=True)
+        if self.strip_comments_sql is None:
+            self.strip_comments_sql = sqlparse.format(
+                self.stripped(), strip_comments=True
+            )
+
+        return self.strip_comments_sql
 
     def get_statements(self) -> list[str]:
         """Returns a list of SQL statements as strings, stripped"""


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<h2>Improve speed of ParsedQuery for checking is_read_only_query too slow</h2>

Line: [superset/db_engine_specs/base.py](https://github.com/vuongtlt13/superset/blob/feature/improve_parsed_query/superset/db_engine_specs/base.py#L2027)
![image](https://github.com/apache/superset/assets/14292473/f3bebc1e-b3b2-432a-af5e-2bbbeb986ffb)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://github.com/apache/superset/assets/14292473/f8e36f54-40fc-4382-88d4-01ca5778989d)

First, I have a sql statement with length is 17121. I need check **is_read_only_query** 

As you can see:

-  **For current ParsedQuery class**:
    Each function in **is_select**, **is_explain**, **is_show** will format sql statement by calling **sqlparse.format** function. But it takes quite long (~**0.332s** for one call). So you need to call **3 times** for checking **is_read_only_query**  --> Total time: **0.9996**s

- **For new ParsedQuery class**:
     You need to call only **1 time** for checking **is_read_only_query**  --> Total time: **0.3278**s

   <h4>    ---> Reduce 66% in total time for checking is_read_only_query </4>

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
