### PR TITLE
perf: Lazy load React Ace

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/ace-builds.d.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/ace-builds.d.ts
@@ -16,5 +16,5 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-declare module 'ace-builds/src-min-noconflict/worker-css';
-declare module 'ace-builds/src-min-noconflict/ace';
+
+declare module 'ace-builds/src-min-noconflict/mode-sql';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/SQLPopover.tsx
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useEffect, useState } from 'react';
 import { Popover } from 'antd';
+import type ReactAce from 'react-ace';
 import type { PopoverProps } from 'antd/lib/popover';
-import AceEditor from 'react-ace';
 import { CalculatorOutlined } from '@ant-design/icons';
 import { css, styled, useTheme, t } from '@superset-ui/core';
-import 'ace-builds/src-noconflict/mode-sql';
 
 const StyledCalculatorIcon = styled(CalculatorOutlined)`
   ${({ theme }) => css`
@@ -36,6 +36,19 @@ const StyledCalculatorIcon = styled(CalculatorOutlined)`
 
 export const SQLPopover = (props: PopoverProps & { sqlExpression: string }) => {
   const theme = useTheme();
+  const [AceEditor, setAceEditor] = useState<typeof ReactAce | null>(null);
+  useEffect(() => {
+    Promise.all([
+      import('react-ace'),
+      import('ace-builds/src-min-noconflict/mode-sql'),
+    ]).then(([reactAceModule]) => {
+      setAceEditor(() => reactAceModule.default);
+    });
+  }, []);
+
+  if (!AceEditor) {
+    return null;
+  }
   return (
     <Popover
       content={

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -18,26 +18,23 @@
  */
 import { forwardRef, useEffect, ComponentType } from 'react';
 
-import {
+import type {
   Editor as OrigEditor,
   IEditSession,
   Position,
   TextMode as OrigTextMode,
 } from 'brace';
-import AceEditor, { IAceEditorProps } from 'react-ace';
-import { config } from 'ace-builds';
-import { acequire } from 'ace-builds/src-noconflict/ace';
+import type AceEditor from 'react-ace';
+import type { IAceEditorProps } from 'react-ace';
+
 import AsyncEsmComponent, {
   PlaceholderProps,
 } from 'src/components/AsyncEsmComponent';
 import useEffectEvent from 'src/hooks/useEffectEvent';
-import cssWorkerUrl from 'ace-builds/src-noconflict/worker-css';
 import { useTheme, css } from '@superset-ui/core';
 import { Global } from '@emotion/react';
 
 export { getTooltipHTML } from './Tooltip';
-
-config.setModuleUrl('ace/mode/css_worker', cssWorkerUrl);
 
 export interface AceCompleterKeywordData {
   name: string;
@@ -116,7 +113,26 @@ export default function AsyncAceEditor(
   }: AsyncAceEditorOptions = {},
 ) {
   return AsyncEsmComponent(async () => {
-    const { default: ReactAceEditor } = await import('react-ace');
+    const reactAcePromise = import('react-ace');
+    const aceBuildsConfigPromise = import('ace-builds');
+    const cssWorkerUrlPromise = import(
+      'ace-builds/src-min-noconflict/worker-css'
+    );
+    const acequirePromise = import('ace-builds/src-min-noconflict/ace');
+
+    const [
+      { default: ReactAceEditor },
+      { config },
+      { default: cssWorkerUrl },
+      { acequire },
+    ] = await Promise.all([
+      reactAcePromise,
+      aceBuildsConfigPromise,
+      cssWorkerUrlPromise,
+      acequirePromise,
+    ]);
+
+    config.setModuleUrl('ace/mode/css_worker', cssWorkerUrl);
 
     await Promise.all(aceModules.map(x => aceModuleLoaders[x]()));
 


### PR DESCRIPTION
### SUMMARY
`ace-builds` was 1 of the largest libraries in our bundle. It was always fetched when opening a dashboard even though it's only used in dashboard's edit mode (if there are markdown components), SQL lab, and SQL Editor popover in Explore.
This PR implements lazy loading that library.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Notice that we no longer fetch a 1.3MB chunk when opening a dashboard

Before:

<img width="837" alt="Screenshot 2024-07-31 at 16 36 23" src="https://github.com/user-attachments/assets/5ffe5fdf-989d-4933-acde-5ceb8a96c5df">

After:

<img width="837" alt="Screenshot 2024-07-31 at 18 17 22" src="https://github.com/user-attachments/assets/8e939703-77cc-4265-9d38-10ef949bb27f">


### TESTING INSTRUCTIONS
1. Open a dashboard
2. Verify that the chunk containing ace-builds is not fetched initially
3. Open edit mode and try to edit a markdown component - verify that it works fine
4. Open SQL Lab - verify that SQL editor works fine
5. Open a chart and metrics edit popover - verify that SQL editor works fine

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
