### PR TITLE
fix(Jinja): Extra cache keys for Jinja columns

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1980,6 +1980,12 @@ class SqlaTable(
             templatable_statements.append(extras["where"])
         if "having" in extras:
             templatable_statements.append(extras["having"])
+        if "columns" in query_obj:
+            templatable_statements += [
+                c["sqlExpression"]
+                for c in query_obj["columns"]
+                if c.get("sqlExpression")
+            ]
         if self.is_rls_supported:
             templatable_statements += [
                 f.clause for f in security_manager.get_rls_filters(self)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1984,7 +1984,7 @@ class SqlaTable(
             templatable_statements += [
                 c["sqlExpression"]
                 for c in query_obj["columns"]
-                if c.get("sqlExpression")
+                if isinstance(c, dict) and c.get("sqlExpression")
             ]
         if self.is_rls_supported:
             templatable_statements += [

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -116,7 +116,7 @@ from superset.superset_typing import (
 )
 from superset.utils import core as utils, json
 from superset.utils.backports import StrEnum
-from superset.utils.core import GenericDataType, MediumText
+from superset.utils.core import GenericDataType, is_adhoc_column, MediumText
 
 config = app.config
 metadata = Model.metadata  # pylint: disable=no-member
@@ -1982,9 +1982,7 @@ class SqlaTable(
             templatable_statements.append(extras["having"])
         if "columns" in query_obj:
             templatable_statements += [
-                c["sqlExpression"]
-                for c in query_obj["columns"]
-                if isinstance(c, dict) and c.get("sqlExpression")
+                c["sqlExpression"] for c in query_obj["columns"] if is_adhoc_column(c)
             ]
         if self.is_rls_supported:
             templatable_statements += [

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -913,6 +913,55 @@ def test_extra_cache_keys_in_sql_expression(
 
 @pytest.mark.usefixtures("app_context")
 @pytest.mark.parametrize(
+    "sql_expression,expected_cache_keys,has_extra_cache_keys",
+    [
+        ("'{{ current_username() }}'", ["abc"], True),
+        ("(user != 'abc')", [], False),
+    ],
+)
+@patch("superset.jinja_context.get_user_id", return_value=1)
+@patch("superset.jinja_context.get_username", return_value="abc")
+@patch("superset.jinja_context.get_user_email", return_value="abc@test.com")
+def test_extra_cache_keys_in_columns(
+    mock_user_email,
+    mock_username,
+    mock_user_id,
+    sql_expression,
+    expected_cache_keys,
+    has_extra_cache_keys,
+):
+    table = SqlaTable(
+        table_name="test_has_no_extra_cache_keys_table",
+        sql="SELECT 'abc' as user",
+        database=get_example_database(),
+    )
+    base_query_obj = {
+        "granularity": None,
+        "from_dttm": None,
+        "to_dttm": None,
+        "groupby": [],
+        "metrics": [],
+        "is_timeseries": False,
+        "filter": [],
+    }
+
+    query_obj = dict(
+        **base_query_obj,
+        columns=[
+            {
+                "expressionType": "SQL",
+                "sqlExpression": sql_expression,
+            }
+        ],
+    )
+
+    extra_cache_keys = table.get_extra_cache_keys(query_obj)
+    assert table.has_extra_cache_key_calls(query_obj) == has_extra_cache_keys
+    assert extra_cache_keys == expected_cache_keys
+
+
+@pytest.mark.usefixtures("app_context")
+@pytest.mark.parametrize(
     "row,dimension,result",
     [
         (pd.Series({"foo": "abc"}), "foo", "abc"),

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -949,6 +949,7 @@ def test_extra_cache_keys_in_columns(
         **base_query_obj,
         columns=[
             {
+                "label": None,
                 "expressionType": "SQL",
                 "sqlExpression": sql_expression,
             }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR fixes an issue where Jinja in columns was not considered during cache key checks, leading to cache spillover.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create an aggregated table chart using the `Vehicle Sales` dataset from the `examples` connection.
2. Create below dimensions:
    a. `'{{current_user_id()}}'` as `id`
    a. `'{{current_username()}}'` as `username`
    a. `'{{current_user_email()}}'` as `email`
    a. `'{{url_param('test', 'default')}}'` as `url_param`
3. Set the row limit to 1.
4. Save the chart to a dashboard and access it.
5. Notice that the user-related macros will show your account data, and the `url_param` column will show `default` (which is set in the macro to be returned when the param is not defined).
6. Copy the dashboard URL, and append `&test=blah` to it (after the `native_filters_key` value) and access it.
7. The `url_param` column should now how the param value (`blah`).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
