### PR TITLE
feat(jinja): add option to format time filters using strftime

### DIFF
--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -361,7 +361,7 @@ The macro takes the following parameters:
   `DATETIME`). If `column` is defined, the format will default to the type of the column. This is used to produce
   the format of the `from_expr` and `to_expr` properties of the returned `TimeFilter` object.
 - `strftime`: format using the `strftime` method of `datetime` for custom time formatting.
-  ([see docs for valid format codes](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior)).
+  ([see docs for valid format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)).
   When defined `target_type` will be ignored.
 - `remove_filter`: When set to true, mark the filter as processed, removing it from the outer query. Useful when a
   filter should only apply to the inner query.

--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -360,6 +360,9 @@ The macro takes the following parameters:
 - `target_type`: The target temporal type as recognized by the target  database (e.g. `TIMESTAMP`, `DATE` or
   `DATETIME`). If `column` is defined, the format will default to the type of the column. This is used to produce
   the format of the `from_expr` and `to_expr` properties of the returned `TimeFilter` object.
+- `strftime`: format using the `strftime` method of `datetime` for custom time formatting.
+  ([see docs for valid format codes](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior)).
+  When defined `target_type` will be ignored.
 - `remove_filter`: When set to true, mark the filter as processed, removing it from the outer query. Useful when a
   filter should only apply to the inner query.
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -375,11 +375,13 @@ class ExtraCache:
 
         return filters
 
+    # pylint: disable=too-many-arguments
     def get_time_filter(
         self,
         column: str | None = None,
         default: str | None = None,
         target_type: str | None = None,
+        strftime: str | None = None,
         remove_filter: bool = False,
     ) -> TimeFilter:
         """Get the time filter with appropriate formatting,
@@ -395,6 +397,8 @@ class ExtraCache:
             the format will default to the type of the column. This is used to produce
             the format of the `from_expr` and `to_expr` properties of the returned
             `TimeFilter` object.
+        :param strftime: format using the `strftime` method of `datetime`. When defined
+            `target_type` will be ignored.
         :param remove_filter: When set to true, mark the filter as processed,
             removing it from the outer query. Useful when a filter should
             only apply to the inner query.
@@ -434,6 +438,8 @@ class ExtraCache:
         from_expr, to_expr = get_since_until_from_time_range(time_range)
 
         def _format_dttm(dttm: datetime | None) -> str | None:
+            if strftime and dttm:
+                return dttm.strftime(strftime)
             return (
                 self.database.db_engine_spec.convert_dttm(target_type or "", dttm)
                 if self.database and dttm

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -958,6 +958,30 @@ def test_metric_macro_no_dataset_id_with_context_chart_no_datasource_id(
             ["dttm"],
             ["dttm"],
         ),
+        (
+            "Filter is formatted with the custom format, ignoring target_type",
+            ["dttm"],
+            {"target_type": "DATE", "strftime": "%Y%m%d", "remove_filter": True},
+            "trino://mydb",
+            [
+                {
+                    "filters": [
+                        {
+                            "col": "dttm",
+                            "op": "TEMPORAL_RANGE",
+                            "val": "Last month",
+                        },
+                    ],
+                }
+            ],
+            TimeFilter(
+                from_expr="20240803",
+                to_expr="20240903",
+                time_range="Last month",
+            ),
+            ["dttm"],
+            ["dttm"],
+        ),
     ],
 )
 def test_get_time_filter(


### PR DESCRIPTION
### SUMMARY
A continuation on #30142, making it possible to format `from_expr` and `to_expr` using `datetime.strftime`. This is handy if the target column is string based using a custom format, like `YYYY-MM-DD`, which tends to be the typical partitioning scheme, and we want to avoid having to cast the column to a temporal type.

### AFTER

Now you can format like this (assuming `my_date` is a `VARCHAR` with `YYYY-MM-DD`):
```python
{% set time_filter = get_time_filter(strftime="%y-%m-%d") %}
{% set from_expr = time_filter.from_expr %}
{% set to_expr = time_filter.to_expr %}
SELECT
...
{% if from_expr or to_expr %}WHERE 1 = 1
{% if from_expr %}AND my_date >= '{{ from_expr }}'{% endif %}
{% if to_expr %}AND my_date < '{{ to_expr }}'{% endif %}
{% endif %}
```

This will render
```sql
SELECT
  ...
WHERE 1 = 1
AND my_date >= '2024-08-03'
AND my_date < '2024-09-03'
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
