### PR TITLE
fix: Required native filter message wrongfully appearing

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -675,31 +675,33 @@ const DashboardBuilder: FC<DashboardBuilderProps> = () => {
             editMode={editMode}
             marginLeft={dashboardContentMarginLeft}
           >
-            {missingInitialFilters.length > 0 ? (
-              <div
-                css={css`
-                  display: flex;
-                  flex-direction: row;
-                  align-items: center;
-                  justify-content: center;
-                  flex: 1;
-                  & div {
-                    width: 500px;
-                  }
-                `}
-              >
-                <BasicErrorAlert
-                  title={t('Unable to load dashboard')}
-                  body={t(
-                    `The following filters have the 'Select first filter value by default'
+            {showDashboard ? (
+              missingInitialFilters.length > 0 ? (
+                <div
+                  css={css`
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    justify-content: center;
+                    flex: 1;
+                    & div {
+                      width: 500px;
+                    }
+                  `}
+                >
+                  <BasicErrorAlert
+                    title={t('Unable to load dashboard')}
+                    body={t(
+                      `The following filters have the 'Select first filter value by default'
                     option checked and could not be loaded, which is preventing the dashboard
                     from rendering: %s`,
-                    missingInitialFilters.join(', '),
-                  )}
-                />
-              </div>
-            ) : showDashboard ? (
-              <DashboardContainer topLevelTabs={topLevelTabs} />
+                      missingInitialFilters.join(', '),
+                    )}
+                  />
+                </div>
+              ) : (
+                <DashboardContainer topLevelTabs={topLevelTabs} />
+              )
             ) : (
               <Loading />
             )}


### PR DESCRIPTION
### SUMMARY
The required filter message introduced by https://github.com/apache/superset/pull/29456 was wrongfully appearing while the filters were still loading. This PR only changes the code to consider the `showDashboard` condition before displaying that message.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/edab3f13-a0ea-4e88-a5d1-c59af55def9c

https://github.com/user-attachments/assets/cfafa8f7-407e-4064-84ae-8dabeda2d60b

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
