### PR TITLE
chore(docker): move mysql os-level deps (GPL) to dev image only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,7 +70,6 @@ jobs:
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
 
-      # Needed as pip install base.txt overflows out of mem
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,10 +70,13 @@ jobs:
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
 
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 16
+      - name: Set up swap space
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo sh -c 'echo "/swapfile none swap sw 0 0" >> /etc/fstab'
 
       - name: Build Docker Image
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,6 +75,8 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_STEP_LOG_MAX_SIZE: 1
         run: |
           # Single platform builds in pull_request context to speed things up
           if [ "${{ github.event_name }}" = "push" ]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,13 +70,17 @@ jobs:
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
 
+      # Needed as pip install base.txt overflows out of mem
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 16
+
       - name: Build Docker Image
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_STEP_LOG_MAX_SIZE: 1
         run: |
           # Single platform builds in pull_request context to speed things up
           if [ "${{ github.event_name }}" = "push" ]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,14 +70,6 @@ jobs:
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
 
-      - name: Set up swap space
-        run: |
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          sudo sh -c 'echo "/swapfile none swap sw 0 0" >> /etc/fstab'
-
       - name: Build Docker Image
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,8 @@ COPY --chown=superset:superset requirements/base.txt requirements/
 RUN --mount=type=cache,target=/root/.cache/pip \
     apt-get update -qq && apt-get install -yqq --no-install-recommends \
       build-essential \
-    && pip install --upgrade setuptools pip \
-    && pip install -r requirements/base.txt \
+    && pip install --no-cache-dir --upgrade setuptools pip \
+    && pip install --no-cache-dir -r requirements/base.txt \
     && apt-get autoremove -yqq --purge build-essential \
     && rm -rf /var/lib/apt/lists/*
 
@@ -125,7 +125,7 @@ COPY --chown=superset:superset --from=superset-node /app/superset/static/assets 
 ## Lastly, let's install superset itself
 COPY --chown=superset:superset superset superset
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -e .
+    pip install --no-cache-dir -e .
 
 # Copy the .json translations from the frontend layer
 COPY --chown=superset:superset --from=superset-node /app/superset/translations superset/translations
@@ -165,7 +165,7 @@ RUN apt-get update -qq \
         && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install playwright
+    pip install --no-cache-dir playwright
 RUN playwright install-deps
 
 RUN if [ "$INCLUDE_CHROMIUM" = "true" ]; then \
@@ -196,7 +196,7 @@ COPY --chown=superset:superset requirements/development.txt requirements/
 RUN --mount=type=cache,target=/root/.cache/pip \
     apt-get update -qq && apt-get install -yqq --no-install-recommends \
       build-essential \
-    && pip install -r requirements/development.txt \
+    && pip install --no-cache-dir -r requirements/development.txt \
     && apt-get autoremove -yqq --purge build-essential \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,6 @@ RUN mkdir -p ${PYTHONPATH} superset/static requirements superset-frontend apache
     && useradd --user-group -d ${SUPERSET_HOME} -m --no-log-init --shell /bin/bash superset \
     && apt-get update -qq && apt-get install -yqq --no-install-recommends \
         curl \
-        default-libmysqlclient-dev \
         libsasl2-dev \
         libsasl2-modules-gssapi-mit \
         libpq-dev \
@@ -188,7 +187,11 @@ RUN if [ "$INCLUDE_FIREFOX" = "true" ]; then \
         && apt-get autoremove -yqq --purge wget bzip2 && rm -rf /var/[log,tmp]/* /tmp/* /var/lib/apt/lists/*; \
     fi
 
-# Cache everything for dev purposes...
+# Installing mysql client os-level dependencies in dev image only because GPL
+RUN apt-get install -yqq --no-install-recommends \
+        default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --chown=superset:superset requirements/development.txt requirements/
 RUN --mount=type=cache,target=/root/.cache/pip \
     apt-get update -qq && apt-get install -yqq --no-install-recommends \


### PR DESCRIPTION
Since mysql client libs are GPL-licensed, we don't want to package them in our default images. Prior to this PR, the `default-libmysqlclient-dev` apt-get package would get installed in the `lean` docker image, though the pypi `mysqlclient` package that depends on this os-level dep was only installed in the `dev` layer.

After this PR, all GPL/mysql related package won't be in `lean`, but still be in `dev` for convenience and CI script that test against mysql.
