### PR TITLE
fix: cypress on master doesn't work because of --parallel flag

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -165,7 +165,7 @@ cypress-run-all() {
   # UNCOMMENT the next few commands to monitor memory usage
   # monitor_memory &  # Start memory monitoring in the background
   # memoryMonitorPid=$!
-  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --group $PARALLEL_ID --retries 5 $USE_DASHBOARD_FLAG
+  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group $PARALLEL_ID --retries 5 $USE_DASHBOARD_FLAG
   # kill $memoryMonitorPid
 
   # After job is done, print out Flask log for debugging

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -165,7 +165,7 @@ cypress-run-all() {
   # UNCOMMENT the next few commands to monitor memory usage
   # monitor_memory &  # Start memory monitoring in the background
   # memoryMonitorPid=$!
-  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --retries 5 $USE_DASHBOARD_FLAG
+  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --group $PARALLEL_ID --retries 5 $USE_DASHBOARD_FLAG
   # kill $memoryMonitorPid
 
   # After job is done, print out Flask log for debugging

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -48,6 +48,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
+      # use the dashboard feature when running manually OR merging to master
       USE_DASHBOARD: ${{ github.event.inputs.use_dashboard || (github.ref == 'refs/heads/master' && 'true') || 'false' }}
     services:
       postgres:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -49,7 +49,7 @@ jobs:
       REDIS_PORT: 16379
       GITHUB_TOKEN: ${{ github.token }}
       # use the dashboard feature when running manually OR merging to master
-      USE_DASHBOARD: ${{ github.event.inputs.use_dashboard || (github.ref == 'refs/heads/master' && 'true') || 'false' }}
+      USE_DASHBOARD: ${{ github.event.inputs.use_dashboard == 'true'|| (github.ref == 'refs/heads/master' && 'true') || 'false' }}
     services:
       postgres:
         image: postgres:15-alpine

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -37,7 +37,7 @@ def generate_build_id() -> str:
 
 
 def run_cypress_for_test_file(
-    test_file: str, retries: int, use_dashboard: bool, group: str, dry_run: bool
+    test_file: str, retries: int, use_dashboard: bool, group: str, dry_run: bool, i: int
 ) -> int:
     """Runs Cypress for a single test file and retries upon failure."""
     cypress_cmd = "./node_modules/.bin/cypress run"
@@ -52,7 +52,7 @@ def run_cypress_for_test_file(
         cmd = (
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{test_file}" --browser {browser} '
-            f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
+            f"--record --group {group}-{i} --tag {REPO},{GITHUB_EVENT_NAME} "
             f"--ci-build-id {build_id} "
             f"-- {chrome_flags}"
         )
@@ -159,9 +159,9 @@ def main() -> None:
 
     # Run each test file independently with retry logic or dry-run
     processed_file_count: int = 0
-    for test_file in spec_list:
+    for i, test_file in enumerate(spec_list):
         result = run_cypress_for_test_file(
-            test_file, args.retries, args.use_dashboard, args.group, args.dry_run
+            test_file, args.retries, args.use_dashboard, args.group, args.dry_run, i
         )
         if result != 0:
             print(f"Exiting due to failure in {test_file}")

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -53,7 +53,7 @@ def run_cypress_for_test_file(
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{test_file}" --browser {browser} '
             f"--record --group {group} --tag {REPO},{GITHUB_EVENT_NAME} "
-            f"--parallel --ci-build-id {build_id} "
+            f"--ci-build-id {build_id} "
             f"-- {chrome_flags}"
         )
     else:

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -52,7 +52,7 @@ def run_cypress_for_test_file(
         cmd = (
             f"{XVFB_PRE_CMD} "
             f'{cypress_cmd} --spec "{test_file}" --browser {browser} '
-            f"--record --group {group}-{i} --tag {REPO},{GITHUB_EVENT_NAME} "
+            f"--record --group matrix{group}-file{i} --tag {REPO},{GITHUB_EVENT_NAME} "
             f"--ci-build-id {build_id} "
             f"-- {chrome_flags}"
         )


### PR DESCRIPTION
I was really confused as to why my PR worked in my PR but not on the main branch after merging, and found out why... we're running a slightly different command on master where we want to use the Cypress dashboard feature (gets expensive quick on PRs, but is manageable on the main branch). Since my change went towards running a single spec at a time, the --parallel flag doesn't make sense and was erroring out.

I can't really test this easily outside master, so here we go.

I don't think anyone uses the Cypress dashboard tbh

tested here with `gh workflow run superset-e2e.yml --ref no_dash --field use_dashboard=true --field ref=no_dash`:
https://github.com/apache/superset/actions/runs/11098683939
