### PR TITLE
feat(time_comparison): Support all date formats when computing custom and inherit offsets

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -78,3 +78,5 @@ export const DEFAULT_XAXIS_SORT_SERIES_DATA: SortSeriesData = {
   sort_series_type: SortSeriesType.Name,
   sort_series_ascending: true,
 };
+
+export const DEFAULT_DATE_PATTERN = /\d{4}-\d{2}-\d{2}/g;

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -154,9 +154,6 @@ export const computeCustomDateTime = (
   let parsed: Date;
   if (dttm === 'now' || dttm === 'today') {
     parsed = new Date();
-    if (dttm === 'today') {
-      parsed.setHours(0, 0, 0, 0);
-    }
   } else {
     parsed = new Date(dttm);
   }

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -280,9 +280,12 @@ export const getTimeOffset = ({
 
   const customShift =
     customStartDateTime &&
+    filterStartDateTime &&
     Math.round((filterStartDateTime - customStartDateTime) / DAY_IN_MS);
   const inInheritShift =
     isInherit &&
+    filterEndDateTime &&
+    filterStartDateTime &&
     Math.round((filterEndDateTime - filterStartDateTime) / DAY_IN_MS);
 
   const newShifts = ensureIsArray(shifts)
@@ -292,7 +295,7 @@ export const getTimeOffset = ({
           if (includeFutureOffsets && customShift < 0) {
             return `${customShift * -1} days after`;
           }
-          if (customShift >= 0) {
+          if (customShift >= 0 && filterStartDateTime) {
             return `${customShift} days ago`;
           }
         }

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -21,6 +21,28 @@ import { ensureIsArray } from '../utils';
 import { customTimeRangeDecode } from './customTimeRangeDecode';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export const parseDateParts = (dateParts: string[]) => {
+  const parts = ensureIsArray(dateParts);
+  if (parts.length === 3) {
+    const [a, b, c] = parts;
+    const parsedA = parseInt(a, 10);
+    const parsedB = parseInt(b, 10);
+    const parsedC = parseInt(c, 10);
+    if (parsedA > 31)
+      return { year: parsedA, month: parsedB - 1, day: parsedC }; // a is year: YYYY-MM-DD
+    if (parsedC > 31)
+      return { year: parsedC, month: parsedA - 1, day: parsedB }; // c is year: MM-DD-YYYY
+  } else if (parts.length === 2) {
+    const [a, b] = parts;
+    const parsedA = parseInt(a, 10);
+    const parsedB = parseInt(b, 10);
+    if (parsedA > 31) return { year: parsedA, month: parsedB - 1, day: 0 }; // a is year: YYYY-MM
+    return { year: parsedB, month: parsedA - 1, day: 0 }; // b is year: MM-YYYY
+  }
+  return { year: 0, month: 0, day: 0 };
+};
+
 export const parseDttmToDate = (
   dttm: string,
   isEndDate = false,
@@ -119,15 +141,11 @@ export const parseDttmToDate = (
     if (parts.length === 1) {
       parsed = new Date(Date.UTC(parseInt(parts[0], 10), 0));
     } else if (parts.length === 2) {
-      parsed = new Date(
-        Date.UTC(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1),
-      );
+      const parsedParts = parseDateParts(parts);
+      parsed = new Date(Date.UTC(parsedParts.year, parsedParts.month));
     } else if (parts.length === 3) {
-      parsed = new Date(
-        parseInt(parts[0], 10),
-        parseInt(parts[1], 10) - 1,
-        parseInt(parts[2], 10),
-      );
+      const parsedParts = parseDateParts(parts);
+      parsed = new Date(parsedParts.year, parsedParts.month, parsedParts.day);
     } else {
       parsed = new Date(dttm);
     }

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -27,12 +27,12 @@ export const parseDttmToDate = (
   computingShifts = false,
 ) => {
   const now = new Date();
-  if (
-    dttm === 'now' ||
-    dttm === 'today' ||
-    dttm === 'No filter' ||
-    dttm === ''
-  ) {
+  if (dttm === 'now' || dttm === 'No filter' || dttm === '') {
+    return now;
+  }
+
+  if (dttm === 'today') {
+    now.setHours(0, 0, 0, 0);
     return now;
   }
 
@@ -154,6 +154,9 @@ export const computeCustomDateTime = (
   let parsed: Date;
   if (dttm === 'now' || dttm === 'today') {
     parsed = new Date();
+    if (dttm === 'today') {
+      parsed.setHours(0, 0, 0, 0);
+    }
   } else {
     parsed = new Date(dttm);
   }

--- a/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-comparison/getTimeOffset.ts
@@ -22,27 +22,6 @@ import { customTimeRangeDecode } from './customTimeRangeDecode';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-export const parseDateParts = (dateParts: string[]) => {
-  const parts = ensureIsArray(dateParts);
-  if (parts.length === 3) {
-    const [a, b, c] = parts;
-    const parsedA = parseInt(a, 10);
-    const parsedB = parseInt(b, 10);
-    const parsedC = parseInt(c, 10);
-    if (parsedA > 31)
-      return { year: parsedA, month: parsedB - 1, day: parsedC }; // a is year: YYYY-MM-DD
-    if (parsedC > 31)
-      return { year: parsedC, month: parsedA - 1, day: parsedB }; // c is year: MM-DD-YYYY
-  } else if (parts.length === 2) {
-    const [a, b] = parts;
-    const parsedA = parseInt(a, 10);
-    const parsedB = parseInt(b, 10);
-    if (parsedA > 31) return { year: parsedA, month: parsedB - 1, day: 0 }; // a is year: YYYY-MM
-    return { year: parsedB, month: parsedA - 1, day: 0 }; // b is year: MM-YYYY
-  }
-  return { year: 0, month: 0, day: 0 };
-};
-
 export const parseDttmToDate = (
   dttm: string,
   isEndDate = false,
@@ -141,11 +120,15 @@ export const parseDttmToDate = (
     if (parts.length === 1) {
       parsed = new Date(Date.UTC(parseInt(parts[0], 10), 0));
     } else if (parts.length === 2) {
-      const parsedParts = parseDateParts(parts);
-      parsed = new Date(Date.UTC(parsedParts.year, parsedParts.month));
+      parsed = new Date(
+        Date.UTC(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1),
+      );
     } else if (parts.length === 3) {
-      const parsedParts = parseDateParts(parts);
-      parsed = new Date(parsedParts.year, parsedParts.month, parsedParts.day);
+      parsed = new Date(
+        parseInt(parts[0], 10),
+        parseInt(parts[1], 10) - 1,
+        parseInt(parts[2], 10),
+      );
     } else {
       parsed = new Date(dttm);
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -26,7 +26,7 @@ import {
   t,
   useTheme,
 } from '@superset-ui/core';
-import { Tooltip } from '@superset-ui/chart-controls';
+import { DEFAULT_DATE_PATTERN, Tooltip } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash';
 import {
   ColorSchemeEnum,
@@ -95,8 +95,7 @@ export default function PopKPI(props: PopKPIProps) {
         currentTimeRangeFilter.subject,
       );
       Promise.resolve(promise).then((res: any) => {
-        const datePattern = /\d{4}-\d{2}-\d{2}/g;
-        const dates = res?.value?.match(datePattern);
+        const dates = res?.value?.match(DEFAULT_DATE_PATTERN);
         const [parsedStartDate, parsedEndDate] = dates ?? [];
         const newShift = getTimeOffset({
           timeRangeFilter: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -57,7 +57,7 @@ export default function buildQuery(formData: QueryFormData) {
         previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
     }
 
-    const timeOffsets = ensureIsArray(
+    let timeOffsets = ensureIsArray(
       isTimeComparison(formData, baseQueryObject)
         ? getTimeOffset({
             timeRangeFilter: {
@@ -74,6 +74,13 @@ export default function buildQuery(formData: QueryFormData) {
           })
         : [],
     );
+    if (isEmpty(timeOffsets)) {
+      if (formData.time_compare && formData.time_compare === 'custom') {
+        timeOffsets = [formData.start_date_offset];
+      } else {
+        timeOffsets = ensureIsArray(formData.time_compare) || [];
+      }
+    }
     return [
       {
         ...baseQueryObject,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/buildQuery.ts
@@ -21,9 +21,6 @@ import {
   QueryFormData,
   PostProcessingRule,
   ensureIsArray,
-  SimpleAdhocFilter,
-  getTimeOffset,
-  parseDttmToDate,
 } from '@superset-ui/core';
 import {
   isTimeComparison,
@@ -37,48 +34,28 @@ export default function buildQuery(formData: QueryFormData) {
   const queryContextA = buildQueryContext(formData, baseQueryObject => {
     const postProcessing: PostProcessingRule[] = [];
     postProcessing.push(timeCompareOperator(formData, baseQueryObject));
-    const TimeRangeFilters =
-      formData.adhoc_filters?.filter(
-        (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-      ) || [];
 
-    // In case the viz is using all version of controls, we try to load them
-    const previousCustomTimeRangeFilters: any =
-      formData.adhoc_custom?.filter(
-        (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-      ) || [];
+    const nonCustomNorInheritShifts = ensureIsArray(
+      formData.time_compare,
+    ).filter((shift: string) => shift !== 'custom' && shift !== 'inherit');
+    const customOrInheritShifts = ensureIsArray(formData.time_compare).filter(
+      (shift: string) => shift === 'custom' || shift === 'inherit',
+    );
 
-    let previousCustomStartDate = '';
-    if (
-      !isEmpty(previousCustomTimeRangeFilters) &&
-      previousCustomTimeRangeFilters[0]?.comparator !== 'No Filter'
-    ) {
-      previousCustomStartDate =
-        previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
+    let timeOffsets: string[] = [];
+
+    // Shifts for non-custom or non inherit time comparison
+    if (!isEmpty(nonCustomNorInheritShifts)) {
+      timeOffsets = nonCustomNorInheritShifts;
     }
 
-    let timeOffsets = ensureIsArray(
-      isTimeComparison(formData, baseQueryObject)
-        ? getTimeOffset({
-            timeRangeFilter: {
-              ...TimeRangeFilters[0],
-              comparator:
-                baseQueryObject?.time_range ??
-                (TimeRangeFilters[0] as any)?.comparator,
-            },
-            shifts: formData.time_compare,
-            startDate:
-              previousCustomStartDate && !formData.start_date_offset
-                ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
-                : formData.start_date_offset,
-          })
-        : [],
-    );
-    if (isEmpty(timeOffsets)) {
-      if (formData.time_compare && formData.time_compare === 'custom') {
-        timeOffsets = [formData.start_date_offset];
-      } else {
-        timeOffsets = ensureIsArray(formData.time_compare) || [];
+    // Shifts for custom or inherit time comparison
+    if (!isEmpty(customOrInheritShifts)) {
+      if (customOrInheritShifts.includes('custom')) {
+        timeOffsets = timeOffsets.concat([formData.start_date_offset]);
+      }
+      if (customOrInheritShifts.includes('inherit')) {
+        timeOffsets = timeOffsets.concat(['inherit']);
       }
     }
     return [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -130,6 +130,13 @@ export default function transformProps(chartProps: ChartProps) {
           ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
           : startDateOffset,
     });
+    if (isEmpty(dataOffset)) {
+      if (timeComparison && timeComparison === 'custom') {
+        dataOffset = [startDateOffset];
+      } else {
+        dataOffset = ensureIsArray(timeComparison) || [];
+      }
+    }
   }
 
   const { value1, value2 } = data.reduce(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -24,10 +24,7 @@ import {
   getNumberFormatter,
   SimpleAdhocFilter,
   ensureIsArray,
-  getTimeOffset,
-  parseDttmToDate,
 } from '@superset-ui/core';
-import { isEmpty } from 'lodash';
 import { getComparisonFontSize, getHeaderFontSize } from './utils';
 
 export const parseMetricValue = (metricValue: number | string | null) => {
@@ -99,43 +96,15 @@ export default function transformProps(chartProps: ChartProps) {
     (adhoc_filter: SimpleAdhocFilter) =>
       adhoc_filter.operator === 'TEMPORAL_RANGE',
   )?.[0];
-  // In case the viz is using all version of controls, we try to load them
-  const previousCustomTimeRangeFilters: any =
-    chartProps.rawFormData?.adhoc_custom?.filter(
-      (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-    ) || [];
 
-  let previousCustomStartDate = '';
-  if (
-    !isEmpty(previousCustomTimeRangeFilters) &&
-    previousCustomTimeRangeFilters[0]?.comparator !== 'No Filter'
-  ) {
-    previousCustomStartDate =
-      previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
-  }
   const isCustomOrInherit =
     timeComparison === 'custom' || timeComparison === 'inherit';
   let dataOffset: string[] = [];
   if (isCustomOrInherit) {
-    dataOffset = getTimeOffset({
-      timeRangeFilter: {
-        ...currentTimeRangeFilter,
-        comparator:
-          formData?.extraFormData?.time_range ??
-          (currentTimeRangeFilter as any)?.comparator,
-      },
-      shifts: ensureIsArray(timeComparison),
-      startDate:
-        previousCustomStartDate && !startDateOffset
-          ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
-          : startDateOffset,
-    });
-    if (isEmpty(dataOffset)) {
-      if (timeComparison && timeComparison === 'custom') {
-        dataOffset = [startDateOffset];
-      } else {
-        dataOffset = ensureIsArray(timeComparison) || [];
-      }
+    if (timeComparison && timeComparison === 'custom') {
+      dataOffset = [startDateOffset];
+    } else {
+      dataOffset = ensureIsArray(timeComparison) || [];
     }
   }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -107,7 +107,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
     }
 
-    const timeOffsets = ensureIsArray(
+    let timeOffsets = ensureIsArray(
       isTimeComparison(formData, baseQueryObject)
         ? getTimeOffset({
             timeRangeFilter: {
@@ -124,6 +124,14 @@ const buildQuery: BuildQuery<TableChartFormData> = (
           })
         : [],
     );
+
+    if (isEmpty(timeOffsets)) {
+      if (formData.time_compare && formData.time_compare === 'custom') {
+        timeOffsets = [formData.start_date_offset];
+      } else {
+        timeOffsets = ensureIsArray(formData.time_compare) || [];
+      }
+    }
 
     let temporalColumAdded = false;
     let temporalColum = null;

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -21,13 +21,10 @@ import {
   buildQueryContext,
   ensureIsArray,
   getMetricLabel,
-  getTimeOffset,
   isPhysicalColumn,
-  parseDttmToDate,
   QueryMode,
   QueryObject,
   removeDuplicates,
-  SimpleAdhocFilter,
 } from '@superset-ui/core';
 import { PostProcessingRule } from '@superset-ui/core/src/query/types/PostProcessing';
 import { BuildQuery } from '@superset-ui/core/src/chart/registries/ChartBuildQueryRegistrySingleton';
@@ -87,49 +84,33 @@ const buildQuery: BuildQuery<TableChartFormData> = (
     let { metrics, orderby = [], columns = [] } = baseQueryObject;
     const { extras = {} } = baseQueryObject;
     let postProcessing: PostProcessingRule[] = [];
-    const TimeRangeFilters =
-      formData.adhoc_filters?.filter(
-        (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-      ) || [];
-
-    // In case the viz is using all version of controls, we try to load them
-    const previousCustomTimeRangeFilters: any =
-      formData.adhoc_custom?.filter(
-        (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-      ) || [];
-
-    let previousCustomStartDate = '';
-    if (
-      !isEmpty(previousCustomTimeRangeFilters) &&
-      previousCustomTimeRangeFilters[0]?.comparator !== 'No Filter'
-    ) {
-      previousCustomStartDate =
-        previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
-    }
-
-    let timeOffsets = ensureIsArray(
-      isTimeComparison(formData, baseQueryObject)
-        ? getTimeOffset({
-            timeRangeFilter: {
-              ...TimeRangeFilters[0],
-              comparator:
-                baseQueryObject?.time_range ??
-                (TimeRangeFilters[0] as any)?.comparator,
-            },
-            shifts: formData.time_compare,
-            startDate:
-              previousCustomStartDate && !formData.start_date_offset
-                ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
-                : formData.start_date_offset,
-          })
-        : [],
+    const nonCustomNorInheritShifts = ensureIsArray(
+      formData.time_compare,
+    ).filter((shift: string) => shift !== 'custom' && shift !== 'inherit');
+    const customOrInheritShifts = ensureIsArray(formData.time_compare).filter(
+      (shift: string) => shift === 'custom' || shift === 'inherit',
     );
 
-    if (isEmpty(timeOffsets)) {
-      if (formData.time_compare && formData.time_compare === 'custom') {
-        timeOffsets = [formData.start_date_offset];
-      } else {
-        timeOffsets = ensureIsArray(formData.time_compare) || [];
+    let timeOffsets: string[] = [];
+
+    // Shifts for non-custom or non inherit time comparison
+    if (
+      isTimeComparison(formData, baseQueryObject) &&
+      !isEmpty(nonCustomNorInheritShifts)
+    ) {
+      timeOffsets = nonCustomNorInheritShifts;
+    }
+
+    // Shifts for custom or inherit time comparison
+    if (
+      isTimeComparison(formData, baseQueryObject) &&
+      !isEmpty(customOrInheritShifts)
+    ) {
+      if (customOrInheritShifts.includes('custom')) {
+        timeOffsets = timeOffsets.concat([formData.start_date_offset]);
+      }
+      if (customOrInheritShifts.includes('inherit')) {
+        timeOffsets = timeOffsets.concat(['inherit']);
       }
     }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -615,7 +615,7 @@ const transformProps = (
       previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
   }
 
-  const timeOffsets = getTimeOffset({
+  let timeOffsets = getTimeOffset({
     timeRangeFilter: {
       ...TimeRangeFilters[0],
       comparator:
@@ -628,6 +628,13 @@ const transformProps = (
         ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
         : formData.start_date_offset,
   });
+  if (isEmpty(timeOffsets)) {
+    if (formData.time_compare && formData.time_compare === 'custom') {
+      timeOffsets = [formData.start_date_offset];
+    } else {
+      timeOffsets = ensureIsArray(formData.time_compare) || [];
+    }
+  }
   const comparisonSuffix = isUsingTimeComparison
     ? ensureIsArray(timeOffsets)[0]
     : '';

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -35,9 +35,6 @@ import {
   SMART_DATE_ID,
   TimeFormats,
   TimeFormatter,
-  SimpleAdhocFilter,
-  getTimeOffset,
-  parseDttmToDate,
 } from '@superset-ui/core';
 import {
   ColorFormatters,
@@ -597,42 +594,27 @@ const transformProps = (
   };
 
   const timeGrain = extractTimegrain(formData);
-  const TimeRangeFilters =
-    chartProps.rawFormData?.adhoc_filters?.filter(
-      (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-    ) || [];
-  const previousCustomTimeRangeFilters: any =
-    chartProps.rawFormData?.adhoc_custom?.filter(
-      (filter: SimpleAdhocFilter) => filter.operator === 'TEMPORAL_RANGE',
-    ) || [];
 
-  let previousCustomStartDate = '';
-  if (
-    !isEmpty(previousCustomTimeRangeFilters) &&
-    previousCustomTimeRangeFilters[0]?.comparator !== 'No Filter'
-  ) {
-    previousCustomStartDate =
-      previousCustomTimeRangeFilters[0]?.comparator.split(' : ')[0];
+  const nonCustomNorInheritShifts = ensureIsArray(formData.time_compare).filter(
+    (shift: string) => shift !== 'custom' && shift !== 'inherit',
+  );
+  const customOrInheritShifts = ensureIsArray(formData.time_compare).filter(
+    (shift: string) => shift === 'custom' || shift === 'inherit',
+  );
+
+  let timeOffsets: string[] = [];
+
+  if (isUsingTimeComparison && !isEmpty(nonCustomNorInheritShifts)) {
+    timeOffsets = nonCustomNorInheritShifts;
   }
 
-  let timeOffsets = getTimeOffset({
-    timeRangeFilter: {
-      ...TimeRangeFilters[0],
-      comparator:
-        formData?.extra_form_data?.time_range ??
-        (TimeRangeFilters[0] as any)?.comparator,
-    },
-    shifts: formData.time_compare,
-    startDate:
-      previousCustomStartDate && !formData.start_date_offset
-        ? parseDttmToDate(previousCustomStartDate)?.toUTCString()
-        : formData.start_date_offset,
-  });
-  if (isEmpty(timeOffsets)) {
-    if (formData.time_compare && formData.time_compare === 'custom') {
-      timeOffsets = [formData.start_date_offset];
-    } else {
-      timeOffsets = ensureIsArray(formData.time_compare) || [];
+  // Shifts for custom or inherit time comparison
+  if (isUsingTimeComparison && !isEmpty(customOrInheritShifts)) {
+    if (customOrInheritShifts.includes('custom')) {
+      timeOffsets = timeOffsets.concat([formData.start_date_offset]);
+    }
+    if (customOrInheritShifts.includes('inherit')) {
+      timeOffsets = timeOffsets.concat(['inherit']);
     }
   }
   const comparisonSuffix = isUsingTimeComparison

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -122,7 +122,25 @@ export const ComparisonRangeLabel = ({
             ensureIsArray(newShifts),
           );
         }
-        return Promise.resolve({ value: '' });
+        return fetchTimeRange(filter.comparator, filter.subject).then(res => {
+          const datePattern = /\d{4}-\d{2}-\d{2}/g;
+          const dates = res?.value?.match(datePattern);
+          const [startDate, endDate] = dates ?? [];
+          const postProcessedShifts = getTimeOffset({
+            timeRangeFilter: {
+              ...filter,
+              comparator: `${startDate} : ${endDate}`,
+            },
+            shifts: shiftsArray,
+            startDate: useStartDate,
+            includeFutureOffsets: false, // So we don't trigger requests for future dates
+          });
+          return fetchTimeRange(
+            filter.comparator,
+            filter.subject,
+            ensureIsArray(postProcessedShifts),
+          );
+        });
       });
       Promise.all(promises).then(res => {
         // access the value property inside the res and set the labels with it in the state

--- a/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/ComparisonRangeLabel.tsx
@@ -35,6 +35,7 @@ import ControlHeader, {
   ControlHeaderProps,
 } from 'src/explore/components/ControlHeader';
 import { RootState } from 'src/views/store';
+import { DEFAULT_DATE_PATTERN } from '@superset-ui/chart-controls';
 
 const MOMENT_FORMAT = 'YYYY-MM-DD';
 
@@ -132,8 +133,7 @@ export const ComparisonRangeLabel = ({
           ensureIsArray(customOrInheritShifts).includes('inherit')
         ) {
           return fetchTimeRange(filter.comparator, filter.subject).then(res => {
-            const datePattern = /\d{4}-\d{2}-\d{2}/g;
-            const dates = res?.value?.match(datePattern);
+            const dates = res?.value?.match(DEFAULT_DATE_PATTERN);
             const [parsedStartDate, parsedEndDate] = dates ?? [];
             if (parsedStartDate) {
               const parsedDateMoment = moment(parseDttmToDate(parsedStartDate));

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -26,6 +26,7 @@ import {
   css,
   customTimeRangeDecode,
   computeCustomDateTime,
+  fetchTimeRange,
 } from '@superset-ui/core';
 import { DatePicker } from 'antd';
 import { RangePickerProps } from 'antd/lib/date-picker';
@@ -132,7 +133,20 @@ export default function TimeOffsetControls({
     if (!isEmpty(currentTimeRangeFilters)) {
       customTimeRange(currentTimeRangeFilters[0]?.comparator ?? '');
       const date = currentTimeRangeFilters[0]?.comparator.split(' : ')[0];
-      setFormatedFilterDate(moment(parseDttmToDate(date)));
+      const parsedDate = parseDttmToDate(date);
+      if (parsedDate) {
+        setFormatedFilterDate(moment(parseDttmToDate(date)));
+      } else {
+        fetchTimeRange(
+          currentTimeRangeFilters[0]?.comparator,
+          currentTimeRangeFilters[0]?.subject,
+        ).then(res => {
+          const datePattern = /\d{4}-\d{2}-\d{2}/g;
+          const dates = res?.value?.match(datePattern);
+          const [startDate, _] = dates ?? [];
+          setFormatedFilterDate(moment(parseDttmToDate(startDate)));
+        });
+      }
     } else {
       setCustomStartDateInFilter(undefined);
       setFormatedFilterDate(moment(parseDttmToDate('')));

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -131,22 +131,16 @@ export default function TimeOffsetControls({
 
   useEffect(() => {
     if (!isEmpty(currentTimeRangeFilters)) {
-      customTimeRange(currentTimeRangeFilters[0]?.comparator ?? '');
-      const date = currentTimeRangeFilters[0]?.comparator.split(' : ')[0];
-      const parsedDate = parseDttmToDate(date);
-      if (parsedDate) {
-        setFormatedFilterDate(moment(parseDttmToDate(date)));
-      } else {
-        fetchTimeRange(
-          currentTimeRangeFilters[0]?.comparator,
-          currentTimeRangeFilters[0]?.subject,
-        ).then(res => {
-          const datePattern = /\d{4}-\d{2}-\d{2}/g;
-          const dates = res?.value?.match(datePattern);
-          const [startDate, _] = dates ?? [];
-          setFormatedFilterDate(moment(parseDttmToDate(startDate)));
-        });
-      }
+      fetchTimeRange(
+        currentTimeRangeFilters[0]?.comparator,
+        currentTimeRangeFilters[0]?.subject,
+      ).then(res => {
+        const datePattern = /\d{4}-\d{2}-\d{2}/g;
+        const dates = res?.value?.match(datePattern);
+        const [startDate, endDate] = dates ?? [];
+        customTimeRange(`${startDate} : ${endDate}` ?? '');
+        setFormatedFilterDate(moment(parseDttmToDate(startDate)));
+      });
     } else {
       setCustomStartDateInFilter(undefined);
       setFormatedFilterDate(moment(parseDttmToDate('')));

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.tsx
@@ -34,6 +34,7 @@ import { useSelector } from 'react-redux';
 
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { RootState } from 'src/views/store';
+import { DEFAULT_DATE_PATTERN } from '@superset-ui/chart-controls';
 
 export interface TimeOffsetControlsProps {
   label?: ReactNode;
@@ -135,8 +136,7 @@ export default function TimeOffsetControls({
         currentTimeRangeFilters[0]?.comparator,
         currentTimeRangeFilters[0]?.subject,
       ).then(res => {
-        const datePattern = /\d{4}-\d{2}-\d{2}/g;
-        const dates = res?.value?.match(datePattern);
+        const dates = res?.value?.match(DEFAULT_DATE_PATTERN);
         const [startDate, endDate] = dates ?? [];
         customTimeRange(`${startDate} : ${endDate}` ?? '');
         setFormatedFilterDate(moment(parseDttmToDate(startDate)));

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -370,7 +370,7 @@ class QueryContextProcessor:
                 axis=1,
             )
 
-    def is_valid_date(self, date_string: str):
+    def is_valid_date(self, date_string: str) -> bool:
         try:
             # Attempt to parse the string as a date in the format YYYY-MM-DD
             datetime.strptime(date_string, "%Y-%m-%d")

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -494,9 +494,19 @@ class QueryContextProcessor:
                 if flt.get("col") != x_axis_label
             ]
 
+            # Inherit or custom start dates might compute the same offset but the response cannot be given
+            # using cached data unless you are using the same date of inherited range, that's why we
+            # set the cache cache using a custom key that includes the original offset and the computed offset
+            # for those two scenarios, the rest of the scenarios will use the original offset as cache key
+            cached_time_offset_key = (
+                offset if offset == original_offset else f"{offset}_{original_offset}"
+            )
+
             # `offset` is added to the hash function
             cache_key = self.query_cache_key(
-                query_object_clone, time_offset=offset, time_grain=time_grain
+                query_object_clone,
+                time_offset=cached_time_offset_key,
+                time_grain=time_grain,
             )
             cache = QueryCacheManager.get(
                 cache_key, CacheRegion.DATA, query_context.force

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 import copy
-from datetime import datetime
 import logging
 import re
+from datetime import datetime
 from typing import Any, cast, ClassVar, TYPE_CHECKING, TypedDict
 
 import numpy as np
@@ -379,7 +379,7 @@ class QueryContextProcessor:
             # If parsing fails, it's not a valid date in the format YYYY-MM-DD
             return False
 
-    def get_time_offset_for_custom_or_inherit(
+    def get_offset_custom_or_inherit(
         self,
         offset: str,
         outer_from_dttm: datetime,
@@ -444,7 +444,7 @@ class QueryContextProcessor:
                 #    }
                 original_offset = offset
                 if self.is_valid_date(offset) or offset == "inherit":
-                    offset = self.get_time_offset_for_custom_or_inherit(
+                    offset = self.get_offset_custom_or_inherit(
                         offset,
                         outer_from_dttm,
                         outer_to_dttm,


### PR DESCRIPTION
### SUMMARY
The time comparison feature that's being used in Table and Big Number charts does not support Human Readable dates and it's very limited on what date formats it  supports. 

Now the API supports sending `inherit` or a `YYYY-MM-DD` date as offset value so we can rely on the existing API to parse any date before computing the custom or inherit offset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="1670" alt="error" src="https://github.com/user-attachments/assets/96aa0f2a-94fd-4b9b-a4e3-6e9bb148263e">


Now
<img width="1670" alt="test" src="https://github.com/user-attachments/assets/ae3106b3-12bf-443a-b0d2-d732632f8319">


### TESTING INSTRUCTIONS
1. Set up a Table Chart with a date filter with value: `Aug 2024` until `tomorrow``
2. Select inherit time shift
3. The chart must display the correct data and the comparison label


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
