### PR TITLE
chore: Allow auto pruning of the query table

### DIFF
--- a/superset/commands/sql_lab/query.py
+++ b/superset/commands/sql_lab/query.py
@@ -22,7 +22,6 @@ import sqlalchemy as sa
 from superset import db
 from superset.commands.base import BaseCommand
 from superset.models.sql_lab import Query
-from superset.utils.decorators import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -46,22 +45,52 @@ class QueryPruneCommand(BaseCommand):
         """
         self.retention_period_days = retention_period_days
 
-    @transaction()
     def run(self) -> None:
         """
         Executes the prune command.
         """
-        result = db.session.execute(
-            sa.delete(Query).where(
-                Query.changed_on
-                < datetime.now() - timedelta(days=self.retention_period_days)
+        retention_date = datetime.now() - timedelta(days=self.retention_period_days)
+
+        # Query the total number of rows to be deleted
+        total_rows = db.session.query(Query).filter(
+            Query.changed_on < retention_date
+        ).count()
+
+        logger.info("Total rows to be deleted: %s", total_rows)
+
+        batch_size = 100_000
+
+        total_deleted = 0
+
+        for _ in range(0, total_rows, batch_size):
+            # Select a batch of records to delete
+            subquery = (
+                sa.select(Query.id)
+                .where(Query.changed_on < retention_date)
+                .limit(batch_size)
+                .subquery()
             )
-        )
-        logger.info(
-            "Deleted %s rows from the query table older than %s days",
-            result.rowcount,
-            self.retention_period_days,
-        )
+
+            # Delete the selected batch using equality
+            result = db.session.execute(
+                sa.delete(Query).where(Query.id == subquery.c.id).execution_options(synchronize_session="fetch")
+            )
+
+            # Update the total number of deleted records
+            total_deleted += result.rowcount
+
+            # Explicitly commit the transaction given that if an error occurs, we want to ensure that the
+            # records that have been deleted so far are committed
+            db.session.commit()
+
+            # Log the number of deleted records
+            logger.info(
+                "Deleted %s rows from the query table older than %s days",
+                total_deleted,
+                self.retention_period_days,
+            )
+
+        logger.info("Pruning complete")
 
     def validate(self) -> None:
         pass

--- a/superset/commands/sql_lab/query.py
+++ b/superset/commands/sql_lab/query.py
@@ -26,6 +26,7 @@ from superset.models.sql_lab import Query
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable=consider-using-transaction
 class QueryPruneCommand(BaseCommand):
     """
     Command to prune the query table by deleting rows older than the specified retention period.
@@ -47,14 +48,14 @@ class QueryPruneCommand(BaseCommand):
 
     def run(self) -> None:
         """
-        Executes the prune command.
+        Executes the prune command
         """
         retention_date = datetime.now() - timedelta(days=self.retention_period_days)
 
         # Query the total number of rows to be deleted
-        total_rows = db.session.query(Query).filter(
-            Query.changed_on < retention_date
-        ).count()
+        total_rows = (
+            db.session.query(Query).filter(Query.changed_on < retention_date).count()
+        )
 
         logger.info("Total rows to be deleted: %s", total_rows)
 
@@ -73,7 +74,9 @@ class QueryPruneCommand(BaseCommand):
 
             # Delete the selected batch using equality
             result = db.session.execute(
-                sa.delete(Query).where(Query.id == subquery.c.id).execution_options(synchronize_session="fetch")
+                sa.delete(Query)
+                .where(Query.id == subquery.c.id)
+                .execution_options(synchronize_session="fetch")
             )
 
             # Update the total number of deleted records

--- a/superset/commands/sql_lab/query.py
+++ b/superset/commands/sql_lab/query.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+from datetime import datetime, timedelta
+
+import sqlalchemy as sa
+
+from superset import db
+from superset.commands.base import BaseCommand
+from superset.models.sql_lab import Query
+from superset.utils.decorators import transaction
+
+logger = logging.getLogger(__name__)
+
+
+class QueryPruneCommand(BaseCommand):
+    """
+    Command to prune the query table by deleting rows older than the specified retention period.
+
+    This command deletes records from the `Query` table that have not been changed within the
+    specified number of days. It helps in maintaining the database by removing outdated entries
+    and freeing up space.
+
+    Attributes:
+        retention_period_days (int): The number of days for which records should be retained.
+                                     Records older than this period will be deleted.
+    """
+
+    def __init__(self, retention_period_days: int):
+        """
+        :param retention_period_days: Number of days to keep in the query table
+        """
+        self.retention_period_days = retention_period_days
+
+    @transaction()
+    def run(self) -> None:
+        """
+        Executes the prune command.
+        """
+        result = db.session.execute(
+            sa.delete(Query).where(
+                Query.changed_on
+                < datetime.now() - timedelta(days=self.retention_period_days)
+            )
+        )
+        logger.info(
+            "Deleted %s rows from the query table older than %s days",
+            result.rowcount,
+            self.retention_period_days,
+        )
+
+    def validate(self) -> None:
+        pass

--- a/superset/config.py
+++ b/superset/config.py
@@ -999,6 +999,12 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
             "task": "reports.prune_log",
             "schedule": crontab(minute=0, hour=0),
         },
+        # Uncomment to enable pruning of the query table
+        # "prune_query": {
+        #     "task": "prune_query",
+        #     "schedule": crontab(minute=0, hour=0, day_of_month=1),
+        #     "options": {"retention_period_days": 180},
+        # },
     }
 
 


### PR DESCRIPTION
### SUMMARY
Enhance the Celery configuration to allow auto pruning of the `query` table. By default, no pruning is executed but admins now have the option to configure a schedule and retention period in days for the table's records.

### TESTING INSTRUCTIONS
1 - Add the required configuration
2 - Check the job execution

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
