### PR TITLE
feat(Digest): Add RLS at digest generation for Charts and Dashboards

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1046,14 +1046,14 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             cache_dashboard_screenshot.delay(
                 username=get_current_user(),
                 guest_token=g.user.guest_token
-                if isinstance(g.user, GuestUser)
+                if hasattr(g, "user") and isinstance(g.user, GuestUser)
                 else None,
                 dashboard_id=dashboard.id,
                 dashboard_url=dashboard_url,
+                cache_key=cache_key,
                 force=True,
                 thumb_size=thumb_size,
                 window_size=window_size,
-                cache_key=cache_key,
             )
             return self.response(
                 202,

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1040,14 +1040,13 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         image_url = get_url_path(
             "DashboardRestApi.screenshot", pk=dashboard.id, digest=cache_key
         )
-        username = get_current_user()
 
         def trigger_celery() -> WerkzeugResponse:
             logger.info("Triggering screenshot ASYNC")
             cache_dashboard_screenshot.delay(
-                username=username,
+                username=get_current_user(),
                 guest_token=g.user.guest_token
-                if username and isinstance(g.user, GuestUser)
+                if get_current_user() and isinstance(g.user, GuestUser)
                 else None,
                 dashboard_id=dashboard.id,
                 dashboard_url=dashboard_url,

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1040,13 +1040,14 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         image_url = get_url_path(
             "DashboardRestApi.screenshot", pk=dashboard.id, digest=cache_key
         )
+        username = get_current_user()
 
         def trigger_celery() -> WerkzeugResponse:
             logger.info("Triggering screenshot ASYNC")
             cache_dashboard_screenshot.delay(
-                username=get_current_user(),
+                username=username,
                 guest_token=g.user.guest_token
-                if hasattr(g, "user") and isinstance(g.user, GuestUser)
+                if username and isinstance(g.user, GuestUser)
                 else None,
                 dashboard_id=dashboard.id,
                 dashboard_url=dashboard_url,

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -67,6 +67,7 @@ from superset.security.guest_token import (
     GuestUser,
 )
 from superset.sql_parse import extract_tables_from_jinja_sql, Table
+from superset.tasks.utils import get_current_user
 from superset.utils import json
 from superset.utils.core import (
     DatasourceName,
@@ -2641,7 +2642,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return False
 
         if not user:
-            if not hasattr(g, "user"):
+            if not get_current_user():
                 return False
             user = g.user
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2639,13 +2639,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
 
         if not is_feature_enabled("EMBEDDED_SUPERSET"):
             return False
+
         if not user:
-            current_user = g.user if hasattr(g, "user") else None
+            user = g.user if hasattr(g, "user") else None
 
-        if not current_user:
-            return False
-
-        return hasattr(current_user, "is_guest_user") and current_user.is_guest_user
+        return user and hasattr(user, "is_guest_user") and user.is_guest_user
 
     def get_current_guest_user_if_guest(self) -> Optional[GuestUser]:
         return g.user if self.is_guest_user() else None

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2640,8 +2640,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if not is_feature_enabled("EMBEDDED_SUPERSET"):
             return False
         if not user:
-            user = g.user
-        return hasattr(user, "is_guest_user") and user.is_guest_user
+            current_user = g.user if hasattr(g, "user") else None
+
+        if not current_user:
+            return False
+
+        return hasattr(current_user, "is_guest_user") and current_user.is_guest_user
 
     def get_current_guest_user_if_guest(self) -> Optional[GuestUser]:
         return g.user if self.is_guest_user() else None

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2641,9 +2641,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return False
 
         if not user:
-            user = g.user if hasattr(g, "user") else None
+            if not hasattr(g, "user"):
+                return False
+            user = g.user
 
-        return user and hasattr(user, "is_guest_user") and user.is_guest_user
+        return hasattr(user, "is_guest_user") and user.is_guest_user
 
     def get_current_guest_user_if_guest(self) -> Optional[GuestUser]:
         return g.user if self.is_guest_user() else None

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -114,10 +114,10 @@ def cache_dashboard_screenshot(  # pylint: disable=too-many-arguments
     dashboard_id: int,
     dashboard_url: str,
     force: bool = True,
+    cache_key: Optional[str] = None,
     guest_token: Optional[GuestToken] = None,
     thumb_size: Optional[WindowSize] = None,
     window_size: Optional[WindowSize] = None,
-    cache_key: Optional[str] = None,
 ) -> None:
     # pylint: disable=import-outside-toplevel
     from superset.models.dashboard import Dashboard

--- a/superset/thumbnails/digest.py
+++ b/superset/thumbnails/digest.py
@@ -77,7 +77,7 @@ def _adjust_string_with_rls(
                     rls_filters = datasource.get_sqla_row_level_filters()
                     stringified_rls += "".join([str(f) for f in rls_filters])
 
-        if stringified_rls != "":
+        if stringified_rls:
             unique_string = f"{unique_string}\n{stringified_rls}"
 
     return unique_string

--- a/superset/thumbnails/digest.py
+++ b/superset/thumbnails/digest.py
@@ -75,7 +75,13 @@ def _adjust_string_with_rls(
                     and datasource.is_rls_supported
                 ):
                     rls_filters = datasource.get_sqla_row_level_filters()
-                    stringified_rls += "".join([str(f) for f in rls_filters])
+
+                    if len(rls_filters) > 0:
+                        stringified_rls += (
+                            f"{str(datasource.id)}\t"
+                            + "\t".join([str(f) for f in rls_filters])
+                            + "\n"
+                        )
 
         if stringified_rls:
             unique_string = f"{unique_string}\n{stringified_rls}"

--- a/tests/unit_tests/thumbnails/test_digest.py
+++ b/tests/unit_tests/thumbnails/test_digest.py
@@ -166,7 +166,7 @@ def prepare_datasource_mock(
                     "get_sqla_row_level_filters": MagicMock(return_value=["filter1"]),
                 }
             ],
-            "f4f262a649225d62717cdb11a9f2b8ee",
+            "4138959f275c1991466cafcfb190fd72",
         ),
         (
             None,
@@ -187,7 +187,7 @@ def prepare_datasource_mock(
                     ),
                 },
             ],
-            "4903ad13cfe28a5fc41478147d87211a",
+            "80d3bfcc7144bccdba8c718cf49b6420",
         ),
         (
             None,
@@ -206,7 +206,7 @@ def prepare_datasource_mock(
                     ),
                 },
             ],
-            "774b0c1ed98142ee8f60aae51f128000",
+            "e8fc68cd5aba22a5f1acf06164bfc0f4",
         ),
         (
             None,
@@ -218,7 +218,7 @@ def prepare_datasource_mock(
         ),
     ],
 )
-def test_dashboard_digest_with_rls(
+def test_dashboard_digest(
     dashboard_overrides: dict[str, Any] | None,
     execute_as: list[ExecutorType],
     has_current_user: bool,
@@ -313,7 +313,7 @@ def test_dashboard_digest_with_rls(
                 "is_rls_supported": True,
                 "get_sqla_row_level_filters": MagicMock(return_value=["filter1"]),
             },
-            "aa9a5f74de01407aaf329734e78ee7f9",
+            "61e70336c27eb97fb050328a0b050373",
         ),
         (
             None,
@@ -326,7 +326,7 @@ def test_dashboard_digest_with_rls(
                     return_value=["filter1", "filter2"]
                 ),
             },
-            "508aa7084728ef609469ad0c4410014a",
+            "95c7cefde8cb519f005f33bfb33cb196",
         ),
         (
             None,
@@ -349,7 +349,7 @@ def test_dashboard_digest_with_rls(
         ),
     ],
 )
-def test_chart_digest_with_rls(
+def test_chart_digest(
     chart_overrides: dict[str, Any] | None,
     execute_as: list[ExecutorType],
     has_current_user: bool,

--- a/tests/unit_tests/thumbnails/test_digest.py
+++ b/tests/unit_tests/thumbnails/test_digest.py
@@ -18,14 +18,15 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from typing import Any, TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 from flask_appbuilder.security.sqla.models import User
 
+from superset.connectors.sqla.models import BaseDatasource, SqlaTable
 from superset.tasks.exceptions import ExecutorNotFoundError
 from superset.tasks.types import ExecutorType
-from superset.utils.core import override_user
+from superset.utils.core import DatasourceType, override_user
 
 if TYPE_CHECKING:
     from superset.models.dashboard import Dashboard
@@ -62,14 +63,28 @@ def CUSTOM_CHART_FUNC(
     return f"{chart.id}.{executor_type.value}.{executor}"
 
 
+def prepare_datasource_mock(
+    datasource_conf: dict[str, Any], spec: type[BaseDatasource | SqlaTable]
+) -> BaseDatasource | SqlaTable:
+    datasource = MagicMock(spec=spec)
+    datasource.id = 1
+    datasource.type = DatasourceType.TABLE
+    datasource.is_rls_supported = datasource_conf.get("is_rls_supported", False)
+    datasource.get_sqla_row_level_filters = datasource_conf.get(
+        "get_sqla_row_level_filters", MagicMock(return_value=[])
+    )
+    return datasource
+
+
 @pytest.mark.parametrize(
-    "dashboard_overrides,execute_as,has_current_user,use_custom_digest,expected_result",
+    "dashboard_overrides,execute_as,has_current_user,use_custom_digest,rls_datasources,expected_result",
     [
         (
             None,
             [ExecutorType.SELENIUM],
             False,
             False,
+            [],
             "71452fee8ffbd8d340193d611bcd4559",
         ),
         (
@@ -77,99 +92,103 @@ def CUSTOM_CHART_FUNC(
             [ExecutorType.CURRENT_USER],
             True,
             False,
+            [],
             "209dc060ac19271b8708731e3b8280f5",
-        ),
-        (
-            {
-                "dashboard_title": "My Other Title",
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "209dc060ac19271b8708731e3b8280f5",
-        ),
-        (
-            {
-                "id": 2,
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "06a4144466dbd5ffad0c3c2225e96296",
-        ),
-        (
-            {
-                "slices": [{"id": 2, "slice_name": "My Other Chart"}],
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "a823ece9563895ccb14f3d9095e84f7a",
-        ),
-        (
-            {
-                "position_json": {"b": "c"},
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "33c5475f92a904925ab3ef493526e5b5",
-        ),
-        (
-            {
-                "css": "background-color: darkblue;",
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "cec57345e6402c0d4b3caee5cfaa0a03",
-        ),
-        (
-            {
-                "json_metadata": {"d": "e"},
-            },
-            [ExecutorType.CURRENT_USER],
-            True,
-            False,
-            "5380dcbe94621a0759b09554404f3d02",
         ),
         (
             None,
             [ExecutorType.CURRENT_USER],
             True,
+            False,
+            [
+                {
+                    "is_rls_supported": True,
+                    "get_sqla_row_level_filters": MagicMock(return_value=["filter1"]),
+                }
+            ],
+            "f4f262a649225d62717cdb11a9f2b8ee",
+        ),
+        (
+            None,
+            [ExecutorType.CURRENT_USER],
             True,
-            "1.current_user.1",
+            False,
+            [
+                {
+                    "is_rls_supported": True,
+                    "get_sqla_row_level_filters": MagicMock(
+                        return_value=["filter1", "filter2"]
+                    ),
+                },
+                {
+                    "is_rls_supported": True,
+                    "get_sqla_row_level_filters": MagicMock(
+                        return_value=["filter3", "filter4"]
+                    ),
+                },
+            ],
+            "4903ad13cfe28a5fc41478147d87211a",
+        ),
+        (
+            None,
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [
+                {
+                    "is_rls_supported": False,
+                    "get_sqla_row_level_filters": MagicMock(return_value=[]),
+                },
+                {
+                    "is_rls_supported": True,
+                    "get_sqla_row_level_filters": MagicMock(
+                        return_value=["filter1", "filter2"]
+                    ),
+                },
+            ],
+            "774b0c1ed98142ee8f60aae51f128000",
         ),
         (
             None,
             [ExecutorType.CURRENT_USER],
             False,
             False,
+            [],
             ExecutorNotFoundError(),
         ),
     ],
 )
-def test_dashboard_digest(
+def test_dashboard_digest_with_rls(
     dashboard_overrides: dict[str, Any] | None,
     execute_as: list[ExecutorType],
     has_current_user: bool,
     use_custom_digest: bool,
+    rls_datasources: list[dict[str, Any]],
     expected_result: str | Exception,
 ) -> None:
-    from superset import app
+    from superset import app, security_manager
     from superset.models.dashboard import Dashboard
     from superset.models.slice import Slice
     from superset.thumbnails.digest import get_dashboard_digest
 
+    # Prepare dashboard and slices
     kwargs = {
         **_DEFAULT_DASHBOARD_KWARGS,
         **(dashboard_overrides or {}),
     }
     slices = [Slice(**slice_kwargs) for slice_kwargs in kwargs.pop("slices")]
     dashboard = Dashboard(**kwargs, slices=slices)
+
+    # Mock datasources with RLS
+    datasources = []
+    for rls_source in rls_datasources:
+        datasource = prepare_datasource_mock(rls_source, BaseDatasource)
+        datasources.append(datasource)
+
     user: User | None = None
     if has_current_user:
         user = User(id=1, username="1")
+
     func = CUSTOM_DASHBOARD_FUNC if use_custom_digest else None
 
     with (
@@ -180,6 +199,13 @@ def test_dashboard_digest(
                 "THUMBNAIL_DASHBOARD_DIGEST_FUNC": func,
             },
         ),
+        patch.object(
+            type(dashboard),
+            "datasources",
+            new_callable=PropertyMock,
+            return_value=datasources,
+        ),
+        patch.object(security_manager, "find_user", return_value=user),
         override_user(user),
     ):
         cm = (
@@ -192,13 +218,14 @@ def test_dashboard_digest(
 
 
 @pytest.mark.parametrize(
-    "chart_overrides,execute_as,has_current_user,use_custom_digest,expected_result",
+    "chart_overrides,execute_as,has_current_user,use_custom_digest,rls_datasource,expected_result",
     [
         (
             None,
             [ExecutorType.SELENIUM],
             False,
             False,
+            None,
             "47d852b5c4df211c115905617bb722c1",
         ),
         (
@@ -206,6 +233,7 @@ def test_dashboard_digest(
             [ExecutorType.CURRENT_USER],
             True,
             False,
+            None,
             "4f8109d3761e766e650af514bb358f10",
         ),
         (
@@ -213,36 +241,82 @@ def test_dashboard_digest(
             [ExecutorType.CURRENT_USER],
             True,
             True,
+            None,
             "2.current_user.1",
+        ),
+        (
+            None,
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            {
+                "is_rls_supported": True,
+                "get_sqla_row_level_filters": MagicMock(return_value=["filter1"]),
+            },
+            "aa9a5f74de01407aaf329734e78ee7f9",
+        ),
+        (
+            None,
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            {
+                "is_rls_supported": True,
+                "get_sqla_row_level_filters": MagicMock(
+                    return_value=["filter1", "filter2"]
+                ),
+            },
+            "508aa7084728ef609469ad0c4410014a",
+        ),
+        (
+            None,
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            {
+                "is_rls_supported": False,
+                "get_sqla_row_level_filters": MagicMock(return_value=[]),
+            },
+            "4f8109d3761e766e650af514bb358f10",
         ),
         (
             None,
             [ExecutorType.CURRENT_USER],
             False,
             False,
+            None,
             ExecutorNotFoundError(),
         ),
     ],
 )
-def test_chart_digest(
+def test_chart_digest_with_rls(
     chart_overrides: dict[str, Any] | None,
     execute_as: list[ExecutorType],
     has_current_user: bool,
     use_custom_digest: bool,
+    rls_datasource: dict[str, Any] | None,
     expected_result: str | Exception,
 ) -> None:
-    from superset import app
+    from superset import app, security_manager
     from superset.models.slice import Slice
     from superset.thumbnails.digest import get_chart_digest
 
+    # Mock datasource with RLS if provided
+    datasource = None
+    if rls_datasource:
+        datasource = prepare_datasource_mock(rls_datasource, SqlaTable)
+
+    # Prepare chart with the datasource in the constructor
     kwargs = {
         **_DEFAULT_CHART_KWARGS,
         **(chart_overrides or {}),
     }
     chart = Slice(**kwargs)
+
     user: User | None = None
     if has_current_user:
         user = User(id=1, username="1")
+
     func = CUSTOM_CHART_FUNC if use_custom_digest else None
 
     with (
@@ -253,6 +327,13 @@ def test_chart_digest(
                 "THUMBNAIL_CHART_DIGEST_FUNC": func,
             },
         ),
+        patch.object(
+            type(chart),
+            "datasource",
+            new_callable=PropertyMock,
+            return_value=datasource,
+        ),
+        patch.object(security_manager, "find_user", return_value=user),
         override_user(user),
     ):
         cm = (

--- a/tests/unit_tests/thumbnails/test_digest.py
+++ b/tests/unit_tests/thumbnails/test_digest.py
@@ -96,6 +96,66 @@ def prepare_datasource_mock(
             "209dc060ac19271b8708731e3b8280f5",
         ),
         (
+            {
+                "dashboard_title": "My Other Title",
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "209dc060ac19271b8708731e3b8280f5",
+        ),
+        (
+            {
+                "id": 2,
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "06a4144466dbd5ffad0c3c2225e96296",
+        ),
+        (
+            {
+                "slices": [{"id": 2, "slice_name": "My Other Chart"}],
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "a823ece9563895ccb14f3d9095e84f7a",
+        ),
+        (
+            {
+                "position_json": {"b": "c"},
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "33c5475f92a904925ab3ef493526e5b5",
+        ),
+        (
+            {
+                "css": "background-color: darkblue;",
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "cec57345e6402c0d4b3caee5cfaa0a03",
+        ),
+        (
+            {
+                "json_metadata": {"d": "e"},
+            },
+            [ExecutorType.CURRENT_USER],
+            True,
+            False,
+            [],
+            "5380dcbe94621a0759b09554404f3d02",
+        ),
+        (
             None,
             [ExecutorType.CURRENT_USER],
             True,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Digest generation for charts and dashboards wasn't considering RLS for users and guest users (via Embedded). This PR includes the RLS in the hash generation for the digest. The digest is included in cache keys and will be updated according to the RLS rules. Previously you could generate a screenshot and any RLS applied later won't be applied to follow-up screenshots as the same cache key was being reused.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Generate a screenshot of a Dashboard
2. Add RLS rules for the current user
3. Generate the screenshot again
4. The screenshot should present the Dashboard with RLS rules applied

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
