### PR TITLE
chore(GHA): Making the Linkinator STEP non-blocking, rather than the JOB.

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -17,12 +17,12 @@ jobs:
     # See docs here: https://github.com/marketplace/actions/linkinator
     name: Link Checking
     runs-on: ubuntu-latest
-    continue-on-error: true # This will make the job advisory (non-blocking, no red X)
     steps:
       - uses: actions/checkout@v4
       # Do not bump this linkinator-action version without opening
       # an ASF Infra ticket to allow the new verison first!
       - uses: JustinBeckwith/linkinator-action@v1.11.0
+        continue-on-error: true # This will make the job advisory (non-blocking, no red X)
         with:
           paths: "**/*.md, **/*.mdx"
           linksToSkip: >-


### PR DESCRIPTION
It's annoying that random link failures cause a scary red X on CI. This is one more modest attempt to clean that up.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
