### PR TITLE
chore(datetime warning): catching datetime parse error and reraising as warning

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -335,6 +335,10 @@ class SupersetParseError(SupersetErrorException):
         super().__init__(error)
 
 
+class SupersetDatetimeParseError(SupersetException):
+    status = 422
+
+
 class OAuth2RedirectError(SupersetErrorException):
     """
     Exception used to start OAuth2 dance for personal tokens.

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -82,6 +82,7 @@ from superset.constants import (
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.exceptions import (
     CertificateException,
+    SupersetDatetimeParseError,
     SupersetException,
     SupersetTimeoutException,
 )
@@ -1667,20 +1668,23 @@ def normalize_dttm_col(
 
         if _col.timestamp_format in ("epoch_s", "epoch_ms"):
             dttm_series = df[_col.col_label]
-            if is_numeric_dtype(dttm_series):
-                # Column is formatted as a numeric value
-                unit = _col.timestamp_format.replace("epoch_", "")
-                df[_col.col_label] = pd.to_datetime(
-                    dttm_series,
-                    utc=False,
-                    unit=unit,
-                    origin="unix",
-                    errors="raise",
-                    exact=False,
-                )
-            else:
-                # Column has already been formatted as a timestamp.
-                df[_col.col_label] = dttm_series.apply(pd.Timestamp)
+            try:
+                if is_numeric_dtype(dttm_series):
+                    # Column is formatted as a numeric value
+                    unit = _col.timestamp_format.replace("epoch_", "")
+                    df[_col.col_label] = pd.to_datetime(
+                        dttm_series,
+                        utc=False,
+                        unit=unit,
+                        origin="unix",
+                        errors="raise",
+                        exact=False,
+                    )
+                else:
+                    # Column has already been formatted as a timestamp.
+                    df[_col.col_label] = dttm_series.apply(pd.Timestamp)
+            except UserWarning as ex:
+                raise SupersetDatetimeParseError() from ex
         else:
             df[_col.col_label] = pd.to_datetime(
                 df[_col.col_label],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following warning is being raised as an error. The changes introduced catch this error and reraise as a `422` `SupersetException`.
| WARNING | /superset/utils/core.py:1814: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
