### PR TITLE
fix(explore): Missing markarea component broke annotations in echarts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -55,6 +55,7 @@ import {
   ToolboxComponent,
   GraphicComponent,
   AriaComponent,
+  MarkAreaComponent,
 } from 'echarts/components';
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
@@ -84,6 +85,7 @@ use([
   DataZoomComponent,
   GraphicComponent,
   GridComponent,
+  MarkAreaComponent,
   LegendComponent,
   ToolboxComponent,
   TooltipComponent,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -56,6 +56,7 @@ import {
   GraphicComponent,
   AriaComponent,
   MarkAreaComponent,
+  MarkLineComponent,
 } from 'echarts/components';
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
@@ -86,6 +87,7 @@ use([
   GraphicComponent,
   GridComponent,
   MarkAreaComponent,
+  MarkLineComponent,
   LegendComponent,
   ToolboxComponent,
   TooltipComponent,


### PR DESCRIPTION
### SUMMARY
Recent Echarts bundle size optimization PR didn't register `MarkLineComponent` and `MarkAreaComponent` from `echarts/components` package, which broke annotations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/1015f78c-9ea8-4bf4-baeb-2351785e958d">

After:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/33f735d8-3fbd-428e-beb0-b611507c0005">


### TESTING INSTRUCTIONS
1. Create an annotation layer 
    * date 2000-01-01 -> 2002-01-01
2. Save
3. Create an Echarts line chart with wb_health_population dataset
4. Use `year` as x-axis, `sum__SP_POP_TOTL` as metric
4. Add the annotation 
    * Show labe = checked
    * annotation layer type = interval
    * annotation source = Superset annotation 
    * annotation layer = your annotation layer
    * hit ok
5. click update chart
6. Verify that the annotation is visible
7. Do the same for annotation layer type = Event

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
