### PR TITLE
feat: custom values to sandbox iframe

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -110,7 +110,7 @@ Example `POST /security/guest_token` payload:
 ```
 ### Sandbox iframe
 
-The Embedded SDK creates an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode by default 
+The Embedded SDK creates an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode by default
 which applies certain restrictions to the iframe's content.
 To pass additional sandbox attributes you can use `iframeSandboxExtras`:
 ```js

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -108,7 +108,7 @@ Example `POST /security/guest_token` payload:
   ]
 }
 ```
-### Sandbox Iframe
+### Sandbox iframe
 
 The Embedded SDK creates an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode by default 
 which applies certain restrictions to the iframe's content.

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -110,9 +110,9 @@ Example `POST /security/guest_token` payload:
 ```
 ### Sandbox Iframe
 
-Embedded SDK by default create an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode
-which applies extra restrictions to the content in the frame, for some cases default sandbox values are not enough
-you can pass `iframeSandboxExtras` to add additional values for example
+The Embedded SDK creates an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode by default 
+which applies certain restrictions to the iframe's content.
+To pass additional sandbox attributes you can use `iframeSandboxExtras`:
 ```js
   // optional additional iframe sandbox attributes
   iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -54,6 +54,8 @@ embedDashboard({
           // ...
       }
   },
+    // optional additional iframe sandbox attributes
+  iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
 });
 ```
 
@@ -85,8 +87,8 @@ Guest tokens can have Row Level Security rules which filter data for the user ca
 The agent making the `POST` request must be authenticated with the `can_grant_guest_token` permission.
 
 Within your app, using the Guest Token will then allow authentication to your Superset instance via creating an Anonymous user object.  This guest anonymous user will default to the public role as per this setting `GUEST_ROLE_NAME = "Public"`.
-+
-+The user parameters in the example below are optional and are provided as a means of passing user attributes that may be accessed in jinja templates inside your charts.
+
+The user parameters in the example below are optional and are provided as a means of passing user attributes that may be accessed in jinja templates inside your charts.
 
 Example `POST /security/guest_token` payload:
 
@@ -105,4 +107,13 @@ Example `POST /security/guest_token` payload:
     { "clause": "publisher = 'Nintendo'" }
   ]
 }
+```
+### Sandbox Iframe
+
+Embedded SDK by default create an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode
+which applies extra restrictions to the content in the frame, for some cases default sandbox values are not enough
+you can pass `iframeSandboxExtras` to add additional values for example
+```js
+  // optional additional iframe sandbox attributes
+  iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
 ```

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/embedded-sdk",
-  "version": "0.1.0-alpha.11",
+  "version": "0.1.0-alpha.12",
   "description": "SDK for embedding resources from Superset into your own application",
   "access": "public",
   "keywords": [

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -61,7 +61,7 @@ export type EmbedDashboardParams = {
   /** Are we in debug mode? */
   debug?: boolean
   /** The iframe title attribute */
-  iframeTitle?: string,
+  iframeTitle?: string
   /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
   iframeSandboxExtras?: string[]
 }
@@ -138,7 +138,7 @@ export async function embedDashboard({
       iframe.sandbox.add("allow-downloads"); // for downloading charts as image
       iframe.sandbox.add("allow-forms"); // for forms to submit
       iframe.sandbox.add("allow-popups"); // for exporting charts as csv
-      //additional sandbox props
+      // additional sandbox props
       iframeSandboxExtras.forEach((key: string) => {
         iframe.sandbox.add(key);
       });

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -61,7 +61,9 @@ export type EmbedDashboardParams = {
   /** Are we in debug mode? */
   debug?: boolean
   /** The iframe title attribute */
-  iframeTitle?: string
+  iframeTitle?: string,
+  /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
+  iframeSandboxExtras?: string[]
 }
 
 export type Size = {
@@ -86,6 +88,7 @@ export async function embedDashboard({
   dashboardUiConfig,
   debug = false,
   iframeTitle = "Embedded Dashboard",
+  iframeSandboxExtras = []
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   function log(...info: unknown[]) {
     if (debug) {
@@ -137,6 +140,9 @@ export async function embedDashboard({
       iframe.sandbox.add("allow-popups"); // for exporting charts as csv
       // add these if it turns out we need them:
       // iframe.sandbox.add("allow-top-navigation");
+      iframeSandboxExtras.forEach((key: string) => {
+        iframe.sandbox.add(key);
+      });
 
       // add the event listener before setting src, to be 100% sure that we capture the load event
       iframe.addEventListener('load', () => {

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -61,7 +61,9 @@ export type EmbedDashboardParams = {
   /** Are we in debug mode? */
   debug?: boolean
   /** The iframe title attribute */
-  iframeTitle?: string
+  iframeTitle?: string,
+  /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
+  iframeSandboxExtras?: string[]
 }
 
 export type Size = {
@@ -86,6 +88,7 @@ export async function embedDashboard({
   dashboardUiConfig,
   debug = false,
   iframeTitle = "Embedded Dashboard",
+  iframeSandboxExtras = []
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   function log(...info: unknown[]) {
     if (debug) {
@@ -135,8 +138,10 @@ export async function embedDashboard({
       iframe.sandbox.add("allow-downloads"); // for downloading charts as image
       iframe.sandbox.add("allow-forms"); // for forms to submit
       iframe.sandbox.add("allow-popups"); // for exporting charts as csv
-      // add these if it turns out we need them:
-      // iframe.sandbox.add("allow-top-navigation");
+      //additional sandbox props
+      iframeSandboxExtras.forEach((key: string) => {
+        iframe.sandbox.add(key);
+      });
 
       // add the event listener before setting src, to be 100% sure that we capture the load event
       iframe.addEventListener('load', () => {


### PR DESCRIPTION
### SUMMARY
when inside a dashboard any component as a Table that has links to external sities are blocked when open.
For example in a Table that renders a list of top post of tweets or Facebook post with a link to open this post in Twitter or Facebook when click the new window are opened but show as blocked content.
To avoid this issue need aggregate  `allow-popups-to-escape-sandbox`  to handle this we add a generic method to allow add any custom value to sandbox attribute of iframe passing using the new `iframeSandboxExtras` .

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
