### PR TITLE
docs: Fixing missing 'c' in installation guide documentation

### DIFF
--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -15,7 +15,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 :::caution
 Since `docker compose` is primarily designed to run a set of containers on **a single host**
 and can't support requirements for **high availability**, we do not support nor recommend
-using our `docker- ompose` constructs to support production-type use-cases. For single host
+using our `docker-compose` constructs to support production-type use-cases. For single host
 environments, we recommend using [minikube](https://minikube.sigs.k8s.io/docs/start/) along
 our [installing on k8s](https://superset.apache.org/docs/installation/running-on-kubernetes)
 documentation.

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -15,7 +15,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 :::caution
 Since `docker compose` is primarily designed to run a set of containers on **a single host**
 and can't support requirements for **high availability**, we do not support nor recommend
-using our `docker-compose` constructs to support production-type use-cases. For single host
+using our `docker compose` constructs to support production-type use-cases. For single host
 environments, we recommend using [minikube](https://minikube.sigs.k8s.io/docs/start/) along
 our [installing on k8s](https://superset.apache.org/docs/installation/running-on-kubernetes)
 documentation.


### PR DESCRIPTION
Fixed missing 'c' in 'docker-compose'

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
