### PR TITLE
fix(frontend): Include CSRF token value in beacon call

### DIFF
--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -118,10 +118,6 @@ describe('logger middleware', () => {
       writable: true,
       value: beaconMock,
     });
-    Object.defineProperty(document, 'getElementById', {
-      writable: true,
-      value: () => null,
-    });
 
     logger(mockStore)(next)(action);
     expect(beaconMock.mock.calls.length).toBe(0);
@@ -137,10 +133,6 @@ describe('logger middleware', () => {
     Object.defineProperty(navigator, 'sendBeacon', {
       writable: true,
       value: beaconMock,
-    });
-    Object.defineProperty(document, 'getElementById', {
-      writable: true,
-      value: () => null,
     });
     SupersetClient.configure({ guestToken: 'token' });
 

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -152,9 +152,9 @@ describe('logger middleware', () => {
       value: beaconMock,
     });
     SupersetClient.configure({ guestToken: 'token' });
-    tokenInput = document.createElement('input')
-    tokenInput.id = 'csrf_token'
-    tokenInput.value = 'csrf'
+    const tokenInput = document.createElement('input');
+    tokenInput.id = 'csrf_token';
+    tokenInput.value = 'csrf';
 
     logger(mockStore)(next)(action);
     expect(beaconMock.mock.calls.length).toBe(0);

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -166,7 +166,7 @@ describe('logger middleware', () => {
     expect(beaconMock.mock.calls.length).toBe(1);
     expect(docMoc.mock.calls.length).toBe(2);
     expect(docMoc.mock.calls[0][0]).toMatch('csrf_token');
-    expect(docMoc.mock.calls[0][1]).toMatch('csrf_token');
+    expect(docMoc.mock.calls[1][0]).toMatch('csrf_token');
 
     const formData = beaconMock.mock.calls[0][1];
     expect(formData.getAll('csrf_token')[0]).toMatch('csrf');

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -161,7 +161,7 @@ describe('logger middleware', () => {
     });
     SupersetClient.configure({ guestToken: 'token' });
     
-    const docMock = jest.fn(x => {'value': 'csrf'});
+    const docMock = jest.fn(x => ({'value': 'csrf'}));
     Object.defineProperty(document, 'getElementById', {
       writable: true,
       value: docMock,

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -156,7 +156,7 @@ describe('logger middleware', () => {
     const docMoc = jest.fn();
     Object.defineProperty(document, 'getElementById', {
       writable: true,
-      value: () => ({ 'value': 'csrf' }),
+      value: () => ({ value: 'csrf' }),
     });
 
     logger(mockStore)(next)(action);

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -160,8 +160,8 @@ describe('logger middleware', () => {
       value: beaconMock,
     });
     SupersetClient.configure({ guestToken: 'token' });
-    
-    const docMock = jest.fn(x => ({'value': 'csrf'}));
+
+    const docMock = jest.fn(() => ({ value: 'csrf' }));
     Object.defineProperty(document, 'getElementById', {
       writable: true,
       value: docMock,

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -153,10 +153,10 @@ describe('logger middleware', () => {
     });
     SupersetClient.configure({ guestToken: 'token' });
 
-    const docMoc = jest.fn();
+    const docMoc = jest.fn(() => ({ value: 'csrf' }));
     Object.defineProperty(document, 'getElementById', {
       writable: true,
-      value: () => ({ value: 'csrf' }),
+      value: docMoc,
     });
 
     logger(mockStore)(next)(action);

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -152,20 +152,14 @@ describe('logger middleware', () => {
       value: beaconMock,
     });
     SupersetClient.configure({ guestToken: 'token' });
-
-    const docMock = jest.fn(() => ({ value: 'csrf' }));
-    Object.defineProperty(document, 'getElementById', {
-      writable: true,
-      value: docMock,
-    });
+    tokenInput = document.createElement('input')
+    tokenInput.id = 'csrf_token'
+    tokenInput.value = 'csrf'
 
     logger(mockStore)(next)(action);
     expect(beaconMock.mock.calls.length).toBe(0);
-    expect(docMock.mock.calls.length).toBe(0);
     timeSandbox.clock.tick(2000);
     expect(beaconMock.mock.calls.length).toBe(1);
-    expect(docMock.mock.calls.length).toBe(1);
-    expect(docMock.mock.calls[0][1]).toMatch('csrf_token');
 
     const formData = beaconMock.mock.calls[0][1];
     expect(formData.getAll('csrf_token')[0]).toMatch('csrf');

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -152,14 +152,21 @@ describe('logger middleware', () => {
       value: beaconMock,
     });
     SupersetClient.configure({ guestToken: 'token' });
-    const tokenInput = document.createElement('input');
-    tokenInput.id = 'csrf_token';
-    tokenInput.value = 'csrf';
+
+    const docMoc = jest.fn();
+    Object.defineProperty(document, 'getElementById', {
+      writable: true,
+      value: () => ({ 'value': 'csrf' }),
+    });
 
     logger(mockStore)(next)(action);
     expect(beaconMock.mock.calls.length).toBe(0);
+    expect(docMoc.mock.calls.length).toBe(0);
     timeSandbox.clock.tick(2000);
     expect(beaconMock.mock.calls.length).toBe(1);
+    expect(docMoc.mock.calls.length).toBe(2);
+    expect(docMoc.mock.calls[0][0]).toMatch('csrf_token');
+    expect(docMoc.mock.calls[0][1]).toMatch('csrf_token');
 
     const formData = beaconMock.mock.calls[0][1];
     expect(formData.getAll('csrf_token')[0]).toMatch('csrf');

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -44,8 +44,8 @@ const sendBeacon = events => {
   if (navigator.sendBeacon) {
     const formData = new FormData();
     formData.append('events', safeStringify(events));
-    if (document.getElementBy('csrf_token')) {
-      formData.append('csrf_token', document.getElementBy('csrf_token').value);
+    if (document.getElementById('csrf_token')) {
+      formData.append('csrf_token', document.getElementById('csrf_token').value);
     }
     if (SupersetClient.getGuestToken()) {
       // if we have a guest token, we need to send it for auth via the form

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -45,7 +45,10 @@ const sendBeacon = events => {
     const formData = new FormData();
     formData.append('events', safeStringify(events));
     if (document.getElementById('csrf_token')) {
-      formData.append('csrf_token', document.getElementById('csrf_token').value);
+      formData.append(
+        'csrf_token',
+        document.getElementById('csrf_token').value,
+      );
     }
     if (SupersetClient.getGuestToken()) {
       // if we have a guest token, we need to send it for auth via the form

--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -44,6 +44,9 @@ const sendBeacon = events => {
   if (navigator.sendBeacon) {
     const formData = new FormData();
     formData.append('events', safeStringify(events));
+    if (document.getElementBy('csrf_token')) {
+      formData.append('csrf_token', document.getElementBy('csrf_token').value);
+    }
     if (SupersetClient.getGuestToken()) {
       // if we have a guest token, we need to send it for auth via the form
       formData.append('guest_token', SupersetClient.getGuestToken());


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Before sending the log beacon call, include the CSRF token if it exists.

### TESTING INSTRUCTIONS
1. Be sure that CSRF is enabled
2. Navigate the site and watch logs
3. Verify that the `POST /superset/log` messages are 200s and not 302s.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #30717 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
