### PR TITLE
feat: add a script to check environment software versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,11 @@ RUN npm run build-translation
 RUN rm /app/superset/translations/*/LC_MESSAGES/*.po
 RUN rm /app/superset/translations/messages.pot
 
+FROM python:${PY_VER} AS python-base
 ######################################################################
 # Final lean image...
 ######################################################################
-FROM python:${PY_VER} AS lean
+FROM python-base AS lean
 
 WORKDIR /app
 ENV LANG=C.UTF-8 \
@@ -89,6 +90,7 @@ COPY --chown=superset:superset pyproject.toml setup.py MANIFEST.in README.md ./
 # setup.py uses the version information in package.json
 COPY --chown=superset:superset superset-frontend/package.json superset-frontend/
 COPY --chown=superset:superset requirements/base.txt requirements/
+COPY --chown=superset:superset scripts/check-env.py scripts/
 RUN --mount=type=cache,target=/root/.cache/pip \
     apt-get update -qq && apt-get install -yqq --no-install-recommends \
       build-essential \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-superset-user: &superset-user root
 x-superset-depends-on: &superset-depends-on
   - db
   - redis
+  - superset-checks
 x-superset-volumes: &superset-volumes
   # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
   - ./docker:/app/docker
@@ -127,6 +128,23 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_SSL=false
+
+  superset-checks:
+    build:
+      context: .
+      target: python-base
+      cache_from:
+        - apache/superset-cache:3.10-slim-bookworm
+    container_name: superset_checks
+    command: ["/app/scripts/check-env.py"]
+    env_file:
+      - path: docker/.env # default
+        required: true
+      - path: docker/.env-local # optional override
+        required: false
+    user: *superset-user
+    healthcheck:
+      disable: true
 
   superset-init:
     build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ development = [
     "pip-compile-multi",
     "pre-commit",
     "progress>=1.5,<2",
+    "psutil",
     "pyfakefs",
     "pyinstrument>=4.0.2,<5",
     "pylint",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,8 @@ apispec[yaml]==6.3.0
     # via flask-appbuilder
 apsw==3.46.0.0
     # via shillelagh
+async-timeout==4.0.3
+    # via redis
 attrs==23.2.0
     # via
     #   cattrs
@@ -91,6 +93,8 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via flask-appbuilder
+exceptiongroup==1.2.2
+    # via cattrs
 flask==2.3.3
     # via
     #   apache-superset
@@ -358,6 +362,7 @@ typing-extensions==4.12.0
     # via
     #   alembic
     #   apache-superset
+    #   cattrs
     #   flask-limiter
     #   limits
     #   shillelagh

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,7 +6,7 @@
 #    pip-compile-multi
 #
 -r base.txt
--e file:///Users/max/code/superset
+-e file:.
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,7 +6,7 @@
 #    pip-compile-multi
 #
 -r base.txt
--e file:.
+-e file:///Users/max/code/superset
     # via
     #   -r requirements/base.in
     #   -r requirements/development.in
@@ -174,6 +174,8 @@ protobuf==4.23.0
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
+psutil==6.0.0
+    # via apache-superset
 psycopg2-binary==2.9.6
     # via apache-superset
 pure-sasl==0.6.2
@@ -186,7 +188,7 @@ pyee==11.0.1
     # via playwright
 pyfakefs==5.3.5
     # via apache-superset
-pyhive[hive_pure_sasl]==0.7.0
+pyhive[presto]==0.7.0
     # via apache-superset
 pyinstrument==4.4.0
     # via apache-superset
@@ -233,6 +235,16 @@ thrift==0.16.0
     #   thrift-sasl
 thrift-sasl==0.4.3
     # via apache-superset
+tomli==2.0.1
+    # via
+    #   build
+    #   coverage
+    #   pip-tools
+    #   pylint
+    #   pyproject-api
+    #   pyproject-hooks
+    #   pytest
+    #   tox
 tomlkit==0.12.5
     # via pylint
 toposort==1.10

--- a/scripts/check-env.py
+++ b/scripts/check-env.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+check-env.py
+
+This script checks the local environment for the following software versions and provides feedback on whether they are ideal, supported, or unsupported. The software checked includes:
+
+- Core Python version
+- npm
+- Node.js
+- Docker
+- Docker Compose
+- Git
+
+Each check will display a green check mark (✅) for ideal versions, a yellow warning (🟡) for supported versions, and a red cross (❌) for unsupported versions.
+"""
+
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+from packaging.version import InvalidVersion, Version
+
+
+def get_version(command: str) -> Optional[str]:
+    try:
+        version = subprocess.check_output(command, shell=True).decode().strip()
+        return version
+    except subprocess.CalledProcessError:
+        return None
+
+
+def check_version(
+    software: str,
+    version: Optional[str],
+    ideal_range: Tuple[Version, Version],
+    supported_range: Tuple[Version, Version],
+) -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    if version is None:
+        return f"❌ {software}", ideal_range, supported_range
+
+    try:
+        version_number = Version(version)
+    except InvalidVersion:
+        return f"❌ {software} {version}", ideal_range, supported_range
+
+    ideal_min, ideal_max = ideal_range
+    supported_min, supported_max = supported_range
+
+    if ideal_min <= version_number <= ideal_max:
+        return f"✅ {software} {version}", ideal_range, supported_range
+    elif supported_min <= version_number:
+        return f"🟡 {software} {version}", ideal_range, supported_range
+    else:
+        return f"❌ {software} {version}", ideal_range, supported_range
+
+
+def check_core_python() -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    version = sys.version.split()[0]
+    ideal_range = (Version("3.10.0"), Version("3.10.999"))
+    supported_range = (Version("3.9.0"), Version("3.11.999"))
+    return check_version("Python", version, ideal_range, supported_range)
+
+
+def check_npm() -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    version = get_version("npm -v")
+    ideal_range = (Version("10.0.0"), Version("10.999.999"))
+    supported_range = ideal_range  # Only ideal range is considered supported
+    return check_version("npm", version, ideal_range, supported_range)
+
+
+def check_node() -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    version = get_version("node -v")
+    if version:
+        version = version.lstrip("v")
+    ideal_range = (Version("18.0.0"), Version("18.999.999"))
+    supported_range = ideal_range  # Only ideal range is considered supported
+    return check_version("Node", version, ideal_range, supported_range)
+
+
+def check_docker() -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    version = get_version("docker --version")
+    if version:
+        version = version.split()[2].rstrip(",")
+    ideal_range = (Version("20.10.0"), Version("999.999.999"))
+    supported_range = (Version("19.0.0"), Version("999.999.999"))
+    return check_version("Docker", version, ideal_range, supported_range)
+
+
+def check_docker_compose() -> (
+    Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]
+):
+    version = get_version("docker-compose --version")
+    if version:
+        version = version.split()[-1]
+    ideal_range = (Version("2.28.0"), Version("999.999.999"))
+    supported_range = (Version("1.29.0"), Version("999.999.999"))
+    return check_version("Docker Compose", version, ideal_range, supported_range)
+
+
+def check_git() -> Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]:
+    version = get_version("git --version")
+    if version:
+        version = version.split()[2]
+    ideal_range = (Version("2.30.0"), Version("999.999.999"))
+    supported_range = (Version("2.20.0"), Version("999.999.999"))
+    return check_version("Git", version, ideal_range, supported_range)
+
+
+def main() -> None:
+    checks: List[Tuple[str, Tuple[Version, Version], Tuple[Version, Version]]] = [
+        check_core_python(),
+        check_npm(),
+        check_node(),
+        check_docker(),
+        check_docker_compose(),
+        check_git(),
+    ]
+
+    headers = ["Status", "Software", "Ideal Range", "Supported Range"]
+    row_format = "{:<2} {:<25} {:<25} {:<25}"
+
+    print(row_format.format(*headers))
+    print("=" * 90)
+
+    for check, ideal_range, supported_range in checks:
+        status, software_info = check.split(" ", 1)
+        ideal_range_str = f"{ideal_range[0]} - {ideal_range[1]}"
+        supported_range_str = f"{supported_range[0]} - {supported_range[1]}"
+        print(
+            row_format.format(
+                status, software_info, ideal_range_str, supported_range_str
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-env.py
+++ b/scripts/check-env.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 import subprocess
 import sys

--- a/scripts/check-env.py
+++ b/scripts/check-env.py
@@ -129,8 +129,8 @@ def main(docker: bool, frontend: bool, backend: bool) -> None:
         ),
         Requirement(
             "node",
-            (Version("18.0.0"), Version("18.999.999")),
-            (Version("18.0.0"), Version("18.999.999")),
+            (Version("20.0.0"), Version("20.999.999")),
+            (Version("20.0.0"), Version("20.999.999")),
             "frontend",
             "node -v",
         ),


### PR DESCRIPTION
quick utility to check environment requirements. Written with GPT's help, versions pretty open-ended for now but could become more specific as we go.
```
$ ./scripts/check-env.py
Status Software                  Version Found             Ideal Range               Supported Range
==============================================================================================================
✅ python                    3.10.13                   3.10.0 - 3.10.999         3.9.0 - 3.11.999
✅ npm                       10.5.2                    10.0.0 - 999.999.999      10.0.0 - 999.999.999
✅ node                      v18.20.0                  18.0.0 - 18.999.999       18.0.0 - 18.999.999
✅ docker                    26.1.4                    20.10.0 - 999.999.999     19.0.0 - 999.999.999
✅ docker-compose            2.28.1                    2.28.0 - 999.999.999      1.29.0 - 999.999.999
✅ git                       2.44.0                    2.30.0 - 999.999.999      2.20.0 - 999.999.999
✅ Memory: 16.00 GB
```

Seems it'd be useful for maintainers to point to the script and tell people to make some assertion on their environment. There's a whole class of confusing errors that can be weeded with something like this.