### PR TITLE
fix(examples): fix examples uri for sqlite

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -45,7 +45,7 @@ from flask import Blueprint
 from flask_appbuilder.security.manager import AUTH_DB
 from flask_caching.backends.base import BaseCache
 from pandas import Series
-from pandas._libs.parsers import STR_NA_VALUES
+from pandas._libs.parsers import STR_NA_VALUES  # pylint: disable=no-name-in-module
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm.query import Query
 
@@ -1632,7 +1632,9 @@ SEND_FILE_MAX_AGE_DEFAULT = int(timedelta(days=365).total_seconds())
 
 # URI to database storing the example data, points to
 # SQLALCHEMY_DATABASE_URI by default if set to `None`
-SQLALCHEMY_EXAMPLES_URI = "sqlite:///" + os.path.join(DATA_DIR, "examples.db")
+SQLALCHEMY_EXAMPLES_URI = (
+    f"""sqlite:///{os.path.join(DATA_DIR, "examples.db")}?check_same_thread=false"""
+)
 
 # Optional prefix to be added to all static asset paths when rendering the UI.
 # This is useful for hosting assets in an external CDN, for example

--- a/superset/config.py
+++ b/superset/config.py
@@ -45,7 +45,7 @@ from flask import Blueprint
 from flask_appbuilder.security.manager import AUTH_DB
 from flask_caching.backends.base import BaseCache
 from pandas import Series
-from pandas._libs.parsers import STR_NA_VALUES  # pylint: disable=no-name-in-module
+from pandas._libs.parsers import STR_NA_VALUES
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm.query import Query
 
@@ -1633,7 +1633,7 @@ SEND_FILE_MAX_AGE_DEFAULT = int(timedelta(days=365).total_seconds())
 # URI to database storing the example data, points to
 # SQLALCHEMY_DATABASE_URI by default if set to `None`
 SQLALCHEMY_EXAMPLES_URI = (
-    f"""sqlite:///{os.path.join(DATA_DIR, "examples.db")}?check_same_thread=false"""
+    "sqlite:///" + os.path.join(DATA_DIR, "examples.db") + "?check_same_thread=false"
 )
 
 # Optional prefix to be added to all static asset paths when rendering the UI.


### PR DESCRIPTION
### SUMMARY
The PR #25680 fixed the default sqlite connection string for the metastore connection so that it works correctly in an async use case. However, this fix was not applied to the Examples data URI, causing async access to fail.

### TESTING INSTRUCTIONS
1. Install a fresh local devenv using sqlite 
2. Enable async execution for the `examples` database
3. Issue a `select 1` on the `examples` database

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: SIP-143: #29839
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
