### PR TITLE
chore: publish wheels

### DIFF
--- a/RELEASING/README.md
+++ b/RELEASING/README.md
@@ -437,7 +437,7 @@ cd ${SUPERSET_RELEASE_RC}
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements/base.txt
-pip install twine
+pip install build twine
 ```
 
 Create the distribution
@@ -455,7 +455,7 @@ cd ../
 ./scripts/translations/generate_po_files.sh
 
 # build the python distribution
-python setup.py sdist
+python -m build
 ```
 
 Publish to PyPI
@@ -466,6 +466,7 @@ an account first if you don't have one, and reference your username
 while requesting access to push packages.
 
 ```bash
+twine upload dist/apache_superset-${SUPERSET_VERSION}-py3-none-any.whl
 twine upload dist/apache-superset-${SUPERSET_VERSION}.tar.gz
 ```
 


### PR DESCRIPTION
- direct invocation of setup.py is deprecated
- publish wheels