### PR TITLE
chore(🦾): bump python chardet 5.1.0 -> 5.2.0

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,7 @@
 -r base.txt
 -e file:.
     # via
-    #   -r requirements/base.in
+    #   -r /private/var/folders/_q/y09bp3b946s3cxkw81tbkpsh0000gn/T/update-26dbXL/requirements/base.in
     #   -r requirements/development.in
 astroid==3.1.0
     # via pylint
@@ -26,7 +26,7 @@ cached-property==1.5.2
     # via tableschema
 cfgv==3.3.1
     # via pre-commit
-chardet==5.1.0
+chardet==5.2.0
     # via
     #   dataflows-tabulator
     #   tox


### PR DESCRIPTION
Updates the python "chardet" library version from 5.1.0 to 5.2.0. 

Generated by @supersetbot 🦾

🌳:
```
chardet
  dataflows-tabulator
    tableschema
      apache-superset
  tox
    apache-superset
```