### PR TITLE
fix(chart): Table and page entries misaligned

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -133,7 +133,6 @@ const defaultProps: Partial<ChartProps> = {
 const Styles = styled.div<{ height: number; width?: number }>`
   min-height: ${p => p.height}px;
   position: relative;
-  text-align: center;
 
   .chart-tooltip {
     opacity: 0.75;
@@ -167,6 +166,7 @@ const LoadingDiv = styled.div`
 
 const MessageSpan = styled.span`
   display: block;
+  text-align: center;
   margin: ${({ theme }) => theme.gridUnit * 4}px auto;
   width: fit-content;
   color: ${({ theme }) => theme.colors.grayscale.base};


### PR DESCRIPTION
### SUMMARY
The table content and other page elements are misaligned with the center.
This issue arises because the text-align property is applied to the entire chart container instead of just the loading container in #27611. This commit resolves the problem by applying `text-align: center` to the loading message container.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
|Before|After|
|--|--|
|![Screenshot 2024-10-22 at 3 22 06 PM](https://github.com/user-attachments/assets/95e519f4-f9b7-4292-bb61-a0f8993d9244)|![Screenshot 2024-10-22 at 3 23 02 PM](https://github.com/user-attachments/assets/4801e81e-7ce1-45b9-bad4-3d8df66b40f4)|
|![Screenshot 2024-10-22 at 3 29 32 PM](https://github.com/user-attachments/assets/a99a658c-9e08-4e1d-875e-b89622ddb501)|![Screenshot 2024-10-22 at 3 29 04 PM](https://github.com/user-attachments/assets/421bc4dc-2352-42e0-961d-d52f9bebe8cc)|

Confirmed that the loading spinner is center-aligned

![Screenshot 2024-10-22 at 3 26 48 PM](https://github.com/user-attachments/assets/6703318c-d861-4351-a170-7e87cff7b0ff)


### TESTING INSTRUCTIONS
Screenshots


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
