### PR TITLE
fix: try to re-enable gh-pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,6 +53,8 @@ github:
     merge: false
     rebase: false
 
+  ghp_branch:  gh-pages
+
   protected_branches:
     master:
       required_status_checks:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,6 +54,7 @@ github:
     rebase: false
 
   ghp_branch:  gh-pages
+  ghp_path: /
 
   protected_branches:
     master:


### PR DESCRIPTION
Trying to re-enable gh-pages using .asf.yml as documented here https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#github-pages

The thinking is maybe deleting the branch de-configured the pointer `gh-pages` (?) 