### PR TITLE
fix(dashboard): Invalid owner's name displayed after updates

### DIFF
--- a/superset-frontend/src/components/FacePile/index.tsx
+++ b/superset-frontend/src/components/FacePile/index.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type Owner from 'src/types/Owner';
 import {
   getCategoricalSchemeRegistry,
   styled,
@@ -23,12 +24,13 @@ import {
   FeatureFlag,
   SupersetTheme,
 } from '@superset-ui/core';
+import getOwnerName from 'src/utils/getOwnerName';
 import { Tooltip } from 'src/components/Tooltip';
 import { Avatar } from 'src/components';
 import { getRandomColor } from './utils';
 
 interface FacePileProps {
-  users: { first_name: string; last_name: string; id: number }[];
+  users: Owner[];
   maxCount?: number;
 }
 
@@ -57,8 +59,9 @@ const StyledGroup = styled(Avatar.Group)`
 export default function FacePile({ users, maxCount = 4 }: FacePileProps) {
   return (
     <StyledGroup maxCount={maxCount}>
-      {users.map(({ first_name, last_name, id }) => {
-        const name = `${first_name} ${last_name}`;
+      {users.map(user => {
+        const { first_name, last_name, id } = user;
+        const name = getOwnerName(user);
         const uniqueKey = `${id}-${first_name}-${last_name}`;
         const color = getRandomColor(uniqueKey, colorList);
         const avatarUrl = isFeatureEnabled(FeatureFlag.SlackEnableAvatars)

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -45,6 +45,8 @@ import TagType from 'src/types/TagType';
 import { fetchTags, OBJECT_TYPES } from 'src/features/tags/tags';
 import { loadTags } from 'src/components/Tags/utils';
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
+import getOwnerName from 'src/utils/getOwnerName';
+import Owner from 'src/types/Owner';
 
 const StyledFormItem = styled(FormItem)`
   margin-bottom: 0;
@@ -250,17 +252,10 @@ const PropertiesModal = ({
   };
 
   const handleOwnersSelectValue = () => {
-    const parsedOwners = (owners || []).map(
-      (owner: {
-        id: number;
-        first_name?: string;
-        last_name?: string;
-        full_name?: string;
-      }) => ({
-        value: owner.id,
-        label: owner.full_name || `${owner.first_name} ${owner.last_name}`,
-      }),
-    );
+    const parsedOwners = (owners || []).map((owner: Owner) => ({
+      value: owner.id,
+      label: getOwnerName(owner),
+    }));
     return parsedOwners;
   };
 

--- a/superset-frontend/src/types/Owner.ts
+++ b/superset-frontend/src/types/Owner.ts
@@ -22,7 +22,8 @@
  */
 
 export default interface Owner {
-  first_name: string;
+  first_name?: string;
   id: number;
-  last_name: string;
+  last_name?: string;
+  full_name?: string;
 }

--- a/superset-frontend/src/utils/getOwnerName.test.ts
+++ b/superset-frontend/src/utils/getOwnerName.test.ts
@@ -22,6 +22,8 @@ test('render owner name correctly', () => {
   expect(getOwnerName({ id: 1, first_name: 'Foo', last_name: 'Bar' })).toEqual(
     'Foo Bar',
   );
+
+  expect(getOwnerName({ id: 2, full_name: 'John Doe' })).toEqual('John Doe');
 });
 
 test('return empty string for undefined owner', () => {

--- a/superset-frontend/src/utils/getOwnerName.ts
+++ b/superset-frontend/src/utils/getOwnerName.ts
@@ -22,5 +22,5 @@ export default function getOwnerName(owner?: Owner): string {
   if (!owner) {
     return '';
   }
-  return `${owner.first_name} ${owner.last_name}`;
+  return owner.full_name || `${owner.first_name} ${owner.last_name}`;
 }


### PR DESCRIPTION
Fixes #30259

### SUMMARY
The action DASHBOARD_INFO_UPDATED changes the `first_name` and `last_name` properties of the owner to a `full_name` property [[#17570](https://github.com/apache/superset/pull/17570/files#diff-bbab1592904855ed63c204cedb8c14efc9eed397dac25756ac32f1cca4843518R206-R211)].
![Screenshot 2024-09-13 at 1 53 01 PM](https://github.com/user-attachments/assets/e8a91290-f667-44f3-9bc1-d4401aa22a7b)


However, the display change logic for the `full_name` property is only applied in the property modal, resulting in an error where other code referencing the owner outputs `undefined`.
To resolve this issue, the same Owner type and display getter function have been applied in the affected code.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/83ca57ec-db36-4080-8fd7-40466d696ba7

After:

https://github.com/user-attachments/assets/cc0b410f-062d-4fc3-a1cf-709639bf52ec


### TESTING INSTRUCTIONS

1. Update the dashboard owners
2. Check the metadata bar owners

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
