### PR TITLE
refactor(controls): Migrate AdhocMetricOption.test to RTL

### DIFF
--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricOption.test.jsx
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import sinon from 'sinon';
-import { shallow } from 'enzyme';
-
+import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import { AGGREGATES } from 'src/explore/constants';
 import AdhocMetricOption from 'src/explore/components/controls/MetricControl/AdhocMetricOption';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
-import ControlPopover from '../ControlPopover/ControlPopover';
+import userEvent from '@testing-library/user-event';
 
 const columns = [
   { type: 'VARCHAR(255)', column_name: 'source' },
@@ -35,49 +33,73 @@ const sumValueAdhocMetric = new AdhocMetric({
   aggregate: AGGREGATES.SUM,
 });
 
+const datasource = {
+  type: 'table',
+  id: 1,
+  uid: '1__table',
+  columnFormats: {},
+  verboseMap: {},
+};
+
+const defaultProps = {
+  adhocMetric: sumValueAdhocMetric,
+  savedMetric: {},
+  savedMetricsOptions: [],
+  onMetricEdit: jest.fn(),
+  columns,
+  datasource,
+  onMoveLabel: jest.fn(),
+  onDropLabel: jest.fn(),
+  index: 0,
+};
+
 function setup(overrides) {
-  const onMetricEdit = sinon.spy();
   const props = {
-    adhocMetric: sumValueAdhocMetric,
-    savedMetric: {},
-    savedMetrics: [],
-    onMetricEdit,
-    columns,
-    onMoveLabel: () => {},
-    onDropLabel: () => {},
-    index: 0,
+    ...defaultProps,
     ...overrides,
   };
-  const wrapper = shallow(<AdhocMetricOption {...props} />)
-    .find('AdhocMetricPopoverTrigger')
-    .shallow();
-  return { wrapper, onMetricEdit };
+  return render(<AdhocMetricOption {...props} />, { useDnd: true });
 }
 
-describe('AdhocMetricOption', () => {
-  it('renders an overlay trigger wrapper for the label', () => {
-    const { wrapper } = setup();
-    expect(wrapper.find(ControlPopover)).toExist();
-    expect(wrapper.find('OptionControlLabel')).toExist();
+test('renders an overlay trigger wrapper for the label', () => {
+  setup();
+  expect(screen.getByText('SUM(value)')).toBeInTheDocument();
+});
+
+test('overwrites the adhocMetric in state with onLabelChange', async () => {
+  setup();
+  userEvent.click(screen.getByText('SUM(value)'));
+  userEvent.click(screen.getByTestId(/AdhocMetricEditTitle#trigger/i));
+  const labelInput = await screen.findByTestId(/AdhocMetricEditTitle#input/i);
+  userEvent.clear(labelInput);
+  userEvent.type(labelInput, 'new label');
+  expect(labelInput).toHaveValue('new label');
+  fireEvent.keyPress(labelInput, {
+    key: 'Enter',
+    charCode: 13,
   });
+  expect(screen.getByText(/new label/i)).toBeInTheDocument();
+});
 
-  it('overwrites the adhocMetric in state with onLabelChange', () => {
-    const { wrapper } = setup();
-    wrapper.instance().onLabelChange({ target: { value: 'new label' } });
-    expect(wrapper.state('title').label).toBe('new label');
-    expect(wrapper.state('title').hasCustomLabel).toBe(true);
+test('returns to default labels when the custom label is cleared', async () => {
+  setup();
+  userEvent.click(screen.getByText('SUM(value)'));
+  userEvent.click(screen.getByTestId(/AdhocMetricEditTitle#trigger/i));
+  const labelInput = await screen.findByTestId(/AdhocMetricEditTitle#input/i);
+  userEvent.clear(labelInput);
+  userEvent.type(labelInput, 'new label');
+  fireEvent.keyPress(labelInput, {
+    key: 'Enter',
+    charCode: 13,
   });
-
-  it('returns to default labels when the custom label is cleared', () => {
-    const { wrapper } = setup();
-    expect(wrapper.state('title').label).toBe('SUM(value)');
-
-    wrapper.instance().onLabelChange({ target: { value: 'new label' } });
-    expect(wrapper.state('title').label).toBe('new label');
-
-    wrapper.instance().onLabelChange({ target: { value: '' } });
-
-    expect(wrapper.state('title').label).toBe('SUM(value)');
-    expect(wrapper.state('title').hasCustomLabel).toBe(false);
+  expect(labelInput).not.toBeInTheDocument();
+  expect(screen.getByText(/new label/i)).toBeInTheDocument();
+  userEvent.click(screen.getByTestId(/AdhocMetricEditTitle#trigger/i));
+  expect(screen.getByPlaceholderText(/new label/i)).toBeInTheDocument();
+  userEvent.clear(labelInput);
+  fireEvent.keyPress(labelInput, {
+    key: 'Enter',
+    charCode: 13,
   });
+  expect(screen.getByPlaceholderText('SUM(value)')).toBeInTheDocument();
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Converts the current tests to use RTL

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
