### PR TITLE
fix: don't show metadata for embedded dashboards

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, fireEvent } from 'spec/helpers/testing-library';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { getExtensionsRegistry } from '@superset-ui/core';
+import { fireEvent, render, screen } from 'spec/helpers/testing-library';
 import setupExtensions from 'src/setup/setupExtensions';
 import getOwnerName from 'src/utils/getOwnerName';
-import { HeaderProps } from './types';
 import Header from '.';
+import { HeaderProps } from './types';
 
 const createProps = () => ({
   addSuccessToast: jest.fn(),
@@ -372,4 +372,30 @@ test('should render an extension component if one is supplied', () => {
   expect(
     screen.getByText('dashboard.nav.right extension component'),
   ).toBeInTheDocument();
+});
+
+test('should render metadata when !isEmbedded is true', () => {
+  const mockedProps = {
+    ...createProps(),
+    dashboardInfo: {
+      ...createProps().dashboardInfo,
+      userId: undefined,
+    },
+  };
+  setup(mockedProps);
+  expect(
+    screen.getByText(getOwnerName(mockedProps.dashboardInfo.created_by)),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
+  ).toBeInTheDocument();
+});
+
+test('should NOT render MetadataBar when embedded', () => {
+  const mockedProps = createProps();
+  setup(mockedProps);
+
+  expect(
+    screen.queryByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
+  ).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -374,9 +374,25 @@ test('should render an extension component if one is supplied', () => {
   ).toBeInTheDocument();
 });
 
-test('should render metadata when !isEmbedded is true', () => {
+test('should NOT render MetadataBar when in edit mode', () => {
   const mockedProps = {
     ...createProps(),
+    editMode: true,
+    dashboardInfo: {
+      ...createProps().dashboardInfo,
+      userId: '123',
+    },
+  };
+  setup(mockedProps);
+  expect(
+    screen.queryByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
+  ).not.toBeInTheDocument();
+});
+
+test('should NOT render MetadataBar when embedded', () => {
+  const mockedProps = {
+    ...createProps(),
+    editMode: false,
     dashboardInfo: {
       ...createProps().dashboardInfo,
       userId: undefined,
@@ -384,18 +400,21 @@ test('should render metadata when !isEmbedded is true', () => {
   };
   setup(mockedProps);
   expect(
-    screen.getByText(getOwnerName(mockedProps.dashboardInfo.created_by)),
-  ).toBeInTheDocument();
+    screen.queryByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
+  ).not.toBeInTheDocument();
+});
+
+test('should render MetadataBar when not in edit mode and not embedded', () => {
+  const mockedProps = {
+    ...createProps(),
+    editMode: false,
+    dashboardInfo: {
+      ...createProps().dashboardInfo,
+      userId: '123',
+    },
+  };
+  setup(mockedProps);
   expect(
     screen.getByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
   ).toBeInTheDocument();
-});
-
-test('should NOT render MetadataBar when embedded', () => {
-  const mockedProps = createProps();
-  setup(mockedProps);
-
-  expect(
-    screen.queryByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
-  ).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getExtensionsRegistry } from '@superset-ui/core';
+import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import setupExtensions from 'src/setup/setupExtensions';
 import getOwnerName from 'src/utils/getOwnerName';
-import Header from '.';
 import { HeaderProps } from './types';
+import Header from '.';
 
 const createProps = () => ({
   addSuccessToast: jest.fn(),

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -17,44 +17,44 @@
  * under the License.
  */
 /* eslint-env browser */
-import moment from 'moment';
-import { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import {
-  styled,
-  css,
-  isFeatureEnabled,
-  FeatureFlag,
-  t,
-  getExtensionsRegistry,
-} from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import {
-  LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
-  LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
-  LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
-} from 'src/logger/LogUtils';
-import Icons from 'src/components/Icons';
+  css,
+  FeatureFlag,
+  getExtensionsRegistry,
+  isFeatureEnabled,
+  styled,
+  t,
+} from '@superset-ui/core';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { Button } from 'src/components/';
-import { findPermission } from 'src/utils/findPermission';
+import Icons from 'src/components/Icons';
+import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
+import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { Tooltip } from 'src/components/Tooltip';
-import { safeStringify } from 'src/utils/safeStringify';
 import ConnectedHeaderActionsDropdown from 'src/dashboard/components/Header/HeaderActionsDropdown';
+import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import PublishedStatus from 'src/dashboard/components/PublishedStatus';
 import UndoRedoKeyListeners from 'src/dashboard/components/UndoRedoKeyListeners';
-import PropertiesModal from 'src/dashboard/components/PropertiesModal';
-import { chartPropShape } from 'src/dashboard/util/propShapes';
-import getOwnerName from 'src/utils/getOwnerName';
 import {
-  UNDO_LIMIT,
-  SAVE_TYPE_OVERWRITE,
   DASHBOARD_POSITION_DATA_LIMIT,
+  SAVE_TYPE_OVERWRITE,
+  UNDO_LIMIT,
 } from 'src/dashboard/util/constants';
+import { chartPropShape } from 'src/dashboard/util/propShapes';
 import setPeriodicRunner, {
   stopPeriodicRender,
 } from 'src/dashboard/util/setPeriodicRunner';
-import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
-import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
+import {
+  LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
+  LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
+  LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
+} from 'src/logger/LogUtils';
+import { findPermission } from 'src/utils/findPermission';
+import getOwnerName from 'src/utils/getOwnerName';
+import { safeStringify } from 'src/utils/safeStringify';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
 
@@ -496,6 +496,7 @@ class Header extends PureComponent {
     const refreshWarning =
       dashboardInfo.common?.conf
         ?.SUPERSET_DASHBOARD_PERIODICAL_REFRESH_WARNING_MESSAGE;
+    const isEmbedded = !dashboardInfo?.userId;
 
     const handleOnPropertiesChange = updates => {
       const { dashboardInfoChanged, dashboardTitleChanged } = this.props;
@@ -553,7 +554,7 @@ class Header extends PureComponent {
                 visible={!editMode}
               />
             ),
-            !editMode && (
+            (!editMode || !isEmbedded) && (
               <MetadataBar
                 items={this.getMetadataItems()}
                 tooltipPlacement="bottom"

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -554,7 +554,7 @@ class Header extends PureComponent {
                 visible={!editMode}
               />
             ),
-            (!editMode || !isEmbedded) && (
+            !editMode && !isEmbedded && (
               <MetadataBar
                 items={this.getMetadataItems()}
                 tooltipPlacement="bottom"

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -17,44 +17,44 @@
  * under the License.
  */
 /* eslint-env browser */
+import moment from 'moment';
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import {
+  styled,
+  css,
+  isFeatureEnabled,
+  FeatureFlag,
+  t,
+  getExtensionsRegistry,
+} from '@superset-ui/core';
 import { Global } from '@emotion/react';
 import {
-  css,
-  FeatureFlag,
-  getExtensionsRegistry,
-  isFeatureEnabled,
-  styled,
-  t,
-} from '@superset-ui/core';
-import moment from 'moment';
-import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
-import { Button } from 'src/components/';
+  LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
+  LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
+  LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
+} from 'src/logger/LogUtils';
 import Icons from 'src/components/Icons';
-import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
-import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
+import { Button } from 'src/components/';
+import { findPermission } from 'src/utils/findPermission';
 import { Tooltip } from 'src/components/Tooltip';
+import { safeStringify } from 'src/utils/safeStringify';
 import ConnectedHeaderActionsDropdown from 'src/dashboard/components/Header/HeaderActionsDropdown';
-import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import PublishedStatus from 'src/dashboard/components/PublishedStatus';
 import UndoRedoKeyListeners from 'src/dashboard/components/UndoRedoKeyListeners';
-import {
-  DASHBOARD_POSITION_DATA_LIMIT,
-  SAVE_TYPE_OVERWRITE,
-  UNDO_LIMIT,
-} from 'src/dashboard/util/constants';
+import PropertiesModal from 'src/dashboard/components/PropertiesModal';
 import { chartPropShape } from 'src/dashboard/util/propShapes';
+import getOwnerName from 'src/utils/getOwnerName';
+import {
+  UNDO_LIMIT,
+  SAVE_TYPE_OVERWRITE,
+  DASHBOARD_POSITION_DATA_LIMIT,
+} from 'src/dashboard/util/constants';
 import setPeriodicRunner, {
   stopPeriodicRender,
 } from 'src/dashboard/util/setPeriodicRunner';
-import {
-  LOG_ACTIONS_FORCE_REFRESH_DASHBOARD,
-  LOG_ACTIONS_PERIODIC_RENDER_DASHBOARD,
-  LOG_ACTIONS_TOGGLE_EDIT_DASHBOARD,
-} from 'src/logger/LogUtils';
-import { findPermission } from 'src/utils/findPermission';
-import getOwnerName from 'src/utils/getOwnerName';
-import { safeStringify } from 'src/utils/safeStringify';
+import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
+import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As part of https://github.com/apache/superset/pull/27857 we started to show metadata even on embedded dashboards. This could have a potential of displaying data that embedded don't need to see. This PR will remove it if we are in embedded view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/30188
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
