### PR TITLE
fix(sqllab): Remove redundant scrolling

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -163,10 +163,14 @@ const StyledToolbar = styled.div`
   }
 `;
 
-const StyledSidebar = styled.div<{ width: number; hide: boolean | undefined }>`
+const StyledSidebar = styled.div<{
+  width: number;
+  hide: boolean | undefined;
+  padding: number;
+}>`
   flex: 0 0 ${({ width }) => width}px;
   width: ${({ width }) => width}px;
-  padding: ${({ theme, hide }) => (hide ? 0 : theme.gridUnit * 2.5)}px;
+  padding: ${({ padding }) => padding}px;
   border-right: 1px solid
     ${({ theme, hide }) =>
       hide ? 'transparent' : theme.colors.grayscale.light2};
@@ -932,6 +936,7 @@ const SqlEditor: FC<Props> = ({
   const leftBarStateClass = hideLeftBar
     ? 'schemaPane-exit-done'
     : 'schemaPane-enter-done';
+  const leftBarPadding = hideLeftBar ? 0 : theme.gridUnit * 2.5;
   return (
     <StyledSqlEditor ref={sqlEditorRef} className="SqlEditor">
       <CSSTransition classNames="schemaPane" in={!hideLeftBar} timeout={300}>
@@ -940,12 +945,14 @@ const SqlEditor: FC<Props> = ({
           minWidth={SQL_EDITOR_LEFTBAR_WIDTH}
           initialWidth={SQL_EDITOR_LEFTBAR_WIDTH}
           enable={!hideLeftBar}
+          padding={leftBarPadding}
         >
           {adjustedWidth => (
             <StyledSidebar
               className={`schemaPane ${leftBarStateClass}`}
               width={adjustedWidth}
               hide={hideLeftBar}
+              padding={leftBarPadding}
             >
               <SqlEditorLeftBar
                 database={database}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -166,11 +166,10 @@ const StyledToolbar = styled.div`
 const StyledSidebar = styled.div<{
   width: number;
   hide: boolean | undefined;
-  padding: number;
 }>`
   flex: 0 0 ${({ width }) => width}px;
   width: ${({ width }) => width}px;
-  padding: ${({ padding }) => padding}px;
+  padding: ${({ theme, hide }) => (hide ? 0 : theme.gridUnit * 2.5)}px;
   border-right: 1px solid
     ${({ theme, hide }) =>
       hide ? 'transparent' : theme.colors.grayscale.light2};
@@ -936,7 +935,6 @@ const SqlEditor: FC<Props> = ({
   const leftBarStateClass = hideLeftBar
     ? 'schemaPane-exit-done'
     : 'schemaPane-enter-done';
-  const leftBarPadding = hideLeftBar ? 0 : theme.gridUnit * 2.5;
   return (
     <StyledSqlEditor ref={sqlEditorRef} className="SqlEditor">
       <CSSTransition classNames="schemaPane" in={!hideLeftBar} timeout={300}>
@@ -945,14 +943,12 @@ const SqlEditor: FC<Props> = ({
           minWidth={SQL_EDITOR_LEFTBAR_WIDTH}
           initialWidth={SQL_EDITOR_LEFTBAR_WIDTH}
           enable={!hideLeftBar}
-          padding={leftBarPadding}
         >
           {adjustedWidth => (
             <StyledSidebar
               className={`schemaPane ${leftBarStateClass}`}
               width={adjustedWidth}
               hide={hideLeftBar}
-              padding={leftBarPadding}
             >
               <SqlEditorLeftBar
                 database={database}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -163,10 +163,7 @@ const StyledToolbar = styled.div`
   }
 `;
 
-const StyledSidebar = styled.div<{
-  width: number;
-  hide: boolean | undefined;
-}>`
+const StyledSidebar = styled.div<{ width: number; hide: boolean | undefined }>`
   flex: 0 0 ${({ width }) => width}px;
   width: ${({ width }) => width}px;
   padding: ${({ theme, hide }) => (hide ? 0 : theme.gridUnit * 2.5)}px;

--- a/superset-frontend/src/components/ResizableSidebar/index.tsx
+++ b/superset-frontend/src/components/ResizableSidebar/index.tsx
@@ -21,9 +21,9 @@ import { Resizable } from 're-resizable';
 import { styled } from '@superset-ui/core';
 import useStoredSidebarWidth from './useStoredSidebarWidth';
 
-const ResizableWrapper = styled.div<{ padding?: number }>`
+const ResizableWrapper = styled.div`
   position: absolute;
-  height: ${({ padding }) => (padding ? `calc(100% - ${padding}px)` : '100%')};
+  height: 100%;
 
   :hover .sidebar-resizer::after {
     background-color: ${({ theme }) => theme.colors.primary.base};
@@ -49,7 +49,6 @@ type Props = {
   enable: boolean;
   minWidth?: number;
   maxWidth?: number;
-  padding?: number;
   children: (width: number) => ReactNode;
 };
 
@@ -60,16 +59,20 @@ const ResizableSidebar: FC<Props> = ({
   maxWidth,
   enable,
   children,
-  padding,
 }) => {
   const [width, setWidth] = useStoredSidebarWidth(id, initialWidth);
 
   return (
     <>
-      <ResizableWrapper padding={padding}>
+      <ResizableWrapper>
         <Resizable
           enable={{ right: enable }}
-          handleClasses={{ right: 'sidebar-resizer' }}
+          handleClasses={{
+            right: 'sidebar-resizer',
+            bottom: 'hidden',
+            bottomRight: 'hidden',
+            bottomLeft: 'hidden',
+          }}
           size={{ width, height: '100%' }}
           minWidth={minWidth}
           maxWidth={maxWidth}

--- a/superset-frontend/src/components/ResizableSidebar/index.tsx
+++ b/superset-frontend/src/components/ResizableSidebar/index.tsx
@@ -21,9 +21,9 @@ import { Resizable } from 're-resizable';
 import { styled } from '@superset-ui/core';
 import useStoredSidebarWidth from './useStoredSidebarWidth';
 
-const ResizableWrapper = styled.div`
+const ResizableWrapper = styled.div<{ padding?: number }>`
   position: absolute;
-  height: 100%;
+  height: ${({ padding }) => (padding ? `calc(100% - ${padding}px)` : '100%')};
 
   :hover .sidebar-resizer::after {
     background-color: ${({ theme }) => theme.colors.primary.base};
@@ -49,6 +49,7 @@ type Props = {
   enable: boolean;
   minWidth?: number;
   maxWidth?: number;
+  padding?: number;
   children: (width: number) => ReactNode;
 };
 
@@ -59,12 +60,13 @@ const ResizableSidebar: FC<Props> = ({
   maxWidth,
   enable,
   children,
+  padding,
 }) => {
   const [width, setWidth] = useStoredSidebarWidth(id, initialWidth);
 
   return (
     <>
-      <ResizableWrapper>
+      <ResizableWrapper padding={padding}>
         <Resizable
           enable={{ right: enable }}
           handleClasses={{ right: 'sidebar-resizer' }}


### PR DESCRIPTION
### SUMMARY
This commit fixes the redundant vertical scrolling in SQL Lab caused by the bottom resize handlers, which are not used for the sidebar resizer.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/bac25cbf-448d-4b3c-8021-06e3eb300c8f

After:

https://github.com/user-attachments/assets/8182ce66-a880-41d1-a9aa-bfa936af26f2


### TESTING INSTRUCTIONS
Go to SQL Lab and then check the scrollbar in the query panel.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
