### PR TITLE
chore: add link to Superset when report error

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -426,6 +426,7 @@ class BaseReportState:
                     name=self._report_schedule.name,
                     text=error_text,
                     header_data=header_data,
+                    url=url,
                 )
 
         if (
@@ -533,13 +534,14 @@ class BaseReportState:
         :raises: CommandException
         """
         header_data = self._get_log_data()
+        url = self._get_url(user_friendly=True)
         logger.info(
             "header_data in notifications for alerts and reports %s, taskid, %s",
             header_data,
             self._execution_id,
         )
         notification_content = NotificationContent(
-            name=name, text=message, header_data=header_data
+            name=name, text=message, header_data=header_data, url=url
         )
 
         # filter recipients to recipients who are also owners

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1760,6 +1760,7 @@ def test_email_dashboard_report_fails_uncaught_exception(
 
     screenshot_mock.return_value = SCREENSHOT_FILE
     email_mock.side_effect = Exception("Uncaught exception")
+    app.config["EMAIL_REPORTS_CTA"] = "Call to action"
 
     with pytest.raises(Exception):
         AsyncExecuteReportScheduleCommand(
@@ -1767,6 +1768,11 @@ def test_email_dashboard_report_fails_uncaught_exception(
         ).run()
 
     assert_log(ReportState.ERROR, error_message="Uncaught exception")
+    assert (
+        '<a href="http://0.0.0.0:8080/superset/dashboard/'
+        f"{create_report_email_dashboard.dashboard.uuid}/"
+        '?force=false">Call to action</a>' in email_mock.call_args[0][2]
+    )
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a link to the dashboard or chart for the report/alert when there is an error so that the root cause can more easily be found by accessing the asset that has the error. Also updated the error message to be more friendly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1120" alt="Screenshot 2024-10-17 at 1 49 34 PM" src="https://github.com/user-attachments/assets/89f027eb-21af-4eb3-8367-9b73f06cc9ca">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
