### PR TITLE
docs: make it more clear that GLOBAL_ASYNC_QUERIES is experimental/beta

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -486,6 +486,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "ESCAPE_MARKDOWN_HTML": False,
     "DASHBOARD_CROSS_FILTERS": True,  # deprecated
     "DASHBOARD_VIRTUALIZATION": True,
+    # This feature flag is stil in beta and is not recommended for production use.
     "GLOBAL_ASYNC_QUERIES": False,
     "EMBEDDED_SUPERSET": False,
     # Enables Alerts and reports new implementation


### PR DESCRIPTION
Not sure if we're all aligned on this, but I've seen confusion around GLOBAL_ASYNC_QUERIES and the reality is we shouldn't recommend flipping this on until we iron out at least a few things. This comment I'm adding makes it a bit more clear you should steer away unless you know what you're doing
