### PR TITLE
fix(time_range): None time range should equal No filter

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -180,7 +180,7 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     _relative_start = relative_start if relative_start else "today"
     _relative_end = relative_end if relative_end else "today"
 
-    if time_range == NO_TIME_RANGE or time_range == _(NO_TIME_RANGE):
+    if not time_range or time_range == NO_TIME_RANGE or time_range == _(NO_TIME_RANGE):
         return None, None
 
     if time_range and time_range.startswith("Last") and separator not in time_range:

--- a/tests/unit_tests/common/test_time_range_utils.py
+++ b/tests/unit_tests/common/test_time_range_utils.py
@@ -26,6 +26,7 @@ from superset.common.utils.time_range_utils import (
 
 
 def test__get_since_until_from_time_range():
+    assert get_since_until_from_time_range(time_range=None) == (None, None)
     assert get_since_until_from_time_range(time_range="2001 : 2002") == (
         datetime(2001, 1, 1),
         datetime(2002, 1, 1),


### PR DESCRIPTION
### SUMMARY
While working on a Jinja time filtering feature, I noticed a curious quirk in how `get_since_until_from_time_range` works:
- When `time_range="No filter"` it returns `(None, None)` for `since` and `until` respectively
- For `time_range=None` it returns `(None, datetime(current_date))`

I don't see any reason for this, and can only assume it's a quirk of how the complex function works for other more intricate time ranges. Therefore, I feel it prudent to change the behavior, so that `None` and `"No filter"` both returns the same value.

Let's see if this change breaks some tests - if not, I can only assume this isn't intended, but rather an artifact of the current logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
