### PR TITLE
fix: add imports back to celery file

### DIFF
--- a/superset/tasks/celery_app.py
+++ b/superset/tasks/celery_app.py
@@ -32,6 +32,9 @@ from superset.extensions import celery_app, db
 flask_app = create_app()
 
 # Need to import late, as the celery_app will have been setup by "create_app()"
+# ruff: noqa: E402, F401
+# pylint: disable=wrong-import-position, unused-import
+from . import cache, scheduler
 
 # Export the celery app globally for Celery (as run on the cmd line) to find
 app = celery_app


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes issue https://github.com/apache/superset/issues/29708. When we were adding ruff in https://github.com/apache/superset/pull/28158, I'm guessing it was removed as these were unused imports.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
