### PR TITLE
chore(tests): skip extremely flaky gaq test

### DIFF
--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -718,6 +718,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         if get_example_database().backend != "presto":
             assert "(\n      'boy' = 'boy'\n    )" in result
 
+    @unittest.skip("Extremely flaky test on MySQL")
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_chart_data_async(self):


### PR DESCRIPTION
### SUMMARY
The `test_chart_data_async` has been disabled, then re-enabled in the hopes that the new sleeps would fix it. This was not the case, and it's causing a lot of headache for getting CI green on PRs. I'm disabling it for now, and these will all likely be rewritten soon as part of SIP-134.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
