### PR TITLE
fix(native filter): undefined layout type on filterInScope

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -84,7 +84,7 @@ function useSelectChartTabParents() {
       layoutItem => layoutItem.meta?.chartId === chartId,
     );
     return chartLayoutItem?.parents.filter(
-      (parent: string) => dashboardLayout[parent].type === TAB_TYPE,
+      (parent: string) => dashboardLayout[parent]?.type === TAB_TYPE,
     );
   };
 }


### PR DESCRIPTION
### SUMMARY
The dashboard layout metadata item has become corrupted, resulting in some values remaining in the filter layout parent ID items that are not included in the dashboard layout. This commit resolves such undefined errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2024-09-05 at 9 59 35 AM](https://github.com/user-attachments/assets/41f724d8-16b7-4c75-83f5-c0e6605d13fd)
![Screenshot 2024-09-05 at 9 54 58 AM](https://github.com/user-attachments/assets/5856baec-ca84-47ad-8162-089e93463e74)

After:
No error shown

### TESTING INSTRUCTIONS
locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
