### PR TITLE
fix(embedded): Hide "Edit chart" menu option as well as "Edit chart" button in "View as table" modal for embedded context

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -106,6 +106,7 @@ const createProps = (viz_type = 'sunburst_v2') =>
 const renderWrapper = (
   overrideProps?: SliceHeaderControlsProps,
   roles?: Record<string, string[][]>,
+  isEmbedded = false,
 ) => {
   const props = overrideProps || createProps();
   return render(<SliceHeaderControls {...props} />, {
@@ -113,6 +114,10 @@ const renderWrapper = (
     useRouter: true,
     initialState: {
       ...mockState,
+      dashboardInfo: {
+        ...mockState.dashboardInfo,
+        userId: isEmbedded ? null : mockState.dashboardInfo.userId,
+      },
       user: {
         ...mockState.user,
         roles: roles ?? {
@@ -431,20 +436,40 @@ test('Should not show "View as table"', () => {
   expect(screen.queryByText('View as table')).not.toBeInTheDocument();
 });
 
-test('Should not show the "Edit chart" button', () => {
-  const props = {
-    ...createProps(),
+const editChartArrangeVariants = [
+  {
     supersetCanExplore: false,
-  };
-  props.slice.slice_id = 18;
-  renderWrapper(props, {
-    Admin: [
-      ['can_samples', 'Datasource'],
-      ['can_view_query', 'Dashboard'],
-      ['can_view_chart_as_table', 'Dashboard'],
-    ],
+    isEmbedded: false,
+  },
+  {
+    supersetCanExplore: false,
+    isEmbedded: true,
+  },
+  {
+    supersetCanExplore: true,
+    isEmbedded: true,
+  },
+];
+editChartArrangeVariants.forEach(({ supersetCanExplore, isEmbedded }) => {
+  test(`should not show the "Edit chart" button for supersetCanExplore=${String(supersetCanExplore)} and isEmbedded=${String(isEmbedded)}`, () => {
+    const props = {
+      ...createProps(),
+      supersetCanExplore,
+    };
+    props.slice.slice_id = 18;
+    renderWrapper(
+      props,
+      {
+        Admin: [
+          ['can_samples', 'Datasource'],
+          ['can_view_query', 'Dashboard'],
+          ['can_view_chart_as_table', 'Dashboard'],
+        ],
+      },
+      isEmbedded,
+    );
+    expect(screen.queryByText('Edit chart')).not.toBeInTheDocument();
   });
-  expect(screen.queryByText('Edit chart')).not.toBeInTheDocument();
 });
 
 describe('handleDropdownNavigation', () => {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -109,6 +109,15 @@ const renderWrapper = (
   isEmbedded = false,
 ) => {
   const props = overrideProps || createProps();
+  const dataBootstrap = isEmbedded
+    ? JSON.stringify({
+        embedded: {
+          dashboardId: 1,
+        },
+      })
+    : '';
+  document.body.innerHTML = `<div id="app" data-bootstrap=${dataBootstrap}></div>`;
+
   return render(<SliceHeaderControls {...props} />, {
     useRedux: true,
     useRouter: true,

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -68,6 +68,7 @@ import { LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE } from 'src/logger/LogUtils';
 import { MenuKeys, RootState } from 'src/dashboard/types';
 import { findPermission } from 'src/utils/findPermission';
 import { useCrossFiltersScopingModal } from '../nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal';
+import { useIsEmbedded } from 'src/hooks/useIsEmbedded';
 
 const ACTION_KEYS = {
   enter: 'Enter',
@@ -451,6 +452,7 @@ const ViewResultsModalTrigger = ({
   const theme = useTheme();
   const openModal = useCallback(() => setShowModal(true), []);
   const closeModal = useCallback(() => setShowModal(false), []);
+  const isEmbedded = useIsEmbedded();
 
   return (
     <>
@@ -476,7 +478,7 @@ const ViewResultsModalTrigger = ({
           title={modalTitle}
           footer={
             <>
-              <Button
+              {!isEmbedded && (<Button
                 buttonStyle="secondary"
                 buttonSize="small"
                 onClick={exploreChart}
@@ -490,7 +492,7 @@ const ViewResultsModalTrigger = ({
                 }
               >
                 {t('Edit chart')}
-              </Button>
+              </Button>)}
               <Button
                 buttonStyle="primary"
                 buttonSize="small"
@@ -571,6 +573,8 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
   const canViewTable = useSelector((state: RootState) =>
     findPermission('can_view_chart_as_table', 'Dashboard', state.user?.roles),
   );
+  const isEmbedded = useIsEmbedded();
+  
   const refreshChart = () => {
     if (props.updatedDttm) {
       props.forceRefresh(props.slice.slice_id, props.dashboardId);
@@ -765,7 +769,7 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
         </Menu.Item>
       )}
 
-      {canExplore && (
+      {canExplore && !isEmbedded && (
         <Menu.Item key={MenuKeys.ExploreChart}>
           <Tooltip title={getSliceHeaderTooltip(props.slice.slice_name)}>
             {t('Edit chart')}

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -67,8 +67,8 @@ import { DrillDetailMenuItems } from 'src/components/Chart/DrillDetail';
 import { LOG_ACTIONS_CHART_DOWNLOAD_AS_IMAGE } from 'src/logger/LogUtils';
 import { MenuKeys, RootState } from 'src/dashboard/types';
 import { findPermission } from 'src/utils/findPermission';
+import getBootstrapData from 'src/utils/getBootstrapData';
 import { useCrossFiltersScopingModal } from '../nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal';
-import { useIsEmbedded } from 'src/hooks/useIsEmbedded';
 
 const ACTION_KEYS = {
   enter: 'Enter',
@@ -452,7 +452,7 @@ const ViewResultsModalTrigger = ({
   const theme = useTheme();
   const openModal = useCallback(() => setShowModal(true), []);
   const closeModal = useCallback(() => setShowModal(false), []);
-  const isEmbedded = useIsEmbedded();
+  const isEmbedded = !!getBootstrapData().embedded;
 
   return (
     <>
@@ -478,21 +478,23 @@ const ViewResultsModalTrigger = ({
           title={modalTitle}
           footer={
             <>
-              {!isEmbedded && (<Button
-                buttonStyle="secondary"
-                buttonSize="small"
-                onClick={exploreChart}
-                disabled={!canExplore}
-                tooltip={
-                  !canExplore
-                    ? t(
-                        'You do not have sufficient permissions to edit the chart',
-                      )
-                    : undefined
-                }
-              >
-                {t('Edit chart')}
-              </Button>)}
+              {!isEmbedded && (
+                <Button
+                  buttonStyle="secondary"
+                  buttonSize="small"
+                  onClick={exploreChart}
+                  disabled={!canExplore}
+                  tooltip={
+                    !canExplore
+                      ? t(
+                          'You do not have sufficient permissions to edit the chart',
+                        )
+                      : undefined
+                  }
+                >
+                  {t('Edit chart')}
+                </Button>
+              )}
               <Button
                 buttonStyle="primary"
                 buttonSize="small"
@@ -573,8 +575,7 @@ const SliceHeaderControls = (props: SliceHeaderControlsPropsWithRouter) => {
   const canViewTable = useSelector((state: RootState) =>
     findPermission('can_view_chart_as_table', 'Dashboard', state.user?.roles),
   );
-  const isEmbedded = useIsEmbedded();
-  
+  const isEmbedded = !!getBootstrapData().embedded;
   const refreshChart = () => {
     if (props.updatedDttm) {
       props.forceRefresh(props.slice.slice_id, props.dashboardId);

--- a/superset-frontend/src/hooks/useIsEmbedded.ts
+++ b/superset-frontend/src/hooks/useIsEmbedded.ts
@@ -1,0 +1,5 @@
+import { useSelector } from 'react-redux';
+import { RootState } from 'src/dashboard/types';
+
+export const useIsEmbedded = () =>
+  useSelector<RootState, boolean>(({ dashboardInfo }) => !dashboardInfo.userId);

--- a/superset-frontend/src/hooks/useIsEmbedded.ts
+++ b/superset-frontend/src/hooks/useIsEmbedded.ts
@@ -1,5 +1,0 @@
-import { useSelector } from 'react-redux';
-import { RootState } from 'src/dashboard/types';
-
-export const useIsEmbedded = () =>
-  useSelector<RootState, boolean>(({ dashboardInfo }) => !dashboardInfo.userId);


### PR DESCRIPTION


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a dashboard is loaded in embedded mode, no 'Edit chart' functionality makes sense regardless of whether the guest user has `supersetCanExplore` permission.
Why? Because the `/explore` page isn't available in the DashboardEmbed mode so if the role provided for `GUEST_ROLE_NAME` has `supersetCanExplore` permission the 'Edit chart' functionality would not work (guest user will see a blank page in the embed mode)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
![Screenshot 2024-10-28 at 09 06 14](https://github.com/user-attachments/assets/f9090ea1-f9b2-47d8-bbbf-d690edb97819)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
