### PR TITLE
fix(trino): handle missing db in migration

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -296,10 +296,13 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         return "from_unixtime({col})"
 
     @classmethod
-    def get_default_catalog(cls, database: "Database") -> str | None:
+    def get_default_catalog(cls, database: Database) -> str | None:
         """
         Return the default catalog.
         """
+        if database.url_object.database is None:
+            return None
+
         return database.url_object.database.split("/")[0]
 
     @classmethod

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
+from __future__ import annotations
+
 import copy
 from collections import namedtuple
 from datetime import datetime
@@ -719,7 +721,15 @@ def test_adjust_engine_params_catalog_only() -> None:
     assert str(uri) == "trino://user:pass@localhost:8080/new_catalog/new_schema"
 
 
-def test_get_default_catalog() -> None:
+@pytest.mark.parametrize(
+    "sqlalchemy_uri,result",
+    [
+        ("trino://user:pass@localhost:8080/system", "system"),
+        ("trino://user:pass@localhost:8080/system/default", "system"),
+        ("trino://trino@localhost:8081", None),
+    ],
+)
+def test_get_default_catalog(sqlalchemy_uri: str, result: str | None) -> None:
     """
     Test the ``get_default_catalog`` method.
     """
@@ -728,15 +738,9 @@ def test_get_default_catalog() -> None:
 
     database = Database(
         database_name="my_db",
-        sqlalchemy_uri="trino://user:pass@localhost:8080/system",
+        sqlalchemy_uri=sqlalchemy_uri,
     )
-    assert TrinoEngineSpec.get_default_catalog(database) == "system"
-
-    database = Database(
-        database_name="my_db",
-        sqlalchemy_uri="trino://user:pass@localhost:8080/system/default",
-    )
-    assert TrinoEngineSpec.get_default_catalog(database) == "system"
+    assert TrinoEngineSpec.get_default_catalog(database) == result
 
 
 @patch("superset.db_engine_specs.trino.TrinoEngineSpec.latest_partition")


### PR DESCRIPTION
### SUMMARY
When running `superset db upgrade` on my local devenv, the `87ffc36f9842` migration errored out on the following Trino connection string: `trino://trino@localhost:8081`.

### AFTER
**executes successfully**

### BEFORE
```python
  File "/Users/ville/apple/apache-superset/superset/migrations/versions/2024-05-09_18-44_87ffc36f9842_enable_catalog_in_bigquery_presto_trino_.py", line 36, in upgrade
    upgrade_catalog_perms(engines={"trino", "presto", "bigquery", "snowflake"})
  File "/Users/ville/apple/apache-superset/superset/migrations/shared/catalogs.py", line 384, in upgrade_catalog_perms
    if default_catalog := database.get_default_catalog():
  File "/Users/ville/apple/apache-superset/superset/models/core.py", line 580, in get_default_catalog
    return self.db_engine_spec.get_default_catalog(self)
  File "/Users/ville/apple/apache-superset/superset/db_engine_specs/presto.py", line 306, in get_default_catalog
    return database.url_object.database.split("/")[0]
AttributeError: 'NoneType' object has no attribute 'split'
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
