### PR TITLE
fix(filters): Adds a fix for saving time range adhoc_filters

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -20,7 +20,7 @@ import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 import { Dispatch } from 'redux';
 import { ADD_TOAST } from 'src/components/MessageToasts/actions';
-import { DatasourceType, QueryFormData } from '@superset-ui/core';
+import { DatasourceType, QueryFormData, SimpleAdhocFilter } from '@superset-ui/core';
 import {
   createDashboard,
   createSlice,
@@ -31,6 +31,7 @@ import {
   getSlicePayload,
   PayloadSlice,
 } from './saveModalActions';
+import { Operators } from '../constants';
 
 // Define test constants and mock data using imported types
 const sliceId = 10;
@@ -594,6 +595,7 @@ describe('getSlicePayload', () => {
         },
       ],
     };
+
     const formDataWithAdhocFiltersWithExtra: QueryFormData = {
       ...formDataWithNativeFilters,
       viz_type: 'mixed_timeseries',
@@ -625,11 +627,58 @@ describe('getSlicePayload', () => {
       owners as [],
       formDataFromSliceWithAdhocFilterB,
     );
+
     expect(JSON.parse(result.params as string).adhoc_filters).toEqual(
       formDataFromSliceWithAdhocFilterB.adhoc_filters,
     );
-    expect(JSON.parse(result.params as string).adhoc_filters).toEqual(
+    expect(JSON.parse(result.params as string).adhoc_filters_b).toEqual(
       formDataFromSliceWithAdhocFilterB.adhoc_filters_b,
     );
+  });
+
+  test('should return the correct payload when formDataFromSliceWithAdhocFilter has no time range filters in mixed chart', () => {
+    const formDataFromSliceWithAdhocFilterB: QueryFormData = {
+      ...formDataFromSlice,
+      adhoc_filters: [],
+      adhoc_filters_b: [],
+    };
+
+    const formDataWithAdhocFiltersWithExtra: QueryFormData = {
+      ...formDataWithNativeFilters,
+      viz_type: 'mixed_timeseries',
+      adhoc_filters: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+      adhoc_filters_b: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: 'No filter',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+    };
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithAdhocFiltersWithExtra,
+      dashboards,
+      owners as [],
+      formDataFromSliceWithAdhocFilterB,
+    );
+
+    const hasTemporalRange = (JSON.parse(result.params as string).adhoc_filters_b || []).some(
+      (filter: SimpleAdhocFilter) => filter.operator === Operators.TemporalRange,
+    );
+
+    expect(hasTemporalRange).toBe(true);
   });
 });

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -20,7 +20,11 @@ import sinon from 'sinon';
 import fetchMock from 'fetch-mock';
 import { Dispatch } from 'redux';
 import { ADD_TOAST } from 'src/components/MessageToasts/actions';
-import { DatasourceType, QueryFormData, SimpleAdhocFilter } from '@superset-ui/core';
+import {
+  DatasourceType,
+  QueryFormData,
+  SimpleAdhocFilter,
+} from '@superset-ui/core';
 import {
   createDashboard,
   createSlice,
@@ -675,8 +679,11 @@ describe('getSlicePayload', () => {
       formDataFromSliceWithAdhocFilterB,
     );
 
-    const hasTemporalRange = (JSON.parse(result.params as string).adhoc_filters_b || []).some(
-      (filter: SimpleAdhocFilter) => filter.operator === Operators.TemporalRange,
+    const hasTemporalRange = (
+      JSON.parse(result.params as string).adhoc_filters_b || []
+    ).some(
+      (filter: SimpleAdhocFilter) =>
+        filter.operator === Operators.TemporalRange,
     );
 
     expect(hasTemporalRange).toBe(true);

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -119,19 +119,22 @@ export const getSlicePayload = (
   }
 
   if (!hasTemporalRangeFilter(adhocFilters)) {
-    formDataWithNativeFilters.adhoc_filters?.forEach(
-      (filter: SimpleAdhocFilter) => {
-        if (filter.operator === Operators.TemporalRange && filter.isExtra) {
-          if (!adhocFilters.adhoc_filters) {
-            adhocFilters.adhoc_filters = [];
+    const adhocFiltersKeys = Object.keys(formDataWithNativeFilters).filter(key => ADHOC_FILTER_REGEX.test(key))
+    adhocFiltersKeys?.forEach(filtersKey => {
+      formDataWithNativeFilters[filtersKey]?.forEach(
+        (filter: SimpleAdhocFilter) => {
+          if (filter.operator === Operators.TemporalRange && filter.isExtra) {
+            if (!adhocFilters[filtersKey]) {
+              adhocFilters[filtersKey] = [];
+            }
+            adhocFilters[filtersKey].push({
+              ...filter,
+              comparator: 'No filter',
+            });
           }
-          adhocFilters.adhoc_filters.push({
-            ...filter,
-            comparator: 'No filter',
-          });
-        }
-      },
-    );
+        },
+      );
+    })
   }
   const formData = {
     ...formDataWithNativeFilters,

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -119,7 +119,9 @@ export const getSlicePayload = (
   }
 
   if (!hasTemporalRangeFilter(adhocFilters)) {
-    const adhocFiltersKeys = Object.keys(formDataWithNativeFilters).filter(key => ADHOC_FILTER_REGEX.test(key))
+    const adhocFiltersKeys = Object.keys(formDataWithNativeFilters).filter(
+      key => ADHOC_FILTER_REGEX.test(key),
+    );
     adhocFiltersKeys?.forEach(filtersKey => {
       formDataWithNativeFilters[filtersKey]?.forEach(
         (filter: SimpleAdhocFilter) => {
@@ -134,7 +136,7 @@ export const getSlicePayload = (
           }
         },
       );
-    })
+    });
   }
   const formData = {
     ...formDataWithNativeFilters,


### PR DESCRIPTION
…aveModalActions.ts

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The bug occurs when you have a mixed time series chart inside a dashboard and the time range filter from the dashboard does not apply to both queries of the mixed time series chart. If you compare the changes, the previous code would only take care of the adhoc_filters key. The changes make sure that all the adhoc filters keys of the regex /^adhoc_filters/ receive the adhoc time range filter. In case of mixed time series there are two keys namely, adhoc_filters and adhoc_filters_b.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
For manual testing, here is the [link](https://github.com/apache/superset/issues/30582) of the issue with reproduction steps. You can verify the fix by following them.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
