### PR TITLE
fix: Rename database from 'couchbasedb' to 'couchbase' in documentation and db_engine_specs

### DIFF
--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -80,7 +80,6 @@ Join our growing community!
 - [Caizin](https://caizin.com/) [@tejaskatariya]
 - [Careem](https://www.careem.com/) [@SamraHanifCareem]
 - [Cloudsmith](https://cloudsmith.io) [@alancarson]
-- [CnOvit](http://www.cnovit.com/) [@xieshaohu]
 - [Cyberhaven](https://www.cyberhaven.com/) [@toliver-ch]
 - [Deepomatic](https://deepomatic.com/) [@Zanoellia]
 - [Dial Once](https://www.dial-once.com/)

--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -80,6 +80,7 @@ Join our growing community!
 - [Caizin](https://caizin.com/) [@tejaskatariya]
 - [Careem](https://www.careem.com/) [@SamraHanifCareem]
 - [Cloudsmith](https://cloudsmith.io) [@alancarson]
+- [CnOvit](https://www.cnovit.com/) [@xieshaohu]
 - [Cyberhaven](https://www.cyberhaven.com/) [@toliver-ch]
 - [Deepomatic](https://deepomatic.com/) [@Zanoellia]
 - [Dial Once](https://www.dial-once.com/)

--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -378,7 +378,7 @@ cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable
 #### Couchbase
 
 The Couchbase's Superset connection is designed to support two services: Couchbase Analytics and Couchbase Columnar.
-The recommended connector library for is
+The recommended connector library for couchbase is
 [couchbase-sqlalchemy](https://github.com/couchbase/couchbase-sqlalchemy).
 ```
 pip install couchbase-sqlalchemy

--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -54,7 +54,7 @@ are compatible with Superset.
 | [Azure MS SQL](/docs/configuration/databases#sql-server)                | `pip install pymssql`                                                              | `mssql+pymssql://UserName@presetSQL:TestPassword@presetSQL.database.windows.net:1433/TestSchema`                                                       |
 | [ClickHouse](/docs/configuration/databases#clickhouse)                  | `pip install clickhouse-connect`                                                   | `clickhousedb://{username}:{password}@{hostname}:{port}/{database}`                                                                                    |
 | [CockroachDB](/docs/configuration/databases#cockroachdb)                | `pip install cockroachdb`                                                          | `cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable`                                                                                      |
-| [CouchbaseDB](/docs/configuration/databases#couchbaseDB)                | `pip install couchbase-sqlalchemy`                                                          | `couchbasedb://{username}:{password}@{hostname}:{port}?truststorepath={ssl certificate path}`                                                                                      |
+| [Couchbase](/docs/configuration/databases#couchbase)                | `pip install couchbase-sqlalchemy`                                                          | `couchbase://{username}:{password}@{hostname}:{port}?truststorepath={ssl certificate path}`                                                                                      |
 | [Dremio](/docs/configuration/databases#dremio)                          | `pip install sqlalchemy_dremio`                                                    | `dremio://user:pwd@host:31010/`                                                                                                                        |
 | [Elasticsearch](/docs/configuration/databases#elasticsearch)            | `pip install elasticsearch-dbapi`                                                  | `elasticsearch+http://{user}:{password}@{host}:9200/`                                                                                                  |
 | [Exasol](/docs/configuration/databases#exasol)                          | `pip install sqlalchemy-exasol`                                                    | `exa+pyodbc://{username}:{password}@{hostname}:{port}/my_schema?CONNECTIONLCALL=en_US.UTF-8&driver=EXAODBC`                                            |
@@ -375,9 +375,10 @@ cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable
 
 
 
-#### CouchbaseDB
+#### Couchbase
 
-The recommended connector library for CouchbaseDB is
+The Couchbase's Superset connection is designed to support two services: Couchbase Analytics and Couchbase Columnar.
+The recommended connector library for is
 [couchbase-sqlalchemy](https://github.com/couchbase/couchbase-sqlalchemy).
 ```
 pip install couchbase-sqlalchemy
@@ -386,7 +387,7 @@ pip install couchbase-sqlalchemy
 The expected connection string is formatted as follows:
 
 ```
-couchbasedb://{username}:{password}@{hostname}:{port}?truststorepath={certificate path}?ssl={true/false}
+couchbase://{username}:{password}@{hostname}:{port}?truststorepath={certificate path}?ssl={true/false}
 ```
 
 

--- a/superset/db_engine_specs/couchbase.py
+++ b/superset/db_engine_specs/couchbase.py
@@ -74,14 +74,14 @@ class CouchbaseParametersSchema(Schema):
     )
 
 
-class CouchbaseDbEngineSpec(BasicParametersMixin, BaseEngineSpec):
-    engine = "couchbasedb"
+class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
+    engine = "couchbase"
     engine_name = "Couchbase"
-    default_driver = "couchbasedb"
+    default_driver = "couchbase"
     allows_joins = False
     allows_subqueries = False
     sqlalchemy_uri_placeholder = (
-        "couchbasedb://user:password@host[:port]?truststorepath=value?ssl=value"
+        "couchbase://user:password@host[:port]?truststorepath=value?ssl=value"
     )
     parameters_schema = CouchbaseParametersSchema()
 
@@ -128,7 +128,7 @@ class CouchbaseDbEngineSpec(BasicParametersMixin, BaseEngineSpec):
 
         if parameters.get("port") is None:
             uri = URL.create(
-                "couchbasedb",
+                "couchbase",
                 username=parameters.get("username"),
                 password=parameters.get("password"),
                 host=parameters["host"],
@@ -137,7 +137,7 @@ class CouchbaseDbEngineSpec(BasicParametersMixin, BaseEngineSpec):
             )
         else:
             uri = URL.create(
-                "couchbasedb",
+                "couchbase",
                 username=parameters.get("username"),
                 password=parameters.get("password"),
                 host=parameters["host"],

--- a/superset/db_engine_specs/couchbase.py
+++ b/superset/db_engine_specs/couchbase.py
@@ -76,6 +76,7 @@ class CouchbaseParametersSchema(Schema):
 
 class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
     engine = "couchbase"
+    engine_aliases = {"couchbasedb"}
     engine_name = "Couchbase"
     default_driver = "couchbase"
     allows_joins = False

--- a/superset/db_engine_specs/couchbase.py
+++ b/superset/db_engine_specs/couchbase.py
@@ -76,7 +76,7 @@ class CouchbaseParametersSchema(Schema):
 
 class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
     engine = "couchbase"
-    engine_aliases = {"couchbase", "couchbasedb"}
+    engine_aliases = {"couchbasedb"}
     engine_name = "Couchbase"
     default_driver = "couchbase"
     allows_joins = False

--- a/superset/db_engine_specs/couchbase.py
+++ b/superset/db_engine_specs/couchbase.py
@@ -76,7 +76,7 @@ class CouchbaseParametersSchema(Schema):
 
 class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
     engine = "couchbase"
-    engine_aliases = {"couchbasedb"}
+    engine_aliases = {"couchbase", "couchbasedb"}
     engine_name = "Couchbase"
     default_driver = "couchbase"
     allows_joins = False

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -102,7 +102,7 @@ SQLGLOT_DIALECTS = {
     "clickhouse": Dialects.CLICKHOUSE,
     "clickhousedb": Dialects.CLICKHOUSE,
     "cockroachdb": Dialects.POSTGRES,
-    "couchbasedb": Dialects.MYSQL,
+    "couchbase": Dialects.MYSQL,
     # "crate": ???
     # "databend": ???
     "databricks": Dialects.DATABRICKS,

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -102,7 +102,8 @@ SQLGLOT_DIALECTS = {
     "clickhouse": Dialects.CLICKHOUSE,
     "clickhousedb": Dialects.CLICKHOUSE,
     "cockroachdb": Dialects.POSTGRES,
-    "couchbase": Dialects.MYSQL,
+    "couchbasedb": Dialects.MYSQL,
+    "couchbase": Dialects.MYSQL,  
     # "crate": ???
     # "databend": ???
     "databricks": Dialects.DATABRICKS,

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -103,7 +103,7 @@ SQLGLOT_DIALECTS = {
     "clickhousedb": Dialects.CLICKHOUSE,
     "cockroachdb": Dialects.POSTGRES,
     "couchbasedb": Dialects.MYSQL,
-    "couchbase": Dialects.MYSQL,  
+    "couchbase": Dialects.MYSQL,
     # "crate": ???
     # "databend": ???
     "databricks": Dialects.DATABRICKS,

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -102,7 +102,6 @@ SQLGLOT_DIALECTS = {
     "clickhouse": Dialects.CLICKHOUSE,
     "clickhousedb": Dialects.CLICKHOUSE,
     "cockroachdb": Dialects.POSTGRES,
-    "couchbasedb": Dialects.MYSQL,
     "couchbase": Dialects.MYSQL,
     # "crate": ???
     # "databend": ???

--- a/tests/unit_tests/db_engine_specs/test_couchbase.py
+++ b/tests/unit_tests/db_engine_specs/test_couchbase.py
@@ -33,18 +33,18 @@ def test_epoch_to_dttm() -> None:
     """
     DB Eng Specs (couchbase): Test epoch to dttm
     """
-    from superset.db_engine_specs.couchbasedb import CouchbaseDbEngineSpec
+    from superset.db_engine_specs.couchbase import CouchbaseEngineSpec
 
-    assert CouchbaseDbEngineSpec.epoch_to_dttm() == "MILLIS_TO_STR({col} * 1000)"
+    assert CouchbaseEngineSpec.epoch_to_dttm() == "MILLIS_TO_STR({col} * 1000)"
 
 
 def test_epoch_ms_to_dttm() -> None:
     """
     DB Eng Specs (couchbase): Test epoch ms to dttm
     """
-    from superset.db_engine_specs.couchbasedb import CouchbaseDbEngineSpec
+    from superset.db_engine_specs.couchbase import CouchbaseEngineSpec
 
-    assert CouchbaseDbEngineSpec.epoch_ms_to_dttm() == "MILLIS_TO_STR({col})"
+    assert CouchbaseEngineSpec.epoch_ms_to_dttm() == "MILLIS_TO_STR({col})"
 
 
 @pytest.mark.parametrize(
@@ -62,7 +62,7 @@ def test_convert_dttm(
     expected_result: Optional[str],
     dttm: datetime,  # noqa: F811
 ) -> None:
-    from superset.db_engine_specs.couchbasedb import CouchbaseDbEngineSpec as spec
+    from superset.db_engine_specs.couchbase import CouchbaseEngineSpec as spec
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
 
@@ -88,6 +88,6 @@ def test_get_column_spec(
     generic_type: GenericDataType,
     is_dttm: bool,
 ) -> None:
-    from superset.db_engine_specs.couchbasedb import CouchbaseDbEngineSpec as spec
+    from superset.db_engine_specs.couchbase import CouchbaseEngineSpec as spec
 
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)


### PR DESCRIPTION


### SUMMARY
Changing Name from couchbasedb to couchbase. Makes it more clear and logical about underlying database.
No major change done.
### TESTING INSTRUCTIONS
mannual testing

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
