### PR TITLE
chore(number-formatter): upgrade pretty-ms to 9.1.0

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -56,7 +56,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   snapshotSerializers: ['@emotion/jest/enzyme-serializer'],
   transformIgnorePatterns: [
-    'node_modules/(?!d3-(interpolate|color|time)|remark-gfm|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|@rjsf/*.|sinon|echarts|zrender|fetch-mock)',
+    'node_modules/(?!d3-(interpolate|color|time)|remark-gfm|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|@rjsf/*.|sinon|echarts|zrender|fetch-mock|pretty-ms|parse-ms)',
   ],
   globals: {
     __DEV__: true,

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -274,7 +274,7 @@
         "react-resizable": "^3.0.5",
         "react-test-renderer": "^16.14.0",
         "redux-mock-store": "^1.5.4",
-        "sinon": "^18.0.1",
+        "sinon": "^18.0.0",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",
         "speed-measure-webpack-plugin": "^1.5.0",
@@ -42771,13 +42771,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "dev": true,
@@ -43811,19 +43804,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prismjs": {
@@ -55643,7 +55623,7 @@
         "jed": "^1.1.1",
         "lodash": "^4.17.21",
         "math-expression-evaluator": "^1.3.8",
-        "pretty-ms": "^7.0.0",
+        "pretty-ms": "^9.1.0",
         "react-error-boundary": "^1.2.5",
         "react-markdown": "^8.0.7",
         "rehype-raw": "^7.0.0",
@@ -56071,6 +56051,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/superset-ui-core/node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/superset-ui-core/node_modules/pretty-ms": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+      "integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/superset-ui-core/node_modules/remark-gfm": {
@@ -65866,7 +65865,7 @@
         "jest-mock-console": "^2.0.0",
         "lodash": "^4.17.21",
         "math-expression-evaluator": "^1.3.8",
-        "pretty-ms": "^7.0.0",
+        "pretty-ms": "^9.1.0",
         "react-error-boundary": "^1.2.5",
         "react-markdown": "^8.0.7",
         "rehype-raw": "^7.0.0",
@@ -66140,6 +66139,19 @@
             "micromark-util-symbol": "^1.0.0",
             "micromark-util-types": "^1.0.0",
             "uvu": "^0.5.0"
+          }
+        },
+        "parse-ms": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+          "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+        },
+        "pretty-ms": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+          "integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+          "requires": {
+            "parse-ms": "^4.0.0"
           }
         },
         "remark-gfm": {
@@ -87765,9 +87777,6 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
-    "parse-ms": {
-      "version": "2.1.0"
-    },
     "parse-node-version": {
       "version": "1.0.1",
       "dev": true
@@ -88354,12 +88363,6 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3"
-    },
-    "pretty-ms": {
-      "version": "7.0.1",
-      "requires": {
-        "parse-ms": "^2.1.0"
-      }
     },
     "prismjs": {
       "version": "1.27.0"

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -37,7 +37,7 @@
     "jed": "^1.1.1",
     "lodash": "^4.17.21",
     "math-expression-evaluator": "^1.3.8",
-    "pretty-ms": "^7.0.0",
+    "pretty-ms": "^9.1.0",
     "react-error-boundary": "^1.2.5",
     "react-markdown": "^8.0.7",
     "rehype-raw": "^7.0.0",

--- a/superset-frontend/packages/superset-ui-core/src/number-format/factories/createDurationFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/number-format/factories/createDurationFormatter.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import prettyMsFormatter from 'pretty-ms';
+import prettyMilliseconds, { Options } from 'pretty-ms';
 import NumberFormatter from '../NumberFormatter';
 
 export default function createDurationFormatter(
@@ -26,13 +26,14 @@ export default function createDurationFormatter(
     id?: string;
     label?: string;
     multiplier?: number;
-  } & prettyMsFormatter.Options = {},
+  } & Options = {},
 ) {
   const { description, id, label, multiplier = 1, ...prettyMsOptions } = config;
 
   return new NumberFormatter({
     description,
-    formatFunc: value => prettyMsFormatter(value * multiplier, prettyMsOptions),
+    formatFunc: value =>
+      prettyMilliseconds(value * multiplier, prettyMsOptions),
     id: id ?? 'duration_format',
     label: label ?? `Duration formatter`,
   });

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createDurationFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createDurationFormatter.test.ts
@@ -19,40 +19,41 @@
 
 import { NumberFormatter, createDurationFormatter } from '@superset-ui/core';
 
-describe('createDurationFormatter()', () => {
-  it('creates an instance of NumberFormatter', () => {
-    const formatter = createDurationFormatter();
-    expect(formatter).toBeInstanceOf(NumberFormatter);
+test('creates an instance of NumberFormatter', () => {
+  const formatter = createDurationFormatter();
+  expect(formatter).toBeInstanceOf(NumberFormatter);
+});
+test('format milliseconds in human readable format with default options', () => {
+  const formatter = createDurationFormatter();
+  expect(formatter(-1000)).toBe('-1s');
+  expect(formatter(0)).toBe('0ms');
+  expect(formatter(1000)).toBe('1s');
+  expect(formatter(1337)).toBe('1.3s');
+  expect(formatter(10500)).toBe('10.5s');
+  expect(formatter(60 * 1000)).toBe('1m');
+  expect(formatter(90 * 1000)).toBe('1m 30s');
+});
+test('format seconds in human readable format with default options', () => {
+  const formatter = createDurationFormatter({ multiplier: 1000 });
+  expect(formatter(-0.5)).toBe('-500ms');
+  expect(formatter(0.5)).toBe('500ms');
+  expect(formatter(1)).toBe('1s');
+  expect(formatter(30)).toBe('30s');
+  expect(formatter(60)).toBe('1m');
+  expect(formatter(90)).toBe('1m 30s');
+});
+test('format milliseconds in human readable format with additional pretty-ms options', () => {
+  const colonNotationFormatter = createDurationFormatter({
+    colonNotation: true,
   });
-  it('format milliseconds in human readable format with default options', () => {
-    const formatter = createDurationFormatter();
-    expect(formatter(0)).toBe('0ms');
-    expect(formatter(1000)).toBe('1s');
-    expect(formatter(1337)).toBe('1.3s');
-    expect(formatter(10500)).toBe('10.5s');
-    expect(formatter(60 * 1000)).toBe('1m');
-    expect(formatter(90 * 1000)).toBe('1m 30s');
+  expect(colonNotationFormatter(-10500)).toBe('-0:10.5');
+  expect(colonNotationFormatter(10500)).toBe('0:10.5');
+  const zeroDecimalFormatter = createDurationFormatter({
+    secondsDecimalDigits: 0,
   });
-  it('format seconds in human readable format with default options', () => {
-    const formatter = createDurationFormatter({ multiplier: 1000 });
-    expect(formatter(0.5)).toBe('500ms');
-    expect(formatter(1)).toBe('1s');
-    expect(formatter(30)).toBe('30s');
-    expect(formatter(60)).toBe('1m');
-    expect(formatter(90)).toBe('1m 30s');
+  expect(zeroDecimalFormatter(10500)).toBe('10s');
+  const subMillisecondFormatter = createDurationFormatter({
+    formatSubMilliseconds: true,
   });
-  it('format milliseconds in human readable format with additional pretty-ms options', () => {
-    const colonNotationFormatter = createDurationFormatter({
-      colonNotation: true,
-    });
-    expect(colonNotationFormatter(10500)).toBe('0:10.5');
-    const zeroDecimalFormatter = createDurationFormatter({
-      secondsDecimalDigits: 0,
-    });
-    expect(zeroDecimalFormatter(10500)).toBe('10s');
-    const subMillisecondFormatter = createDurationFormatter({
-      formatSubMilliseconds: true,
-    });
-    expect(subMillisecondFormatter(100.40008)).toBe('100ms 400µs 80ns');
-  });
+  expect(subMillisecondFormatter(100.40008)).toBe('100ms 400µs 80ns');
 });


### PR DESCRIPTION
### SUMMARY
Bump `pretty-ms` from 7.0.0 to 9.1.0, as this package hasn't been bumped in a long time. [Notable changes](https://github.com/sindresorhus/pretty-ms/releases):
- 7.0.1: Fix to `colonNotation` for sub-second durations (the lock file was actually already pointing to 7.0.1)
- 8.0.0: Drop support for CJS
- 9.0.0 Support BigInt
- 9.1.0 Support negative durations

Other changes:
- Refactor tests from `describe` + `it` to `test`.
- Add tests for negative durations, as those are now supported since 9.1.0. I recommend reviewing the diff with "Hide whitespace" to see the new tests.
- Do a few minor tweaks to get `jest` working with the new version, as `pretty-ms` and `parse-ms` are now fully ESM.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
