### PR TITLE
fix: adjust line type as well as weight for time series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -281,7 +281,7 @@ export default function transformProps(
   const array = ensureIsArray(chartProps.rawFormData?.time_compare);
   const inverted = invert(verboseMap);
 
-  const offsetLineWidths: { [key: string]: number } = {};
+  const offsetLineWidths: string[] = [];
 
   rawSeries.forEach(entry => {
     const derivedSeries = isDerivedSeries(entry, chartProps.rawFormData);
@@ -291,11 +291,20 @@ export default function transformProps(
         entry,
         ensureIsArray(chartProps.rawFormData?.time_compare),
       )!;
-      if (!offsetLineWidths[offset]) {
-        offsetLineWidths[offset] = Object.keys(offsetLineWidths).length + 1;
+      if (!offsetLineWidths.includes(offset)) {
+        offsetLineWidths.push(offset);
+        const position = offsetLineWidths.length;
+        if (position < 5) {
+          // increase the width of the line only up to 5
+          // or it gets too thick and hard to distinguish
+          lineStyle.width = position;
+          lineStyle.type = 'dashed';
+        } else {
+          // use a combination of dash and dot for the line style
+          lineStyle.width = (position % 3) + 1;
+          lineStyle.type = [(position % 5) + 1, (position % 3) + 1];
+        }
       }
-      lineStyle.type = 'dashed';
-      lineStyle.width = offsetLineWidths[offset];
       lineStyle.opacity = OpacityEnum.DerivedSeries;
     }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -45,7 +45,6 @@ import {
   extractExtraMetrics,
   getOriginalSeries,
   isDerivedSeries,
-  getTimeOffset,
 } from '@superset-ui/chart-controls';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { LineStyleOption } from 'echarts/types/src/util/types';
@@ -281,30 +280,15 @@ export default function transformProps(
   const array = ensureIsArray(chartProps.rawFormData?.time_compare);
   const inverted = invert(verboseMap);
 
-  const offsetLineWidths: string[] = [];
+  let patternIncrement = 0;
 
   rawSeries.forEach(entry => {
     const derivedSeries = isDerivedSeries(entry, chartProps.rawFormData);
     const lineStyle: LineStyleOption = {};
     if (derivedSeries) {
-      const offset = getTimeOffset(
-        entry,
-        ensureIsArray(chartProps.rawFormData?.time_compare),
-      )!;
-      if (!offsetLineWidths.includes(offset)) {
-        offsetLineWidths.push(offset);
-        const position = offsetLineWidths.length;
-        if (position < 5) {
-          // increase the width of the line only up to 5
-          // or it gets too thick and hard to distinguish
-          lineStyle.width = position;
-          lineStyle.type = 'dashed';
-        } else {
-          // use a combination of dash and dot for the line style
-          lineStyle.width = (position % 3) + 1;
-          lineStyle.type = [(position % 5) + 1, (position % 3) + 1];
-        }
-      }
+      patternIncrement += 1;
+      // use a combination of dash and dot for the line style
+      lineStyle.type = [(patternIncrement % 5) + 1, (patternIncrement % 3) + 1];
       lineStyle.opacity = OpacityEnum.DerivedSeries;
     }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -315,15 +315,7 @@ export function transformSeries(
             opacity: opacity * areaOpacity,
           }
         : undefined,
-    emphasis: {
-      // bold on hover as required since 5.3.0 to retain backwards feature parity:
-      // https://apache.github.io/echarts-handbook/en/basics/release-note/5-3-0/#removing-the-default-bolding-emphasis-effect-in-the-line-chart
-      // TODO: should consider only adding emphasis to currently hovered series
-      lineStyle: {
-        width: 'bolder',
-      },
-      ...emphasis,
-    },
+    emphasis,
     showSymbol,
     symbolSize: markerSize,
     label: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The line thicknesses were with time adjustments were making the visualization difficult to read. Instead, I kept the existing thickness to match the legacy line chart and adjusted the dashed pattern instead. 

I also removed the line boldness on hover because on dashed lines the animation is a bit distracting. 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before: 
![image](https://github.com/user-attachments/assets/3adfd5ec-ab52-492f-aa9d-13b0679778a8)
![image](https://github.com/user-attachments/assets/0d5ba6b5-a90f-4dba-811f-ee78aa00bb94)

After: 
<img width="1181" alt="Screenshot 2025-01-17 at 4 35 39 PM" src="https://github.com/user-attachments/assets/8fd9a636-cb51-4f8e-a555-1296f2d91e60" />

<img width="1181" alt="Screenshot 2025-01-17 at 4 35 07 PM" src="https://github.com/user-attachments/assets/ac6d71be-2e23-4299-a860-feb5aa9fd4a2" />


**Hover animation:** 
Before:

https://github.com/user-attachments/assets/3eccc254-5c7f-406a-b8b7-e59c05c5e1f4

After:

https://github.com/user-attachments/assets/d7eea24c-9aed-48ef-bcc3-eada66612fe6






### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a line chart with a time comparison and add more than 5 time comparisons. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
