### PR TITLE
fix: Allows X-Axis Sort By for custom SQL

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -23,7 +23,6 @@ import {
   GenericDataType,
   getColumnLabel,
   getMetricLabel,
-  isPhysicalColumn,
   QueryFormColumn,
   QueryFormMetric,
   t,
@@ -40,6 +39,7 @@ import {
   SORT_SERIES_CHOICES,
 } from '../constants';
 import { checkColumnType } from '../utils/checkColumnType';
+import { isSortable } from '../utils/isSortable';
 
 export const contributionModeControl = {
   name: 'contributionMode',
@@ -55,33 +55,6 @@ export const contributionModeControl = {
     description: t('Calculate contribution per series or row'),
   },
 };
-
-function isForcedCategorical(controls: ControlStateMapping): boolean {
-  return (
-    checkColumnType(
-      getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
-      controls?.datasource?.datasource,
-      [GenericDataType.Numeric],
-    ) && !!controls?.xAxisForceCategorical?.value
-  );
-}
-
-function isSortable(controls: ControlStateMapping): boolean {
-  const xAxisValue = controls?.x_axis?.value as QueryFormColumn;
-  // Given that we don't know the type of a custom SQL column,
-  // we treat it as sortable and give the responsibility to the
-  // user to provide a sortable result.
-  const isCustomSQL = !isPhysicalColumn(xAxisValue);
-  return (
-    isForcedCategorical(controls) ||
-    isCustomSQL ||
-    checkColumnType(
-      getColumnLabel(xAxisValue),
-      controls?.datasource?.datasource,
-      [GenericDataType.String, GenericDataType.Boolean],
-    )
-  );
-}
 
 const xAxisSortVisibility = ({ controls }: { controls: ControlStateMapping }) =>
   isSortable(controls) &&

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -23,6 +23,7 @@ import {
   GenericDataType,
   getColumnLabel,
   getMetricLabel,
+  isPhysicalColumn,
   QueryFormColumn,
   QueryFormMetric,
   t,
@@ -66,10 +67,16 @@ function isForcedCategorical(controls: ControlStateMapping): boolean {
 }
 
 function isSortable(controls: ControlStateMapping): boolean {
+  const xAxisValue = controls?.x_axis?.value as QueryFormColumn;
+  // Given that we don't know the type of a custom SQL column,
+  // we treat it as sortable and give the responsibility to the
+  // user to provide a sortable result.
+  const isCustomSQL = !isPhysicalColumn(xAxisValue);
   return (
     isForcedCategorical(controls) ||
+    isCustomSQL ||
     checkColumnType(
-      getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
+      getColumnLabel(xAxisValue),
       controls?.datasource?.datasource,
       [GenericDataType.String, GenericDataType.Boolean],
     )

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/isSortable.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/isSortable.ts
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  GenericDataType,
+  getColumnLabel,
+  isPhysicalColumn,
+  QueryFormColumn,
+} from '@superset-ui/core';
+import { checkColumnType, ControlStateMapping } from '..';
+
+export function isSortable(controls: ControlStateMapping): boolean {
+  const isForcedCategorical =
+    checkColumnType(
+      getColumnLabel(controls?.x_axis?.value as QueryFormColumn),
+      controls?.datasource?.datasource,
+      [GenericDataType.Numeric],
+    ) && !!controls?.xAxisForceCategorical?.value;
+
+  const xAxisValue = controls?.x_axis?.value as QueryFormColumn;
+
+  // Given that we don't know the type of a custom SQL column,
+  // we treat it as sortable and give the responsibility to the
+  // user to provide a sortable result.
+  const isCustomSQL = !isPhysicalColumn(xAxisValue);
+
+  return (
+    isForcedCategorical ||
+    isCustomSQL ||
+    checkColumnType(
+      getColumnLabel(xAxisValue),
+      controls?.datasource?.datasource,
+      [GenericDataType.String, GenericDataType.Boolean],
+    )
+  );
+}

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/isSortable.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/isSortable.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ControlStateMapping } from '@superset-ui/chart-controls';
+import { GenericDataType } from '@superset-ui/core';
+import { isSortable } from '../../src/utils/isSortable';
+
+const controls: ControlStateMapping = {
+  datasource: {
+    datasource: {
+      columns: [
+        { column_name: 'a', type_generic: GenericDataType.String },
+        { column_name: 'b', type_generic: GenericDataType.Numeric },
+        { column_name: 'c', type_generic: GenericDataType.Boolean },
+      ],
+    },
+    type: 'Select',
+  },
+};
+
+test('should return true if the column is forced to be categorical', () => {
+  const c: ControlStateMapping = {
+    ...controls,
+    x_axis: { value: 'b', type: 'Select' },
+    xAxisForceCategorical: { value: true, type: 'Checkbox' },
+  };
+  expect(isSortable(c)).toBe(true);
+});
+
+test('should return true if the column is a custom SQL column', () => {
+  const c: ControlStateMapping = {
+    ...controls,
+    x_axis: {
+      value: { label: 'custom_sql', sqlExpression: 'MAX(ID)' },
+      type: 'Select',
+    },
+  };
+  expect(isSortable(c)).toBe(true);
+});
+
+test('should return true if the column type is String or Boolean', () => {
+  const c: ControlStateMapping = {
+    ...controls,
+    x_axis: { value: 'c', type: 'Checkbox' },
+  };
+  expect(isSortable(c)).toBe(true);
+});
+
+test('should return false if none of the conditions are met', () => {
+  const c: ControlStateMapping = {
+    ...controls,
+    x_axis: { value: 'b', type: 'Input' },
+  };
+  expect(isSortable(c)).toBe(false);
+});


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue where the X-Axis Sort By control was disappearing when a custom SQL was being used as an x-axis. Given that we currently have no way to identify the result type of a custom SQL, we make the control available and give the responsibility to the user to provide a sortable result. We implement the same behavior for the Time Grain control as you can see in the recordings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/f40cbd8c-c957-45b7-83be-0df5a5f25ec3

https://github.com/user-attachments/assets/c4a48703-95c8-4780-a669-e101e214ac9d

### TESTING INSTRUCTIONS
Check the videos for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
