### PR TITLE
docs: updated the install process in pypi.mdx

### DIFF
--- a/docs/docs/installation/pypi.mdx
+++ b/docs/docs/installation/pypi.mdx
@@ -130,21 +130,22 @@ First, start by installing `apache-superset`:
 pip install apache-superset
 ```
 
+Then, define mandatory configurations, SECRET_KEY and FLASK_APP:
+```bash
+export SUPERSET_SECRET_KEY=YOUR-SECRET-KEY
+export FLASK_APP=superset
+```
+
 Then, you need to initialize the database:
 
 ```bash
 superset db upgrade
 ```
 
-:::tip
-Note that some configuration is mandatory for production instances of Superset. In particular, Superset will not start without a user-specified value of SECRET_KEY. Please see [Configuring Superset](/docs/configuration/configuring-superset).
-:::
-
 Finish installing by running through the following commands:
 
 ```bash
 # Create an admin user in your metadata database (use `admin` as username to be able to load the examples)
-export FLASK_APP=superset
 superset fab create-admin
 
 # Load some data to play with


### PR DESCRIPTION
docs: updated the install process in pipy.mdx

### SUMMARY
In order to execute the command "superset db upgrade", you first need to define the two configurations secret_key and flask_app. Before my change, the "flask_app" config was defined after "superset db upgarde", which resulted in an error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before when following the instructions in the documentation I get this error: 
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/ed0f98c3-d6ed-48aa-8377-ee849ec0a118">

### TESTING INSTRUCTIONS
Just go to the documentation page pipy.mdx

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
