### PR TITLE
fix(superset-frontend/src/dataMask/reducer.ts): Fix getInitialDataMask overload order and remove return type assertion; convert id to a string

### DIFF
--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -47,6 +47,10 @@ export function getInitialDataMask(
 ): DataMaskWithId;
 export function getInitialDataMask(
   id?: string | number,
+  moreProps?: DataMask,
+): DataMask;
+export function getInitialDataMask(
+  id?: string | number,
   moreProps: DataMask = {},
 ): DataMask {
   return {

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -42,26 +42,20 @@ import {
 import { areObjectsEqual } from '../reduxUtils';
 
 export function getInitialDataMask(
-  id?: string | number,
-  moreProps?: DataMask,
-): DataMask;
-export function getInitialDataMask(
   id: string | number,
+  moreProps?: DataMask,
+): DataMaskWithId;
+export function getInitialDataMask(
+  id?: string | number,
   moreProps: DataMask = {},
-): DataMaskWithId {
-  let otherProps = {};
-  if (id) {
-    otherProps = {
-      id,
-    };
-  }
+): DataMask {
   return {
-    ...otherProps,
+    id: id !== undefined ? String(id) : undefined,
     extraFormData: {},
     filterState: {},
     ownState: {},
     ...moreProps,
-  } as DataMaskWithId;
+  };
 }
 
 function fillNativeFilters(


### PR DESCRIPTION
### SUMMARY
Fixes a bug where a number id was being set where a string is expected. The type assertion was preventing TypeScript from catching this problem.

### TESTING INSTRUCTIONS
Add a cross filter, then click reset in the dashboard header.
