### PR TITLE
docs(templating): Replace "true" with "1 = 1" and explain its purpose

### DIFF
--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -55,8 +55,8 @@ WHERE (
 The `1 = 1` at the end ensures a value is present for the `WHERE` clause even when
 the time filter is not set. For many database engines, this could be replaced with `true`.
 
-Note that the Jinja parameters are called within double brackets in the query with single
-brackets in the logic blocks. 
+Note that the Jinja parameters are called within _double_ brackets in the query and with
+_single_ brackets in the logic blocks. 
 
 To add custom functionality to the Jinja context, you need to overload the default Jinja
 context in your environment by defining the `JINJA_CONTEXT_ADDONS` in your superset configuration

--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -48,12 +48,15 @@ WHERE (
     {% if to_dttm is not none %}
         dttm_col < '{{ to_dttm }}' AND
     {% endif %}
-    true
+    1 = 1
 )
 ```
 
-Note how the Jinja parameters are called within double brackets in the query, and without in the
-logic blocks.
+The `1 = 1` at the end ensures a value is present for the `WHERE` clause even when
+the time filter is not set. For many database engines, this could be replaced with `true`.
+
+Note that the Jinja parameters are called within double brackets in the query with single
+brackets in the logic blocks. 
 
 To add custom functionality to the Jinja context, you need to overload the default Jinja
 context in your environment by defining the `JINJA_CONTEXT_ADDONS` in your superset configuration

--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -56,7 +56,7 @@ The `1 = 1` at the end ensures a value is present for the `WHERE` clause even wh
 the time filter is not set. For many database engines, this could be replaced with `true`.
 
 Note that the Jinja parameters are called within _double_ brackets in the query and with
-_single_ brackets in the logic blocks. 
+_single_ brackets in the logic blocks.
 
 To add custom functionality to the Jinja context, you need to overload the default Jinja
 context in your environment by defining the `JINJA_CONTEXT_ADDONS` in your superset configuration


### PR DESCRIPTION
### SUMMARY
`true` doesn't work for Microsoft SQL Server, Oracle, or DB2 (see https://en.wikipedia.org/wiki/List_of_SQL_reserved_words) and its purpose confused me with no explanation.  @nytai and @giftig helped me figure it out on Slack.

### TESTING INSTRUCTIONS
I tried `WHERE 1 = 1` on SQL Server and Postgres to verify they both accept that logic ... I would think no RDBMS would fail there but who knows.