### PR TITLE
feat: Postgres-based meta database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ hive = [
 impala = ["impyla>0.16.2, <0.17"]
 kusto = ["sqlalchemy-kusto>=2.0.0, <3"]
 kylin = ["kylinpy>=2.8.1, <2.9"]
+metadb = ["shillelagh[all]>=1.3.0, <2"]
 mssql = ["pymssql>=2.2.8, <3"]
 mysql = ["mysqlclient>=2.1.0, <3"]
 ocient = [

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "postgres.psycopg2 = sqlalchemy.dialects.postgresql:dialect",
             "postgres = sqlalchemy.dialects.postgresql:dialect",
             "superset = superset.extensions.metadb:SupersetAPSWDialect",
+            "superset.multicorn2 = superset.extensions.metadb:SupersetMulticorn2Dialect",
         ],
         "shillelagh.adapter": [
             "superset=superset.extensions.metadb:SupersetShillelaghAdapter"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Shillelagh can now use Postgres as a backend (via the [Multicorn2 extension](http://multicorn2.org/). This PR adds support for it to the meta database.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Install the latest version of Shillelagh: `pip install "shillelagh[all]>=1.3.0"`
2. Run the docker container [in the Shillelagh repo](https://github.com/betodealmeida/shillelagh/blob/main/postgres/docker-compose.yml) that has Multicorn2 installed: `docker compose -f postgres/docker-compose.yml up`
3. Add a new Superset Meta Database with the URI `superset+multicorn2://shillelagh:shillelagh123@localhost:5432/shillelagh`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
