### PR TITLE
fix(migrations): Fix the time comparison migration

### DIFF
--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -65,16 +65,17 @@ time_map = {
 def upgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
     params = deepcopy(slice_params)
 
-    if "enable_time_comparison" in params:
-        # Remove enable_time_comparison
-        del params["enable_time_comparison"]
-
     # Update time_comparison to time_compare
     if "time_comparison" in params:
         time_comp = params.pop("time_comparison")
-        params["time_compare"] = time_map.get(
-            time_comp, "inherit"
-        )  # Default to 'inherit' if not found
+        params["time_compare"] = (
+            time_map.get(time_comp, "inherit")
+            if "enable_time_comparison" in params and params["enable_time_comparison"]
+            else ""
+        )
+
+    if "enable_time_comparison" in params:
+        del params["enable_time_comparison"]
 
     # Add comparison_type
     params["comparison_type"] = "values"
@@ -119,20 +120,19 @@ def upgrade():
 
 def downgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
     params = deepcopy(slice_params)
+    params["enable_time_comparison"] = False
 
     reverse_time_map = {
         v: k for k, v in time_map.items()
     }  # Reverse the map from the upgrade function
 
-    # Add enable_time_comparison
-    params["enable_time_comparison"] = True
-
     # Revert time_compare to time_comparison
     if "time_compare" in params:
         time_comp = params.pop("time_compare")
-        params["time_comparison"] = reverse_time_map.get(
-            time_comp, "r"
-        )  # Default to 'r' if not found
+        params["time_comparison"] = reverse_time_map.get(time_comp, "r")
+        # If the chart was using any time compare, enable time comparison
+        if time_comp:
+            params["enable_time_comparison"] = True
 
     # Remove comparison_type
     if "comparison_type" in params:

--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -69,9 +69,9 @@ def upgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
     if "time_comparison" in params:
         time_comp = params.pop("time_comparison")
         params["time_compare"] = (
-            time_map.get(time_comp, "inherit")
+            [time_map.get(time_comp, "inherit")]
             if "enable_time_comparison" in params and params["enable_time_comparison"]
-            else ""
+            else []
         )
 
     if "enable_time_comparison" in params:
@@ -129,6 +129,8 @@ def downgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
     # Revert time_compare to time_comparison
     if "time_compare" in params:
         time_comp = params.pop("time_compare")
+        # Max one element in the time_compare list
+        time_comp = time_comp[0] if time_comp else ""
         params["time_comparison"] = reverse_time_map.get(time_comp, "r")
         # If the chart was using any time compare, enable time comparison
         if time_comp:

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -83,7 +83,7 @@ base_params: dict[str, Any] = {
 }
 
 # Specific parameter objects overriding only the differing properties
-params_v1_with_custom = {
+params_v1_with_custom: dict[str, Any] = {
     **base_params,
     "metric": {
         **base_params["metric"],
@@ -113,7 +113,7 @@ params_v1_with_custom = {
     ],
 }
 
-params_v1_other_than_custom = {
+params_v1_other_than_custom: dict[str, Any] = {
     **base_params,
     "metric": {
         **base_params["metric"],
@@ -132,12 +132,12 @@ params_v1_other_than_custom = {
     ],
 }
 
-params_v1_other_than_custom_false = {
+params_v1_other_than_custom_false: dict[str, Any] = {
     **params_v1_other_than_custom,
     "enable_time_comparison": False,
 }
 
-params_v2_with_custom = {
+params_v2_with_custom: dict[str, Any] = {
     **base_params,
     "metric": {
         **base_params["metric"],
@@ -155,7 +155,7 @@ params_v2_with_custom = {
     "start_date_offset": "1981-01-01",
 }
 
-params_v2_other_than_custom = {
+params_v2_other_than_custom: dict[str, Any] = {
     **base_params,
     "metric": {
         **base_params["metric"],
@@ -165,7 +165,7 @@ params_v2_other_than_custom = {
     "comparison_type": "values",
 }
 
-params_v2_other_than_custom_false = {
+params_v2_other_than_custom_false: dict[str, Any] = {
     **params_v2_other_than_custom,
     "time_compare": [],
 }

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -277,7 +277,7 @@ params_v2_with_custom: dict[str, Any] = {
     "comparison_color_scheme": "Green",
     "extra_form_data": {},
     "dashboards": [],
-    "time_compare": "custom",
+    "time_compare": ["custom"],
     "comparison_type": "values",
     "start_date_offset": "1981-01-01",
 }
@@ -333,7 +333,7 @@ params_v2_other_than_custom: dict[str, Any] = {
     "comparison_color_scheme": "Green",
     "extra_form_data": {},
     "dashboards": [],
-    "time_compare": "inherit",
+    "time_compare": ["inherit"],
     "comparison_type": "values",
 }
 params_v2_other_than_custom_false: dict[str, Any] = {
@@ -388,7 +388,7 @@ params_v2_other_than_custom_false: dict[str, Any] = {
     "comparison_color_scheme": "Green",
     "extra_form_data": {},
     "dashboards": [],
-    "time_compare": "",
+    "time_compare": [],
     "comparison_type": "values",
 }
 

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -161,6 +161,70 @@ params_v1_other_than_custom: dict[str, Any] = {
         }
     ],
 }
+params_v1_other_than_custom_false: dict[str, Any] = {
+    "datasource": "2__table",
+    "viz_type": "pop_kpi",
+    "metric": {
+        "expressionType": "SIMPLE",
+        "column": {
+            "advanced_data_type": None,
+            "certification_details": None,
+            "certified_by": None,
+            "column_name": "num_boys",
+            "description": None,
+            "expression": None,
+            "filterable": True,
+            "groupby": True,
+            "id": 334,
+            "is_certified": False,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "BIGINT",
+            "type_generic": 0,
+            "verbose_name": None,
+            "warning_markdown": None,
+        },
+        "aggregate": "SUM",
+        "sqlExpression": None,
+        "datasourceWarning": False,
+        "hasCustomLabel": False,
+        "label": "SUM(num_boys)",
+        "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
+    },
+    "adhoc_filters": [
+        {
+            "expressionType": "SIMPLE",
+            "subject": "ds",
+            "operator": "TEMPORAL_RANGE",
+            "comparator": "1984 : 2000",
+            "clause": "WHERE",
+            "sqlExpression": None,
+            "isExtra": False,
+            "isNew": False,
+            "datasourceWarning": False,
+            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
+        }
+    ],
+    "row_limit": 10000,
+    "y_axis_format": "SMART_NUMBER",
+    "percentDifferenceFormat": "SMART_NUMBER",
+    "header_font_size": 0.2,
+    "subheader_font_size": 0.125,
+    "comparison_color_scheme": "Green",
+    "extra_form_data": {},
+    "dashboards": [],
+    "time_comparison": "r",
+    "enable_time_comparison": False,
+    "adhoc_custom": [
+        {
+            "clause": "WHERE",
+            "subject": "ds",
+            "operator": "TEMPORAL_RANGE",
+            "comparator": "No filter",
+            "expressionType": "SIMPLE",
+        }
+    ],
+}
 params_v2_with_custom: dict[str, Any] = {
     "datasource": "2__table",
     "viz_type": "pop_kpi",
@@ -272,6 +336,61 @@ params_v2_other_than_custom: dict[str, Any] = {
     "time_compare": "inherit",
     "comparison_type": "values",
 }
+params_v2_other_than_custom_false: dict[str, Any] = {
+    "datasource": "2__table",
+    "viz_type": "pop_kpi",
+    "metric": {
+        "expressionType": "SIMPLE",
+        "column": {
+            "advanced_data_type": None,
+            "certification_details": None,
+            "certified_by": None,
+            "column_name": "num_boys",
+            "description": None,
+            "expression": None,
+            "filterable": True,
+            "groupby": True,
+            "id": 334,
+            "is_certified": False,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "BIGINT",
+            "type_generic": 0,
+            "verbose_name": None,
+            "warning_markdown": None,
+        },
+        "aggregate": "SUM",
+        "sqlExpression": None,
+        "datasourceWarning": False,
+        "hasCustomLabel": False,
+        "label": "SUM(num_boys)",
+        "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
+    },
+    "adhoc_filters": [
+        {
+            "expressionType": "SIMPLE",
+            "subject": "ds",
+            "operator": "TEMPORAL_RANGE",
+            "comparator": "1984 : 2000",
+            "clause": "WHERE",
+            "sqlExpression": None,
+            "isExtra": False,
+            "isNew": False,
+            "datasourceWarning": False,
+            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
+        }
+    ],
+    "row_limit": 10000,
+    "y_axis_format": "SMART_NUMBER",
+    "percentDifferenceFormat": "SMART_NUMBER",
+    "header_font_size": 0.2,
+    "subheader_font_size": 0.125,
+    "comparison_color_scheme": "Green",
+    "extra_form_data": {},
+    "dashboards": [],
+    "time_compare": "",
+    "comparison_type": "values",
+}
 
 
 def test_upgrade_chart_params_with_custom():
@@ -313,3 +432,22 @@ def test_downgrade_chart_params_other_than_custom():
     original_params = deepcopy(params_v2_other_than_custom)
     downgraded_params = downgrade_comparison_params(original_params)
     assert downgraded_params == params_v1_other_than_custom
+
+
+def test_upgrade_chart_params_other_than_custom_false():
+    """
+    ensure that the new time comparison params are added
+    """
+    original_params = deepcopy(params_v1_other_than_custom_false)
+    upgraded_params = upgrade_comparison_params(original_params)
+    assert upgraded_params == params_v2_other_than_custom_false
+
+
+def test_downgrade_chart_params_other_than_custom_false():
+    """
+    ensure that the params downgrade operation produces an almost identical dict
+    as the original value
+    """
+    original_params = deepcopy(params_v2_other_than_custom_false)
+    downgraded_params = downgrade_comparison_params(original_params)
+    assert downgraded_params == params_v1_other_than_custom_false

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -29,7 +29,8 @@ upgrade_comparison_params = (
     migrate_time_comparison_to_new_format.upgrade_comparison_params
 )
 
-params_v1_with_custom: dict[str, Any] = {
+# Base object containing common properties
+base_params: dict[str, Any] = {
     "datasource": "2__table",
     "viz_type": "pop_kpi",
     "metric": {
@@ -57,20 +58,18 @@ params_v1_with_custom: dict[str, Any] = {
         "datasourceWarning": False,
         "hasCustomLabel": False,
         "label": "SUM(num_boys)",
-        "optionName": "metric_o6rj1h6jty_3t6mrruogfv",
     },
     "adhoc_filters": [
         {
             "expressionType": "SIMPLE",
             "subject": "ds",
             "operator": "TEMPORAL_RANGE",
-            "comparator": "1984 : 1986",
+            "comparator": "1984 : 2000",
             "clause": "WHERE",
             "sqlExpression": None,
             "isExtra": False,
             "isNew": False,
             "datasourceWarning": False,
-            "filterOptionName": "filter_p50i4xw50d_8x8e4ypwjs8",
         }
     ],
     "row_limit": 10000,
@@ -81,6 +80,22 @@ params_v1_with_custom: dict[str, Any] = {
     "comparison_color_scheme": "Green",
     "extra_form_data": {},
     "dashboards": [],
+}
+
+# Specific parameter objects overriding only the differing properties
+params_v1_with_custom = {
+    **base_params,
+    "metric": {
+        **base_params["metric"],
+        "optionName": "metric_o6rj1h6jty_3t6mrruogfv",
+    },
+    "adhoc_filters": [
+        {
+            **base_params["adhoc_filters"][0],
+            "comparator": "1984 : 1986",
+            "filterOptionName": "filter_p50i4xw50d_8x8e4ypwjs8",
+        }
+    ],
     "time_comparison": "c",
     "enable_time_comparison": True,
     "adhoc_custom": [
@@ -97,58 +112,13 @@ params_v1_with_custom: dict[str, Any] = {
         }
     ],
 }
-params_v1_other_than_custom: dict[str, Any] = {
-    "datasource": "2__table",
-    "viz_type": "pop_kpi",
+
+params_v1_other_than_custom = {
+    **base_params,
     "metric": {
-        "expressionType": "SIMPLE",
-        "column": {
-            "advanced_data_type": None,
-            "certification_details": None,
-            "certified_by": None,
-            "column_name": "num_boys",
-            "description": None,
-            "expression": None,
-            "filterable": True,
-            "groupby": True,
-            "id": 334,
-            "is_certified": False,
-            "is_dttm": False,
-            "python_date_format": None,
-            "type": "BIGINT",
-            "type_generic": 0,
-            "verbose_name": None,
-            "warning_markdown": None,
-        },
-        "aggregate": "SUM",
-        "sqlExpression": None,
-        "datasourceWarning": False,
-        "hasCustomLabel": False,
-        "label": "SUM(num_boys)",
+        **base_params["metric"],
         "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
     },
-    "adhoc_filters": [
-        {
-            "expressionType": "SIMPLE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
-            "comparator": "1984 : 2000",
-            "clause": "WHERE",
-            "sqlExpression": None,
-            "isExtra": False,
-            "isNew": False,
-            "datasourceWarning": False,
-            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
-        }
-    ],
-    "row_limit": 10000,
-    "y_axis_format": "SMART_NUMBER",
-    "percentDifferenceFormat": "SMART_NUMBER",
-    "header_font_size": 0.2,
-    "subheader_font_size": 0.125,
-    "comparison_color_scheme": "Green",
-    "extra_form_data": {},
-    "dashboards": [],
     "time_comparison": "r",
     "enable_time_comparison": True,
     "adhoc_custom": [
@@ -161,235 +131,43 @@ params_v1_other_than_custom: dict[str, Any] = {
         }
     ],
 }
-params_v1_other_than_custom_false: dict[str, Any] = {
-    "datasource": "2__table",
-    "viz_type": "pop_kpi",
-    "metric": {
-        "expressionType": "SIMPLE",
-        "column": {
-            "advanced_data_type": None,
-            "certification_details": None,
-            "certified_by": None,
-            "column_name": "num_boys",
-            "description": None,
-            "expression": None,
-            "filterable": True,
-            "groupby": True,
-            "id": 334,
-            "is_certified": False,
-            "is_dttm": False,
-            "python_date_format": None,
-            "type": "BIGINT",
-            "type_generic": 0,
-            "verbose_name": None,
-            "warning_markdown": None,
-        },
-        "aggregate": "SUM",
-        "sqlExpression": None,
-        "datasourceWarning": False,
-        "hasCustomLabel": False,
-        "label": "SUM(num_boys)",
-        "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
-    },
-    "adhoc_filters": [
-        {
-            "expressionType": "SIMPLE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
-            "comparator": "1984 : 2000",
-            "clause": "WHERE",
-            "sqlExpression": None,
-            "isExtra": False,
-            "isNew": False,
-            "datasourceWarning": False,
-            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
-        }
-    ],
-    "row_limit": 10000,
-    "y_axis_format": "SMART_NUMBER",
-    "percentDifferenceFormat": "SMART_NUMBER",
-    "header_font_size": 0.2,
-    "subheader_font_size": 0.125,
-    "comparison_color_scheme": "Green",
-    "extra_form_data": {},
-    "dashboards": [],
-    "time_comparison": "r",
+
+params_v1_other_than_custom_false = {
+    **params_v1_other_than_custom,
     "enable_time_comparison": False,
-    "adhoc_custom": [
-        {
-            "clause": "WHERE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
-            "comparator": "No filter",
-            "expressionType": "SIMPLE",
-        }
-    ],
 }
-params_v2_with_custom: dict[str, Any] = {
-    "datasource": "2__table",
-    "viz_type": "pop_kpi",
+
+params_v2_with_custom = {
+    **base_params,
     "metric": {
-        "expressionType": "SIMPLE",
-        "column": {
-            "advanced_data_type": None,
-            "certification_details": None,
-            "certified_by": None,
-            "column_name": "num_boys",
-            "description": None,
-            "expression": None,
-            "filterable": True,
-            "groupby": True,
-            "id": 334,
-            "is_certified": False,
-            "is_dttm": False,
-            "python_date_format": None,
-            "type": "BIGINT",
-            "type_generic": 0,
-            "verbose_name": None,
-            "warning_markdown": None,
-        },
-        "aggregate": "SUM",
-        "sqlExpression": None,
-        "datasourceWarning": False,
-        "hasCustomLabel": False,
-        "label": "SUM(num_boys)",
+        **base_params["metric"],
         "optionName": "metric_o6rj1h6jty_3t6mrruogfv",
     },
     "adhoc_filters": [
         {
-            "expressionType": "SIMPLE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
+            **base_params["adhoc_filters"][0],
             "comparator": "1984 : 1986",
-            "clause": "WHERE",
-            "sqlExpression": None,
-            "isExtra": False,
-            "isNew": False,
-            "datasourceWarning": False,
             "filterOptionName": "filter_p50i4xw50d_8x8e4ypwjs8",
         }
     ],
-    "row_limit": 10000,
-    "y_axis_format": "SMART_NUMBER",
-    "percentDifferenceFormat": "SMART_NUMBER",
-    "header_font_size": 0.2,
-    "subheader_font_size": 0.125,
-    "comparison_color_scheme": "Green",
-    "extra_form_data": {},
-    "dashboards": [],
     "time_compare": ["custom"],
     "comparison_type": "values",
     "start_date_offset": "1981-01-01",
 }
-params_v2_other_than_custom: dict[str, Any] = {
-    "datasource": "2__table",
-    "viz_type": "pop_kpi",
+
+params_v2_other_than_custom = {
+    **base_params,
     "metric": {
-        "expressionType": "SIMPLE",
-        "column": {
-            "advanced_data_type": None,
-            "certification_details": None,
-            "certified_by": None,
-            "column_name": "num_boys",
-            "description": None,
-            "expression": None,
-            "filterable": True,
-            "groupby": True,
-            "id": 334,
-            "is_certified": False,
-            "is_dttm": False,
-            "python_date_format": None,
-            "type": "BIGINT",
-            "type_generic": 0,
-            "verbose_name": None,
-            "warning_markdown": None,
-        },
-        "aggregate": "SUM",
-        "sqlExpression": None,
-        "datasourceWarning": False,
-        "hasCustomLabel": False,
-        "label": "SUM(num_boys)",
+        **base_params["metric"],
         "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
     },
-    "adhoc_filters": [
-        {
-            "expressionType": "SIMPLE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
-            "comparator": "1984 : 2000",
-            "clause": "WHERE",
-            "sqlExpression": None,
-            "isExtra": False,
-            "isNew": False,
-            "datasourceWarning": False,
-            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
-        }
-    ],
-    "row_limit": 10000,
-    "y_axis_format": "SMART_NUMBER",
-    "percentDifferenceFormat": "SMART_NUMBER",
-    "header_font_size": 0.2,
-    "subheader_font_size": 0.125,
-    "comparison_color_scheme": "Green",
-    "extra_form_data": {},
-    "dashboards": [],
     "time_compare": ["inherit"],
     "comparison_type": "values",
 }
-params_v2_other_than_custom_false: dict[str, Any] = {
-    "datasource": "2__table",
-    "viz_type": "pop_kpi",
-    "metric": {
-        "expressionType": "SIMPLE",
-        "column": {
-            "advanced_data_type": None,
-            "certification_details": None,
-            "certified_by": None,
-            "column_name": "num_boys",
-            "description": None,
-            "expression": None,
-            "filterable": True,
-            "groupby": True,
-            "id": 334,
-            "is_certified": False,
-            "is_dttm": False,
-            "python_date_format": None,
-            "type": "BIGINT",
-            "type_generic": 0,
-            "verbose_name": None,
-            "warning_markdown": None,
-        },
-        "aggregate": "SUM",
-        "sqlExpression": None,
-        "datasourceWarning": False,
-        "hasCustomLabel": False,
-        "label": "SUM(num_boys)",
-        "optionName": "metric_96s7b8iypsr_4wrlgm0i7il",
-    },
-    "adhoc_filters": [
-        {
-            "expressionType": "SIMPLE",
-            "subject": "ds",
-            "operator": "TEMPORAL_RANGE",
-            "comparator": "1984 : 2000",
-            "clause": "WHERE",
-            "sqlExpression": None,
-            "isExtra": False,
-            "isNew": False,
-            "datasourceWarning": False,
-            "filterOptionName": "filter_2sefqq1rwb7_lhqvw7ukc6",
-        }
-    ],
-    "row_limit": 10000,
-    "y_axis_format": "SMART_NUMBER",
-    "percentDifferenceFormat": "SMART_NUMBER",
-    "header_font_size": 0.2,
-    "subheader_font_size": 0.125,
-    "comparison_color_scheme": "Green",
-    "extra_form_data": {},
-    "dashboards": [],
+
+params_v2_other_than_custom_false = {
+    **params_v2_other_than_custom,
     "time_compare": [],
-    "comparison_type": "values",
 }
 
 


### PR DESCRIPTION
### SUMMARY
After the initial version of the time comparison feature for Table and Big Number  we introduced a migration to upgrade old charts to the new comparison controls, however, during that upgrade a table that never had comparison in it was wrongly showing Time Comparison Data.

This PR is fixing the migration so we can properly upgrade such old tables if needed, also we extend our tests to not only consider charts that have the enabled_time_comparison flag set to True.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### BEFORE
Old version of Chart using Time Comparison once but then removing it from the controls:
<img width="1911" alt="initial" src="https://github.com/user-attachments/assets/7d82c73d-3160-4bc4-983e-9a172bb8bcd6">
<img width="1911" alt="removed" src="https://github.com/user-attachments/assets/2eb46f63-f52b-4093-adec-01e20ea0e546">

The old Chart is upgraded with the previous version of the migration:
<img width="906" alt="upgrade" src="https://github.com/user-attachments/assets/04ef8887-f66e-4448-a31f-74036a2ee826">

The chart start showing comparison data:
<img width="1889" alt="wrong" src="https://github.com/user-attachments/assets/c125abcf-b47a-4e40-98b4-d37591b24add">

### AFTER
Old version of Chart using Time Comparison once but then removing it from the controls:
<img width="1889" alt="v2_initial" src="https://github.com/user-attachments/assets/81658fbd-d6f2-430c-ad96-9e67794757bf">
<img width="1889" alt="v2_no_comp" src="https://github.com/user-attachments/assets/123fbfc8-4b08-48c2-8043-8851afd13272">


The old Chart is upgraded with the new version of the migration:
<img width="921" alt="v2_upgrade" src="https://github.com/user-attachments/assets/1cce877f-6b0b-489f-b8ef-d88dedaccf30">


The chart doesn't show comparison data:
<img width="1884" alt="correct" src="https://github.com/user-attachments/assets/d9a081fb-7eee-485a-84e6-54e707440db7">





### TESTING INSTRUCTIONS
1. Create a table chart with a version of the time comparison where Enable Time Comparison checkbox was used
2. Run a comparison data (Mark the checkbox and select a time range)
3. Unmark the checkbox and run the chart data again so your chart has no longer comparison info
4. Use more updated version and run the migrations so your table is upgraded
5. You must not see time comparison data in the table.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
