### PR TITLE
chore(Dashboard): Simplify scoping logic for cross/native filters

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -286,7 +286,7 @@ describe('Native filters', () => {
 
     it('User can cancel creating a new filter', () => {
       enterNativeFilterEditModal(false);
-      cancelNativeFilterSettings();
+      cancelNativeFilterSettings(true);
     });
 
     it('Verify setting options and tooltips for value filter', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -286,7 +286,7 @@ describe('Native filters', () => {
 
     it('User can cancel creating a new filter', () => {
       enterNativeFilterEditModal(false);
-      cancelNativeFilterSettings(true);
+      cancelNativeFilterSettings();
     });
 
     it('Verify setting options and tooltips for value filter', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
@@ -369,16 +369,19 @@ export function saveNativeFilterSettings(charts: ChartSpec[]) {
  * @returns {None}
  * @summary helper for cancel native filters settings
  ************************************************************************* */
-export function cancelNativeFilterSettings() {
-  cy.get(nativeFilters.modal.footer)
-    .find(nativeFilters.modal.cancelButton)
-    .should('be.visible')
-    .click();
+export function cancelNativeFilterSettings(confirm = false) {
+  if (!confirm) {
+    cy.get(nativeFilters.modal.footer)
+      .find(nativeFilters.modal.cancelButton)
+      .should('be.visible')
+      .click();
+  }
+
   cy.get(nativeFilters.modal.alertXUnsavedFilters)
     .should('be.visible')
     .should('have.text', 'There are unsaved changes.');
   cy.get(nativeFilters.modal.footer)
-    .find(nativeFilters.modal.yesCancelButton)
+    .find(nativeFilters.modal.confirmCancelButton)
     .contains('cancel')
     .click({ force: true });
   cy.get(nativeFilters.modal.container).should('not.exist');

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
@@ -369,14 +369,11 @@ export function saveNativeFilterSettings(charts: ChartSpec[]) {
  * @returns {None}
  * @summary helper for cancel native filters settings
  ************************************************************************* */
-export function cancelNativeFilterSettings(confirm = false) {
-  if (!confirm) {
-    cy.get(nativeFilters.modal.footer)
-      .find(nativeFilters.modal.cancelButton)
-      .should('be.visible')
-      .click();
-  }
-
+export function cancelNativeFilterSettings() {
+  cy.get(nativeFilters.modal.footer)
+    .find(nativeFilters.modal.cancelButton)
+    .should('be.visible')
+    .click();
   cy.get(nativeFilters.modal.alertXUnsavedFilters)
     .should('be.visible')
     .should('have.text', 'There are unsaved changes.');

--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -322,7 +322,9 @@ export const nativeFilters = {
     footer: '.ant-modal-footer',
     saveButton: dataTestLocator('native-filter-modal-save-button'),
     cancelButton: dataTestLocator('native-filter-modal-cancel-button'),
-    yesCancelButton: '[type="button"]',
+    confirmCancelButton: dataTestLocator(
+      'native-filter-modal-confirm-cancel-button',
+    ),
     alertXUnsavedFilters: '.ant-alert-message',
     tabsList: {
       filterItemsContainer: dataTestLocator('filter-title-container'),

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -212,7 +212,7 @@ class Dashboard extends PureComponent {
 
   applyFilters() {
     const { appliedFilters } = this;
-    const { activeFilters, ownDataCharts, datasources, slices } = this.props;
+    const { activeFilters, ownDataCharts, slices } = this.props;
 
     // refresh charts if a filter was removed, added, or changed
 
@@ -231,22 +231,12 @@ class Dashboard extends PureComponent {
       ) {
         // filterKey is removed?
         affectedChartIds.push(
-          ...getRelatedCharts(
-            appliedFilters,
-            activeFilters,
-            slices,
-            datasources,
-          )[filterKey],
+          ...getRelatedCharts(appliedFilters, activeFilters, slices)[filterKey],
         );
       } else if (!appliedFilterKeys.includes(filterKey)) {
         // filterKey is newly added?
         affectedChartIds.push(
-          ...getRelatedCharts(
-            activeFilters,
-            appliedFilters,
-            slices,
-            datasources,
-          )[filterKey],
+          ...getRelatedCharts(activeFilters, appliedFilters, slices)[filterKey],
         );
       } else {
         // if filterKey changes value,
@@ -261,12 +251,9 @@ class Dashboard extends PureComponent {
           )
         ) {
           affectedChartIds.push(
-            ...getRelatedCharts(
-              activeFilters,
-              appliedFilters,
-              slices,
-              datasources,
-            )[filterKey],
+            ...getRelatedCharts(activeFilters, appliedFilters, slices)[
+              filterKey
+            ],
           );
         }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.tsx
@@ -21,6 +21,7 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NativeFilterScope, styled, t } from '@superset-ui/core';
 import { Radio } from 'src/components/Radio';
 import { AntdForm, Typography } from 'src/components';
+import { areObjectsEqual } from 'src/reduxUtils';
 import { ScopingType } from './types';
 import ScopingTree from './ScopingTree';
 import { getDefaultScopeValue, isScopingAll } from './utils';
@@ -86,13 +87,16 @@ const FilterScope: FC<FilterScopeProps> = ({
 
   const updateScopes = useCallback(
     updatedFormValues => {
-      if (hasScopeBeenModified) {
+      if (
+        hasScopeBeenModified ||
+        areObjectsEqual(updatedFormValues.scope, filterScope)
+      ) {
         return;
       }
 
       updateFormValues(updatedFormValues);
     },
-    [hasScopeBeenModified, updateFormValues],
+    [filterScope, hasScopeBeenModified, updateFormValues],
   );
 
   useEffect(() => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -583,9 +583,9 @@ const FiltersConfigForm = (
     !datasetId || datasetDetails || formFilter?.dataset?.label;
 
   const updateFormValues = useCallback(
-    (values: any) => {
+    (values: any, triggerFormChange = true) => {
       setNativeFilterFieldValues(form, filterId, values);
-      formChanged();
+      if (triggerFormChange) formChanged();
     },
     [filterId, form, formChanged],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -297,7 +297,6 @@ function FiltersConfigModal({
     setRemovedFilters,
     setOrderedFilters,
     setSaveAlertVisible,
-    filterChanges,
     filterId => {
       setFilterChanges(prev => ({
         ...prev,
@@ -510,7 +509,8 @@ function FiltersConfigModal({
       unsavedFiltersIds.length > 0 ||
       form.isFieldsTouched() ||
       changed ||
-      didChangeOrder
+      didChangeOrder ||
+      Object.values(removedFilters).some(f => f?.isPending)
     ) {
       setSaveAlertVisible(true);
     } else {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/Footer/CancelConfirmationAlert.tsx
@@ -61,6 +61,7 @@ export function CancelConfirmationAlert({
             buttonSize="small"
             buttonStyle="primary"
             onClick={onConfirm}
+            data-test="native-filter-modal-confirm-cancel-button"
           >
             {t('Yes, cancel')}
           </Button>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/utils.ts
@@ -170,7 +170,6 @@ export const createHandleRemoveItem =
       val: string[] | ((prevState: string[]) => string[]),
     ) => void,
     setSaveAlertVisible: Function,
-    filterChanges: FilterChangesType,
     removeFilter: (filterId: string) => void,
   ) =>
   (filterId: string) => {

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.test.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.test.ts
@@ -19,11 +19,9 @@
 
 import {
   AppliedCrossFilterType,
-  DatasourceType,
   Filter,
   NativeFilterType,
 } from '@superset-ui/core';
-import { DatasourcesState } from '../types';
 import { getRelatedCharts } from './getRelatedCharts';
 
 const slices = {
@@ -32,48 +30,11 @@ const slices = {
   '3': { datasource: 'ds1', slice_id: 3 },
 } as any;
 
-const datasources: DatasourcesState = {
-  ds1: {
-    uid: 'ds1',
-    datasource_name: 'ds1',
-    table_name: 'table1',
-    description: '',
-    id: 100,
-    columns: [{ column_name: 'column1' }, { column_name: 'column2' }],
-    column_names: ['column1', 'column2'],
-    column_types: [],
-    type: DatasourceType.Table,
-    metrics: [],
-    column_formats: {},
-    currency_formats: {},
-    verbose_map: {},
-    main_dttm_col: '',
-    filter_select_enabled: true,
-  },
-  ds2: {
-    uid: 'ds2',
-    datasource_name: 'ds2',
-    table_name: 'table2',
-    description: '',
-    id: 200,
-    columns: [{ column_name: 'column3' }, { column_name: 'column4' }],
-    column_names: ['column3', 'column4'],
-    column_types: [],
-    type: DatasourceType.Table,
-    metrics: [],
-    column_formats: {},
-    currency_formats: {},
-    verbose_map: {},
-    main_dttm_col: '',
-    filter_select_enabled: true,
-  },
-};
-
-test('Return chart ids matching the dataset id with native filter', () => {
+test('Return all chart ids in global scope with native filters', () => {
   const filters = {
     filterKey1: {
       filterType: 'filter_select',
-      chartsInScope: [1, 2],
+      chartsInScope: [1, 2, 3],
       scope: {
         excluded: [],
         rootPath: [],
@@ -88,54 +49,54 @@ test('Return chart ids matching the dataset id with native filter', () => {
     } as unknown as Filter,
   };
 
-  const result = getRelatedCharts(filters, null, slices, datasources);
+  const result = getRelatedCharts(filters, null, slices);
   expect(result).toEqual({
-    filterKey1: [1],
+    filterKey1: [1, 2, 3],
   });
 });
 
-test('Return chart ids matching the dataset id with cross filter', () => {
-  const filters = {
-    '3': {
-      filterType: undefined,
-      scope: [1, 2],
-      targets: [],
-      values: null,
-    } as AppliedCrossFilterType,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    '3': [1],
-  });
-});
-
-test('Return chart ids matching the column name with native filter', () => {
+test('Return only chart ids in specific scope with native filters', () => {
   const filters = {
     filterKey1: {
       filterType: 'filter_select',
-      chartsInScope: [1, 2],
+      chartsInScope: [1, 3],
       scope: {
         excluded: [],
         rootPath: [],
       },
       targets: [
         {
-          column: { name: 'column3' },
-          datasetId: 999,
+          column: { name: 'column1' },
+          datasetId: 100,
         },
       ],
       type: NativeFilterType.NativeFilter,
     } as unknown as Filter,
   };
 
-  const result = getRelatedCharts(filters, null, slices, datasources);
+  const result = getRelatedCharts(filters, null, slices);
   expect(result).toEqual({
-    filterKey1: [2],
+    filterKey1: [1, 3],
   });
 });
 
-test('Return chart ids matching the column name with cross filter', () => {
+test('Return all chart ids with cross filter in global scope', () => {
+  const filters = {
+    '3': {
+      filterType: undefined,
+      scope: [1, 2, 3],
+      targets: [],
+      values: null,
+    } as AppliedCrossFilterType,
+  };
+
+  const result = getRelatedCharts(filters, null, slices);
+  expect(result).toEqual({
+    '3': [1, 2],
+  });
+});
+
+test('Return only chart ids in specific scope with cross filter', () => {
   const filters = {
     '1': {
       filterType: undefined,
@@ -147,108 +108,8 @@ test('Return chart ids matching the column name with cross filter', () => {
     } as AppliedCrossFilterType,
   };
 
-  const result = getRelatedCharts(filters, null, slices, datasources);
+  const result = getRelatedCharts(filters, null, slices);
   expect(result).toEqual({
     '1': [2],
-  });
-});
-
-test('Return chart ids when column display name matches with native filter', () => {
-  const filters = {
-    filterKey1: {
-      filterType: 'filter_select',
-      chartsInScope: [1, 2],
-      scope: {
-        excluded: [],
-        rootPath: [],
-      },
-      targets: [
-        {
-          column: { name: 'column4', displayName: 'column4' },
-          datasetId: 999,
-        },
-      ],
-      type: NativeFilterType.NativeFilter,
-    } as unknown as Filter,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    filterKey1: [2],
-  });
-});
-
-test('Return chart ids when column display name matches with cross filter', () => {
-  const filters = {
-    '1': {
-      filterType: undefined,
-      scope: [1, 2],
-      targets: [],
-      values: {
-        filters: [{ col: 'column4' }],
-      },
-    } as AppliedCrossFilterType,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    '1': [2],
-  });
-});
-
-test('Return scope when filterType is not filter_select', () => {
-  const filters = {
-    filterKey1: {
-      filterType: 'filter_time',
-      chartsInScope: [3, 4],
-    } as Filter,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    filterKey1: [3, 4],
-  });
-});
-
-test('Return an empty array if no matching charts found with native filter', () => {
-  const filters = {
-    filterKey1: {
-      filterType: 'filter_select',
-      chartsInScope: [1, 2],
-      scope: {
-        excluded: [],
-        rootPath: [],
-      },
-      targets: [
-        {
-          column: { name: 'nonexistent_column' },
-          datasetId: 300,
-        },
-      ],
-      type: NativeFilterType.NativeFilter,
-    } as unknown as Filter,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    filterKey1: [],
-  });
-});
-
-test('Return an empty array if no matching charts found with cross filter', () => {
-  const filters = {
-    '1': {
-      filterType: undefined,
-      scope: [1, 2],
-      targets: [],
-      values: {
-        filters: [{ col: 'nonexistent_column' }],
-      },
-    } as AppliedCrossFilterType,
-  };
-
-  const result = getRelatedCharts(filters, null, slices, datasources);
-  expect(result).toEqual({
-    '1': [],
   });
 });

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.ts
@@ -20,57 +20,31 @@
 import {
   AppliedCrossFilterType,
   AppliedNativeFilterType,
-  ensureIsArray,
   Filter,
   isAppliedCrossFilterType,
   isAppliedNativeFilterType,
   isNativeFilter,
 } from '@superset-ui/core';
 import { Slice } from 'src/types/Chart';
-import { DatasourcesState } from '../types';
 
-function checkForExpression(formData?: Record<string, any>) {
-  const groupby = ensureIsArray(formData?.groupby);
-  const allColumns = ensureIsArray(formData?.all_columns);
-  const adhocFilters = ensureIsArray(formData?.adhoc_filters);
-  const checkExpressions = groupby.concat(allColumns).concat(adhocFilters);
-  return checkExpressions.some(
-    (ex: string | Record<string, any>) =>
-      ex && typeof ex === 'object' && ex.expressionType === 'SQL',
-  );
+function isGlobalScope(scope: number[], slices: Record<string, Slice>) {
+  return scope.length === Object.keys(slices).length;
 }
 
 function getRelatedChartsForSelectFilter(
   nativeFilter: AppliedNativeFilterType | Filter,
   slices: Record<string, Slice>,
   chartsInScope: number[],
-  datasources: DatasourcesState,
 ) {
   return Object.values(slices)
     .filter(slice => {
-      const { datasource, slice_id } = slice;
-      // not in scope, ignore
-      if (!chartsInScope.includes(slice_id)) return false;
+      const { slice_id } = slice;
+      // all have been selected, always apply
+      if (isGlobalScope(chartsInScope, slices)) return true;
+      // hand-picked in scope, always apply
+      if (chartsInScope.includes(slice_id)) return true;
 
-      const chartDatasource = datasource
-        ? datasources[datasource]
-        : Object.values(datasources).find(ds => ds.id === slice.datasource_id);
-
-      const { column, datasetId } = nativeFilter.targets?.[0] ?? {};
-      const datasourceColumnNames = chartDatasource?.column_names ?? [];
-
-      // same datasource, always apply
-      if (chartDatasource?.id === datasetId) return true;
-
-      // let backend deal with adhoc columns and jinja
-      const hasSqlExpression = checkForExpression(slice.form_data);
-      if (hasSqlExpression) {
-        return true;
-      }
-
-      return datasourceColumnNames.some(
-        col => col === column?.name || col === column?.displayName,
-      );
+      return false;
     })
     .map(slice => slice.slice_id);
 }
@@ -79,52 +53,23 @@ function getRelatedChartsForCrossFilter(
   crossFilter: AppliedCrossFilterType,
   slices: Record<string, Slice>,
   scope: number[],
-  datasources: DatasourcesState,
 ): number[] {
   const sourceSlice = slices[filterKey];
-  const filters = crossFilter?.values?.filters ?? [];
 
   if (!sourceSlice) return [];
-
-  const sourceDatasource = sourceSlice.datasource
-    ? datasources[sourceSlice.datasource]
-    : Object.values(datasources).find(
-        ds => ds.id === sourceSlice.datasource_id,
-      );
 
   return Object.values(slices)
     .filter(slice => {
       // cross-filter emitter
       if (slice.slice_id === Number(filterKey)) return false;
-      // not in scope, ignore
-      if (!scope.includes(slice.slice_id)) return false;
-
-      const targetDatasource = slice.datasource
-        ? datasources[slice.datasource]
-        : Object.values(datasources).find(ds => ds.id === slice.datasource_id);
-
-      // same datasource, always apply
-      if (targetDatasource === sourceDatasource) return true;
-
-      const targetColumnNames = targetDatasource?.column_names ?? [];
-
-      // let backend deal with adhoc columns and jinja
-      const hasSqlExpression = checkForExpression(slice.form_data);
-      if (hasSqlExpression) {
-        return true;
-      }
-
-      for (const filter of filters) {
-        // let backend deal with adhoc columns
-        if (
-          typeof filter.col !== 'string' &&
-          filter.col.expressionType !== undefined
-        ) {
-          return true;
-        }
-        // shared column names, different datasources, apply filter
-        if (targetColumnNames.includes(filter.col)) return true;
-      }
+      // hand-picked in the scope, always apply
+      const fullScope = [
+        ...scope.filter(s => String(s) !== filterKey),
+        Number(filterKey),
+      ];
+      if (isGlobalScope(fullScope, slices)) return true;
+      // hand-picked in the scope, always apply
+      if (scope.includes(slice.slice_id)) return true;
 
       return false;
     })
@@ -141,7 +86,6 @@ export function getRelatedCharts(
     AppliedNativeFilterType | AppliedCrossFilterType | Filter
   > | null,
   slices: Record<string, Slice>,
-  datasources: DatasourcesState,
 ) {
   const related = Object.entries(filters).reduce((acc, [filterKey, filter]) => {
     const isCrossFilter =
@@ -169,7 +113,6 @@ export function getRelatedCharts(
           actualCrossFilter,
           slices,
           chartsInScope,
-          datasources,
         ),
       };
     }
@@ -187,7 +130,6 @@ export function getRelatedCharts(
           nativeFilter,
           slices,
           chartsInScope,
-          datasources,
         ),
       };
     }

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.ts
@@ -30,12 +30,13 @@ import { Slice } from 'src/types/Chart';
 import { DatasourcesState } from '../types';
 
 function checkForExpression(formData?: Record<string, any>) {
-  const groupby = ensureIsArray(formData?.groupby) ?? [];
-  const allColumns = ensureIsArray(formData?.all_columns) ?? [];
-  const checkColumns = groupby.concat(allColumns);
-  return checkColumns.some(
-    (col: string | Record<string, any>) =>
-      typeof col !== 'string' && col.expressionType !== undefined,
+  const groupby = ensureIsArray(formData?.groupby);
+  const allColumns = ensureIsArray(formData?.all_columns);
+  const adhocFilters = ensureIsArray(formData?.adhoc_filters);
+  const checkExpressions = groupby.concat(allColumns).concat(adhocFilters);
+  return checkExpressions.some(
+    (ex: string | Record<string, any>) =>
+      ex && typeof ex === 'object' && ex.expressionType === 'SQL',
   );
 }
 

--- a/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.ts
+++ b/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.ts
@@ -51,8 +51,6 @@ const useFilterFocusHighlightStyles = (chartId: number) => {
     dashboardFilters,
   );
 
-  const datasources =
-    useSelector((state: RootState) => state.datasources) || {};
   const slices =
     useSelector((state: RootState) => state.sliceEntities.slices) || {};
 
@@ -60,7 +58,6 @@ const useFilterFocusHighlightStyles = (chartId: number) => {
     nativeFilters.filters as Record<string, Filter>,
     null,
     slices,
-    datasources,
   );
 
   const highlightedFilterId =


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
PR https://github.com/apache/superset/pull/30438 introduced optimizations to enhance performance by reducing backend requests for cross and native filters. However, due to a lack of clarity around the specific use cases these functionalities are meant to support, and in response to reports of certain broken use cases (such as https://github.com/apache/superset/issues/30687), this PR simplifies the scoping logic to accommodate all use cases while still addressing the original issue of preventing requests for charts that are out of scope.

Specifically:

- When in global scope, all charts will be affected by the filter
- When in specific scope, only the selected charts will be affected by the filter

Fixes https://github.com/apache/superset/issues/30687

### TESTING INSTRUCTIONS
1. Create a native or cross filter
2. Change the scope to be global
3. All charts will be affected by the filter
4. Change the scope to only specific charts
5. Only charts that were selected should be affected by the filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
