### PR TITLE
fix: upgrade_catalog_perms and downgrade_catalog_perms implementation

### DIFF
--- a/superset/migrations/shared/catalogs.py
+++ b/superset/migrations/shared/catalogs.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Type
+from typing import Any, Type, Union
 
 import sqlalchemy as sa
 from alembic import op
@@ -95,7 +95,7 @@ class Slice(Base):
     schema_perm = sa.Column(sa.String(1000))
 
 
-ModelType = Type[Query] | Type[SavedQuery] | Type[TabState] | Type[TableSchema]
+ModelType = Union[Type[Query], Type[SavedQuery], Type[TabState], Type[TableSchema]]
 
 BATCH_SIZE = 10000
 


### PR DESCRIPTION
### SUMMARY
This PR fixes the implementation of `upgrade_catalog_perms` and `downgrade_catalog_perms` methods to handle tables with millions of rows. To achieve this, I changed the algorithm to execute the migrations using a batched approach invoking the update/delete commands directly using a subquery instead of changing the records one by one. It also commits the transaction on every batch to avoid keeping a long standing transaction which leads to memory and timeout issues. Finally, I added detailed logging to help system administrators to track the migration progress and prepare for downtime.

Fixes https://github.com/apache/superset/issues/29801

### TESTING INSTRUCTIONS
1 - Run any migration that uses the changed commands
2 - Check that both upgrades and downgrades work

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
