### PR TITLE
feat(auth): when user is not logged in, failure to access a dashboard should redirect to login screen

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -793,8 +793,16 @@ class Superset(BaseSupersetView):
             dashboard.raise_for_access()
         except SupersetSecurityException as ex:
             # anonymous users should get the login screen, others should go to dashboard list
-            redirect_url = f"{appbuilder.get_url_for_login}?next={request.url}" if g.user is None or g.user.is_anonymous else "/dashboard/list/"
-            warn_msg = "This dashboard does not allow public access." if g.user is None or g.user.is_anonymous else utils.error_msg_from_exception(ex)
+            redirect_url = (
+                f"{appbuilder.get_url_for_login}?next={request.url}"
+                if g.user is None or g.user.is_anonymous
+                else "/dashboard/list/"
+            )
+            warn_msg = (
+                "This dashboard does not allow public access."
+                if g.user is None or g.user.is_anonymous
+                else utils.error_msg_from_exception(ex)
+            )
             return redirect_with_flash(
                 url=redirect_url,
                 message=warn_msg,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -792,9 +792,12 @@ class Superset(BaseSupersetView):
         try:
             dashboard.raise_for_access()
         except SupersetSecurityException as ex:
+            # anonymous users should get the login screen, others should go to dashboard list
+            redirect_url = f"{appbuilder.get_url_for_login}?next={request.url}" if g.user is None or g.user.is_anonymous else "/dashboard/list/"
+            warn_msg = "This dashboard does not allow public access." if g.user is None or g.user.is_anonymous else utils.error_msg_from_exception(ex)
             return redirect_with_flash(
-                url="/dashboard/list/",
-                message=utils.error_msg_from_exception(ex),
+                url=redirect_url,
+                message=warn_msg,
                 category="danger",
             )
         add_extra_log_payload(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -793,16 +793,12 @@ class Superset(BaseSupersetView):
             dashboard.raise_for_access()
         except SupersetSecurityException as ex:
             # anonymous users should get the login screen, others should go to dashboard list
-            redirect_url = (
-                f"{appbuilder.get_url_for_login}?next={request.url}"
-                if g.user is None or g.user.is_anonymous
-                else "/dashboard/list/"
-            )
-            warn_msg = (
-                "This dashboard does not allow public access."
-                if g.user is None or g.user.is_anonymous
-                else utils.error_msg_from_exception(ex)
-            )
+            if g.user is None or g.user.is_anonymous:
+                redirect_url = f"{appbuilder.get_url_for_login}?next={request.url}"
+                warn_msg = "Users must be logged in to view this dashboard."
+            else:
+                redirect_url = "/dashboard/list/"
+                warn_msg = utils.error_msg_from_exception(ex)
             return redirect_with_flash(
                 url=redirect_url,
                 message=warn_msg,


### PR DESCRIPTION
### SUMMARY
If a viewer is not logged in, or they are the public/anonymous user, and they click a link that takes them to a Superset dashboard that is _not_ public, they are currently told "You don't have access" and sent to the list of dashboards, where they will see only public ones listed.  This is often misleading: in most cases, the problem is not that they don't have access -- they just need to log in.

After the PR, such cases are routed to the login screen, and after a successful login the users are sent back to the dashboard they were trying to access.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE**

https://github.com/user-attachments/assets/053bbf0e-a2f5-4e2b-8498-47694ff213a6

**AFTER**

https://github.com/user-attachments/assets/fc78d404-0d63-4512-9ec4-c1e813b7a66b

note I've changed the error message since recording this

### TESTING INSTRUCTIONS
Create a dashboard with restricted access, try to view it while not logged in.

### ADDITIONAL INFORMATION
Implements this feature request: https://github.com/apache/superset/discussions/22190 
Replaces this stale PR: https://github.com/apache/superset/pull/23280

I have the DASHBOARD_RBAC flag enabled as well as the Public role in use.  My code alterations are minimal so I don't think it will negatively affect deployments that differ from mine, but it would be good to have someone check.

I'm not sure how to write tests for this but am open to it if someone can advise.