### PR TITLE
refactor: Migrate UndoRedoKeyListeners to typescript

### DIFF
--- a/superset-frontend/src/dashboard/components/UndoRedoKeyListeners/index.tsx
+++ b/superset-frontend/src/dashboard/components/UndoRedoKeyListeners/index.tsx
@@ -17,15 +17,15 @@
  * under the License.
  */
 import { PureComponent } from 'react';
-import PropTypes from 'prop-types';
+import { HeaderProps } from '../Header/types';
 
-const propTypes = {
-  onUndo: PropTypes.func.isRequired,
-  onRedo: PropTypes.func.isRequired,
+type UndoRedoKeyListenersProps = {
+  onUndo: HeaderProps['onUndo'];
+  onRedo: HeaderProps['onRedo'];
 };
 
-class UndoRedoKeyListeners extends PureComponent {
-  constructor(props) {
+class UndoRedoKeyListeners extends PureComponent<UndoRedoKeyListenersProps> {
+  constructor(props: UndoRedoKeyListenersProps) {
     super(props);
     this.handleKeydown = this.handleKeydown.bind(this);
   }
@@ -38,15 +38,17 @@ class UndoRedoKeyListeners extends PureComponent {
     document.removeEventListener('keydown', this.handleKeydown);
   }
 
-  handleKeydown(event) {
+  handleKeydown(event: KeyboardEvent) {
     const controlOrCommand = event.ctrlKey || event.metaKey;
     if (controlOrCommand) {
       const isZChar = event.key === 'z' || event.keyCode === 90;
       const isYChar = event.key === 'y' || event.keyCode === 89;
-      const isEditingMarkdown =
-        document && document.querySelector('.dashboard-markdown--editing');
-      const isEditingTitle =
-        document && document.querySelector('.editable-title--editing');
+      const isEditingMarkdown = document?.querySelector(
+        '.dashboard-markdown--editing',
+      );
+      const isEditingTitle = document?.querySelector(
+        '.editable-title--editing',
+      );
 
       if (!isEditingMarkdown && !isEditingTitle && (isZChar || isYChar)) {
         event.preventDefault();
@@ -60,7 +62,5 @@ class UndoRedoKeyListeners extends PureComponent {
     return null;
   }
 }
-
-UndoRedoKeyListeners.propTypes = propTypes;
 
 export default UndoRedoKeyListeners;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migrate UndoRedoKeyListeners to typescript

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N.A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
