### PR TITLE
chore(🦾): bump python fonttools 4.51.0 -> 4.55.0

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,7 @@
 -r base.txt
 -e file:.
     # via
-    #   -r requirements/base.in
+    #   -r /private/var/folders/_q/y09bp3b946s3cxkw81tbkpsh0000gn/T/update-rxMJEu/requirements/base.in
     #   -r requirements/development.in
 astroid==3.1.0
     # via pylint
@@ -58,7 +58,7 @@ flask-cors==4.0.0
     # via apache-superset
 flask-testing==0.8.1
     # via apache-superset
-fonttools==4.51.0
+fonttools==4.55.0
     # via matplotlib
 freezegun==1.5.1
     # via apache-superset


### PR DESCRIPTION
Updates the python "fonttools" library version from 4.51.0 to 4.55.0. 

Generated by @supersetbot 🦾

🌳:
```
fonttools
  matplotlib
    prophet
      apache-superset
```