### PR TITLE
fix(sqllab): prev shema/table options remained on fail

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -95,7 +95,7 @@ export function useKeywords(
     { skip: skipFetch || !dbId || !schema },
   );
 
-  const { data: functionNames, isError } = useDatabaseFunctionsQuery(
+  const { currentData: functionNames, isError } = useDatabaseFunctionsQuery(
     { dbId },
     { skip: skipFetch || !dbId },
   );

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -77,7 +77,7 @@ export function useKeywords(
   // skipFetch is used to prevent re-evaluating memoized keywords
   // due to updated api results by skip flag
   const skipFetch = hasFetchedKeywords && skip;
-  const { data: schemaOptions } = useSchemasQueryState(
+  const { currentData: schemaOptions } = useSchemasQueryState(
     {
       dbId,
       catalog: catalog || undefined,
@@ -85,7 +85,7 @@ export function useKeywords(
     },
     { skip: skipFetch || !dbId },
   );
-  const { data: tableData } = useTablesQueryState(
+  const { currentData: tableData } = useTablesQueryState(
     {
       dbId,
       catalog,

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -70,7 +70,11 @@ const QueryHistory = ({
     ({ sqlLab: { queries } }: SqlLabRootState) => queries,
     shallowEqual,
   );
-  const { data, isLoading, isFetching } = useEditorQueriesQuery(
+  const {
+    currentData: data,
+    isLoading,
+    isFetching,
+  } = useEditorQueriesQuery(
     { editorId: `${queryEditorId}`, pageIndex },
     {
       skip: !isFeatureEnabled(FeatureFlag.SqllabBackendPersistence),

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -105,7 +105,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
   const theme = useTheme();
   const dispatch = useDispatch();
   const {
-    data: tableMetadata,
+    currentData: tableMetadata,
     isSuccess: isMetadataSuccess,
     isLoading: isMetadataLoading,
     isError: hasMetadataError,
@@ -119,7 +119,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
     { skip: !expanded },
   );
   const {
-    data: tableExtendedMetadata,
+    currentData: tableExtendedMetadata,
     isSuccess: isExtraMetadataSuccess,
     isLoading: isExtraMetadataLoading,
     isError: hasExtendedMetadataError,

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -272,7 +272,6 @@ test('should display options in order of the api response', async () => {
 });
 
 test('Should fetch the search keyword when total count exceeds initial options', async () => {
-  fetchMock.reset();
   fetchMock.get(
     databaseApiRoute,
     {
@@ -365,7 +364,7 @@ test('Sends the correct schema when changing the schema', async () => {
   });
   await waitFor(() => expect(fetchMock.calls(databaseApiRoute).length).toBe(1));
   rerender(<DatabaseSelector {...props} />);
-  expect(props.onSchemaChange).toBeCalledTimes(0);
+  expect(props.onSchemaChange).toHaveBeenCalledTimes(0);
   const select = screen.getByRole('combobox', {
     name: 'Select schema or type to search schemas',
   });
@@ -376,5 +375,5 @@ test('Sends the correct schema when changing the schema', async () => {
   await waitFor(() =>
     expect(props.onSchemaChange).toHaveBeenCalledWith('information_schema'),
   );
-  expect(props.onSchemaChange).toBeCalledTimes(1);
+  expect(props.onSchemaChange).toHaveBeenCalledTimes(1);
 });

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -260,7 +260,7 @@ export default function DatabaseSelector({
   }
 
   const {
-    data: schemaData,
+    currentData: schemaData,
     isFetching: loadingSchemas,
     refetch: refetchSchemas,
   } = useSchemas({

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -188,7 +188,7 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
     SelectValue | undefined
   >(undefined);
   const {
-    data,
+    currentData: data,
     isFetching: loadingTables,
     refetch,
   } = useTables({

--- a/superset-frontend/src/hooks/apiResources/sqlLab.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlLab.ts
@@ -69,7 +69,7 @@ export type InitialState = {
   }[];
 };
 
-const queryValidationApi = api.injectEndpoints({
+const initialStateApi = api.injectEndpoints({
   endpoints: builder => ({
     sqlLabInitialState: builder.query<InitialState, void>({
       providesTags: ['SqlLabInitialState'],
@@ -83,4 +83,4 @@ const queryValidationApi = api.injectEndpoints({
 });
 
 export const { useSqlLabInitialStateQuery: useSqlLabInitialState } =
-  queryValidationApi;
+  initialStateApi;

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -203,13 +203,13 @@ export function useTables(options: Params) {
         isSuccess,
         isError,
         isFetching,
-        data,
+        currentData,
         error,
         originalArgs,
       } = result;
       if (!originalArgs?.forceRefresh && requestId && !isFetching) {
-        if (isSuccess && data) {
-          handleOnSuccess(data, false);
+        if (isSuccess && currentData) {
+          handleOnSuccess(currentData, false);
         }
         if (isError) {
           handleOnError(error as Response);

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -152,7 +152,7 @@ export const {
 export function useTables(options: Params) {
   const { dbId, catalog, schema, onSuccess, onError } = options || {};
   const isMountedRef = useRef(false);
-  const { data: schemaOptions, isFetching } = useSchemas({
+  const { currentData: schemaOptions, isFetching } = useSchemas({
     dbId,
     catalog: catalog || undefined,
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Due to the difference between the data of the RDK query and currentData, an issue occurred in SQL Lab where, instead of showing an empty selection due to (permission) errors, the schema and table selector allowed the selection of previous database or schema options.

```
  data?: T // The latest returned result regardless of hook arg, if present
  currentData?: T // The latest returned result for the current hook arg, if present
```

As a result, it was possible to combine schema and table selections that do not actually exist, causing errors and potentially confusing users.
This commit addresses these issues by changing to currentData, ensuring that only results existing in the **strictly** selected database and schema are displayed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/e7b06e9e-d091-4174-8fd7-62081be566ff

After:

https://github.com/user-attachments/assets/de84841f-5fd0-40d5-b021-502da1403022

### TESTING INSTRUCTIONS
Select a db/schema/tables in Sql Lab page
Choose a db that doesn't allow to access the schemas
See the schema selection remained or not after db selection changed

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
