### PR TITLE
fix(ECharts): Revert ECharts version bump

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -70,6 +70,7 @@
         "core-js": "^3.38.1",
         "d3-scale": "^2.1.2",
         "dom-to-image-more": "^3.2.0",
+        "echarts": "^5.5.1",
         "emotion-rgba": "0.0.12",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.2.0",
@@ -22301,6 +22302,20 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/echarts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -53383,6 +53398,19 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zrender": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "license": "MIT",
@@ -57176,7 +57204,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.5.1",
+        "echarts": "^5.4.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1"
       },
@@ -57185,28 +57213,6 @@
         "@superset-ui/core": "*",
         "memoize-one": "*",
         "react": "^16.13.1"
-      }
-    },
-    "plugins/plugin-chart-echarts/node_modules/echarts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
-      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "5.6.0"
-      }
-    },
-    "plugins/plugin-chart-echarts/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-    },
-    "plugins/plugin-chart-echarts/node_modules/zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
-      "dependencies": {
-        "tslib": "2.3.0"
       }
     },
     "plugins/plugin-chart-handlebars": {
@@ -67474,33 +67480,9 @@
       "version": "file:plugins/plugin-chart-echarts",
       "requires": {
         "d3-array": "^1.2.0",
-        "echarts": "^5.5.1",
+        "echarts": "^5.4.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1"
-      },
-      "dependencies": {
-        "echarts": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
-          "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
-          "requires": {
-            "tslib": "2.3.0",
-            "zrender": "5.6.0"
-          }
-        },
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-        },
-        "zrender": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-          "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
-          "requires": {
-            "tslib": "2.3.0"
-          }
-        }
       }
     },
     "@superset-ui/plugin-chart-handlebars": {
@@ -74597,6 +74579,22 @@
       "version": "1.0.11",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "echarts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+      "requires": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "ee-first": {
@@ -94046,6 +94044,21 @@
     "zod": {
       "version": "3.23.8",
       "dev": true
+    },
+    "zrender": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "requires": {
+        "tslib": "2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     },
     "zwitch": {
       "version": "2.0.4"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "d3-array": "^1.2.0",
-    "echarts": "^5.5.1",
+    "echarts": "^5.4.1",
     "lodash": "^4.17.21",
     "moment": "^2.30.1"
   },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
PR https://github.com/apache/superset/pull/29963 has bumped ECharts to version 5.5.1. However, we have seen several issues with running the frontend. This PR reverts ECharts to previous version 5.4.1.

### BEFORE
![image](https://github.com/user-attachments/assets/dd3c9727-611a-49c9-bc28-a982415019b8)

### TESTING INSTRUCTIONS
1. Open a Dashboard with ECharts
2. ECharts should load

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
