### PR TITLE
feat: `is_mutating` method

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -56,7 +56,7 @@ const fakeDatabaseApiResult = {
     allow_file_upload: 'Allow Csv Upload',
     allow_ctas: 'Allow Ctas',
     allow_cvas: 'Allow Cvas',
-    allow_dml: 'Allow Dml',
+    allow_dml: 'Allow DDL and DML',
     allow_run_async: 'Allow Run Async',
     allows_cost_estimate: 'Allows Cost Estimate',
     allows_subquery: 'Allows Subquery',

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -172,11 +172,11 @@ const ExtraOptions = ({
                   indeterminate={false}
                   checked={!!db?.allow_dml}
                   onChange={onInputChange}
-                  labelText={t('Allow DML')}
+                  labelText={t('Allow DDL and DML')}
                 />
                 <InfoTooltip
                   tooltip={t(
-                    'Allow manipulation of the database using non-SELECT statements such as UPDATE, DELETE, CREATE, etc.',
+                    'Allow the execution of DDL (Data Definition Language: CREATE, DROP, TRUNCATE, etc.) and DML (Data Modification Language: INSERT, UPDATE, DELETE, etc)',
                   )}
                 />
               </div>

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -700,9 +700,9 @@ describe('DatabaseModal', () => {
         /force all tables and views to be created in this schema when clicking ctas or cvas in sql lab\./i,
       );
       const allowDMLCheckbox = screen.getByRole('checkbox', {
-        name: /allow dml/i,
+        name: /allow ddl and dml/i,
       });
-      const allowDMLText = screen.getByText(/allow dml/i);
+      const allowDMLText = screen.getByText(/allow ddl and dml/i);
       const enableQueryCostEstimationCheckbox = screen.getByRole('checkbox', {
         name: /enable query cost estimation/i,
       });

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/LeftPanel.test.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
       allow_file_upload: 'Allow Csv Upload',
       allow_ctas: 'Allow Ctas',
       allow_cvas: 'Allow Cvas',
-      allow_dml: 'Allow Dml',
+      allow_dml: 'Allow DDL and DML',
       allow_multi_schema_metadata_fetch: 'Allow Multi Schema Metadata Fetch',
       allow_run_async: 'Allow Run Async',
       allows_cost_estimate: 'Allows Cost Estimate',

--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -274,7 +274,7 @@ class SupersetShillelaghAdapter(Adapter):
         # to perform updates and deletes. Otherwise we can only do inserts and selects.
         self._rowid: str | None = None
 
-        # Does the database allow DML?
+        # Does the database allow DDL/DML?
         self._allow_dml: bool = False
 
         # Read column information from the database, and store it for later.

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -56,6 +56,7 @@ from superset.sql_parse import (
     insert_rls_as_subquery,
     insert_rls_in_predicate,
     ParsedQuery,
+    SQLStatement,
     Table,
 )
 from superset.sqllab.limiting_factor import LimitingFactor
@@ -194,7 +195,7 @@ def get_sql_results(  # pylint: disable=too-many-arguments
                 return handle_query_error(ex, query)
 
 
-def execute_sql_statement(  # pylint: disable=too-many-statements
+def execute_sql_statement(  # pylint: disable=too-many-statements, too-many-locals
     sql_statement: str,
     query: Query,
     cursor: Any,
@@ -236,7 +237,8 @@ def execute_sql_statement(  # pylint: disable=too-many-statements
     # We are testing to see if more rows exist than the limit.
     increased_limit = None if query.limit is None else query.limit + 1
 
-    if not db_engine_spec.is_readonly_query(parsed_query) and not database.allow_dml:
+    parsed_statement = SQLStatement(sql_statement, engine=db_engine_spec.engine)
+    if parsed_statement.is_dml() and not database.allow_dml:
         raise SupersetErrorException(
             SupersetError(
                 message=__("Only SELECT statements are allowed against this database."),

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -238,7 +238,7 @@ def execute_sql_statement(  # pylint: disable=too-many-statements, too-many-loca
     increased_limit = None if query.limit is None else query.limit + 1
 
     parsed_statement = SQLStatement(sql_statement, engine=db_engine_spec.engine)
-    if parsed_statement.is_dml() and not database.allow_dml:
+    if parsed_statement.is_mutating() and not database.allow_dml:
         raise SupersetErrorException(
             SupersetError(
                 message=__("Only SELECT statements are allowed against this database."),

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -452,6 +452,14 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def is_dml(self) -> bool:
+        """
+        Check if the statement is DML.
+
+        :return: True if the statement is DML
+        """
+        raise NotImplementedError()
+
     def __str__(self) -> str:
         return self.format()
 
@@ -521,6 +529,43 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         """
         dialect = SQLGLOT_DIALECTS.get(engine)
         return extract_tables_from_statement(parsed, dialect)
+
+    def is_dml(self) -> bool:
+        """
+        Check if the statement is DML.
+
+        :return: True if the statement is DML
+        """
+        for node in self._parsed.walk():
+            if isinstance(
+                node,
+                (
+                    exp.Insert,
+                    exp.Update,
+                    exp.Delete,
+                    exp.Merge,
+                    exp.Create,
+                    exp.Drop,
+                    exp.TruncateTable,
+                ),
+            ):
+                return True
+
+            if isinstance(node, exp.Command) and node.name == "ALTER":
+                return True
+
+        # Postgres runs DMLs prefixed by `EXPLAIN ANALYZE`, see
+        # https://www.postgresql.org/docs/current/sql-explain.html
+        if (
+            self._dialect == Dialects.POSTGRES
+            and isinstance(self._parsed, exp.Command)
+            and self._parsed.name == "EXPLAIN"
+            and self._parsed.expression.name.upper().startswith("ANALYZE ")
+        ):
+            analyzed_sql = self._parsed.expression.name[len("ANALYZE ") :]
+            return SQLStatement(analyzed_sql, self.engine).is_dml()
+
+        return False
 
     def format(self, comments: bool = True) -> str:
         """
@@ -688,6 +733,14 @@ class KustoKQLStatement(BaseSQLStatement[str]):
 
         return {}
 
+    def is_dml(self) -> bool:
+        """
+        Check if the statement is DML.
+
+        :return: True if the statement is DML
+        """
+        return self._parsed.startswith(".") and not self._parsed.startswith(".show")
+
 
 class SQLScript:
     """
@@ -729,6 +782,14 @@ class SQLScript:
             settings.update(statement.get_settings())
 
         return settings
+
+    def has_dml(self) -> bool:
+        """
+        Check if the script contains DML statements.
+
+        :return: True if the script contains DML statements
+        """
+        return any(statement.is_dml() for statement in self.statements)
 
 
 class ParsedQuery:

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -452,11 +452,11 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
-    def is_dml(self) -> bool:
+    def is_mutating(self) -> bool:
         """
-        Check if the statement is DML.
+        Check if the statement mutates data (DDL/DML).
 
-        :return: True if the statement is DML
+        :return: True if the statement mutates data.
         """
         raise NotImplementedError()
 
@@ -530,11 +530,11 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         dialect = SQLGLOT_DIALECTS.get(engine)
         return extract_tables_from_statement(parsed, dialect)
 
-    def is_dml(self) -> bool:
+    def is_mutating(self) -> bool:
         """
-        Check if the statement is DML.
+        Check if the statement mutates data (DDL/DML).
 
-        :return: True if the statement is DML
+        :return: True if the statement mutates data.
         """
         for node in self._parsed.walk():
             if isinstance(
@@ -563,7 +563,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             and self._parsed.expression.name.upper().startswith("ANALYZE ")
         ):
             analyzed_sql = self._parsed.expression.name[len("ANALYZE ") :]
-            return SQLStatement(analyzed_sql, self.engine).is_dml()
+            return SQLStatement(analyzed_sql, self.engine).is_mutating()
 
         return False
 
@@ -733,11 +733,11 @@ class KustoKQLStatement(BaseSQLStatement[str]):
 
         return {}
 
-    def is_dml(self) -> bool:
+    def is_mutating(self) -> bool:
         """
-        Check if the statement is DML.
+        Check if the statement mutates data (DDL/DML).
 
-        :return: True if the statement is DML
+        :return: True if the statement mutates data.
         """
         return self._parsed.startswith(".") and not self._parsed.startswith(".show")
 
@@ -783,13 +783,13 @@ class SQLScript:
 
         return settings
 
-    def has_dml(self) -> bool:
+    def has_mutation(self) -> bool:
         """
-        Check if the script contains DML statements.
+        Check if the script contains mutating statements.
 
-        :return: True if the script contains DML statements
+        :return: True if the script contains mutating statements
         """
-        return any(statement.is_dml() for statement in self.statements)
+        return any(statement.is_mutating() for statement in self.statements)
 
 
 class ParsedQuery:

--- a/superset/views/database/mixins.py
+++ b/superset/views/database/mixins.py
@@ -187,7 +187,7 @@ class DatabaseMixin:
         "expose_in_sqllab": _("Expose in SQL Lab"),
         "allow_ctas": _("Allow CREATE TABLE AS"),
         "allow_cvas": _("Allow CREATE VIEW AS"),
-        "allow_dml": _("Allow DML"),
+        "allow_dml": _("Allow DDL/DML"),
         "force_ctas_schema": _("CTAS Schema"),
         "database_name": _("Database"),
         "creator": _("Creator"),

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -2058,3 +2058,60 @@ on $left.Day1 == $right.Day
 | project Day1, Day2, Percentage = count_*100.0/count_1
     """,
     ]
+
+
+@pytest.mark.parametrize(
+    ("engine", "sql", "expected"),
+    [
+        # SQLite tests
+        ("sqlite", "SELECT 1", False),
+        ("sqlite", "INSERT INTO foo VALUES (1)", True),
+        ("sqlite", "UPDATE foo SET bar = 2 WHERE id = 1", True),
+        ("sqlite", "DELETE FROM foo WHERE id = 1", True),
+        ("sqlite", "CREATE TABLE foo (id INT, bar TEXT)", True),
+        ("sqlite", "DROP TABLE foo", True),
+        ("sqlite", "EXPLAIN SELECT * FROM foo", False),
+        ("sqlite", "PRAGMA table_info(foo)", False),
+        ("postgresql", "SELECT 1", False),
+        ("postgresql", "INSERT INTO foo (id, bar) VALUES (1, 'test')", True),
+        ("postgresql", "UPDATE foo SET bar = 'new' WHERE id = 1", True),
+        ("postgresql", "DELETE FROM foo WHERE id = 1", True),
+        ("postgresql", "CREATE TABLE foo (id SERIAL PRIMARY KEY, bar TEXT)", True),
+        ("postgresql", "DROP TABLE foo", True),
+        ("postgresql", "EXPLAIN ANALYZE SELECT * FROM foo", False),
+        ("postgresql", "EXPLAIN ANALYZE DELETE FROM foo", True),
+        ("postgresql", "SHOW search_path", False),
+        ("postgresql", "SET search_path TO public", False),
+        (
+            "postgres",
+            """
+            with source as (
+                select 1 as one
+            )
+            select * from source
+            """,
+            False,
+        ),
+        ("trino", "SELECT 1", False),
+        ("trino", "INSERT INTO foo VALUES (1, 'bar')", True),
+        ("trino", "UPDATE foo SET bar = 'baz' WHERE id = 1", True),
+        ("trino", "DELETE FROM foo WHERE id = 1", True),
+        ("trino", "CREATE TABLE foo (id INT, bar VARCHAR)", True),
+        ("trino", "DROP TABLE foo", True),
+        ("trino", "EXPLAIN SELECT * FROM foo", False),
+        ("trino", "SHOW SCHEMAS", False),
+        ("trino", "SET SESSION optimization_level = '3'", False),
+        ("kustokql", "tbl | limit 100", False),
+        ("kustokql", "let foo = 1; tbl | where bar == foo", False),
+        ("kustokql", ".show tables", False),
+        ("kustokql", "print 1", False),
+        ("kustokql", "set querytrace; Events | take 100", False),
+        ("kustokql", ".drop table foo", True),
+        ("kustokql", ".set-or-append table foo <| bar", True),
+    ],
+)
+def test_has_dml(engine: str, sql: str, expected: bool) -> None:
+    """
+    Test the `has_dml` method.
+    """
+    assert SQLScript(sql, engine).has_dml() == expected

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -2110,8 +2110,8 @@ on $left.Day1 == $right.Day
         ("kustokql", ".set-or-append table foo <| bar", True),
     ],
 )
-def test_has_dml(engine: str, sql: str, expected: bool) -> None:
+def test_has_mutation(engine: str, sql: str, expected: bool) -> None:
     """
-    Test the `has_dml` method.
+    Test the `has_mutation` method.
     """
-    assert SQLScript(sql, engine).has_dml() == expected
+    assert SQLScript(sql, engine).has_mutation() == expected


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Part of the work on [SIP-117](https://github.com/apache/superset/issues/26786), this PR introduces a `has_mutation()` method to `SQLScript`, as well as a `is_mutating()` method to `SQLStatement`, in order to check if the SQL contains any DML.

This also fixes a bug where this SQL is flagged incorrectly as DML:

```sql
with source as (
  select 1 as one
)
select * from source
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
