### PR TITLE
fix: handle empty catalog when DB supports them

### DIFF
--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -52,7 +52,7 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 def fetch_files_github_api(url: str):  # type: ignore
     """Fetches data using GitHub API."""
     req = Request(url)
-    req.add_header("Authorization", f"token {GITHUB_TOKEN}")
+    req.add_header("Authorization", f"Bearer {GITHUB_TOKEN}")
     req.add_header("Accept", "application/vnd.github.v3+json")
 
     print(f"Fetching from {url}")

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -33,4 +33,4 @@ superset load-test-users
 
 echo "Running tests"
 
-pytest --durations-min=2 --maxfail=1 --cov-report= --cov=superset ./tests/integration_tests "$@"
+pytest --durations-min=2 --cov-report= --cov=superset ./tests/integration_tests "$@"

--- a/scripts/python_tests.sh
+++ b/scripts/python_tests.sh
@@ -33,4 +33,4 @@ superset load-test-users
 
 echo "Running tests"
 
-pytest --durations-min=2 --cov-report= --cov=superset ./tests/integration_tests "$@"
+pytest --durations-min=2 --maxfail=1 --cov-report= --cov=superset ./tests/integration_tests "$@"

--- a/superset/cachekeys/schemas.py
+++ b/superset/cachekeys/schemas.py
@@ -32,6 +32,10 @@ class Datasource(Schema):
     datasource_name = fields.String(
         metadata={"description": datasource_name_description},
     )
+    catalog = fields.String(
+        allow_none=True,
+        metadata={"description": "Datasource catalog"},
+    )
     schema = fields.String(
         metadata={"description": "Datasource schema"},
     )

--- a/superset/commands/dataset/create.py
+++ b/superset/commands/dataset/create.py
@@ -61,15 +61,15 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
 
         table = Table(self._properties["table_name"], schema, catalog)
 
-        # Validate uniqueness
-        if not DatasetDAO.validate_uniqueness(database_id, table):
-            exceptions.append(DatasetExistsValidationError(table))
-
         # Validate/Populate database
         database = DatasetDAO.get_database_by_id(database_id)
         if not database:
             exceptions.append(DatabaseNotFoundValidationError())
         self._properties["database"] = database
+
+        # Validate uniqueness
+        if database and not DatasetDAO.validate_uniqueness(database, table):
+            exceptions.append(DatasetExistsValidationError(table))
 
         # Validate table exists on dataset if sql is not provided
         # This should be validated when the dataset is physical

--- a/superset/commands/dataset/create.py
+++ b/superset/commands/dataset/create.py
@@ -54,12 +54,11 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
     def validate(self) -> None:
         exceptions: list[ValidationError] = []
         database_id = self._properties["database"]
-        schema = self._properties.get("schema")
         catalog = self._properties.get("catalog")
+        schema = self._properties.get("schema")
+        table_name = self._properties["table_name"]
         sql = self._properties.get("sql")
         owner_ids: Optional[list[int]] = self._properties.get("owners")
-
-        table = Table(self._properties["table_name"], schema, catalog)
 
         # Validate/Populate database
         database = DatasetDAO.get_database_by_id(database_id)
@@ -68,8 +67,14 @@ class CreateDatasetCommand(CreateMixin, BaseCommand):
         self._properties["database"] = database
 
         # Validate uniqueness
-        if database and not DatasetDAO.validate_uniqueness(database, table):
-            exceptions.append(DatasetExistsValidationError(table))
+        if database:
+            if not catalog:
+                catalog = self._properties["catalog"] = database.get_default_catalog()
+
+            table = Table(table_name, schema, catalog)
+
+            if not DatasetDAO.validate_uniqueness(database, table):
+                exceptions.append(DatasetExistsValidationError(table))
 
         # Validate table exists on dataset if sql is not provided
         # This should be validated when the dataset is physical

--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -166,7 +166,7 @@ def import_dataset(
 
     try:
         table_exists = dataset.database.has_table(
-            Table(dataset.table_name, dataset.schema),
+            Table(dataset.table_name, dataset.schema, dataset.catalog),
         )
     except Exception:  # pylint: disable=broad-except
         # MySQL doesn't play nice with GSheets table names

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -93,10 +93,16 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
 
         database_id = self._properties.get("database")
 
+        catalog = self._properties.get("catalog")
+        if not catalog:
+            catalog = self._properties["catalog"] = (
+                self._model.database.get_default_catalog()
+            )
+
         table = Table(
             self._properties.get("table_name"),  # type: ignore
             self._properties.get("schema"),
-            self._properties.get("catalog"),
+            catalog,
         )
 
         # Validate uniqueness

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -461,9 +461,11 @@ class BaseDatasource(AuditMixinNullable, ImportExportMixin):  # pylint: disable=
                 )
             else:
                 _columns = [
-                    utils.get_column_name(column_)
-                    if utils.is_adhoc_column(column_)
-                    else column_
+                    (
+                        utils.get_column_name(column_)
+                        if utils.is_adhoc_column(column_)
+                        else column_
+                    )
                     for column_param in COLUMN_FORM_DATA_PARAMS
                     for column_ in utils.as_list(form_data.get(column_param) or [])
                 ]
@@ -1963,7 +1965,7 @@ class SqlaTable(
         if self.has_extra_cache_key_calls(query_obj):
             sqla_query = self.get_sqla_query(**query_obj)
             extra_cache_keys += sqla_query.extra_cache_keys
-        return extra_cache_keys
+        return list(set(extra_cache_keys))
 
     @property
     def quote_identifier(self) -> Callable[[str], str]:

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -84,15 +84,19 @@ class DatasetDAO(BaseDAO[SqlaTable]):
 
     @staticmethod
     def validate_uniqueness(
-        database_id: int,
+        database: Database,
         table: Table,
         dataset_id: int | None = None,
     ) -> bool:
+        # The catalog might not be set even if the database supports catalogs, in case
+        # multi-catalog is disabled.
+        catalog = table.catalog or database.get_default_catalog()
+
         dataset_query = db.session.query(SqlaTable).filter(
             SqlaTable.table_name == table.table,
             SqlaTable.schema == table.schema,
-            SqlaTable.catalog == table.catalog,
-            SqlaTable.database_id == database_id,
+            SqlaTable.catalog == catalog,
+            SqlaTable.database_id == database.id,
         )
 
         if dataset_id:
@@ -103,15 +107,19 @@ class DatasetDAO(BaseDAO[SqlaTable]):
 
     @staticmethod
     def validate_update_uniqueness(
-        database_id: int,
+        database: Database,
         table: Table,
         dataset_id: int,
     ) -> bool:
+        # The catalog might not be set even if the database supports catalogs, in case
+        # multi-catalog is disabled.
+        catalog = table.catalog or database.get_default_catalog()
+
         dataset_query = db.session.query(SqlaTable).filter(
             SqlaTable.table_name == table.table,
-            SqlaTable.database_id == database_id,
+            SqlaTable.database_id == database.id,
             SqlaTable.schema == table.schema,
-            SqlaTable.catalog == table.catalog,
+            SqlaTable.catalog == catalog,
             SqlaTable.id != dataset_id,
         )
         return not db.session.query(dataset_query.exists()).scalar()

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1159,7 +1159,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
         self.incr_stats("init", self.select_star.__name__)
         try:
             result = database.select_star(
-                Table(table_name, schema_name),
+                Table(table_name, schema_name, database.get_default_catalog()),
                 latest_partition=True,
             )
         except NoSuchTableError:

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -501,6 +501,7 @@ class BaseTemplateProcessor:
         kwargs.update(self._context)
 
         context = validate_template_context(self.engine, kwargs)
+        print("FOO", type(template.render(context)))
         return template.render(context)
 
 
@@ -565,7 +566,7 @@ class NoOpTemplateProcessor(BaseTemplateProcessor):
         """
         Makes processing a template a noop
         """
-        return sql
+        return str(sql)
 
 
 class PrestoTemplateProcessor(JinjaTemplateProcessor):

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -501,7 +501,6 @@ class BaseTemplateProcessor:
         kwargs.update(self._context)
 
         context = validate_template_context(self.engine, kwargs)
-        print("FOO", type(template.render(context)))
         return template.render(context)
 
 

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -116,9 +116,7 @@ class ConfigurationMethod(StrEnum):
     DYNAMIC_FORM = "dynamic_form"
 
 
-class Database(
-    Model, AuditMixinNullable, ImportExportMixin
-):  # pylint: disable=too-many-public-methods
+class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable=too-many-public-methods
     """An ORM object that stores Database related information"""
 
     __tablename__ = "dbs"
@@ -392,7 +390,9 @@ class Database(
         return (
             username
             if (username := get_username())
-            else object_url.username if self.impersonate_user else None
+            else object_url.username
+            if self.impersonate_user
+            else None
         )
 
     @contextmanager

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -116,7 +116,9 @@ class ConfigurationMethod(StrEnum):
     DYNAMIC_FORM = "dynamic_form"
 
 
-class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable=too-many-public-methods
+class Database(
+    Model, AuditMixinNullable, ImportExportMixin
+):  # pylint: disable=too-many-public-methods
     """An ORM object that stores Database related information"""
 
     __tablename__ = "dbs"
@@ -390,9 +392,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         return (
             username
             if (username := get_username())
-            else object_url.username
-            if self.impersonate_user
-            else None
+            else object_url.username if self.impersonate_user else None
         )
 
     @contextmanager
@@ -490,7 +490,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
                 g.user.id,
                 self.db_engine_spec,
             )
-            if hasattr(g, "user") and hasattr(g.user, "id") and oauth2_config
+            if oauth2_config and hasattr(g, "user") and hasattr(g.user, "id")
             else None
         )
         # If using MySQL or Presto for example, will set url.username

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -369,6 +369,7 @@ def set_related_perm(_mapper: Mapper, _connection: Connection, target: Slice) ->
         ds = db.session.query(src_class).filter_by(id=int(id_)).first()
         if ds:
             target.perm = ds.perm
+            target.catalog_perm = ds.catalog_perm
             target.schema_perm = ds.schema_perm
 
 

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -284,6 +284,7 @@ class SqlLabRestApi(BaseSupersetApi):
             "client_id": client_id,
             "row_count": row_count,
             "database": query.database.name,
+            "catalog": query.catalog,
             "schema": query.schema,
             "sql": query.sql,
             "exported_format": "csv",

--- a/superset/sqllab/sqllab_execution_context.py
+++ b/superset/sqllab/sqllab_execution_context.py
@@ -125,6 +125,8 @@ class SqlJsonExecutionContext:  # pylint: disable=too-many-instance-attributes
     def set_database(self, database: Database) -> None:
         self._validate_db(database)
         self.database = database
+        if self.catalog is None:
+            self.catalog = database.get_default_catalog()
         if self.select_as_cta:
             schema_name = self._get_ctas_target_schema_name(database)
             self.create_table_as_select.target_schema_name = schema_name  # type: ignore

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -239,6 +239,7 @@ class TableSchemaView(BaseSupersetView):
         db.session.query(TableSchema).filter(
             TableSchema.tab_state_id == table["queryEditorId"],
             TableSchema.database_id == table["dbId"],
+            TableSchema.catalog == table["catalog"],
             TableSchema.schema == table["schema"],
             TableSchema.table == table["name"],
         ).delete(synchronize_session=False)
@@ -246,6 +247,7 @@ class TableSchemaView(BaseSupersetView):
         table_schema = TableSchema(
             tab_state_id=table["queryEditorId"],
             database_id=table["dbId"],
+            catalog=table["catalog"],
             schema=table["schema"],
             table=table["name"],
             description=json.dumps(table),

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2041,9 +2041,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
 
         rv = self.get_assert_metric(uri, "export")
 
-        headers = (
-            "attachment; filename=dashboard_export_20220101T000000.zip"  # noqa: F541
-        )
+        headers = "attachment; filename=dashboard_export_20220101T000000.zip"  # noqa: F541
         assert rv.status_code == 200
         assert rv.headers["Content-Disposition"] == headers
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2041,7 +2041,9 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
 
         rv = self.get_assert_metric(uri, "export")
 
-        headers = "attachment; filename=dashboard_export_20220101T000000.zip"  # noqa: F541
+        headers = (
+            "attachment; filename=dashboard_export_20220101T000000.zip"  # noqa: F541
+        )
         assert rv.status_code == 200
         assert rv.headers["Content-Disposition"] == headers
 

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -1563,34 +1563,6 @@ class TestDatabaseApi(SupersetTestCase):
         rv = self.client.get(uri)
         self.assertEqual(rv.status_code, 404)
 
-    def test_get_select_star_datasource_access(self):
-        """
-        Database API: Test get select star with datasource access
-        """
-        table = SqlaTable(
-            schema="main", table_name="ab_permission", database=get_main_database()
-        )
-        db.session.add(table)
-        db.session.commit()
-
-        tmp_table_perm = security_manager.find_permission_view_menu(
-            "datasource_access", table.get_perm()
-        )
-        gamma_role = security_manager.find_role("Gamma")
-        security_manager.add_permission_role(gamma_role, tmp_table_perm)
-
-        self.login(GAMMA_USERNAME)
-        main_db = get_main_database()
-        uri = f"api/v1/database/{main_db.id}/select_star/ab_permission/"
-        rv = self.client.get(uri)
-        self.assertEqual(rv.status_code, 200)
-
-        # rollback changes
-        security_manager.del_permission_role(gamma_role, tmp_table_perm)
-        db.session.delete(table)
-        db.session.delete(main_db)
-        db.session.commit()
-
     def test_get_select_star_not_found_database(self):
         """
         Database API: Test get select star not found database

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -527,11 +527,8 @@ def test_get_catalog_names(app_context: AppContext) -> None:
     """
     database = get_example_database()
 
-    if database.backend != "postgresql":
-        return
-
     with database.get_inspector() as inspector:
         assert PostgresEngineSpec.get_catalog_names(database, inspector) == {
             "postgres",
-            "superset",
+            "test",
         }

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -25,6 +25,7 @@ from superset.db_engine_specs import load_engine_specs
 from superset.db_engine_specs.postgres import PostgresEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.models.sql_lab import Query
+from superset.utils.core import backend
 from superset.utils.database import get_example_database
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 from tests.integration_tests.fixtures.certificates import ssl_certificate
@@ -525,8 +526,10 @@ def test_get_catalog_names(app_context: AppContext) -> None:
     """
     Test the ``get_catalog_names`` method.
     """
-    database = get_example_database()
+    if backend() != "postgresql":
+        return
 
+    database = get_example_database()
     with database.get_inspector() as inspector:
         assert PostgresEngineSpec.get_catalog_names(database, inspector) == {
             "postgres",

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -533,5 +533,5 @@ def test_get_catalog_names(app_context: AppContext) -> None:
     with database.get_inspector() as inspector:
         assert PostgresEngineSpec.get_catalog_names(database, inspector) == {
             "postgres",
-            "test",
+            "superset",
         }

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -898,7 +898,9 @@ class TestRolePermission(SupersetTestCase):
             db.session.query(SqlaTable).filter_by(table_name="tmp_table1").one()
         )
         self.assertEqual(changed_table1.perm, f"[tmp_db2].[tmp_table1](id:{table1.id})")
-        self.assertEqual(changed_table1.schema_perm, "[tmp_db2].[tmp_schema]")  # noqa: F541
+        self.assertEqual(
+            changed_table1.schema_perm, "[tmp_db2].[tmp_schema]"
+        )  # noqa: F541
 
         # Test Chart permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()
@@ -956,12 +958,16 @@ class TestRolePermission(SupersetTestCase):
             db.session.query(SqlaTable).filter_by(table_name="tmp_table1").one()
         )
         self.assertEqual(changed_table1.perm, f"[tmp_db1].[tmp_table1](id:{table1.id})")
-        self.assertEqual(changed_table1.schema_perm, "[tmp_db1].[tmp_schema_changed]")  # noqa: F541
+        self.assertEqual(
+            changed_table1.schema_perm, "[tmp_db1].[tmp_schema_changed]"
+        )  # noqa: F541
 
         # Test Chart schema permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()
         self.assertEqual(slice1.perm, f"[tmp_db1].[tmp_table1](id:{table1.id})")
-        self.assertEqual(slice1.schema_perm, "[tmp_db1].[tmp_schema_changed]")  # noqa: F541
+        self.assertEqual(
+            slice1.schema_perm, "[tmp_db1].[tmp_schema_changed]"
+        )  # noqa: F541
 
         # cleanup
         db.session.delete(slice1)
@@ -1069,7 +1075,9 @@ class TestRolePermission(SupersetTestCase):
         self.assertEqual(
             changed_table1.perm, f"[tmp_db2].[tmp_table1_changed](id:{table1.id})"
         )
-        self.assertEqual(changed_table1.schema_perm, "[tmp_db2].[tmp_schema]")  # noqa: F541
+        self.assertEqual(
+            changed_table1.schema_perm, "[tmp_db2].[tmp_schema]"
+        )  # noqa: F541
 
         # Test Chart permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()
@@ -1633,7 +1641,10 @@ class TestSecurityManager(SupersetTestCase):
     @patch("superset.security.SupersetSecurityManager.can_access")
     def test_raise_for_access_query(self, mock_can_access, mock_is_owner):
         query = Mock(
-            database=get_example_database(), schema="bar", sql="SELECT * FROM foo"
+            database=get_example_database(),
+            schema="bar",
+            sql="SELECT * FROM foo",
+            catalog=None,
         )
 
         mock_can_access.return_value = True

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -898,9 +898,7 @@ class TestRolePermission(SupersetTestCase):
             db.session.query(SqlaTable).filter_by(table_name="tmp_table1").one()
         )
         self.assertEqual(changed_table1.perm, f"[tmp_db2].[tmp_table1](id:{table1.id})")
-        self.assertEqual(
-            changed_table1.schema_perm, "[tmp_db2].[tmp_schema]"
-        )  # noqa: F541
+        self.assertEqual(changed_table1.schema_perm, "[tmp_db2].[tmp_schema]")  # noqa: F541
 
         # Test Chart permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()
@@ -958,16 +956,12 @@ class TestRolePermission(SupersetTestCase):
             db.session.query(SqlaTable).filter_by(table_name="tmp_table1").one()
         )
         self.assertEqual(changed_table1.perm, f"[tmp_db1].[tmp_table1](id:{table1.id})")
-        self.assertEqual(
-            changed_table1.schema_perm, "[tmp_db1].[tmp_schema_changed]"
-        )  # noqa: F541
+        self.assertEqual(changed_table1.schema_perm, "[tmp_db1].[tmp_schema_changed]")  # noqa: F541
 
         # Test Chart schema permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()
         self.assertEqual(slice1.perm, f"[tmp_db1].[tmp_table1](id:{table1.id})")
-        self.assertEqual(
-            slice1.schema_perm, "[tmp_db1].[tmp_schema_changed]"
-        )  # noqa: F541
+        self.assertEqual(slice1.schema_perm, "[tmp_db1].[tmp_schema_changed]")  # noqa: F541
 
         # cleanup
         db.session.delete(slice1)
@@ -1075,9 +1069,7 @@ class TestRolePermission(SupersetTestCase):
         self.assertEqual(
             changed_table1.perm, f"[tmp_db2].[tmp_table1_changed](id:{table1.id})"
         )
-        self.assertEqual(
-            changed_table1.schema_perm, "[tmp_db2].[tmp_schema]"
-        )  # noqa: F541
+        self.assertEqual(changed_table1.schema_perm, "[tmp_db2].[tmp_schema]")  # noqa: F541
 
         # Test Chart permission changed
         slice1 = db.session.query(Slice).filter_by(slice_name="tmp_slice1").one()

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -34,7 +34,9 @@ from superset.connectors.sqla.models import SqlaTable, TableColumn, SqlMetric
 from superset.constants import EMPTY_STRING, NULL_STRING
 from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 from superset.db_engine_specs.druid import DruidEngineSpec
-from superset.exceptions import QueryObjectValidationError, SupersetSecurityException  # noqa: F401
+from superset.exceptions import (
+    QueryObjectValidationError,
+)  # noqa: F401
 from superset.models.core import Database
 from superset.utils.core import (
     AdhocMetricExpressionType,
@@ -160,7 +162,7 @@ class TestDatabaseModel(SupersetTestCase):
         query_obj = dict(**base_query_obj, extras={})
         extra_cache_keys = table1.get_extra_cache_keys(query_obj)
         self.assertTrue(table1.has_extra_cache_key_calls(query_obj))
-        assert extra_cache_keys == [1, "abc", "abc@test.com"]
+        assert set(extra_cache_keys) == {1, "abc", "abc@test.com"}
 
         # Table with Jinja callable disabled.
         table2 = SqlaTable(

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -255,11 +255,11 @@ def test_dataset_uniqueness(session: Session) -> None:
 
     # but the DAO enforces application logic for uniqueness
     assert not DatasetDAO.validate_uniqueness(
-        database.id,
+        database,
         Table("table", "schema", None),
     )
 
     assert DatasetDAO.validate_uniqueness(
-        database.id,
+        database,
         Table("table", "schema", "some_catalog"),
     )

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -53,7 +53,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
 
     assert (
         DatasetDAO.validate_update_uniqueness(
-            database_id=database.id,
+            database=database,
             table=Table(dataset1.table_name, dataset1.schema),
             dataset_id=dataset1.id,
         )
@@ -62,7 +62,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
 
     assert (
         DatasetDAO.validate_update_uniqueness(
-            database_id=database.id,
+            database=database,
             table=Table(dataset1.table_name, dataset2.schema),
             dataset_id=dataset1.id,
         )
@@ -71,7 +71,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
 
     assert (
         DatasetDAO.validate_update_uniqueness(
-            database_id=database.id,
+            database=database,
             table=Table(dataset1.table_name),
             dataset_id=dataset1.id,
         )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Handle edge cases when catalog is passed as `null` but the database supports catalog. This happens when "Allow changing catalogs" is disabled in the database. In these cases we need to use the default catalog, so that permissions checks work as expected.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Add a database with catalogs (eg, Postgres)
  - [X] Catalog permissions are created (eg, `[Postgres].[superset]`)
  - [X] Schema permissions are created (eg, `[Postgres].[superset].[public]`)

2. Create a user A with catalog-level permissions to the default catalog
  - [X] User can see schemas in SQL Lab
  - [X] User can choose schema in SQL Lab
  - [X] User can choose table in SQL Lab
  - [X] User can run queries
  - [X] User can create a new dataset
  - [X] User can see charts built from the dataset

3. Create a user B with schema-level permissions to the default catalog
  - [X] User can see only 1 schema in SQL Lab
  - [X] User can choose table in SQL Lab
  - [X] User can run queries
  - [X] User can create a new dataset
  - [X] User can see charts built from the dataset

4. Create a user C with catalog-level permissions to a non-default catalog
  - [X] User can't see schemas/tables in SQL Lab
  - [X] User can't run queries in SQL Lab

5. Create a user D with schema-level permissions to a non-default catalog
  - [X] User can't see schemas/tables in SQL Lab
  - [X] User can't run queries in SQL Lab

6. Enable multi-catalog
  - [X] Admin should see all catalogs
  - [X] A, B, C, D should only see the catalogs they have access to
  - [X] Repeat steps from (2)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
