### PR TITLE
fix: JSON loading logs

### DIFF
--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -174,7 +174,11 @@ def validate_json(obj: Union[bytes, bytearray, str]) -> None:
     :param obj: an object that should be parseable to JSON
     """
     if obj:
-        loads(obj)
+        try:
+            loads(obj)
+        except JSONDecodeError as ex:
+            logger.error("JSON is not valid %s", str(ex), exc_info=True)
+            raise
 
 
 def dumps(  # pylint: disable=too-many-arguments
@@ -236,16 +240,12 @@ def loads(
     :param object_hook: function that will be called to decode objects values
     :returns: A Python object deserialized from string
     """
-    try:
-        return simplejson.loads(
-            obj,
-            encoding=encoding,
-            allow_nan=allow_nan,
-            object_hook=object_hook,
-        )
-    except JSONDecodeError as ex:
-        logger.error("JSON is not valid %s", str(ex), exc_info=True)
-        raise
+    return simplejson.loads(
+        obj,
+        encoding=encoding,
+        allow_nan=allow_nan,
+        object_hook=object_hook,
+    )
 
 
 def redact_sensitive(


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/28702 unified JSON calls to a single module which is great. Unfortunately, that PR also altered the default behavior when loading a JSON object and added a log entry every time an invalid object is parsed to the utility function. It is the responsibility of the caller to decide how to deal with an invalid JSON. In many places, a default empty object is used when an invalid JSON is received and there's no need for extra logs. This PR restores the previous behavior.

Fixes https://github.com/apache/superset/issues/30079

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
