### PR TITLE
fix(virtual dataset sync): Sync virtual dataset columns when changing the SQL query

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/explore/control.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/control.test.ts
@@ -51,8 +51,8 @@ describe('Datasource control', () => {
     )
       .first()
       .focus();
-    cy.focused().clear();
-    cy.focused().type(`${newMetricName}{enter}`);
+    cy.focused().clear({ force: true });
+    cy.focused().type(`${newMetricName}{enter}`, { force: true });
 
     cy.get('[data-test="datasource-modal-save"]').click();
     cy.get('.antd5-modal-confirm-btns button').contains('OK').click();

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -75,4 +75,5 @@ module.exports = {
       },
     ],
   ],
+  testTimeout: 10000,
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -84,6 +84,12 @@ export interface Dataset {
   filter_select?: boolean;
   filter_select_enabled?: boolean;
   column_names?: string[];
+  catalog?: string;
+  schema?: string;
+  table_name?: string;
+  database?: Record<string, unknown>;
+  normalize_columns?: boolean;
+  always_filter_main_dttm?: boolean;
 }
 
 export interface ControlPanelState {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Metric.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Metric.ts
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Maybe, QueryFormMetric } from '../../types';
+import { Currency, Maybe, QueryFormMetric } from '../../types';
 import { Column } from './Column';
 
 export type Aggregate =
@@ -65,7 +65,7 @@ export interface Metric {
   certification_details?: Maybe<string>;
   certified_by?: Maybe<string>;
   d3format?: Maybe<string>;
-  currency?: Maybe<string>;
+  currency?: Maybe<Currency>;
   description?: Maybe<string>;
   is_certified?: boolean;
   verbose_name?: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
@@ -173,7 +173,7 @@ describe('BigNumberWithTrendline', () => {
               label: 'value',
               metric_name: 'value',
               d3format: '.2f',
-              currency: `{symbol: 'USD', symbolPosition: 'prefix' }`,
+              currency: { symbol: 'USD', symbolPosition: 'prefix' },
             },
           ],
         },

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -23,7 +23,6 @@ import { Radio } from 'src/components/Radio';
 import Card from 'src/components/Card';
 import Alert from 'src/components/Alert';
 import Badge from 'src/components/Badge';
-import { nanoid } from 'nanoid';
 import {
   css,
   isFeatureEnabled,
@@ -57,6 +56,7 @@ import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
 import CollectionTable from './CollectionTable';
 import Fieldset from './Fieldset';
 import Field from './Field';
+import { fetchSyncedColumns, updateColumns } from './utils';
 
 const DatasourceContainer = styled.div`
   .change-warning {
@@ -139,6 +139,14 @@ const StyledButtonWrapper = styled.span`
     margin-left: ${theme.gridUnit * 3}px;
   `}
 `;
+
+const sqlTooltipOptions = {
+  placement: 'topRight',
+  title: t(
+    'If changes are made to your SQL query, ' +
+      'columns in your dataset will be synced when saving the dataset.',
+  ),
+};
 
 const checkboxGenerator = (d, onChange) => (
   <CheckboxControl value={d} onChange={onChange} />
@@ -694,116 +702,27 @@ class DatasourceEditor extends PureComponent {
     });
   }
 
-  updateColumns(cols) {
-    // cols: Array<{column_name: string; is_dttm: boolean; type: string;}>
-    const { databaseColumns } = this.state;
-    const databaseColumnNames = cols.map(col => col.column_name);
-    const currentCols = databaseColumns.reduce(
-      (agg, col) => ({
-        ...agg,
-        [col.column_name]: col,
-      }),
-      {},
-    );
-    const finalColumns = [];
-    const results = {
-      added: [],
-      modified: [],
-      removed: databaseColumns
-        .map(col => col.column_name)
-        .filter(col => !databaseColumnNames.includes(col)),
-    };
-    cols.forEach(col => {
-      const currentCol = currentCols[col.column_name];
-      if (!currentCol) {
-        // new column
-        finalColumns.push({
-          id: nanoid(),
-          column_name: col.column_name,
-          type: col.type,
-          groupby: true,
-          filterable: true,
-          is_dttm: col.is_dttm,
-        });
-        results.added.push(col.column_name);
-      } else if (
-        currentCol.type !== col.type ||
-        (!currentCol.is_dttm && col.is_dttm)
-      ) {
-        // modified column
-        finalColumns.push({
-          ...currentCol,
-          type: col.type,
-          is_dttm: currentCol.is_dttm || col.is_dttm,
-        });
-        results.modified.push(col.column_name);
-      } else {
-        // unchanged
-        finalColumns.push(currentCol);
-      }
-    });
-    if (
-      results.added.length ||
-      results.modified.length ||
-      results.removed.length
-    ) {
-      this.setColumns({ databaseColumns: finalColumns });
-    }
-    return results;
-  }
-
-  syncMetadata() {
+  async syncMetadata() {
     const { datasource } = this.state;
-    const params = {
-      datasource_type: datasource.type || datasource.datasource_type,
-      database_name:
-        datasource.database.database_name || datasource.database.name,
-      catalog_name: datasource.catalog,
-      schema_name: datasource.schema,
-      table_name: datasource.table_name,
-      normalize_columns: datasource.normalize_columns,
-      always_filter_main_dttm: datasource.always_filter_main_dttm,
-    };
-    Object.entries(params).forEach(([key, value]) => {
-      // rison can't encode the undefined value
-      if (value === undefined) {
-        params[key] = null;
-      }
-    });
-    const endpoint = `/datasource/external_metadata_by_name/?q=${rison.encode_uri(
-      params,
-    )}`;
     this.setState({ metadataLoading: true });
-
-    SupersetClient.get({ endpoint })
-      .then(({ json }) => {
-        const results = this.updateColumns(json);
-        if (results.modified.length) {
-          this.props.addSuccessToast(
-            t('Modified columns: %s', results.modified.join(', ')),
-          );
-        }
-        if (results.removed.length) {
-          this.props.addSuccessToast(
-            t('Removed columns: %s', results.removed.join(', ')),
-          );
-        }
-        if (results.added.length) {
-          this.props.addSuccessToast(
-            t('New columns added: %s', results.added.join(', ')),
-          );
-        }
-        this.props.addSuccessToast(t('Metadata has been synced'));
-        this.setState({ metadataLoading: false });
-      })
-      .catch(response =>
-        getClientErrorObject(response).then(({ error, statusText }) => {
-          this.props.addDangerToast(
-            error || statusText || t('An error has occurred'),
-          );
-          this.setState({ metadataLoading: false });
-        }),
+    try {
+      const newCols = await fetchSyncedColumns(datasource);
+      const columnChanges = updateColumns(
+        datasource.columns,
+        newCols,
+        this.props.addSuccessToast,
       );
+      this.setColumns({ databaseColumns: columnChanges.finalColumns });
+      this.props.addSuccessToast(t('Metadata has been synced'));
+      this.setState({ metadataLoading: false });
+    } catch (error) {
+      const { error: clientError, statusText } =
+        await getClientErrorObject(error);
+      this.props.addDangerToast(
+        clientError || statusText || t('An error has occurred'),
+      );
+      this.setState({ metadataLoading: false });
+    }
   }
 
   findDuplicates(arr, accessor) {
@@ -1146,6 +1065,7 @@ class DatasourceEditor extends PureComponent {
                         maxLines={Infinity}
                         readOnly={!this.state.isEditMode}
                         resize="both"
+                        tooltipOptions={sqlTooltipOptions}
                       />
                     }
                   />

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { FunctionComponent, useState, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
 import {
@@ -33,7 +34,15 @@ import Modal from 'src/components/Modal';
 import AsyncEsmComponent from 'src/components/AsyncEsmComponent';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import { useSelector } from 'react-redux';
+import {
+  startMetaDataLoading,
+  stopMetaDataLoading,
+  syncDatasourceMetadata,
+} from 'src/explore/actions/exploreActions';
+import {
+  fetchSyncedColumns,
+  updateColumns,
+} from 'src/components/Datasource/utils';
 
 const DatasourceEditor = AsyncEsmComponent(() => import('./DatasourceEditor'));
 
@@ -60,6 +69,7 @@ const StyledDatasourceModal = styled(Modal)`
 
 interface DatasourceModalProps {
   addSuccessToast: (msg: string) => void;
+  addDangerToast: (msg: string) => void;
   datasource: any;
   onChange: () => {};
   onDatasourceSave: (datasource: object, errors?: Array<any>) => {};
@@ -83,11 +93,13 @@ function buildExtraJsonObject(item: Record<string, unknown>) {
 
 const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   addSuccessToast,
+  addDangerToast,
   datasource,
   onDatasourceSave,
   onHide,
   show,
 }) => {
+  const dispatch = useDispatch();
   const [currentDatasource, setCurrentDatasource] = useState({
     ...datasource,
     metrics: datasource?.metrics?.map((metric: Metric) => ({
@@ -108,130 +120,143 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const dialog = useRef<any>(null);
   const [modal, contextHolder] = Modal.useModal();
-
-  const onConfirmSave = () => {
+  const buildPayload = (datasource: Record<string, any>) => ({
+    table_name: datasource.table_name,
+    database_id: datasource.database?.id,
+    sql: datasource.sql,
+    filter_select_enabled: datasource.filter_select_enabled,
+    fetch_values_predicate: datasource.fetch_values_predicate,
+    schema:
+      datasource.tableSelector?.schema ||
+      datasource.databaseSelector?.schema ||
+      datasource.schema,
+    description: datasource.description,
+    main_dttm_col: datasource.main_dttm_col,
+    normalize_columns: datasource.normalize_columns,
+    always_filter_main_dttm: datasource.always_filter_main_dttm,
+    offset: datasource.offset,
+    default_endpoint: datasource.default_endpoint,
+    cache_timeout:
+      datasource.cache_timeout === '' ? null : datasource.cache_timeout,
+    is_sqllab_view: datasource.is_sqllab_view,
+    template_params: datasource.template_params,
+    extra: datasource.extra,
+    is_managed_externally: datasource.is_managed_externally,
+    external_url: datasource.external_url,
+    metrics: datasource?.metrics?.map((metric: Record<string, unknown>) => {
+      const metricBody: any = {
+        expression: metric.expression,
+        description: metric.description,
+        metric_name: metric.metric_name,
+        metric_type: metric.metric_type,
+        d3format: metric.d3format || null,
+        currency: !isDefined(metric.currency)
+          ? null
+          : JSON.stringify(metric.currency),
+        verbose_name: metric.verbose_name,
+        warning_text: metric.warning_text,
+        uuid: metric.uuid,
+        extra: buildExtraJsonObject(metric),
+      };
+      if (!Number.isNaN(Number(metric.id))) {
+        metricBody.id = metric.id;
+      }
+      return metricBody;
+    }),
+    columns: datasource?.columns?.map((column: Record<string, unknown>) => ({
+      id: typeof column.id === 'number' ? column.id : undefined,
+      column_name: column.column_name,
+      type: column.type,
+      advanced_data_type: column.advanced_data_type,
+      verbose_name: column.verbose_name,
+      description: column.description,
+      expression: column.expression,
+      filterable: column.filterable,
+      groupby: column.groupby,
+      is_active: column.is_active,
+      is_dttm: column.is_dttm,
+      python_date_format: column.python_date_format || null,
+      uuid: column.uuid,
+      extra: buildExtraJsonObject(column),
+    })),
+    owners: datasource.owners.map(
+      (o: Record<string, number>) => o.value || o.id,
+    ),
+  });
+  const onConfirmSave = async () => {
     // Pull out extra fields into the extra object
-    const schema =
-      currentDatasource.tableSelector?.schema ||
-      currentDatasource.databaseSelector?.schema ||
-      currentDatasource.schema;
-
     setIsSaving(true);
-    SupersetClient.put({
-      endpoint: `/api/v1/dataset/${currentDatasource.id}`,
-      jsonPayload: {
-        table_name: currentDatasource.table_name,
-        database_id: currentDatasource.database?.id,
-        sql: currentDatasource.sql,
-        filter_select_enabled: currentDatasource.filter_select_enabled,
-        fetch_values_predicate: currentDatasource.fetch_values_predicate,
-        schema,
-        description: currentDatasource.description,
-        main_dttm_col: currentDatasource.main_dttm_col,
-        normalize_columns: currentDatasource.normalize_columns,
-        always_filter_main_dttm: currentDatasource.always_filter_main_dttm,
-        offset: currentDatasource.offset,
-        default_endpoint: currentDatasource.default_endpoint,
-        cache_timeout:
-          currentDatasource.cache_timeout === ''
-            ? null
-            : currentDatasource.cache_timeout,
-        is_sqllab_view: currentDatasource.is_sqllab_view,
-        template_params: currentDatasource.template_params,
-        extra: currentDatasource.extra,
-        is_managed_externally: currentDatasource.is_managed_externally,
-        external_url: currentDatasource.external_url,
-        metrics: currentDatasource?.metrics?.map(
-          (metric: Record<string, unknown>) => {
-            const metricBody: any = {
-              expression: metric.expression,
-              description: metric.description,
-              metric_name: metric.metric_name,
-              metric_type: metric.metric_type,
-              d3format: metric.d3format || null,
-              currency: !isDefined(metric.currency)
-                ? null
-                : JSON.stringify(metric.currency),
-              verbose_name: metric.verbose_name,
-              warning_text: metric.warning_text,
-              uuid: metric.uuid,
-              extra: buildExtraJsonObject(metric),
-            };
-            if (!Number.isNaN(Number(metric.id))) {
-              metricBody.id = metric.id;
-            }
-            return metricBody;
-          },
-        ),
-        columns: currentDatasource?.columns?.map(
-          (column: Record<string, unknown>) => ({
-            id: typeof column.id === 'number' ? column.id : undefined,
-            column_name: column.column_name,
-            type: column.type,
-            advanced_data_type: column.advanced_data_type,
-            verbose_name: column.verbose_name,
-            description: column.description,
-            expression: column.expression,
-            filterable: column.filterable,
-            groupby: column.groupby,
-            is_active: column.is_active,
-            is_dttm: column.is_dttm,
-            python_date_format: column.python_date_format || null,
-            uuid: column.uuid,
-            extra: buildExtraJsonObject(column),
-          }),
-        ),
-        owners: currentDatasource.owners.map(
-          (o: Record<string, number>) => o.value || o.id,
-        ),
-      },
-    })
-      .then(() => {
-        addSuccessToast(t('The dataset has been saved'));
-        return SupersetClient.get({
-          endpoint: `/api/v1/dataset/${currentDatasource?.id}`,
-        });
-      })
-      .then(({ json }) => {
-        // eslint-disable-next-line no-param-reassign
-        json.result.type = 'table';
-        onDatasourceSave({
-          ...json.result,
-          owners: currentDatasource.owners,
-        });
-        onHide();
-      })
-      .catch(response => {
-        setIsSaving(false);
-        getClientErrorObject(response).then(error => {
-          let errorResponse: SupersetError | undefined;
-          let errorText: string | undefined;
-          // sip-40 error response
-          if (error?.errors?.length) {
-            errorResponse = error.errors[0];
-          } else if (typeof error.error === 'string') {
-            // backward compatible with old error messages
-            errorText = error.error;
-          }
-          modal.error({
-            title: t('Error saving dataset'),
-            okButtonProps: { danger: true, className: 'btn-danger' },
-            content: (
-              <ErrorMessageWithStackTrace
-                error={errorResponse}
-                source="crud"
-                fallback={errorText}
-              />
-            ),
-          });
-        });
+    try {
+      await SupersetClient.put({
+        endpoint: `/api/v1/dataset/${currentDatasource.id}`,
+        jsonPayload: buildPayload(currentDatasource),
       });
+      if (datasource.sql !== currentDatasource.sql) {
+        // if sql has changed, save a second time with synced columns
+        dispatch(startMetaDataLoading());
+        try {
+          const columnJson = await fetchSyncedColumns(currentDatasource);
+          const columnChanges = updateColumns(
+            currentDatasource.columns,
+            columnJson,
+            addSuccessToast,
+          );
+          currentDatasource.columns = columnChanges.finalColumns;
+          dispatch(syncDatasourceMetadata(currentDatasource));
+          dispatch(stopMetaDataLoading());
+          addSuccessToast(t('Metadata has been synced'));
+        } catch (error) {
+          dispatch(stopMetaDataLoading());
+          addDangerToast(
+            t('An error has occurred while syncing virtual dataset columns'),
+          );
+        }
+        await SupersetClient.put({
+          endpoint: `/api/v1/dataset/${currentDatasource.id}`,
+          jsonPayload: buildPayload(currentDatasource),
+        });
+      }
+      const { json } = await SupersetClient.get({
+        endpoint: `/api/v1/dataset/${currentDatasource?.id}`,
+      });
+      addSuccessToast(t('The dataset has been saved'));
+      // eslint-disable-next-line no-param-reassign
+      json.result.type = 'table';
+      onDatasourceSave({
+        ...json.result,
+        owners: currentDatasource.owners,
+      });
+      onHide();
+    } catch (response) {
+      setIsSaving(false);
+      const error = await getClientErrorObject(response);
+      let errorResponse: SupersetError | undefined;
+      let errorText: string | undefined;
+      // sip-40 error response
+      if (error?.errors?.length) {
+        errorResponse = error.errors[0];
+      } else if (typeof error.error === 'string') {
+        // backward compatible with old error messages
+        errorText = error.error;
+      }
+      modal.error({
+        title: t('Error saving dataset'),
+        okButtonProps: { danger: true, className: 'btn-danger' },
+        content: (
+          <ErrorMessageWithStackTrace
+            error={errorResponse}
+            source="crud"
+            fallback={errorText}
+          />
+        ),
+      });
+    }
   };
 
   const onDatasourceChange = (data: Record<string, any>, err: Array<any>) => {
     setCurrentDatasource({
       ...data,
-      metrics: data?.metrics.map((metric: Record<string, unknown>) => ({
+      metrics: data?.metrics.map((metric: Metric) => ({
         ...metric,
         is_certified: metric?.certified_by || metric?.certification_details,
       })),

--- a/superset-frontend/src/components/Datasource/utils.js
+++ b/superset-frontend/src/components/Datasource/utils.js
@@ -18,7 +18,7 @@
  */
 import { Children, cloneElement } from 'react';
 import { nanoid } from 'nanoid';
-import { SupersetClient, t } from '@superset-ui/core';
+import { SupersetClient, tn } from '@superset-ui/core';
 import rison from 'rison';
 
 export function recurseReactClone(children, type, propExtender) {
@@ -91,14 +91,30 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
   });
   if (columnChanges.modified.length) {
     addSuccessToast(
-      t('Modified columns: %s', columnChanges.modified.join(', ')),
+      tn(
+        'Modified 1 column in the virtual dataset',
+        'Modified %s columns in the virtual dataset',
+        columnChanges.modified.length,
+      ),
     );
   }
   if (columnChanges.removed.length) {
-    addSuccessToast(t('Removed columns: %s', columnChanges.removed.join(', ')));
+    addSuccessToast(
+      tn(
+        'Removed 1 column from the virtual dataset',
+        'Removed %s columns from the virtual dataset',
+        columnChanges.removed.length,
+      ),
+    );
   }
   if (columnChanges.added.length) {
-    addSuccessToast(t('New columns added: %s', columnChanges.added.join(', ')));
+    addSuccessToast(
+      tn(
+        'Added 1 new column to the virtual dataset',
+        'Added %s new columns to the virtual dataset',
+        columnChanges.added.length,
+      ),
+    );
   }
   return columnChanges;
 }

--- a/superset-frontend/src/components/Tooltip/index.tsx
+++ b/superset-frontend/src/components/Tooltip/index.tsx
@@ -18,13 +18,9 @@
  */
 import { supersetTheme } from '@superset-ui/core';
 import { Tooltip as AntdTooltip } from 'antd-v5';
-import {
-  TooltipProps as AntdTooltipProps,
-  TooltipPlacement as AntdTooltipPlacement,
-} from 'antd-v5/lib/tooltip';
+import { TooltipProps, TooltipPlacement } from 'antd-v5/lib/tooltip';
 
-export type TooltipPlacement = AntdTooltipPlacement;
-export type TooltipProps = AntdTooltipProps;
+export { TooltipProps, TooltipPlacement };
 
 export const Tooltip = ({ overlayStyle, ...props }: TooltipProps) => (
   <>

--- a/superset-frontend/src/explore/actions/exploreActions.ts
+++ b/superset-frontend/src/explore/actions/exploreActions.ts
@@ -164,6 +164,21 @@ export function setStashFormData(
   };
 }
 
+export const START_METADATA_LOADING = 'START_METADATA_LOADING';
+export function startMetaDataLoading() {
+  return { type: START_METADATA_LOADING };
+}
+
+export const STOP_METADATA_LOADING = 'STOP_METADATA_LOADING';
+export function stopMetaDataLoading() {
+  return { type: STOP_METADATA_LOADING };
+}
+
+export const SYNC_DATASOURCE_METADATA = 'SYNC_DATASOURCE_METADATA';
+export function syncDatasourceMetadata(datasource: Dataset) {
+  return { type: SYNC_DATASOURCE_METADATA, datasource };
+}
+
 export const exploreActions = {
   ...toastActions,
   fetchDatasourcesStarted,
@@ -178,6 +193,7 @@ export const exploreActions = {
   createNewSlice,
   sliceUpdated,
   setForceQuery,
+  syncDatasourceMetadata,
 };
 
 export type ExploreActions = typeof exploreActions;

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -19,6 +19,10 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TextArea } from 'src/components/Input';
+import {
+  Tooltip,
+  TooltipProps as TooltipOptions,
+} from 'src/components/Tooltip';
 import { t, withTheme } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
@@ -55,6 +59,7 @@ const propTypes = {
     'vertical',
   ]),
   textAreaStyles: PropTypes.object,
+  tooltipOptions: PropTypes.oneOf([null, TooltipOptions]),
 };
 
 const defaultProps = {
@@ -67,6 +72,7 @@ const defaultProps = {
   readOnly: false,
   resize: null,
   textAreaStyles: {},
+  tooltipOptions: {},
 };
 
 class TextAreaControl extends Component {
@@ -94,31 +100,44 @@ class TextAreaControl extends Component {
       if (this.props.readOnly) {
         style.backgroundColor = '#f2f2f2';
       }
-
-      return (
-        <TextAreaEditor
-          mode={this.props.language}
-          style={style}
-          minLines={minLines}
-          maxLines={inModal ? 1000 : this.props.maxLines}
-          editorProps={{ $blockScrolling: true }}
-          defaultValue={this.props.initialValue}
-          readOnly={this.props.readOnly}
-          key={this.props.name}
-          {...this.props}
-          onChange={this.onAreaEditorChange.bind(this)}
-        />
+      const codeEditor = (
+        <div>
+          <TextAreaEditor
+            mode={this.props.language}
+            style={style}
+            minLines={minLines}
+            maxLines={inModal ? 1000 : this.props.maxLines}
+            editorProps={{ $blockScrolling: true }}
+            defaultValue={this.props.initialValue}
+            readOnly={this.props.readOnly}
+            key={this.props.name}
+            {...this.props}
+            onChange={this.onAreaEditorChange.bind(this)}
+          />
+        </div>
       );
+
+      if (this.props.tooltipOptions) {
+        return <Tooltip {...this.props.tooltipOptions}>{codeEditor}</Tooltip>;
+      }
+      return codeEditor;
     }
-    return (
-      <TextArea
-        placeholder={t('textarea')}
-        onChange={this.onControlChange.bind(this)}
-        defaultValue={this.props.initialValue}
-        disabled={this.props.readOnly}
-        style={{ height: this.props.height }}
-      />
+
+    const textArea = (
+      <div>
+        <TextArea
+          placeholder={t('textarea')}
+          onChange={this.onControlChange.bind(this)}
+          defaultValue={this.props.initialValue}
+          disabled={this.props.readOnly}
+          style={{ height: this.props.height }}
+        />
+      </div>
     );
+    if (this.props.tooltipOptions) {
+      return <Tooltip {...this.props.tooltipOptions}>{textArea}</Tooltip>;
+    }
+    return textArea;
   }
 
   renderModalBody() {

--- a/superset-frontend/src/explore/reducers/exploreReducer.js
+++ b/superset-frontend/src/explore/reducers/exploreReducer.js
@@ -50,6 +50,24 @@ export default function exploreReducer(state = {}, action) {
         isDatasourceMetaLoading: true,
       };
     },
+    [actions.START_METADATA_LOADING]() {
+      return {
+        ...state,
+        isDatasourceMetaLoading: true,
+      };
+    },
+    [actions.STOP_METADATA_LOADING]() {
+      return {
+        ...state,
+        isDatasourceMetaLoading: false,
+      };
+    },
+    [actions.SYNC_DATASOURCE_METADATA]() {
+      return {
+        ...state,
+        datasource: action.datasource,
+      };
+    },
     [actions.UPDATE_FORM_DATA_BY_DATASOURCE]() {
       const newFormData = { ...state.form_data };
       const { prevDatasource, newDatasource } = action;

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { SupersetTheme, t } from '@superset-ui/core';
 import { Button, AntdSelect } from 'src/components';
 import InfoTooltip from 'src/components/InfoTooltip';
@@ -46,6 +46,7 @@ export const EncryptedField = ({
   db,
   editNewDb,
 }: FieldPropTypes) => {
+  const selectedFileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploadOption, setUploadOption] = useState<number>(
     CredentialInfoOptions.JsonUpload.valueOf(),
   );
@@ -152,9 +153,7 @@ export const EncryptedField = ({
             {!fileToUpload && (
               <Button
                 className="input-upload-btn"
-                onClick={() =>
-                  document?.getElementById('selectedFile')?.click()
-                }
+                onClick={() => selectedFileInputRef.current?.click()}
               >
                 {t('Choose File')}
               </Button>
@@ -178,6 +177,7 @@ export const EncryptedField = ({
             )}
 
             <input
+              ref={selectedFileInputRef}
               id="selectedFile"
               accept=".json"
               className="input-upload"
@@ -196,9 +196,9 @@ export const EncryptedField = ({
                     checked: false,
                   },
                 });
-                (
-                  document.getElementById('selectedFile') as HTMLInputElement
-                ).value = null as any;
+                if (selectedFileInputRef.current) {
+                  selectedFileInputRef.current.value = null as any;
+                }
               }}
             />
           </div>

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -309,6 +309,9 @@ describe('DatabaseModal', () => {
     });
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   afterEach(() => {
     fetchMock.restore();
   });

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -26,7 +26,6 @@ import {
   screen,
   within,
   cleanup,
-  act,
   waitFor,
 } from 'spec/helpers/testing-library';
 import { getExtensionsRegistry } from '@superset-ui/core';
@@ -321,14 +320,14 @@ describe('DatabaseModal', () => {
       }),
     );
 
-  beforeEach(async () => {
-    await renderAndWait();
+  afterEach(() => {
+    cleanup();
   });
 
-  afterEach(cleanup);
-
   describe('Visual: New database connection', () => {
-    test('renders the initial load of Step 1 correctly', () => {
+    test('renders the initial load of Step 1 correctly', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // <TabHeader> - AntD header
       const closeButton = screen.getByLabelText('Close');
@@ -420,6 +419,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the "Basic" tab of SQL Alchemy form (step 2 of 2) correctly', async () => {
+      await renderAndWait();
+
       // On step 1, click dbButton to access SQL Alchemy form
       userEvent.click(
         screen.getByRole('button', {
@@ -528,6 +529,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the unexpanded "Advanced" tab correctly', async () => {
+      await renderAndWait();
+
       // On step 1, click dbButton to access step 2
       userEvent.click(
         screen.getByRole('button', {
@@ -627,6 +630,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the "Advanced" - SQL LAB tab correctly (unexpanded)', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -789,6 +794,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the "Advanced" - PERFORMANCE tab correctly', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -852,6 +859,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the "Advanced" - SECURITY tab correctly', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -936,6 +945,8 @@ describe('DatabaseModal', () => {
     });
 
     it('renders the "Advanced" - SECURITY tab correctly after selecting Allow file uploads', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -1022,6 +1033,8 @@ describe('DatabaseModal', () => {
     });
 
     test('renders the "Advanced" - OTHER tab correctly', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -1093,6 +1106,8 @@ describe('DatabaseModal', () => {
     });
 
     test('Dynamic form', async () => {
+      await renderAndWait();
+
       // ---------- Components ----------
       // On step 1, click dbButton to access step 2
       userEvent.click(
@@ -1108,6 +1123,8 @@ describe('DatabaseModal', () => {
 
   describe('Functional: Create new database', () => {
     test('directs databases to the appropriate form (dynamic vs. SQL Alchemy)', async () => {
+      await renderAndWait();
+
       // ---------- Dynamic example (3-step form)
       // Click the PostgreSQL button to enter the dynamic form
       const postgreSQLButton = screen.getByRole('button', {
@@ -1140,6 +1157,8 @@ describe('DatabaseModal', () => {
 
     describe('SQL Alchemy form flow', () => {
       test('enters step 2 of 2 when proper database is selected', async () => {
+        await renderAndWait();
+
         userEvent.click(
           screen.getByRole('button', {
             name: /sqlite/i,
@@ -1168,6 +1187,8 @@ describe('DatabaseModal', () => {
 
       describe('step 2 component interaction', () => {
         test('properly interacts with textboxes', async () => {
+          await renderAndWait();
+
           userEvent.click(
             screen.getByRole('button', {
               name: /sqlite/i,
@@ -1212,6 +1233,8 @@ describe('DatabaseModal', () => {
 
       describe('SSH Tunnel Form interaction', () => {
         test('properly interacts with SSH Tunnel form textboxes for dynamic form', async () => {
+          await renderAndWait();
+
           userEvent.click(
             screen.getByRole('button', {
               name: /postgresql/i,
@@ -1247,6 +1270,8 @@ describe('DatabaseModal', () => {
         });
 
         test('properly interacts with SSH Tunnel form textboxes', async () => {
+          await renderAndWait();
+
           userEvent.click(
             screen.getByRole('button', {
               name: /sqlite/i,
@@ -1283,6 +1308,8 @@ describe('DatabaseModal', () => {
         });
 
         test('if the SSH Tunneling toggle is not true, no inputs are displayed', async () => {
+          await renderAndWait();
+
           userEvent.click(
             screen.getByRole('button', {
               name: /sqlite/i,
@@ -1311,6 +1338,8 @@ describe('DatabaseModal', () => {
         });
 
         test('If user changes the login method, the inputs change', async () => {
+          await renderAndWait();
+
           userEvent.click(
             screen.getByRole('button', {
               name: /sqlite/i,
@@ -1349,6 +1378,8 @@ describe('DatabaseModal', () => {
 
     describe('Dynamic form flow', () => {
       test('enters step 2 of 3 when proper database is selected', async () => {
+        await renderAndWait();
+
         expect(await screen.findByText(/step 1 of 3/i)).toBeInTheDocument();
         userEvent.click(
           screen.getByRole('button', {
@@ -1362,6 +1393,8 @@ describe('DatabaseModal', () => {
       });
 
       test('enters form credentials and runs fetchResource when "Connect" is clicked', async () => {
+        await renderAndWait();
+
         userEvent.click(
           screen.getByRole('button', {
             name: /postgresql/i,
@@ -1404,6 +1437,8 @@ describe('DatabaseModal', () => {
 
     describe('Import database flow', () => {
       test('imports a file', async () => {
+        await renderAndWait();
+
         const importDbButton = screen.getByTestId(
           'import-database-btn',
         ) as HTMLInputElement;
@@ -1424,21 +1459,15 @@ describe('DatabaseModal', () => {
   });
 
   describe('DatabaseModal w/ Deeplinking Engine', () => {
-    const renderAndWait = async () => {
-      const mounted = act(async () => {
+    const renderAndWait = async () =>
+      waitFor(() =>
         render(<DatabaseModal {...dbProps} dbEngine="PostgreSQL" />, {
           useRedux: true,
-        });
-      });
+        }),
+      );
 
-      return mounted;
-    };
-
-    beforeEach(async () => {
+    test('enters step 2 of 3 when proper database is selected', async () => {
       await renderAndWait();
-    });
-
-    test('enters step 2 of 3 when proper database is selected', () => {
       const step2of3text = screen.getByText(/step 2 of 3/i);
       expect(step2of3text).toBeInTheDocument();
     });
@@ -1451,25 +1480,22 @@ describe('DatabaseModal', () => {
         database_name: 'my database',
         sqlalchemy_uri: 'gsheets://',
       };
-      const mounted = act(async () => {
+      return waitFor(() =>
         render(<DatabaseModal {...dbProps} dbEngine="Google Sheets" />, {
           useRedux: true,
-        });
-      });
-
-      return mounted;
+        }),
+      );
     };
 
-    beforeEach(async () => {
+    it('enters step 2 of 2 when proper database is selected', async () => {
       await renderAndWait();
-    });
-
-    it('enters step 2 of 2 when proper database is selected', () => {
       const step2of2text = screen.getByText(/step 2 of 2/i);
       expect(step2of2text).toBeInTheDocument();
     });
 
     it('renders the "Advanced" - SECURITY tab without Allow File Upload Checkbox', async () => {
+      await renderAndWait();
+
       // Click the "Advanced" tab
       userEvent.click(screen.getByRole('tab', { name: /advanced/i }));
       // Click the "Security" tab
@@ -1510,6 +1536,8 @@ describe('DatabaseModal', () => {
     });
 
     it('if the SSH Tunneling toggle is not displayed, nothing should get displayed', async () => {
+      await renderAndWait();
+
       const SSHTunnelingToggle = screen.queryByTestId('ssh-tunnel-switch');
       expect(SSHTunnelingToggle).not.toBeInTheDocument();
       const SSHTunnelServerAddressInput = screen.queryByTestId(
@@ -1537,21 +1565,15 @@ describe('DatabaseModal', () => {
       useSingleViewResource: jest.fn(),
     }));
 
-    const renderAndWait = async () => {
-      const mounted = act(async () => {
+    const renderAndWait = async () =>
+      waitFor(() =>
         render(<DatabaseModal {...dbProps} dbEngine="PostgreSQL" />, {
           useRedux: true,
-        });
-      });
-
-      return mounted;
-    };
-
-    beforeEach(async () => {
-      await renderAndWait();
-    });
+        }),
+      );
 
     test('Error displays when it is an object', async () => {
+      await renderAndWait();
       const step2of3text = screen.getByText(/step 2 of 3/i);
       const errorSection = screen.getByText(/Database Creation Error/i);
       expect(step2of3text).toBeInTheDocument();
@@ -1582,21 +1604,16 @@ describe('DatabaseModal', () => {
       setResource: jest.fn(),
     });
 
-    const renderAndWait = async () => {
-      const mounted = act(async () => {
+    const renderAndWait = async () =>
+      waitFor(() =>
         render(<DatabaseModal {...dbProps} dbEngine="PostgreSQL" />, {
           useRedux: true,
-        });
-      });
-
-      return mounted;
-    };
-
-    beforeEach(async () => {
-      await renderAndWait();
-    });
+        }),
+      );
 
     test('Error displays when it is a string', async () => {
+      await renderAndWait();
+
       const step2of3text = screen.getByText(/step 2 of 3/i);
       const errorTitleMessage = screen.getByText(/Database Creation Error/i);
       const button = screen.getByText('See more');
@@ -1609,7 +1626,14 @@ describe('DatabaseModal', () => {
   });
 
   describe('DatabaseModal w Extensions', () => {
-    const renderAndWait = async () => {
+    const renderAndWait = async () =>
+      waitFor(() =>
+        render(<DatabaseModal {...dbProps} dbEngine="SQLite" />, {
+          useRedux: true,
+        }),
+      );
+
+    beforeAll(() => {
       const extensionsRegistry = getExtensionsRegistry();
 
       extensionsRegistry.set('ssh_tunnel.form.switch', () => (
@@ -1617,21 +1641,10 @@ describe('DatabaseModal', () => {
       ));
 
       setupExtensions();
-
-      const mounted = act(async () => {
-        render(<DatabaseModal {...dbProps} dbEngine="SQLite" />, {
-          useRedux: true,
-        });
-      });
-
-      return mounted;
-    };
-
-    beforeEach(async () => {
-      await renderAndWait();
     });
 
-    test('should render an extension component if one is supplied', () => {
+    test('should render an extension component if one is supplied', async () => {
+      await renderAndWait();
       expect(
         screen.getByText('ssh_tunnel.form.switch extension component'),
       ).toBeInTheDocument();

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -376,7 +376,8 @@ describe('DatabaseModal', () => {
         hidden: true,
       });
 
-      const footer = document.getElementsByClassName('ant-modal-footer');
+      const modal = screen.getByRole('dialog');
+      const footer = modal.querySelector('.ant-modal-footer');
       // ---------- TODO (lyndsiWilliams): Selector options, can't seem to get these to render properly.
 
       // renderAvailableSelector() => <Alert> - Supported databases alert
@@ -415,7 +416,7 @@ describe('DatabaseModal', () => {
         expect(component).toBeInTheDocument();
       });
       // there should be a footer but it should not have any buttons in it
-      expect(footer[0]).toBeEmptyDOMElement();
+      expect(footer).toBeEmptyDOMElement();
     });
 
     test('renders the "Basic" tab of SQL Alchemy form (step 2 of 2) correctly', async () => {

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -139,7 +139,7 @@ const SSHTunnelContainer = styled.div`
   `};
 `;
 
-interface DatabaseModalProps {
+export interface DatabaseModalProps {
   addDangerToast: (msg: string) => void;
   addSuccessToast: (msg: string) => void;
   onDatabaseAdd?: (database?: DatabaseObject) => void;

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -1335,7 +1335,7 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
   useEffect(() => {
     if (importingModal) {
       document
-        .getElementsByClassName('ant-upload-list-item-name')[0]
+        ?.getElementsByClassName('ant-upload-list-item-name')[0]
         .scrollIntoView();
     }
   }, [importingModal]);

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -622,7 +622,7 @@ test('CSV form post', async () => {
 
   // Select a file from the file dialog
   const file = new File(['test'], 'test.csv', { type: 'text' });
-  const inputElement = document.querySelector('input[type="file"]');
+  const inputElement = screen.getByTestId('model-file-input');
 
   if (inputElement) {
     userEvent.upload(inputElement as HTMLElement, file);
@@ -680,7 +680,7 @@ test('Excel form post', async () => {
 
   // Select a file from the file dialog
   const file = new File(['test'], 'test.xls', { type: 'text' });
-  const inputElement = document.querySelector('input[type="file"]');
+  const inputElement = screen.getByTestId('model-file-input');
 
   if (inputElement) {
     userEvent.upload(inputElement as HTMLElement, file);
@@ -738,7 +738,7 @@ test('Columnar form post', async () => {
 
   // Select a file from the file dialog
   const file = new File(['test'], 'test.parquet', { type: 'text' });
-  const inputElement = document.querySelector('input[type="file"]');
+  const inputElement = screen.getByTestId('model-file-input');
 
   if (inputElement) {
     userEvent.upload(inputElement as HTMLElement, file);

--- a/superset-frontend/src/features/datasets/types.ts
+++ b/superset-frontend/src/features/datasets/types.ts
@@ -1,4 +1,5 @@
-import { Currency } from '@superset-ui/core';
+import { Currency, type DatasourceType } from '@superset-ui/core';
+import { Owner } from '@superset-ui/chart-controls';
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -32,37 +33,52 @@ export type ColumnObject = {
   python_date_format?: string;
   uuid?: string;
   extra?: string;
+  certified_by?: string;
+  certification_details?: string;
+  warning_markdown?: string;
+  advanced_data_type?: string;
 };
 
 type MetricObject = {
   id: number;
+  uuid: number;
   expression?: string;
   description?: string;
   metric_name: string;
+  verbose_name?: string;
   metric_type: string;
   d3format?: string;
   currency?: Currency;
   warning_text?: string;
+  certified_by?: string;
+  certification_details?: string;
+  warning_markdown?: string;
 };
 
 export type DatasetObject = {
+  id: number;
   table_name?: string;
   sql?: string;
   filter_select_enabled?: boolean;
   fetch_values_predicate?: string;
   schema?: string;
-  description?: string;
-  main_dttm_col?: string;
+  description: string | null;
+  main_dttm_col: string;
   offset?: number;
   default_endpoint?: string;
   cache_timeout?: number;
   is_sqllab_view?: boolean;
   template_params?: string;
-  owners: number[];
+  owners: Owner[];
   columns: ColumnObject[];
   metrics: MetricObject[];
   extra?: string;
   is_managed_externally: boolean;
   normalize_columns: boolean;
   always_filter_main_dttm: boolean;
+  type: DatasourceType;
+  column_formats: Record<string, string>;
+  currency_formats: Record<string, Currency>;
+  datasource_name: string | null;
+  verbose_map: Record<string, string>;
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When changing the SQL query for virtual datasets, the user first needs to save the virtual dataset, then needs to reopen the "edit dataset" modal and manually sync the columns. This PR will introduce changes to automatically sync the columns upon saving a virtual dataset with a new SQL query.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://www.loom.com/share/b9a1121ec44b47438e2675334403ee79
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
