### PR TITLE
fix(screenshots): dashboard screenshots do not capture filter state

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
@@ -44,9 +44,19 @@ export default function DownloadScreenshot({
   logEvent?: Function;
   format: string;
 }) {
-  const anchor = useSelector(
-    (state: RootState) => last(state.dashboardState.activeTabs) || undefined,
+  const activeTabs = useSelector(
+    (state: RootState) => state.dashboardState.activeTabs || undefined,
   );
+
+  const anchor = useSelector(
+    (state: RootState) =>
+      last(state.dashboardState.directPathToChild) || undefined,
+  );
+
+  const dataMask = useSelector(
+    (state: RootState) => state.dataMask || undefined,
+  );
+
   const { addDangerToast, addSuccessToast, addInfoToast } = useToasts();
 
   const onDownloadScreenshot = () => {
@@ -106,6 +116,8 @@ export default function DownloadScreenshot({
       endpoint: `/api/v1/dashboard/${dashboardId}/cache_dashboard_screenshot`,
       jsonPayload: {
         anchor,
+        activeTabs,
+        dataMask,
       },
     })
       .then(({ json }) => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When downloading a Dashboard as image or Export to PDF, the filters applied to the dashboard are not considered in the downloaded/exported file.

To fix this, I've pulled the relevant slices of dashboard state from the redux store and attached them to the screenshot request payload.


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Create a Dashboard with a table using the vehicle sales dataset with the date column.

Apply any dashboard Time filter (Time Grain filter → year) 

Publish your changes.

Click on the three ellipses > Download as image or Export as PDF

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
