### PR TITLE
fix(PivotTable): Pass string only to safeHtmlSpan

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -44,9 +44,10 @@ function displayHeaderCell(
 ) {
   const name = namesMapping[value] || value;
   const parsedLabel = parseLabel(name);
-  const labelContent = allowRenderHtml
-    ? safeHtmlSpan(parsedLabel)
-    : parsedLabel;
+  const labelContent =
+    allowRenderHtml && typeof parsedLabel === 'string'
+      ? safeHtmlSpan(parsedLabel)
+      : parsedLabel;
   return needToggle ? (
     <span className="toggle-wrapper">
       <span


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR https://github.com/apache/superset/pull/29724 introduced an issue likely caused by the label being a number.

### BEFORE

![image](https://github.com/user-attachments/assets/b7369bb2-4749-4c08-a403-976abe17cce5)

### TESTING INSTRUCTIONS
1. Pivot Table should render

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
