### PR TITLE
fix: Incorrect hovered items in tooltips

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -593,7 +593,7 @@ export default function transformProps(
           extractForecastValuesFromTooltipParams(forecastValue);
 
         const keys = Object.keys(forecastValues);
-        let focusedRow = -1;
+        let focusedRow;
         keys.forEach(key => {
           const value = forecastValues[key];
           // if there are no dimensions, key is a verbose name of a metric,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -593,6 +593,7 @@ export default function transformProps(
           extractForecastValuesFromTooltipParams(forecastValue);
 
         const keys = Object.keys(forecastValues);
+        let focusedRow = -1;
         keys.forEach(key => {
           const value = forecastValues[key];
           // if there are no dimensions, key is a verbose name of a metric,
@@ -627,12 +628,11 @@ export default function transformProps(
               : tooltipFormatterSecondary,
           });
           rows.push(row);
+          if (key === focusedSeries) {
+            focusedRow = rows.length - 1;
+          }
         });
-        return tooltipHtml(
-          rows,
-          tooltipFormatter(xValue),
-          keys.findIndex(key => key === focusedSeries),
-        );
+        return tooltipHtml(rows, tooltipFormatter(xValue), focusedRow);
       },
     },
     legend: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -569,7 +569,7 @@ export default function transformProps(
         const showTotal = Boolean(isMultiSeries) && richTooltip && !isForecast;
         const showPercentage = showTotal && !forcePercentFormatter;
         const keys = Object.keys(forecastValues);
-        let focusedRow = -1;
+        let focusedRow;
         keys.forEach(key => {
           const value = forecastValues[key];
           if (value.observation === 0 && stack) {
@@ -590,7 +590,9 @@ export default function transformProps(
         });
         if (stack) {
           rows.reverse();
-          focusedRow = rows.length - focusedRow - 1;
+          if (focusedRow) {
+            focusedRow = rows.length - focusedRow - 1;
+          }
         }
         if (showTotal) {
           const totalRow = ['Total', formatter.format(total)];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -569,6 +569,7 @@ export default function transformProps(
         const showTotal = Boolean(isMultiSeries) && richTooltip && !isForecast;
         const showPercentage = showTotal && !forcePercentFormatter;
         const keys = Object.keys(forecastValues);
+        let focusedRow = -1;
         keys.forEach(key => {
           const value = forecastValues[key];
           if (value.observation === 0 && stack) {
@@ -583,10 +584,13 @@ export default function transformProps(
             row.push(percentFormatter.format(value.observation / (total || 1)));
           }
           rows.push(row);
+          if (key === focusedSeries) {
+            focusedRow = rows.length - 1;
+          }
         });
         if (stack) {
-          keys.reverse();
           rows.reverse();
+          focusedRow = rows.length - focusedRow - 1;
         }
         if (showTotal) {
           const totalRow = ['Total', formatter.format(total)];
@@ -595,11 +599,7 @@ export default function transformProps(
           }
           rows.push(totalRow);
         }
-        return tooltipHtml(
-          rows,
-          tooltipFormatter(xValue),
-          keys.findIndex(key => key === focusedSeries),
-        );
+        return tooltipHtml(rows, tooltipFormatter(xValue), focusedRow);
       },
     },
     legend: {


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue with incorrect hovered items in tooltips. The problem was that the algorithm was not considering that some dimension/metric combinations might result in series with missing data points.

Fixes https://github.com/apache/superset/issues/29565
Fixes https://github.com/apache/superset/issues/30045

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/cdc73641-4e2b-4d6d-8ca8-0d15a1bb00a9

https://github.com/user-attachments/assets/b3454e0e-d6f1-4605-ac70-99bc9bc4c6ca

### TESTING INSTRUCTIONS
Check the original issues for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
