### PR TITLE
chore: pre-matrixify pre-commit check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -70,7 +70,6 @@ github:
           - cypress-matrix (4, chrome)
           - cypress-matrix (5, chrome)
           - frontend-build
-          - pre-commit
           - python-lint
           - test-mysql
           - test-postgres (current)


### PR DESCRIPTION
in order to get https://github.com/apache/superset/pull/29864 through, I first need to remove the `pre-commit` check, so that PR can be merged, and add new required checks for past, future and current

