### PR TITLE
fix(embedded): Remove CSRF requirement for dashboard download API

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -258,6 +258,7 @@ WTF_CSRF_EXEMPT_LIST = [
     "superset.views.core.log",
     "superset.views.core.explore_json",
     "superset.charts.data.api.data",
+    "superset.dashboards.api.cache_dashboard_screenshot",
 ]
 
 # Whether to run the web server in debug mode or not


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/29187 introduced a new API endpoint to process the dashboard `PDF` / `PNG` download. Since the **Download >** menu options can be exposed in Embedded, then this new endpoint must accept requests without a `CSRF` token.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Launch a dashboard in embedded mode (make sure that `chartControls` are visible).
2. Trigger a dashboard download.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
