### PR TITLE
feat(dataset API): Add parameter to optionally render Jinja macros in API response

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1097,8 +1097,10 @@ class DatasetRestApi(BaseSupersetModelRestApi):
                 schema:
                   $ref: '#/components/schemas/get_item_schema'
           - in: query
-            name: render
-            description: Should Jinja macros from sql, metrics and columns be rendered
+            name: include_rendered_sql
+            description: >-
+              Should Jinja macros from sql, metrics and columns be rendered
+              and included in the response
             schema:
               type: boolean
           responses:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1160,7 +1160,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         Renders Jinja macros in the ``sql``, ``metrics`` and ``columns`` fields.
 
         :param data: Dataset info to be rendered
-        :param tp: A ``TemplateProcessor`` instance
+        :param processor: A ``TemplateProcessor`` instance
         :return: Rendered dataset data
         """
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1144,7 +1144,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         response["id"] = pk
         response[API_RESULT_RES_KEY] = show_model_schema.dump(item, many=False)
 
-        if parse_boolean_string(request.args.get("render")):
+        if parse_boolean_string(request.args.get("include_rendered_sql")):
             processor = get_template_processor(database=item.database)
             response["result"] = self.render_dataset_fields(
                 response["result"], processor
@@ -1166,7 +1166,12 @@ class DatasetRestApi(BaseSupersetModelRestApi):
 
         def render_item_list(item_list: list[dict[str, Any]]) -> list[dict[str, Any]]:
             return [
-                {**item, "expression": processor.process_template(item["expression"])}
+                {
+                    **item,
+                    "rendered_expression": processor.process_template(
+                        item["expression"]
+                    ),
+                }
                 if item.get("expression")
                 else item
                 for item in item_list
@@ -1179,6 +1184,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             data["columns"] = render_item_list(columns)
 
         if sql := data.get("sql"):
-            data["sql"] = processor.process_template(sql)
+            data["rendered_sql"] = processor.process_template(sql)
 
         return data

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=too-many-lines
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any
 from zipfile import is_zipfile, ZipFile
 
 from flask import request, Response, send_file
@@ -1117,7 +1119,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             500:
               $ref: '#/components/responses/500'
         """
-        item: Optional[SqlaTable] = self.datamodel.get(
+        item: SqlaTable | None = self.datamodel.get(
             pk,
             self._base_filters,
             self.show_select_columns,

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -29,7 +29,6 @@ get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
 get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
 
 openapi_spec_methods_override = {
-    "get": {"get": {"summary": "Get a dataset detail information"}},
     "get_list": {
         "get": {
             "summary": "Get a list of datasets",

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -454,7 +454,6 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.get_assert_metric(uri, "get")
         assert rv.status_code == 200
         response = json.loads(rv.data.decode("utf-8"))
-        print(response)
 
         assert response["result"] == {
             "id": dataset.id,
@@ -479,6 +478,73 @@ class TestDatasetApi(SupersetTestCase):
                 },
             ],
         }
+
+        db.session.delete(dataset)
+        db.session.commit()
+
+    def test_get_dataset_render_jinja_exceptions(self):
+        """
+        Dataset API: Test get dataset with the render parameter
+        when rendering raises an exception.
+        """
+        database = get_example_database()
+        dataset = SqlaTable(
+            table_name="test_sql_table_with_incorrect_jinja",
+            database=database,
+            schema=get_example_default_schema(),
+            main_dttm_col="default_dttm",
+            columns=[
+                TableColumn(
+                    column_name="my_user_id",
+                    type="INTEGER",
+                    is_dttm=False,
+                ),
+                TableColumn(
+                    column_name="calculated_test",
+                    type="VARCHAR(255)",
+                    is_dttm=False,
+                    expression="'{{ current_username() }'",
+                ),
+            ],
+            metrics=[
+                SqlMetric(
+                    metric_name="param_test",
+                    expression="{{ url_param('multiplier') } * 1.4",
+                )
+            ],
+            sql="SELECT {{ current_user_id() } as my_user_id",
+        )
+        db.session.add(dataset)
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+
+        uri = f"api/v1/dataset/{dataset.id}?q=(columns:!(id,sql))&include_rendered_sql=true"
+        rv = self.get_assert_metric(uri, "get")
+        assert rv.status_code == 400
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["message"] == "Unable to render expression from dataset query."
+
+        uri = (
+            f"api/v1/dataset/{dataset.id}?q=(columns:!(id,metrics.expression))"
+            "&include_rendered_sql=true&multiplier=4"
+        )
+        rv = self.get_assert_metric(uri, "get")
+        assert rv.status_code == 400
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["message"] == "Unable to render expression from dataset metric."
+
+        uri = (
+            f"api/v1/dataset/{dataset.id}?q=(columns:!(id,columns.expression))"
+            "&include_rendered_sql=true"
+        )
+        rv = self.get_assert_metric(uri, "get")
+        assert rv.status_code == 400
+        response = json.loads(rv.data.decode("utf-8"))
+        assert (
+            response["message"]
+            == "Unable to render expression from dataset calculated column."
+        )
 
         db.session.delete(dataset)
         db.session.commit()

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -449,7 +449,7 @@ class TestDatasetApi(SupersetTestCase):
         uri = (
             f"api/v1/dataset/{dataset.id}?"
             "q=(columns:!(id,sql,columns.column_name,columns.expression,metrics.metric_name,metrics.expression))"
-            "&render=true&multiplier=4"
+            "&include_rendered_sql=true&multiplier=4"
         )
         rv = self.get_assert_metric(uri, "get")
         assert rv.status_code == 200
@@ -458,7 +458,8 @@ class TestDatasetApi(SupersetTestCase):
 
         assert response["result"] == {
             "id": dataset.id,
-            "sql": f"SELECT {admin.id} as my_user_id",
+            "sql": "SELECT {{ current_user_id() }} as my_user_id",
+            "rendered_sql": f"SELECT {admin.id} as my_user_id",
             "columns": [
                 {
                     "column_name": "my_user_id",
@@ -466,13 +467,15 @@ class TestDatasetApi(SupersetTestCase):
                 },
                 {
                     "column_name": "calculated_test",
-                    "expression": f"'{admin.username}'",
+                    "expression": "'{{ current_username() }}'",
+                    "rendered_expression": f"'{admin.username}'",
                 },
             ],
             "metrics": [
                 {
                     "metric_name": "param_test",
-                    "expression": "4 * 1.4",
+                    "expression": "{{ url_param('multiplier') }} * 1.4",
+                    "rendered_expression": "4 * 1.4",
                 },
             ],
         }


### PR DESCRIPTION
### SUMMARY
This PR adds support for optionally rendering Jinja macros in the API response when getting a dataset. The motivation for this feature is that external tools might be fetching dataset metadata via the API to define lineage/etc, and in case Jinja is used it's not possible to fully parse the SQL query to identify dependencies/etc. An example query:

``` sql
select * from {{dataset(1)}}
join cleaned_sales_data s on dataset_1.product_code = s.product_code
```

The query parameter `include_rendered_sql` (bool) can be used to add keys to the response:
* `rendered_sql` for the rendered virtual dataset SQL query.
* `rendered_expression` for the rendered expression from `metrics` and `columns`.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
![image](https://github.com/user-attachments/assets/bb1f920f-f144-4408-b12e-80c663db0333)

**After**
![image](https://github.com/user-attachments/assets/197f139c-e813-4840-a14e-011800915306)


### TESTING INSTRUCTIONS
Testing added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
