### PR TITLE
chore(deps): bumping underscore via npm override

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -50447,10 +50447,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
-      "dev": true
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -56005,10 +56004,6 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
       }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/underscore": {
-      "version": "1.13.7",
-      "license": "MIT"
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/xss": {
       "version": "1.0.15",
@@ -66008,9 +66003,6 @@
           "requires": {
             "bootstrap-slider": "^11.0.2"
           }
-        },
-        "underscore": {
-          "version": "1.13.7"
         },
         "xss": {
           "version": "1.0.15",
@@ -83880,7 +83872,7 @@
       "dev": true,
       "requires": {
         "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
+        "underscore": "^1.13.7"
       },
       "dependencies": {
         "ansi-styles": {
@@ -90485,10 +90477,9 @@
       }
     },
     "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
-      "dev": true
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "undici-types": {
       "version": "5.26.5"

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -364,7 +364,8 @@
       "ansi-regex": "^4.1.1"
     },
     "puppeteer": "^22.4.1",
-    "@types/react": "^16.9.53"
+    "@types/react": "^16.9.53",
+    "underscore": "^1.13.7"
   },
   "readme": "ERROR: No README data found!",
   "scarfSettings": {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This just adds an npm override for underscore, making sure we resolve to a version without critical CVEs. This takes us from 4 critical CVEs in superset to 1.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
