### PR TITLE
fix: Domain 'undefined' error in Storybook

### DIFF
--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -148,7 +148,7 @@ export const DEFAULT_COMMON_BOOTSTRAP_DATA: CommonBootstrapData = {
   locale: 'en',
   feature_flags: {},
   language_pack: {
-    domain: '',
+    domain: 'superset',
     locale_data: {
       superset: {
         '': {


### PR DESCRIPTION

### SUMMARY
Due to incorrect configuration of the default bootstrap data, part of the language pack was undefined, causing every component that uses `t()` (translation function) to crash.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/21bd9f32-c5e7-45f3-a940-77fc96dbdd83">

After:

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/c7eef047-8ca4-4502-998c-d08e553cf5f5">


### TESTING INSTRUCTIONS
1. npm run storybook
2. Verify that storybook runs normally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
