### PR TITLE
Problem Exporting Charts as Image

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -169,16 +169,16 @@ class Row extends PureComponent {
           rootMargin: '100% 0px',
         },
       );
-      this.observerDisabler = new IntersectionObserver(
-        ([entry]) => {
-          if (!entry.isIntersecting && this.state.isInView) {
-            this.setState({ isInView: false });
-          }
-        },
-        {
-          rootMargin: '400% 0px',
-        },
-      );
+      // this.observerDisabler = new IntersectionObserver(
+      //   ([entry]) => {
+      //     if (!entry.isIntersecting && this.state.isInView) {
+      //       this.setState({ isInView: false });
+      //     }
+      //   },
+      //   {
+      //     rootMargin: '400% 0px',
+      //   },
+      // );
       const element = this.containerRef.current;
       if (element) {
         this.observerEnabler.observe(element);


### PR DESCRIPTION
It is wrong not to display a chart if it is not in the browser window display range. When we download the dashboard as a picture, we find that some charts are not displayed

https://github.com/apache/superset/issues/28713

fix(dashboard): load charts correctly
