### PR TITLE
feat: cancel impala query on stop

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1510,6 +1510,14 @@ SQL_VALIDATORS_BY_ENGINE = {
     "postgresql": "PostgreSQLValidator",
 }
 
+# A list of database dialects which the query ID is not related to the connection.
+# The database dialects set here will update the `cancel_query` value
+# in the `extra` field of the `query` object after executing the corresponding SQL and
+# before retrieving the result set
+QUERY_ID_NOT_ASSOCIATED_CONNECT: list[str] = [
+    "impala",
+]
+
 # A list of preferred databases, in order. These databases will be
 # displayed prominently in the "Add Database" dialog. You should
 # use the "engine_name" attribute of the corresponding DB engine spec

--- a/superset/config.py
+++ b/superset/config.py
@@ -1510,14 +1510,6 @@ SQL_VALIDATORS_BY_ENGINE = {
     "postgresql": "PostgreSQLValidator",
 }
 
-# A list of database dialects which the query ID is not related to the connection.
-# The database dialects set here will update the `cancel_query` value
-# in the `extra` field of the `query` object after executing the corresponding SQL and
-# before retrieving the result set
-QUERY_ID_NOT_ASSOCIATED_CONNECT: list[str] = [
-    "impala",
-]
-
 # A list of preferred databases, in order. These databases will be
 # displayed prominently in the "Add Database" dialog. You should
 # use the "engine_name" attribute of the corresponding DB engine spec

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -443,7 +443,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # When this is changed to false in a DB engine spec it means the query id
     # is determined only after the specific query is executed and it will update
     # the `cancel_query` value in the `extra` field of the `query` object
-    is_query_id_associated_connect = True
+    has_query_id_before_execute = True
 
     @classmethod
     def is_oauth2_enabled(cls) -> bool:
@@ -1342,7 +1342,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         logger.debug("Query %d: Running query: %s", query.id, sql)
         cls.execute(cursor, sql, query.database, async_=True)
-        if not cls.is_query_id_associated_connect:
+        if not cls.has_query_id_before_execute:
             cancel_query_id = query.database.db_engine_spec.get_cancel_query_id(
                 cursor, query
             )

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -58,7 +58,7 @@ from sqlalchemy.sql.expression import ColumnClause, Select, TextAsFrom, TextClau
 from sqlalchemy.types import TypeEngine
 from sqlparse.tokens import CTE
 
-from superset import app, db, sql_parse
+from superset import db, sql_parse
 from superset.constants import QUERY_CANCEL_KEY, TimeGrain as TimeGrainConstants
 from superset.databases.utils import get_table_metadata, make_url_safe
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -84,8 +84,6 @@ if TYPE_CHECKING:
     from superset.databases.schemas import TableMetadataResponse
     from superset.models.core import Database
     from superset.models.sql_lab import Query
-
-query_id_not_associated_connect = app.config.get("QUERY_ID_NOT_ASSOCIATED_CONNECT", [])
 
 
 ColumnTypeMapping = tuple[
@@ -438,6 +436,14 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     # Driver-specific exception that should be mapped to OAuth2RedirectError
     oauth2_exception = OAuth2RedirectError
+
+    # Does the query id related to the connection?
+    # The default value is True, which means that the query id is determined when
+    # the connection is created.
+    # When this is changed to false in a DB engine spec it means the query id
+    # is determined only after the specific query is executed and it will update
+    # the `cancel_query` value in the `extra` field of the `query` object
+    is_query_id_associated_connect = True
 
     @classmethod
     def is_oauth2_enabled(cls) -> bool:
@@ -1336,7 +1342,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         logger.debug("Query %d: Running query: %s", query.id, sql)
         cls.execute(cursor, sql, query.database, async_=True)
-        if cls.is_query_id_not_associated_connect(query.database.get_dialect().name):
+        if not cls.is_query_id_associated_connect:
             cancel_query_id = query.database.db_engine_spec.get_cancel_query_id(
                 cursor, query
             )
@@ -1345,12 +1351,6 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
                 db.session.commit()
         logger.debug("Query %d: Handling cursor", query.id)
         cls.handle_cursor(cursor, query)
-
-    @classmethod
-    def is_query_id_not_associated_connect(cls, database_dialect: str) -> bool:
-        # Determine the specify database dialect
-        # whether the query ID is not related to the connection
-        return database_dialect in query_id_not_associated_connect
 
     @classmethod
     def extract_error_message(cls, ex: Exception) -> str:

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -58,7 +58,7 @@ class ImpalaEngineSpec(BaseEngineSpec):
         TimeGrain.YEAR: "TRUNC({col}, 'YYYY')",
     }
 
-    is_query_id_associated_connect = False
+    has_query_id_before_execute = False
 
     @classmethod
     def epoch_to_dttm(cls) -> str:

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -58,6 +58,8 @@ class ImpalaEngineSpec(BaseEngineSpec):
         TimeGrain.YEAR: "TRUNC({col}, 'YYYY')",
     }
 
+    is_query_id_associated_connect = False
+
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return "from_unixtime({col})"

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -21,8 +21,9 @@ import logging
 import re
 import time
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
+import requests
 from flask import current_app
 from sqlalchemy import types
 from sqlalchemy.engine.reflection import Inspector
@@ -91,7 +92,7 @@ class ImpalaEngineSpec(BaseEngineSpec):
         :see: handle_cursor
         """
 
-        return True
+        return False
 
     @classmethod
     def execute(
@@ -160,3 +161,38 @@ class ImpalaEngineSpec(BaseEngineSpec):
         except Exception:  # pylint: disable=broad-except
             logger.debug("Call to status() failed ")
             return
+
+    @classmethod
+    def get_cancel_query_id(cls, cursor: Any, query: Query) -> Optional[str]:
+        """
+        Get Impala Query ID that will be used to cancel the running
+        queries to release impala resources.
+
+        :param cursor: Cursor instance in which the query will be executed
+        :param query: Query instance
+        :return: Impala Query ID
+        """
+        last_operation = getattr(cursor, "_last_operation", None)
+        if not last_operation:
+            return None
+        guid = last_operation.handle.operationId.guid[::-1].hex()
+        return f"{guid[-16:]}:{guid[:16]}"
+
+    @classmethod
+    def cancel_query(cls, cursor: Any, query: Query, cancel_query_id: str) -> bool:
+        """
+        Cancel query in the underlying database.
+
+        :param cursor: New cursor instance to the db of the query
+        :param query: Query instance
+        :param cancel_query_id: impala db not need
+        :return: True if query cancelled successfully, False otherwise
+        """
+        try:
+            impala_host = query.database.url_object.host
+            url = f"http://{impala_host}:25000/cancel_query?query_id={cancel_query_id}"
+            response = requests.post(url, timeout=3)
+        except Exception:  # pylint: disable=broad-except
+            return False
+
+        return bool(response and response.status_code == 200)

--- a/tests/unit_tests/db_engine_specs/test_impala.py
+++ b/tests/unit_tests/db_engine_specs/test_impala.py
@@ -17,9 +17,13 @@
 
 from datetime import datetime
 from typing import Optional
+from unittest.mock import Mock, patch
 
 import pytest
 
+from superset.db_engine_specs.impala import ImpalaEngineSpec as spec
+from superset.models.core import Database
+from superset.models.sql_lab import Query
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm  # noqa: F401
 
@@ -37,6 +41,77 @@ def test_convert_dttm(
     expected_result: Optional[str],
     dttm: datetime,  # noqa: F811
 ) -> None:
-    from superset.db_engine_specs.impala import ImpalaEngineSpec as spec
-
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_get_cancel_query_id() -> None:
+    query = Query()
+
+    cursor_mock = Mock()
+    last_operation_mock = Mock()
+    cursor_mock._last_operation = last_operation_mock
+
+    guid = bytes(reversed(bytes.fromhex("9fbdba20000000006940643a2731718b")))
+    last_operation_mock.handle.operationId.guid = guid
+
+    assert (
+        spec.get_cancel_query_id(cursor_mock, query)
+        == "6940643a2731718b:9fbdba2000000000"
+    )
+
+
+@patch("requests.post")
+def test_cancel_query(post_mock: Mock) -> None:
+    query = Query()
+    database = Database(
+        database_name="test_impala", sqlalchemy_uri="impala://localhost:21050/default"
+    )
+    query.database = database
+
+    response_mock = Mock()
+    response_mock.status_code = 200
+    post_mock.return_value = response_mock
+
+    result = spec.cancel_query(None, query, "6940643a2731718b:9fbdba2000000000")
+
+    post_mock.assert_called_once_with(
+        "http://localhost:25000/cancel_query?query_id=6940643a2731718b:9fbdba2000000000",
+        timeout=3,
+    )
+    assert result is True
+
+
+@patch("requests.post")
+def test_cancel_query_failed(post_mock: Mock) -> None:
+    query = Query()
+    database = Database(
+        database_name="test_impala", sqlalchemy_uri="impala://localhost:21050/default"
+    )
+    query.database = database
+
+    response_mock = Mock()
+    response_mock.status_code = 500
+    post_mock.return_value = response_mock
+
+    result = spec.cancel_query(None, query, "6940643a2731718b:9fbdba2000000000")
+
+    post_mock.assert_called_once_with(
+        "http://localhost:25000/cancel_query?query_id=6940643a2731718b:9fbdba2000000000",
+        timeout=3,
+    )
+    assert result is False
+
+
+@patch("requests.post")
+def test_cancel_query_exception(post_mock: Mock) -> None:
+    query = Query()
+    database = Database(
+        database_name="test_impala", sqlalchemy_uri="impala://localhost:21050/default"
+    )
+    query.database = database
+
+    post_mock.side_effect = Exception("Network error")
+
+    result = spec.cancel_query(None, query, "6940643a2731718b:9fbdba2000000000")
+
+    assert result is False


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat: cancel sqllab impala query on stop
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, when executing an Impala query in SQL Lab, clicking the cancel button only cancels the query in Superset, but the query is not canceled on the Impala side, and the resources are not released.
This commit resolves the issue by ensuring that when an Impala query is canceled in SQL Lab, the query is also canceled on the Impala side, achieving the goal of releasing resources.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before
[impala_sql_lab_cancel_before.webm](https://github.com/user-attachments/assets/05750ebd-023b-4a2f-a6b6-652d2e082770)

after
[impala_cancel_query.webm](https://github.com/user-attachments/assets/80cdb661-1daa-47c7-9a00-aa4c8a43735e)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
