### PR TITLE
feat: Enable injecting custom html into head

### DIFF
--- a/superset/templates/head_custom_extra.html
+++ b/superset/templates/head_custom_extra.html
@@ -1,0 +1,24 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+#}
+
+{#
+  This file may be overridden in your custom deployment.
+  It will be included in the head block in every view in superset and is a
+  good place to include your custom link, meta, style or script elements.
+#}

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -36,6 +36,7 @@
 {% block head_js %}
   {{ super() }}
   {{ js_bundle("theme") }}
+  {% include "head_custom_extra.html" %}
 {% endblock %}
 
 {% block tail_js %}

--- a/superset/templates/superset/base.html
+++ b/superset/templates/superset/base.html
@@ -35,8 +35,8 @@
 
 {% block head_js %}
   {{ super() }}
-  {{ js_bundle("theme") }}
   {% include "head_custom_extra.html" %}
+  {{ js_bundle("theme") }}
 {% endblock %}
 
 {% block tail_js %}

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -15,6 +15,7 @@ governing permissions and limitations under the License. #}
 %} {% set favicons = appbuilder.app.config['FAVICONS'] %}
 <html>
   <head>
+    {% include "head_custom_extra.html" %}
     <title>
       {% block title %} {% if title %} {{ title }} {% elif appbuilder and
       appbuilder.app_name %} {{ appbuilder.app_name }} {% endif %} {% endblock
@@ -56,8 +57,6 @@ governing permissions and limitations under the License. #}
       type="text/css"
       href="{{ assets_prefix }}/static/appbuilder/css/select2/select2.min.css"
     />
-
-    {% include "head_custom_extra.html" %}
 
     {{ css_bundle("theme") }} {% if entry %} {{ css_bundle(entry) }} {% endif %}
     {% endblock %} {{ js_bundle("theme") }}

--- a/superset/templates/superset/basic.html
+++ b/superset/templates/superset/basic.html
@@ -57,6 +57,8 @@ governing permissions and limitations under the License. #}
       href="{{ assets_prefix }}/static/appbuilder/css/select2/select2.min.css"
     />
 
+    {% include "head_custom_extra.html" %}
+
     {{ css_bundle("theme") }} {% if entry %} {{ css_bundle(entry) }} {% endif %}
     {% endblock %} {{ js_bundle("theme") }}
 


### PR DESCRIPTION
### SUMMARY
Enable injecting custom \<link>, \<meta>, <style> etc. elements into <head>.

Similarly to how `tail_js_custom_extra.html` works, this PR adds `head_custom_extra.html` file where users can define elements that will be injected into head.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Add some html code to `head_custom_extra.html` file, verify that it appears in \<head>

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
