### PR TITLE
chore: accelerate docker compose by skipping frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and # limitations under the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 ######################################################################
@@ -25,6 +26,8 @@ FROM --platform=${BUILDPLATFORM} node:20-bullseye-slim AS superset-node
 
 ARG NPM_BUILD_CMD="build"
 
+# Used by docker-compose to skip the frontend build,
+# in dev we mount the repo and build the frontend inside docker
 ARG DEV_MODE="false"
 
 # Include headless browsers? Allows for alerts, reports & thumbnails, but bloats the images
@@ -47,13 +50,14 @@ RUN --mount=type=bind,target=/frontend-mem-nag.sh,src=./docker/frontend-mem-nag.
     /frontend-mem-nag.sh
 
 WORKDIR /app/superset-frontend
+# Creating empty folders to avoid errors when running COPY later on
 RUN mkdir -p /app/superset/static/assets && mkdir -p /app/superset/translations
 RUN --mount=type=bind,target=./package.json,src=./superset-frontend/package.json \
     --mount=type=bind,target=./package-lock.json,src=./superset-frontend/package-lock.json \
     if [ "$DEV_MODE" = "false" ]; then \
         npm ci; \
     else \
-        echo "Skipping npm ci in dev mode"; \
+        echo "Skipping 'npm ci' in dev mode"; \
     fi
 
 # Runs the webpack build process
@@ -61,7 +65,7 @@ COPY superset-frontend /app/superset-frontend
 RUN if [ "$DEV_MODE" = "false" ]; then \
         npm run ${BUILD_CMD}; \
     else \
-        echo "Skipping npm run ${BUILD_CMD} in dev mode"; \
+        echo "Skipping 'npm run ${BUILD_CMD}' in dev mode"; \
     fi
 
 # This copies the .po files needed for translation

--- a/RESOURCES/INTHEWILD.md
+++ b/RESOURCES/INTHEWILD.md
@@ -112,7 +112,7 @@ Join our growing community!
 - [Showmax](https://showmax.com) [@bobek]
 - [TechAudit](https://www.techaudit.info) [@ETselikov]
 - [Tenable](https://www.tenable.com) [@dflionis]
-- [Tentacle](https://tentaclecmi.com) [@jdclarke5]
+- [Tentacle](https://www.linkedin.com/company/tentacle-cmi/) [@jdclarke5]
 - [timbr.ai](https://timbr.ai/) [@semantiDan]
 - [Tobii](http://www.tobii.com/) [@dwa]
 - [Tooploox](https://www.tooploox.com/) [@jakubczaplicki]

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -59,6 +59,7 @@ assists people when migrating to a new version.
   as part of your bundling to expose translation packages, it's probably not needed anymore.
 - [29264](https://github.com/apache/superset/pull/29264) Slack has updated its file upload api, and we are now supporting this new api in Superset, although the Slack api is not backward compatible. The original Slack integration is deprecated and we will require a new Slack scope `channels:read` to be added to Slack workspaces in order to use this new api. In an upcoming release, we will make this new Slack scope mandatory and remove the old Slack functionality.
 - [29798](https://github.com/apache/superset/pull/29798) Since 3.1.0, the intial schedule for an alert or report was mistakenly offset by the specified timezone's relation to UTC. The initial schedule should now begin at the correct time.
+- [30021](https://github.com/apache/superset/pull/30021) The `dev` layer in our Dockerfile no long includes firefox binaries, only Chromium to reduce bloat/docker-build-time
 
 ### Potential Downtime
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ x-common-build: &common-build
   target: dev
   cache_from:
     - apache/superset-cache:3.10-slim-bookworm
+  args:
+    DEV_MODE: "true"
 
 services:
   nginx:

--- a/docs/docs/installation/docker-builds.mdx
+++ b/docs/docs/installation/docker-builds.mdx
@@ -52,10 +52,24 @@ without a build_preset are lean builds, e.g., `latest`.
   this specific SHA, which could be from a `master` merge, or release.
 - `websocket-latest`: The WebSocket image for use in a Superset cluster.
 
+
+
 For insights or modifications to the build matrix and tagging conventions,
 check the [build_docker.py](https://github.com/apache/superset/blob/master/scripts/build_docker.py)
 script and the [docker.yml](https://github.com/apache/superset/blob/master/.github/workflows/docker.yml)
 GitHub action.
+
+## Key ARGs in Dockerfile
+- `DEV_MODE`: whether to skip the frontend build, this is used by our `docker-compose` dev setup
+  where we mount the local volume and build using `webpack` in `--watch` mode, meaning as you
+  alter the code in the local file system, webpack, from within a docker image used for this
+  purpose, will constantly rebuild the frontend as you go. This ARG enables the initial
+  `docker-compose` build to take much less time and resources
+- `INCLUDE_CHROMIUM`: whether to include chromium in the backend build so that it can be
+  used as a headless browser for workloads related to "Alerts & Reports" and thumbnail generation
+- `INCLUDE_FIREFOX`: same as above, but for firefox
+- `PY_VER`: specifying the base image for the python backend, we don't recommend altering
+  this setting if you're not working on forwards or backwards compatibility
 
 ## Caching
 


### PR DESCRIPTION
while waiting for a `docker-compose build`, I decided to go and skip the long steps around the frontend buildsthat are not required while in dev mode while using  `docker-compose` where we mount the local repo and build it inside docker.

Note that it's always tricky to have conditional logic in docker files as things aren't procedural. I took the approach of using and `ARG` and having conditions in `RUN` commands which accomplishes the goal of skipping the frontend builds in DEV_MODE=true. 

changes:
    - skip `npm ci` when DEV_MODE=true
    - skip `npm run build` when DEV_MODE=true
    - introduce an ARG for INCLUDE_FIREFOX, skip by default
    - introduce an ARG for INCLUDE_CHROMIUM, include in `dev` layer by default - added a note in `UPDATING.md` even though people shouldn't really use the `dev` target from our Dockerfile.