### PR TITLE
chore(legacy-plugin-chart-map-box): replace viewport-mercator-project with @math.gl/web-mercator

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -57539,7 +57539,7 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "*"
+        "react": "^15 || ^16"
       }
     },
     "plugins/legacy-plugin-chart-map-box/node_modules/@math.gl/core": {
@@ -57727,9 +57727,9 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "*",
-        "react-dom": "*",
-        "react-map-gl": "*"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
+        "react-map-gl": "^6.1.19"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -52661,14 +52661,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/viewport-mercator-project": {
-      "version": "6.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "gl-matrix": "^3.0.0"
-      }
-    },
     "node_modules/vlq": {
       "version": "0.2.3",
       "license": "MIT"
@@ -57538,16 +57530,40 @@
       "version": "0.18.25",
       "license": "Apache-2.0",
       "dependencies": {
+        "@math.gl/web-mercator": "^4.1.0",
         "prop-types": "^15.8.1",
         "react-map-gl": "^6.1.19",
-        "supercluster": "^8.0.1",
-        "viewport-mercator-project": "^6.1.1"
+        "supercluster": "^8.0.1"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^15 || ^16"
+        "react": "*"
+      }
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/@math.gl/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/@math.gl/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==",
+      "license": "MIT"
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/@math.gl/web-mercator": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+      "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0"
       }
     },
     "plugins/legacy-plugin-chart-map-box/node_modules/kdbush": {
@@ -57711,9 +57727,9 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
-        "react-map-gl": "^6.1.19"
+        "react": "*",
+        "react-dom": "*",
+        "react-map-gl": "*"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers": {
@@ -68245,12 +68261,33 @@
     "@superset-ui/legacy-plugin-chart-map-box": {
       "version": "file:plugins/legacy-plugin-chart-map-box",
       "requires": {
+        "@math.gl/web-mercator": "^4.1.0",
         "prop-types": "^15.8.1",
         "react-map-gl": "^6.1.19",
-        "supercluster": "^8.0.1",
-        "viewport-mercator-project": "^6.1.1"
+        "supercluster": "^8.0.1"
       },
       "dependencies": {
+        "@math.gl/core": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+          "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+          "requires": {
+            "@math.gl/types": "4.1.0"
+          }
+        },
+        "@math.gl/types": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+          "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="
+        },
+        "@math.gl/web-mercator": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+          "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+          "requires": {
+            "@math.gl/core": "4.1.0"
+          }
+        },
         "kdbush": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -94641,13 +94678,6 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
-      }
-    },
-    "viewport-mercator-project": {
-      "version": "6.2.3",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "gl-matrix": "^3.0.0"
       }
     },
     "vlq": {

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
@@ -26,10 +26,10 @@
     "lib"
   ],
   "dependencies": {
+    "@math.gl/web-mercator": "^4.1.0",
     "prop-types": "^15.8.1",
     "react-map-gl": "^6.1.19",
-    "supercluster": "^8.0.1",
-    "viewport-mercator-project": "^6.1.1"
+    "supercluster": "^8.0.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -21,7 +21,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import MapGL from 'react-map-gl';
-import ViewportMercator from 'viewport-mercator-project';
+import { WebMercatorViewport } from '@math.gl/web-mercator';
 import ScatterPlotGlowOverlay from './ScatterPlotGlowOverlay';
 import './MapBox.css';
 
@@ -63,7 +63,7 @@ class MapBox extends Component {
     // Get a viewport that fits the given bounds, which all marks to be clustered.
     // Derive lat, lon and zoom from this viewport. This is only done on initial
     // render as the bounds don't update as we pan/zoom in the current design.
-    const mercator = new ViewportMercator({
+    const mercator = new WebMercatorViewport({
       width,
       height,
     }).fitBounds(bounds);


### PR DESCRIPTION
Part of #30307 

**Legacy Mapbox Plugin**

viewport-mercator-project was deprecated some years ago
https://www.npmjs.com/package/viewport-mercator-project/

It's continued development happens in `@math.gl/web-mercator`:
https://visgl.github.io/math.gl/docs/whats-new#v31

This PR replaces the deprecated package for the active one