### PR TITLE
chore(oauth2): enable user impersonation by default

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.tsx
@@ -67,6 +67,16 @@ export const OAuth2ClientField = ({ changeMethods, db }: FieldPropTypes) => {
       },
     };
     changeMethods.onEncryptedExtraInputChange(event);
+
+    // enable user impersonation if client info is provided
+    changeMethods.onParametersChange({
+      target: {
+        type: 'toggle',
+        name: 'impersonate_user',
+        checked: !!(updatedInfo.id && updatedInfo.secret),
+        value: !!(updatedInfo.id && updatedInfo.secret),
+      },
+    });
   };
 
   return (

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -430,7 +430,8 @@ const ExtraOptions = ({
               checked={!!db?.impersonate_user}
               onChange={onInputChange}
               labelText={t(
-                'Impersonate logged in user (Presto, Trino, Drill, Hive, and GSheets)',
+                'Impersonate logged in user (Presto, Trino, Drill, GSheets, StarRocks, Hive). ' +
+                  'This is needed for databases configured with OAuth2.',
               )}
             />
             <InfoTooltip


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When configuring a database, if the user provides OAuth2 client information (ID and secret) then we should automatically enable user impersonation for them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

WIP

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
