### PR TITLE
fix: set default mysql isolation level to 'READ COMMITTED'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 docker/**/*.sh text eol=lf
+*.svg binary

--- a/superset/config.py
+++ b/superset/config.py
@@ -196,6 +196,15 @@ SQLALCHEMY_DATABASE_URI = (
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
+# This config is exposed through flask-sqlalchemy, and can be used to set your metadata
+# database connection settings. You can use this to set arbitrary connection settings
+# that may be specific to the database engine you are using.
+# Note that you can use this to set the isolation level of your database, as in
+# `SQLALCHEMY_ENGINE_OPTIONS = {"isolation_level": "READ COMMITTED"}`
+# Also note that we recommend READ COMMITTED for regular operation.
+# Find out more here https://flask-sqlalchemy.palletsprojects.com/en/3.1.x/config/
+SQLALCHEMY_ENGINE_OPTIONS = {}
+
 # In order to hook up a custom password store for all SQLALCHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',
 # returns a password and set SQLALCHEMY_CUSTOM_PASSWORD_STORE.

--- a/superset/config.py
+++ b/superset/config.py
@@ -196,13 +196,6 @@ SQLALCHEMY_DATABASE_URI = (
 # SQLALCHEMY_DATABASE_URI = 'mysql://myapp@localhost/myapp'
 # SQLALCHEMY_DATABASE_URI = 'postgresql://root:password@localhost/myapp'
 
-# The default MySQL isolation level is REPEATABLE READ whereas the default PostgreSQL
-# isolation level is READ COMMITTED. All backends should use READ COMMITTED (or similar)
-# to help ensure consistent behavior.
-SQLALCHEMY_ENGINE_OPTIONS = {
-    "isolation_level": "SERIALIZABLE",  # SQLite does not support READ COMMITTED.
-}
-
 # In order to hook up a custom password store for all SQLALCHEMY connections
 # implement a function that takes a single argument of type 'sqla.engine.url',
 # returns a password and set SQLALCHEMY_CUSTOM_PASSWORD_STORE.

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -507,9 +507,8 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         if set_isolation_level_to:
             logger.info(
-                "Setting isolation level to %s for engine %s",
+                "Setting database isolation level to %s",
                 set_isolation_level_to,
-                db.engine,
             )
             with self.superset_app.app_context():
                 db.engine.execution_options(isolation_level=set_isolation_level_to)

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -502,9 +502,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             backend = make_url_safe(
                 self.config["SQLALCHEMY_DATABASE_URI"]
             ).get_backend_name()
-            if backend == "mysql":
-                set_isolation_level_to = "READ COMMITTED"
-            elif backend == "postgresql":
+            if backend in ("mysql", "postgresql"):
                 set_isolation_level_to = "READ COMMITTED"
 
         if set_isolation_level_to:

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -498,7 +498,8 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         if not isolation_level and self.config["SQLALCHEMY_DATABASE_URI"].startswith(
             "mysql"
         ):
-            db.engine.execution_options(isolation_level="READ COMMITTED")
+            with self.superset_app.app_context():
+                db.engine.execution_options(isolation_level="READ COMMITTED")
 
     def configure_auth_provider(self) -> None:
         machine_auth_provider_factory.init_app(self.superset_app)

--- a/tests/integration_tests/superset_test_config.py
+++ b/tests/integration_tests/superset_test_config.py
@@ -59,9 +59,6 @@ if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() == "sqlite":
         "removed in a future version of Superset."
     )
 
-if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() in ("postgresql", "mysql"):
-    SQLALCHEMY_ENGINE_OPTIONS["isolation_level"] = "READ COMMITTED"  # noqa: F405
-
 # Speeding up the tests.integration_tests.
 PRESTO_POLL_INTERVAL = 0.1
 HIVE_POLL_INTERVAL = 0.1

--- a/tests/integration_tests/superset_test_config_thumbnails.py
+++ b/tests/integration_tests/superset_test_config_thumbnails.py
@@ -41,9 +41,6 @@ if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() == "sqlite":
         in a future version of Superset."
     )
 
-if make_url(SQLALCHEMY_DATABASE_URI).get_backend_name() in ("postgresql", "mysql"):
-    SQLALCHEMY_ENGINE_OPTIONS["isolation_level"] = "READ COMMITTED"  # noqa: F405
-
 SQL_SELECT_AS_CTA = True
 SQL_MAX_ROW = 666
 


### PR DESCRIPTION
https://github.com/apache/superset/pull/28628 had the virtuous intent to align mysql and postgres to a consistent isolation_level (READ COMMITTED), which seems fitted for Superset. Though instead of doing this, and because sqlite doesn't support that specific one, it set the default to SERIALIZABLE which seems to exist by many engines.

Now SERIALIZABLE can create issues like this one: https://github.com/apache/superset/issues/30064 and upping the isolation level can have serious load implications for large deployments (or databases that are fitted "just-right" for their loads, like someone may use a tiny RDS for Superset)

Here I'm realizing we need dynamic defaults for isolation_level based on which engine is in used, which can't be done in config.py as we don't know yet what engine will be set by the admin at that time. So I thought the superset/initialization package might be the right place for this.

Open to other solutions, but I think this one works.

## alternative considered
* using DB_CONNECTION_MUTATOR, but that one applies only to analytics workloads, not the metadata db