### PR TITLE
fix(sqllab): race condition when updating same cursor position

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -142,9 +142,15 @@ const AceEditorWrapper = ({
 
       currentSelectionCache.current = selectedText;
     });
+
     editor.selection.on('changeCursor', () => {
       const cursor = editor.getCursorPosition();
-      onCursorPositionChange(cursor);
+      const { row, column } = cursorPosition;
+      // Prevent a maximum update depth exceeded error
+      // by skipping repeated updates to the same cursor position
+      if (cursor.row !== row && cursor.column !== column) {
+        onCursorPositionChange(cursor);
+      }
     });
 
     const { row, column } = cursorPosition;


### PR DESCRIPTION
### SUMMARY
In certain cases, a race condition was observed where the cursor position in the Redux state and the cursor position in the ACE editor would repeatedly update each other.
This commit modifies the behavior to update the position only when the current cursor position differs from the value in the Redux state, in order to prevent this issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/8992a0b6-5763-4471-8921-63c10c7622d1

After:

No maximum update depth exceeded error thrown

### TESTING INSTRUCTIONS
locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
