### PR TITLE
fix: Module is not defined in Partition chart

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -21314,6 +21314,15 @@
       "version": "0.2.2",
       "license": "BSD-3-Clause"
     },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "license": "ISC",
@@ -57601,13 +57610,6 @@
         "react-dom": "^16.13.1"
       }
     },
-    "plugins/legacy-plugin-chart-partition/node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "plugins/legacy-plugin-chart-rose": {
       "name": "@superset-ui/legacy-plugin-chart-rose",
       "version": "0.18.25",
@@ -68285,11 +68287,6 @@
         "d3": "^3.5.17",
         "d3-hierarchy": "^3.1.2",
         "prop-types": "^15.8.1"
-      },
-      "dependencies": {
-        "d3-hierarchy": {
-          "version": "3.1.2"
-        }
       }
     },
     "@superset-ui/legacy-plugin-chart-rose": {
@@ -74916,6 +74913,11 @@
     },
     "d3-hexbin": {
       "version": "0.2.2"
+    },
+    "d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
     },
     "d3-interpolate": {
       "version": "3.0.1",


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/28294 broke the Partition chart dependencies producing a `module is not defined` error. This PR fixes the dependencies in `package-lock.json` to restore the plugin.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1917" alt="Screenshot 2024-10-16 at 09 13 27" src="https://github.com/user-attachments/assets/49235176-08ef-48c0-bc2e-7a7070e6c9df">
<img width="1912" alt="Screenshot 2024-10-16 at 09 25 23" src="https://github.com/user-attachments/assets/b2153fed-6cfc-4281-9a1f-307a77cbac71">

### TESTING INSTRUCTIONS
Make sure you can create a Partition chart.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
