### PR TITLE
fix: set default timezone to UTC for cron timezone conversions

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from celery import Celery
 from celery.exceptions import SoftTimeLimitExceeded
@@ -50,7 +50,7 @@ def scheduler() -> None:
         datetime.fromisoformat(scheduler.request.expires)
         - app.config["CELERY_BEAT_SCHEDULER_EXPIRES"]
         if scheduler.request.expires
-        else datetime.utcnow()
+        else datetime.now(tz=timezone.utc)
     )
     for active_schedule in active_schedules:
         for schedule in cron_schedule_window(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fix addresses the issue mentioned in #29797. The datetime object passed into the cron scheduling function may not have a timezone associated with it. Therefore, when trying to convert the datetime to the specified timezone, it just adds timezone to the datetime. This is an issue because the function attempts to convert the datetime back into UTC, which causes an incorrect timezone conversion in this case. The fix is to add UTC to the timezone info for the datetime object before converting it to the specified timezone.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Attempt to reproduce the bug as described in #29797. The alert should trigger correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: #29797
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
