### PR TITLE
fix: Unable to parse escaped tables

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -48,7 +48,6 @@ from pandas import Series
 from pandas._libs.parsers import STR_NA_VALUES
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm.query import Query
-from sqlglot import Dialect, Dialects
 
 from superset.advanced_data_type.plugins.internet_address import internet_address
 from superset.advanced_data_type.plugins.internet_port import internet_port
@@ -69,6 +68,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from flask_appbuilder.security.sqla import models
+    from sqlglot import Dialect, Dialects
 
     from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database

--- a/superset/config.py
+++ b/superset/config.py
@@ -48,6 +48,7 @@ from pandas import Series
 from pandas._libs.parsers import STR_NA_VALUES
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm.query import Query
+from sqlglot import Dialect, Dialects
 
 from superset.advanced_data_type.plugins.internet_address import internet_address
 from superset.advanced_data_type.plugins.internet_port import internet_port
@@ -249,6 +250,10 @@ SQLALCHEMY_CUSTOM_PASSWORD_STORE = None
 SQLALCHEMY_ENCRYPTED_FIELD_TYPE_ADAPTER = (  # pylint: disable=invalid-name
     SQLAlchemyUtilsAdapter
 )
+
+# Extends the default SQLGlot dialects with additional dialects
+SQLGLOT_DIALECTS_EXTENSIONS: map[str, Dialects | type[Dialect]] = {}
+
 # The limit of queries fetched for query search
 QUERY_SEARCH_LIMIT = 1000
 

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -54,6 +54,7 @@ from superset.extensions import (
     talisman,
 )
 from superset.security import SupersetSecurityManager
+from superset.sql.parse import SQLGLOT_DIALECTS
 from superset.superset_typing import FlaskResponse
 from superset.tags.core import register_sqla_event_listeners
 from superset.utils.core import is_test, pessimistic_connection_handling
@@ -484,6 +485,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         self.configure_middlewares()
         self.configure_cache()
         self.set_db_default_isolation()
+        self.configure_sqlglot_dialects()
 
         with self.superset_app.app_context():
             self.init_app_in_ctx()
@@ -543,6 +545,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
     def configure_feature_flags(self) -> None:
         feature_flag_manager.init_app(self.superset_app)
+
+    def configure_sqlglot_dialects(self) -> None:
+        SQLGLOT_DIALECTS.update(self.config["SQLGLOT_DIALECTS_EXTENSIONS"])
 
     @transaction()
     def configure_fab(self) -> None:

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -28,7 +28,6 @@ import sqlparse
 from flask_babel import gettext as __
 from jinja2 import nodes
 from sqlalchemy import and_
-from sqlglot.dialects.dialect import Dialects
 from sqlparse import keywords
 from sqlparse.lexer import Lexer
 from sqlparse.sql import (
@@ -61,7 +60,12 @@ from superset.exceptions import (
     SupersetParseError,
     SupersetSecurityException,
 )
-from superset.sql.parse import extract_tables_from_statement, SQLScript, Table
+from superset.sql.parse import (
+    extract_tables_from_statement,
+    SQLGLOT_DIALECTS,
+    SQLScript,
+    Table,
+)
 from superset.utils.backports import StrEnum
 
 try:
@@ -86,61 +90,6 @@ lex = Lexer.get_default_instance()
 sqlparser_sql_regex = keywords.SQL_REGEX
 sqlparser_sql_regex.insert(25, (r"'(''|\\\\|\\|[^'])*'", sqlparse.tokens.String.Single))
 lex.set_SQL_REGEX(sqlparser_sql_regex)
-
-
-# mapping between DB engine specs and sqlglot dialects
-SQLGLOT_DIALECTS = {
-    "ascend": Dialects.HIVE,
-    "awsathena": Dialects.PRESTO,
-    "bigquery": Dialects.BIGQUERY,
-    "clickhouse": Dialects.CLICKHOUSE,
-    "clickhousedb": Dialects.CLICKHOUSE,
-    "cockroachdb": Dialects.POSTGRES,
-    "couchbase": Dialects.MYSQL,
-    # "crate": ???
-    # "databend": ???
-    "databricks": Dialects.DATABRICKS,
-    # "db2": ???
-    # "dremio": ???
-    "drill": Dialects.DRILL,
-    # "druid": ???
-    "duckdb": Dialects.DUCKDB,
-    # "dynamodb": ???
-    # "elasticsearch": ???
-    # "exa": ???
-    # "firebird": ???
-    # "firebolt": ???
-    "gsheets": Dialects.SQLITE,
-    "hana": Dialects.POSTGRES,
-    "hive": Dialects.HIVE,
-    # "ibmi": ???
-    # "impala": ???
-    # "kustokql": ???
-    # "kylin": ???
-    "mssql": Dialects.TSQL,
-    "mysql": Dialects.MYSQL,
-    "netezza": Dialects.POSTGRES,
-    # "ocient": ???
-    # "odelasticsearch": ???
-    "oracle": Dialects.ORACLE,
-    # "pinot": ???
-    "postgresql": Dialects.POSTGRES,
-    "presto": Dialects.PRESTO,
-    "pydoris": Dialects.DORIS,
-    "redshift": Dialects.REDSHIFT,
-    # "risingwave": ???
-    # "rockset": ???
-    "shillelagh": Dialects.SQLITE,
-    "snowflake": Dialects.SNOWFLAKE,
-    # "solr": ???
-    "spark": Dialects.SPARK,
-    "sqlite": Dialects.SQLITE,
-    "starrocks": Dialects.STARROCKS,
-    "superset": Dialects.SQLITE,
-    "teradatasql": Dialects.TERADATA,
-    "trino": Dialects.TRINO,
-    "vertica": Dialects.POSTGRES,
-}
 
 
 class CtasMethod(StrEnum):

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -18,6 +18,7 @@
 
 
 import pytest
+from sqlglot import Dialects
 
 from superset.exceptions import SupersetParseError
 from superset.sql.parse import (
@@ -932,3 +933,15 @@ search_path -- another one
 SELECT * FROM some_table;
     """
     assert SQLScript(sql, "postgresql").get_settings() == {"search_path": "bar"}
+
+
+@pytest.mark.parametrize(
+    "app",
+    [{"SQLGLOT_DIALECTS_EXTENSIONS": {"custom": Dialects.MYSQL}}],
+    indirect=True,
+)
+def test_custom_dialect(app: None) -> None:
+    """
+    Test that custom dialects are loaded correctly.
+    """
+    assert SQLGLOT_DIALECTS.get("custom") == Dialects.MYSQL


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/26476 introduced a `SQLGLOT_DIALECTS` mapping to be used when parsing SQL queries with SQLGlot. For companies that have custom database engines, with a name not present in the mapping, the default SQLGlot dialect would be used and could generate problems such as https://github.com/apache/superset/issues/30551. This PR adds a new configuration to allow extending registered SQLGlot dialects.

Fixes https://github.com/apache/superset/issues/30551

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
