### PR TITLE
docs(contributing): fix broken link to translations sub-section

### DIFF
--- a/docs/docs/contributing/contributing.mdx
+++ b/docs/docs/contributing/contributing.mdx
@@ -86,7 +86,7 @@ text strings from Superset's UI. You can jump into the existing
 language dictionaries at
 `superset/translations/<language_code>/LC_MESSAGES/messages.po`, or
 even create a dictionary for a new language altogether.
-See [Translating](howtos#contribute-translations) for more details.
+See [Translating](howtos#contributing-translations) for more details.
 
 ### Ask Questions
 


### PR DESCRIPTION
### SUMMARY
Fix broken link to sub-section header.  You can see the header is "Contributing Translations" so the link needs to reflect that:

![image](https://github.com/user-attachments/assets/a7bdc68b-cd9c-42d2-a859-d7185be5b77f)
