### PR TITLE
fix(#29965): add assets prefix on all manifest assets

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -59,6 +59,7 @@ assists people when migrating to a new version.
   as part of your bundling to expose translation packages, it's probably not needed anymore.
 - [29264](https://github.com/apache/superset/pull/29264) Slack has updated its file upload api, and we are now supporting this new api in Superset, although the Slack api is not backward compatible. The original Slack integration is deprecated and we will require a new Slack scope `channels:read` to be added to Slack workspaces in order to use this new api. In an upcoming release, we will make this new Slack scope mandatory and remove the old Slack functionality.
 - [29798](https://github.com/apache/superset/pull/29798) Since 3.1.0, the intial schedule for an alert or report was mistakenly offset by the specified timezone's relation to UTC. The initial schedule should now begin at the correct time.
+- [29966](https://github.com/apache/superset/pull/29966) If the config `STATIC_ASSETS_PREFIX` is set, bundles will now be fetched from that location.
 
 ### Potential Downtime
 

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -73,7 +73,11 @@ class UIManifestProcessor:
 
     def get_manifest(self) -> dict[str, Union[Callable[[str], list[str]], str]]:
         loaded_chunks = set()
-        assets_prefix = self.app.config["STATIC_ASSETS_PREFIX"]
+
+        if self.app:
+            assets_prefix = self.app.config["STATIC_ASSETS_PREFIX"]
+        else:
+            assets_prefix = ""
 
         def get_files(bundle: str, asset_type: str = "js") -> list[str]:
             files = self.get_manifest_files(bundle, asset_type)
@@ -89,9 +93,7 @@ class UIManifestProcessor:
         return {
             "js_manifest": lambda bundle: get_files(bundle, "js"),
             "css_manifest": lambda bundle: get_files(bundle, "css"),
-            "assets_prefix": assets_prefix
-            if self.app
-            else "",
+            "assets_prefix": assets_prefix,
         }
 
     def parse_manifest_json(self) -> None:

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -85,10 +85,7 @@ class UIManifestProcessor:
             for f in filtered_files:
                 loaded_chunks.add(f)
 
-            if assets_prefix:
-                return [f"{assets_prefix}{f}" for f in filtered_files]
-
-            return filtered_files
+            return [f"{assets_prefix}{f}" for f in filtered_files]
 
         return {
             "js_manifest": lambda bundle: get_files(bundle, "js"),

--- a/tests/unit_tests/extension_tests.py
+++ b/tests/unit_tests/extension_tests.py
@@ -30,9 +30,15 @@ def test_get_manifest_with_prefix():
     manifest_processor = UIManifestProcessor(APP_DIR)
     manifest_processor.init_app(app)
     manifest = manifest_processor.get_manifest()
-    assert manifest["js_manifest"]("main") == ["/static/dist/main-js.js"]
-    assert manifest["css_manifest"]("main") == ["/static/dist/main-css.css"]
-    assert manifest["js_manifest"]("styles") == ["/static/dist/styles-js.js"]
+    assert manifest["js_manifest"]("main") == [
+        "https://cool.url/here/static/dist/main-js.js"
+    ]
+    assert manifest["css_manifest"]("main") == [
+        "https://cool.url/here/static/dist/main-css.css"
+    ]
+    assert manifest["js_manifest"]("styles") == [
+        "https://cool.url/here/static/dist/styles-js.js"
+    ]
     assert manifest["css_manifest"]("styles") == []
     assert manifest["assets_prefix"] == "https://cool.url/here"
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Per #29965, this PR fixes the issue that static assets prefix is not added to static assets listed in manifest.json.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #29965
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
