### PR TITLE
fix: mypy fails related to simplejson.dumps

### DIFF
--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -18,7 +18,7 @@ import decimal
 import logging
 import uuid
 from datetime import date, datetime, time, timedelta
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -183,6 +183,7 @@ def dumps(  # pylint: disable=too-many-arguments
     indent: Union[str, int, None] = None,
     separators: Union[tuple[str, str], None] = None,
     cls: Union[type[simplejson.JSONEncoder], None] = None,
+    encoding: Optional[str] = "utf-8",
 ) -> str:
     """
     Dumps object to compatible JSON format
@@ -199,29 +200,21 @@ def dumps(  # pylint: disable=too-many-arguments
     """
 
     results_string = ""
+    dumps_kwargs: Dict[str, Any] = {
+        "default": default,
+        "allow_nan": allow_nan,
+        "ignore_nan": ignore_nan,
+        "sort_keys": sort_keys,
+        "indent": indent,
+        "separators": separators,
+        "cls": cls,
+        "encoding": encoding,
+    }
     try:
-        results_string = simplejson.dumps(
-            obj,
-            default=default,
-            allow_nan=allow_nan,
-            ignore_nan=ignore_nan,
-            sort_keys=sort_keys,
-            indent=indent,
-            separators=separators,
-            cls=cls,
-        )
+        results_string = simplejson.dumps(obj, **dumps_kwargs)
     except UnicodeDecodeError:
-        results_string = simplejson.dumps(
-            obj,
-            default=default,
-            allow_nan=allow_nan,
-            ignore_nan=ignore_nan,
-            sort_keys=sort_keys,
-            indent=indent,
-            separators=separators,
-            cls=cls,
-            encoding=None,
-        )
+        dumps_kwargs["encoding"] = None
+        results_string = simplejson.dumps(obj, **dumps_kwargs)
     return results_string
 
 


### PR DESCRIPTION
I'm not sure why this mypy pre-commit issue started triggering, but decided to take on fixing the issue and making the code more readable and DRY

For the record, and searchability, the original error was
```bash
superset/utils/json.py:215: error: No overload variant of "dumps" matches argument types "Any", "Optional[Callable[[Any], Any]]", "bool", "bool", "bool", "Union[str, int, None]", "Optional[Tuple[str, str]]", "Optional[Type[JSONEncoder]]", "None"  [call-overload]
superset/utils/json.py:215: note: Possible overload variants:
superset/utils/json.py:215: note:     def dumps(obj: Any, skipkeys: bool = ..., ensure_ascii: bool = ..., check_circular: bool = ..., allow_nan: bool = ..., *, cls: Type[JSONEncoder], indent: Union[str, int, None] = ..., separators: Optional[Tuple[str, str]] = ..., encoding: str = ..., default: Optional[Callable[[Any], Any]] = ..., use_decimal: bool = ..., namedtuple_as_object: bool = ..., tuple_as_array: bool = ..., bigint_as_string: bool = ..., sort_keys: bool = ..., item_sort_key: Optional[Callable[[Any], Union[SupportsDunderLT[Any], SupportsDunderGT[Any]]]] = ..., for_json: bool = ..., ignore_nan: bool = ..., int_as_string_bitcount: Optional[int] = ..., iterable_as_array: bool = ..., **kw: Any) -> str
superset/utils/json.py:215: note:     def dumps(obj: Any, skipkeys: bool = ..., ensure_ascii: bool = ..., check_circular: bool = ..., allow_nan: bool = ..., cls: Optional[Type[JSONEncoder]] = ..., indent: Union[str, int, None] = ..., separators: Optional[Tuple[str, str]] = ..., encoding: str = ..., default: Optional[Callable[[Any], Any]] = ..., use_decimal: bool = ..., namedtuple_as_object: bool = ..., tuple_as_array: bool = ..., bigint_as_string: bool = ..., sort_keys: bool = ..., item_sort_key: Optional[Callable[[Any], Union[SupportsDunderLT[Any], SupportsDunderGT[Any]]]] = ..., for_json: bool = ..., ignore_nan: bool = ..., int_as_string_bitcount: Optional[int] = ..., iterable_as_array: bool = ...) -> str
Found 1 error in 1 file (checked 1 source file)
```
