### PR TITLE
chore(🦾): bump python numba 0.59.1 -> 0.60.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -185,7 +185,7 @@ korean-lunar-calendar==0.3.1
     # via holidays
 limits==3.12.0
     # via flask-limiter
-llvmlite==0.42.0
+llvmlite==0.43.0
     # via numba
 mako==1.3.5
     # via
@@ -215,7 +215,7 @@ msgspec==0.18.6
     # via flask-session
 nh3==0.2.17
     # via apache-superset
-numba==0.59.1
+numba==0.60.0
     # via pandas
 numexpr==2.10.0
     # via


### PR DESCRIPTION
Updates the python "numba" library version from 0.59.1 to 0.60.0. 

Generated by @supersetbot 🦾

🌳:
```
numba
  pandas
```