### PR TITLE
chore: Revert "build(deps): bump JustinBeckwith/linkinator-action from 1.10.4 to 1.11.0"

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true # This will make the job advisory (non-blocking, no red X)
     steps:
       - uses: actions/checkout@v4
-      - uses: JustinBeckwith/linkinator-action@v1.11.0
+      - uses: JustinBeckwith/linkinator-action@v1.10.4
         with:
           paths: "**/*.md, **/*.mdx"
           linksToSkip: >-

--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -20,6 +20,8 @@ jobs:
     continue-on-error: true # This will make the job advisory (non-blocking, no red X)
     steps:
       - uses: actions/checkout@v4
+      # Do not bump this linkinator-action version without opening
+      # an ASF Infra ticket to allow the new verison first!
       - uses: JustinBeckwith/linkinator-action@v1.10.4
         with:
           paths: "**/*.md, **/*.mdx"


### PR DESCRIPTION
Reverts apache/superset#30802 - the upgraded version of the Linkinator script needs to be allow-listed by ASF. Only one version was allowed in [this ticket](https://issues.apache.org/jira/browse/INFRA-25781?jql=text%20~%20%22linkinator%22). 