### PR TITLE
feat(datasets): Allow swap dataset after deletion

### DIFF
--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.test.ts
@@ -286,3 +286,175 @@ test('SQL ad-hoc filter values', () => {
     sqlExpression: 'select * from sample_column_1;',
   });
 });
+
+test('no controlState value but valid column in datasource', () => {
+  const controlState = {
+    ...sharedControls.columns,
+    options: [], // no options in the control state
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'sample_column_1', // column only available in datasource
+    }),
+  ).toEqual('sample_column_1');
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'non_existing_column',
+    }),
+  ).toEqual(controlState.default);
+});
+
+test('no controlState value but valid saved metric in datasource', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+    savedMetrics: [], // no saved metrics in the control state
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'saved_metric_2', // metric only available in datasource
+    }),
+  ).toEqual('saved_metric_2');
+
+  expect(
+    getValues({
+      ...controlState,
+      value: 'non_existing_metric',
+    }),
+  ).toEqual(controlState.default);
+});
+
+test('no controlState value but valid adhoc metric in datasource', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+    columns: [], // no columns in control state
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        column: { column_name: 'sample_column_1' }, // only in datasource
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SIMPLE',
+    column: { column_name: 'sample_column_1' },
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        column: { column_name: 'non_existing_column' },
+      },
+    }),
+  ).toEqual(controlState.default);
+});
+
+test('no controlState value but valid adhoc filter in datasource', () => {
+  const controlState = {
+    ...sharedControls.adhoc_filters,
+    columns: [], // no columns in control state
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        subject: 'sample_column_1', // column available in datasource
+      },
+    }),
+  ).toEqual({
+    expressionType: 'SIMPLE',
+    subject: 'sample_column_1',
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SIMPLE',
+        subject: 'non_existing_column',
+      },
+    }),
+  ).toEqual(controlState.default);
+});
+
+test('SQL ad-hoc metric values without controlState columns', () => {
+  const controlState = {
+    ...sharedControls.metrics,
+    columns: [], // No columns in controlState
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'SELECT COUNT(*) FROM sample_table;',
+      },
+    }),
+  ).toEqual({
+    datasourceWarning: true,
+    expressionType: 'SQL',
+    sqlExpression: 'SELECT COUNT(*) FROM sample_table;',
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'SELECT column FROM non_existing_table;',
+      },
+    }),
+  ).toEqual({
+    datasourceWarning: true,
+    expressionType: 'SQL',
+    sqlExpression: 'SELECT column FROM non_existing_table;',
+  });
+});
+
+test('SQL ad-hoc filter values without controlState columns', () => {
+  const controlState = {
+    ...sharedControls.adhoc_filters,
+    columns: [], // No columns in controlState
+  };
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'SELECT * FROM sample_table WHERE column = 1;',
+      },
+    }),
+  ).toEqual({
+    datasourceWarning: true,
+    expressionType: 'SQL',
+    sqlExpression: 'SELECT * FROM sample_table WHERE column = 1;',
+  });
+
+  expect(
+    getValues({
+      ...controlState,
+      value: {
+        expressionType: 'SQL',
+        sqlExpression: 'SELECT * FROM non_existing_table;',
+      },
+    }),
+  ).toEqual({
+    datasourceWarning: true,
+    expressionType: 'SQL',
+    sqlExpression: 'SELECT * FROM non_existing_table;',
+  });
+});

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -54,37 +54,34 @@ const isControlValueCompatibleWithDatasource = (
       );
     }
   }
-  if (controlState.savedMetrics && isSavedMetric(value)) {
-    if (
-      controlState.savedMetrics.some(
-        (savedMetric: Metric) => savedMetric.metric_name === value,
-      ) ||
-      !isEmpty(datasource?.metrics)
-    ) {
-      return datasource.metrics.some(
-        (metric: Metric) => metric.metric_name === value,
-      );
-    }
+  if (
+    controlState.savedMetrics &&
+    isSavedMetric(value) &&
+    (controlState.savedMetrics.some(
+      (savedMetric: Metric) => savedMetric.metric_name === value,
+    ) ||
+      !isEmpty(datasource?.metrics))
+  ) {
+    return datasource.metrics.some(
+      (metric: Metric) => metric.metric_name === value,
+    );
   }
   if (
     controlState.columns &&
-    (isAdhocMetricSimple(value) || isSimpleAdhocFilter(value))
-  ) {
-    if (
-      (!isEmpty(controlState.columns) &&
-        controlState.columns.some(
-          (column: Column) =>
-            column.column_name === (value as AdhocMetric).column?.column_name ||
-            column.column_name === (value as SimpleAdhocFilter).subject,
-        )) ||
-      !isEmpty(datasource?.columns)
-    ) {
-      return datasource.columns.some(
+    (isAdhocMetricSimple(value) || isSimpleAdhocFilter(value)) &&
+    ((!isEmpty(controlState.columns) &&
+      controlState.columns.some(
         (column: Column) =>
           column.column_name === (value as AdhocMetric).column?.column_name ||
           column.column_name === (value as SimpleAdhocFilter).subject,
-      );
-    }
+      )) ||
+      !isEmpty(datasource?.columns))
+  ) {
+    return datasource.columns.some(
+      (column: Column) =>
+        column.column_name === (value as AdhocMetric).column?.column_name ||
+        column.column_name === (value as SimpleAdhocFilter).subject,
+    );
   }
   if (isAdhocMetricSQL(value)) {
     Object.assign(value, { datasourceWarning: true });

--- a/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlValuesCompatibleWithDatasource.ts
@@ -27,6 +27,7 @@ import {
   JsonValue,
   SimpleAdhocFilter,
 } from '@superset-ui/core';
+import { isEmpty } from 'lodash';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 
 const isControlValueCompatibleWithDatasource = (
@@ -34,43 +35,56 @@ const isControlValueCompatibleWithDatasource = (
   controlState: ControlState,
   value: any,
 ) => {
+  // A datasource might have been deleted, in which case we can't validate
+  // only using the control state since it might have been hydrated with
+  // the wrong options or columns (empty arrays).
   if (controlState.options && typeof value === 'string') {
     if (
-      controlState.options.some(
-        (option: [string | number, string] | { column_name: string }) =>
-          Array.isArray(option)
-            ? option[0] === value
-            : option.column_name === value,
-      )
+      (!isEmpty(controlState.options) &&
+        controlState.options.some(
+          (option: [string | number, string] | { column_name: string }) =>
+            Array.isArray(option)
+              ? option[0] === value
+              : option.column_name === value,
+        )) ||
+      !isEmpty(datasource?.columns)
     ) {
-      return datasource.columns.some(column => column.column_name === value);
+      return datasource.columns.some(
+        (column: Column) => column.column_name === value,
+      );
+    }
+  }
+  if (controlState.savedMetrics && isSavedMetric(value)) {
+    if (
+      controlState.savedMetrics.some(
+        (savedMetric: Metric) => savedMetric.metric_name === value,
+      ) ||
+      !isEmpty(datasource?.metrics)
+    ) {
+      return datasource.metrics.some(
+        (metric: Metric) => metric.metric_name === value,
+      );
     }
   }
   if (
-    controlState.savedMetrics &&
-    isSavedMetric(value) &&
-    controlState.savedMetrics.some(
-      (savedMetric: Metric) => savedMetric.metric_name === value,
-    )
-  ) {
-    return datasource.metrics.some(
-      (metric: Metric) => metric.metric_name === value,
-    );
-  }
-  if (
     controlState.columns &&
-    (isAdhocMetricSimple(value) || isSimpleAdhocFilter(value)) &&
-    controlState.columns.some(
-      (column: Column) =>
-        column.column_name === (value as AdhocMetric).column?.column_name ||
-        column.column_name === (value as SimpleAdhocFilter).subject,
-    )
+    (isAdhocMetricSimple(value) || isSimpleAdhocFilter(value))
   ) {
-    return datasource.columns.some(
-      (column: Column) =>
-        column.column_name === (value as AdhocMetric).column?.column_name ||
-        column.column_name === (value as SimpleAdhocFilter).subject,
-    );
+    if (
+      (!isEmpty(controlState.columns) &&
+        controlState.columns.some(
+          (column: Column) =>
+            column.column_name === (value as AdhocMetric).column?.column_name ||
+            column.column_name === (value as SimpleAdhocFilter).subject,
+        )) ||
+      !isEmpty(datasource?.columns)
+    ) {
+      return datasource.columns.some(
+        (column: Column) =>
+          column.column_name === (value as AdhocMetric).column?.column_name ||
+          column.column_name === (value as SimpleAdhocFilter).subject,
+      );
+    }
   }
   if (isAdhocMetricSQL(value)) {
     Object.assign(value, { datasourceWarning: true });

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -45,7 +45,7 @@ import { getFormDataWithDashboardContext } from 'src/explore/controlUtils/getFor
 const isValidResult = (rv: JsonObject): boolean =>
   rv?.result?.form_data && rv?.result?.dataset;
 
-const hasDataseId = (rv: JsonObject): boolean =>
+const hasDatasetId = (rv: JsonObject): boolean =>
   isDefined(rv?.result?.dataset?.id);
 
 const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
@@ -55,7 +55,7 @@ const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
       endpoint: 'api/v1/explore/',
     })(exploreUrlParams);
     if (isValidResult(rv)) {
-      if (hasDataseId(rv)) {
+      if (hasDatasetId(rv)) {
         return rv;
       }
       // Since there's no dataset id but the API responded with a valid payload,

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -58,10 +58,16 @@ const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
       if (hasDataseId(rv)) {
         return rv;
       }
+      // Since there's no dataset id but the API responded with a valid payload,
+      // we assume the dataset was deleted, so we preserve some values from previous
+      // state so if the user decide to swap the datasource, the chart config remains
       fallbackExploreInitialData.form_data = {
         ...rv.result.form_data,
         ...fallbackExploreInitialData.form_data,
       };
+      if (rv.result?.slice) {
+        fallbackExploreInitialData.slice = rv.result.slice;
+      }
     }
     let message = t('Failed to load chart data');
     const responseError = rv?.result?.message;

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -43,7 +43,10 @@ import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import { getFormDataWithDashboardContext } from 'src/explore/controlUtils/getFormDataWithDashboardContext';
 
 const isValidResult = (rv: JsonObject): boolean =>
-  rv?.result?.form_data && isDefined(rv?.result?.dataset?.id);
+  rv?.result?.form_data && rv?.result?.dataset;
+
+const hasDataseId = (rv: JsonObject): boolean =>
+  isDefined(rv?.result?.dataset?.id);
 
 const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
   try {
@@ -52,7 +55,13 @@ const fetchExploreData = async (exploreUrlParams: URLSearchParams) => {
       endpoint: 'api/v1/explore/',
     })(exploreUrlParams);
     if (isValidResult(rv)) {
-      return rv;
+      if (hasDataseId(rv)) {
+        return rv;
+      }
+      fallbackExploreInitialData.form_data = {
+        ...rv.result.form_data,
+        ...fallbackExploreInitialData.form_data,
+      };
     }
     let message = t('Failed to load chart data');
     const responseError = rv?.result?.message;


### PR DESCRIPTION
### SUMMARY
Currently, if you delete a dataset, the charts that were using it don't keep the controls config when swapping to a dataset that have similar structure.
This is because the state gets overwritten with form data that doesn't have the controls configs so the sync method is not able to fetch the correct values for them.

This PR keeps the values and other configs when the API response doesn't include dataset id (deleted) and fallback to read from the datasource when getting the controls values in case there's nothing in the state.

One thing to notice is that before, when you first loaded a chart that have no dataset because it was deleted, the explore data was a fallback and didn't trigger the API requests, now, because we're not using this fallback explore but keeping the form data info from the API response, the UI will show a `Not Found` error until you swap the dataset and update the chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/504820d1-de8b-469c-a471-31867649dacd


Now:

https://github.com/user-attachments/assets/f5495027-5270-42d4-9a9e-25fb9cbbe3a2






### TESTING INSTRUCTIONS
Create two datasets with the same schema (columns and metrics).
Create a chart using one of these and save it.
Delete this dataset.
Access the chart -- you'll see an option to swap the dataset.
Remap the chart to use the other dataset.
Your controls config must be kept

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
