### PR TITLE
fix(Dashboard): Ensure shared label colors are updated

### DIFF
--- a/superset-frontend/src/utils/colorScheme.ts
+++ b/superset-frontend/src/utils/colorScheme.ts
@@ -35,6 +35,7 @@ export const getColorNamespace = (namespace?: string) => namespace || undefined;
  * Get labels shared across all charts in a dashboard.
  * Merges a fresh instance of shared label colors with a stored one.
  *
+ * @param currentSharedLabels - existing shared labels to merge with fresh
  * @returns Record<string, string>
  */
 export const getFreshSharedLabels = (
@@ -74,7 +75,7 @@ export const getSharedLabelsColorMapEntries = (
  * @returns all color entries except custom label colors
  */
 export const getLabelsColorMapEntries = (
-  customLabelsColor: Record<string, string>,
+  customLabelsColor: Record<string, string> = {},
 ): Record<string, string> => {
   const labelsColorMapInstance = getLabelsColorMap();
   const allEntries = Object.fromEntries(labelsColorMapInstance.getColorMap());


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Follow-up PR for [#30646](https://github.com/apache/superset/pull/30646) to ensure that when certain dimensions or metrics are removed or no longer present in the charts, the stored `shared_label_colors` can detect these changes and reflect the current state. This is achieved by comparing all labels across all charts to infer the shared ones once a Dashboard has rendered all its charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Enter an existing Dashboard
2. Update a chart that has shared labels with other charts
3. Remove those dimensions/metrics from the chart
4. Ensure that when going back to the dashboard the dashboard is being updated with current shared label colors (by checking the network activity)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
