### PR TITLE
perf: Lazy load rehype-raw and react-markdown

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/SafeMarkdown.tsx
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
+import { useEffect, useMemo, useState } from 'react';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
-import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import { mergeWith, isArray } from 'lodash';
 import { FeatureFlag, isFeatureEnabled } from '../utils';
@@ -45,11 +43,21 @@ function SafeMarkdown({
   htmlSchemaOverrides = {},
 }: SafeMarkdownProps) {
   const escapeHtml = isFeatureEnabled(FeatureFlag.EscapeMarkdownHtml);
+  const [rehypeRawPlugin, setRehypeRawPlugin] = useState<any>(null);
+  const [ReactMarkdown, setReactMarkdown] = useState<any>(null);
+  useEffect(() => {
+    Promise.all([import('rehype-raw'), import('react-markdown')]).then(
+      ([rehypeRaw, ReactMarkdown]) => {
+        setRehypeRawPlugin(() => rehypeRaw.default);
+        setReactMarkdown(() => ReactMarkdown.default);
+      },
+    );
+  }, []);
 
   const rehypePlugins = useMemo(() => {
     const rehypePlugins: any = [];
-    if (!escapeHtml) {
-      rehypePlugins.push(rehypeRaw);
+    if (!escapeHtml && rehypeRawPlugin) {
+      rehypePlugins.push(rehypeRawPlugin);
       if (htmlSanitization) {
         const schema = getOverrideHtmlSchema(
           defaultSchema,
@@ -59,7 +67,11 @@ function SafeMarkdown({
       }
     }
     return rehypePlugins;
-  }, [escapeHtml, htmlSanitization, htmlSchemaOverrides]);
+  }, [escapeHtml, htmlSanitization, htmlSchemaOverrides, rehypeRawPlugin]);
+
+  if (!ReactMarkdown || !rehypeRawPlugin) {
+    return null;
+  }
 
   // React Markdown escapes HTML by default
   return (


### PR DESCRIPTION
### SUMMARY
Lazy load rehype-raw and react-markdown libraries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Notice that rehype-raw is now in a separate chunk instead of an entry, meaning that it will only load when there's a markdown component on a dashboard.

Before:

<img width="851" alt="Screenshot 2024-08-05 at 15 50 10" src="https://github.com/user-attachments/assets/b5d7d3e1-6289-48ce-b13d-6f64fe7da1d0">

After:

<img width="1392" alt="Screenshot 2024-08-05 at 15 33 45" src="https://github.com/user-attachments/assets/43eed7f6-bf0e-47b5-9c98-69d89ce4515f">


### TESTING INSTRUCTIONS
Dashboard should work fine with and without markdown components

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
