### PR TITLE
chore(build): remove extraneous prettier step in superset-frontend CI

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -49,11 +49,6 @@ jobs:
         working-directory: ./superset-frontend
         run: |
           npm run type
-      - name: prettier
-        if: steps.check.outputs.frontend
-        working-directory: ./superset-frontend
-        run: |
-          npm run prettier-check
       - name: Build plugins packages
         if: steps.check.outputs.frontend
         working-directory: ./superset-frontend


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(build): remove extraneous prettier step in superset-frontend CI

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed there are duplicate CI steps in `superset-frontend` and `pre-commit` jobs. Since `pre-commit` job is ran regardless of all changes, I think it's better to remove the duplication in `superset-frontend`.

Unless there are missing historical contexts I'm not aware of ...

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
