### PR TITLE
fix(dataset import): Support catalog field during dataset import

### DIFF
--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -249,6 +249,7 @@ class ImportV1DatasetSchema(Schema):
     offset = fields.Integer()
     cache_timeout = fields.Integer(allow_none=True)
     schema = fields.String(allow_none=True)
+    catalog = fields.String(allow_none=True)
     sql = fields.String(allow_none=True)
     params = fields.Dict(allow_none=True)
     template_params = fields.Dict(allow_none=True)

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -494,6 +494,7 @@ dataset_config: dict[str, Any] = {
     "offset": 66,
     "cache_timeout": 55,
     "schema": "",
+    "catalog": "default",
     "sql": "",
     "params": None,
     "template_params": {},


### PR DESCRIPTION
### SUMMARY
Support for catalogs have been recently added to Superset. The field is now included in the dataset metadata (including the exported YAML). This PR adds the `catalog` field to the import schema (logic to handle the catalog during import was already there).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added the `catalog` field to the mock dataset. Manual test would require:
1. Create a dataset. Make sure the `catalog` field is added to the metadata.
2. Export the dataset.
3. Import it.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
