### PR TITLE
fix: KeyError 'sql' when opening a Trino virtual dataset

### DIFF
--- a/superset/commands/sql_lab/execute.py
+++ b/superset/commands/sql_lab/execute.py
@@ -17,7 +17,6 @@
 # pylint: disable=too-few-public-methods, too-many-arguments
 from __future__ import annotations
 
-import copy
 import logging
 from typing import Any, TYPE_CHECKING
 
@@ -152,8 +151,6 @@ class ExecuteSqlCommand(BaseCommand):
             self._validate_access(query)
             self._execution_context.set_query(query)
             rendered_query = self._sql_query_render.render(self._execution_context)
-            validate_rendered_query = copy.copy(query)
-            validate_rendered_query.sql = rendered_query
             self._set_query_limit_if_required(rendered_query)
             self._query_dao.update(
                 query, {"limit": self._execution_context.query.limit}

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -90,7 +90,6 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
         rendered_query: str,
         log_params: dict[str, Any] | None,
     ) -> SqlJsonExecutionStatus:
-        print(">>> execute <<<")
         query_id = execution_context.query.id
         try:
             data = self._get_sql_results_with_timeout(
@@ -102,7 +101,6 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             raise
         except Exception as ex:
             logger.exception("Query %i failed unexpectedly", query_id)
-            print(str(ex))
             raise SupersetGenericDBErrorException(
                 utils.error_msg_from_exception(ex)
             ) from ex

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -260,7 +260,9 @@ def transaction(  # pylint: disable=redefined-outer-name
                 db.session.commit()  # pylint: disable=consider-using-transaction
                 return result
             except Exception as ex:
-                db.session.rollback()  # pylint: disable=consider-using-transaction
+                # An error can happen before the session becomes active
+                if db.session.is_active:
+                    db.session.rollback()  # pylint: disable=consider-using-transaction
 
                 if on_error:
                     return on_error(ex)

--- a/superset/utils/decorators.py
+++ b/superset/utils/decorators.py
@@ -260,9 +260,7 @@ def transaction(  # pylint: disable=redefined-outer-name
                 db.session.commit()  # pylint: disable=consider-using-transaction
                 return result
             except Exception as ex:
-                # An error can happen before the session becomes active
-                if db.session.is_active:
-                    db.session.rollback()  # pylint: disable=consider-using-transaction
+                db.session.rollback()  # pylint: disable=consider-using-transaction
 
                 if on_error:
                     return on_error(ex)


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/27470 modified the logic to validate a SQL Lab query by checking the access permission before any Jinja rendering occurs as some Jinja macros execute statements upon rendering. Those changes left an unused shallow copy statement that was interfering with SQL Alchemy internal state provoking key errors. This PR removes the unused statements.

Fixes https://github.com/apache/superset/issues/30338

### TESTING INSTRUCTIONS
Follow the instructions described in the original issue.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
