### PR TITLE
fix(explore): verified props is not updated

### DIFF
--- a/superset-frontend/src/explore/components/controls/withAsyncVerification.tsx
+++ b/superset-frontend/src/explore/components/controls/withAsyncVerification.tsx
@@ -142,12 +142,14 @@ export default function withAsyncVerification({
     } = props;
     const otherPropsRef = useRef(restProps);
     const [verifiedProps, setVerifiedProps] = useState({});
+    const verifiedPropsRef = useRef(verifiedProps);
     const [isLoading, setIsLoading] = useState<boolean>(initialIsLoading);
     const { addWarningToast } = restProps.actions;
 
     // memoize `restProps`, so that verification only triggers when material
     // props are actually updated.
     let otherProps = otherPropsRef.current;
+    verifiedPropsRef.current = verifiedProps;
     if (hasUpdates(otherProps, restProps)) {
       otherProps = otherPropsRef.current = restProps;
     }
@@ -175,7 +177,10 @@ export default function withAsyncVerification({
             if (showLoadingState) {
               setIsLoading(false);
             }
-            if (updatedProps && hasUpdates(otherProps, updatedProps)) {
+            if (
+              updatedProps &&
+              hasUpdates(otherProps, verifiedPropsRef.current)
+            ) {
               setVerifiedProps({
                 // save isLoading in combination with other props to avoid
                 // rendering twice.


### PR DESCRIPTION
### SUMMARY
A bug occurred because the verifiedProps are modified by comparing the verify results with the existing otherProps, causing the verify results to be retained as the previous verify results when the original list resets to its original state.

This commit has been made to address this issue by ensuring that updates are made in comparison with the verified props.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![Screenshot 2024-11-20 at 5 13 19 PM](https://github.com/user-attachments/assets/b2a7f809-3938-4eeb-bb9a-03d852c5ddfd)

After:

![Screenshot 2024-11-20 at 5 13 43 PM](https://github.com/user-attachments/assets/8c5a4e1d-0ef6-41c5-a9af-26dec2ce5c6f)


### TESTING INSTRUCTIONS
locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
