### PR TITLE
fix: Use default custom time range time without timezone

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/customTimeRangeDecode.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/customTimeRangeDecode.ts
@@ -39,14 +39,14 @@ export const ISO8601_AND_CONSTANT = RegExp(
 );
 const DATETIME_CONSTANT = ['now', 'today'];
 const SEVEN_DAYS_AGO = new Date();
-SEVEN_DAYS_AGO.setUTCHours(0, 0, 0, 0);
+SEVEN_DAYS_AGO.setHours(0, 0, 0, 0);
 
 const MIDNIGHT = new Date();
-MIDNIGHT.setUTCHours(0, 0, 0, 0);
+MIDNIGHT.setHours(0, 0, 0, 0);
 
 const defaultCustomRange: CustomRangeType = {
-  sinceDatetime: SEVEN_DAYS_AGO.setUTCDate(
-    SEVEN_DAYS_AGO.getUTCDate() - 7,
+  sinceDatetime: SEVEN_DAYS_AGO.setDate(
+    SEVEN_DAYS_AGO.getDate() - 7,
   ).toString(),
   sinceMode: 'relative',
   sinceGrain: 'day',

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/customTimeRangeDecode.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/customTimeRangeDecode.test.ts
@@ -151,14 +151,14 @@ describe('customTimeRangeDecode', () => {
   it('7) default', () => {
     const SEVEN_DAYS_AGO = new Date();
     const MIDNIGHT = new Date();
-    SEVEN_DAYS_AGO.setUTCHours(0, 0, 0, 0);
-    MIDNIGHT.setUTCHours(0, 0, 0, 0);
+    SEVEN_DAYS_AGO.setHours(0, 0, 0, 0);
+    MIDNIGHT.setHours(0, 0, 0, 0);
     expect(
       customTimeRangeDecode('now : DATEADD(DATETIME("TODAY"), -7, day)'),
     ).toEqual({
       customRange: {
-        sinceDatetime: SEVEN_DAYS_AGO.setUTCDate(
-          SEVEN_DAYS_AGO.getUTCDate() - 7,
+        sinceDatetime: SEVEN_DAYS_AGO.setDate(
+          SEVEN_DAYS_AGO.getDate() - 7,
         ).toString(),
         sinceMode: 'relative',
         sinceGrain: 'day',
@@ -176,18 +176,18 @@ describe('customTimeRangeDecode', () => {
 
   it('8) relative : relative return default', () => {
     const SEVEN_DAYS_AGO = new Date();
-    SEVEN_DAYS_AGO.setUTCHours(0, 0, 0, 0);
+    SEVEN_DAYS_AGO.setHours(0, 0, 0, 0);
 
     const MIDNIGHT = new Date();
-    MIDNIGHT.setUTCHours(0, 0, 0, 0);
+    MIDNIGHT.setHours(0, 0, 0, 0);
     expect(
       customTimeRangeDecode(
         'DATEADD(DATETIME("2021-01-26T00:00:00"), -55, day) : DATEADD(DATETIME("2021-01-27T00:00:00"), 7, day)',
       ),
     ).toEqual({
       customRange: {
-        sinceDatetime: SEVEN_DAYS_AGO.setUTCDate(
-          SEVEN_DAYS_AGO.getUTCDate() - 7,
+        sinceDatetime: SEVEN_DAYS_AGO.setDate(
+          SEVEN_DAYS_AGO.getDate() - 7,
         ).toString(),
         sinceMode: 'relative',
         sinceGrain: 'day',


### PR DESCRIPTION


### SUMMARY
In custom time range filter, in specific mode, the default time would show UTC midnight adjusted to user's current timezone. This PR fixes that behaviour by using the time without timezone.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1074" alt="Screenshot 2024-07-23 at 15 04 59" src="https://github.com/user-attachments/assets/9d7b57c2-0616-4b48-88a5-10e2dd49dc9d">

After:

<img width="1074" alt="Screenshot 2024-07-23 at 15 05 58" src="https://github.com/user-attachments/assets/c3f8dc00-5dab-455b-9f85-529a5d74ab9c">


### TESTING INSTRUCTIONS
1. Open explore and add a time range filter
2. Open time range filter edit modal
3. Select Custom -> Specific Date/Time
4. Verify that the default value is the current day and the time is 00:00:00

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
