### PR TITLE
feat(lang): update Italian language

### DIFF
--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -8421,7 +8421,7 @@ msgid "Refresh"
 msgstr ""
 
 msgid "Refresh dashboard"
-msgstr "Rimuovi il grafico dalla dashboard"
+msgstr "Ricarica la dashboard"
 
 msgid "Refresh frequency"
 msgstr ""


### PR DESCRIPTION
Update Italian translation of the "refresh dashboard" field

### SUMMARY
Update Italian translation of the "refresh dashboard" field as the current translation is incorrect.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Current translation is not correct, as it translates to "Remove the chart from the dashboard".
![image](https://github.com/user-attachments/assets/ad494c17-8b0b-4bf2-a23a-d755a46673fc)

### TESTING INSTRUCTIONS
Switch to Italian language, go to a dashboard, open the menu at the top right and see that the translation in the image above has changed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [X] Required feature flags: LANGUAGES = {"it": {"flag": "it", "name": "Italian"}}
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
