### PR TITLE
chore: linkinator to NOT validate links in INTHEWILD.md

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: JustinBeckwith/linkinator-action@v1.10.4
         with:
-          paths: "**/*.md, **/*.mdx"
+          paths: "**/*.md, **/*.mdx, !INTHEWILD.md"
           linksToSkip: >-
             ^https://github.com/apache/(superset|incubator-superset)/(pull|issue)/\d+,
             http://localhost:8088/,
@@ -38,6 +38,7 @@ jobs:
             http://theiconic.com.au/,
             https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html,
             ^https://img\.shields\.io/.*,
+            ^https://www.qpidhealth.com.*,
             https://vkusvill.ru/
   build-deploy:
     name: Build & Deploy


### PR DESCRIPTION
Linkinator makes sure that our docs points to valid URL. Lately I've seen 2-3 instances of CI failing because a link in INTHEWILD.md is temporarily or permanently broken. I'm hoping this doesn't affect CI as this is disruptive for daily work
