### PR TITLE
fix(sqllab): Over-rendering on result table

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -221,11 +221,11 @@ const ResultSet = ({
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showStreamingModal, setShowStreamingModal] = useState(false);
   const orderedColumnKeys = useMemo(
-    () => query.results?.columns.map(col => col.column_name),
+    () => query.results?.columns?.map(col => col.column_name) ?? EMPTY,
     [query.results?.columns],
   );
   const expandedColumns = useMemo(
-    () => query.results?.expanded_columns.map(col => col.column_name) ?? EMPTY,
+    () => query.results?.expanded_columns?.map(col => col.column_name) ?? EMPTY,
     [query.results?.expanded_columns],
   );
 

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -23,6 +23,7 @@ import {
   memo,
   ChangeEvent,
   MouseEvent,
+  useMemo,
 } from 'react';
 
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -157,6 +158,7 @@ const ResultSetButtons = styled.div`
 const GAP = 8;
 
 const extensionsRegistry = getExtensionsRegistry();
+const EMPTY: string[] = [];
 
 const ResultSet = ({
   cache = false,
@@ -218,6 +220,14 @@ const ResultSet = ({
   const [cachedData, setCachedData] = useState<Record<string, unknown>[]>([]);
   const [showSaveDatasetModal, setShowSaveDatasetModal] = useState(false);
   const [showStreamingModal, setShowStreamingModal] = useState(false);
+  const orderedColumnKeys = useMemo(
+    () => query.results?.columns.map(col => col.column_name),
+    [query.results?.columns],
+  );
+  const expandedColumns = useMemo(
+    () => query.results?.expanded_columns.map(col => col.column_name) ?? EMPTY,
+    [query.results?.expanded_columns],
+  );
 
   const history = useHistory();
   const dispatch = useDispatch();
@@ -655,9 +665,6 @@ const ResultSet = ({
       ({ data } = results);
     }
     if (data && data.length > 0) {
-      const expandedColumns = results.expanded_columns
-        ? results.expanded_columns.map(col => col.column_name)
-        : [];
       const allowHTML = getItem(
         LocalStorageKeys.SqllabIsRenderHtmlEnabled,
         true,
@@ -666,7 +673,7 @@ const ResultSet = ({
       const tableProps = {
         data,
         queryId: query.id,
-        orderedColumnKeys: results.columns.map(col => col.column_name),
+        orderedColumnKeys,
         filterText: searchText,
         expandedColumns,
         allowHTML,

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo, useRef, useCallback } from 'react';
+import { useMemo, useRef, useCallback, memo } from 'react';
 import { GridSize } from 'src/components/GridTable/constants';
 import { GridTable } from 'src/components/GridTable';
 import { type ColDef } from 'src/components/GridTable/types';
@@ -137,3 +137,4 @@ export const FilterableTable = ({
 };
 
 export type { FilterableTableProps };
+export default memo(FilterableTable);


### PR DESCRIPTION
### SUMMARY
The issue of the grid table being over-rendered every time the tab is changed is caused by the mapping of `orderedColumns`. To prevent this over-rendering, this commit modified the code to use `useMemo` and `React.memo`, ensuring that the same properties from the previous tab are passed to avoid unnecessary re-renders.

### TESTING INSTRUCTIONS
locally perf check

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
