### PR TITLE
chore: use playwright to install browsers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,14 +183,15 @@ RUN apt-get update -qq \
 ARG INCLUDE_CHROMIUM="true"
 ARG INCLUDE_FIREFOX="false"
 
-RUN if [ "$INCLUDE_CHROMIUM" = "true" ] || [ "$INCLUDE_FIREFOX" = "true" ]; then \
-      --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$INCLUDE_CHROMIUM" = "true" ] || [ "$INCLUDE_FIREFOX" = "true" ]; then \
       uv pip install --system --no-cache-dir playwright; \
     else \
       echo "Skipping Playwright installation"; \
     fi
 
-RUN if [ "$INCLUDE_CHROMIUM" = "true" ]; then \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$INCLUDE_CHROMIUM" = "true" ]; then \
         playwright install chromium --with-deps; \
     else \
         echo "Skipping Chromium installation"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,7 @@ ARG INCLUDE_FIREFOX="false"
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$INCLUDE_CHROMIUM" = "true" ] || [ "$INCLUDE_FIREFOX" = "true" ]; then \
-      uv pip install --system --no-cache-dir playwright; \
+      pip install --system --no-cache-dir playwright; \
     else \
       echo "Skipping Playwright installation"; \
     fi


### PR DESCRIPTION
Seems we use playwright to install chromium in some places, but not consistently for chromium and firefox. This makes for confusing/fragile stuff in the Dockerfile. Here I'm just using playwright consistently and in
the docs. Note that this bloats the dev/ci images with BOTH browsers, but people should really just build on top of lean and add their browsers and database drivers from there. We may want to have a single primary browse
r we support and just keep that one in our Dockerfile
