### PR TITLE
fix: Nested transaction is inactive when embedding dashboard

### DIFF
--- a/superset/cachekeys/api.py
+++ b/superset/cachekeys/api.py
@@ -114,8 +114,8 @@ class CacheRestApi(BaseSupersetModelRestApi):
                     CacheKey.cache_key.in_(cache_keys)
                 )
 
-                with db.session.begin_nested():
-                    db.session.execute(delete_stmt)
+                db.session.execute(delete_stmt)
+                db.session.commit()  # pylint: disable=consider-using-transaction
 
                 stats_logger_manager.instance.gauge(
                     "invalidated_cache", len(cache_keys)
@@ -126,6 +126,7 @@ class CacheRestApi(BaseSupersetModelRestApi):
                     len(datasource_uids),
                 )
             except SQLAlchemyError as ex:  # pragma: no cover
+                db.session.rollback()  # pylint: disable=consider-using-transaction
                 logger.error(ex, exc_info=True)
                 return self.response_500(str(ex))
         return self.response(201)

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1125,9 +1125,11 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             logger.info("Triggering screenshot ASYNC")
             cache_dashboard_screenshot.delay(
                 username=get_current_user(),
-                guest_token=g.user.guest_token
-                if get_current_user() and isinstance(g.user, GuestUser)
-                else None,
+                guest_token=(
+                    g.user.guest_token
+                    if get_current_user() and isinstance(g.user, GuestUser)
+                    else None
+                ),
                 dashboard_id=dashboard.id,
                 dashboard_url=dashboard_url,
                 cache_key=cache_key,
@@ -1595,15 +1597,16 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         try:
             body = self.embedded_config_schema.load(request.json)
 
-            with db.session.begin_nested():
-                embedded = EmbeddedDashboardDAO.upsert(
-                    dashboard,
-                    body["allowed_domains"],
-                )
+            embedded = EmbeddedDashboardDAO.upsert(
+                dashboard,
+                body["allowed_domains"],
+            )
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
             result = self.embedded_response_schema.dump(embedded)
             return self.response(200, result=result)
         except ValidationError as error:
+            db.session.rollback()  # pylint: disable=consider-using-transaction
             return self.response_400(message=error.messages)
 
     @expose("/<id_or_slug>/embedded", methods=("DELETE",))


### PR DESCRIPTION
### SUMMARY
There are still some steps required to complete [[SIP-99B] Proposal for (re)defining a "unit of work"]( https://github.com/apache/superset/issues/25108) to allow us to use `begin_nested`. This PR reverts the last 2 references to that method while the prerequisites are not completed.

Fixes https://github.com/apache/superset/issues/30216

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
