### PR TITLE
fix(accessibility): logo outline on tab navigation, but not on click

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -68,6 +68,12 @@ const StyledHeader = styled.header`
           height: 100%;
           object-fit: contain;
         }
+        &:focus {
+          border-color: transparent;
+        }
+        &:focus-visible {
+          border-color: ${theme.colors.primary.dark1};
+        }
       }
       .navbar-brand-text {
         border-left: 1px solid ${theme.colors.grayscale.light2};
@@ -306,11 +312,7 @@ export function Menu({
             arrowPointAtCenter
           >
             {isFrontendRoute(window.location.pathname) ? (
-              <GenericLink
-                className="navbar-brand"
-                to={brand.path}
-                tabIndex={-1}
-              >
+              <GenericLink className="navbar-brand" to={brand.path}>
                 <img src={brand.icon} alt={brand.alt} />
               </GenericLink>
             ) : (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes https://github.com/apache/superset/issues/30054

Overrides bootstrap's `focus` style to hide the outline, and adds `focus-visible` which works for keyboard navigation. Also disable the disabling of keyboard navigation, so you _can_ actually navigate to it by keyboard.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
