### PR TITLE
chore(docs): remove mention of MariaDB in dev environment setup

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   linkinator:
+    # See docs here: https://github.com/marketplace/actions/linkinator
     name: Link Checking
     runs-on: ubuntu-latest
     steps:
@@ -20,8 +21,24 @@ jobs:
       - uses: JustinBeckwith/linkinator-action@v1.10.4
         with:
           paths: "**/*.md, **/*.mdx"
-          linksToSkip: '^https://github.com/apache/(superset|incubator-superset)/(pull|issue)/\d+, http://localhost:8088/, docker/.env-non-dev, http://127.0.0.1:3000/, http://localhost:9001/, https://charts.bitnami.com/bitnami, https://www.li.me/, https://www.fanatics.com/, https://tails.com/gb/, https://www.techaudit.info/, https://avetilearning.com/, https://www.udemy.com/, https://trustmedis.com/, http://theiconic.com.au/, https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html, https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fembedded-sdk?style=flat, https://img.shields.io/librariesio/release/npm/%40superset-ui%2Fplugin-chart-pivot-table?style=flat, https://vkusvill.ru/'
-          # verbosity: 'ERROR'
+          linksToSkip: >-
+            ^https://github.com/apache/(superset|incubator-superset)/(pull|issue)/\d+,
+            http://localhost:8088/,
+            docker/.env-non-dev,
+            http://127.0.0.1:3000/,
+            http://localhost:9001/,
+            https://charts.bitnami.com/bitnami,
+            https://www.li.me/,
+            https://www.fanatics.com/,
+            https://tails.com/gb/,
+            https://www.techaudit.info/,
+            https://avetilearning.com/,
+            https://www.udemy.com/,
+            https://trustmedis.com/,
+            http://theiconic.com.au/,
+            https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html,
+            ^https://img\.shields\.io/.*,
+            https://vkusvill.ru/
   build-deploy:
     name: Build & Deploy
     runs-on: ubuntu-22.04

--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -108,7 +108,7 @@ functioning across environments.
 #### OS Dependencies
 
 Make sure your machine meets the [OS dependencies](https://superset.apache.org/docs/installation/pypi#os-dependencies) before following these steps.
-You also need to install MySQL or [MariaDB](https://mariadb.com/downloads).
+You also need to install MySQL.
 
 Ensure that you are using Python version 3.9, 3.10 or 3.11, then proceed with:
 


### PR DESCRIPTION
MariaDB is not a supported backend for Superset, so it is misleading to suggest it for a development environment.  The commit that named MariaDB here is quite old -- I traced it back to [a docs overall from 3 years ago](https://github.com/apache/superset/pull/17411), it is likely older than that (the PR was upgrading the docs system) but I stopped there.

There are two other things that could be addressed here:
- Does, in fact, a DB need to be installed at this step?  I didn't see it referenced immediately.  If no, remove this whole sentence.  If yes, provide an example command.
- Would Postgres be an acceptable alternative?  If so, say that.

If someone knows the answer please feel free to suggest the complete fix.  But if no one knows, removing the MariaDB mention is an adequate improvement for now.