### PR TITLE
fix(dashboard): Include `urlParams` in the screenshot generation

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
@@ -32,6 +32,7 @@ import { RootState } from 'src/dashboard/types';
 import { useSelector } from 'react-redux';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { last } from 'lodash';
+import { getDashboardUrlParams } from 'src/utils/urlUtils';
 import { DownloadScreenshotFormat } from './types';
 
 const RETRY_INTERVAL = 3000;
@@ -127,6 +128,7 @@ export default function DownloadScreenshot({
         anchor,
         activeTabs,
         dataMask,
+        urlParams: getDashboardUrlParams(),
       },
     })
       .then(({ json }) => {

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -123,7 +123,7 @@ function getChartUrlParams(excludedUrlParams?: string[]): UrlParamEntries {
   return getUrlParamEntries(urlParams);
 }
 
-function getDashboardUrlParams(): UrlParamEntries {
+export function getDashboardUrlParams(): UrlParamEntries {
   const urlParams = getUrlParams(RESERVED_DASHBOARD_URL_PARAMS);
   const filterBoxFilters = getActiveFilters();
   if (!isEmpty(filterBoxFilters))


### PR DESCRIPTION
### SUMMARY
The `/api/v1/dashboard/{{id}}/cache_dashboard_screenshot/` API endpoint accepts a `urlParam` configuration, however the client was not including it in the payload.

This PR adds the `urlParam` configuration to the request payload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
![image](https://github.com/user-attachments/assets/ae8af5c9-7543-4e24-b869-263f73b07748)

**After**
![image](https://github.com/user-attachments/assets/59f929b9-a4f0-4da2-96fc-156dcafd5a0b)

### TESTING INSTRUCTIONS
1. Access a dashboard with a URL param set. 
2. Validate that the URL param is included in the payload to create the screenshot.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
