### PR TITLE
fix: machine auth for GAQ enabled deployments

### DIFF
--- a/superset/utils/machine_auth.py
+++ b/superset/utils/machine_auth.py
@@ -126,6 +126,8 @@ class MachineAuthProvider:
             login_user(user)
             # A mock response object to get the cookie information from
             response = Response()
+            # To ensure all `after_request` functions are called i.e Websockets JWT Auth
+            current_app.process_response(response)
             current_app.session_interface.save_session(current_app, session, response)
 
         cookies = {}


### PR DESCRIPTION
### SUMMARY
Ensures all `after_request` decorated functions are called. This allows Reports to work flawlessly with GAQ enabled deployments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA

### TESTING INSTRUCTIONS
Enable Global Async Queries and all the supporting params, try generating a report with an image.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
