### PR TITLE
fix(Dashboard): DatePicker to not autoclose modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -307,7 +307,11 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
         <AdvancedFrame value={timeRangeValue} onChange={setTimeRangeValue} />
       )}
       {frame === 'Custom' && (
-        <CustomFrame value={timeRangeValue} onChange={setTimeRangeValue} />
+        <CustomFrame
+          value={timeRangeValue}
+          onChange={setTimeRangeValue}
+          isOverflowingFilterBar={isOverflowingFilterBar}
+        />
       )}
       {frame === 'No filter' && <div data-test={DateFilterTestKey.NoFilter} />}
       <Divider />

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/components/CustomFrame.tsx
@@ -166,6 +166,11 @@ export function CustomFrame(props: FrameComponentProps) {
                 }
                 allowClear={false}
                 locale={datePickerLocale}
+                getPopupContainer={triggerNode =>
+                  props.isOverflowingFilterBar
+                    ? (triggerNode.parentNode as HTMLElement)
+                    : document.body
+                }
               />
             </Row>
           )}
@@ -219,6 +224,11 @@ export function CustomFrame(props: FrameComponentProps) {
                 }
                 allowClear={false}
                 locale={datePickerLocale}
+                getPopupContainer={triggerNode =>
+                  props.isOverflowingFilterBar
+                    ? (triggerNode.parentNode as HTMLElement)
+                    : document.body
+                }
               />
             </Row>
           )}
@@ -277,6 +287,11 @@ export function CustomFrame(props: FrameComponentProps) {
                   allowClear={false}
                   className="control-anchor-to-datetime"
                   locale={datePickerLocale}
+                  getPopupContainer={triggerNode =>
+                    props.isOverflowingFilterBar
+                      ? (triggerNode.parentNode as HTMLElement)
+                      : document.body
+                  }
                 />
               </Col>
             )}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CustomFrame.test.tsx
@@ -28,7 +28,9 @@ import {
 import userEvent from '@testing-library/user-event';
 import { CustomFrame } from '../components';
 
+const TODAY = '2024-06-03';
 jest.useFakeTimers();
+jest.setSystemTime(new Date(TODAY).getTime());
 
 const emptyValue = '';
 const nowValue = 'now : now';
@@ -279,4 +281,99 @@ test('should translate Date Picker', async () => {
   expect(screen.getByText('ve')).toBeInTheDocument();
   expect(screen.getByText('sa')).toBeInTheDocument();
   expect(screen.getByText('di')).toBeInTheDocument();
+});
+
+test('calls onChange when START Specific Date/Time is selected', async () => {
+  const onChange = jest.fn();
+  render(
+    <Provider store={store}>
+      <CustomFrame
+        onChange={onChange}
+        value={specificValue}
+        isOverflowingFilterBar
+      />
+    </Provider>,
+  );
+
+  await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
+
+  const specificDateTimeOptions = screen.getAllByText('Specific Date/Time');
+  expect(specificDateTimeOptions.length).toBe(2);
+
+  const calendarIcons = screen.getAllByRole('img', { name: 'calendar' });
+  userEvent.click(calendarIcons[0]);
+
+  const randomDate = screen.getByTitle('2021-03-11');
+  userEvent.click(randomDate);
+
+  const okButton = screen.getByText('Ok');
+  userEvent.click(okButton);
+
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('calls onChange when END Specific Date/Time is selected', async () => {
+  const onChange = jest.fn();
+  render(
+    <Provider store={store}>
+      <CustomFrame
+        onChange={onChange}
+        value={specificValue}
+        isOverflowingFilterBar
+      />
+    </Provider>,
+  );
+
+  await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
+
+  const specificDateTimeOptions = screen.getAllByText('Specific Date/Time');
+  expect(specificDateTimeOptions.length).toBe(2);
+
+  const calendarIcons = screen.getAllByRole('img', { name: 'calendar' });
+  userEvent.click(calendarIcons[1]);
+
+  const randomDate = screen.getByTitle('2021-03-28');
+  userEvent.click(randomDate);
+
+  const okButton = screen.getByText('Ok');
+  userEvent.click(okButton);
+
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('calls onChange when a date is picked from anchor mode date picker', async () => {
+  const onChange = jest.fn();
+  render(
+    <Provider store={store}>
+      <CustomFrame
+        onChange={onChange}
+        value={relativeTodayValue}
+        isOverflowingFilterBar
+      />
+    </Provider>,
+  );
+
+  await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
+
+  const relativeDateTimeOptions = screen.getAllByText('Relative Date/Time');
+  expect(relativeDateTimeOptions.length).toBe(2);
+
+  await waitFor(() =>
+    expect(screen.getByText('Anchor to')).toBeInTheDocument(),
+  );
+
+  const dateTimeRadio = screen.getByRole('radio', { name: 'Date/Time' });
+
+  expect(dateTimeRadio).toBeChecked();
+
+  const calendarIcon = screen.getByRole('img', { name: 'calendar' });
+  userEvent.click(calendarIcon);
+
+  const randomDate = screen.getByTitle('2024-06-05');
+  userEvent.click(randomDate);
+
+  const okButton = screen.getByText('Ok');
+  userEvent.click(okButton);
+
+  expect(onChange).toHaveBeenCalled();
 });

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -101,6 +101,7 @@ export type CurrentRangeType =
 export type FrameComponentProps = {
   onChange: (timeRange: string) => void;
   value: string;
+  isOverflowingFilterBar?: boolean;
 };
 
 export interface DateFilterControlProps {


### PR DESCRIPTION
### SUMMARY
Fixed the bug: the time range custom filter pop-up closes automatically without applying the selected date filter when choosing "Specific Date/Time" within a nested custom time grain.

### BEFORE


https://github.com/user-attachments/assets/fe7458bb-a6b4-400d-8d8d-8a055d1a38ad


https://github.com/user-attachments/assets/e74011c1-aede-48ab-876b-6efcf3488148


https://github.com/user-attachments/assets/d9698882-b0be-400a-87c3-9d8783b75893


### AFTER


https://github.com/user-attachments/assets/23807255-d2a6-4fcc-a98a-f5e1b4d741bd


https://github.com/user-attachments/assets/f4a343b4-28c7-4c1c-bf7d-a643cc58f714


https://github.com/user-attachments/assets/2b5c5f44-432e-4277-b95f-049e7470d375


### TESTING INSTRUCTIONS
1. **Go to** a dashboard or chart with time filtering options and have the FilterBar horizontally inclined
2. **Click on** the "More Filters" dropdown.
3. **Scroll down to** the "Time Range" filter, and click to open it.
4. Select "Custom" as the **Range Type**
5. Choose "Specific Date/Time" as the time range, then attempt to select a date.
6. Notice that when you try to select a date, the pop-up closes automatically before applying the filter.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
