### PR TITLE
fix(explore): column data type tooltip format

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -55,8 +55,7 @@ const TooltipSection = ({
   text: ReactNode;
 }) => (
   <TooltipSectionWrapper>
-    <TooltipSectionLabel>{label}</TooltipSectionLabel>
-    <span>{text}</span>
+    <TooltipSectionLabel>{label}</TooltipSectionLabel>: <span>{text}</span>
   </TooltipSectionWrapper>
 );
 
@@ -71,12 +70,7 @@ export const getColumnTypeTooltipNode = (column: ColumnMeta): ReactNode => {
     return null;
   }
 
-  return (
-    <TooltipSection
-      label={t('Column datatype')}
-      text={column.type.toLowerCase()}
-    />
-  );
+  return <TooltipSection label={t('Column type')} text={column.type} />;
 };
 
 export const getColumnTooltipNode = (

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -90,7 +90,7 @@ test('should get column datatype rendered as tooltip when column has a type', ()
     </>,
   );
 
-  expect(screen.getByText('Column datatype')).toBeVisible();
+  expect(screen.getByText('Column type')).toBeVisible();
   expect(screen.getByText('text')).toBeVisible();
 });
 


### PR DESCRIPTION
Minor visual tweak to add a column and a space inside the Explore -> LeftPanelDatasetView -> Column datatype tooltip.

Adding a colon and a space, and showing the data type as uppercase as it's pretty standard to expose it in that way elsewhere in Superset and as a general convention

### before
<img width="312" alt="Screenshot 2024-10-11 at 5 47 05 PM" src="https://github.com/user-attachments/assets/e08001ab-fe47-418f-a8d5-b44b34fe84fa">

### after
<img width="341" alt="Screenshot 2024-10-11 at 5 48 28 PM" src="https://github.com/user-attachments/assets/e9273908-3452-4d91-8abe-30e42e1890e0">


