### PR TITLE
fix: Retrieving Slack channels when Slack is disabled

### DIFF
--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -259,7 +259,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   };
 
   useEffect(() => {
-    if (!slackOptions[0]?.options.length) {
+    const slackEnabled = options?.some(
+      option =>
+        option === NotificationMethodOption.Slack ||
+        option === NotificationMethodOption.SlackV2,
+    );
+    if (slackEnabled && !slackOptions[0]?.options.length) {
       fetchSlackChannels({ types: ['public_channel', 'private_channel'] })
         .then(({ json }) => {
           const { result } = json;


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/30026

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
