### PR TITLE
fix: remove --no-optional from docker-compose build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,7 @@ services:
     environment:
       # set this to false if you have perf issues running the npm i; npm run dev in-docker
       # if you do so, you have to run this manually on the host, which should perform better!
+      BUILD_SUPERSET_FRONTEND_IN_DOCKER: true
       SCARF_ANALYTICS: "${SCARF_ANALYTICS:-}"
     container_name: superset_node
     command: ["/app/docker/docker-frontend.sh"]

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -25,8 +25,7 @@ fi
 
 if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     cd /app/superset-frontend
-    npm install -f --no-optional --global webpack webpack-cli
-    npm install -f
+    npm install
 
     echo "Running frontend"
     npm run dev

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -35,4 +35,5 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
 
 else
     echo "Skipping frontend build steps - YOU NEED TO RUN IT MANUALLY ON THE HOST!"
+    echo "https://superset.apache.org/docs/contributing/development/#webpack-dev-server"
 fi

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -24,11 +24,15 @@ if [ "$PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" = "false" ]; then
 fi
 
 if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
+    echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
+
+    echo "Running `npm install`"
     npm install
 
     echo "Running frontend"
     npm run dev
+
 else
-    echo "Skipping frontend build steps - YOU RUN IT MANUALLY ON THE HOST!"
+    echo "Skipping frontend build steps - YOU NEED TO RUN IT MANUALLY ON THE HOST!"
 fi


### PR DESCRIPTION
Remove unusual artifact from local docker-compose setup, using vanilla `npm install`
