### PR TITLE
fix(Dashboard): Copying a Dashboard does not commit the transaction

### DIFF
--- a/superset/commands/dashboard/copy.py
+++ b/superset/commands/dashboard/copy.py
@@ -16,10 +16,7 @@
 # under the License.
 import logging
 from functools import partial
-from typing import Any, Optional
-
-from flask import g
-from marshmallow import ValidationError
+from typing import Any
 
 from superset import is_feature_enabled, security_manager
 from superset.commands.base import BaseCommand
@@ -45,5 +42,7 @@ class CopyDashboardCommand(BaseCommand):
         return DashboardDAO.copy_dashboard(self._original_dash, self._properties)
 
     def validate(self) -> None:
-        if is_feature_enabled("DASHBOARD_RBAC") and not security_manager.is_owner(self._original_dash):
+        if is_feature_enabled("DASHBOARD_RBAC") and not security_manager.is_owner(
+            self._original_dash
+        ):
             raise DashboardForbiddenError()

--- a/superset/commands/dashboard/copy.py
+++ b/superset/commands/dashboard/copy.py
@@ -42,6 +42,11 @@ class CopyDashboardCommand(BaseCommand):
         return DashboardDAO.copy_dashboard(self._original_dash, self._properties)
 
     def validate(self) -> None:
+        if (
+            not self._properties["dashboard_title"]
+            or not self._properties["json_metadata"]
+        ):
+            raise DashboardInvalidError()
         if is_feature_enabled("DASHBOARD_RBAC") and not security_manager.is_owner(
             self._original_dash
         ):

--- a/superset/commands/dashboard/copy.py
+++ b/superset/commands/dashboard/copy.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from functools import partial
+from typing import Any, Optional
+
+from flask import g
+from marshmallow import ValidationError
+
+from superset import is_feature_enabled, security_manager
+from superset.commands.base import BaseCommand
+from superset.commands.dashboard.exceptions import (
+    DashboardForbiddenError,
+    DashboardInvalidError,
+)
+from superset.daos.dashboard import DashboardDAO
+from superset.models.dashboard import Dashboard
+from superset.utils.decorators import on_error, transaction
+
+logger = logging.getLogger(__name__)
+
+
+class CopyDashboardCommand(BaseCommand):
+    def __init__(self, original_dash: Dashboard, data: dict[str, Any]) -> None:
+        self._original_dash = original_dash
+        self._properties = data.copy()
+
+    @transaction(on_error=partial(on_error, reraise=DashboardInvalidError))
+    def run(self) -> Dashboard:
+        self.validate()
+        return DashboardDAO.copy_dashboard(self._original_dash, self._properties)
+
+    def validate(self) -> None:
+        if is_feature_enabled("DASHBOARD_RBAC") and not security_manager.is_owner(self._original_dash):
+            raise DashboardForbiddenError()

--- a/superset/commands/dashboard/exceptions.py
+++ b/superset/commands/dashboard/exceptions.py
@@ -76,3 +76,7 @@ class DashboardImportError(ImportFailedError):
 
 class DashboardAccessDeniedError(ForbiddenError):
     message = _("You don't have access to this dashboard.")
+
+
+class DashboardCopyError(CommandInvalidError):
+    message = _("Dashboard cannot be copied due to invalid parameters.")

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -39,6 +39,7 @@ from superset.commands.dashboard.create import CreateDashboardCommand
 from superset.commands.dashboard.delete import DeleteDashboardCommand
 from superset.commands.dashboard.exceptions import (
     DashboardAccessDeniedError,
+    DashboardCopyError,
     DashboardCreateFailedError,
     DashboardDeleteFailedError,
     DashboardForbiddenError,
@@ -1610,7 +1611,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             dash = CopyDashboardCommand(original_dash, data).run()
         except DashboardForbiddenError:
             return self.response_403()
-        except DashboardInvalidError:
+        except DashboardCopyError:
             return self.response_400()
 
         return self.response(

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -34,6 +34,7 @@ from werkzeug.wsgi import FileWrapper
 
 from superset import db, is_feature_enabled, thumbnail_cache
 from superset.charts.schemas import ChartEntityResponseSchema
+from superset.commands.dashboard.copy import CopyDashboardCommand
 from superset.commands.dashboard.create import CreateDashboardCommand
 from superset.commands.dashboard.delete import DeleteDashboardCommand
 from superset.commands.dashboard.exceptions import (
@@ -1606,9 +1607,11 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             return self.response_400(message=error.messages)
 
         try:
-            dash = DashboardDAO.copy_dashboard(original_dash, data)
+            dash = CopyDashboardCommand(original_dash, data).run()
         except DashboardForbiddenError:
             return self.response_403()
+        except DashboardInvalidError:
+            return self.response_400()
 
         return self.response(
             200,

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -23,7 +23,11 @@ from werkzeug.utils import secure_filename
 
 from superset import db, security_manager
 from superset.commands.dashboard.copy import CopyDashboardCommand
-from superset.commands.dashboard.exceptions import DashboardForbiddenError, DashboardInvalidError, DashboardNotFoundError
+from superset.commands.dashboard.exceptions import (
+    DashboardForbiddenError,
+    DashboardInvalidError,
+    DashboardNotFoundError,
+)
 from superset.commands.dashboard.export import (
     append_charts,
     ExportDashboardsCommand,
@@ -663,6 +667,7 @@ class TestImportDashboardsCommand(SupersetTestCase):
             }
         }
 
+
 class TestCopyDashboardCommand(SupersetTestCase):
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_copy_dashboard_command(self):
@@ -686,7 +691,7 @@ class TestCopyDashboardCommand(SupersetTestCase):
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     def test_copy_dashboard_command_no_access(self):
-        """Test that a non-owner user cannot copy a dashboard if DASHBOARD_RBAC is enabled"""        
+        """Test that a non-owner user cannot copy a dashboard if DASHBOARD_RBAC is enabled"""
         with self.client.application.test_request_context():
             example_dashboard = (
                 db.session.query(Dashboard).filter_by(slug="world_health").one()
@@ -694,7 +699,10 @@ class TestCopyDashboardCommand(SupersetTestCase):
             copy_data = {"dashboard_title": "Copied Dashboard", "json_metadata": "{}"}
 
             with override_user(security_manager.find_user("gamma")):
-                with patch("superset.commands.dashboard.copy.is_feature_enabled", return_value=True):
+                with patch(
+                    "superset.commands.dashboard.copy.is_feature_enabled",
+                    return_value=True,
+                ):
                     command = CopyDashboardCommand(example_dashboard, copy_data)
                     with self.assertRaises(DashboardForbiddenError):
                         command.run()

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -22,7 +22,8 @@ import yaml
 from werkzeug.utils import secure_filename
 
 from superset import db, security_manager
-from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.dashboard.copy import CopyDashboardCommand
+from superset.commands.dashboard.exceptions import DashboardForbiddenError, DashboardInvalidError, DashboardNotFoundError
 from superset.commands.dashboard.export import (
     append_charts,
     ExportDashboardsCommand,
@@ -36,6 +37,7 @@ from superset.models.core import Database
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils import json
+from superset.utils.core import override_user
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.importexport import (
     chart_config,
@@ -660,3 +662,53 @@ class TestImportDashboardsCommand(SupersetTestCase):
                 "table_name": ["Missing data for required field."],
             }
         }
+
+class TestCopyDashboardCommand(SupersetTestCase):
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_copy_dashboard_command(self):
+        """Test that an admin user can copy a dashboard"""
+        with self.client.application.test_request_context():
+            example_dashboard = (
+                db.session.query(Dashboard).filter_by(slug="world_health").one()
+            )
+            copy_data = {"dashboard_title": "Copied Dashboard", "json_metadata": "{}"}
+
+            with override_user(security_manager.find_user("admin")):
+                command = CopyDashboardCommand(example_dashboard, copy_data)
+                copied_dashboard = command.run()
+
+            assert copied_dashboard.dashboard_title == "Copied Dashboard"
+            assert copied_dashboard.slug != example_dashboard.slug
+            assert copied_dashboard.slices == example_dashboard.slices
+
+            db.session.delete(copied_dashboard)
+            db.session.commit()
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_copy_dashboard_command_no_access(self):
+        """Test that a non-owner user cannot copy a dashboard if DASHBOARD_RBAC is enabled"""        
+        with self.client.application.test_request_context():
+            example_dashboard = (
+                db.session.query(Dashboard).filter_by(slug="world_health").one()
+            )
+            copy_data = {"dashboard_title": "Copied Dashboard", "json_metadata": "{}"}
+
+            with override_user(security_manager.find_user("gamma")):
+                with patch("superset.commands.dashboard.copy.is_feature_enabled", return_value=True):
+                    command = CopyDashboardCommand(example_dashboard, copy_data)
+                    with self.assertRaises(DashboardForbiddenError):
+                        command.run()
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    def test_copy_dashboard_command_invalid_data(self):
+        """Test that invalid data raises a DashboardInvalidError"""
+        with self.client.application.test_request_context():
+            example_dashboard = (
+                db.session.query(Dashboard).filter_by(slug="world_health").one()
+            )
+        invalid_copy_data = {"dashboard_title": ""}
+
+        with override_user(security_manager.find_user("admin")):
+            command = CopyDashboardCommand(example_dashboard, invalid_copy_data)
+            with self.assertRaises(DashboardInvalidError):
+                command.run()

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -714,7 +714,7 @@ class TestCopyDashboardCommand(SupersetTestCase):
             example_dashboard = (
                 db.session.query(Dashboard).filter_by(slug="world_health").one()
             )
-        invalid_copy_data = {"dashboard_title": ""}
+        invalid_copy_data = {"dashboard_title": "", "json_metadata": "{}"}
 
         with override_user(security_manager.find_user("admin")):
             command = CopyDashboardCommand(example_dashboard, invalid_copy_data)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We noticed that when copying a Dashboard the transaction wasn't being committed. This PR introduces a command for the dashboard copy operation and uses the transaction decorator to commit the transaction.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Copy a Dashboard
2. The Dashboard should be copied successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
