### PR TITLE
docs: fix broken links in CI

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -80,9 +80,9 @@ If you believe someone is violating this code of conduct, you may reply to them 
 
 Or one of our volunteers:
 
-* [Mark Thomas](http://home.apache.org/~markt/coc.html)
-* [Joan Touzet](http://home.apache.org/~wohali/)
-* [Sharan Foga](http://home.apache.org/~sharan/coc.html)
+* [Mark Thomas](https://www.linkedin.com/in/mark-thomas-b16751158/)
+* [Joan Touzet](https://www.apache.org/foundation/conduct-team/wohali.html)
+* [Sharan Foga](https://www.linkedin.com/in/sfoga/)
 
 If the violation is in documentation or code, for example inappropriate pronoun usage or word choice within official documentation, we ask that people report these privately to the project in question at <private@project.apache.org>, and, if they have sufficient ability within the project, to resolve or remove the concerning material, being mindful of the perspective of the person originally reporting the issue.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+
 This is the public documentation site for Superset, built using
 [Docusaurus 2](https://docusaurus.io/). See
 [CONTRIBUTING.md](../CONTRIBUTING.md#documentation) for documentation on


### PR DESCRIPTION
^^^ title, CI link validator was firing with those links

Seen on another PR ->
<img width="613" alt="Screenshot 2024-10-01 at 4 32 11 PM" src="https://github.com/user-attachments/assets/192d70a3-3865-4b06-be9d-a4cccf89b779">

