### PR TITLE
fix: pass if table is already removed on upgrade

### DIFF
--- a/superset/migrations/shared/constraints.py
+++ b/superset/migrations/shared/constraints.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from alembic import op
+from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
 from sqlalchemy.engine.reflection import Inspector
 
+from superset.migrations.shared.utils import has_table
 from superset.utils.core import generic_find_fk_constraint_name
 
 
@@ -75,13 +77,19 @@ def redefine(
 
 def drop_fks_for_table(table_name: str) -> None:
     """
-    Drop all foreign key constraints for a table.
+    Drop all foreign key constraints for a table if it exist and the database
+    is not sqlite.
 
     :param table_name: The table name to drop foreign key constraints for
     """
     connection = op.get_bind()
     inspector = Inspector.from_engine(connection)
-    foreign_keys = inspector.get_foreign_keys(table_name)
 
-    for fk in foreign_keys:
-        op.drop_constraint(fk["name"], table_name, type_="foreignkey")
+    if isinstance(connection.dialect, SQLiteDialect):
+        return  # sqlite doesn't like constraints
+
+    if has_table(table_name):
+        foreign_keys = inspector.get_foreign_keys(table_name)
+
+        for fk in foreign_keys:
+            op.drop_constraint(fk["name"], table_name, type_="foreignkey")

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -168,3 +168,18 @@ def try_load_json(data: Optional[str]) -> dict[str, Any]:
     except json.JSONDecodeError:
         print(f"Failed to parse: {data}")
         return {}
+
+
+def has_table(table_name: str) -> bool:
+    """
+    Check if a table exists in the database.
+
+    :param table_name: The table name
+    :returns: True if the table exists
+    """
+
+    insp = inspect(op.get_context().bind)
+    table_exists = insp.has_table(table_name)
+
+    print(f"Table {table_name} exist: {table_exists}")
+    return table_exists

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -181,5 +181,4 @@ def has_table(table_name: str) -> bool:
     insp = inspect(op.get_context().bind)
     table_exists = insp.has_table(table_name)
 
-    print(f"Table {table_name} exist: {table_exists}")
     return table_exists

--- a/superset/migrations/versions/2024-05-24_11-31_02f4f7811799_remove_sl_dataset_columns_table.py
+++ b/superset/migrations/versions/2024-05-24_11-31_02f4f7811799_remove_sl_dataset_columns_table.py
@@ -26,22 +26,24 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "02f4f7811799"
 down_revision = "f7b6750b67e8"
 
+table_name = "sl_dataset_columns"
+
 
 def upgrade():
-    connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_dataset_columns")
-    op.drop_table("sl_dataset_columns")
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():
     op.create_table(
-        "sl_dataset_columns",
+        table_name,
         sa.Column("dataset_id", sa.Integer(), nullable=False),
         sa.Column("column_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(

--- a/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
+++ b/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
@@ -34,9 +34,13 @@ down_revision = "02f4f7811799"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_table_columns")
-    op.drop_table("sl_table_columns")
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_table_columns")
+        op.drop_table("sl_table_columns")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
+++ b/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "39549add7bfc"
 down_revision = "02f4f7811799"
 
+table_name = "sl_table_columns"
+
 
 def upgrade():
-    table_name = "sl_table_columns"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_table_columns",
+        table_name,
         sa.Column("table_id", sa.Integer(), nullable=False),
         sa.Column("column_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(

--- a/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
+++ b/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "39549add7bfc"
@@ -33,14 +34,11 @@ down_revision = "02f4f7811799"
 
 
 def upgrade():
-    connection = op.get_bind()
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_table_columns")
-        op.drop_table("sl_table_columns")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    table_name = "sl_table_columns"
+
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
@@ -34,9 +34,14 @@ down_revision = "39549add7bfc"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_dataset_tables")
-    op.drop_table("sl_dataset_tables")
+
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_dataset_tables")
+        op.drop_table("sl_dataset_tables")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "38f4144e8558"
 down_revision = "39549add7bfc"
 
+table_name = "sl_dataset_tables"
+
 
 def upgrade():
-    table_name = "sl_dataset_tables"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_dataset_tables",
+        table_name,
         sa.Column("dataset_id", sa.Integer(), nullable=False),
         sa.Column("table_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(

--- a/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "38f4144e8558"
@@ -33,15 +34,11 @@ down_revision = "39549add7bfc"
 
 
 def upgrade():
-    connection = op.get_bind()
+    table_name = "sl_dataset_tables"
 
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_dataset_tables")
-        op.drop_table("sl_dataset_tables")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
+++ b/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "e53fd48cc078"
 down_revision = "38f4144e8558"
 
+table_name = "sl_dataset_users"
+
 
 def upgrade():
-    table_name = "sl_dataset_users"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_dataset_users",
+        table_name,
         sa.Column("dataset_id", sa.Integer(), nullable=False),
         sa.Column("user_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(

--- a/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
+++ b/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
@@ -34,9 +34,14 @@ down_revision = "38f4144e8558"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_dataset_users")
-    op.drop_table("sl_dataset_users")
+
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_dataset_users")
+        op.drop_table("sl_dataset_users")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
+++ b/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "e53fd48cc078"
@@ -33,15 +34,11 @@ down_revision = "38f4144e8558"
 
 
 def upgrade():
-    connection = op.get_bind()
+    table_name = "sl_dataset_users"
 
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_dataset_users")
-        op.drop_table("sl_dataset_users")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
+++ b/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "a6b32d2d07b1"
 down_revision = "e53fd48cc078"
 
+table_name = "sl_columns"
+
 
 def upgrade():
-    table_name = "sl_columns"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_columns",
+        table_name,
         sa.Column("uuid", sa.Numeric(precision=16), nullable=True),
         sa.Column("created_on", sa.DateTime(), nullable=True),
         sa.Column("changed_on", sa.DateTime(), nullable=True),

--- a/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
+++ b/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
@@ -34,9 +34,14 @@ down_revision = "e53fd48cc078"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_columns")
-    op.drop_table("sl_columns")
+
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_columns")
+        op.drop_table("sl_columns")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
+++ b/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "a6b32d2d07b1"
@@ -33,15 +34,11 @@ down_revision = "e53fd48cc078"
 
 
 def upgrade():
-    connection = op.get_bind()
+    table_name = "sl_columns"
 
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_columns")
-        op.drop_table("sl_columns")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
@@ -34,9 +34,14 @@ down_revision = "a6b32d2d07b1"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_tables")
-    op.drop_table("sl_tables")
+
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_tables")
+        op.drop_table("sl_tables")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "007a1abffe7e"
 down_revision = "a6b32d2d07b1"
 
+table_name = "sl_tables"
+
 
 def upgrade():
-    table_name = "sl_tables"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_tables",
+        table_name,
         sa.Column("uuid", sa.Numeric(precision=16), nullable=True),
         sa.Column("created_on", sa.DateTime(), nullable=True),
         sa.Column("changed_on", sa.DateTime(), nullable=True),

--- a/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "007a1abffe7e"
@@ -33,15 +34,11 @@ down_revision = "a6b32d2d07b1"
 
 
 def upgrade():
-    connection = op.get_bind()
+    table_name = "sl_tables"
 
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_tables")
-        op.drop_table("sl_tables")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
+++ b/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
@@ -32,10 +32,10 @@ from superset.migrations.shared.utils import has_table
 revision = "48cbb571fa3a"
 down_revision = "007a1abffe7e"
 
+table_name = "sl_datasets"
+
 
 def upgrade():
-    table_name = "sl_datasets"
-
     if has_table(table_name):
         drop_fks_for_table(table_name)
         op.drop_table(table_name)
@@ -43,7 +43,7 @@ def upgrade():
 
 def downgrade():
     op.create_table(
-        "sl_datasets",
+        table_name,
         sa.Column("uuid", sa.Numeric(precision=16), nullable=True),
         sa.Column("created_on", sa.DateTime(), nullable=True),
         sa.Column("changed_on", sa.DateTime(), nullable=True),

--- a/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
+++ b/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
@@ -34,9 +34,14 @@ down_revision = "007a1abffe7e"
 
 def upgrade():
     connection = op.get_bind()
-    if connection.dialect.name != "sqlite":
-        drop_fks_for_table("sl_datasets")
-    op.drop_table("sl_datasets")
+
+    try:
+        if connection.dialect.name != "sqlite":
+            drop_fks_for_table("sl_datasets")
+        op.drop_table("sl_datasets")
+    except sa.exc.NoSuchTableError:
+        # Table doesn't exist, so we can safely ignore this error
+        pass
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
+++ b/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from superset.migrations.shared.constraints import drop_fks_for_table
+from superset.migrations.shared.utils import has_table
 
 # revision identifiers, used by Alembic.
 revision = "48cbb571fa3a"
@@ -33,15 +34,11 @@ down_revision = "007a1abffe7e"
 
 
 def upgrade():
-    connection = op.get_bind()
+    table_name = "sl_datasets"
 
-    try:
-        if connection.dialect.name != "sqlite":
-            drop_fks_for_table("sl_datasets")
-        op.drop_table("sl_datasets")
-    except sa.exc.NoSuchTableError:
-        # Table doesn't exist, so we can safely ignore this error
-        pass
+    if has_table(table_name):
+        drop_fks_for_table(table_name)
+        op.drop_table(table_name)
 
 
 def downgrade():


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Looks like if you try to run the migrations but the sl_ tables don't already exist the migrations will fail. This will just pass the upgrade check if the table doesn't already exist.

* Added a `has_table` function to return a boolean if the table exist or not
* Updated `drop_fks_for_table` to handle sqlite in the function

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
