### PR TITLE
fix: thumbnail url json response was malformed

### DIFF
--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { MemoryRouter } from 'react-router-dom';
-import { FeatureFlag, SupersetClient } from '@superset-ui/core';
+import { FeatureFlag, JsonResponse, SupersetClient } from '@superset-ui/core';
 import * as uiCore from '@superset-ui/core';
 
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
@@ -101,11 +101,9 @@ it('Renders the modified date', () => {
 
 it('should fetch thumbnail when dashboard has no thumbnail URL and feature flag is enabled', async () => {
   const mockGet = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
-    response: new Response(
-      JSON.stringify({ thumbnail_url: '/new-thumbnail.png' }),
-    ),
-    json: () => Promise.resolve({ thumbnail_url: '/new-thumbnail.png' }),
-  });
+    json: { result: { thumbnail_url: '/new-thumbnail.png' } },
+  } as unknown as JsonResponse);
+
   const { rerender } = render(
     <DashboardCard
       dashboard={{

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -91,7 +91,7 @@ function DashboardCard({
       SupersetClient.get({
         endpoint: `/api/v1/dashboard/${dashboard.id}`,
       }).then(({ json = {} }) => {
-        setThumbnailUrl(json.thumbnail_url || '');
+        setThumbnailUrl(json.result?.thumbnail_url || '');
         setFetchingThumbnail(false);
       });
     }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The dashboard url json has a result property that was missing when looking up the thumbnail url. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
