### PR TITLE
fix(sqllab): flaky json explore modal due to shallow equality checks for extra data

### DIFF
--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { normalizeTimestamp, QueryState, t } from '@superset-ui/core';
-import { omit } from 'lodash';
+import { isEqual, omit } from 'lodash';
 import { shallowEqual } from 'react-redux';
 import * as actions from '../actions/sqlLab';
 import { now } from '../../utils/dates';
@@ -698,14 +698,12 @@ export default function sqlLabReducer(state = {}, action) {
                 ? prevState
                 : currentState,
           };
-          const newExtra = JSON.stringify(newQueries[id].extra);
-          const prevExtra = JSON.stringify(state.queries[id].extra);
           if (
             shallowEqual(
               omit(newQueries[id], ['extra']),
               omit(state.queries[id], ['extra']),
             ) &&
-            newExtra === prevExtra
+            isEqual(newQueries[id].extra, state.queries[id].extra)
           ) {
             newQueries[id] = state.queries[id];
           } else {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -17,6 +17,8 @@
  * under the License.
  */
 import { normalizeTimestamp, QueryState, t } from '@superset-ui/core';
+import { omit } from 'lodash';
+import { shallowEqual } from 'react-redux';
 import * as actions from '../actions/sqlLab';
 import { now } from '../../utils/dates';
 import {
@@ -696,7 +698,19 @@ export default function sqlLabReducer(state = {}, action) {
                 ? prevState
                 : currentState,
           };
-          change = true;
+          const newExtra = JSON.stringify(newQueries[id].extra);
+          const prevExtra = JSON.stringify(state.queries[id].extra);
+          if (
+            shallowEqual(
+              omit(newQueries[id], ['extra']),
+              omit(state.queries[id], ['extra']),
+            ) &&
+            newExtra === prevExtra
+          ) {
+            newQueries[id] = state.queries[id];
+          } else {
+            change = true;
+          }
         }
       });
       if (!change) {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -449,6 +449,35 @@ describe('sqlLabReducer', () => {
       expect(newState.queries.abcd.endDttm).toBe(Number(endDttmInStr));
       expect(newState.queriesLastUpdate).toBe(CHANGED_ON_TIMESTAMP);
     });
+    it('should skip refreshing queries when polling contains existing results', () => {
+      const completedQuery = {
+        ...query,
+        extra: {
+          columns: [],
+          progress: null,
+        },
+      };
+      newState = sqlLabReducer(
+        {
+          ...newState,
+          queries: { abcd: query, def: completedQuery },
+        },
+        actions.refreshQueries({
+          abcd: {
+            ...query,
+          },
+          def: {
+            ...completedQuery,
+            extra: {
+              columns: [],
+              progress: null,
+            },
+          },
+        }),
+      );
+      expect(newState.queries.abcd).toBe(query);
+      expect(newState.queries.def).toBe(completedQuery);
+    });
     it('should refresh queries when polling returns empty', () => {
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
     });


### PR DESCRIPTION
### SUMMARY
In the async query, the `extra` field of the pulling data is in object form, and when the result is completed, it fails to verify equality due to shallow equality checks.
This caused unnecessary over-rendering of the result panel, so this commit resolved the issue by comparing the extra field separately.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/cb329bf1-2b8f-4f3e-8ac6-10b846794d3d

After:

https://github.com/user-attachments/assets/c77006f2-2f09-496d-804a-07af50ee57a2

### TESTING INSTRUCTIONS
Run a large query in a new tab, then switch to another tab.
Run a quick query that includes a JSON value, then click the value to verify that the JSON modal is shown steadily.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
