### PR TITLE
fix: use StrEnum type for GuestTokenResourceType to fix token parsing

### DIFF
--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -14,19 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import sys
-from enum import Enum
 from typing import Optional, TypedDict, Union
 
 from flask_appbuilder.security.sqla.models import Role
 from flask_login import AnonymousUserMixin
 
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    # Define StrEnum for Python 3.10 and earlier
-    class StrEnum(str, Enum):
-        pass
+from superset.utils.backports import StrEnum
 
 
 class GuestTokenUser(TypedDict, total=False):

--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -14,11 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from enum import StrEnum
+import sys
+from enum import Enum
 from typing import Optional, TypedDict, Union
 
 from flask_appbuilder.security.sqla.models import Role
 from flask_login import AnonymousUserMixin
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    # Define StrEnum for Python 3.10 and earlier
+    class StrEnum(str, Enum):
+        pass
 
 
 class GuestTokenUser(TypedDict, total=False):

--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from enum import Enum
+from enum import StrEnum
 from typing import Optional, TypedDict, Union
 
 from flask_appbuilder.security.sqla.models import Role
@@ -27,7 +27,7 @@ class GuestTokenUser(TypedDict, total=False):
     last_name: str
 
 
-class GuestTokenResourceType(Enum):
+class GuestTokenResourceType(StrEnum):
     DASHBOARD = "dashboard"
 
 


### PR DESCRIPTION
### SUMMARY
This change is to fix the "incorrect" check results from comparing the `guest_token` claims with the enum value. By changing the type to be `StrEnum`, the str based comparison will output the desired results.

Additional context: guest user jwt token claims are casted to the `GuestToken` type [here](https://github.com/apache/superset/blob/75c500c9a53ce503b8636761f17b5b63eb8ee8e2/superset/security/manager.py#L2614).


### TESTING INSTRUCTIONS
Manual check before / after
```
>>> 'dashboard' == GuestTokenResourceType.DASHBOARD
False
```
```
>>> 'dashboard' == GuestTokenResourceType.DASHBOARD
True
```

and CI checks.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
