### PR TITLE
chore(legacy-plugin-chart-map-box): bump supercluster to v8

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -49490,17 +49490,6 @@
       "version": "4.2.0",
       "license": "MIT"
     },
-    "node_modules/supercluster": {
-      "version": "4.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^2.0.1"
-      }
-    },
-    "node_modules/supercluster/node_modules/kdbush": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "license": "MIT",
@@ -55876,7 +55865,7 @@
       "dependencies": {
         "prop-types": "^15.8.1",
         "react-map-gl": "^6.1.19",
-        "supercluster": "^4.1.1",
+        "supercluster": "^8.0.1",
         "viewport-mercator-project": "^6.1.1"
       },
       "peerDependencies": {
@@ -55884,6 +55873,19 @@
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
         "react": "^15 || ^16"
+      }
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "plugins/legacy-plugin-chart-paired-t-test": {
@@ -65882,8 +65884,23 @@
       "requires": {
         "prop-types": "^15.8.1",
         "react-map-gl": "^6.1.19",
-        "supercluster": "^4.1.1",
+        "supercluster": "^8.0.1",
         "viewport-mercator-project": "^6.1.1"
+      },
+      "dependencies": {
+        "kdbush": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+          "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+        },
+        "supercluster": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+          "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+          "requires": {
+            "kdbush": "^4.0.2"
+          }
+        }
       }
     },
     "@superset-ui/legacy-plugin-chart-paired-t-test": {
@@ -90459,17 +90476,6 @@
     },
     "stylis": {
       "version": "4.2.0"
-    },
-    "supercluster": {
-      "version": "4.1.1",
-      "requires": {
-        "kdbush": "^2.0.1"
-      },
-      "dependencies": {
-        "kdbush": {
-          "version": "2.0.1"
-        }
-      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "prop-types": "^15.8.1",
     "react-map-gl": "^6.1.19",
-    "supercluster": "^4.1.1",
+    "supercluster": "^8.0.1",
     "viewport-mercator-project": "^6.1.1"
   },
   "peerDependencies": {

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/transformProps.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import supercluster from 'supercluster';
+import Supercluster from 'supercluster';
 import { DEFAULT_POINT_RADIUS, DEFAULT_MAX_ZOOM } from './MapBox';
 
 const NOOP = () => {};
@@ -72,7 +72,7 @@ export default function transformProps(chartProps) {
       /* eslint-enable no-param-reassign */
     };
   }
-  const clusterer = supercluster(opts);
+  const clusterer = new Supercluster(opts);
   clusterer.load(geoJSON.features);
 
   return {


### PR DESCRIPTION
### SUMMARY
Part of:
- #30307 

Modernizing the legacy-plugin-chart-map-box reduces the diff towards MapLibre.



This PR updates Supercluster from v4 to v8, which [improves performance and memory use](https://github.com/mapbox/supercluster/pull/223) for of this plugin.

### TESTING INSTRUCTIONS
- set the mapbox key in .env
- docker compose up
- open a mapbox chart, and it should still show clusters like below image

<img width="1726" alt="Screenshot 2024-09-17 at 11 15 56" src="https://github.com/user-attachments/assets/ca4b7a7e-5a43-4109-bafe-e6b0abbdf82e">

@rusackas , how does the review process generally work for these plugins? Are there some specific people who cover this part of the code?