### PR TITLE
docs: fix for role sync issues in case of custom OAuth2 configuration

### DIFF
--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -265,7 +265,7 @@ AUTH_USER_REGISTRATION_ROLE = "Public"
 
 In case you want to assign the `Admin` role on new user registration, it can be assigned as follows:
 ```python
-AUTH_USER_REGISTRATION_ROLE = "Admin" 
+AUTH_USER_REGISTRATION_ROLE = "Admin"
 ```
 If you encounter the [issue](https://github.com/apache/superset/issues/13243) of not being able to list users from the Superset main page settings, although a newly registered user has an `Admin` role, please re-run `superset init` to sync the required permissions. Below is the command to re-run `superset init` using docker compose.
 ```

--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -263,6 +263,15 @@ AUTH_USER_REGISTRATION = True
 AUTH_USER_REGISTRATION_ROLE = "Public"
 ```
 
+In case you want to assign the `Admin` role on new user registration, it can be assigned as follows:
+```python
+AUTH_USER_REGISTRATION_ROLE = "Admin" 
+```
+If you encounter the [issue](https://github.com/apache/superset/issues/13243) of not being able to list users from the Superset main page settings, although a newly registered user has an `Admin` role, please re-run `superset init` to sync the required permissions. Below is the command to re-run `superset init` using docker compose.
+```
+docker-compose exec superset superset init
+```
+
 Then, create a `CustomSsoSecurityManager` that extends `SupersetSecurityManager` and overrides
 `oauth_user_info`:
 


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/13243

Unable to list users on Superset main page settings despite having Admin role in case of custom OAuth2 configuration.

### EXPECTED RESULT
If user has registered with Admin role then he should be able to list users for settings of Superset.

### ACTUAL RESULT
User with `Admin` role is getting permission denied error when trying to list users from settings of Superset.

### TESTING INSTRUCTIONS
please re-run `superset init` to sync the required permissions. Below is the command to re-run `superset init` using docker compose.
```
docker-compose exec superset superset init
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x]  Has associated issue: Fixes https://github.com/apache/superset/issues/13243
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
