### PR TITLE
fix(package.json): Pin luxon version to unblock master

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -87,6 +87,7 @@
         "json-bigint": "^1.0.0",
         "json-stringify-pretty-compact": "^2.0.0",
         "lodash": "^4.17.21",
+        "luxon": "^3.5.0",
         "mapbox-gl": "^2.10.0",
         "markdown-to-jsx": "^7.4.7",
         "match-sorter": "^6.3.4",
@@ -34959,10 +34960,10 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.4.4",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -58103,7 +58104,7 @@
         "d3-array": "^1.2.4",
         "d3-color": "^1.4.1",
         "d3-scale": "^3.0.0",
-        "deck.gl": "9.0.28",
+        "deck.gl": "9.0.34",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "mousetrap": "^1.6.5",
@@ -68831,7 +68832,7 @@
         "d3-array": "^1.2.4",
         "d3-color": "^1.4.1",
         "d3-scale": "^3.0.0",
-        "deck.gl": "9.0.28",
+        "deck.gl": "9.0.34",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "mousetrap": "^1.6.5",
@@ -84308,9 +84309,9 @@
       }
     },
     "luxon": {
-      "version": "3.4.4",
-      "optional": true,
-      "peer": true
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
     },
     "lz-string": {
       "version": "1.5.0"

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -153,6 +153,7 @@
     "json-bigint": "^1.0.0",
     "json-stringify-pretty-compact": "^2.0.0",
     "lodash": "^4.17.21",
+    "luxon": "^3.5.0",
     "mapbox-gl": "^2.10.0",
     "markdown-to-jsx": "^7.4.7",
     "match-sorter": "^6.3.4",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Master is currently broken due to a mismatch with luxon version. This PR pins the version in the package.json to unblock master.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. `npm ci` should run successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
