### PR TITLE
fix(ci): release process for labeling PRs

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -54,7 +54,6 @@ jobs:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Use Node.js 20
@@ -110,14 +109,12 @@ jobs:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          fetch-depth: 0
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
           tags: true
 
       - name: Use Node.js 20
@@ -112,6 +113,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          tags: true
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -58,9 +58,6 @@ jobs:
           tags: true
           fetch-depth: 0
 
-      - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
-
       - name: Try to login to DockerHub
         continue-on-error: true
         uses: docker/login-action@v3
@@ -94,7 +91,15 @@ jobs:
             --platform "linux/arm64" \
             --platform "linux/amd64"
 
-      # Going back on original branch to allow "post" GHA operations
+  update-prs-with-release-info:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -109,6 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -124,9 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --all --tags
-          git show ${{ github.sha }}
-          git show 68c5a48c1ffcc65029c479212e9063074b54eb47
-          git branch -a
+          git checkout master
           RELEASE="${{ github.event.release.tag_name }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -56,7 +56,6 @@ jobs:
         with:
           persist-credentials: false
           tags: true
-          fetch-depth: 0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
@@ -99,6 +98,9 @@ jobs:
             --platform "linux/arm64" \
             --platform "linux/amd64"
 
+          # Returning to master to support closing setup-supersetbot
+          git checkout master
+
   update-prs-with-release-info:
     needs: config
     if: needs.config.outputs.has-secrets
@@ -115,6 +117,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          fetch-depth: 0
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -56,7 +56,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          tags: true
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
@@ -113,7 +112,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          tags: true
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -104,6 +104,9 @@ jobs:
     needs: config
     if: needs.config.outputs.has-secrets
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
 
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -58,6 +58,14 @@ jobs:
           tags: true
           fetch-depth: 0
 
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
+
       - name: Try to login to DockerHub
         continue-on-error: true
         uses: docker/login-action@v3
@@ -101,6 +109,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -97,13 +97,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-      - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
-
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Setup supersetbot
+        uses: ./.github/actions/setup-supersetbot/
 
       - name: Label the PRs with the right release-related labels
         env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -124,6 +124,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --all --tags
+          git show ${{ github.sha }}
+          git show 68c5a48c1ffcc65029c479212e9063074b54eb47
+          git branch -a
           RELEASE="${{ github.event.release.tag_name }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -126,6 +126,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          export GITHUB_ACTOR=""
           git fetch --all --tags
           git checkout master
           RELEASE="${{ github.event.release.tag_name }}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git fetch --all --tags
           RELEASE="${{ github.event.release.tag_name }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # in the case of a manually-triggered run, read release from input


### PR DESCRIPTION
It appears the CI script that runs on-release to label PRs isn't working
as expected. Here I'm taking the `supersetbot` command out of the matrix
and running it in parallel with the docker image publication.

Tested with:
```
gh workflow run tag-release.yml --ref fix_release_tags --field release="4.0.2" --field git-ref="4.0.2" --field force-latest="true"
```

Test run:
```
https://github.com/apache/superset/actions/runs/10118610898
```
