### PR TITLE
fix: duplicate `truncateXAxis` option in `BarChart`

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -213,8 +213,6 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         },
       },
     ],
-    [truncateXAxis],
-    [xAxisBounds],
     [
       {
         name: 'truncateYAxis',
@@ -314,6 +312,8 @@ const config: ControlPanelConfig = {
         ...legendSection,
         [<ControlSubSectionHeader>{t('X Axis')}</ControlSubSectionHeader>],
         ...createAxisControl('x'),
+        [truncateXAxis],
+        [xAxisBounds],
         ...richTooltipSection,
         [<ControlSubSectionHeader>{t('Y Axis')}</ControlSubSectionHeader>],
         ...createAxisControl('y'),


### PR DESCRIPTION
### SUMMARY
In control panel for echart/BarChart there is a factory-function that supposed to build panels for x/y axises. Unfortunately `truncateXAxis` and `xAxisBounds` do not affected by axis name, therefore those options appears in both panels('X Axis', 'Y Axis'). They are complete duplicate and share the same state. Solution is to move those options from factory-function directly to `controlSetRows`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1800" alt="Screenshot 2024-08-12 at 11 35 38" src="https://github.com/user-attachments/assets/e3006055-2d84-43d6-baa8-e21edde2f3dc">
<img width="1800" alt="Screenshot 2024-08-12 at 11 57 19" src="https://github.com/user-attachments/assets/cc60f6f4-3cc1-450a-9844-2aab79056318">


### TESTING INSTRUCTIONS
The problem is available in the chart editor in the customization panel. Since both options have a same state, the value changes in both.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
