### PR TITLE
feat(sqllab): Adds refresh button to table metadata in SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/TableElement.test.tsx
@@ -51,11 +51,13 @@ const getTableMetadataEndpoint =
   /\/api\/v1\/database\/\d+\/table_metadata\/(?:\?.*)?$/;
 const getExtraTableMetadataEndpoint =
   /\/api\/v1\/database\/\d+\/table_metadata\/extra\/(?:\?.*)?$/;
-const updateTableSchemaEndpoint = 'glob:*/tableschemaview/*/expanded';
+const updateTableSchemaExpandedEndpoint = 'glob:*/tableschemaview/*/expanded';
+const updateTableSchemaEndpoint = 'glob:*/tableschemaview/';
 
 beforeEach(() => {
   fetchMock.get(getTableMetadataEndpoint, table);
   fetchMock.get(getExtraTableMetadataEndpoint, {});
+  fetchMock.post(updateTableSchemaExpandedEndpoint, {});
   fetchMock.post(updateTableSchemaEndpoint, {});
 });
 
@@ -84,7 +86,7 @@ test('has 4 IconTooltip elements', async () => {
     initialState,
   });
   await waitFor(() =>
-    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(4),
+    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(5),
   );
 });
 
@@ -104,7 +106,7 @@ test('fades table', async () => {
     initialState,
   });
   await waitFor(() =>
-    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(4),
+    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(5),
   );
   const style = window.getComputedStyle(getAllByTestId('fade')[0]);
   expect(style.opacity).toBe('0');
@@ -125,7 +127,7 @@ test('sorts columns', async () => {
     },
   );
   await waitFor(() =>
-    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(4),
+    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(5),
   );
   expect(
     getAllByTestId('mock-column-element').map(el => el.textContent),
@@ -154,7 +156,7 @@ test('removes the table', async () => {
     },
   );
   await waitFor(() =>
-    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(4),
+    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(5),
   );
   expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(0);
   fireEvent.click(getByText('Remove table preview'));
@@ -174,6 +176,29 @@ test('fetches table metadata when expanded', async () => {
   await waitFor(() =>
     expect(fetchMock.calls(getTableMetadataEndpoint)).toHaveLength(1),
   );
-  expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(0);
+  expect(fetchMock.calls(updateTableSchemaExpandedEndpoint)).toHaveLength(0);
   expect(fetchMock.calls(getExtraTableMetadataEndpoint)).toHaveLength(1);
+});
+
+test('refreshes table metadata when triggered', async () => {
+  const { getAllByTestId, getByText } = render(
+    <TableElement {...mockedProps} />,
+    {
+      useRedux: true,
+      initialState,
+    },
+  );
+  await waitFor(() =>
+    expect(getAllByTestId('mock-icon-tooltip')).toHaveLength(5),
+  );
+  expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(0);
+  expect(fetchMock.calls(getTableMetadataEndpoint)).toHaveLength(1);
+
+  fireEvent.click(getByText('Refresh table schema'));
+  await waitFor(() =>
+    expect(fetchMock.calls(getTableMetadataEndpoint)).toHaveLength(2),
+  );
+  await waitFor(() =>
+    expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(1),
+  );
 });

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -32,6 +32,7 @@ import {
   syncTable,
 } from 'src/SqlLab/actions/sqlLab';
 import {
+  tableApiUtil,
   useTableExtendedMetadataQuery,
   useTableMetadataQuery,
 } from 'src/hooks/apiResources';
@@ -107,7 +108,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
   const {
     currentData: tableMetadata,
     isSuccess: isMetadataSuccess,
-    isLoading: isMetadataLoading,
+    isFetching: isMetadataLoading,
     isError: hasMetadataError,
   } = useTableMetadataQuery(
     {
@@ -175,6 +176,13 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
 
   const toggleSortColumns = () => {
     setSortColumns(prevState => !prevState);
+  };
+
+  const refreshTableMetadata = () => {
+    dispatch(
+      tableApiUtil.invalidateTags([{ type: 'TableMetadatas', id: name }]),
+    );
+    dispatch(syncTable(table, tableData));
   };
 
   const renderWell = () => {
@@ -268,6 +276,11 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
           }
         `}
       >
+        <IconTooltip
+          className="fa fa-refresh pull-left m-l-2 pointer"
+          onClick={refreshTableMetadata}
+          tooltip={t('Refresh table schema')}
+        />
         {keyLink}
         <IconTooltip
           className={

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -108,7 +108,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
   const {
     currentData: tableMetadata,
     isSuccess: isMetadataSuccess,
-    isFetching: isMetadataLoading,
+    isFetching: isMetadataFetching,
     isError: hasMetadataError,
   } = useTableMetadataQuery(
     {
@@ -354,7 +354,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
         </Tooltip>
 
         <div className="pull-right header-right-side">
-          {isMetadataLoading || isExtraMetadataLoading ? (
+          {isMetadataFetching || isExtraMetadataLoading ? (
             <Loading position="inline" />
           ) : (
             <Fade

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -117,6 +117,13 @@ const tableApi = api.injectEndpoints({
       }),
     }),
     tableMetadata: builder.query<TableMetaData, FetchTableMetadataQueryParams>({
+      providesTags: result =>
+        result
+          ? [
+              { type: 'TableMetadatas', id: result.name },
+              { type: 'TableMetadatas', id: 'LIST' },
+            ]
+          : [{ type: 'TableMetadatas', id: 'LIST' }],
       query: ({ dbId, catalog, schema, table }) => ({
         endpoint: `/api/v1/database/${dbId}/table_metadata/${toQueryString({
           name: table,


### PR DESCRIPTION
### SUMMARY

When table metadata changes (e.g. due to queries launched in Superset or other external changes) the user has no convenient way to force a refresh of the data for their `TabState`. The metadata is persisted even across sessions and will never update if the user stays on the current tab.

This feature is a first step to make this experience better by adding a refresh button for each table that allows a manual refresh.

**Future improvements:**
- Automatically refresh when query is _likely_ to change the metadata
- Refresh metadata from time to time
- Do not persist the metadata for a SQL Lab tab forever: Maybe remove `TableSchema` and instead use a shared cache with well defined expiry

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img src="https://github.com/user-attachments/assets/7f3b1ee1-cf5f-4e5d-96fa-8332bff8d35c" alt="Refresh Button in Action" style="max-width: 100%; display: inline-block;" data-target="animated-image.originalImage" width="400">

### TESTING INSTRUCTIONS

1. Load SQL Lab and expand a table
2. Change the table (e.g. add column)
3. Click refresh button
4. **Expected**: New column appears
5. Refresh the whole page
6. **Expected**: Column is still there (asserts the server-side `TableSchema` was properly updated)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
