### PR TITLE
fix: update celery config imports

### DIFF
--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -74,7 +74,12 @@ DATA_CACHE_CONFIG = CACHE_CONFIG
 
 class CeleryConfig:
     broker_url = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
-    imports = ("superset.sql_lab",)
+    imports = (
+        "superset.sql_lab",
+        "superset.tasks.scheduler",
+        "superset.tasks.thumbnails",
+        "superset.tasks.cache",
+    )
     result_backend = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_RESULTS_DB}"
     worker_prefetch_multiplier = 1
     task_acks_late = False

--- a/superset/config.py
+++ b/superset/config.py
@@ -975,7 +975,12 @@ CELERY_BEAT_SCHEDULER_EXPIRES = timedelta(weeks=1)
 
 class CeleryConfig:  # pylint: disable=too-few-public-methods
     broker_url = "sqla+sqlite:///celerydb.sqlite"
-    imports = ("superset.sql_lab", "superset.tasks.scheduler")
+    imports = (
+        "superset.sql_lab",
+        "superset.tasks.scheduler",
+        "superset.tasks.thumbnails",
+        "superset.tasks.cache",
+    )
     result_backend = "db+sqlite:///celery_results.sqlite"
     worker_prefetch_multiplier = 1
     task_acks_late = False


### PR DESCRIPTION
closes https://github.com/apache/superset/issues/29708

related error in docker-compose:
```
superset_worker       | The full contents of the message headers:
superset_worker       | {'lang': 'py', 'task': 'reports.scheduler', 'id': 'b150a39b-57bb-4a58-9556-cc7d1a47132a', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'tim
elimit': [None, None], 'root_id': 'b150a39b-57bb-4a58-9556-cc7d1a47132a', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': '{}', 'origin': 'gen8@daf2692c865a', 'ignore_result': False, 'replaced_task_nesting': 0,
'stamped_headers': None, 'stamps': {}}
superset_worker       |
superset_worker       | The delivery info for this task is:
superset_worker       | {'exchange': '', 'routing_key': 'celery'}
superset_worker       | Traceback (most recent call last):
superset_worker       |   File "/usr/local/lib/python3.10/site-packages/celery/worker/consumer/consumer.py", line 659, in on_task_received
superset_worker       |     strategy = strategies[type_]
superset_worker       | KeyError: 'reports.scheduler'
```

I confirmed that this issue is gone after applying this fix and re-running `docker-compose up`
