### PR TITLE
fix to avoid replacing charts with the Loading logo when charts are n…

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -33,6 +33,7 @@ export enum FeatureFlag {
   /** @deprecated */
   DashboardCrossFilters = 'DASHBOARD_CROSS_FILTERS',
   DashboardVirtualization = 'DASHBOARD_VIRTUALIZATION',
+  DashboardDisableLoading = 'DASHBOARD_DISABLE_LOADING',
   DashboardRbac = 'DASHBOARD_RBAC',
   DatapanelClosedByDefault = 'DATAPANEL_CLOSED_BY_DEFAULT',
   DisableLegacyDatasourceEditor = 'DISABLE_LEGACY_DATASOURCE_EDITOR',

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -301,7 +301,7 @@ class Chart extends PureComponent<ChartProps, {}> {
         {this.props.isInView ||
         !isFeatureEnabled(FeatureFlag.DashboardVirtualization) ||
         isCurrentUserBot() || 
-        isFeatureEnabled(FeatureFlag.DashboardDisableLoading)? (
+        isFeatureEnabled(FeatureFlag.DashboardDisableLoading) ? (
           <ChartRenderer
             {...this.props}
             source={this.props.dashboardId ? 'dashboard' : 'explore'}

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -300,7 +300,8 @@ class Chart extends PureComponent<ChartProps, {}> {
       <div className="slice_container" data-test="slice-container">
         {this.props.isInView ||
         !isFeatureEnabled(FeatureFlag.DashboardVirtualization) ||
-        isCurrentUserBot() ? (
+        isCurrentUserBot() || 
+        isFeatureEnabled(FeatureFlag.DashboardDisableLoading)? (
           <ChartRenderer
             {...this.props}
             source={this.props.dashboardId ? 'dashboard' : 'explore'}

--- a/superset/config.py
+++ b/superset/config.py
@@ -494,6 +494,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "ESCAPE_MARKDOWN_HTML": False,
     "DASHBOARD_CROSS_FILTERS": True,  # deprecated
     "DASHBOARD_VIRTUALIZATION": True,
+    "DASHBOARD_DISABLE_LOADING": False, # useful to avoid rerendering charts not in the current view
     # This feature flag is stil in beta and is not recommended for production use.
     "GLOBAL_ASYNC_QUERIES": False,
     "EMBEDDED_SUPERSET": False,


### PR DESCRIPTION
this is to fix issue 27532

### SUMMARY
by setting to True the following feature flag in config.py

`"DASHBOARD_DISABLE_LOADING": True`

one can avoid having charts replaced by the login icon when charts are not in the current view.
This is useful to export all the charts of a dashboard to a pdf file.

### TESTING INSTRUCTIONS
after having set the feature flag DASHBOARD_DISABLE_LOADING, see in the DOM that charts don't get replaced by the "loading" img upon scrolling the page.

Fixes #27532