### PR TITLE
fix: Partition calls from Jinja context

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -34,6 +34,7 @@ from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.constants import LRU_CACHE_MAX_SIZE
 from superset.exceptions import SupersetTemplateException
 from superset.extensions import feature_flag_manager
+from superset.sql_parse import Table
 from superset.utils import json
 from superset.utils.core import (
     convert_legacy_filters_into_adhoc,
@@ -619,7 +620,7 @@ class PrestoTemplateProcessor(JinjaTemplateProcessor):
 
         table_name, schema = self._schema_table(table_name, self._schema)
         return cast(PrestoEngineSpec, self._database.db_engine_spec).latest_partition(
-            table_name, schema, self._database
+            database=self._database, table=Table(table_name, schema)
         )[1]
 
     def latest_sub_partition(self, table_name: str, **kwargs: Any) -> Any:
@@ -631,7 +632,7 @@ class PrestoTemplateProcessor(JinjaTemplateProcessor):
         return cast(
             PrestoEngineSpec, self._database.db_engine_spec
         ).latest_sub_partition(
-            table_name=table_name, schema=schema, database=self._database, **kwargs
+            database=self._database, table=Table(table_name, schema), **kwargs
         )
 
     latest_partition = first_latest_partition


### PR DESCRIPTION
### SUMMARY
In https://github.com/apache/superset/pull/28122, all methods that take a `table_name` and a `schema` were updated to received a `Table` instance. Unfortunately, the Jinja context calls to partition methods were not updated breaking the functionality. This PR fixes the problem by making the necessary changes.

It's not in the scope of this PR to potentially support catalogs, which was the reason for the Table instance changes but this might be needed. @betodealmeida 

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
