### PR TITLE
fix(Embedded): Dashboard screenshot should use GuestUser

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1041,7 +1041,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         def trigger_celery() -> WerkzeugResponse:
             logger.info("Triggering screenshot ASYNC")
             cache_dashboard_screenshot.delay(
-                current_user=get_current_user(),
                 dashboard_id=dashboard.id,
                 dashboard_url=dashboard_url,
                 force=True,


### PR DESCRIPTION
### SUMMARY
The dashboard screenshot endpoint would fail when used from an Embedded Dashboard as the `find_user` method would not find the user. This PR introduces a check so that the executor will always be the `GuestUser` when the request fires from an Embedded Dashboard,

### TESTING INSTRUCTIONS
1. Visit an Embedded Dashboard
2. Generate a screenshot of the Dashboard
3. The screenshot should be downloaded successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
