### PR TITLE
fix(plugin-chart-echarts): sort tooltip correctly

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -65,6 +65,7 @@ import {
   extractDataTotalValues,
   extractSeries,
   extractShowValueIndexes,
+  extractTooltipKeys,
   getAxisType,
   getColtypesMapping,
   getLegendProps,
@@ -251,7 +252,7 @@ export default function transformProps(
     legendState,
   });
   const seriesContexts = extractForecastSeriesContexts(
-    Object.values(rawSeries).map(series => series.name as string),
+    rawSeries.map(series => series.name as string),
   );
   const isAreaExpand = stack === StackControlsValue.Expand;
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
@@ -543,11 +544,12 @@ export default function transformProps(
           ? params[0].value[xIndex]
           : params.value[xIndex];
         const forecastValue: any[] = richTooltip ? params : [params];
-
-        if (richTooltip && tooltipSortByMetric) {
-          forecastValue.sort((a, b) => b.data[yIndex] - a.data[yIndex]);
-        }
-
+        const sortedKeys = extractTooltipKeys(
+          forecastValue,
+          yIndex,
+          richTooltip,
+          tooltipSortByMetric,
+        );
         const forecastValues: Record<string, ForecastValue> =
           extractForecastValuesFromTooltipParams(forecastValue, isHorizontal);
 
@@ -570,24 +572,28 @@ export default function transformProps(
         const showPercentage = showTotal && !forcePercentFormatter;
         const keys = Object.keys(forecastValues);
         let focusedRow;
-        keys.forEach(key => {
-          const value = forecastValues[key];
-          if (value.observation === 0 && stack) {
-            return;
-          }
-          const row = formatForecastTooltipSeries({
-            ...value,
-            seriesName: key,
-            formatter,
+        sortedKeys
+          .filter(key => keys.includes(key))
+          .forEach(key => {
+            const value = forecastValues[key];
+            if (value.observation === 0 && stack) {
+              return;
+            }
+            const row = formatForecastTooltipSeries({
+              ...value,
+              seriesName: key,
+              formatter,
+            });
+            if (showPercentage && value.observation !== undefined) {
+              row.push(
+                percentFormatter.format(value.observation / (total || 1)),
+              );
+            }
+            rows.push(row);
+            if (key === focusedSeries) {
+              focusedRow = rows.length - 1;
+            }
           });
-          if (showPercentage && value.observation !== undefined) {
-            row.push(percentFormatter.format(value.observation / (total || 1)));
-          }
-          rows.push(row);
-          if (key === focusedSeries) {
-            focusedRow = rows.length - 1;
-          }
-        });
         if (stack) {
           rows.reverse();
           if (focusedRow !== undefined) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -267,7 +267,11 @@ export function extractSeries(
     xAxisSortSeries?: SortSeriesType;
     xAxisSortSeriesAscending?: boolean;
   } = {},
-): [SeriesOption[], number[], number | undefined] {
+): [
+  { id: string; name: string; data: DataRecordValue[][] }[],
+  number[],
+  number | undefined,
+] {
   const {
     fillNeighborValue,
     xAxis = DTTM_ALIAS,
@@ -641,4 +645,23 @@ export function getTimeCompareStackId(
       return name?.toString().includes(value);
     }) || defaultId
   );
+}
+
+const TOOLTIP_SERIES_KEY = 'seriesId';
+export function extractTooltipKeys(
+  forecastValue: any[],
+  yIndex: number,
+  richTooltip?: boolean,
+  tooltipSortByMetric?: boolean,
+): string[] {
+  if (richTooltip && tooltipSortByMetric) {
+    return forecastValue
+      .slice()
+      .sort((a, b) => b.data[yIndex] - a.data[yIndex])
+      .map(value => value[TOOLTIP_SERIES_KEY]);
+  }
+  if (richTooltip) {
+    return forecastValue.map(s => s[TOOLTIP_SERIES_KEY]);
+  }
+  return [forecastValue[0][TOOLTIP_SERIES_KEY]];
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -267,11 +267,7 @@ export function extractSeries(
     xAxisSortSeries?: SortSeriesType;
     xAxisSortSeriesAscending?: boolean;
   } = {},
-): [
-  { id: string; name: string; data: DataRecordValue[][] }[],
-  number[],
-  number | undefined,
-] {
+): [SeriesOption[], number[], number | undefined] {
   const {
     fillNeighborValue,
     xAxis = DTTM_ALIAS,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -31,6 +31,7 @@ import {
   extractGroupbyLabel,
   extractSeries,
   extractShowValueIndexes,
+  extractTooltipKeys,
   formatSeriesName,
   getAxisType,
   getChartPadding,
@@ -1071,4 +1072,30 @@ describe('getTimeCompareStackId', () => {
     const result = getTimeCompareStackId('default', ['123', '456'], 123);
     expect(result).toEqual('123');
   });
+});
+
+const forecastValue = [
+  {
+    data: [0, 1],
+    seriesId: 'foo',
+  },
+  {
+    data: [0, 2],
+    seriesId: 'bar',
+  },
+];
+
+test('extractTooltipKeys with rich tooltip', () => {
+  const result = extractTooltipKeys(forecastValue, 1, true, false);
+  expect(result).toEqual(['foo', 'bar']);
+});
+
+test('extractTooltipKeys with rich tooltip and sorting by metrics', () => {
+  const result = extractTooltipKeys(forecastValue, 1, true, true);
+  expect(result).toEqual(['bar', 'foo']);
+});
+
+test('extractTooltipKeys with non-rich tooltip', () => {
+  const result = extractTooltipKeys(forecastValue, 1, false, false);
+  expect(result).toEqual(['foo']);
 });


### PR DESCRIPTION
### SUMMARY
The main ECharts series chart tooltips aren't sorting correctly. This is due to the tooltip keys being populated from `Object.keys` from an object that was originally an array, which of course doesn't have a guaranteed sort order. This issue appears to have been there for a very long time: I treid to hunt it down with Blame, and I stopped searching when I got to three years ago where the code had already changed considerably, but the same bug seemed to be there.

This PR fixes the bug, DRYs the code as the same logic is also needed in Mixed Timeseries chart, and adds simple tests for the new util. Naturally a full `transformProps` integration test would be preferable here, but it felt like too much added code for such a small fix. Also, the util test looks concise enough for people to understand what it's used for.

P.S. In the screenshots below please excuse my awful theme colors (I have those in my devenv to remind myself of the importance of theming work)

P.P.S. I suggest reviewing with hidden whitespace changes, as the changes are mostly that.

### AFTER
Notice how "Tooltip sort by metric" is working as expected (biggest metric values are on the bottom due to stacking):
<img width="856" alt="image" src="https://github.com/user-attachments/assets/777edb2c-a43c-467d-8914-723397a5a1f5">

Also sorting series by "Category name" works as expected (this can be seen comparing the tooltip colors vs the bars):
<img width="855" alt="image" src="https://github.com/user-attachments/assets/092f2f3c-8da6-4a99-a5d7-e66d0b84a420">

### BEFORE
Currently "Tooltip sort by metric" doesn't do anything (metric values are not monotonically growing):
<img width="858" alt="image" src="https://github.com/user-attachments/assets/58979041-2a55-4755-86ef-ade3aed12ea3">
When not sorting by metric, the series sort order isn't reflected in the tooltip order (the order is not the same in tooltip as on the bars):
<img width="863" alt="image" src="https://github.com/user-attachments/assets/d6787f9d-41b7-4563-bdc4-b6fbdda668c4">

### TESTING INSTRUCTIONS
1. Create a bar/line chart with a dimension to sort by
2. Try changing the series sort order to see if it's reflected in the tooltip
3. Try toggling "Tooltip sort by metric" control

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
