### PR TITLE
fix: Graph chart colors

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -198,6 +198,7 @@ export default function transformProps(
   const refs: Refs = {};
   const metricLabel = getMetricLabel(metric);
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
+  const firstColor = colorFn.range()[0];
   const nodes: { [name: string]: number } = {};
   const categories: Set<string> = new Set();
   const echartNodes: EChartGraphNode[] = [];
@@ -256,11 +257,10 @@ export default function transformProps(
       : undefined;
     const sourceNodeColor = sourceCategoryName
       ? colorFn(sourceCategoryName)
-      : colorFn('node');
+      : firstColor;
     const targetNodeColor = targetCategoryName
       ? colorFn(targetCategoryName)
-      : colorFn('node');
-    const linkColor = colorFn('link');
+      : firstColor;
 
     const sourceNode = getOrCreateNode(
       sourceName,
@@ -283,7 +283,7 @@ export default function transformProps(
       target: targetNode.id,
       value,
       lineStyle: {
-        color: linkColor,
+        color: firstColor,
       },
       emphasis: {},
       select: {},

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -248,26 +248,19 @@ export default function transformProps(
     }
     const sourceName = link[source] as string;
     const targetName = link[target] as string;
-    let sourceCategoryName;
-    let targetCategoryName;
-    let sourceNodeColor = colorFn('node');
-    let targetNodeColor = colorFn('node');
+    const sourceCategoryName = sourceCategory
+      ? getCategoryName(sourceCategory, link[sourceCategory])
+      : undefined;
+    const targetCategoryName = targetCategory
+      ? getCategoryName(targetCategory, link[targetCategory])
+      : undefined;
+    const sourceNodeColor = sourceCategoryName
+      ? colorFn(sourceCategoryName)
+      : colorFn('node');
+    const targetNodeColor = targetCategoryName
+      ? colorFn(targetCategoryName)
+      : colorFn('node');
     const linkColor = colorFn('link');
-
-    if (sourceCategory) {
-      sourceCategoryName = getCategoryName(
-        sourceCategory,
-        link[sourceCategory],
-      );
-      sourceNodeColor = colorFn(sourceCategoryName);
-    }
-    if (targetCategory) {
-      targetCategoryName = getCategoryName(
-        targetCategory,
-        link[targetCategory],
-      );
-      targetNodeColor = colorFn(targetCategoryName);
-    }
 
     const sourceNode = getOrCreateNode(
       sourceName,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -207,7 +207,12 @@ export default function transformProps(
    * Get the node id of an existing node,
    * or create a new node if it doesn't exist.
    */
-  function getOrCreateNode(name: string, col: string, category?: string) {
+  function getOrCreateNode(
+    name: string,
+    col: string,
+    category?: string,
+    color?: string,
+  ) {
     if (!(name in nodes)) {
       nodes[name] = echartNodes.length;
       echartNodes.push({
@@ -221,6 +226,7 @@ export default function transformProps(
           ...getDefaultTooltip(refs),
           ...DEFAULT_GRAPH_SERIES_OPTION.tooltip,
         },
+        itemStyle: { color },
       });
     }
     const node = echartNodes[nodes[name]];
@@ -242,14 +248,39 @@ export default function transformProps(
     }
     const sourceName = link[source] as string;
     const targetName = link[target] as string;
-    const sourceCategoryName = sourceCategory
-      ? getCategoryName(sourceCategory, link[sourceCategory])
-      : undefined;
-    const targetCategoryName = targetCategory
-      ? getCategoryName(targetCategory, link[targetCategory])
-      : undefined;
-    const sourceNode = getOrCreateNode(sourceName, source, sourceCategoryName);
-    const targetNode = getOrCreateNode(targetName, target, targetCategoryName);
+    let sourceCategoryName;
+    let targetCategoryName;
+    let sourceNodeColor = colorFn('node');
+    let targetNodeColor = colorFn('node');
+    const linkColor = colorFn('link');
+
+    if (sourceCategory) {
+      sourceCategoryName = getCategoryName(
+        sourceCategory,
+        link[sourceCategory],
+      );
+      sourceNodeColor = colorFn(sourceCategoryName);
+    }
+    if (targetCategory) {
+      targetCategoryName = getCategoryName(
+        targetCategory,
+        link[targetCategory],
+      );
+      targetNodeColor = colorFn(targetCategoryName);
+    }
+
+    const sourceNode = getOrCreateNode(
+      sourceName,
+      source,
+      sourceCategoryName,
+      sourceNodeColor,
+    );
+    const targetNode = getOrCreateNode(
+      targetName,
+      target,
+      targetCategoryName,
+      targetNodeColor,
+    );
 
     sourceNode.value += value;
     targetNode.value += value;
@@ -258,7 +289,9 @@ export default function transformProps(
       source: sourceNode.id,
       target: targetNode.id,
       value,
-      lineStyle: {},
+      lineStyle: {
+        color: linkColor,
+      },
       emphasis: {},
       select: {},
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/transformProps.ts
@@ -283,7 +283,7 @@ export default function transformProps(
       target: targetNode.id,
       value,
       lineStyle: {
-        color: firstColor,
+        color: sourceNodeColor,
       },
       emphasis: {},
       select: {},

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
@@ -144,7 +144,7 @@ describe('EchartsGraph transformProps', () => {
               links: [
                 {
                   emphasis: { lineStyle: { width: 12 } },
-                  lineStyle: { width: 6, color: '#ff7f0e' },
+                  lineStyle: { width: 6, color: '#1f77b4' },
                   select: {
                     lineStyle: { opacity: 1, width: 9.600000000000001 },
                   },
@@ -154,7 +154,7 @@ describe('EchartsGraph transformProps', () => {
                 },
                 {
                   emphasis: { lineStyle: { width: 5 } },
-                  lineStyle: { width: 1.5, color: '#ff7f0e' },
+                  lineStyle: { width: 1.5, color: '#1f77b4' },
                   select: { lineStyle: { opacity: 1, width: 5 } },
                   source: '2',
                   target: '3',
@@ -230,7 +230,7 @@ describe('EchartsGraph transformProps', () => {
                 {
                   id: '0',
                   itemStyle: {
-                    color: '#2ca02c',
+                    color: '#1f77b4',
                   },
                   col: 'source_column',
                   name: 'source_value',
@@ -244,7 +244,7 @@ describe('EchartsGraph transformProps', () => {
                 {
                   id: '1',
                   itemStyle: {
-                    color: '#d62728',
+                    color: '#ff7f0e',
                   },
                   col: 'target_column',
                   name: 'target_value',

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
@@ -74,6 +74,9 @@ describe('EchartsGraph transformProps', () => {
                   col: 'source_column',
                   category: undefined,
                   id: '0',
+                  itemStyle: {
+                    color: '#1f77b4',
+                  },
                   label: { show: true },
                   name: 'source_value_1',
                   select: {
@@ -88,6 +91,9 @@ describe('EchartsGraph transformProps', () => {
                   col: 'target_column',
                   category: undefined,
                   id: '1',
+                  itemStyle: {
+                    color: '#1f77b4',
+                  },
                   label: { show: true },
                   name: 'target_value_1',
                   select: {
@@ -102,6 +108,9 @@ describe('EchartsGraph transformProps', () => {
                   col: 'source_column',
                   category: undefined,
                   id: '2',
+                  itemStyle: {
+                    color: '#1f77b4',
+                  },
                   label: { show: true },
                   name: 'source_value_2',
                   select: {
@@ -116,6 +125,9 @@ describe('EchartsGraph transformProps', () => {
                   col: 'target_column',
                   category: undefined,
                   id: '3',
+                  itemStyle: {
+                    color: '#1f77b4',
+                  },
                   label: { show: true },
                   name: 'target_value_2',
                   select: {
@@ -132,7 +144,7 @@ describe('EchartsGraph transformProps', () => {
               links: [
                 {
                   emphasis: { lineStyle: { width: 12 } },
-                  lineStyle: { width: 6 },
+                  lineStyle: { width: 6, color: '#ff7f0e' },
                   select: {
                     lineStyle: { opacity: 1, width: 9.600000000000001 },
                   },
@@ -142,7 +154,7 @@ describe('EchartsGraph transformProps', () => {
                 },
                 {
                   emphasis: { lineStyle: { width: 5 } },
-                  lineStyle: { width: 1.5 },
+                  lineStyle: { width: 1.5, color: '#ff7f0e' },
                   select: { lineStyle: { opacity: 1, width: 5 } },
                   source: '2',
                   target: '3',
@@ -217,6 +229,9 @@ describe('EchartsGraph transformProps', () => {
               data: [
                 {
                   id: '0',
+                  itemStyle: {
+                    color: '#2ca02c',
+                  },
                   col: 'source_column',
                   name: 'source_value',
                   value: 11,
@@ -228,6 +243,9 @@ describe('EchartsGraph transformProps', () => {
                 },
                 {
                   id: '1',
+                  itemStyle: {
+                    color: '#d62728',
+                  },
                   col: 'target_column',
                   name: 'target_value',
                   value: 11,


### PR DESCRIPTION
### SUMMARY
Fixes the Graph chart to obey to the color scheme when there are no color categories.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/3ba531af-b925-4573-aca6-5996be149f5b

https://github.com/user-attachments/assets/c9b60d2c-71df-49b1-a8cc-c55d423d6c71

### TESTING INSTRUCTIONS
1 - Check that the color scheme is applied when there are no color categories.
2 - Check that the color scheme is applied when there are color categories. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
