### PR TITLE
fix(frontend/docker, ci): fix borked Docker build due to Lerna v8 uplift

### DIFF
--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -26,7 +26,7 @@ fi
 if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     cd /app/superset-frontend
     npm install -f --no-optional --global webpack webpack-cli
-    npm install -f --no-optional
+    npm install -f
 
     echo "Running frontend"
     npm run dev

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -156,7 +156,7 @@
     "mousetrap": "^1.6.5",
     "mustache": "^2.2.1",
     "polished": "^4.3.1",
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.8.1",
     "query-string": "^6.13.7",
     "rc-trigger": "^5.3.4",
     "re-resizable": "^6.9.11",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(frontend/docker, ci): fix borked Docker build due to Lerna v8 uplift

### SUMMARY
Closes #29658
<!--- Describe the change below, including rationale and design decisions -->
Remove `--no-optional` in `docker-frontend.sh` to allow installing `@nx` optional dependencies which is necessary for Lerna v8

Also upgrading `prop-types` to next minor version to assess reproducibility of issue raised in PR https://github.com/apache/superset/pull/29723

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
