### PR TITLE
fix(table): Use extras in queries

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -198,10 +198,15 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         (ownState.currentPage ?? 0) * (ownState.pageSize ?? 0);
     }
 
+    if (!temporalColum) {
+      // This query is using only textual columns, so it doesn't need time grain
+      extras.time_grain_sqla = undefined;
+    }
+
     let queryObject = {
       ...baseQueryObject,
       columns,
-      extras: !isEmpty(timeOffsets) && !temporalColum ? {} : extras,
+      extras,
       orderby,
       metrics,
       post_processing: postProcessing,
@@ -239,7 +244,6 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         row_limit: 0,
         row_offset: 0,
         post_processing: [],
-        extras: undefined, // we don't need time grain here
         order_desc: undefined, // we don't need orderby stuff here,
         orderby: undefined, // because this query will be used for get total aggregation.
       });

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -114,8 +114,8 @@ const buildQuery: BuildQuery<TableChartFormData> = (
       }
     }
 
-    let temporalColumAdded = false;
-    let temporalColum = null;
+    let temporalColumnAdded = false;
+    let temporalColumn = null;
 
     if (queryMode === QueryMode.Aggregate) {
       metrics = metrics || [];
@@ -169,23 +169,23 @@ const buildQuery: BuildQuery<TableChartFormData> = (
           time_grain_sqla &&
           temporalColumnsLookup?.[col];
 
-        if (shouldBeAdded && !temporalColumAdded) {
-          temporalColum = {
+        if (shouldBeAdded && !temporalColumnAdded) {
+          temporalColumn = {
             timeGrain: time_grain_sqla,
             columnType: 'BASE_AXIS',
             sqlExpression: col,
             label: col,
             expressionType: 'SQL',
           } as AdhocColumn;
-          temporalColumAdded = true;
+          temporalColumnAdded = true;
           return false; // Do not include this in the output; it's added separately
         }
         return true;
       });
 
       // So we ensure the temporal column is added first
-      if (temporalColum) {
-        columns = [temporalColum, ...columns];
+      if (temporalColumn) {
+        columns = [temporalColumn, ...columns];
       }
     }
 
@@ -198,8 +198,8 @@ const buildQuery: BuildQuery<TableChartFormData> = (
         (ownState.currentPage ?? 0) * (ownState.pageSize ?? 0);
     }
 
-    if (!temporalColum) {
-      // This query is using only textual columns, so it doesn't need time grain
+    if (!temporalColumn) {
+      // This query is not using temporal column, so it doesn't need time grain
       extras.time_grain_sqla = undefined;
     }
 

--- a/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -25,6 +25,28 @@ const basicFormData: TableChartFormData = {
   datasource: '11__table',
 };
 
+const extraQueryFormData: TableChartFormData = {
+  ...basicFormData,
+  time_grain_sqla: TimeGranularity.MONTH,
+  groupby: ['col1'],
+  query_mode: QueryMode.Aggregate,
+  show_totals: true,
+  metrics: ['aaa', 'aaa'],
+  adhoc_filters: [
+    {
+      expressionType: 'SQL',
+      sqlExpression: "status IN ('In Process')",
+      clause: 'WHERE',
+      subject: null,
+      operator: null,
+      comparator: null,
+      isExtra: false,
+      isNew: false,
+      datasourceWarning: false,
+      filterOptionName: 'filter_v8m9t9oq5re_ndzk6g5am7',
+    } as any,
+  ],
+};
 describe('plugin-chart-table', () => {
   describe('buildQuery', () => {
     it('should add post-processing and ignore duplicate metrics', () => {
@@ -116,27 +138,8 @@ describe('plugin-chart-table', () => {
     });
     it('should include time_grain_sqla in extras if temporal colum is used and keep the rest', () => {
       const { queries } = buildQuery({
-        ...basicFormData,
-        time_grain_sqla: TimeGranularity.MONTH,
-        groupby: ['col1'],
-        query_mode: QueryMode.Aggregate,
+        ...extraQueryFormData,
         temporal_columns_lookup: { col1: true },
-        show_totals: true,
-        metrics: ['aaa', 'aaa'],
-        adhoc_filters: [
-          {
-            expressionType: 'SQL',
-            sqlExpression: "status IN ('In Process')",
-            clause: 'WHERE',
-            subject: null,
-            operator: null,
-            comparator: null,
-            isExtra: false,
-            isNew: false,
-            datasourceWarning: false,
-            filterOptionName: 'filter_v8m9t9oq5re_ndzk6g5am7',
-          } as any,
-        ],
       });
       // Extras in regular query
       expect(queries[0].extras?.time_grain_sqla).toEqual(TimeGranularity.MONTH);
@@ -146,28 +149,7 @@ describe('plugin-chart-table', () => {
       expect(queries[1].extras?.where).toEqual("(status IN ('In Process'))");
     });
     it('should not include time_grain_sqla in extras if temporal colum is not used and keep the rest', () => {
-      const { queries } = buildQuery({
-        ...basicFormData,
-        time_grain_sqla: TimeGranularity.MONTH,
-        groupby: ['col1'],
-        query_mode: QueryMode.Aggregate,
-        show_totals: true,
-        metrics: ['aaa', 'aaa'],
-        adhoc_filters: [
-          {
-            expressionType: 'SQL',
-            sqlExpression: "status IN ('In Process')",
-            clause: 'WHERE',
-            subject: null,
-            operator: null,
-            comparator: null,
-            isExtra: false,
-            isNew: false,
-            datasourceWarning: false,
-            filterOptionName: 'filter_v8m9t9oq5re_ndzk6g5am7',
-          } as any,
-        ],
-      });
+      const { queries } = buildQuery(extraQueryFormData);
       // Extras in regular query
       expect(queries[0].extras?.time_grain_sqla).toBeUndefined();
       expect(queries[0].extras?.where).toEqual("(status IN ('In Process'))");

--- a/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -114,5 +114,66 @@ describe('plugin-chart-table', () => {
         expressionType: 'SQL',
       });
     });
+    it('should include time_grain_sqla in extras if temporal colum is used and keep the rest', () => {
+      const { queries } = buildQuery({
+        ...basicFormData,
+        time_grain_sqla: TimeGranularity.MONTH,
+        groupby: ['col1'],
+        query_mode: QueryMode.Aggregate,
+        temporal_columns_lookup: { col1: true },
+        show_totals: true,
+        metrics: ['aaa', 'aaa'],
+        adhoc_filters: [
+          {
+            expressionType: 'SQL',
+            sqlExpression: "status IN ('In Process')",
+            clause: 'WHERE',
+            subject: null,
+            operator: null,
+            comparator: null,
+            isExtra: false,
+            isNew: false,
+            datasourceWarning: false,
+            filterOptionName: 'filter_v8m9t9oq5re_ndzk6g5am7',
+          } as any,
+        ],
+      });
+      // Extras in regular query
+      expect(queries[0].extras?.time_grain_sqla).toEqual(TimeGranularity.MONTH);
+      expect(queries[0].extras?.where).toEqual("(status IN ('In Process'))");
+      // Extras in summary query
+      expect(queries[1].extras?.time_grain_sqla).toEqual(TimeGranularity.MONTH);
+      expect(queries[1].extras?.where).toEqual("(status IN ('In Process'))");
+    });
+    it('should not include time_grain_sqla in extras if temporal colum is not used and keep the rest', () => {
+      const { queries } = buildQuery({
+        ...basicFormData,
+        time_grain_sqla: TimeGranularity.MONTH,
+        groupby: ['col1'],
+        query_mode: QueryMode.Aggregate,
+        show_totals: true,
+        metrics: ['aaa', 'aaa'],
+        adhoc_filters: [
+          {
+            expressionType: 'SQL',
+            sqlExpression: "status IN ('In Process')",
+            clause: 'WHERE',
+            subject: null,
+            operator: null,
+            comparator: null,
+            isExtra: false,
+            isNew: false,
+            datasourceWarning: false,
+            filterOptionName: 'filter_v8m9t9oq5re_ndzk6g5am7',
+          } as any,
+        ],
+      });
+      // Extras in regular query
+      expect(queries[0].extras?.time_grain_sqla).toBeUndefined();
+      expect(queries[0].extras?.where).toEqual("(status IN ('In Process'))");
+      // Extras in summary query
+      expect(queries[1].extras?.time_grain_sqla).toBeUndefined();
+      expect(queries[1].extras?.where).toEqual("(status IN ('In Process'))");
+    });
   });
 });


### PR DESCRIPTION
### SUMMARY
`Table` chart was removing the `extras` from the summary query, assuming they were only used for time grains. This PR fixes that and put the extras back in the queryObject sent as payload, now, only excluding `time_grain_sqla` if no temporal column is included in your chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Excluding extras from summary query and only adding it if no time comparison was used
<img width="1898" alt="before" src="https://github.com/user-attachments/assets/fbba5471-45d1-4431-a113-e75a80df3e7d">

Now: Sending extras in the total query regardless you're using time comparison
No temporal Column
<img width="1898" alt="now_no_temp" src="https://github.com/user-attachments/assets/ce1f9c9e-e33b-43c7-b892-e2ba2ba12c7b">
With temporal Column
<img width="1898" alt="now_temp" src="https://github.com/user-attachments/assets/7f50441a-2c26-4885-b6d3-0e551d2c3079">



### TESTING INSTRUCTIONS
1. Create a `Table` Chart
2. Use no temporal column and a custom SQL filter
3. Mark the `Show summary` checkbox
4. The queries sent as payload must include the `where` in extras for both queries and not include a `time_grain_sqla`
5. Now add a temporal column to your chart and run the query again
6. The `time_grain_sqla` must be present in the extras alongside with the `where` clause

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/30193
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
