### PR TITLE
chore(🦾): bump python pyinstrument 4.4.0 -> 4.7.3

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,7 @@
 -r base.txt
 -e file:.
     # via
-    #   -r requirements/base.in
+    #   -r /Users/max/code/superset/requirements/base.in
     #   -r requirements/development.in
 astroid==3.1.0
     # via pylint
@@ -190,7 +190,7 @@ pyfakefs==5.3.5
     # via apache-superset
 pyhive[presto]==0.7.0
     # via apache-superset
-pyinstrument==4.4.0
+pyinstrument==4.7.3
     # via apache-superset
 pylint==3.1.0
     # via apache-superset


### PR DESCRIPTION
Updates the python "pyinstrument" library version from 4.4.0 to 4.7.3. 

Generated by @supersetbot 🦾

🌳:
```
pyinstrument
  apache-superset
```