### PR TITLE
fix(TimezoneSelector): Failing unit tests due to timezone change

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.DaylightSavingTime.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.DaylightSavingTime.test.tsx
@@ -35,9 +35,12 @@ const loadComponent = (mockCurrentTime?: string) => {
   return new Promise<FC<TimezoneSelectorProps>>(resolve => {
     const { default: TimezoneSelector } = module.require('./index');
     resolve(TimezoneSelector);
-    jest.useRealTimers();
   });
 };
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 test('render timezones in correct order for daylight saving time', async () => {
   const TimezoneSelector = await loadComponent('2022-07-01');

--- a/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/TimezoneSelector.test.tsx
@@ -35,7 +35,6 @@ const loadComponent = (mockCurrentTime?: string) => {
   return new Promise<FC<TimezoneSelectorProps>>(resolve => {
     const { default: TimezoneSelector } = module.require('./index');
     resolve(TimezoneSelector);
-    jest.useRealTimers();
   });
 };
 
@@ -48,6 +47,10 @@ const openSelectMenu = () => {
 };
 
 jest.spyOn(moment.tz, 'guess').mockReturnValue('America/New_York');
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 test('use the timezone from `moment` if no timezone provided', async () => {
   const TimezoneSelector = await loadComponent('2022-01-01');
@@ -96,10 +99,9 @@ test('render timezones in correct order for standard time', async () => {
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading'));
   openSelectMenu();
   const options = await getSelectOptions();
-  expect(options[0]).toHaveTextContent('GMT -04:00 (Eastern Daylight Time)');
+  expect(options[0]).toHaveTextContent('GMT -05:00 (Eastern Standard Time)');
   expect(options[1]).toHaveTextContent('GMT -11:00 (Pacific/Pago_Pago)');
   expect(options[2]).toHaveTextContent('GMT -10:00 (Hawaii Standard Time)');
-  expect(options[3]).toHaveTextContent('GMT -09:30 (Pacific/Marquesas)');
 });
 
 test('can select a timezone values and returns canonical timezone name', async () => {
@@ -116,8 +118,8 @@ test('can select a timezone values and returns canonical timezone name', async (
 
   const searchInput = screen.getByRole('combobox');
   // search for mountain time
-  await userEvent.type(searchInput, 'mou', { delay: 10 });
-  const findTitle = 'GMT -06:00 (Mountain Daylight Time)';
+  await userEvent.type(searchInput, 'mou');
+  const findTitle = 'GMT -07:00 (Mountain Standard Time)';
   const selectOption = await screen.findByTitle(findTitle);
   userEvent.click(selectOption);
   expect(onTimezoneChange).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The TimezoneSelector unit tests were failing due to timers not resetting correctly and several errors in handling actual timezone changes between Standard and Daylight time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
Unit tests should not fail

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
