### PR TITLE
docs: sql-templating

### DIFF
--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -94,7 +94,7 @@ There is a special ``_filters`` parameter which can be used to test filters used
 ```sql
 SELECT action, count(*) as times
 FROM logs
-WHERE action in {{ filter_values('action_type'))|where_in }}
+WHERE action in {{ filter_values('action_type')|where_in }}
 GROUP BY action
 ```
 


### PR DESCRIPTION
"filter_values" function was more than one close parenthesis.

### SUMMARY
Fixed documentation, to avoid using mistakes.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
