### PR TITLE
fix: bump FAB to 4.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "cryptography>=42.0.4, <44.0.0",
     "deprecation>=2.1.0, <2.2.0",
     "flask>=2.2.5, <3.0.0",
-    "flask-appbuilder>=4.5.0, <5.0.0",
+    "flask-appbuilder==4.5.2rc1",
     "flask-caching>=2.1.0, <3",
     "flask-compress>=1.13, <2.0",
     "flask-talisman>=1.0.0, <2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "cryptography>=42.0.4, <44.0.0",
     "deprecation>=2.1.0, <2.2.0",
     "flask>=2.2.5, <3.0.0",
-    "flask-appbuilder==4.5.0, <5.0.0",
+    "flask-appbuilder>=4.5.0, <5.0.0",
     "flask-caching>=2.1.0, <3",
     "flask-compress>=1.13, <2.0",
     "flask-talisman>=1.0.0, <2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "cryptography>=42.0.4, <44.0.0",
     "deprecation>=2.1.0, <2.2.0",
     "flask>=2.2.5, <3.0.0",
-    "flask-appbuilder==4.5.2rc1",
+    "flask-appbuilder==4.5.0, <5.0.0",
     "flask-caching>=2.1.0, <3",
     "flask-compress>=1.13, <2.0",
     "flask-talisman>=1.0.0, <2.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -109,7 +109,7 @@ flask==2.3.3
     #   flask-session
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.5.0
+flask-appbuilder==4.5.2rc1
     # via apache-superset
 flask-babel==2.0.0
     # via flask-appbuilder
@@ -394,7 +394,7 @@ werkzeug==3.0.3
     #   flask-login
 wrapt==1.16.0
     # via deprecated
-wtforms==3.1.2
+wtforms==3.2.1
     # via
     #   apache-superset
     #   flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -109,7 +109,7 @@ flask==2.3.3
     #   flask-session
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==4.5.2rc1
+flask-appbuilder==4.5.2
     # via apache-superset
 flask-babel==2.0.0
     # via flask-appbuilder


### PR DESCRIPTION
### SUMMARY

WTForms 3.2.X breaks superset with the following error:

```
AttributeError: 'tuple' object has no attribute 'items'
```

More details on: https://github.com/dpgaspar/Flask-AppBuilder/pull/2279


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
