### PR TITLE
chore: Enable suppressing default chart context menu

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
@@ -50,6 +50,8 @@ export interface ChartMetadataConfig {
   labelExplanation?: string | null;
   queryObjectCount?: number;
   parseMethod?: ParseMethod;
+  // suppressContextMenu: true hides the default context menu for the chart.
+  // This is useful for viz plugins that define their own context menu.
   suppressContextMenu?: boolean;
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
@@ -50,6 +50,7 @@ export interface ChartMetadataConfig {
   labelExplanation?: string | null;
   queryObjectCount?: number;
   parseMethod?: ParseMethod;
+  suppressContextMenu?: boolean;
 }
 
 export default class ChartMetadata {
@@ -91,6 +92,8 @@ export default class ChartMetadata {
 
   parseMethod: ParseMethod;
 
+  suppressContextMenu?: boolean;
+
   constructor(config: ChartMetadataConfig) {
     const {
       name,
@@ -111,6 +114,7 @@ export default class ChartMetadata {
       labelExplanation = null,
       queryObjectCount = 1,
       parseMethod = 'json-bigint',
+      suppressContextMenu = false,
     } = config;
 
     this.name = name;
@@ -140,6 +144,7 @@ export default class ChartMetadata {
     this.labelExplanation = labelExplanation;
     this.queryObjectCount = queryObjectCount;
     this.parseMethod = parseMethod;
+    this.suppressContextMenu = suppressContextMenu;
   }
 
   canBeAnnotationType(type: string): boolean {

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -84,9 +84,13 @@ const defaultProps = {
 class ChartRenderer extends Component {
   constructor(props) {
     super(props);
+    const suppressContextMenu = getChartMetadataRegistry().get(
+      props.formData.viz_type ?? props.vizType,
+    )?.suppressContextMenu;
     this.state = {
       showContextMenu:
         props.source === ChartSource.Dashboard &&
+        !suppressContextMenu &&
         (isFeatureEnabled(FeatureFlag.DrillToDetail) ||
           isFeatureEnabled(FeatureFlag.DashboardCrossFilters)),
       inContextMenu: false,


### PR DESCRIPTION
### SUMMARY
Add a config option to chart metadata to allow suppressing the default chart context menu on the dashboard (the one with the default cross filter and drill to detail menu items)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF


### TESTING INSTRUCTIONS
1. Tests should pass
2. The dashboard context menu should work like before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
