### PR TITLE
feat(sqllab): Highlight and make actionable table name in the editor

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -155,8 +155,10 @@ const defaultTheme = {
     },
   },
   zIndex: {
+    aboveEditorActiveLine: 3,
     aboveDashboardCharts: 10,
     dropdown: 11,
+    belowModal: 900,
     max: 3000,
   },
   transitionTiming: 0.3,

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/AceEditorMetadataPopup.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/AceEditorMetadataPopup.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { render } from 'spec/helpers/testing-library';
+import { defaultQueryEditor, initialState } from 'src/SqlLab/fixtures';
+import AceEditorTokenProvider, {
+  useTokenContext,
+  LookUpParams,
+} from './AceEditorTokenProvider';
+import AceEditorMetadataPopup from '.';
+
+fetchMock.get('glob:*/api/v1/database/*/schemas/?*', {
+  count: 1,
+  result: ['main'],
+});
+fetchMock.get('glob:*/api/v1/database/*/tables/?*', {
+  result: [
+    {
+      label: 'table2',
+      value: 'table2',
+      type: 'table',
+    },
+  ],
+});
+fetchMock.get('glob:*/api/v1/database/*/table_metadata/extra/*', {});
+fetchMock.get('glob:*/api/v1/database/*/table_metadata/?*', {
+  status: 200,
+  body: {
+    name: 'table1',
+    columns: [
+      {
+        name: 'column1',
+        type: 'VARCHAR',
+        keys: [],
+        comment: null,
+      },
+      {
+        name: 'column2',
+        type: 'VARCHAR',
+        keys: [],
+        comment: null,
+      },
+    ],
+  },
+});
+
+const TestTrigger = (params: Partial<LookUpParams>) => {
+  const { getMatchTokenData, setActiveTokenData } = useTokenContext();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        const tokenData = getMatchTokenData({
+          token: {
+            type: 'keyword',
+            value: 'table1',
+            index: 2,
+          },
+          siblingTokens: [
+            {
+              type: 'keyword',
+              value: 'main',
+              index: 0,
+            },
+            {
+              type: 'text',
+              value: '.',
+              index: 1,
+            },
+          ],
+          position: {
+            row: 0,
+            column: 0,
+          },
+          ...params,
+        });
+        if (tokenData) {
+          const [metadataType, metadata] = tokenData;
+          setActiveTokenData({
+            metadataType,
+            metadata,
+            markerStyle: { x: 0, y: 0, width: 10 },
+          });
+        }
+      }}
+    >
+      Trigger
+    </button>
+  );
+};
+
+const setup = (params: Partial<LookUpParams>) =>
+  render(
+    <AceEditorTokenProvider>
+      <AceEditorMetadataPopup />
+      <TestTrigger {...params} />
+    </AceEditorTokenProvider>,
+    {
+      useRedux: true,
+      initialState: {
+        ...initialState,
+        sqlLab: {
+          ...initialState.sqlLab,
+          queryEditors: [
+            {
+              ...defaultQueryEditor,
+              dbId: 1,
+            },
+          ],
+          tabHistory: [defaultQueryEditor.id],
+        },
+      },
+    },
+  );
+
+const waitLoadMetadataValidators = () => new Promise(r => setTimeout(r, 300));
+
+test('should pop up the table metadata when sibling token is in the list', async () => {
+  const { getByText, queryByText, findByText } = await setup({});
+  expect(queryByText('table1')).not.toBeInTheDocument();
+  await waitLoadMetadataValidators();
+  getByText('Trigger').click();
+  const popupTitle = await findByText('main.table1');
+  expect(popupTitle).toBeInTheDocument();
+  expect(getByText('column1')).toBeInTheDocument();
+  expect(getByText('column2')).toBeInTheDocument();
+});
+
+test('should pop up the table metadata when table token is in the list', async () => {
+  const { getByText, queryByText, findByText } = await setup({
+    token: { type: 'table', value: 'table2', index: 0 },
+    siblingTokens: [],
+  });
+  expect(queryByText('main.table2')).not.toBeInTheDocument();
+  await waitLoadMetadataValidators();
+  getByText('Trigger').click();
+  const popupTitle = await findByText('main.table2');
+  expect(popupTitle).toBeInTheDocument();
+  expect(getByText('column1')).toBeInTheDocument();
+  expect(getByText('column2')).toBeInTheDocument();
+});
+
+test('should ignore poping up when table token is not in the list', async () => {
+  const { getByText, queryByText } = await setup({
+    token: { type: 'table', value: 'table3', index: 0 },
+    siblingTokens: [],
+  });
+  expect(queryByText('main.table3')).not.toBeInTheDocument();
+  await waitLoadMetadataValidators();
+  getByText('Trigger').click();
+  expect(queryByText('main.table3')).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/AceEditorTokenProvider.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/AceEditorTokenProvider.tsx
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  createContext,
+  FC,
+  useRef,
+  useMemo,
+  useContext,
+  useState,
+} from 'react';
+import type { Position as AcePosition } from 'brace';
+
+export type AceToken = {
+  type: string;
+  value: string;
+  index: number;
+  start?: number;
+};
+
+export enum MetadataType {
+  TABLE = 'table',
+}
+
+export type TokenMetadata = {
+  type: string;
+  value: string;
+  title: string;
+  dbId: number | string;
+  schema?: string;
+  catalog?: string | null;
+};
+
+export type LookUpParams = {
+  token: AceToken;
+  siblingTokens: AceToken[];
+  position: AcePosition;
+};
+
+export type ValidatorFuncType = (
+  lookUpParams: LookUpParams,
+) => TokenMetadata | undefined;
+
+type TokenData = {
+  metadataType: MetadataType;
+  metadata?: TokenMetadata;
+  markerStyle?: {
+    x: number;
+    y: number;
+    width: number;
+  };
+};
+
+type ContextProps = {
+  setValidators: (key: MetadataType, validator: ValidatorFuncType) => void;
+  getMatchTokenData: (
+    lookUpParams: LookUpParams,
+  ) => [MetadataType, TokenMetadata] | undefined;
+  setActiveTokenData: (data: TokenData) => void;
+};
+
+const TokenContext = createContext<ContextProps>({
+  setValidators: () => {},
+  getMatchTokenData: () => undefined,
+  setActiveTokenData: () => {},
+});
+const ActiveTokenContext = createContext<TokenData | undefined>(undefined);
+
+export const useTokenContext = () => useContext(TokenContext);
+export const useActiveTokenContext = () => useContext(ActiveTokenContext);
+
+const AceEditorTokenProvider: FC = ({ children }) => {
+  const validationsRef = useRef<Record<MetadataType, ValidatorFuncType>>();
+  const [activeTokenData, setActiveTokenData] = useState<TokenData>();
+
+  const contextValue = useMemo(
+    () => ({
+      setValidators: (key: MetadataType, validator: ValidatorFuncType) => {
+        validationsRef.current = {
+          ...validationsRef.current,
+          [key]: validator,
+        };
+      },
+      getMatchTokenData: (params: LookUpParams) =>
+        validationsRef.current &&
+        (Object.entries(validationsRef.current)
+          .map(([key, validate]) => [key, validate(params)])
+          .find(([, metadata]) => Boolean(metadata)) as [
+          MetadataType,
+          TokenMetadata,
+        ]),
+      setActiveTokenData,
+    }),
+    [],
+  );
+
+  return (
+    <TokenContext.Provider value={contextValue}>
+      <ActiveTokenContext.Provider value={activeTokenData}>
+        {children}
+      </ActiveTokenContext.Provider>
+    </TokenContext.Provider>
+  );
+};
+
+export default AceEditorTokenProvider;

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/TableMetadataContent.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/TableMetadataContent.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { fireEvent, render, waitFor } from 'spec/helpers/testing-library';
+import { initialState } from 'src/SqlLab/fixtures';
+import TableMetadataContent from './TableMetadataContent';
+
+beforeEach(() => {
+  fetchMock.get('glob:*/api/v1/database/*/table_metadata/extra/*', {});
+  fetchMock.get('glob:*/api/v1/database/*/table_metadata/?*', {
+    status: 200,
+    body: {
+      name: 'table1',
+      selectStar: 'SELECT * FROM table1',
+      columns: [
+        {
+          name: 'column1',
+          type: 'VARCHAR',
+          keys: [],
+          comment: null,
+        },
+        {
+          name: 'column2',
+          type: 'VARCHAR',
+          keys: [],
+          comment: null,
+        },
+      ],
+    },
+  });
+});
+
+afterEach(() => {
+  fetchMock.reset();
+});
+
+const mockProps = {
+  dbId: 1,
+  type: 'table',
+  title: 'main.table1',
+  schema: 'main',
+  value: 'table1',
+};
+
+test('renders the table metadata from the metadata api', async () => {
+  const { getByText, findByText } = render(
+    <TableMetadataContent {...mockProps} />,
+    {
+      useRedux: true,
+    },
+  );
+  await findByText('Columns (2)');
+  expect(getByText('column1')).toBeInTheDocument();
+  expect(getByText('column2')).toBeInTheDocument();
+});
+
+test('renders a error message when api fails', async () => {
+  fetchMock.get(
+    'glob:*/api/v1/database/*/table_metadata/?*',
+    {
+      status: 500,
+      body: 'custom error message',
+    },
+    { overwriteRoutes: true },
+  );
+  const { findByRole } = render(<TableMetadataContent {...mockProps} />, {
+    useRedux: true,
+  });
+  const alert = await findByRole('alert');
+  expect(alert).toBeInTheDocument();
+});
+
+test('renders empty message when no columns data is returned', async () => {
+  fetchMock.get(
+    'glob:*/api/v1/database/*/table_metadata/?*',
+    {
+      status: 200,
+      body: {
+        name: 'table2',
+        columns: [],
+      },
+    },
+    { overwriteRoutes: true },
+  );
+  const { findByRole } = render(
+    <TableMetadataContent {...mockProps} value="table2" />,
+    {
+      useRedux: true,
+    },
+  );
+  const alert = await findByRole('alert');
+  expect(alert).toHaveTextContent('Cannot find the table (table2) metadata.');
+});
+
+test('fetch data preview query on preview tab clicked', async () => {
+  const previewFetchUrl = 'glob:*/api/v1/sqllab/execute/*';
+  fetchMock.post(previewFetchUrl, {});
+  const { findByText } = render(<TableMetadataContent {...mockProps} />, {
+    useRedux: true,
+    initialState: {
+      ...initialState,
+      sqlLab: {
+        ...initialState.sqlLab,
+        databases: {
+          1: {
+            id: 1,
+            database_name: 'main',
+            backend: 'sqlite',
+          },
+        },
+      },
+    },
+  });
+  const previewTab = await findByText('Preview');
+  fireEvent.click(previewTab);
+  await waitFor(() => expect(fetchMock.calls(previewFetchUrl)).toHaveLength(1));
+});

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/TableMetadataContent.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/TableMetadataContent.tsx
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FC, useCallback, useMemo, useState } from 'react';
+import { nanoid } from 'nanoid';
+import { ClientErrorObject, getExtensionsRegistry, t } from '@superset-ui/core';
+import { useDispatch } from 'react-redux';
+import { Skeleton } from 'src/components';
+import FilterableTable from 'src/components/FilterableTable';
+import Tabs from 'src/components/Tabs';
+import {
+  useTableExtendedMetadataQuery,
+  useTableMetadataQuery,
+} from 'src/hooks/apiResources';
+import { runTablePreviewQuery } from 'src/SqlLab/actions/sqlLab';
+import Alert from 'src/components/Alert';
+import { renderWell } from '../TableElement';
+import ResultSet from '../ResultSet';
+import type { TokenMetadata } from './AceEditorTokenProvider';
+
+const extensionsRegistry = getExtensionsRegistry();
+
+const COLUMN_KEYS = ['column_name', 'column_type'];
+
+const CONTENT_HEIGHT = 300;
+const PREVIEW_QUERY_LIMIT = 100;
+
+const TableMetadataContent: FC<TokenMetadata> = ({
+  dbId,
+  catalog,
+  schema,
+  value,
+}) => {
+  const [previewQueryId, setPreviewQueryId] = useState<string>();
+  const {
+    currentData: tableMetadata,
+    isLoading: isMetadataLoading,
+    isError: hasMetadataError,
+    error: metadataError,
+  } = useTableMetadataQuery(
+    {
+      dbId,
+      catalog,
+      schema: schema ?? '',
+      table: value ?? '',
+    },
+    { skip: !dbId || !schema || !value },
+  );
+  const { currentData: tableExtendedMetadata, error: metadataExtrError } =
+    useTableExtendedMetadataQuery(
+      {
+        dbId,
+        catalog,
+        schema: schema ?? '',
+        table: value ?? '',
+      },
+      { skip: !dbId || !schema || !value },
+    );
+  const data = useMemo(
+    () =>
+      (tableMetadata?.columns.length ?? 0) > 0
+        ? tableMetadata?.columns.map(({ name, type, keys, comment }) => ({
+            column_name: name,
+            column_type: type,
+            keys,
+            comment,
+          }))
+        : undefined,
+    [tableMetadata],
+  );
+  const hasKeys = useMemo(
+    () => data?.some(({ keys }) => Boolean(keys?.length)),
+    [data],
+  );
+  const tableData = {
+    ...tableMetadata,
+    ...tableExtendedMetadata,
+  };
+  const ResultTable =
+    extensionsRegistry.get('sqleditor.extension.resultTable') ??
+    FilterableTable;
+  const dispatch = useDispatch();
+  const onTabSwitch = useCallback(
+    (activeKey: string) => {
+      if (activeKey === 'preview' && !previewQueryId) {
+        const queryId = nanoid(11);
+        dispatch(
+          runTablePreviewQuery(
+            {
+              previewQueryId: queryId,
+              dbId,
+              catalog,
+              schema,
+              name: value,
+              selectStar: tableData.selectStar,
+            },
+            true,
+          ),
+        );
+        setPreviewQueryId(queryId);
+      }
+    },
+    [
+      previewQueryId,
+      dbId,
+      catalog,
+      schema,
+      value,
+      tableData.selectStar,
+      dispatch,
+    ],
+  );
+
+  if (isMetadataLoading) {
+    return <Skeleton active />;
+  }
+
+  if (hasMetadataError || metadataExtrError) {
+    return (
+      <Alert
+        type="warning"
+        message={
+          ((metadataError || metadataExtrError) as ClientErrorObject)?.error
+        }
+      />
+    );
+  }
+  if (!data) {
+    return (
+      <Alert
+        type="warning"
+        message={t('Cannot find the table (%s) metadata.', value)}
+        closable={false}
+      />
+    );
+  }
+  return (
+    <>
+      {tableData.comment}
+      {tableMetadata && renderWell(tableMetadata)}
+      <Tabs onTabClick={onTabSwitch}>
+        <Tabs.TabPane tab={t('Columns (%s)', data.length)} key="columns">
+          <ResultTable
+            queryId="table-metadata-preview"
+            height={CONTENT_HEIGHT}
+            data={data}
+            orderedColumnKeys={
+              hasKeys ? COLUMN_KEYS.concat('keys') : COLUMN_KEYS
+            }
+          />
+        </Tabs.TabPane>
+        {tableData?.selectStar && (
+          <Tabs.TabPane tab={t('Preview')} key="preview">
+            {previewQueryId && (
+              <ResultSet
+                queryId={previewQueryId}
+                visualize={false}
+                csv={false}
+                cache
+                height={CONTENT_HEIGHT}
+                displayLimit={PREVIEW_QUERY_LIMIT}
+                defaultQueryLimit={PREVIEW_QUERY_LIMIT}
+              />
+            )}
+          </Tabs.TabPane>
+        )}
+      </Tabs>
+    </>
+  );
+};
+
+export default TableMetadataContent;

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/index.tsx
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FC, useRef, useEffect, memo, useState, useCallback } from 'react';
+import { styled, useTheme } from '@superset-ui/core';
+import Popover from 'src/components/Popover';
+import TableMetadataContent from './TableMetadataContent';
+import useTableMetadataPrepare from './useTableMetadataPrepare';
+import { MetadataType, useActiveTokenContext } from './AceEditorTokenProvider';
+
+const InvisibleButton = styled.button<{
+  x: number;
+  y: number;
+  width: number;
+  visible: boolean;
+}>`
+  opacity: 0;
+  position: fixed;
+  height: 14px;
+  display: ${({ visible }) => (visible ? 'block' : 'none')};
+  top: ${({ y }) => y}px;
+  left: ${({ x }) => x}px;
+  width: ${({ width }) => width}px;
+`;
+
+const COMPONENTS = {
+  [MetadataType.TABLE]: TableMetadataContent,
+};
+
+const AceEditorMetadataPopup: FC = () => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [visible, setVisible] = useState(false);
+  const theme = useTheme();
+  const activeTokenData = useActiveTokenContext();
+  const { markerStyle } = activeTokenData || {};
+  const metadata = activeTokenData?.metadata;
+  const metadataType = activeTokenData?.metadataType;
+  const Component = metadataType && COMPONENTS[metadataType];
+
+  useTableMetadataPrepare({
+    dbId: metadata?.dbId,
+    schema: metadata?.schema,
+    catalog: metadata?.catalog,
+  });
+
+  useEffect(() => {
+    setVisible(Boolean(markerStyle));
+  }, [markerStyle]);
+
+  const onVisibleChange = useCallback((visible: boolean) => {
+    if (!visible) {
+      setVisible(false);
+    }
+  }, []);
+
+  return (
+    <Popover
+      title={metadata?.title}
+      content={metadata && Component && <Component {...metadata} />}
+      trigger="click"
+      placement="bottom"
+      visible={visible}
+      onVisibleChange={onVisibleChange}
+      overlayStyle={{ zIndex: theme.zIndex.belowModal }}
+      overlayInnerStyle={{ width: 500 }}
+    >
+      <InvisibleButton
+        ref={buttonRef}
+        x={markerStyle?.x || 0}
+        y={markerStyle?.y || 0}
+        width={markerStyle?.width || 0}
+        visible={visible}
+      >
+        .
+      </InvisibleButton>
+    </Popover>
+  );
+};
+
+export default memo(AceEditorMetadataPopup);

--- a/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/useTableMetadataPrepare.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorMetadataPopup/useTableMetadataPrepare.ts
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useSchemas, useTablesQuery } from 'src/hooks/apiResources';
+import type { SqlLabRootState } from 'src/SqlLab/types';
+import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
+import {
+  MetadataType,
+  useTokenContext,
+  ValidatorFuncType,
+} from './AceEditorTokenProvider';
+
+type Params = {
+  dbId?: string | number;
+  catalog?: string | null;
+  schema?: string;
+};
+
+const stripQuotes = (value: string) =>
+  /\s/.test(value) ? value.slice(1, -1) : value;
+
+function useTableMetadataPrepare(params: Params) {
+  const queryEditorId = useSelector<SqlLabRootState, string>(
+    ({ sqlLab }) => sqlLab.tabHistory.slice(-1)[0],
+  );
+  const queryEditor = useQueryEditor(queryEditorId, [
+    'dbId',
+    'catalog',
+    'schema',
+  ]);
+  const dbId = params.dbId ?? queryEditor.dbId;
+  const catalog = params.catalog ?? queryEditor.catalog;
+  const schema = params.schema ?? queryEditor.schema;
+
+  const { currentData: schemaOptions } = useSchemas({
+    dbId,
+    catalog: catalog || undefined,
+  });
+
+  const schemas = useMemo(
+    () =>
+      dbId && schemaOptions
+        ? Object.fromEntries(
+            schemaOptions?.map(({ value }) => [
+              value,
+              {
+                dbId,
+                catalog,
+                schema: value,
+                type: 'schema',
+              },
+            ]),
+          )
+        : undefined,
+    [dbId, catalog, schemaOptions],
+  );
+
+  const { currentData: tableData } = useTablesQuery(
+    {
+      dbId,
+      catalog,
+      schema,
+      forceRefresh: false,
+    },
+    { skip: !dbId || !schema },
+  );
+
+  const fetchedTables = useMemo(
+    () =>
+      dbId && schema && tableData?.options
+        ? Object.fromEntries(
+            tableData.options.map(({ value, type }) => [
+              value,
+              {
+                dbId,
+                catalog,
+                schema,
+                title: `${schema}.${value}`,
+                value,
+                type,
+              },
+            ]),
+          )
+        : undefined,
+    [tableData, dbId, catalog, schema],
+  );
+
+  const { setValidators } = useTokenContext();
+
+  const schemasRef = useRef(schemas);
+  const fetchedTablesRef = useRef(fetchedTables);
+  schemasRef.current = schemas;
+  fetchedTablesRef.current = fetchedTables;
+
+  const validator = useCallback<ValidatorFuncType>(
+    ({ token, siblingTokens }) => {
+      const schemaValue =
+        siblingTokens[token.index - 1]?.value === '.'
+          ? stripQuotes(siblingTokens[token.index - 2]?.value)
+          : undefined;
+      const tokenValue = stripQuotes(token.value);
+      if (schemaValue && schemasRef.current?.[schemaValue]) {
+        return {
+          ...schemasRef.current?.[schemaValue],
+          value: token.value,
+          title: `${schemaValue}.${token.value}`,
+        };
+      }
+      return fetchedTablesRef.current?.[tokenValue];
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setValidators(MetadataType.TABLE, validator);
+  }, [validator, setValidators]);
+}
+
+export default useTableMetadataPrepare;

--- a/superset-frontend/src/SqlLab/components/App/App.test.tsx
+++ b/superset-frontend/src/SqlLab/components/App/App.test.tsx
@@ -38,6 +38,9 @@ jest.mock('src/SqlLab/components/TabbedSqlEditors', () => () => (
 jest.mock('src/SqlLab/components/QueryAutoRefresh', () => () => (
   <div data-test="mock-query-auto-refresh" />
 ));
+jest.mock('src/SqlLab/components/AceEditorMetadataPopup', () => () => (
+  <div data-test="mock-ace-editor-metadata-popup" />
+));
 jest.mock('mousetrap', () => ({
   reset: jest.fn(),
 }));
@@ -68,6 +71,7 @@ describe('SqlLab App', () => {
     const { getByTestId } = render(<App />, { useRedux: true, store });
     expect(getByTestId('SqlLabApp')).toBeInTheDocument();
     expect(getByTestId('mock-tabbed-sql-editors')).toBeInTheDocument();
+    expect(getByTestId('mock-ace-editor-metadata-popup')).toBeInTheDocument();
   });
 
   it('reset hotkey events on unmount', () => {

--- a/superset-frontend/src/SqlLab/components/App/index.tsx
+++ b/superset-frontend/src/SqlLab/components/App/index.tsx
@@ -36,6 +36,7 @@ import {
 } from 'src/logger/LogUtils';
 import TabbedSqlEditors from '../TabbedSqlEditors';
 import QueryAutoRefresh from '../QueryAutoRefresh';
+import AceEditorMetadataPopup from '../AceEditorMetadataPopup';
 
 const SqlLabStyles = styled.div`
   ${({ theme }) => css`
@@ -216,6 +217,7 @@ class App extends PureComponent<AppProps, AppState> {
           queriesLastUpdate={queriesLastUpdate}
         />
         <TabbedSqlEditors />
+        <AceEditorMetadataPopup />
       </SqlLabStyles>
     );
   }

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -32,6 +32,7 @@ import {
   syncTable,
 } from 'src/SqlLab/actions/sqlLab';
 import {
+  TableMetaData,
   useTableExtendedMetadataQuery,
   useTableMetadataQuery,
 } from 'src/hooks/apiResources';
@@ -99,6 +100,65 @@ const StyledCollapsePanel = styled(Collapse.Panel)`
     }
   `}
 `;
+
+export const renderWell = (tableData: TableMetaData) => {
+  let partitions;
+  let metadata;
+  if (tableData.partitions) {
+    let partitionQuery;
+    let partitionClipBoard;
+    if (tableData.partitions.partitionQuery) {
+      ({ partitionQuery } = tableData.partitions);
+      const tt = t('Copy partition query to clipboard');
+      partitionClipBoard = (
+        <CopyToClipboard
+          text={partitionQuery}
+          shouldShowText={false}
+          tooltipText={tt}
+          copyNode={<i className="fa fa-clipboard" />}
+        />
+      );
+    }
+    const latest = Object.entries(tableData.partitions?.latest || [])
+      .map(([key, value]) => `${key}=${value}`)
+      .join('/');
+
+    partitions = (
+      <div>
+        <small>
+          {t('latest partition:')} {latest}
+        </small>{' '}
+        {partitionClipBoard}
+      </div>
+    );
+  }
+
+  if (tableData.metadata) {
+    metadata = Object.entries(tableData.metadata).map(([key, value]) => (
+      <div>
+        <small>
+          <strong>{key}:</strong> {value}
+        </small>
+      </div>
+    ));
+    if (!metadata?.length) {
+      // hide metadata card view
+      return null;
+    }
+  }
+
+  if (!partitions) {
+    // hide partition card view
+    return null;
+  }
+
+  return (
+    <Card size="small">
+      {partitions}
+      {metadata}
+    </Card>
+  );
+};
 
 const TableElement = ({ table, ...props }: TableElementProps) => {
   const { dbId, catalog, schema, name, expanded } = table;
@@ -175,65 +235,6 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
 
   const toggleSortColumns = () => {
     setSortColumns(prevState => !prevState);
-  };
-
-  const renderWell = () => {
-    let partitions;
-    let metadata;
-    if (tableData.partitions) {
-      let partitionQuery;
-      let partitionClipBoard;
-      if (tableData.partitions.partitionQuery) {
-        ({ partitionQuery } = tableData.partitions);
-        const tt = t('Copy partition query to clipboard');
-        partitionClipBoard = (
-          <CopyToClipboard
-            text={partitionQuery}
-            shouldShowText={false}
-            tooltipText={tt}
-            copyNode={<i className="fa fa-clipboard" />}
-          />
-        );
-      }
-      const latest = Object.entries(tableData.partitions?.latest || [])
-        .map(([key, value]) => `${key}=${value}`)
-        .join('/');
-
-      partitions = (
-        <div>
-          <small>
-            {t('latest partition:')} {latest}
-          </small>{' '}
-          {partitionClipBoard}
-        </div>
-      );
-    }
-
-    if (tableData.metadata) {
-      metadata = Object.entries(tableData.metadata).map(([key, value]) => (
-        <div>
-          <small>
-            <strong>{key}:</strong> {value}
-          </small>
-        </div>
-      ));
-      if (!metadata?.length) {
-        // hide metadata card view
-        return null;
-      }
-    }
-
-    if (!partitions) {
-      // hide partition card view
-      return null;
-    }
-
-    return (
-      <Card size="small">
-        {partitions}
-        {metadata}
-      </Card>
-    );
   };
 
   const renderControls = () => {
@@ -377,7 +378,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
         onMouseLeave={() => setHover(false)}
         css={{ paddingTop: 6 }}
       >
-        {renderWell()}
+        {renderWell(tableData as TableMetaData)}
         <div>
           {cols?.map(col => <ColumnElement column={col} key={col.name} />)}
         </div>

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -313,7 +313,7 @@ export default function sqlLabReducer(state = {}, action) {
           const queries = { ...state.queries, [q.id]: q };
           newState = { ...state, queries };
         }
-      } else {
+      } else if (!action.runPreviewOnly) {
         newState.activeSouthPaneTab = action.query.id;
       }
       newState = addToObject(newState, 'queries', action.query);

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -400,6 +400,27 @@ describe('sqlLabReducer', () => {
       };
       newState = sqlLabReducer(newState, action);
       expect(Object.keys(newState.queries)).toHaveLength(1);
+      expect(newState.activeSouthPaneTab).toEqual('Results');
+    });
+    it('should start a preview query', () => {
+      const action = {
+        type: actions.START_QUERY,
+        query: {
+          id: 'prevewOnly',
+          progress: 0,
+          changed_on: DENORMALIZED_CHANGED_ON,
+          startDttm: CHANGED_ON_TIMESTAMP,
+          state: 'running',
+          cached: false,
+          sqlEditorId: null,
+        },
+        runPreviewOnly: true,
+      };
+      const { activeSouthPaneTab } = newState;
+      newState = sqlLabReducer(newState, action);
+      expect(newState.queries[action.query.id]).toEqual(action.query);
+      expect(newState.activeSouthPaneTab).not.toEqual(action.query.id);
+      expect(newState.activeSouthPaneTab).toEqual(activeSouthPaneTab);
     });
     it('should stop the query', () => {
       const startQueryAction = {

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -70,6 +70,7 @@ interface Column {
   name: string;
   keys?: { type: ColumnKeyTypeType }[];
   type: string;
+  comment?: string;
 }
 
 export type TableMetaData = {
@@ -83,6 +84,7 @@ export type TableMetaData = {
   selectStar?: string;
   view?: string;
   columns: Column[];
+  comment?: string;
 };
 
 type TableMetadataReponse = {

--- a/superset-frontend/src/pages/SqlLab/index.tsx
+++ b/superset-frontend/src/pages/SqlLab/index.tsx
@@ -28,6 +28,7 @@ import { SqlLabGlobalStyles } from 'src/SqlLab//SqlLabGlobalStyles';
 import App from 'src/SqlLab/components/App';
 import Loading from 'src/components/Loading';
 import EditorAutoSync from 'src/SqlLab/components/EditorAutoSync';
+import AceEditorTokenProvider from 'src/SqlLab/components/AceEditorMetadataPopup/AceEditorTokenProvider';
 import useEffectEvent from 'src/hooks/useEffectEvent';
 import { LocationProvider } from './LocationContext';
 
@@ -63,20 +64,22 @@ export default function SqlLab() {
 
   return (
     <LocationProvider>
-      <div
-        css={css`
-          flex: 1 1 auto;
-          position: relative;
-          display: flex;
-          flex-direction: column;
-        `}
-      >
-        <SqlLabGlobalStyles />
-        <App />
-        {isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) && (
-          <EditorAutoSync />
-        )}
-      </div>
+      <AceEditorTokenProvider>
+        <div
+          css={css`
+            flex: 1 1 auto;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+          `}
+        >
+          <SqlLabGlobalStyles />
+          <App />
+          {isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) && (
+            <EditorAutoSync />
+          )}
+        </div>
+      </AceEditorTokenProvider>
     </LocationProvider>
   );
 }


### PR DESCRIPTION
### SUMMARY
Following https://github.com/apache/superset/discussions/26096

To make the editor smart, this commit highlights actionable items (such as table names) among the tokens hovered over by the mouse. When cmd + click is pressed, additional data linked to the relevant metadata is displayed in a popup.

The first item implemented in this commit is table names. If the SQL content includes a table name with a schema (e.g., main.bart_lines) or if the text matches a table name from the list of tables in the currently selected schema, it is marked as actionable. When clicked, it displays table metadata (including columns) and a preview query in a popup, similar to the left panel.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/26bd4cab-bda8-4dce-93db-688d96d498e3

### TESTING INSTRUCTIONS
type a sql including a table name and then mouse over the table name string

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
