### PR TITLE
fix: First item hovered on stacked bar

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -590,7 +590,7 @@ export default function transformProps(
         });
         if (stack) {
           rows.reverse();
-          if (focusedRow) {
+          if (focusedRow !== undefined) {
             focusedRow = rows.length - focusedRow - 1;
           }
         }


### PR DESCRIPTION

### SUMMARY
Fixes a bug when hovering the first item of a stacked bar chart. There was a problem with the `if` condition which was not considering a zero index.

Follow-up of https://github.com/apache/superset/pull/30405.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1907" alt="Screenshot 2024-10-16 at 11 58 37" src="https://github.com/user-attachments/assets/d0bf7df3-f4c6-4e26-8977-5f528d998d1f">
<img width="1909" alt="Screenshot 2024-10-16 at 11 56 28" src="https://github.com/user-attachments/assets/cb663b3c-12a3-4688-b462-80ed322f4e57">

### TESTING INSTRUCTIONS
Make sure the first item of a stacked chart can be hovered.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
