### PR TITLE
fix: Horizon Chart are not working any more

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/src/controlPanel.ts
@@ -25,6 +25,12 @@ import {
 const config: ControlPanelConfig = {
   controlPanelSections: [
     {
+      label: t('Time'),
+      expanded: true,
+      description: t('Time related form attributes'),
+      controlSetRows: [['granularity_sqla'], ['time_range']],
+    },
+    {
       label: t('Query'),
       expanded: true,
       controlSetRows: [


### PR DESCRIPTION
### SUMMARY
The removal of the legacy "Time" section left the legacy Horizon chart as a casualty. This PR restores the previous behavior.

Fixes https://github.com/apache/superset/issues/25326

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1913" alt="Screenshot 2024-10-09 at 13 13 46" src="https://github.com/user-attachments/assets/ea1d9f47-3823-4334-9c6a-2bab4fe23975">


### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
