### PR TITLE
perf: Prevent redundant calls to getRelevantDataMask

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -62,6 +62,7 @@ const propTypes = {
   impressionId: PropTypes.string.isRequired,
   timeout: PropTypes.number,
   userId: PropTypes.string,
+  children: PropTypes.node,
 };
 
 const defaultProps = {

--- a/superset-frontend/src/dashboard/containers/Dashboard.ts
+++ b/superset-frontend/src/dashboard/containers/Dashboard.ts
@@ -28,23 +28,16 @@ import { setDatasources } from 'src/dashboard/actions/datasources';
 
 import { triggerQuery } from 'src/components/Chart/chartAction';
 import { logEvent } from 'src/logger/actions';
-import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
-import {
-  getAllActiveFilters,
-  getRelevantDataMask,
-} from 'src/dashboard/util/activeAllDashboardFilters';
 import { clearDataMaskState } from '../../dataMask/actions';
 
 function mapStateToProps(state: RootState) {
   const {
     datasources,
     sliceEntities,
-    dataMask,
     dashboardInfo,
     dashboardState,
     dashboardLayout,
     impressionId,
-    nativeFilters,
   } = state;
 
   return {
@@ -53,22 +46,7 @@ function mapStateToProps(state: RootState) {
     dashboardInfo,
     dashboardState,
     datasources,
-    // filters prop: a map structure for all the active filter's values and scope in this dashboard,
-    // for each filter field. map key is [chartId_column]
-    // When dashboard is first loaded into browser,
-    // its value is from preselect_filters that dashboard owner saved in dashboard's meta data
-    activeFilters: {
-      ...getActiveFilters(),
-      ...getAllActiveFilters({
-        // eslint-disable-next-line camelcase
-        chartConfiguration: dashboardInfo.metadata?.chart_configuration,
-        nativeFilters: nativeFilters.filters,
-        dataMask,
-        allSliceIds: dashboardState.sliceIds,
-      }),
-    },
     chartConfiguration: dashboardInfo.metadata?.chart_configuration,
-    ownDataCharts: getRelevantDataMask(dataMask, 'ownState'),
     slices: sliceEntities.slices,
     layout: dashboardLayout.present,
     impressionId,

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -77,11 +77,13 @@ type PageProps = {
   idOrSlug: string;
 };
 
+// TODO: move to Dashboard.jsx when it's refactored to functional component
 const selectRelevantDatamask = createSelector(
   (state: RootState) => state.dataMask, // the first argument accesses relevant data from global state
   dataMask => getRelevantDataMask(dataMask, 'ownState'), // the second parameter conducts the transformation
 );
 
+// TODO: move to Dashboard.jsx when it's refactored to functional component
 const selectActiveFilters = createSelector(
   (state: RootState) => ({
     // eslint-disable-next-line camelcase

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -21,6 +21,7 @@ import { Global } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 import { t, useTheme } from '@superset-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
+import { createSelector } from '@reduxjs/toolkit';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import Loading from 'src/components/Loading';
 import {
@@ -31,7 +32,11 @@ import {
 import { hydrateDashboard } from 'src/dashboard/actions/hydrate';
 import { setDatasources } from 'src/dashboard/actions/datasources';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
-
+import {
+  getAllActiveFilters,
+  getRelevantDataMask,
+} from 'src/dashboard/util/activeAllDashboardFilters';
+import { getActiveFilters } from 'src/dashboard/util/activeDashboardFilters';
 import { LocalStorageKeys, setItem } from 'src/utils/localStorageHelpers';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
@@ -71,6 +76,31 @@ const originalDocumentTitle = document.title;
 type PageProps = {
   idOrSlug: string;
 };
+
+const selectRelevantDatamask = createSelector(
+  (state: RootState) => state.dataMask, // the first argument accesses relevant data from global state
+  dataMask => getRelevantDataMask(dataMask, 'ownState'), // the second parameter conducts the transformation
+);
+
+const selectActiveFilters = createSelector(
+  (state: RootState) => ({
+    // eslint-disable-next-line camelcase
+    chartConfiguration: state.dashboardInfo.metadata?.chart_configuration,
+    nativeFilters: state.nativeFilters.filters,
+    dataMask: state.dataMask,
+    allSliceIds: state.dashboardState.sliceIds,
+  }),
+  ({ chartConfiguration, nativeFilters, dataMask, allSliceIds }) => ({
+    ...getActiveFilters(),
+    ...getAllActiveFilters({
+      // eslint-disable-next-line camelcase
+      chartConfiguration,
+      nativeFilters,
+      dataMask,
+      allSliceIds,
+    }),
+  }),
+);
 
 export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   const theme = useTheme();
@@ -191,6 +221,9 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
     }
   }, [addDangerToast, datasets, datasetsApiError, dispatch]);
 
+  const relevantDataMask = useSelector(selectRelevantDatamask);
+  const activeFilters = useSelector(selectActiveFilters);
+
   if (error) throw error; // caught in error boundary
 
   return (
@@ -208,7 +241,10 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
         <>
           <SyncDashboardState dashboardPageId={dashboardPageId} />
           <DashboardPageIdContext.Provider value={dashboardPageId}>
-            <DashboardContainer>
+            <DashboardContainer
+              activeFilters={activeFilters}
+              ownDataCharts={relevantDataMask}
+            >
               <DashboardBuilder />
             </DashboardContainer>
           </DashboardPageIdContext.Provider>


### PR DESCRIPTION
### SUMMARY
Move `getRelevantDataMask` and `getAllActiveFilters` calls from Dashboard's `mapStateToProps` to a selector. 

On a very large dashboard (300+ charts, 40+ filters) those calls delayed the dashboard loading time by over 3 seconds. After this change, they are negligible. Please keep in mind that you likely won't reproduce that delay on a dashboard from sample data, it only occurs on very large ones.

Sidenote - my key takeaway from this is that we really need to optimize our redux selectors with `createSelector` from redux toolkit more often. Plenty of our selectors have quite complex code that is mostly running unnecessarily.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before - you can see that there's a 3.2s load event task, which really consists of thousands of `getRelevantDataMask` calls:

![image](https://github.com/user-attachments/assets/a41921d1-87c9-47a8-8756-5c3f2536d74d)

![image](https://github.com/user-attachments/assets/399104ac-6b32-4621-bf82-219cd34671fe)

![image](https://github.com/user-attachments/assets/3ebbac1b-9b00-413b-8c74-f42e13d0c057)

After - 0.8ms:

<img width="518" alt="image" src="https://github.com/user-attachments/assets/c609f3ec-e615-4012-84e6-e183ed0e7093">



### TESTING INSTRUCTIONS
Dashboards with native filters should work just like before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
