### PR TITLE
fix: Move copying translation files before npm run build in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,15 +62,16 @@ RUN --mount=type=bind,target=./package.json,src=./superset-frontend/package.json
 
 # Runs the webpack build process
 COPY superset-frontend /app/superset-frontend
+# This copies the .po files needed for translation
+RUN mkdir -p /app/superset/translations
+COPY superset/translations /app/superset/translations
 RUN if [ "$DEV_MODE" = "false" ]; then \
         npm run ${BUILD_CMD}; \
     else \
         echo "Skipping 'npm run ${BUILD_CMD}' in dev mode"; \
     fi
 
-# This copies the .po files needed for translation
-RUN mkdir -p /app/superset/translations
-COPY superset/translations /app/superset/translations
+
 # Compiles .json files from the .po files, then deletes the .po files
 RUN if [ "$DEV_MODE" = "false" ]; then \
         npm run build-translation; \

--- a/docs/docs/installation/docker-builds.mdx
+++ b/docs/docs/installation/docker-builds.mdx
@@ -67,6 +67,10 @@ script and the [docker.yml](https://github.com/apache/superset/blob/master/.gith
 GitHub action.
 
 ## Key ARGs in Dockerfile
+- `BUILD_TRANSLATIONS`: whether to build the translations into the image. For the
+  frontend build this tells webpack to strip out all locales other than `en` from
+  the `moment-timezone` library. For the backendthis skips compiling the
+  `*.po` translation files
 - `DEV_MODE`: whether to skip the frontend build, this is used by our `docker-compose` dev setup
   where we mount the local volume and build using `webpack` in `--watch` mode, meaning as you
   alter the code in the local file system, webpack, from within a docker image used for this

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -45,7 +45,7 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 const TRANSLATIONS_DIR = path.resolve(__dirname, '../superset/translations');
 
 const getAvailableTranslationCodes = () => {
-  if (process.env.BUILD_TRANSLATIONS == 'true') {
+  if (process.env.BUILD_TRANSLATIONS === 'true') {
     const LOCALE_CODE_MAPPING = {
       zh: 'zh-cn',
     };
@@ -58,10 +58,8 @@ const getAvailableTranslationCodes = () => {
       .map(dirName => dirName.replace('_', '-'))
       .map(dirName => LOCALE_CODE_MAPPING[dirName] || dirName);
   }
-  else {
-    // Indicates to the MomentLocalesPlugin that we only want to keep 'en'.
-    return []
-  }
+  // Indicates to the MomentLocalesPlugin that we only want to keep 'en'.
+  return [];
 };
 
 const {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -45,10 +45,10 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 const TRANSLATIONS_DIR = path.resolve(__dirname, '../superset/translations');
 
 const getAvailableTranslationCodes = () => {
-  const LOCALE_CODE_MAPPING = {
-    zh: 'zh-cn',
-  };
-  try {
+  if (process.env.BUILD_TRANSLATIONS == 'true') {
+    const LOCALE_CODE_MAPPING = {
+      zh: 'zh-cn',
+    };
     const files = fs.readdirSync(TRANSLATIONS_DIR);
     return files
       .filter(file =>
@@ -57,9 +57,10 @@ const getAvailableTranslationCodes = () => {
       .filter(dirName => !dirName.startsWith('__'))
       .map(dirName => dirName.replace('_', '-'))
       .map(dirName => LOCALE_CODE_MAPPING[dirName] || dirName);
-  } catch (err) {
-    console.error('Error reading the directory:', err);
-    return [];
+  }
+  else {
+    // Indicates to the MomentLocalesPlugin that we only want to keep 'en'.
+    return []
   }
 };
 


### PR DESCRIPTION
### SUMMARY

Since #29791 the [webpack.config.js](https://github.com/apache/superset/blob/548d543efe81ecd6f0a6657550230b765ab4d955/superset-frontend/webpack.config.js) file now requires that the translation files are present when running the build. This change simply moves the copy of the translation files before the `npm run build` step.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Beforehand, an error printed was printed, although it doesn't seem to stop the build, that can cause confusion as to whether something is wrong with the build:

```sh
#19 [superset-node  7/12] RUN npm run build
#19 0.291
#19 0.291 > superset@0.0.0-dev build
#19 0.291 > cross-env NODE_OPTIONS=--max_old_space_size=8192 NODE_ENV=production BABEL_ENV="${BABEL_ENV:=production}" webpack --color --mode production
#19 0.291
#19 1.087 Error reading the directory: Error: ENOENT: no such file or directory, scandir '/app/superset/translations'
#19 1.087     at Object.readdirSync (node:fs:1507:26)
#19 1.087     at getAvailableTranslationCodes (/app/superset-frontend/webpack.config.js:52:22)
#19 1.087     at Object.<anonymous> (/app/superset-frontend/webpack.config.js:168:20)
#19 1.087     at Module._compile (node:internal/modules/cjs/loader:1469:14)
#19 1.087     at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
#19 1.087     at Module.load (node:internal/modules/cjs/loader:1288:32)
#19 1.087     at Module._load (node:internal/modules/cjs/loader:1104:12)
#19 1.087     at Module.require (node:internal/modules/cjs/loader:1311:19)
#19 1.087     at require (node:internal/modules/helpers:179:18)
#19 1.087     at WebpackCLI.tryRequireThenImport (/app/superset-frontend/node_modules/webpack-cli/lib/webpack-cli.js:204:22) {
#19 1.087   errno: -2,
#19 1.087   code: 'ENOENT',
#19 1.087   syscall: 'scandir',
#19 1.087   path: '/app/superset/translations'
#19 1.087 }
```

### TESTING INSTRUCTIONS

Build the `superset-node` stage and ensure it completes without errors relating to the translations files:

```sh
docker buildx build --progress plain --target superset-node --build-arg PY_VER=3.10-slim-bookworm --no-cache .
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
