### PR TITLE
fix(Dashboard): Exclude edit param in async screenshot

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadScreenshot.tsx
@@ -156,7 +156,7 @@ export default function DownloadScreenshot({
         anchor,
         activeTabs,
         dataMask,
-        urlParams: getDashboardUrlParams(),
+        urlParams: getDashboardUrlParams(['edit']),
       },
     })
       .then(({ json }) => {

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -123,8 +123,13 @@ function getChartUrlParams(excludedUrlParams?: string[]): UrlParamEntries {
   return getUrlParamEntries(urlParams);
 }
 
-export function getDashboardUrlParams(): UrlParamEntries {
-  const urlParams = getUrlParams(RESERVED_DASHBOARD_URL_PARAMS);
+export function getDashboardUrlParams(
+  extraExcludedParams: string[] = [],
+): UrlParamEntries {
+  const urlParams = getUrlParams([
+    ...RESERVED_DASHBOARD_URL_PARAMS,
+    ...extraExcludedParams,
+  ]);
   const filterBoxFilters = getActiveFilters();
   if (!isEmpty(filterBoxFilters))
     urlParams.append(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR https://github.com/apache/superset/pull/30675 introduced a way to pass `urlParams` to the async dashboard screenshot generation endpoint. However, `edit` was an acceptable value which caused the system to take a screenshot in edit mode of a newly created dashboard. This PR fixes that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Create a new dashboard
2. Download the dashboard screenshot as PDF
3. The screenshot should not be showing the dashboard in edit mode

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 
- [x] Required feature flags: ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
