### PR TITLE
fix: Dashboard list row height does not match other lists

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -383,9 +383,6 @@ function DashboardList(props: DashboardListProps) {
         Header: t('Owners'),
         accessor: 'owners',
         disableSortBy: true,
-        cellProps: {
-          style: { padding: '0px' },
-        },
         size: 'xl',
       },
       {


### PR DESCRIPTION
### SUMMARY
Fixes the dashboard list row height to match the height of other lists. This problem was introduced by the [Slack Avatar integration](https://github.com/apache/superset/pull/27849).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
As we can see the row height is not the same between the dashboard and charts list which makes the avatars close to the row separator in the dashboard list.

<img width="1784" alt="Screenshot 2024-08-27 at 11 20 21" src="https://github.com/user-attachments/assets/13601c5d-f7d0-4b6d-b5ed-81c467cc4a59">
<img width="1768" alt="Screenshot 2024-08-27 at 11 20 35" src="https://github.com/user-attachments/assets/7d0afa8f-64bd-45d4-9413-b0621791af5c">

<br>After the fix, the dashboard list matches the layout of charts/datasets lists and there's a space between the avatars and row separators.

<img width="1783" alt="Screenshot 2024-08-27 at 11 21 47" src="https://github.com/user-attachments/assets/1ec09e1d-e6df-42b7-bb17-0a28cefa5d8d">

### TESTING INSTRUCTIONS
Check that the layout match between lists.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
