### PR TITLE
feat: allow create/update OAuth2 DB

### DIFF
--- a/superset/commands/database/create.py
+++ b/superset/commands/database/create.py
@@ -42,7 +42,7 @@ from superset.commands.database.test_connection import TestConnectionDatabaseCom
 from superset.daos.database import DatabaseDAO
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.db_engine_specs.base import GenericDBException
-from superset.exceptions import SupersetErrorsException
+from superset.exceptions import OAuth2RedirectError, SupersetErrorsException
 from superset.extensions import event_logger, security_manager
 from superset.models.core import Database
 from superset.utils.decorators import on_error, transaction
@@ -62,6 +62,11 @@ class CreateDatabaseCommand(BaseCommand):
         try:
             # Test connection before starting create transaction
             TestConnectionDatabaseCommand(self._properties).run()
+        except OAuth2RedirectError:
+            # If we can't connect to the database due to an OAuth2 error we can still
+            # save the database. Later, the user can sync permissions when setting up
+            # data access rules.
+            return self._create_database()
         except (
             SupersetErrorsException,
             SSHTunnelingNotEnabledError,
@@ -79,12 +84,6 @@ class CreateDatabaseCommand(BaseCommand):
                 engine=self._properties.get("sqlalchemy_uri", "").split(":")[0],
             )
             raise DatabaseConnectionFailedError() from ex
-
-        # when creating a new database we don't need to unmask encrypted extra
-        self._properties["encrypted_extra"] = self._properties.pop(
-            "masked_encrypted_extra",
-            "{}",
-        )
 
         ssh_tunnel: Optional[SSHTunnel] = None
 
@@ -195,6 +194,12 @@ class CreateDatabaseCommand(BaseCommand):
             raise exception
 
     def _create_database(self) -> Database:
+        # when creating a new database we don't need to unmask encrypted extra
+        self._properties["encrypted_extra"] = self._properties.pop(
+            "masked_encrypted_extra",
+            "{}",
+        )
+
         database = DatabaseDAO.create(attributes=self._properties)
         database.set_sqlalchemy_uri(database.sqlalchemy_uri)
         return database

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -429,8 +429,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # the user impersonation methods to handle personal tokens.
     supports_oauth2 = False
     oauth2_scope = ""
-    oauth2_authorization_request_uri = ""  # pylint: disable=invalid-name
-    oauth2_token_request_uri = ""
+    oauth2_authorization_request_uri: str | None = None  # pylint: disable=invalid-name
+    oauth2_token_request_uri: str | None = None
 
     # Driver-specific exception that should be mapped to OAuth2RedirectError
     oauth2_exception = OAuth2RedirectError

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -329,6 +329,8 @@ class OAuth2RedirectError(SupersetErrorException):
 
     See the `OAuth2RedirectMessage.tsx` component for more details of how this
     information is handled.
+
+    TODO (betodealmeida): change status to 403.
     """
 
     def __init__(self, url: str, tab_id: str, redirect_uri: str):

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3255,6 +3255,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": True,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
                 {
                     "available_drivers": ["bigquery"],
@@ -3279,6 +3280,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": True,
                         "disable_ssh_tunneling": True,
                     },
+                    "supports_oauth2": False,
                 },
                 {
                     "available_drivers": ["psycopg2"],
@@ -3335,6 +3337,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
                 {
                     "available_drivers": ["apsw"],
@@ -3359,6 +3362,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": True,
                     },
+                    "supports_oauth2": True,
                 },
                 {
                     "available_drivers": ["mysqlconnector", "mysqldb"],
@@ -3415,6 +3419,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
                 {
                     "available_drivers": [""],
@@ -3427,6 +3432,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
             ]
         }
@@ -3460,6 +3466,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
                 {
                     "available_drivers": [""],
@@ -3472,6 +3479,7 @@ class TestDatabaseApi(SupersetTestCase):
                         "supports_dynamic_catalog": False,
                         "disable_ssh_tunneling": False,
                     },
+                    "supports_oauth2": False,
                 },
             ]
         }

--- a/tests/unit_tests/commands/databases/test_connection_test.py
+++ b/tests/unit_tests/commands/databases/test_connection_test.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.commands.database.test_connection import TestConnectionDatabaseCommand
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import OAuth2RedirectError
+
+
+def test_command(mocker: MockerFixture) -> None:
+    """
+    Test the happy path of the command.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    database.db_engine_spec.__name__ = "GSheetsEngineSpec"
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.return_value = True
+
+    DatabaseDAO = mocker.patch("superset.commands.database.test_connection.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "sqlalchemy_uri": "gsheets://",
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = TestConnectionDatabaseCommand(properties)
+    command.run()
+
+
+def test_command_with_oauth2(mocker: MockerFixture) -> None:
+    """
+    Test the command when OAuth2 is needed.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    database.is_oauth2_enabled.return_value = True
+    database.db_engine_spec.needs_oauth2.return_value = True
+    database.start_oauth2_dance.side_effect = OAuth2RedirectError(
+        "url",
+        "tab_id",
+        "redirect_uri",
+    )
+    database.db_engine_spec.__name__ = "GSheetsEngineSpec"
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.side_effect = Exception("OAuth2 needed")
+
+    DatabaseDAO = mocker.patch("superset.commands.database.test_connection.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "sqlalchemy_uri": "gsheets://",
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = TestConnectionDatabaseCommand(properties)
+    with pytest.raises(OAuth2RedirectError) as excinfo:
+        command.run()
+    assert excinfo.value.error == SupersetError(
+        message="You don't have permission to access the data.",
+        error_type=SupersetErrorType.OAUTH2_REDIRECT,
+        level=ErrorLevel.WARNING,
+        extra={"url": "url", "tab_id": "tab_id", "redirect_uri": "redirect_uri"},
+    )

--- a/tests/unit_tests/commands/databases/validate_test.py
+++ b/tests/unit_tests/commands/databases/validate_test.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.commands.database.exceptions import (
+    DatabaseOfflineError,
+    DatabaseTestConnectionFailedError,
+    InvalidParametersError,
+)
+from superset.commands.database.validate import ValidateDatabaseParametersCommand
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+
+
+def test_command(mocker: MockerFixture) -> None:
+    """
+    Test the happy path of the command.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.return_value = True
+
+    DatabaseDAO = mocker.patch("superset.commands.database.validate.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = ValidateDatabaseParametersCommand(properties)
+    command.run()
+
+
+def test_command_invalid(mocker: MockerFixture) -> None:
+    """
+    Test the command when the payload is invalid.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.return_value = True
+
+    DatabaseDAO = mocker.patch("superset.commands.database.validate.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "engine": "gsheets",
+        "driver": "gsheets",
+    }
+    command = ValidateDatabaseParametersCommand(properties)
+    with pytest.raises(InvalidParametersError) as excinfo:
+        command.run()
+    assert excinfo.value.errors == [
+        SupersetError(
+            message="Sheet name is required",
+            error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
+            level=ErrorLevel.WARNING,
+            extra={
+                "catalog": {"idx": 0, "name": True},
+                "issue_codes": [
+                    {
+                        "code": 1018,
+                        "message": (
+                            "Issue 1018 - One or more parameters needed to configure a "
+                            "database are missing."
+                        ),
+                    }
+                ],
+            },
+        )
+    ]
+
+
+def test_command_no_ping(mocker: MockerFixture) -> None:
+    """
+    Test the command when it can't ping the database.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.return_value = False
+
+    DatabaseDAO = mocker.patch("superset.commands.database.validate.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = ValidateDatabaseParametersCommand(properties)
+    with pytest.raises(DatabaseOfflineError) as excinfo:
+        command.run()
+    assert excinfo.value.error == SupersetError(
+        message="Database is offline.",
+        error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+        level=ErrorLevel.ERROR,
+        extra={
+            "issue_codes": [
+                {
+                    "code": 1002,
+                    "message": "Issue 1002 - The database returned an unexpected error.",
+                }
+            ]
+        },
+    )
+
+
+def test_command_with_oauth2(mocker: MockerFixture) -> None:
+    """
+    Test the command when OAuth2 is needed.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    database.is_oauth2_enabled.return_value = True
+    database.db_engine_spec.needs_oauth2.return_value = True
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.side_effect = Exception("OAuth2 needed")
+
+    DatabaseDAO = mocker.patch("superset.commands.database.validate.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = ValidateDatabaseParametersCommand(properties)
+    command.run()
+
+
+def test_command_with_oauth2_not_configured(mocker: MockerFixture) -> None:
+    """
+    Test the command when OAuth2 is needed but not configured in the DB.
+    """
+    user = mocker.MagicMock()
+    user.email = "alice@example.org"
+    mocker.patch("superset.db_engine_specs.gsheets.g", user=user)
+    mocker.patch("superset.db_engine_specs.gsheets.create_engine")
+
+    database = mocker.MagicMock()
+    database.is_oauth2_enabled.return_value = False
+    database.db_engine_spec.needs_oauth2.return_value = True
+    database.db_engine_spec.extract_errors.return_value = [
+        SupersetError(
+            error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+            message="OAuth2 is needed but not configured.",
+            level=ErrorLevel.ERROR,
+            extra={"engine_name": "gsheets"},
+        )
+    ]
+    with database.get_sqla_engine() as engine:
+        engine.dialect.do_ping.side_effect = Exception("OAuth2 needed")
+
+    DatabaseDAO = mocker.patch("superset.commands.database.validate.DatabaseDAO")
+    DatabaseDAO.build_db_for_connection_test.return_value = database
+
+    properties = {
+        "engine": "gsheets",
+        "driver": "gsheets",
+        "catalog": {"test": "https://example.org/"},
+    }
+    command = ValidateDatabaseParametersCommand(properties)
+    with pytest.raises(DatabaseTestConnectionFailedError) as excinfo:
+        command.run()
+    assert excinfo.value.errors == [
+        SupersetError(
+            error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+            message="OAuth2 is needed but not configured.",
+            level=ErrorLevel.ERROR,
+            extra={"engine_name": "gsheets"},
+        )
+    ]

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -38,7 +38,7 @@ from superset.commands.database.uploaders.csv_reader import CSVReader
 from superset.commands.database.uploaders.excel_reader import ExcelReader
 from superset.db_engine_specs.sqlite import SqliteEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import OAuth2RedirectError, SupersetSecurityException
 from superset.sql_parse import Table
 from superset.utils import json
 from tests.unit_tests.fixtures.common import (
@@ -2112,6 +2112,47 @@ def test_catalogs(
     )
 
 
+def test_catalogs_with_oauth2(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test the `catalogs` endpoint when OAuth2 is needed.
+    """
+    database = mocker.MagicMock()
+    database.get_all_catalog_names.side_effect = OAuth2RedirectError(
+        "url",
+        "tab_id",
+        "redirect_uri",
+    )
+    DatabaseDAO = mocker.patch("superset.databases.api.DatabaseDAO")
+    DatabaseDAO.find_by_id.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_catalogs_accessible_by_user.return_value = {"db2"}
+
+    response = client.get("/api/v1/database/1/catalogs/")
+    assert response.status_code == 500
+    assert response.json == {
+        "errors": [
+            {
+                "message": "You don't have permission to access the data.",
+                "error_type": "OAUTH2_REDIRECT",
+                "level": "warning",
+                "extra": {
+                    "url": "url",
+                    "tab_id": "tab_id",
+                    "redirect_uri": "redirect_uri",
+                },
+            }
+        ]
+    }
+
+
 def test_schemas(
     mocker: MockerFixture,
     client: Any,
@@ -2168,3 +2209,46 @@ def test_schemas(
         "catalog2",
         {"schema1", "schema2"},
     )
+
+
+def test_schemas_with_oauth2(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test the `schemas` endpoint when OAuth2 is needed.
+    """
+    from superset.databases.api import DatabaseRestApi
+
+    database = mocker.MagicMock()
+    database.get_all_schema_names.side_effect = OAuth2RedirectError(
+        "url",
+        "tab_id",
+        "redirect_uri",
+    )
+    datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
+    datamodel.get.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_schemas_accessible_by_user.return_value = {"schema2"}
+
+    response = client.get("/api/v1/database/1/schemas/")
+    assert response.status_code == 500
+    assert response.json == {
+        "errors": [
+            {
+                "message": "You don't have permission to access the data.",
+                "error_type": "OAUTH2_REDIRECT",
+                "level": "warning",
+                "extra": {
+                    "url": "url",
+                    "tab_id": "tab_id",
+                    "redirect_uri": "redirect_uri",
+                },
+            }
+        ]
+    }

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -273,7 +273,7 @@ def test_get_sql_results_oauth2(mocker: MockerFixture, app) -> None:
                 "error_type": SupersetErrorType.OAUTH2_REDIRECT,
                 "level": ErrorLevel.WARNING,
                 "extra": {
-                    "url": "https://abcd1234.snowflakecomputing.com/oauth/authorize?scope=refresh_token+session%3Arole%3ASYSADMIN&access_type=offline&include_granted_scopes=false&response_type=code&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9%252EeyJleHAiOjE2MTcyMzU1MDAsImRhdGFiYXNlX2lkIjoxLCJ1c2VyX2lkIjo0MiwiZGVmYXVsdF9yZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0L2FwaS92MS9kYXRhYmFzZS9vYXV0aDIvIiwidGFiX2lkIjoiZmIxMWY1MjgtNmViYS00YThhLTgzN2UtNmIwZDM5ZWU5MTg3In0%252E7nLkei6-V8sVk_Pgm8cFhk0tnKRKayRE1Vc7RxuM9mw&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv1%2Fdatabase%2Foauth2%2F&client_id=my_client_id&prompt=consent",
+                    "url": "https://abcd1234.snowflakecomputing.com/oauth/authorize?scope=refresh_token+session%3Arole%3AUSERADMIN&access_type=offline&include_granted_scopes=false&response_type=code&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9%252EeyJleHAiOjE2MTcyMzU1MDAsImRhdGFiYXNlX2lkIjoxLCJ1c2VyX2lkIjo0MiwiZGVmYXVsdF9yZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0L2FwaS92MS9kYXRhYmFzZS9vYXV0aDIvIiwidGFiX2lkIjoiZmIxMWY1MjgtNmViYS00YThhLTgzN2UtNmIwZDM5ZWU5MTg3In0%252E7nLkei6-V8sVk_Pgm8cFhk0tnKRKayRE1Vc7RxuM9mw&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv1%2Fdatabase%2Foauth2%2F&client_id=my_client_id&prompt=consent",
                     "tab_id": "fb11f528-6eba-4a8a-837e-6b0d39ee9187",
                     "redirect_uri": "http://localhost/api/v1/database/oauth2/",
                 },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR is part of the work to add OAuth2 support for Snowflake. When creating the DB we provide only the OAuth2 client information (ID, secret, scope, auth/token URLs), which is not enough to test and validate the connection. We need to allow the DB to be created before the OAuth2 flow, so we can store the access tokens associated with a given DB.

<del>Depends on https://github.com/apache/superset/pull/30067.</del>

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
