### PR TITLE
fix(translations): Fix language switching when default language is not English

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -26,7 +26,6 @@ import wtforms_json
 from deprecation import deprecated
 from flask import Flask, redirect
 from flask_appbuilder import expose, IndexView
-from flask_babel import gettext as __
 from flask_compress import Compress
 from flask_session import Session
 from werkzeug.middleware.proxy_fix import ProxyFix

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -230,7 +230,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         #
         appbuilder.add_link(
             "Home",
-            label=__("Home"),
+            label="Home",
             href="/superset/welcome/",
             cond=lambda: bool(appbuilder.app.config["LOGO_TARGET_PATH"]),
         )
@@ -238,15 +238,15 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             DatabaseView,
             "Databases",
-            label=__("Database Connections"),
+            label="Database Connections",
             icon="fa-database",
             category="Data",
-            category_label=__("Data"),
+            category_label="Data",
         )
         appbuilder.add_view(
             DashboardModelView,
             "Dashboards",
-            label=__("Dashboards"),
+            label="Dashboards",
             icon="fa-dashboard",
             category="",
             category_icon="",
@@ -254,7 +254,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             SliceModelView,
             "Charts",
-            label=__("Charts"),
+            label="Charts",
             icon="fa-bar-chart",
             category="",
             category_icon="",
@@ -262,7 +262,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         appbuilder.add_link(
             "Datasets",
-            label=__("Datasets"),
+            label="Datasets",
             href="/tablemodelview/list/",
             icon="fa-table",
             category="",
@@ -272,9 +272,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             DynamicPluginsView,
             "Plugins",
-            label=__("Plugins"),
+            label="Plugins",
             category="Manage",
-            category_label=__("Manage"),
+            category_label="Manage",
             icon="fa-puzzle-piece",
             menu_cond=lambda: feature_flag_manager.is_feature_enabled(
                 "DYNAMIC_PLUGINS"
@@ -283,10 +283,10 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             CssTemplateModelView,
             "CSS Templates",
-            label=__("CSS Templates"),
+            label="CSS Templates",
             icon="fa-css3",
             category="Manage",
-            category_label=__("Manage"),
+            category_label="Manage",
             category_icon="",
         )
 
@@ -322,34 +322,34 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         #
         appbuilder.add_link(
             "SQL Editor",
-            label=__("SQL Lab"),
+            label="SQL Lab",
             href="/sqllab/",
             category_icon="fa-flask",
             icon="fa-flask",
             category="SQL Lab",
-            category_label=__("SQL"),
+            category_label="SQL",
         )
         appbuilder.add_link(
             "Saved Queries",
-            label=__("Saved Queries"),
+            label="Saved Queries",
             href="/savedqueryview/list/",
             icon="fa-save",
             category="SQL Lab",
-            category_label=__("SQL"),
+            category_label="SQL",
         )
         appbuilder.add_link(
             "Query Search",
-            label=__("Query History"),
+            label="Query History",
             href="/sqllab/history/",
             icon="fa-search",
             category_icon="fa-flask",
             category="SQL Lab",
-            category_label=__("SQL Lab"),
+            category_label="SQL Lab",
         )
         appbuilder.add_view(
             TagModelView,
             "Tags",
-            label=__("Tags"),
+            label="Tags",
             icon="",
             category_icon="",
             category="Manage",
@@ -359,9 +359,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             LogModelView,
             "Action Log",
-            label=__("Action Log"),
+            label="Action Log",
             category="Security",
-            category_label=__("Security"),
+            category_label="Security",
             icon="fa-list-ol",
             menu_cond=lambda: (
                 self.config["FAB_ADD_SECURITY_VIEWS"]
@@ -376,9 +376,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             AlertView,
             "Alerts & Report",
-            label=__("Alerts & Reports"),
+            label="Alerts & Reports",
             category="Manage",
-            category_label=__("Manage"),
+            category_label="Manage",
             icon="fa-exclamation-triangle",
             menu_cond=lambda: feature_flag_manager.is_feature_enabled("ALERT_REPORTS"),
         )
@@ -386,21 +386,21 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view(
             AnnotationLayerView,
             "Annotation Layers",
-            label=__("Annotation Layers"),
+            label="Annotation Layers",
             href="/annotationlayer/list/",
             icon="fa-comment",
             category_icon="",
             category="Manage",
-            category_label=__("Manage"),
+            category_label="Manage",
         )
 
         appbuilder.add_view(
             RowLevelSecurityView,
             "Row Level Security",
             href="/rowlevelsecurity/list/",
-            label=__("Row Level Security"),
+            label="Row Level Security",
             category="Security",
-            category_label=__("Security"),
+            category_label="Security",
             icon="fa-lock",
         )
 


### PR DESCRIPTION
### SUMMARY
In Flask App Builder, menu translation is already integrated using the label field. However, in Apache Superset, during the initial setup, the label field was translated according to the default language. Upon switching to a different language, the system attempted to translate the already translated value. Since the translated key (in this case, Russian) did not exist in the dictionary, this caused an issue. Therefore, I removed the translation from the application initialization process.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screencastfrom26 08 2024211640-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/7c0614dc-2cbf-4eb3-a0c0-2c909c68d3af)
![Screencastfrom26 08 2024211805-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/ce76b0d8-42aa-486f-8bef-f3f7a80eaaeb)


### TESTING INSTRUCTIONS

1. Set BABEL_DEFAULT_LOCALE = "ru".
2. Start the application.
3. Switch the interface language to English.
4. Verify the translations.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #29882
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
