### PR TITLE
fix: Hive upload to s3

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -78,15 +78,16 @@ def upload_to_s3(filename: str, upload_prefix: str, table: Table) -> str:
             "No upload bucket specified. You can specify one in the config file."
         )
 
-    s3 = boto3.client("s3")
+    s3_resource = boto3.resource("s3")
 
     # The location is merely an S3 prefix and thus we first need to ensure that there is
     # one and only one key associated with the table.
-    bucket = s3.Bucket(bucket_path)
+    bucket = s3_resource.Bucket(bucket_path)
     bucket.objects.filter(Prefix=os.path.join(upload_prefix, table.table)).delete()
 
     location = os.path.join("s3a://", bucket_path, upload_prefix, table.table)
-    s3.upload_file(
+    s3_client = boto3.client("s3")
+    s3_client.upload_file(
         filename,
         bucket_path,
         os.path.join(upload_prefix, table.table, os.path.basename(filename)),

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -544,7 +544,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             raise SupersetException("Append operation not currently supported")
 
         if to_sql_kwargs["if_exists"] == "fail":
-            if database.has_table_by_name(table.table, table.schema):
+            if database.has_table(table):
                 raise SupersetException("Table already exists")
         elif to_sql_kwargs["if_exists"] == "replace":
             with cls.get_engine(database) as engine:


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue when using the `boto3` package to upload files to S3:

```
s3 object has not attribute Bucket
```

Follow-up of https://github.com/apache/superset/pull/29164

### TESTING INSTRUCTIONS
Locally test the upload.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
