### PR TITLE
fix(dashboard): invalid button style in undo/redo button

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -575,7 +575,7 @@ class Header extends PureComponent {
                           title={t('Undo the action')}
                         >
                           <StyledUndoRedoButton
-                            type="text"
+                            buttonStyle="link"
                             disabled={undoLength < 1}
                             onClick={undoLength && onUndo}
                           >
@@ -595,7 +595,7 @@ class Header extends PureComponent {
                           title={t('Redo the action')}
                         >
                           <StyledUndoRedoButton
-                            type="text"
+                            buttonStyle="link"
                             disabled={redoLength < 1}
                             onClick={redoLength && onRedo}
                           >


### PR DESCRIPTION
### SUMMARY
The style properties for the Undo/Redo buttons were incorrectly applied, which caused the button styles to change unexpectedly. This commit restores the original styles by providing the correct button style values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2024-09-13 at 2 20 26 PM](https://github.com/user-attachments/assets/cb8d11ff-b47f-43e0-8b7e-d5d709237259)

After:
![Screenshot 2024-09-13 at 2 18 54 PM](https://github.com/user-attachments/assets/6a82a5b6-70b9-423d-87f3-3428d84e0e5a)

### TESTING INSTRUCTIONS
Go to dashboard and edit
check the undo/redo button style

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
