### PR TITLE
chore: update help text copy on dataset settings

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -895,7 +895,7 @@ class DatasourceEditor extends PureComponent {
           fieldKey="default_endpoint"
           label={t('Default URL')}
           description={t(
-            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as /superset/dashboard/{id}/',
+            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as \n/superset/dashboard/{id}/',
           )}
           control={<TextControl controlId="default_endpoint" />}
         />

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -895,7 +895,7 @@ class DatasourceEditor extends PureComponent {
           fieldKey="default_endpoint"
           label={t('Default URL')}
           description={t(
-            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLS such as /superset/dashboard/{id}/',
+            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as /superset/dashboard/{id}/',
           )}
           control={<TextControl controlId="default_endpoint" />}
         />

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -16,47 +16,47 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import rison from 'rison';
+import { PureComponent, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { Radio } from 'src/components/Radio';
+import Card from 'src/components/Card';
+import Alert from 'src/components/Alert';
+import Badge from 'src/components/Badge';
+import { nanoid } from 'nanoid';
 import {
   css,
+  isFeatureEnabled,
+  getCurrencySymbol,
   ensureIsArray,
   FeatureFlag,
-  getClientErrorObject,
-  getCurrencySymbol,
-  isFeatureEnabled,
   styled,
   SupersetClient,
   t,
   withTheme,
+  getClientErrorObject,
 } from '@superset-ui/core';
-import { nanoid } from 'nanoid';
-import PropTypes from 'prop-types';
-import { PureComponent, useCallback } from 'react';
-import rison from 'rison';
-import { AsyncSelect, Col, Row, Select } from 'src/components';
-import Alert from 'src/components/Alert';
-import Badge from 'src/components/Badge';
-import Button from 'src/components/Button';
-import Card from 'src/components/Card';
-import CertifiedBadge from 'src/components/CertifiedBadge';
-import DatabaseSelector from 'src/components/DatabaseSelector';
-import EditableTitle from 'src/components/EditableTitle';
+import { Select, AsyncSelect, Row, Col } from 'src/components';
 import { FormLabel } from 'src/components/Form';
-import Icons from 'src/components/Icons';
+import Button from 'src/components/Button';
+import Tabs from 'src/components/Tabs';
+import CertifiedBadge from 'src/components/CertifiedBadge';
+import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
+import DatabaseSelector from 'src/components/DatabaseSelector';
 import Label from 'src/components/Label';
 import Loading from 'src/components/Loading';
-import withToasts from 'src/components/MessageToasts/withToasts';
-import { Radio } from 'src/components/Radio';
 import TableSelector from 'src/components/TableSelector';
-import Tabs from 'src/components/Tabs';
-import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
+import EditableTitle from 'src/components/EditableTitle';
 import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
-import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
-import SpatialControl from 'src/explore/components/controls/SpatialControl';
-import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
 import TextControl from 'src/explore/components/controls/TextControl';
+import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
+import SpatialControl from 'src/explore/components/controls/SpatialControl';
+import withToasts from 'src/components/MessageToasts/withToasts';
+import Icons from 'src/components/Icons';
+import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
 import CollectionTable from './CollectionTable';
-import Field from './Field';
 import Fieldset from './Fieldset';
+import Field from './Field';
 
 const DatasourceContainer = styled.div`
   .change-warning {

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -16,47 +16,47 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import rison from 'rison';
-import { PureComponent, useCallback } from 'react';
-import PropTypes from 'prop-types';
-import { Radio } from 'src/components/Radio';
-import Card from 'src/components/Card';
-import Alert from 'src/components/Alert';
-import Badge from 'src/components/Badge';
-import { nanoid } from 'nanoid';
 import {
   css,
-  isFeatureEnabled,
-  getCurrencySymbol,
   ensureIsArray,
   FeatureFlag,
+  getClientErrorObject,
+  getCurrencySymbol,
+  isFeatureEnabled,
   styled,
   SupersetClient,
   t,
   withTheme,
-  getClientErrorObject,
 } from '@superset-ui/core';
-import { Select, AsyncSelect, Row, Col } from 'src/components';
-import { FormLabel } from 'src/components/Form';
+import { nanoid } from 'nanoid';
+import PropTypes from 'prop-types';
+import { PureComponent, useCallback } from 'react';
+import rison from 'rison';
+import { AsyncSelect, Col, Row, Select } from 'src/components';
+import Alert from 'src/components/Alert';
+import Badge from 'src/components/Badge';
 import Button from 'src/components/Button';
-import Tabs from 'src/components/Tabs';
+import Card from 'src/components/Card';
 import CertifiedBadge from 'src/components/CertifiedBadge';
-import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import DatabaseSelector from 'src/components/DatabaseSelector';
+import EditableTitle from 'src/components/EditableTitle';
+import { FormLabel } from 'src/components/Form';
+import Icons from 'src/components/Icons';
 import Label from 'src/components/Label';
 import Loading from 'src/components/Loading';
-import TableSelector from 'src/components/TableSelector';
-import EditableTitle from 'src/components/EditableTitle';
-import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
-import TextControl from 'src/explore/components/controls/TextControl';
-import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
-import SpatialControl from 'src/explore/components/controls/SpatialControl';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import Icons from 'src/components/Icons';
+import { Radio } from 'src/components/Radio';
+import TableSelector from 'src/components/TableSelector';
+import Tabs from 'src/components/Tabs';
+import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
+import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
+import SpatialControl from 'src/explore/components/controls/SpatialControl';
+import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
+import TextControl from 'src/explore/components/controls/TextControl';
 import CollectionTable from './CollectionTable';
-import Fieldset from './Fieldset';
 import Field from './Field';
+import Fieldset from './Fieldset';
 
 const DatasourceContainer = styled.div`
   .change-warning {
@@ -895,8 +895,8 @@ class DatasourceEditor extends PureComponent {
           fieldKey="default_endpoint"
           label={t('Default URL')}
           description={t(
-            'Default URL to redirect to when accessing from the dataset list page. 
-            Accepts relative URLs such as <span style=„white-space: nowrap;”>/superset/dashboard/{id}/</span>',
+            `Default URL to redirect to when accessing from the dataset list page.
+            Accepts relative URLs such as <span style=„white-space: nowrap;”>/superset/dashboard/{id}/</span>`,
           )}
           control={<TextControl controlId="default_endpoint" />}
         />

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -895,7 +895,8 @@ class DatasourceEditor extends PureComponent {
           fieldKey="default_endpoint"
           label={t('Default URL')}
           description={t(
-            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as \n/superset/dashboard/{id}/',
+            'Default URL to redirect to when accessing from the dataset list page. 
+            Accepts relative URLs such as <span style=„white-space: nowrap;”>/superset/dashboard/{id}/</span>',
           )}
           control={<TextControl controlId="default_endpoint" />}
         />

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -895,7 +895,7 @@ class DatasourceEditor extends PureComponent {
           fieldKey="default_endpoint"
           label={t('Default URL')}
           description={t(
-            'Default URL to redirect to when accessing from the dataset list page',
+            'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLS such as /superset/dashboard/{id}/',
           )}
           control={<TextControl controlId="default_endpoint" />}
         />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a bit more copy on the dataset settings help text for the Default URL field 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
<img width="414" alt="image" src="https://github.com/user-attachments/assets/5171a687-39ab-4569-a719-e4a3347dc881">

After: 


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
