### PR TITLE
fix: CI remove cypress command --headed

### DIFF
--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -51,7 +51,6 @@ def run_cypress_for_test_file(
     if use_dashboard:
         cmd = (
             f"{XVFB_PRE_CMD} "
-            f"--headed "
             f'{cypress_cmd} --spec "{test_file}" --browser {browser} '
             f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
             f"--parallel --ci-build-id {build_id} "


### PR DESCRIPTION
I don't understand how this line got in here but it breaks thins. Somehow the last run on the PR's CI did not include this one line, yet it's in there in my PR. Maybe some weird merge conflict thing while squashing/merging? I don't get it.

Anyhow this fixes things. Let's merge quick as CI is broken

