### PR TITLE
fix(catalog): Table Schema View with no catalog

### DIFF
--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -239,7 +239,7 @@ class TableSchemaView(BaseSupersetView):
         db.session.query(TableSchema).filter(
             TableSchema.tab_state_id == table["queryEditorId"],
             TableSchema.database_id == table["dbId"],
-            TableSchema.catalog == table["catalog"],
+            TableSchema.catalog == table.get("catalog"),
             TableSchema.schema == table["schema"],
             TableSchema.table == table["name"],
         ).delete(synchronize_session=False)
@@ -247,7 +247,7 @@ class TableSchemaView(BaseSupersetView):
         table_schema = TableSchema(
             tab_state_id=table["queryEditorId"],
             database_id=table["dbId"],
-            catalog=table["catalog"],
+            catalog=table.get("catalog"),
             schema=table["schema"],
             table=table["name"],
             description=json.dumps(table),


### PR DESCRIPTION
### SUMMARY
 Some tables might not have catalogs when hitting the `tableschemaview` endpoint, so the View must handle that instead of assuming the dict always has the `catalog` key.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/b799f4a2-02a1-4e69-b100-dafc01b27a78

After:

https://github.com/user-attachments/assets/6264a431-cf07-459e-8f56-c73f10f472c1



### TESTING INSTRUCTIONS
1. connect a google sheet to be used as a database
2. go to sql lab
3. select your database
4. select your schema
5. select your table
6. Your table must load the preview


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
