### PR TITLE
fix: x axis title disappears when editing bar chart

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -259,6 +259,7 @@ export interface BaseControlConfig<
     props: ControlPanelsContainerProps,
     controlData: AnyDict,
   ) => boolean;
+  disableStash?: boolean;
   hidden?:
     | boolean
     | ((props: ControlPanelsContainerProps, controlData: AnyDict) => boolean);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -71,8 +71,10 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: '',
           description: t('Changing this control takes effect instantly'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -88,8 +90,10 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_MARGIN_OPTIONS[0],
           choices: formatSelectOptions(sections.TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -102,8 +106,10 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: '',
           description: t('Changing this control takes effect instantly'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -119,8 +125,10 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_MARGIN_OPTIONS[0],
           choices: formatSelectOptions(sections.TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -136,8 +144,10 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_POSITION_OPTIONS[0][0],
           choices: sections.TITLE_POSITION_OPTIONS,
           description: t('Changing this control takes effect instantly'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -158,8 +168,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           ...sharedControls.x_axis_time_format,
           default: 'smart_date',
           description: `${D3_TIME_FORMAT_DOCS}. ${TIME_SERIES_DESCRIPTION_TEXT}`,
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -168,8 +180,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         name: xAxisLabelRotation.name,
         config: {
           ...xAxisLabelRotation.config,
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -179,8 +193,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         config: {
           ...sharedControls.y_axis_format,
           label: t('Axis Format'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -194,8 +210,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: logAxis,
           description: t('Logarithmic axis'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -208,8 +226,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: minorSplitLine,
           description: t('Draw split lines for minor axis ticks'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -222,8 +242,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: truncateYAxis,
           renderTrigger: true,
           description: t('It’s not recommended to truncate axis in Bar chart.'),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],
@@ -241,9 +263,11 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
               "this feature will only expand the axis range. It won't " +
               "narrow the data's extent.",
           ),
-          hidden: ({ controls }: ControlPanelsContainerProps) =>
+          visibility: ({ controls }: ControlPanelsContainerProps) =>
             Boolean(controls?.truncateYAxis?.value) &&
-            (isXAxis ? isVertical(controls) : isHorizontal(controls)),
+            (isXAxis ? isHorizontal(controls) : isVertical(controls)),
+          disableStash: true,
+          resetOnHide: false,
         },
       },
     ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -71,8 +71,8 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: '',
           description: t('Changing this control takes effect instantly'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
         },
       },
     ],
@@ -88,8 +88,8 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_MARGIN_OPTIONS[0],
           choices: formatSelectOptions(sections.TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
         },
       },
     ],
@@ -102,8 +102,8 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: '',
           description: t('Changing this control takes effect instantly'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -119,8 +119,8 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_MARGIN_OPTIONS[0],
           choices: formatSelectOptions(sections.TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -136,8 +136,8 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: sections.TITLE_POSITION_OPTIONS[0][0],
           choices: sections.TITLE_POSITION_OPTIONS,
           description: t('Changing this control takes effect instantly'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -158,8 +158,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           ...sharedControls.x_axis_time_format,
           default: 'smart_date',
           description: `${D3_TIME_FORMAT_DOCS}. ${TIME_SERIES_DESCRIPTION_TEXT}`,
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
         },
       },
     ],
@@ -168,8 +168,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         name: xAxisLabelRotation.name,
         config: {
           ...xAxisLabelRotation.config,
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isVertical(controls) : isHorizontal(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isHorizontal(controls) : isVertical(controls),
         },
       },
     ],
@@ -179,8 +179,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         config: {
           ...sharedControls.y_axis_format,
           label: t('Axis Format'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -194,8 +194,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: logAxis,
           description: t('Logarithmic axis'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -208,8 +208,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           renderTrigger: true,
           default: minorSplitLine,
           description: t('Draw split lines for minor axis ticks'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -222,8 +222,8 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: truncateYAxis,
           renderTrigger: true,
           description: t('It’s not recommended to truncate axis in Bar chart.'),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
-            isXAxis ? isHorizontal(controls) : isVertical(controls),
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
+            isXAxis ? isVertical(controls) : isHorizontal(controls),
         },
       },
     ],
@@ -241,9 +241,9 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
               "this feature will only expand the axis range. It won't " +
               "narrow the data's extent.",
           ),
-          visibility: ({ controls }: ControlPanelsContainerProps) =>
+          hidden: ({ controls }: ControlPanelsContainerProps) =>
             Boolean(controls?.truncateYAxis?.value) &&
-            (isXAxis ? isHorizontal(controls) : isVertical(controls)),
+            (isXAxis ? isVertical(controls) : isHorizontal(controls)),
         },
       },
     ],

--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -46,10 +46,10 @@ export type ControlProps = {
   formData?: QueryFormData | null;
   value?: JsonValue;
   validationErrors?: any[];
-  hidden?: boolean;
   renderTrigger?: boolean;
   default?: JsonValue;
   isVisible?: boolean;
+  isHidden?: boolean;
   resetOnHide?: boolean;
 };
 
@@ -68,7 +68,7 @@ export default function Control(props: ControlProps) {
     actions: { setControlValue },
     name,
     type,
-    hidden,
+    isHidden,
     isVisible,
     resetOnHide = true,
   } = props;
@@ -113,7 +113,7 @@ export default function Control(props: ControlProps) {
     <StyledControl
       className="Control"
       data-test={name}
-      style={hidden ? { display: 'none' } : undefined}
+      style={isHidden ? { display: 'none' } : undefined}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/superset-frontend/src/explore/components/Control.tsx
+++ b/superset-frontend/src/explore/components/Control.tsx
@@ -46,10 +46,10 @@ export type ControlProps = {
   formData?: QueryFormData | null;
   value?: JsonValue;
   validationErrors?: any[];
+  hidden?: boolean;
   renderTrigger?: boolean;
   default?: JsonValue;
   isVisible?: boolean;
-  isHidden?: boolean;
   resetOnHide?: boolean;
 };
 
@@ -68,7 +68,7 @@ export default function Control(props: ControlProps) {
     actions: { setControlValue },
     name,
     type,
-    isHidden,
+    hidden,
     isVisible,
     resetOnHide = true,
   } = props;
@@ -113,7 +113,7 @@ export default function Control(props: ControlProps) {
     <StyledControl
       className="Control"
       data-test={name}
-      style={isHidden ? { display: 'none' } : undefined}
+      style={hidden ? { display: 'none' } : undefined}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -541,7 +541,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           validationErrors={validationErrors}
           actions={props.actions}
           isVisible={isVisible}
-          hidden={isHidden}
+          isHidden={isHidden}
           {...restProps}
         />
       </StashFormDataContainer>

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -448,7 +448,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   const renderControl = ({ name, config }: CustomControlItem) => {
     const { controls, chart, exploreState } = props;
-    const { visibility, hidden, ...restConfig } = config;
+    const { visibility, hidden, disableStash, ...restConfig } = config;
 
     // If the control item is not an object, we have to look up the control data from
     // the centralized controls file.
@@ -529,7 +529,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
     return (
       <StashFormDataContainer
-        shouldStash={isVisible === false}
+        shouldStash={isVisible === false && disableStash !== true}
         fieldNames={[name]}
         key={`control-container-${name}`}
       >
@@ -541,7 +541,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           validationErrors={validationErrors}
           actions={props.actions}
           isVisible={isVisible}
-          isHidden={isHidden}
+          hidden={isHidden}
           {...restProps}
         />
       </StashFormDataContainer>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes #29877

Fixes #30370


The `createAxisTitleControl` and `createAxisControl` functions use the `visibility` prop to hide controls. This caused an issue where controls with duplicate names were stashed from the form data if one of them had `visibility` set to `false` and was rendered later than the visible one.

#### Solution
To resolve this, I introduced a new prop `disableStash`, to the `Control` component, which prevents stashing for the control where it is applied.
Additionally, I set the `resetOnHide` prop to `false` to prevent the axis titles from disappearing on the chart when changing the orientation.

#### Hidden prop bug
Initially, I considered replacing `visibility` with a `hidden` prop in the Bar chart controls. However, this approach led to issues with refreshing hidden control values and I decided to keep the `visibility` prop for a less invasive change.
While working with the `hidden` prop, I discovered a bug where `{...restProps}` overwrote the `hidden` prop's intended value, so `() => false` value was hiding the control. I plan to address this in a separate issue. The first commit reflects this initial approach, but I reverted it in the following commit to keep this PR focused on the `visibility` prop and `disableStash` solution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before
https://github.com/user-attachments/assets/79d349fd-d86d-4320-be88-9b74e3ce7e76

#### After
https://github.com/user-attachments/assets/51013344-3e61-474a-9795-312c8f5f51fa

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open an existing bar chart in Superset or create a new one.
2. Enter the edit mode for the chart.
3. Change the X-axis title and/or margin to a new value.
4. Switch between horizontal and vertical orientation and edit values again

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #29877 #30370
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
