### PR TITLE
fix: Error when downgrading add_catalog_perm_to_tables migration

### DIFF
--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -29,27 +29,17 @@ from alembic import op
 revision = "5f57af97bc3f"
 down_revision = "d60591c5515f"
 
+tables = ["tables", "query", "saved_query", "tab_state", "table_schema"]
+
 
 def upgrade():
-    op.add_column("tables", sa.Column("catalog", sa.String(length=256), nullable=True))
-    op.add_column("query", sa.Column("catalog", sa.String(length=256), nullable=True))
-    op.add_column(
-        "saved_query",
-        sa.Column("catalog", sa.String(length=256), nullable=True),
-    )
-    op.add_column(
-        "tab_state",
-        sa.Column("catalog", sa.String(length=256), nullable=True),
-    )
-    op.add_column(
-        "table_schema",
-        sa.Column("catalog", sa.String(length=256), nullable=True),
-    )
+    for table in tables:
+        op.add_column(
+            table,
+            sa.Column("catalog", sa.String(length=256), nullable=True),
+        )
 
 
 def downgrade():
-    op.drop_column("table_schema", "catalog")
-    op.drop_column("tab_state", "catalog")
-    op.drop_column("saved_query", "catalog")
-    op.drop_column("query", "catalog")
-    op.drop_column("tables", "catalog")
+    for table in reversed(tables):
+        op.drop_column(table, "catalog")

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -48,6 +48,6 @@ def upgrade():
 
 
 def downgrade():
+    downgrade_catalog_perms(engines={"postgresql"})
     op.drop_column("slices", "catalog_perm")
     op.drop_column("tables", "catalog_perm")
-    downgrade_catalog_perms(engines={"postgresql"})


### PR DESCRIPTION
### SUMMARY
Fixes a error when downgrading revision `58d051681a3b`.  The previous code was invoking `downgrade_catalog_perms` after dropping the `catalog_perm` column which is used by that function, generating an error:

```
op.drop_column("slices", "catalog_perm")
op.drop_column("tables", "catalog_perm")
downgrade_catalog_perms(engines={"postgresql"})
```

This PR also rewrites revision `5f57af97bc3f` to remove duplicated code.

### TESTING INSTRUCTIONS
Check both upgrade and downgrade operations for each migration.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
