### PR TITLE
chore: add unit tests for `is_mutating()`

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -901,7 +901,6 @@ on $left.Day1 == $right.Day
 @pytest.mark.parametrize(
     ("engine", "sql", "expected"),
     [
-        # SQLite tests
         ("sqlite", "SELECT 1", False),
         ("sqlite", "INSERT INTO foo VALUES (1)", True),
         ("sqlite", "UPDATE foo SET bar = 2 WHERE id = 1", True),
@@ -979,3 +978,73 @@ def test_custom_dialect(app: None) -> None:
     Test that custom dialects are loaded correctly.
     """
     assert SQLGLOT_DIALECTS.get("custom") == Dialects.MYSQL
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [
+        "ascend",
+        "awsathena",
+        "base",
+        "bigquery",
+        "clickhouse",
+        "clickhousedb",
+        "cockroachdb",
+        "couchbase",
+        "crate",
+        "databend",
+        "databricks",
+        "db2",
+        "denodo",
+        "dremio",
+        "drill",
+        "druid",
+        "duckdb",
+        "dynamodb",
+        "elasticsearch",
+        "exa",
+        "firebird",
+        "firebolt",
+        "gsheets",
+        "hana",
+        "hive",
+        "ibmi",
+        "impala",
+        "kustokql",
+        "kustosql",
+        "kylin",
+        "mariadb",
+        "motherduck",
+        "mssql",
+        "mysql",
+        "netezza",
+        "oceanbase",
+        "ocient",
+        "odelasticsearch",
+        "oracle",
+        "pinot",
+        "postgresql",
+        "presto",
+        "pydoris",
+        "redshift",
+        "risingwave",
+        "rockset",
+        "shillelagh",
+        "snowflake",
+        "solr",
+        "sqlite",
+        "starrocks",
+        "superset",
+        "teradatasql",
+        "trino",
+        "vertica",
+    ],
+)
+def test_is_mutating(engine: str) -> None:
+    """
+    Tests for `is_mutating`.
+    """
+    assert not SQLStatement(
+        "with source as ( select 1 as one ) select * from source",
+        engine=engine,
+    ).is_mutating()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add some unit tests for `is_mutating()`, starting with a regression.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
