### PR TITLE
fix(chart data): removing query from /chart/data payload when accessing as guest user

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -394,8 +394,13 @@ class ChartDataRestApi(ChartRestApi):
             )
 
         if result_format == ChartDataResultFormat.JSON:
+            queries = result["queries"]
+            if security_manager.is_guest_user():
+                for query in queries:
+                    with contextlib.suppress(KeyError):
+                        del query["query"]
             response_data = json.dumps(
-                {"result": result["queries"]},
+                {"result": queries},
                 default=json.json_int_dttm_ser,
                 ignore_nan=True,
             )

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -24,6 +24,7 @@ from zipfile import is_zipfile, ZipFile
 import prison
 import pytest
 import yaml
+from flask import g
 from flask_babel import lazy_gettext as _
 from parameterized import parameterized
 from sqlalchemy import and_
@@ -62,6 +63,7 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_config,
     dataset_metadata_config,
 )
+from tests.integration_tests.fixtures.query_context import get_query_context
 from tests.integration_tests.fixtures.tags import (
     create_custom_tags,  # noqa: F401
     get_filter_params,
@@ -2327,3 +2329,57 @@ class TestChartApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
 
         security_manager.add_permission_role(alpha_role, write_tags_perm)
         security_manager.add_permission_role(alpha_role, tag_charts_perm)
+
+    @patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_get_chart_data_as_guest_user(
+        self, is_guest_user, has_guest_access
+    ):  # get_guest_rls_filters
+        """
+        Chart API: Test create simple chart
+        """
+        self.login(ADMIN_USERNAME)
+        g.user.rls = []
+        is_guest_user.return_value = True
+        has_guest_access.return_value = True
+
+        with mock.patch.object(Slice, "get_query_context") as mock_get_query_context:
+            mock_get_query_context.return_value = get_query_context("birth_names")
+            rv = self.client.post(
+                "api/v1/chart/data",  # noqa: F541
+                json={
+                    "datasource": {"id": 2, "type": "table"},
+                    "queries": [
+                        {
+                            "extras": {"where": "", "time_grain_sqla": "P1D"},
+                            "columns": ["name"],
+                            "metrics": [{"label": "sum__num"}],
+                            "orderby": [("sum__num", False)],
+                            "row_limit": 100,
+                            "granularity": "ds",
+                            "time_range": "100 years ago : now",
+                            "timeseries_limit": 0,
+                            "timeseries_limit_metric": None,
+                            "order_desc": True,
+                            "filters": [
+                                {"col": "gender", "op": "==", "val": "boy"},
+                                {"col": "num", "op": "IS NOT NULL"},
+                                {
+                                    "col": "name",
+                                    "op": "NOT IN",
+                                    "val": ["<NULL>", '"abc"'],
+                                },
+                            ],
+                            "having": "",
+                            "where": "",
+                        }
+                    ],
+                    "result_format": "json",
+                    "result_type": "full",
+                },
+            )
+            data = json.loads(rv.data.decode("utf-8"))
+            result = data["result"]
+            excluded_key = "query"
+            assert all([excluded_key not in query for query in result])


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When accessing a chart as a guest user, the `query` field is attached to the payload revealing the table names of db schema. This fix introduces a check for whether or not the user is a guest user, and removes the query field from the data payload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
