### PR TITLE
chore: add catalog_access to OBJECT_SPEC_PERMISSIONS

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -286,6 +286,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
     OBJECT_SPEC_PERMISSIONS = {
         "database_access",
+        "catalog_access",
         "schema_access",
         "datasource_access",
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In testing catalogs more, I found that `catalog_access` is missing from `OBJECT_SPEC_PERMISSIONS`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
