### PR TITLE
fix(CrossFilters): Do not reload unrelated filters in global scope

### DIFF
--- a/superset-frontend/src/dashboard/util/crossFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.test.ts
@@ -294,14 +294,14 @@ test('Recalculate charts in global filter scope when charts change', () => {
         id: 2,
         crossFilters: {
           scope: 'global',
-          chartsInScope: [1, 3],
+          chartsInScope: [1],
         },
       },
       '3': {
         id: 3,
         crossFilters: {
           scope: 'global',
-          chartsInScope: [1, 2],
+          chartsInScope: [],
         },
       },
     },

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -52,6 +52,20 @@ export const getCrossFiltersConfiguration = (
     return undefined;
   }
 
+  const chartsByDataSource: Record<string, number[]> = Object.values(
+    charts,
+  ).reduce((acc: Record<string, number[]>, chart) => {
+    if (!chart.form_data) {
+      return acc;
+    }
+    const { datasource } = chart.form_data;
+    if (!acc[datasource]) {
+      acc[datasource] = [];
+    }
+    acc[datasource].push(chart.id);
+    return acc;
+  }, {});
+
   const globalChartConfiguration = metadata.global_chart_configuration?.scope
     ? {
         scope: metadata.global_chart_configuration.scope,
@@ -97,10 +111,13 @@ export const getCrossFiltersConfiguration = (
           },
         };
       }
+      const chartDataSource = charts[chartId].form_data.datasource;
       chartConfiguration[chartId].crossFilters.chartsInScope =
         isCrossFilterScopeGlobal(chartConfiguration[chartId].crossFilters.scope)
           ? globalChartConfiguration.chartsInScope.filter(
-              id => id !== Number(chartId),
+              id =>
+                id !== Number(chartId) &&
+                chartsByDataSource[chartDataSource].includes(id),
             )
           : getChartIdsInFilterScope(
               chartConfiguration[chartId].crossFilters.scope,

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -117,7 +117,7 @@ export const getCrossFiltersConfiguration = (
           ? globalChartConfiguration.chartsInScope.filter(
               id =>
                 id !== Number(chartId) &&
-                chartsByDataSource[chartDataSource].includes(id),
+                chartsByDataSource[chartDataSource]?.has(id),
             )
           : getChartIdsInFilterScope(
               chartConfiguration[chartId].crossFilters.scope,

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -52,9 +52,9 @@ export const getCrossFiltersConfiguration = (
     return undefined;
   }
 
-  const chartsByDataSource: Record<string, number[]> = Object.values(
+  const chartsByDataSource: Record<string, Set<number>> = Object.values(
     charts,
-  ).reduce((acc: Record<string, number[]>, chart) => {
+  ).reduce((acc: Record<string, Set<number>>, chart) => {
     if (!chart.form_data) {
       return acc;
     }

--- a/superset-frontend/src/dashboard/util/crossFilters.ts
+++ b/superset-frontend/src/dashboard/util/crossFilters.ts
@@ -60,9 +60,9 @@ export const getCrossFiltersConfiguration = (
     }
     const { datasource } = chart.form_data;
     if (!acc[datasource]) {
-      acc[datasource] = [];
+      acc[datasource] = new Set();
     }
-    acc[datasource].push(chart.id);
+    acc[datasource].add(chart.id);
     return acc;
   }, {});
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR partially accounts for the issue reported on #30061. However, more work is required so that when a scope is applied the frontend can check columns / calculated columns across different datasets to see whether the query should be sent over the backend at all. Working on a follow-up PRs that should solve the issue for both native and cross filters.

### BEFORE

https://github.com/user-attachments/assets/7b91a4a8-2c14-4bfb-84f4-94d82d02ec84

### AFTER

https://github.com/user-attachments/assets/6a85fc52-2c13-4cf4-977f-f9623c0a55f3


### TESTING INSTRUCTIONS
1. In global scope a cross filter should only affect charts of the same dataset

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
