### PR TITLE
fix: Fix delete_fake_db

### DIFF
--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -443,6 +443,7 @@ class SupersetTestCase(TestCase):
         )
         if database:
             db.session.delete(database)
+            db.session.commit()
 
     def create_fake_db_for_macros(self):
         database_name = "db_for_macros_testing"


### PR DESCRIPTION
Function delete_fake_db misses db.session.commit(), which may result in test fake database not being deleted, leading to failing subsequent tests.

delete_fake_db_for_macros, which performs a similar function, includes this line:

```python
def delete_fake_db(self):
    database = (
        db.session.query(Database)
        .filter(Database.database_name == FAKE_DB_NAME)
        .scalar()
    )
    if database:
        db.session.delete(database)
        db.session.commit()  # Added
```

```python
@staticmethod
def delete_fake_db_for_macros():
    database = (
        db.session.query(Database)
        .filter(Database.database_name == "db_for_macros_testing")
        .scalar()
    )
    if database:
        db.session.delete(database)
        db.session.commit()
```

Also consider making delete_fake_db a staticmethod:
```python
@staticmethod
def delete_fake_db():
    database = (
        db.session.query(Database)
        .filter(Database.database_name == FAKE_DB_NAME)
        .scalar()
    )
    if database:
        db.session.delete(database)
        db.session.commit()  # Added
```

