### PR TITLE
fix: filters panel broken due to tabs scroll

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -25,6 +25,8 @@ export function getDefaultTooltip(refs: Refs) {
   return {
     appendToBody: true,
     borderColor: 'transparent',
+    // CSS hack applied on this class to resolve https://github.com/apache/superset/issues/30058
+    className: 'echarts-tooltip',
     position: (
       canvasMousePos: [number, number],
       params: CallbackDataParams,

--- a/superset-frontend/src/GlobalStyles.tsx
+++ b/superset-frontend/src/GlobalStyles.tsx
@@ -34,6 +34,11 @@ export const GlobalStyles = () => (
       th {
         font-weight: ${theme.typography.weights.bold};
       }
+      // CSS hack to resolve the issue caused by the invisible echart tooltip on
+      // https://github.com/apache/superset/issues/30058
+      .echarts-tooltip[style*='visibility: hidden'] {
+        display: none !important;
+      }
       // TODO: Remove when on Ant Design 5.
       // Check src/components/Modal for more info.
       .modal-functions-ok-button {


### PR DESCRIPTION
### SUMMARY
Fixes #30058

The EChart tooltip is hidden using `visibility: hidden` with `opacity: 0` after it disappears, which causes tooltips generated from the previous tab to be recognized as scroll items when configuring the layout for the next tab, resulting in unnecessary scrollbars.

> display:none means that the tag in question will not appear on the page at all (although you can still interact with it through the dom). There will be no space allocated for it between the other tags.
>
> visibility:hidden means that unlike display:none, the tag is not visible, but space is allocated for it on the page. The tag is rendered, it just isn't seen on the page.

This commit addresses the issue by using a CSS hack to change the visibility hidden tooltip to `display: none`, effectively removing it and resolving the scrollbar problem.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/315ac940-47dc-4c0d-b55b-4b16e2237195

After:

https://github.com/user-attachments/assets/8a8e3d1f-e4bb-4022-8982-63229293576f


### TESTING INSTRUCTIONS

1. Create a dashboard with 2 inner tabs
2. In one tab, add a bunch of charts so that it needs scrolling
3. In the other tab, add a few charts so it does not need scrolling
4. Create a native filter
5. Scroll to the bottom on the first tab and **mouse over a chart to show a tooltip**
6. Select the second tab
7. Check that the dashboard height is not calculated correctly and presents a scroll
8. Scroll to the bottom and see the native filters panel break

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
