### PR TITLE
chore: Clear redux localStorage on logout

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -346,3 +346,30 @@ test('If there is NOT a DB with allow_file_upload set as True the option should 
     (await screen.findByText('Upload CSV to database')).closest('a'),
   ).not.toBeInTheDocument();
 });
+
+test('Logs out and clears local storage item redux', async () => {
+  const mockedProps = createProps();
+  resetUseSelectorMock();
+  render(<RightMenu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+  });
+
+  // Set an item in local storage to test if it gets cleared
+  localStorage.setItem('redux', JSON.stringify({ test: 'test' }));
+  expect(localStorage.getItem('redux')).not.toBeNull();
+
+  userEvent.hover(await screen.findByText(/Settings/i));
+
+  // Simulate user clicking the logout button
+  await waitFor(() => {
+    const logoutButton = screen.getByText('Logout');
+    userEvent.click(logoutButton);
+  });
+
+  // Wait for local storage to be cleared
+  await waitFor(() => {
+    expect(localStorage.getItem('redux')).toBeNull();
+  });
+});

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -348,6 +348,10 @@ const RightMenu = ({
 
   const handleDatabaseAdd = () => setQuery({ databaseAdded: true });
 
+  const handleLogout = () => {
+    localStorage.removeItem('redux');
+  };
+
   const theme = useTheme();
 
   return (
@@ -512,7 +516,7 @@ const RightMenu = ({
                   <a href={navbarRight.user_info_url}>{t('Info')}</a>
                 </Menu.Item>
               )}
-              <Menu.Item key="logout">
+              <Menu.Item key="logout" onClick={handleLogout}>
                 <a href={navbarRight.user_logout_url}>{t('Logout')}</a>
               </Menu.Item>
             </Menu.ItemGroup>,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When logging out the redux key in localStorage was not cleared up causing some data to spill over different users. This PR clears out the redux localStorage key on logout.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Logout
2. Login with a different user
3. Make sure no information are spilling over

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
