### PR TITLE
fix: remove old database constraint on the Dataset model

### DIFF
--- a/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
+++ b/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Remove _customer_location_uc
+
+Revision ID: df3d7e2eb9a4
+Revises: 02f4f7811799
+Create Date: 2024-07-19 16:11:26.740368
+"""
+
+import logging
+
+from alembic import op
+from migration_utils import create_unique_constraint, drop_unique_constraint
+
+# revision identifiers, used by Alembic.
+revision = "df3d7e2eb9a4"
+down_revision = "02f4f7811799"
+
+logger = logging.getLogger(__name__)
+
+
+def upgrade():
+    try:
+        drop_unique_constraint(op, "_customer_location_uc", "tables")
+    except Exception:  # pylint: disable=broad-except
+        # Unfortunately the DB migration that creates this constraint has a
+        # try/except block, so that we can't know for sure if the constraint exists.
+        logger.warning(
+            "Error dropping constraint, This is expected for certain databases like "
+            "SQLite and MySQL"
+        )
+
+
+def downgrade():
+    create_unique_constraint(
+        op,
+        "_customer_location_uc",
+        "tables",
+        ["database_id", "schema", "table_name"],
+    )

--- a/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
+++ b/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
@@ -26,6 +26,7 @@ import logging
 
 from alembic import op
 from migration_utils import create_unique_constraint, drop_unique_constraint
+from sqlalchemy.engine.reflection import Inspector
 
 from superset.utils.core import generic_find_uq_constraint_name
 
@@ -37,12 +38,13 @@ logger = logging.getLogger(__name__)
 
 
 def upgrade():
-    inspector = op.get_bind().inspector()
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
 
     # Unfortunately the DB migration that creates this constraint has a
     # try/except block, so that we can't know for sure if the constraint exists.
     if constraint_name := generic_find_uq_constraint_name(
-        "table",
+        "tables",
         ["database_id", "schema", "table_name"],
         inspector,
     ):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The dataset model has a comment that says:

https://github.com/apache/superset/blob/9487d6c9d6b3231b1bf31752c76fc50066be0014/superset/connectors/sqla/models.py#L1135-L1144

But turns out there is an old migration from 2016 that adds the uniqueness constraint to the schema:

https://github.com/apache/superset/blob/9487d6c9d6b3231b1bf31752c76fc50066be0014/superset/migrations/versions/2016-04-15_08-31_b4456560d4f3_change_table_unique_constraint.py#L36-L38

With the introduction of catalogs in [SIP-95](https://github.com/apache/superset/issues/22862) this constraint needs to either be updated to include `catalog`, or removed to align with the `SqlaTable` model. In this PR I went with the latter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
