### PR TITLE
fix(install/docker): use zstd-baked image for building superset-frontend in containerized env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,14 @@ services:
       disable: true
 
   superset-node:
-    image: node:20
+    build:
+      context: .
+      target: superset-node
+      args:
+        # This prevents building the frontend bundle since we'll mount local folder
+        # and build it on startup while firing docker-frontend.sh in dev mode, where
+        # it'll mount and watch local files and rebuild as you update them
+        DEV_MODE: "true"
     environment:
       # set this to false if you have perf issues running the npm i; npm run dev in-docker
       # if you do so, you have to run this manually on the host, which should perform better!

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,8 +27,8 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
-    echo "Installing zstd as prerequisite" 
-    apt update 
+    echo "Installing zstd as prerequisite"
+    apt update
     apt install -y zstd
 
     echo "Running `npm install`"

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,10 +27,6 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
-    echo "Installing zstd as prerequisite"
-    apt update
-    apt install -y zstd
-
     echo "Running `npm install`"
     npm install
 

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -27,6 +27,10 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     echo "Building Superset frontend in dev mode inside docker container"
     cd /app/superset-frontend
 
+    echo "Installing zstd as prerequisite" 
+    apt update 
+    apt install -y zstd
+
     echo "Running `npm install`"
     npm install
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(install/docker): use zstd-baked image for building superset-frontend in containerized environment

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #30206

It turns out that building `superset-node` in development's Docker Compose file [doesn't use image baked with `zstd`](https://github.com/apache/superset/blob/master/docker-compose.yml#L151-L152). This PR fixes the issue by using zstd-baked image from existing Dockerfile.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="789" alt="image" src="https://github.com/user-attachments/assets/37f2bc13-6ec3-4b12-ae9b-09aac540c74c">

After
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/e7049017-409b-4983-a3aa-b1be2605bcb6">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
