### PR TITLE
fix(ci): remove unused "type: ignore" comment to unblock precommit check in CI

### DIFF
--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -211,7 +211,7 @@ def dumps(  # pylint: disable=too-many-arguments
             cls=cls,
         )
     except UnicodeDecodeError:
-        results_string = simplejson.dumps(  # type: ignore[call-overload]
+        results_string = simplejson.dumps(
             obj,
             default=default,
             allow_nan=allow_nan,


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(ci): remove unused "type: ignore" comment to unblock precommit check in CI

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix blocking CI in feature branches, for example:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/43b4aac5-66d5-4d4b-aa44-9cf606a54a05">

Link: https://github.com/apache/superset/actions/runs/10200377636/job/28219694742


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
At least `pre-commit checks` CI  step should pass green

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
