### PR TITLE
docs: improve documentation(docs): clarify URL encoding requirement for connection strings

### DIFF
--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -1287,6 +1287,13 @@ The connection string for SQL Server looks like this:
 mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BServer%3Dtcp%3A%3Cmy_server%3E%2C1433%3BDatabase%3Dmy_database%3BUid%3Dmy_user_name%3BPwd%3Dmy_password%3BEncrypt%3Dyes%3BConnection+Timeout%3D30
 ```
 
+:::note
+You'all might have noticed that some special form of charecters are used in above connection string. For example see the `odbc_connect` parameter, the value is `Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3B` which is URL encoded form of `Driver={ODBC+Driver+17+for+SQL+Server};`. It's important to give the connection string as URL encoded format.
+
+For more information about this check the [sqlalchemy documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords). Which says `When constructing a fully formed URL string to pass to create_engine(), special characters such as those that may be used in the user and password need to be URL encoded to be parsed correctly.. This includes the @ sign.`
+:::
+
+
 #### StarRocks
 
 The [sqlalchemy-starrocks](https://pypi.org/project/starrocks/) library is the recommended

--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -1288,9 +1288,9 @@ mssql+pyodbc:///?odbc_connect=Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3BSer
 ```
 
 :::note
-You'all might have noticed that some special form of charecters are used in above connection string. For example see the `odbc_connect` parameter, the value is `Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3B` which is URL encoded form of `Driver={ODBC+Driver+17+for+SQL+Server};`. It's important to give the connection string as URL encoded format.
+You might have noticed that some special charecters are used in the above connection string. For example see the `odbc_connect` parameter. The value is `Driver%3D%7BODBC+Driver+17+for+SQL+Server%7D%3B` which is a URL-encoded form of `Driver={ODBC+Driver+17+for+SQL+Server};`. It's important to give the connection string is URL encoded.
 
-For more information about this check the [sqlalchemy documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords). Which says `When constructing a fully formed URL string to pass to create_engine(), special characters such as those that may be used in the user and password need to be URL encoded to be parsed correctly.. This includes the @ sign.`
+For more information about this check the [sqlalchemy documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords). Which says `When constructing a fully formed URL string to pass to create_engine(), special characters such as those that may be used in the user and password need to be URL encoded to be parsed correctly. This includes the @ sign.`
 :::
 
 


### PR DESCRIPTION
### SUMMARY
Enhance the documentation of the connection string used in the backend of Superset by adding additional information for improved understanding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
|State|Image|
|-------|------|
|Before|![msedge_y1qctZf1yH](https://github.com/user-attachments/assets/fc178fb4-d9de-44f3-a396-2d641ef4636d)|
|After|![image](https://github.com/user-attachments/assets/12779ac9-da58-482f-99d3-75ec9d36d9bb)|

### TESTING INSTRUCTIONS
1. Start the documentation site following these [instructions](https://superset.apache.org/docs/contributing/howtos#local-development).
2. Navigate to the `SQL Server` section on `Connecting to Databases` page (`/docs/configuration/databases#sql-server`).
3. Verify that the additional notes information is present and accurate.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

See more discussions on this issue #29979