### PR TITLE
fix: helm chart deploy to open PRs to now-protected gh-pages branch

### DIFF
--- a/.github/workflows/superset-helm-lint.yml
+++ b/.github/workflows/superset-helm-lint.yml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: "Helm: lint and test charts"
 
 on:
   pull_request:

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -56,6 +56,20 @@ jobs:
           git tag --list
           git show-ref --tags
           git tag -d superset-helm-chart-0.13.4 || true
+          lookup_latest_tag() {
+            git fetch --tags >/dev/null 2>&1
+            echo "Fetched all tags."
+
+            if git describe --tags --abbrev=0 HEAD~ 2>/dev/null; then
+              echo "Latest tag found by git describe:"
+              git describe --tags --abbrev=0 HEAD~
+            else
+              echo "git describe failed. Falling back to root commit."
+              git rev-list --max-parents=0 --first-parent HEAD
+            fi
+          }
+          lookup_latest_tag()
+
 
 
       - name: Create unique pages branch name

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Add bitnami repo dependency
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
 
+      - name: Fetch/list all tags
+        run: |
+          # Debugging tags
+          git fetch --tags --force
+          git tag --list | grep helm
+
       - name: Create unique pages branch name
         id: vars
         run: echo "branch_name=helm-publish-${GITHUB_SHA:0:7}" >> $GITHUB_ENV

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -1,3 +1,7 @@
+# This workflow automates the release process for Helm charts.
+# The workflow creates a new branch for the release and opens a pull request against the 'gh-pages' branch,
+# allowing the changes to be reviewed and merged manually.
+
 name: "Helm: release charts"
 
 on:

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref_name }}
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
@@ -46,6 +46,15 @@ jobs:
       - name: Create unique pages branch name
         id: vars
         run: echo "branch_name=helm-publish-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Push changes to new branch
+        run: |
+          # Cloning gh-pages into working branch
+          git checkout gh-pages
+          git checkout -b ${{ env.branch_name }}
+
+          # Back to where we started
+          git checkout ${{ inputs.ref || github.ref_name }}
 
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -63,9 +63,8 @@ jobs:
           # Check out and reset the target branch based on gh-pages
           git checkout -B ${{ env.branch_name }} origin/gh-pages
 
-          # Apply changes
-          git add .
-          git commit -m "Release Helm charts" || echo "No changes to commit"
+          # Remove submodules from the branch
+          git submodule deinit -f --all
 
           # Force push to the remote branch
           git push origin ${{ env.branch_name }} --force

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -58,6 +58,7 @@ jobs:
           # Ensure a clean working directory
           git reset --hard
           git clean -fdx
+          git checkout -b local_gha_temp
 
           # Fetch the latest gh-pages branch
           git fetch origin gh-pages
@@ -72,9 +73,7 @@ jobs:
           git push origin ${{ env.branch_name }} --force
 
           # Return to the original branch
-          git fetch origin ${{ inputs.ref || github.ref_name }} --depth=1
-          git checkout ${{ inputs.ref || github.ref_name }}
-
+          git checkout local_gha_temp
 
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action
@@ -90,10 +89,14 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branchName = process.env.BRANCH_NAME;
+            const branchName = '${{ env.branch_name }}';
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
 
-            const pr = await github.pulls.create({
+            if (!branchName) {
+              throw new Error("Branch name is not defined.");
+            }
+
+            const pr = await github.rest.pulls.create({
               owner,
               repo,
               title: `Helm chart release for ${branchName}`,

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -99,6 +99,11 @@ jobs:
           # Return to the original branch
           git checkout local_gha_temp
 
+      - name: Fetch/list all tags
+        run: |
+          git submodule update
+          cat .github/actions/chart-releaser-action/action.yml
+
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action
         with:

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -59,6 +59,7 @@ jobs:
           git reset --hard
           git clean -fdx
           git checkout -b local_gha_temp
+          git submodule update
 
           # Fetch the latest gh-pages branch
           git fetch origin gh-pages

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref_name }}
           persist-credentials: true
           submodules: recursive
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -53,7 +53,10 @@ jobs:
         run: |
           # Debugging tags
           git fetch --tags --force
-          git tag --list | grep helm
+          git tag --list
+          git show-ref --tags
+          git tag -d superset-helm-chart-0.13.4 || true
+
 
       - name: Create unique pages branch name
         id: vars

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -71,13 +71,6 @@ jobs:
           CR_TOKEN: "${{ github.token }}"
           CR_RELEASE_NAME_TEMPLATE: "superset-helm-chart-{{ .Version }}"
 
-      - name: Push changes to new branch
-        run: |
-          git checkout -b ${{ env.branch_name }}
-          git add .
-          git commit -m "Release Helm charts"
-          git push origin ${{ env.branch_name }}
-
       - name: Open Pull Request
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -72,7 +72,7 @@ jobs:
           git push origin ${{ env.branch_name }} --force
 
           # Return to the original branch
-          git checkout ${{ github.ref_name }}
+          git checkout ${{ github.sha }}
 
 
       - name: Run chart-releaser

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -24,6 +24,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -72,7 +72,8 @@ jobs:
           git push origin ${{ env.branch_name }} --force
 
           # Return to the original branch
-          git checkout ${{ github.sha }}
+          git fetch origin ${{ inputs.ref || github.ref_name }} --depth=1
+          git checkout ${{ inputs.ref || github.ref_name }}
 
 
       - name: Run chart-releaser

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -68,7 +68,7 @@ jobs:
               git rev-list --max-parents=0 --first-parent HEAD
             fi
           }
-          lookup_latest_tag()
+          lookup_latest_tag
 
 
 

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -53,24 +53,9 @@ jobs:
         run: |
           # Debugging tags
           git fetch --tags --force
-          git tag --list
-          git show-ref --tags
           git tag -d superset-helm-chart-0.13.4 || true
-          lookup_latest_tag() {
-            git fetch --tags >/dev/null 2>&1
-            echo "Fetched all tags."
-
-            if git describe --tags --abbrev=0 HEAD~ 2>/dev/null; then
-              echo "Latest tag found by git describe:"
-              git describe --tags --abbrev=0 HEAD~
-            else
-              echo "git describe failed. Falling back to root commit."
-              git rev-list --max-parents=0 --first-parent HEAD
-            fi
-          }
-          lookup_latest_tag
-
-
+          echo "DEBUG TAGS"
+          git show-ref --tags
 
       - name: Create unique pages branch name
         id: vars

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -55,7 +55,8 @@ jobs:
         run: |
           # Cloning gh-pages into working branch
           git checkout gh-pages
-          git checkout -b ${{ env.branch_name }}
+          git checkout -B ${{ env.branch_name }}
+          git push origin ${{ env.branch_name }} -f
 
           # Back to where we started
           git checkout ${{ inputs.ref || github.ref_name }}

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref_name }}
           persist-credentials: false
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Configure Git
         run: |

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -1,4 +1,4 @@
-name: Release Charts
+name: "Helm: release charts"
 
 on:
   push:
@@ -7,17 +7,25 @@ on:
       - "[0-9].[0-9]*"
     paths:
       - "helm/**"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag, or commit SHA to check out"
+        required: false
+        default: "master"
 
 jobs:
   release:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
@@ -35,11 +43,43 @@ jobs:
       - name: Add bitnami repo dependency
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
 
+      - name: Create unique pages branch name
+        id: vars
+        run: echo "branch_name=helm-publish-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action
         with:
           charts_dir: helm
           mark_as_latest: false
+          pages_branch: ${{ env.branch_name }}
         env:
           CR_TOKEN: "${{ github.token }}"
           CR_RELEASE_NAME_TEMPLATE: "superset-helm-chart-{{ .Version }}"
+
+      - name: Push changes to new branch
+        run: |
+          git checkout -b ${{ env.branch_name }}
+          git add .
+          git commit -m "Release Helm charts"
+          git push origin ${{ env.branch_name }}
+
+      - name: Open Pull Request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = process.env.BRANCH_NAME;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+
+            const pr = await github.pulls.create({
+              owner,
+              repo,
+              title: `Helm chart release for ${branchName}`,
+              head: branchName,
+              base: "gh-pages", // Adjust if the target branch is different
+              body: `This PR releases Helm charts to the gh-pages branch.`,
+            });
+
+            core.info(`Pull request created: ${pr.data.html_url}`);
+        env:
+          BRANCH_NAME: ${{ env.branch_name }}

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action
         with:
+          version: v1.6.0
           charts_dir: helm
           mark_as_latest: false
           pages_branch: ${{ env.branch_name }}

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -51,15 +51,28 @@ jobs:
         id: vars
         run: echo "branch_name=helm-publish-${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Push changes to new branch
+      - name: Force recreate branch from gh-pages
         run: |
-          # Cloning gh-pages into working branch
-          git checkout gh-pages
-          git checkout -B ${{ env.branch_name }}
-          git push origin ${{ env.branch_name }} -f
+          # Ensure a clean working directory
+          git reset --hard
+          git clean -fdx
 
-          # Back to where we started
-          git checkout ${{ inputs.ref || github.ref_name }}
+          # Fetch the latest gh-pages branch
+          git fetch origin gh-pages
+
+          # Check out and reset the target branch based on gh-pages
+          git checkout -B ${{ env.branch_name }} origin/gh-pages
+
+          # Apply changes
+          git add .
+          git commit -m "Release Helm charts" || echo "No changes to commit"
+
+          # Force push to the remote branch
+          git push origin ${{ env.branch_name }} --force
+
+          # Return to the original branch
+          git checkout ${{ github.ref_name }}
+
 
       - name: Run chart-releaser
         uses: ./.github/actions/chart-releaser-action

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref_name }}
-          persist-credentials: false
+          persist-credentials: true
           submodules: recursive
           fetch-depth: 1
 


### PR DESCRIPTION
Cleaning up the mess I created by deleting the `gh-pages` branch by mistake while deleting hundreds of stale branches in the repo.

The changes here make it such that pushing a new helm chart version will now open a PR against the now-protected `gh-pages` branch, require a review and merge to be deployed.

Testing now with:
```
gh workflow run superset-helm-release.yml --ref helm_fix --field ref=master
```

Logs / iterations can be followed here -> https://github.com/apache/superset/actions/workflows/superset-helm-release.yml

The approach here is to:
- define a working branch `helm-publish-{SHA}`
- pull/push gh-pages onto that temp branch
- tell `chart-releaser-action` that the branch we're working with is NOT `gh-pages` (protected, can't push there), but instead is a temporary branch
- use a small script to open a PR from temp branch to gh-pages

