### PR TITLE
fix: alternate method to override Antd5 style tokens

### DIFF
--- a/superset-frontend/.storybook/preview.jsx
+++ b/superset-frontend/.storybook/preview.jsx
@@ -24,6 +24,7 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import reducerIndex from 'spec/helpers/reducerIndex';
 import { GlobalStyles } from '../src/GlobalStyles';
+import { AntdThemeProvider } from '../src/components/AntdThemeProvider';
 
 import 'src/theme.ts';
 import './storybook.css';

--- a/superset-frontend/src/components/Card/index.tsx
+++ b/superset-frontend/src/components/Card/index.tsx
@@ -35,4 +35,6 @@ const Card = ({ padded, ...props }: CardProps) => (
   />
 );
 
-export default Card;
+export default Object.assign(Card, {
+  Meta: AntdCard.Meta,
+});

--- a/superset-frontend/src/components/Card/index.tsx
+++ b/superset-frontend/src/components/Card/index.tsx
@@ -28,6 +28,8 @@ const Card = ({ padded, ...props }: CardProps) => (
   <AntdCard
     {...props}
     css={(theme: SupersetTheme) => ({
+      // 'border-radius': `${theme.gridUnit}px`,
+      border: `1px solid ${theme.colors.grayscale.light2}`,
       '.antd5-card-body': {
         padding: padded ? theme.gridUnit * 4 : theme.gridUnit,
       },

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -20,10 +20,10 @@ import { ReactNode, ComponentType, ReactElement, FC } from 'react';
 import { styled, useTheme } from '@superset-ui/core';
 import { Skeleton, Card } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
-import { theme as supersetTheme } from 'src/preamble';
 import { ConfigProvider } from 'antd-v5';
 import ImageLoader, { BackgroundPosition } from './ImageLoader';
 import CertifiedBadge from '../CertifiedBadge';
+import { supersetComponentStyles } from 'src/theme/index';
 
 const ActionsWrapper = styled.div`
   width: 64px;
@@ -35,7 +35,7 @@ const ActionsWrapper = styled.div`
 const listViewCardTheme = {
   components: {
     Card: {
-      colorBgContainer: supersetTheme.colors.grayscale.light5,
+      ...supersetComponentStyles.ListViewCard,
     },
   },
 };

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -20,8 +20,10 @@ import { ReactNode, ComponentType, ReactElement, FC } from 'react';
 import { styled, useTheme } from '@superset-ui/core';
 import { Skeleton, Card } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
+import { theme as supersetTheme } from 'src/preamble';
 import ImageLoader, { BackgroundPosition } from './ImageLoader';
 import CertifiedBadge from '../CertifiedBadge';
+import { ConfigProvider } from 'antd-v5';
 
 const ActionsWrapper = styled.div`
   width: 64px;
@@ -29,6 +31,16 @@ const ActionsWrapper = styled.div`
   justify-content: flex-end;
 `;
 
+// Styling part 1: Override Card tokens when possible
+const listViewCardTheme = {
+  components: {
+    Card: {
+      colorBgContainer: supersetTheme.colors.grayscale.light5,
+    },
+  },
+};
+
+// Styling part 2: Use CSS when necessary
 const StyledCard = styled(Card)`
   ${({ theme }) => `
     overflow: hidden;
@@ -179,99 +191,105 @@ function ListViewCard({
   const Link = url && linkComponent ? linkComponent : AnchorLink;
   const theme = useTheme();
   return (
-    <StyledCard
-      data-test="styled-card"
-      padded
-      cover={
-        cover || (
-          <Cover>
-            <Link to={url!}>
-              <div className="gradient-container">
-                <ImageLoader
-                  src={imgURL || ''}
-                  fallback={imgFallbackURL || ''}
-                  isLoading={loading}
-                  position={imgPosition}
-                />
-              </div>
-            </Link>
-            <CoverFooter className="cover-footer">
-              {!loading && coverLeft && (
-                <CoverFooterLeft>{coverLeft}</CoverFooterLeft>
-              )}
-              {!loading && coverRight && (
-                <CoverFooterRight>{coverRight}</CoverFooterRight>
-              )}
-            </CoverFooter>
-          </Cover>
-        )
-      }
-    >
-      {loading && (
-        <Card.Meta
-          title={
-            <>
-              <TitleContainer>
-                <Skeleton.Input
-                  active
-                  size="small"
-                  css={{
-                    width: Math.trunc(theme.gridUnit * 62.5),
-                  }}
-                />
-                <div className="card-actions">
-                  <Skeleton.Button active shape="circle" />{' '}
-                  <Skeleton.Button
-                    active
-                    css={{
-                      width: theme.gridUnit * 10,
-                    }}
+    // <AntdThemeProvider theme={Object.assign(AtndTheme, {
+    //   Card:
+    //   colorBgContainerbackground: theme.grayscale.light4
+    // }}>
+    <ConfigProvider theme={listViewCardTheme}>
+      <StyledCard
+        data-test="styled-card"
+        padded
+        cover={
+          cover || (
+            <Cover>
+              <Link to={url!}>
+                <div className="gradient-container">
+                  <ImageLoader
+                    src={imgURL || ''}
+                    fallback={imgFallbackURL || ''}
+                    isLoading={loading}
+                    position={imgPosition}
                   />
                 </div>
-              </TitleContainer>
-            </>
-          }
-          description={
-            <ThinSkeleton
-              round
-              active
-              title={false}
-              paragraph={paragraphConfig}
-            />
-          }
-        />
-      )}
-      {!loading && (
-        <Card.Meta
-          title={
-            <TitleContainer>
-              {subtitle || null}
-              <div className="titleRow">
-                <Tooltip title={title}>
-                  <TitleLink>
-                    {certifiedBy && (
-                      <>
-                        <CertifiedBadge
-                          certifiedBy={certifiedBy}
-                          details={certificationDetails}
-                        />{' '}
-                      </>
-                    )}
-                    {title}
-                  </TitleLink>
-                </Tooltip>
-                {titleRight && <TitleRight>{titleRight}</TitleRight>}
-                <div className="card-actions" data-test="card-actions">
-                  {actions}
+              </Link>
+              <CoverFooter className="cover-footer">
+                {!loading && coverLeft && (
+                  <CoverFooterLeft>{coverLeft}</CoverFooterLeft>
+                )}
+                {!loading && coverRight && (
+                  <CoverFooterRight>{coverRight}</CoverFooterRight>
+                )}
+              </CoverFooter>
+            </Cover>
+          )
+        }
+      >
+        {loading && (
+          <Card.Meta
+            title={
+              <>
+                <TitleContainer>
+                  <Skeleton.Input
+                    active
+                    size="small"
+                    css={{
+                      width: Math.trunc(theme.gridUnit * 62.5),
+                    }}
+                  />
+                  <div className="card-actions">
+                    <Skeleton.Button active shape="circle" />{' '}
+                    <Skeleton.Button
+                      active
+                      css={{
+                        width: theme.gridUnit * 10,
+                      }}
+                    />
+                  </div>
+                </TitleContainer>
+              </>
+            }
+            description={
+              <ThinSkeleton
+                round
+                active
+                title={false}
+                paragraph={paragraphConfig}
+              />
+            }
+          />
+        )}
+        {!loading && (
+          <Card.Meta
+            title={
+              <TitleContainer>
+                {subtitle || null}
+                <div className="titleRow">
+                  <Tooltip title={title}>
+                    <TitleLink>
+                      {certifiedBy && (
+                        <>
+                          <CertifiedBadge
+                            certifiedBy={certifiedBy}
+                            details={certificationDetails}
+                          />{' '}
+                        </>
+                      )}
+                      {title}
+                    </TitleLink>
+                  </Tooltip>
+                  {titleRight && <TitleRight>{titleRight}</TitleRight>}
+                  <div className="card-actions" data-test="card-actions">
+                    {actions}
+                  </div>
                 </div>
-              </div>
-            </TitleContainer>
-          }
-          description={description}
-          avatar={avatar || null}
-        />
-      )}
-    </StyledCard>
+              </TitleContainer>
+            }
+            description={description}
+            avatar={avatar || null}
+          />
+        )}
+      </StyledCard>
+    </ConfigProvider>
   );
 }
 

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -18,7 +18,7 @@
  */
 import { ReactNode, ComponentType, ReactElement, FC } from 'react';
 import { styled, useTheme } from '@superset-ui/core';
-import { Skeleton, AntdCard } from 'src/components';
+import { Skeleton, Card } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
 import ImageLoader, { BackgroundPosition } from './ImageLoader';
 import CertifiedBadge from '../CertifiedBadge';
@@ -29,7 +29,8 @@ const ActionsWrapper = styled.div`
   justify-content: flex-end;
 `;
 
-const StyledCard = styled(AntdCard)`
+const StyledCard = styled(Card)`
+  // TODO: move all these styles to the Card component.
   ${({ theme }) => `
     border: 1px solid ${theme.colors.grayscale.light2};
     border-radius: ${theme.gridUnit}px;
@@ -216,7 +217,7 @@ function ListViewCard({
       }
     >
       {loading && (
-        <AntdCard.Meta
+        <Card.Meta
           title={
             <>
               <TitleContainer>
@@ -250,7 +251,7 @@ function ListViewCard({
         />
       )}
       {!loading && (
-        <AntdCard.Meta
+        <Card.Meta
           title={
             <TitleContainer>
               {subtitle || null}

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -30,19 +30,9 @@ const ActionsWrapper = styled.div`
 `;
 
 const StyledCard = styled(Card)`
-  // TODO: move all these styles to the Card component.
   ${({ theme }) => `
-    border: 1px solid ${theme.colors.grayscale.light2};
-    border-radius: ${theme.gridUnit}px;
     overflow: hidden;
 
-    .ant-card-body {
-      padding: ${theme.gridUnit * 4}px
-        ${theme.gridUnit * 2}px;
-    }
-    .ant-card-meta-detail > div:not(:last-child) {
-      margin-bottom: 0;
-    }
     .gradient-container {
       position: relative;
       height: 100%;
@@ -191,6 +181,7 @@ function ListViewCard({
   return (
     <StyledCard
       data-test="styled-card"
+      padded
       cover={
         cover || (
           <Cover>

--- a/superset-frontend/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/src/components/ListViewCard/index.tsx
@@ -21,9 +21,9 @@ import { styled, useTheme } from '@superset-ui/core';
 import { Skeleton, Card } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
 import { theme as supersetTheme } from 'src/preamble';
+import { ConfigProvider } from 'antd-v5';
 import ImageLoader, { BackgroundPosition } from './ImageLoader';
 import CertifiedBadge from '../CertifiedBadge';
-import { ConfigProvider } from 'antd-v5';
 
 const ActionsWrapper = styled.div`
   width: 64px;

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -25,6 +25,7 @@
 export { default as Select } from './Select/Select';
 export { default as AsyncSelect } from './Select/AsyncSelect';
 export { default as Button } from './Button';
+export { default as Card } from './Card';
 
 /*
  * Components that don't conflict with the ones in src/components.
@@ -57,7 +58,7 @@ export {
  * or extending the components in src/components.
  */
 export {
-  Breadcrumb as AntdBreadcrumb,
+  Breadcrumb as AntdBreadcrumb, // TODO: Make this a real Component
   Card as AntdCard,
   Checkbox as AntdCheckbox,
   Collapse as AntdCollapse,

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -26,6 +26,7 @@ export { default as Select } from './Select/Select';
 export { default as AsyncSelect } from './Select/AsyncSelect';
 export { default as Button } from './Button';
 export { default as Card } from './Card';
+export { default as Button } from './Button';
 
 /*
  * Components that don't conflict with the ones in src/components.

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -29,9 +29,12 @@ const themes = {
   [ThemeType.LIGHT]: lightAlgorithm,
 };
 
+// Want to figure out which tokens look like what? Try this!
+// https://ant.design/theme-editor
+
 const baseConfig: ThemeConfig = {
   token: {
-    borderRadius: supersetTheme.borderRadius * 10,
+    borderRadius: supersetTheme.borderRadius,
     colorBgBase: supersetTheme.colors.primary.light4,
     colorError: supersetTheme.colors.error.base,
     colorInfo: supersetTheme.colors.info.base,
@@ -56,8 +59,6 @@ const baseConfig: ThemeConfig = {
       paddingXS: supersetTheme.gridUnit * 2,
     },
     Card: {
-      borderRadius: supersetTheme.borderRadius * 10,
-      colorBgContainer: supersetTheme.colors.grayscale.light4,
       paddingLG: supersetTheme.gridUnit * 6,
       fontWeightStrong: supersetTheme.typography.weights.medium,
     },

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -31,7 +31,7 @@ const themes = {
 
 const baseConfig: ThemeConfig = {
   token: {
-    borderRadius: supersetTheme.borderRadius,
+    borderRadius: supersetTheme.borderRadius * 10,
     colorBgBase: supersetTheme.colors.primary.light4,
     colorError: supersetTheme.colors.error.base,
     colorInfo: supersetTheme.colors.info.base,
@@ -56,6 +56,7 @@ const baseConfig: ThemeConfig = {
       paddingXS: supersetTheme.gridUnit * 2,
     },
     Card: {
+      borderRadius: supersetTheme.borderRadius * 10,
       colorBgContainer: supersetTheme.colors.grayscale.light4,
       paddingLG: supersetTheme.gridUnit * 6,
       fontWeightStrong: supersetTheme.typography.weights.medium,

--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -84,6 +84,12 @@ const baseConfig: ThemeConfig = {
   },
 };
 
+export const supersetComponentStyles = {
+  ListViewCard: {
+    colorBgContainer: supersetTheme.colors.grayscale.light5,
+  },
+};
+
 export const getTheme = (themeType?: ThemeType) => ({
   ...baseConfig,
   algorithm: themes[themeType || ThemeType.LIGHT],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In another PR, I added some custom AntD theme overrides IN the ListViewCard component. This is an approach where we can keep those overrides centralized, and import/apply them in the individual components. Maybe this'll be easier to maintain?


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
