### PR TITLE
fix(plugins): display correct tooltip (fixes #3342)

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-chord/src/Chord.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/src/Chord.js
@@ -130,9 +130,9 @@ function Chord(element, props) {
     .text(
       d =>
         `${nodes[d.source.index]} → ${nodes[d.target.index]}: ${f(
-          d.source.value,
-        )}\n${nodes[d.target.index]} → ${nodes[d.source.index]}: ${f(
           d.target.value,
+        )}\n${nodes[d.target.index]} → ${nodes[d.source.index]}: ${f(
+          d.source.value,
         )}`,
     );
 }


### PR DESCRIPTION
### SUMMARY
Fixes #3342
Display the correct tooltip information for chord charts (source and target values were switched)

### BEFORE
![image](https://github.com/user-attachments/assets/c187abea-de09-4161-b812-80c986de5ca4)

### AFTER
![image](https://github.com/user-attachments/assets/54b8ac49-5c42-437f-a228-12cb155cded4)


### TESTING INSTRUCTIONS
Example SQL Dataset:
```sql
SELECT 'Alice' AS source, 'Bob' AS target, 5 AS interactions UNION ALL
SELECT 'Alice', 'Charlie', 3 UNION ALL
SELECT 'Bob', 'Charlie', 2 UNION ALL
SELECT 'Charlie', 'David', 1  UNION ALL
SELECT 'Bob', 'David', 4
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #3342
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
