### PR TITLE
fix: unable to disallow csv upload on header menu

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -308,10 +308,13 @@ test('If there is a DB with allow_file_upload set as True the option should be e
   userEvent.hover(dropdown);
   const dataMenu = await screen.findByText(dropdownItems[0].label);
   userEvent.hover(dataMenu);
-  expect(await screen.findByText('Upload CSV to database')).toBeInTheDocument();
+  const csvMenu = await screen.findByText('Upload CSV to database');
+  expect(csvMenu).toBeInTheDocument();
   expect(
     await screen.findByText('Upload Excel to database'),
   ).toBeInTheDocument();
+
+  expect(csvMenu).not.toHaveAttribute('aria-disabled', 'true');
 });
 
 test('If there is NOT a DB with allow_file_upload set as True the option should be disabled', async () => {
@@ -341,10 +344,11 @@ test('If there is NOT a DB with allow_file_upload set as True the option should 
   userEvent.hover(dropdown);
   const dataMenu = await screen.findByText(dropdownItems[0].label);
   userEvent.hover(dataMenu);
-  expect(await screen.findByText('Upload CSV to database')).toBeInTheDocument();
-  expect(
-    (await screen.findByText('Upload CSV to database')).closest('a'),
-  ).not.toBeInTheDocument();
+  const csvMenu = await screen.findByRole('menuitem', {
+    name: 'Upload CSV to database',
+  });
+  expect(csvMenu).toBeInTheDocument();
+  expect(csvMenu).toHaveAttribute('aria-disabled', 'true');
 });
 
 test('Logs out and clears local storage item redux', async () => {

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -313,7 +313,7 @@ const RightMenu = ({
 
   const buildMenuItem = (item: MenuObjectChildProps) =>
     item.disable ? (
-      <Menu.Item key={item.name} css={styledDisabled}>
+      <Menu.Item key={item.name} css={styledDisabled} disabled>
         <Tooltip placement="top" title={tooltipText}>
           {item.label}
         </Tooltip>


### PR DESCRIPTION
Fixes #30260

### SUMMARY
In the [#28192](https://github.com/apache/superset/pull/28192/files#diff-fe59770000288da9bca75381ca9b5d44d076cba76c37a653881a12763ecbf96eL192), the CSV menu was changed from a page URL to a modal popup, which led to an issue where the popup could be triggered even when the menu was in a disabled state.
This commit addresses the problem by passing the disabled property to the menu, making it impossible to click.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/38fa296c-090f-41da-902c-53ce95eb2c93

After:

https://github.com/user-attachments/assets/99f1420a-7bc0-4bc5-80e0-136d07dc9be1


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
