### PR TITLE
feat: use dialect when tokenizing

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -276,7 +276,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         script: str,
         engine: str,
     ) -> list[SQLStatement]:
-        if engine in SQLGLOT_DIALECTS:
+        if dialect := SQLGLOT_DIALECTS.get(engine):
             try:
                 return [
                     cls(ast.sql(), engine, ast)
@@ -297,7 +297,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         remainder = script
 
         try:
-            tokens = sqlglot.tokenize(script)
+            tokens = sqlglot.tokenize(script, dialect)
         except sqlglot.errors.TokenError as ex:
             raise SupersetParseError(
                 script,

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -281,7 +281,7 @@ def test_extract_tables_illdefined() -> None:
         extract_tables('SELECT * FROM "tbname')
     assert (
         str(excinfo.value)
-        == "You may have an error in your SQL statement. Unable to parse script"
+        == "You may have an error in your SQL statement. Unable to tokenize script"
     )
 
     # odd edge case that works


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A small improvement to https://github.com/apache/superset/pull/30578, using the dialect to do the tokenization. Note that a dialect might be available when `ast.sql()` raises an exception.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
