### PR TITLE
fix(sdk): use latest @supserset-ui/switchboard version to avoid pulling empty dependency

### DIFF
--- a/superset-embedded-sdk/package-lock.json
+++ b/superset-embedded-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-alpha.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@superset-ui/switchboard": "^0.18.26-0",
+        "@superset-ui/switchboard": "^0.20.2",
         "jwt-decode": "^3.1.2"
       },
       "devDependencies": {
@@ -2579,9 +2579,10 @@
       }
     },
     "node_modules/@superset-ui/switchboard": {
-      "version": "0.18.26-0",
-      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.18.26-0.tgz",
-      "integrity": "sha512-MYvigrspA0EgNU6tA9UrsXcrUYid9YktsbIPx/D4Xd5cWWrJrJl303imQ/SIZbC25faJCd2gL30ORll60Yz3Ww=="
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.20.2.tgz",
+      "integrity": "sha512-ORnueRpcnAt/IJB8IFaB+M5uDnItLZRJexWj0TKFcN9TBZhE9bQ6J6ARyfOq6VRVlLcaYfrfBYukaZCg3Fh5Jw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -9829,9 +9830,9 @@
       }
     },
     "@superset-ui/switchboard": {
-      "version": "0.18.26-0",
-      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.18.26-0.tgz",
-      "integrity": "sha512-MYvigrspA0EgNU6tA9UrsXcrUYid9YktsbIPx/D4Xd5cWWrJrJl303imQ/SIZbC25faJCd2gL30ORll60Yz3Ww=="
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@superset-ui/switchboard/-/switchboard-0.20.2.tgz",
+      "integrity": "sha512-ORnueRpcnAt/IJB8IFaB+M5uDnItLZRJexWj0TKFcN9TBZhE9bQ6J6ARyfOq6VRVlLcaYfrfBYukaZCg3Fh5Jw=="
     },
     "@types/babel__core": {
       "version": "7.20.5",

--- a/superset-embedded-sdk/package.json
+++ b/superset-embedded-sdk/package.json
@@ -33,7 +33,7 @@
     "last 3 edge versions"
   ],
   "dependencies": {
-    "@superset-ui/switchboard": "^0.18.26-0",
+    "@superset-ui/switchboard": "^0.20.2",
     "jwt-decode": "^3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(sdk): use latest @supserset-ui/switchboard version to avoid pulling empty dependency

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #30207 
Fix borked `@superset-ui/embedded-sdk` import caused by `@superset-ui/switchboard` v0.18.27 published with no compiled codes

<img width="843" alt="image" src="https://github.com/user-attachments/assets/4f6f5707-1aab-4d91-ba6a-d5313ad62198">


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
