### PR TITLE
docs: adapt docs to suggest 'docker compose up --build'

### DIFF
--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -32,7 +32,9 @@ cd superset
 Setting things up to squeeze a "hello world" into any part of Superset should be as simple as
 
 ```bash
-docker compose up
+# getting docker compose to fire up services, and rebuilding if some docker layers have changed
+# using the `--build` suffix may be slower and optional if layers like py dependencies haven't changed
+docker compose up --build
 ```
 
 Note that:
@@ -619,7 +621,7 @@ If you already have launched Docker environment please use the following command
 
 Launch environment:
 
-`CYPRESS_CONFIG=true docker compose up`
+`CYPRESS_CONFIG=true docker compose up`--build
 
 It will serve the backend and frontend on port 8088.
 
@@ -687,7 +689,7 @@ superset:
 Start Superset as usual
 
 ```bash
-docker compose up
+docker compose up --build
 ```
 
 Install the required libraries and packages to the docker container

--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -621,7 +621,7 @@ If you already have launched Docker environment please use the following command
 
 Launch environment:
 
-`CYPRESS_CONFIG=true docker compose up`--build
+`CYPRESS_CONFIG=true docker compose up --build`
 
 It will serve the backend and frontend on port 8088.
 

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -76,7 +76,8 @@ on latest base images using `docker compose build --pull`. In most cases though,
 ### Option #1 - for an interactive development environment
 
 ```bash
-docker compose up
+# The --build argument insures all the layers are up-to-date
+docker compose up --build
 ```
 
 :::tip
@@ -227,3 +228,11 @@ may want to find the exact hostname you want to use, for that you can do `ifconf
 Docker for you. Alternately if you don't even see the `docker0` interface try (if needed with sudo)
 `docker network inspect bridge` and see if there is an entry for `"Gateway"` and note the IP
 address.
+
+## 4. To build or not to build
+
+When running `docker compose up`, docker will build what is required behind the scene, but
+may use the docker cache if assets already exist. Running `docker compose build` prior to
+`docker compose up` or the equivalent shortcut `docker compose up --build` ensures that your
+docker images matche the definition in the repository. This should only apply to the main
+docker-compose.yml file (default) and not to the alternative methods defined above.


### PR DESCRIPTION
In https://github.com/apache/superset/issues/30183, it appeared to me
that the issue might be around running `docker compose up` without
re-running `docker compose build`. Here I'm recommending running
`docker compose up --build` in the docs which should be safer.

