### PR TITLE
fix: Downgrade of revision 678eefb4ab44 throws error

### DIFF
--- a/superset/migrations/shared/constraints.py
+++ b/superset/migrations/shared/constraints.py
@@ -71,3 +71,17 @@ def redefine(
             ondelete=on_delete,
             onupdate=on_update,
         )
+
+
+def drop_fks_for_table(table_name: str) -> None:
+    """
+    Drop all foreign key constraints for a table.
+
+    :param table_name: The table name to drop foreign key constraints for
+    """
+    connection = op.get_bind()
+    inspector = Inspector.from_engine(connection)
+    foreign_keys = inspector.get_foreign_keys(table_name)
+
+    for fk in foreign_keys:
+        op.drop_constraint(fk["name"], table_name, type_="foreignkey")

--- a/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
+++ b/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
@@ -30,6 +30,8 @@ import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 from sqlalchemy_utils import EncryptedType  # noqa: E402
 
+from superset.migrations.shared.constraints import drop_fks_for_table  # noqa: E402
+
 
 def upgrade():
     op.create_table(
@@ -80,16 +82,6 @@ def upgrade():
 
 
 def downgrade():
-    # get all foreign keys for table database_user_oauth2_tokens
-    connection = op.get_bind()
-    inspector = sa.engine.reflection.Inspector.from_engine(connection)
-    foreign_keys = inspector.get_foreign_keys("database_user_oauth2_tokens")
-
-    # drop all foreign keys
-    for fk in foreign_keys:
-        op.drop_constraint(
-            fk["name"], "database_user_oauth2_tokens", type_="foreignkey"
-        )
-
+    drop_fks_for_table("database_user_oauth2_tokens")
     op.drop_index("idx_user_id_database_id", table_name="database_user_oauth2_tokens")
     op.drop_table("database_user_oauth2_tokens")

--- a/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
+++ b/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
@@ -80,5 +80,16 @@ def upgrade():
 
 
 def downgrade():
+    # get all foreign keys for table database_user_oauth2_tokens
+    connection = op.get_bind()
+    inspector = sa.engine.reflection.Inspector.from_engine(connection)
+    foreign_keys = inspector.get_foreign_keys("database_user_oauth2_tokens")
+
+    # drop all foreign keys
+    for fk in foreign_keys:
+        op.drop_constraint(
+            fk["name"], "database_user_oauth2_tokens", type_="foreignkey"
+        )
+
     op.drop_index("idx_user_id_database_id", table_name="database_user_oauth2_tokens")
     op.drop_table("database_user_oauth2_tokens")


### PR DESCRIPTION
### SUMMARY
Fixes the following error when downgrading revision `678eefb4ab44`:

```
sqlalchemy.exc.OperationalError: (MySQLdb.OperationalError) 
(1553, "Cannot drop index 'idx_user_id_database_id': needed in a foreign key constraint")
```

Fixes https://github.com/apache/superset/issues/29789

### TESTING INSTRUCTIONS
Make sure you can downgrade the revision.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
