### PR TITLE
chore(🦾): bump python nodeenv 1.8.0 -> 1.9.1

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,7 @@
 -r base.txt
 -e file:.
     # via
-    #   -r requirements/base.in
+    #   -r /private/var/folders/_q/y09bp3b946s3cxkw81tbkpsh0000gn/T/update-KJC7ma/requirements/base.in
     #   -r requirements/development.in
 astroid==3.1.0
     # via pylint
@@ -129,7 +129,7 @@ mccabe==0.7.0
     # via pylint
 mysqlclient==2.2.4
     # via apache-superset
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pre-commit
 oauthlib==3.2.2
     # via requests-oauthlib
@@ -188,7 +188,7 @@ pyee==11.0.1
     # via playwright
 pyfakefs==5.3.5
     # via apache-superset
-pyhive[presto]==0.7.0
+pyhive[hive_pure_sasl]==0.7.0
     # via apache-superset
 pyinstrument==4.4.0
     # via apache-superset


### PR DESCRIPTION
Updates the python "nodeenv" library version from 1.8.0 to 1.9.1. 

Generated by @supersetbot 🦾

🌳:
```
nodeenv
  pre-commit
    apache-superset
```