### PR TITLE
chore(explore): Medium font weight for section headers

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -595,6 +595,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           css={(theme: SupersetTheme) => css`
             font-size: ${theme.typography.sizes.m}px;
             line-height: 1.3;
+            font-weight: ${theme.typography.weights.medium};
           `}
         >
           {label}


### PR DESCRIPTION
### SUMMARY
Set `font-weight: 500` for section headers in Explore's control panel.

This is one of a few incoming PRs to improve the visual balance in the control panel + fix readability after uppercase changes in control panel. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5482bdbb-4e99-490f-be4c-fa78b79d0e3c">

After:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/aaf15cfc-6cfb-40da-8903-82873e87d485">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
