### PR TITLE
fix(Card): Use correct class names for Ant Design 5 Card component

### DIFF
--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -53,7 +53,7 @@ export const securityAccess = {
 export const homePage = {
   homeSection: {
     sectionArea: '.ant-collapse-content-box',
-    sectionElement: '.ant-card-meta-title',
+    sectionElement: '.antd5-card-meta-title',
   },
   sections: {
     expandedSection: '.ant-collapse-item-active',
@@ -284,7 +284,7 @@ export const chartListView = {
   },
   card: {
     card: dataTestLocator('styled-card'),
-    cardCover: '[class="ant-card-cover"]',
+    cardCover: '[class="antd5-card-cover"]',
     cardImage: '[class="gradient-container"]',
     selectedStarIcon: "[aria-label='favorite-selected']",
     unselectedStarIcon: "[aria-label='favorite-unselected']",
@@ -401,7 +401,7 @@ export const dashboardListView = {
   },
   card: {
     card: dataTestLocator('styled-card'),
-    cardCover: '[class="ant-card-cover"]',
+    cardCover: '[class="antd5-card-cover"]',
     cardImage: '[class="gradient-container"]',
     selectedStarIcon: "[aria-label='favorite-selected']",
     unselectedStarIcon: "[aria-label='favorite-unselected']",

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -74,7 +74,7 @@ export const CardStyles = styled.div`
   a {
     text-decoration: none;
   }
-  .ant-card-cover {
+  .antd5-card-cover {
     border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
     & > div {
       height: 171px;

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -101,10 +101,10 @@ const WelcomeContainer = styled.div`
       padding: 3px 21px;
     }
   }
-  .ant-card-meta-description {
+  .antd5-card-meta-description {
     margin-top: ${({ theme }) => theme.gridUnit}px;
   }
-  .ant-card.ant-card-bordered {
+  .antd5-card.ant-card-bordered {
     border: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
   }
   .ant-collapse-item .ant-collapse-content {
@@ -119,7 +119,7 @@ const WelcomeContainer = styled.div`
   }
   .loading-cards {
     margin-top: ${({ theme }) => theme.gridUnit * 8}px;
-    .ant-card-cover > div {
+    .antd5-card-cover > div {
       height: 168px;
     }
   }

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -376,7 +376,7 @@ export const CardStyles = styled.div`
   a {
     text-decoration: none;
   }
-  .ant-card-cover > div {
+  .antd5-card-cover > div {
     /* Height is calculated based on 300px width, to keep the same aspect ratio as the 800*450 thumbnails */
     height: 168px;
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR #29389 upgraded the Card component to Ant Design 5 but some class names did not make it to the upgrade causing some effects on the layout. This PR fixes that. 

### BEFORE
<img width="1495" alt="Screenshot 2024-11-18 at 17 43 08" src="https://github.com/user-attachments/assets/b2fa58ef-d97d-48a7-9561-90c21d61a2cb">


### AFTER
<img width="1493" alt="Screenshot 2024-11-18 at 16 30 44" src="https://github.com/user-attachments/assets/bc545bc1-93a3-4a07-b206-a015e08a1fc6">

### TESTING INSTRUCTIONS
1. Open the welcome page
2. Select "All" under the Charts collapsible
3. Cards should show correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
