### PR TITLE
fix: Set correct amount of steps to avoid confusing logs while loading examples

### DIFF
--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -22,7 +22,11 @@ set -e
 #
 /app/docker/docker-bootstrap.sh
 
-STEP_CNT=4
+if [ "$SUPERSET_LOAD_EXAMPLES" = "yes" ]; then
+    STEP_CNT=4
+else
+    STEP_CNT=3
+fi
 
 echo_step() {
 cat <<EOF


### PR DESCRIPTION
### Summary
This pull request addresses an issue with the logging behavior in the `docker/docker-init.sh` script when loading examples in Apache Superset. The change ensures that the number of steps logged during the initialization process reflects whether example data should be loaded, thus preventing confusion in the logs. It was actually confusing in my case when I first ran superset in docker in different modes.

### Changes Made
- Modified the `STEP_CNT` variable initialization logic in the `docker/docker-init.sh` script.
- Added a conditional check to set `STEP_CNT` properly.

### Testing Instructions
1. Verify that the environment variable `SUPSET_LOAD_EXAMPLES` can be set to either `"yes"` or `"no"`.
2. Deploy the superset environment in different modes and observe the logs.