### PR TITLE
fix(migration): replace unquote with double percentages

### DIFF
--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -16,7 +16,6 @@
 # under the License.
 import logging
 import time
-import urllib.parse
 from logging.config import fileConfig
 
 from alembic import context
@@ -43,8 +42,9 @@ if "sqlite" in DATABASE_URI:
         "SQLite Database support for metadata databases will \
         be removed in a future version of Superset."
     )
-decoded_uri = urllib.parse.unquote(DATABASE_URI)
-config.set_main_option("sqlalchemy.url", decoded_uri)
+# Escape % chars in the database URI to avoid interpolation errors in ConfigParser
+escaped_uri = DATABASE_URI.replace("%", "%%")
+config.set_main_option("sqlalchemy.url", escaped_uri)
 target_metadata = Base.metadata  # pylint: disable=no-member
 
 


### PR DESCRIPTION
### SUMMARY

#23421 introduced a regression, where passwords containing `@` characters would break migrations. To avoid having to decode the URL, we can simply escape the connection string for variable interpolation by doubling `%` chars, after which the original encoded connection string works as expected.

Note, that the change is functionally identical to the change proposed in the linked issue.

Here's one of many similar StackOverflow threads: https://stackoverflow.com/questions/39849641/in-flask-migrate-valueerror-invalid-interpolation-syntax-in-connection-string-a

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
This has been tested with a Postgres connection with a huge amount of special characters in the password, including `@` that previously broke the migration workflow.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #23176
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
