### PR TITLE
fix(uploads): respect db engine spec's supports_multivalues_insert value for file uploads & enable multi-insert for MSSQL

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1283,7 +1283,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if getattr(engine.dialect, 'supports_multivalues_insert', False) or getattr(cls, 'supports_multivalues_insert', False):
+            if getattr(engine.dialect, "supports_multivalues_insert", False) or getattr(
+                cls, "supports_multivalues_insert", False
+            ):
                 to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -347,6 +347,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # Does database support join-free timeslot grouping
     time_groupby_inline = False
     limit_method = LimitMethod.FORCE_LIMIT
+    supports_multivalues_insert = False
     allows_joins = True
     allows_subqueries = True
     allows_alias_in_select = True

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1284,9 +1284,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if getattr(engine.dialect, "supports_multivalues_insert", False) or getattr(
-                cls, "supports_multivalues_insert", False
-            ):
+            if getattr(engine.dialect, "supports_multivalues_insert", False) or cls.supports_multivalues_insert:
                 to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1284,7 +1284,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if getattr(engine.dialect, "supports_multivalues_insert", False) or cls.supports_multivalues_insert:
+            if engine.dialect.supports_multivalues_insert or cls.supports_multivalues_insert:
                 to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1284,7 +1284,10 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if engine.dialect.supports_multivalues_insert or cls.supports_multivalues_insert:
+            if (
+                engine.dialect.supports_multivalues_insert
+                or cls.supports_multivalues_insert
+            ):
                 to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1283,7 +1283,8 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if getattr(engine.dialect, 'supports_multivalues_insert', False) or getattr(cls, 'supports_multivalues_insert', False):                to_sql_kwargs["method"] = "multi"
+            if getattr(engine.dialect, 'supports_multivalues_insert', False) or getattr(cls, 'supports_multivalues_insert', False):
+                to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 
     @classmethod

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1283,9 +1283,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             catalog=table.catalog,
             schema=table.schema,
         ) as engine:
-            if engine.dialect.supports_multivalues_insert:
-                to_sql_kwargs["method"] = "multi"
-
+            if getattr(engine.dialect, 'supports_multivalues_insert', False) or getattr(cls, 'supports_multivalues_insert', False):                to_sql_kwargs["method"] = "multi"
             df.to_sql(con=engine, **to_sql_kwargs)
 
     @classmethod

--- a/superset/db_engine_specs/mssql.py
+++ b/superset/db_engine_specs/mssql.py
@@ -53,6 +53,7 @@ class MssqlEngineSpec(BaseEngineSpec):
     max_column_name_length = 128
     allows_cte_in_subquery = False
     allow_limit_clause = False
+    supports_multivalues_insert = True
 
     _time_grain_expressions = {
         None: "{col}",


### PR DESCRIPTION
### SUMMARY
This PR makes two changes to enable the setting of `method = 'multi'` when the Pandas function `.to_sql` is called to write a file upload to a data warehouse.  This speeds up file uploads by 15x.  See discussion https://github.com/apache/superset/discussions/30152 for background and discussion.

**Changes:**
1. The base method `df_to_sql` does not currently access the `supports_multivalues_insert` attribute when it is set in a Superset EngineSpec.  Instead it relies on this attribute being set in the SQLAlchemy implementation for that dialect.  After this PR, Superset will check both of these places for the attribute.
2. Sets the attribute `supports_multivalues_insert` to `True` for Microsoft SQL Server (MSSQL), which has supported this behavior since SQL Server 2008.

Thanks to @nytai for advising.

### TESTING INSTRUCTIONS
Check that uploading a flat file to a data warehouse succeeds.  I tested it for MSSQL.  This PR was written to not reduce any existing functionality (there's an `or` with the previous condition) but someone could check on another data warehouse too.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
