### PR TITLE
fix: Adds the Deprecated label to Time-series Percent Change chart

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/index.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/src/Compare/index.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, ChartMetadata, ChartPlugin } from '@superset-ui/core';
+import { t, ChartMetadata, ChartPlugin, ChartLabel } from '@superset-ui/core';
 import transformProps from '../transformProps';
 import thumbnail from './images/thumbnail.png';
 import example from './images/example.jpg';
@@ -29,6 +29,7 @@ const metadata = new ChartMetadata({
     'Visualizes many different time-series objects in a single chart. This chart is being deprecated and we recommend using the Time-series Chart instead.',
   ),
   exampleGallery: [{ url: example }],
+  label: ChartLabel.Deprecated,
   name: t('Time-series Percent Change'),
   tags: [
     t('Legacy'),


### PR DESCRIPTION
### SUMMARY
The Time-series Percent Change chart description says it's a deprecated chart but it was missing the `Deprecated` label. This PR adds the label. 

Fixes https://github.com/apache/superset/issues/29711

### TESTING INSTRUCTIONS
Check that the label is present.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
