### PR TITLE
chore: Changes the migrations owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # https://github.com/apache/superset/issues/13351
 
-/superset/migrations/ @apache/superset-committers
+/superset/migrations/ @mistercrunch @michael-s-molina
 
 # Notify some committers of changes in the components
 


### PR DESCRIPTION
### SUMMARY
Changes the migrations owners to @mistercrunch and @michael-s-molina as discussed during the previous Town Hall.

### TESTING INSTRUCTIONS
CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
