### PR TITLE
feat(sunburst): Added some options to adjust Sunburst chart view: innerRadius, outerRadius, donut, showNulls

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -28,8 +28,17 @@ import {
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
+import { NULL_STRING } from '../constants';
 
-const { labelType, numberFormat, showLabels } = DEFAULT_FORM_DATA;
+const {
+  labelType,
+  numberFormat,
+  showLabels,
+  outerRadius,
+  innerRadius,
+  donut,
+  ignoreNulls: showNulls,
+} = DEFAULT_FORM_DATA;
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -108,6 +117,8 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [<ControlSubSectionHeader>{t('Shape')}</ControlSubSectionHeader>],
+
         [
           {
             name: 'number_format',
@@ -119,6 +130,62 @@ const config: ControlPanelConfig = {
               default: numberFormat,
               choices: D3_FORMAT_OPTIONS,
               description: `${D3_FORMAT_DOCS} ${D3_NUMBER_FORMAT_DESCRIPTION_VALUES_TEXT}`,
+            },
+          },
+        ],
+        [
+          {
+            name: 'outerRadius',
+            config: {
+              type: 'SliderControl',
+              label: t('Outer Radius'),
+              renderTrigger: true,
+              min: 10,
+              max: 100,
+              step: 1,
+              default: outerRadius,
+              description: t('Outer edge of Pie chart'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'donut',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Donut'),
+              default: donut,
+              renderTrigger: true,
+              description: t('Do you want a donut or a pie?'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'innerRadius',
+            config: {
+              type: 'SliderControl',
+              label: t('Inner Radius'),
+              renderTrigger: true,
+              min: 0,
+              max: 100,
+              step: 1,
+              default: innerRadius,
+              description: t('Inner radius of donut hole'),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.donut?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'showNulls',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show %s values', NULL_STRING),
+              default: showNulls,
+              renderTrigger: true,
+              description: t('Do you want %s slices visible?', NULL_STRING),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -37,7 +37,7 @@ const {
   outerRadius,
   innerRadius,
   donut,
-  ignoreNulls: showNulls,
+  showNulls,
 } = DEFAULT_FORM_DATA;
 
 const config: ControlPanelConfig = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -187,6 +187,10 @@ export default function transformProps(
     showLabelsThreshold,
     showTotal,
     sliceId,
+    innerRadius,
+    outerRadius,
+    donut,
+    showNulls,
   } = formData;
   const { currencyFormats = {}, columnFormats = {} } = datasource;
   const refs: Refs = {};
@@ -276,48 +280,50 @@ export default function transformProps(
     path: string[],
     pathRecords?: DataRecordValue[],
   ) =>
-    treeNodes.map(treeNode => {
-      const { name: nodeName, value, secondaryValue, groupBy } = treeNode;
-      const records = [...(pathRecords || []), nodeName];
-      let name = formatSeriesName(nodeName, {
-        numberFormatter,
-        timeFormatter: getTimeFormatter(dateFormat),
-        ...(coltypeMapping[groupBy] && {
-          coltype: coltypeMapping[groupBy],
-        }),
-      });
-      const newPath = path.concat(name);
-      let item: NodeItemOption = {
-        records,
-        name,
-        value,
-        secondaryValue,
-        itemStyle: {
-          color: colorByCategory
-            ? categoricalColorScale(name, sliceId)
-            : linearColorScale(secondaryValue / value),
-        },
-      };
-      if (treeNode.children?.length) {
-        item.children = traverse(treeNode.children, newPath, records);
-      } else {
-        name = newPath.join(',');
-      }
-      columnsLabelMap.set(name, newPath);
-      if (filterState.selectedValues?.[0]?.includes(name) === false) {
-        item = {
-          ...item,
+    treeNodes
+      .map(treeNode => {
+        const { name: nodeName, value, secondaryValue, groupBy } = treeNode;
+        const records = [...(pathRecords || []), nodeName];
+        let name = formatSeriesName(nodeName, {
+          numberFormatter,
+          timeFormatter: getTimeFormatter(dateFormat),
+          ...(coltypeMapping[groupBy] && {
+            coltype: coltypeMapping[groupBy],
+          }),
+        });
+        const newPath = path.concat(name);
+        let item: NodeItemOption = {
+          records,
+          name,
+          value,
+          secondaryValue,
           itemStyle: {
-            ...item.itemStyle,
-            opacity: OpacityEnum.SemiTransparent,
-          },
-          label: {
-            color: `rgba(0, 0, 0, ${OpacityEnum.SemiTransparent})`,
+            color: colorByCategory
+              ? categoricalColorScale(name, sliceId)
+              : linearColorScale(secondaryValue / value),
           },
         };
-      }
-      return item;
-    });
+        if (treeNode.children?.length) {
+          item.children = traverse(treeNode.children, newPath, records);
+        } else {
+          name = newPath.join(',');
+        }
+        columnsLabelMap.set(name, newPath);
+        if (filterState.selectedValues?.[0]?.includes(name) === false) {
+          item = {
+            ...item,
+            itemStyle: {
+              ...item.itemStyle,
+              opacity: OpacityEnum.SemiTransparent,
+            },
+            label: {
+              color: `rgba(0, 0, 0, ${OpacityEnum.SemiTransparent})`,
+            },
+          };
+        }
+        return item;
+      })
+      .filter(x => showNulls || x.name !== NULL_STRING);
 
   const echartOptions: EChartsCoreOption = {
     grid: {
@@ -357,14 +363,14 @@ export default function transformProps(
           minAngle: minShowLabelAngle,
           overflow: 'breakAll',
         },
-        radius: [radius * 0.3, radius],
+        radius: [`${donut ? innerRadius : 0}%`, `${outerRadius}%`],
         data: traverse(treeData, []),
       },
     ],
     graphic: showTotal
       ? {
           type: 'text',
-          top: 'center',
+          top: donut ? 'center' : 'top',
           left: 'center',
           style: {
             text: t('Total: %s', primaryValueFormatter(totalValue)),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -303,11 +303,9 @@ export default function transformProps(
               : linearColorScale(secondaryValue / value),
           },
         };
-        if (treeNode.children?.length) {
+        if (treeNode.children?.length)
           item.children = traverse(treeNode.children, newPath, records);
-        } else {
-          name = newPath.join(',');
-        }
+        name = newPath.join(',');
         columnsLabelMap.set(name, newPath);
         if (filterState.selectedValues?.[0]?.includes(name) === false) {
           item = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/types.ts
@@ -52,6 +52,10 @@ export const DEFAULT_FORM_DATA: Partial<EchartsSunburstFormData> = {
   labelType: EchartsSunburstLabelType.Key,
   showLabels: false,
   dateFormat: 'smart_date',
+  innerRadius: 30,
+  outerRadius: 70,
+  donut: true,
+  showNulls: false,
 };
 
 export interface EchartsSunburstChartProps

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/types.ts
@@ -55,7 +55,7 @@ export const DEFAULT_FORM_DATA: Partial<EchartsSunburstFormData> = {
   innerRadius: 30,
   outerRadius: 70,
   donut: true,
-  showNulls: false,
+  showNulls: true,
 };
 
 export interface EchartsSunburstChartProps


### PR DESCRIPTION
### SUMMARY
Added some options to adjust Sunburst chart:

- showNulls: allow to show / hide slices with null value
- donut: allow to switch between donut / circle view (donut was fixed before)
- innerRadius: allow to adjust inner radius when donut is checked
- outerRadius: allow to adjust outer radius

### AFTER SCREENSHOT / VIDEO
![obraz](https://github.com/user-attachments/assets/fdfe8483-f036-4ce1-b298-b47c922172a9)

https://github.com/user-attachments/assets/959b022e-2f0b-4537-abc6-c66c435b6ba7



### TESTING INSTRUCTIONS

- create or edit sunburst chart
- switch to Customize control page
- play with "Donut", "Inner Radius", "Outer Radius" & "Show <NULL> values" options

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
