### PR TITLE
fix: Remove unwanted commit on Trino's handle_cursor

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -223,8 +223,6 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         if tracking_url := cls.get_tracking_url(cursor):
             query.tracking_url = tracking_url
 
-        db.session.commit()
-
         # if query cancelation was requested prior to the handle_cursor call, but
         # the query was still executed, trigger the actual query cancelation now
         if query.extra.get(QUERY_EARLY_CANCEL_KEY):


### PR DESCRIPTION
### SUMMARY
There was an unwanted commit on Trino's `handle_cursor` for updating the `tracking_url`. That was causing the following error when running queries with multiple statements:

```
Traceback (most recent call last):
  File "/srv/superset-internal/apache-superset/superset/sql_lab.py", line 302, in execute_sql_statement
    db_engine_spec.execute_with_cursor(cursor, sql, query)
  File "/srv/superset-internal/apache-superset/superset/db_engine_specs/trino.py", line 269, in execute_with_cursor
    cls.handle_cursor(cursor, query)
  File "/srv/superset-internal/apache-superset/superset/db_engine_specs/trino.py", line 195, in handle_cursor
    db.session.commit()
  File "<string>", line 2, in commit
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/orm/session.py", line 1454, in commit
    self._transaction.commit(_to_root=self.future)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/orm/session.py", line 839, in commit
    trans.commit()
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 2469, in commit
    self._do_commit()
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 2659, in _do_commit
    self._connection_commit_impl()
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 2630, in _connection_commit_impl
    self.connection._commit_impl()
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 1096, in _commit_impl
    self._handle_dbapi_exception(e, None, None, None, None)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
    util.raise_(
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 1094, in _commit_impl
    self.engine.dialect.do_commit(self.connection)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/default.py", line 686, in do_commit
    dbapi_connection.commit()
sqlalchemy.exc.OperationalError: (MySQLdb.OperationalError) (2013, 'Lost connection to MySQL server during query')
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```

Query execution is wrapped by the `transaction` decorator which should be responsible for calling `session.commit()`. This fix will provoke another less severe problem where the `tracking_url` will not be fresh. We will open a follow-up PR to fix this.

### TESTING INSTRUCTIONS
Using Trino, run a multi-statement SQL.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
