### PR TITLE
feat: Oauth2 in DatabaseSelector

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.tsx
@@ -162,7 +162,7 @@ function OAuth2RedirectMessage({
       >
         provide authorization
       </a>{' '}
-      in order to run this query.
+      in order to run this operation.
     </>
   );
 

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/ValidatedInputField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/ValidatedInputField.tsx
@@ -22,16 +22,19 @@ import { FieldPropTypes } from '../../types';
 
 const FIELD_TEXT_MAP = {
   account: {
+    label: 'Account',
     helpText: t(
       'Copy the identifier of the account you are trying to connect to.',
     ),
     placeholder: t('e.g. xy12345.us-east-2.aws'),
   },
   warehouse: {
+    label: 'Warehouse',
     placeholder: t('e.g. compute_wh'),
     className: 'form-group-w-50',
   },
   role: {
+    label: 'Role',
     placeholder: t('e.g. AccountAdmin'),
     className: 'form-group-w-50',
   },
@@ -54,7 +57,7 @@ export const validatedInputField = ({
     errorMessage={validationErrors?.[field]}
     placeholder={FIELD_TEXT_MAP[field].placeholder}
     helpText={FIELD_TEXT_MAP[field].helpText}
-    label={field}
+    label={FIELD_TEXT_MAP[field].label || field}
     onChange={changeMethods.onParametersChange}
     className={FIELD_TEXT_MAP[field].className || field}
   />

--- a/superset-frontend/src/hooks/apiResources/catalogs.ts
+++ b/superset-frontend/src/hooks/apiResources/catalogs.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect } from 'react';
+import { ClientErrorObject } from '@superset-ui/core';
 import useEffectEvent from 'src/hooks/useEffectEvent';
 import { api, JsonResponse } from './queryApi';
 
@@ -30,7 +31,7 @@ export type FetchCatalogsQueryParams = {
   dbId?: string | number;
   forceRefresh: boolean;
   onSuccess?: (data: CatalogOption[], isRefetched: boolean) => void;
-  onError?: () => void;
+  onError?: (error: ClientErrorObject) => void;
 };
 
 type Params = Omit<FetchCatalogsQueryParams, 'forceRefresh'>;
@@ -77,6 +78,12 @@ export function useCatalogs(options: Params) {
     },
   );
 
+  useEffect(() => {
+    if (result.isError) {
+      onError?.(result.error as ClientErrorObject);
+    }
+  }, [result.isError, result.error, onError]);
+
   const fetchData = useEffectEvent(
     (dbId: FetchCatalogsQueryParams['dbId'], forceRefresh = false) => {
       if (dbId && (!result.currentData || forceRefresh)) {
@@ -85,7 +92,7 @@ export function useCatalogs(options: Params) {
             onSuccess?.(data || EMPTY_CATALOGS, forceRefresh);
           }
           if (isError) {
-            onError?.();
+            onError?.(result.error as ClientErrorObject);
           }
         });
       }

--- a/superset-frontend/src/hooks/apiResources/queryApi.test.ts
+++ b/superset-frontend/src/hooks/apiResources/queryApi.test.ts
@@ -82,7 +82,7 @@ test('supersetClientQuery should return error when unsuccessful', async () => {
     getBaseQueryApiMock(store),
     {},
   );
-  expect(result.error).toEqual({ error: expectedError });
+  expect(result.error).toEqual({ error: expectedError, errors: [] });
 });
 
 test('supersetClientQuery should return parsed response by parseMethod', async () => {

--- a/superset-frontend/src/hooks/apiResources/queryApi.ts
+++ b/superset-frontend/src/hooks/apiResources/queryApi.ts
@@ -64,6 +64,7 @@ export const supersetClientQuery: BaseQueryFn<
       getClientErrorObject(response).then(errorObj => ({
         error: {
           error: errorObj?.message || errorObj?.error || response.statusText,
+          errors: errorObj?.errors || [], // used by <ErrorMessageWithStackTrace />
           status: response.status,
         },
       })),

--- a/superset-frontend/src/hooks/apiResources/schemas.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useCallback, useEffect } from 'react';
+import { ClientErrorObject } from '@superset-ui/core';
 import useEffectEvent from 'src/hooks/useEffectEvent';
 import { api, JsonResponse } from './queryApi';
 
@@ -31,7 +32,7 @@ export type FetchSchemasQueryParams = {
   catalog?: string;
   forceRefresh: boolean;
   onSuccess?: (data: SchemaOption[], isRefetched: boolean) => void;
-  onError?: () => void;
+  onError?: (error: ClientErrorObject) => void;
 };
 
 type Params = Omit<FetchSchemasQueryParams, 'forceRefresh'>;
@@ -81,6 +82,12 @@ export function useSchemas(options: Params) {
     },
   );
 
+  useEffect(() => {
+    if (result.isError) {
+      onError?.(result.error as ClientErrorObject);
+    }
+  }, [result.isError, result.error, onError]);
+
   const fetchData = useEffectEvent(
     (
       dbId: FetchSchemasQueryParams['dbId'],
@@ -94,7 +101,7 @@ export function useSchemas(options: Params) {
               onSuccess?.(data || EMPTY_SCHEMAS, forceRefresh);
             }
             if (isError) {
-              onError?.();
+              onError?.(result.error as ClientErrorObject);
             }
           },
         );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR modifies `onError` in the `useSchemas` and `useCatalogs` hooks so that the error payload is passed as a parameter. This allow us to prompt the user for OAuth2 when adding datasets or browsing tables in SQL Lab.

Depends on #30071 and #30067.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

After:

![Screenshot 2024-08-31 at 19-21-36 Superset](https://github.com/user-attachments/assets/08fe2be4-f22f-41cb-be0f-ba72d737f52f)

![Screenshot 2024-08-31 at 19-21-30 Superset](https://github.com/user-attachments/assets/44f0a2fb-eeb1-41d0-bb28-9140a7b08e2b)

Before, generic error messages would flash.
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
