### PR TITLE
fix(sqllab): race condition when updating cursor position

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -18,15 +18,28 @@
  */
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { render, waitFor } from 'spec/helpers/testing-library';
+import reducerIndex from 'spec/helpers/reducerIndex';
+import { render, waitFor, createStore } from 'spec/helpers/testing-library';
 import { QueryEditor } from 'src/SqlLab/types';
 import { Store } from 'redux';
 import { initialState, defaultQueryEditor } from 'src/SqlLab/fixtures';
 import AceEditorWrapper from 'src/SqlLab/components/AceEditorWrapper';
-import { AsyncAceEditorProps } from 'src/components/AsyncAceEditor';
+import {
+  AsyncAceEditorProps,
+  FullSQLEditor,
+} from 'src/components/AsyncAceEditor';
+import {
+  queryEditorSetCursorPosition,
+  queryEditorSetDb,
+} from 'src/SqlLab/actions/sqlLab';
+import fetchMock from 'fetch-mock';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
+
+fetchMock.get('glob:*/api/v1/database/*/function_names/', {
+  function_names: [],
+});
 
 jest.mock('src/components/Select/Select', () => () => (
   <div data-test="mock-deprecated-select-select" />
@@ -36,9 +49,11 @@ jest.mock('src/components/Select/AsyncSelect', () => () => (
 ));
 
 jest.mock('src/components/AsyncAceEditor', () => ({
-  FullSQLEditor: (props: AsyncAceEditorProps) => (
-    <div data-test="react-ace">{JSON.stringify(props)}</div>
-  ),
+  FullSQLEditor: jest
+    .fn()
+    .mockImplementation((props: AsyncAceEditorProps) => (
+      <div data-test="react-ace">{JSON.stringify(props)}</div>
+    )),
 }));
 
 const setup = (queryEditor: QueryEditor, store?: Store) =>
@@ -59,6 +74,10 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
   );
 
 describe('AceEditorWrapper', () => {
+  beforeEach(() => {
+    (FullSQLEditor as any as jest.Mock).mockClear();
+  });
+
   it('renders ace editor including sql value', async () => {
     const { getByTestId } = setup(defaultQueryEditor, mockStore(initialState));
     await waitFor(() => expect(getByTestId('react-ace')).toBeInTheDocument());
@@ -90,5 +109,20 @@ describe('AceEditorWrapper', () => {
     expect(getByTestId('react-ace')).toHaveTextContent(
       JSON.stringify({ value: defaultQueryEditor.sql }).slice(1, -1),
     );
+  });
+
+  it('skips rerendering for updating cursor position', () => {
+    const store = createStore(initialState, reducerIndex);
+    setup(defaultQueryEditor, store);
+
+    expect(FullSQLEditor).toHaveBeenCalled();
+    const renderCount = (FullSQLEditor as any as jest.Mock).mock.calls.length;
+    const updatedCursorPosition = { row: 1, column: 9 };
+    store.dispatch(
+      queryEditorSetCursorPosition(defaultQueryEditor, updatedCursorPosition),
+    );
+    expect(FullSQLEditor).toHaveBeenCalledTimes(renderCount);
+    store.dispatch(queryEditorSetDb(defaultQueryEditor, 1));
+    expect(FullSQLEditor).toHaveBeenCalledTimes(renderCount + 1);
   });
 });

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useAnnotations.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useAnnotations.ts
@@ -24,8 +24,11 @@ import { VALIDATION_DEBOUNCE_MS } from 'src/SqlLab/constants';
 import {
   FetchValidationQueryParams,
   useQueryValidationsQuery,
+  ValidationResult,
 } from 'src/hooks/apiResources';
 import { useDebounceValue } from 'src/hooks/useDebounceValue';
+
+const EMPTY = [] as ValidationResult[];
 
 export function useAnnotations(params: FetchValidationQueryParams) {
   const { sql, dbId, schema, templateParams } = params;
@@ -73,7 +76,7 @@ export function useAnnotations(params: FetchValidationQueryParams) {
                       text: `The server failed to validate your query.\n${message}`,
                     },
                   ]
-                : [],
+                : EMPTY,
         };
       },
     },

--- a/superset-frontend/src/hooks/apiResources/queryValidations.ts
+++ b/superset-frontend/src/hooks/apiResources/queryValidations.ts
@@ -26,7 +26,7 @@ export type FetchValidationQueryParams = {
   templateParams?: string;
 };
 
-type ValidationResult = {
+export type ValidationResult = {
   end_column: number | null;
   line_number: number | null;
   message: string | null;


### PR DESCRIPTION
### SUMMARY
#30141 resolved the initial SQLLab page loading issue, but I identified that the same race condition error occurs when the cursor moves.
The problem is that the cursorPosition should only be accessed during onLoad to set the initial cursor position, but an issue arises where the Ace Editor is re-rendered whenever the cursorPosition is changed via useQueryEditor selector. During rerendering, the Ace Editor keeps resetting the cursor position, triggering the cursorUpdate event, which in turn causes onCursorPositionChange to be called repeatedly, leading to an infinite cursor position update loop.
To resolve this, avoided accessing the cursor position in real-time from the unsaved state and limited access to the initial state only, thereby preventing the number of re-renders.

### TESTING INSTRUCTIONS
Specs are added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
