### PR TITLE
fix: Removed fixed width constraint from Save button

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -38,9 +38,6 @@ const SaveDatasetActionButton = ({
     DropdownButton as FC<DropdownButtonProps>,
   )`
     &.ant-dropdown-button button.ant-btn.ant-btn-default {
-      &:first-of-type {
-        width: ${theme.gridUnit * 16}px;
-      }
       font-weight: ${theme.gridUnit * 150};
       background-color: ${theme.colors.primary.light4};
       color: ${theme.colors.primary.dark1};
@@ -58,11 +55,7 @@ const SaveDatasetActionButton = ({
   `;
 
   return !overlayMenu ? (
-    <Button
-      onClick={() => setShowSave(true)}
-      buttonStyle="primary"
-      css={{ width: theme.gridUnit * 25 }}
-    >
+    <Button onClick={() => setShowSave(true)} buttonStyle="primary">
       {t('Save')}
     </Button>
   ) : (

--- a/superset-frontend/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/src/components/DropdownButton/index.tsx
@@ -35,7 +35,6 @@ const StyledDropdownButton = styled.div`
         border-radius: ${({ theme }) =>
           `${theme.gridUnit}px 0 0 ${theme.gridUnit}px`};
         margin: 0;
-        width: 120px;
       }
 
       &:disabled {


### PR DESCRIPTION
### SUMMARY
Currently, "Save" button in SQL Lab has fixed width. So, longer labels are trimmed. This is an attempt to fix that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
English / before:
<img width="647" alt="eng before" src="https://github.com/user-attachments/assets/bbac39de-a4ac-4e42-86b6-0d9dc0e34933">

English / after:
<img width="647" alt="Снимок экрана 2024-07-24 в 18 49 58" src="https://github.com/user-attachments/assets/90d31b2c-94d3-44f5-8535-b1fc705c956b">

Russian / before:
<img width="647" alt="Снимок экрана 2024-07-24 в 18 48 22" src="https://github.com/user-attachments/assets/37fd718b-3a41-4456-b865-a6fcd3f4b4f8">

Russian / after:
<img width="647" alt="Снимок экрана 2024-07-24 в 18 48 51" src="https://github.com/user-attachments/assets/9b971dcc-5f09-4ffd-ad37-828522d7eadb">

### TESTING INSTRUCTIONS
Switch to any language that has long "Save" button translation. Russian, for example.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #29477
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
