### PR TITLE
chore(Dashboard): Unblock Global Styles

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -192,7 +192,6 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   }, [addDangerToast, datasets, datasetsApiError, dispatch]);
 
   if (error) throw error; // caught in error boundary
-  if (!readyToRender || !hasDashboardInfoInitiated) return <Loading />;
 
   return (
     <>
@@ -205,12 +204,18 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
           chartHeaderStyles(theme),
         ]}
       />
-      <SyncDashboardState dashboardPageId={dashboardPageId} />
-      <DashboardPageIdContext.Provider value={dashboardPageId}>
-        <DashboardContainer>
-          <DashboardBuilder />
-        </DashboardContainer>
-      </DashboardPageIdContext.Provider>
+      {readyToRender && hasDashboardInfoInitiated ? (
+        <>
+          <SyncDashboardState dashboardPageId={dashboardPageId} />
+          <DashboardPageIdContext.Provider value={dashboardPageId}>
+            <DashboardContainer>
+              <DashboardBuilder />
+            </DashboardContainer>
+          </DashboardPageIdContext.Provider>
+        </>
+      ) : (
+        <Loading />
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR introduces a small improvement for which Global Styles of the Dashboard do not need to wait for fetching of data to be finished in order to load.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. The Dashboard should load normally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
