### PR TITLE
fix(dataset-api): get_or_create creates a dataset for an existing table_name but different schema

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -431,6 +431,16 @@ class DatasetDAO(BaseDAO[SqlaTable]):
         filterable.update(DATASET_CUSTOM_FIELDS)
         return filterable
 
+    @staticmethod
+    def get_table_by_schema_and_name(
+        database_id: int, schema: str, table_name: str
+    ) -> SqlaTable | None:
+        return (
+            db.session.query(SqlaTable)
+            .filter_by(database_id=database_id, schema=schema, table_name=table_name)
+            .one_or_none()
+        )
+
 
 class DatasetColumnDAO(BaseDAO[TableColumn]):
     pass

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1094,9 +1094,13 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             body = GetOrCreateDatasetSchema().load(request.json)
         except ValidationError as ex:
             return self.response(400, message=ex.messages)
+        schema_name = body.get("schema")
         table_name = body["table_name"]
         database_id = body["database_id"]
-        if table := DatasetDAO.get_table_by_name(database_id, table_name):
+
+        if table := DatasetDAO.get_table_by_schema_and_name(
+            database_id, schema_name, table_name
+        ):
             return self.response(200, result={"table_id": table.id})
 
         body["database"] = database_id

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2983,6 +2983,67 @@ class TestDatasetApi(SupersetTestCase):
         with examples_db.get_sqla_engine() as engine:
             engine.execute("DROP TABLE test_create_sqla_table_api")
 
+    def test_get_or_create_dataset_creates_table_for_different_schema(self):
+        """
+        Dataset API: Test get or create endpoint when table is created
+        """
+        self.login(ADMIN_USERNAME)
+
+        table_name = "test_create_sqla_table_for_schema_api"
+
+        examples_db = get_example_database()
+        with examples_db.get_sqla_engine() as engine:
+            engine.execute(f"DROP TABLE IF EXISTS {table_name}")
+            engine.execute(f"CREATE TABLE {table_name} AS SELECT 2 as col")
+
+        # pre populate for schema s1
+        sqla_ds_1 = self.insert_dataset(
+            table_name,
+            [self.get_user("admin").id],
+            examples_db,
+            schema="s1",
+            fetch_metadata=False,
+        )
+        # pre populate for schema s2
+        sqla_ds_2 = self.insert_dataset(
+            table_name,
+            [self.get_user("admin").id],
+            examples_db,
+            schema="s2",
+            fetch_metadata=False,
+        )
+
+        # attempt to create for a different schema
+        schema_name = None
+
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={
+                "table_name": table_name,
+                "schema": schema_name,
+                "database_id": examples_db.id,
+                "template_params": '{"param": 1}',
+            },
+        )
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        table = (
+            db.session.query(SqlaTable)
+            .filter_by(table_name=table_name, schema=schema_name)
+            .one()
+        )
+        assert response["result"] == {"table_id": table.id}
+        assert table.template_params == '{"param": 1}'
+        assert table.normalize_columns is False
+
+        db.session.delete(table)
+        db.session.delete(sqla_ds_1)
+        db.session.delete(sqla_ds_2)
+        db.session.commit()
+
+        with examples_db.get_sqla_engine() as engine:
+            engine.execute(f"DROP TABLE {table_name}")
+
     @pytest.mark.usefixtures(
         "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"
     )


### PR DESCRIPTION
### SUMMARY

At Pinterest we were trying to use the `get_or_create` endpoint to automate the integration between our MetricsLayer and Superset. During our tests we've encountered the following issue: https://github.com/apache/superset/issues/30377

The issue happens because at the moment the `get_or_create` code does not account for the payload `schema` attribute, doing a search by `table_name` only.

This PR changes `get_or_create` to take the `schema` into account:

* A new `get_table_by_schema_and_name` was added to the `DatasetDAO` class
* `get_or_create` now checks if the dataset exists by calling `DatasetDAO.get_table_by_schema_and_name` (instead of `DatasetDAO.get_table_by_name`)


### TESTING INSTRUCTIONS

- Integration tests were added for the new behaviour
- Manual tests: reproducing the steps described on the issue

**Case 1 - False Positive**

1. Go to the datasets page
2. Pick any existing dataset name and prepare a payload as follows (example using the `users` datasets)

```
{
  'table_name': 'users',
  'schema': 'other',
  'database_id': 1,
}
```

3. Submit this payload via a POST request to /api/v1/dataset/get_or_create
4. A new dataset is created. The API returns with a `200` pointing to the new dataset. No false positives anymore.

**Case 2 - Internal Server Error**

1. Create 2 or more datasets with the same `table_name` and different `schemas` (either via UI or create dataset API)
2. Try to create a new dataset. Again, with same `table_name` but a different schema. Payload example:

```
{
  'table_name': 'users',
  'schema': 'any_new_schema_name',
  'database_id': 1,
}
```

3. Submit this payload via a POST request to /api/v1/dataset/get_or_create
4. A new dataset is created. The API returns with a `200` pointing to the new dataset. No 500 errors anymore.

**Backward Compatibility**

1. Go to the datasets page
2. Pick any existing dataset name and prepare a payload as follows (without passing the schema)

```
{
  'table_name': 'users',
  'database_id': 1,
}
```

3. Submit this payload via a POST request to /api/v1/dataset/get_or_create
4. No new dataset is created. The API returns with a `200` with the response body pointing to the existing dataset.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
