### PR TITLE
fix(imports): Error when importing charts / dashboards with missing DB credentials

### DIFF
--- a/superset/commands/database/importers/v1/utils.py
+++ b/superset/commands/database/importers/v1/utils.py
@@ -83,8 +83,6 @@ def import_database(
         add_permissions(database, ssh_tunnel)
     except Exception:
         logger.info("unable to connect to %s", database)
-    finally:
-        return database
 
     return database
 

--- a/superset/commands/database/importers/v1/utils.py
+++ b/superset/commands/database/importers/v1/utils.py
@@ -22,6 +22,7 @@ from superset import app, db, security_manager
 from superset.commands.exceptions import ImportFailedError
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.databases.utils import make_url_safe
+from superset.db_engine_specs.exceptions import SupersetDBAPIConnectionError
 from superset.exceptions import SupersetSecurityException
 from superset.models.core import Database
 from superset.security.analytics_db_safety import check_sqlalchemy_uri
@@ -81,8 +82,8 @@ def import_database(
 
     try:
         add_permissions(database, ssh_tunnel)
-    except Exception:
-        logger.info("unable to connect to %s", database)
+    except SupersetDBAPIConnectionError as ex:
+        logger.warning(ex.message)
 
     return database
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -738,7 +738,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
     @classmethod
     def parse_error_exception(cls, exception: Exception) -> Exception:
         try:
-            return Exception(str(exception).splitlines()[0].strip())
+            return type(exception)(str(exception).splitlines()[0].strip())
         except Exception:  # pylint: disable=broad-except
             # If for some reason we get an exception, for example, no new line
             # We will return the original exception

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -378,6 +378,20 @@ database_config: dict[str, Any] = {
     "uuid": "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89",
     "version": "1.0.0",
 }
+database_config_no_creds: dict[str, Any] = {
+    "allow_csv_upload": False,
+    "allow_ctas": False,
+    "allow_cvas": False,
+    "allow_dml": False,
+    "allow_run_async": False,
+    "cache_timeout": None,
+    "database_name": "imported_database_no_creds",
+    "expose_in_sqllab": True,
+    "extra": {},
+    "sqlalchemy_uri": "bigquery://test-db/",
+    "uuid": "2ff17edc-f3fa-4609-a5ac-b484281225bc",
+    "version": "1.0.0",
+}
 
 database_with_ssh_tunnel_config_private_key: dict[str, Any] = {
     "allow_csv_upload": True,

--- a/tests/unit_tests/databases/commands/importers/v1/import_test.py
+++ b/tests/unit_tests/databases/commands/importers/v1/import_test.py
@@ -69,6 +69,28 @@ def test_import_database(mocker: MockerFixture, session: Session) -> None:
     assert database.allow_dml is False
 
 
+def test_import_database_no_creds(mocker: MockerFixture, session: Session) -> None:
+    """
+    Test importing a database.
+    """
+    from superset import security_manager
+    from superset.commands.database.importers.v1.utils import import_database
+    from superset.models.core import Database
+    from tests.integration_tests.fixtures.importexport import database_config_no_creds
+
+    mocker.patch.object(security_manager, "can_access", return_value=True)
+
+    engine = db.session.get_bind()
+    Database.metadata.create_all(engine)  # pylint: disable=no-member
+
+    config = copy.deepcopy(database_config_no_creds)
+    database = import_database(config)
+    assert database.database_name == "imported_database_no_creds"
+    assert database.sqlalchemy_uri == "bigquery://test-db/"
+    assert database.extra == "{}"
+    assert database.uuid == "2ff17edc-f3fa-4609-a5ac-b484281225bc"
+
+
 def test_import_database_sqlite_invalid(
     mocker: MockerFixture, session: Session
 ) -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When importing charts, dashboards, and databases, certain databases (BigQuery) require credentials to be entered into the encrypted extra field for authorization. When importing this type of database, or any chart or dashboard that relies on this type of database, the db creation will fail generating an import failed error.

This fix implements a try except block to catch connection errors when attempting to populate db catalogs when importing a db. It prevents bigquery exceptions from being remapped to generic Exception types.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
https://www.loom.com/share/ca5efd11ba004c19aea9c83484bdab47?sid=6be35dfc-42e1-45b2-81dd-0a8df1d41dd6

After:
https://www.loom.com/share/a9cc247ddb434ee198f81503514f6776?sid=93c7481f-9ace-4def-9862-6567ecf2f32b

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Export a bigquery database or a chart/dashboard linked to a bigquery db.
Delete the underlying db
Attempt to import the db, chart, or dashboard.
The import should be successful, even though the db does not have auth creds


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/30383
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
