### PR TITLE
fix: catalog permission check

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -860,7 +860,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             if len(parts) == 2 and default_catalog:
                 accessible_catalogs.add(default_catalog)
             elif len(parts) == 3:
-                accessible_catalogs.add(parts[2])
+                accessible_catalogs.add(parts[1])
 
         # datasource_access
         if perms := self.user_view_menu_names("datasource_access"):
@@ -911,7 +911,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 return datasource_names
 
         if schema:
-            schema_perm = self.get_schema_perm(database, catalog, schema)
+            default_catalog = database.get_default_catalog()
+            schema_perm = self.get_schema_perm(
+                database.database_name,
+                catalog or default_catalog,
+                schema,
+            )
             if schema_perm and self.can_access("schema_access", schema_perm):
                 return datasource_names
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix a couple issues with the catalog permission check when adding a dataset:

- When listing catalogs there is an off-by-one error when including catalogs in which the user has schema access. For example, if a database `db` has 2 catalogs, `A` and `B`, if the user has access to the schema `db.A.schema1` we should show catalog `A` in the response from `get_catalogs_accessible_by_user`. The off by one error makes the method return `schema1` instead, which is then discarded because it is not in `{A, B}`.
- When fetching tables, if a catalog is not specified (either because "Allow changing catalogs" is disabled, or because the DB doesn't support catalogs) then the schema permission still needs to be built with `catalog or default_catalog`, since we need the catalog name in the built schema permission even if "Allow changing catalogs" is disabled, otherwise the schema check will fail.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

WIP

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
