### PR TITLE
chore: add native filters to Covid Vaccines dashboard

### DIFF
--- a/superset/examples/configs/dashboards/COVID_Vaccine_Dashboard.yaml
+++ b/superset/examples/configs/dashboards/COVID_Vaccine_Dashboard.yaml
@@ -263,6 +263,112 @@ metadata:
   expanded_slices: {}
   refresh_frequency: 0
   default_filters: "{}"
+  native_filter_configuration:
+  - id: NATIVE_FILTER-8jS1fx4hl
+    controlValues:
+      enableEmptyFilter: false
+      defaultToFirstItem: false
+      multiSelect: true
+      searchAllOptions: false
+      inverseSelection: false
+    name: Country
+    filterType: filter_select
+    targets:
+    - column:
+        name: country_name
+      datasetUuid: 974b7a1c-22ea-49cb-9214-97b7dbd511e0
+    defaultDataMask:
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    cascadeParentIds: []
+    scope:
+      rootPath:
+      - ROOT_ID
+      excluded: []
+    type: NATIVE_FILTER
+    description: ''
+    chartsInScope:
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 66
+    tabsInScope:
+    - TAB-BCIJF4NvgQ
+  - id: NATIVE_FILTER-3_1wEdKkP
+    controlValues:
+      enableEmptyFilter: false
+      defaultToFirstItem: false
+      multiSelect: true
+      searchAllOptions: false
+      inverseSelection: false
+    name: Vaccine Approach
+    filterType: filter_select
+    targets:
+    - column:
+        name: product_category
+      datasetUuid: 974b7a1c-22ea-49cb-9214-97b7dbd511e0
+    defaultDataMask:
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    cascadeParentIds: []
+    scope:
+      rootPath:
+      - ROOT_ID
+      excluded: []
+    type: NATIVE_FILTER
+    description: ''
+    chartsInScope:
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 66
+    tabsInScope:
+    - TAB-BCIJF4NvgQ
+  - id: NATIVE_FILTER-EWNH3M70z
+    controlValues:
+      enableEmptyFilter: false
+      defaultToFirstItem: false
+      multiSelect: true
+      searchAllOptions: false
+      inverseSelection: false
+    name: Clinical Stage
+    filterType: filter_select
+    targets:
+    - column:
+        name: clinical_stage
+      datasetUuid: 974b7a1c-22ea-49cb-9214-97b7dbd511e0
+    defaultDataMask:
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    cascadeParentIds: []
+    scope:
+      rootPath:
+      - ROOT_ID
+      excluded: []
+    type: NATIVE_FILTER
+    description: ''
+    chartsInScope:
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 66
+    tabsInScope:
+    - TAB-BCIJF4NvgQ
   color_scheme: supersetColors
   label_colors:
     "0": "#D3B3DA"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
None of our current examples dashboards have native filters in them. This will help add one dashboard such that we can test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
