### PR TITLE
chore: add logging for dashboards/get warnings

### DIFF
--- a/superset/commands/database/exceptions.py
+++ b/superset/commands/database/exceptions.py
@@ -202,3 +202,15 @@ class DatabaseOfflineError(SupersetErrorException):
 
 class InvalidParametersError(SupersetErrorsException):
     status = 422
+
+
+class DatasetValidationError(CommandException):
+    status = 422
+
+    def __init__(self, err: Exception) -> None:
+        super().__init__(
+            _(
+                "Dataset schema is invalid, caused by: %(error)s",
+                error=str(err),
+            )
+        )

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -56,6 +56,7 @@ from superset.commands.dashboard.importers.dispatcher import ImportDashboardsCom
 from superset.commands.dashboard.permalink.create import CreateDashboardPermalinkCommand
 from superset.commands.dashboard.unfave import DelFavoriteDashboardCommand
 from superset.commands.dashboard.update import UpdateDashboardCommand
+from superset.commands.database.exceptions import DatasetValidationError
 from superset.commands.exceptions import TagForbiddenError
 from superset.commands.importers.exceptions import NoValidFilesFoundError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
@@ -115,6 +116,7 @@ from superset.views.base_api import (
     requires_json,
     statsd_metrics,
 )
+from superset.views.error_handling import handle_api_exception
 from superset.views.filters import (
     BaseFilterRelatedRoles,
     BaseFilterRelatedUsers,
@@ -369,7 +371,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
 
     @expose("/<id_or_slug>/datasets", methods=("GET",))
     @protect()
-    @safe
+    @handle_api_exception
     @statsd_metrics
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_datasets",
@@ -417,15 +419,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             ]
             return self.response(200, result=result)
         except (TypeError, ValueError) as err:
-            return self.response_400(
-                message=gettext(
-                    "Dataset schema is invalid, caused by: %(error)s", error=str(err)
-                )
-            )
-        except DashboardAccessDeniedError:
-            return self.response_403()
-        except DashboardNotFoundError:
-            return self.response_404()
+            raise DatasetValidationError(err) from err
 
     @expose("/<id_or_slug>/tabs", methods=("GET",))
     @protect()

--- a/superset/views/error_handling.py
+++ b/superset/views/error_handling.py
@@ -45,6 +45,7 @@ from superset.exceptions import (
 )
 from superset.superset_typing import FlaskResponse
 from superset.utils import core as utils, json
+from superset.utils.log import get_logger_from_status
 
 if typing.TYPE_CHECKING:
     from superset.views.base import BaseSupersetView
@@ -108,8 +109,8 @@ def handle_api_exception(
             logger.warning("SupersetErrorException", exc_info=True)
             return json_error_response([ex.error], status=ex.status)
         except SupersetException as ex:
-            if ex.status >= 500:
-                logger.exception(ex)
+            logger_func, _ = get_logger_from_status(ex.status)
+            logger_func(ex.message, exc_info=True)
             return json_error_response(
                 utils.error_msg_from_exception(ex), status=ex.status
             )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We're currently not logging flask warnings to the logger as part of the "catch all" @safe or @handle_api_exception decorators. I think @handle_api_exception does a more thorough job of catching different errors and handling, logging, raising, etc. We're applying @handle_api_exception on most base restapi functions, but using @safe on the adhoc apis. Maybe we can look at combining these and only having one decorator. I also removed the exception handling in the api because they will be caught and handled in the decorator. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
