### PR TITLE
fix: Time-series Line Chart Display unnecessary total

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -171,6 +171,8 @@ export default function transformProps(
     stack,
     tooltipTimeFormat,
     tooltipSortByMetric,
+    showTooltipTotal,
+    showTooltipPercentage,
     truncateXAxis,
     truncateYAxis,
     xAxis: xAxisOrig,
@@ -192,7 +194,9 @@ export default function transformProps(
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
-  const labelMap = Object.entries(label_map).reduce((acc, entry) => {
+  const labelMap: { [key: string]: string[] } = Object.entries(
+    label_map,
+  ).reduce((acc, entry) => {
     if (
       entry[1].length > groupBy.length &&
       Array.isArray(timeCompare) &&
@@ -487,7 +491,9 @@ export default function transformProps(
     minorTick: { show: minorTicks },
     minInterval:
       xAxisType === AxisType.Time && timeGrainSqla
-        ? TIMEGRAIN_TO_TIMESTAMP[timeGrainSqla]
+        ? TIMEGRAIN_TO_TIMESTAMP[
+            timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+          ]
         : 0,
     ...getMinAndMaxFromBounds(
       xAxisType,
@@ -567,8 +573,9 @@ export default function transformProps(
             value.observation !== undefined ? acc + value.observation : acc,
           0,
         );
-        const showTotal = Boolean(isMultiSeries) && richTooltip && !isForecast;
-        const showPercentage = showTotal && !forcePercentFormatter;
+        const allowTotal = Boolean(isMultiSeries) && richTooltip && !isForecast;
+        const showPercentage =
+          allowTotal && !forcePercentFormatter && showTooltipPercentage;
         const keys = Object.keys(forecastValues);
         let focusedRow;
         sortedKeys
@@ -599,7 +606,7 @@ export default function transformProps(
             focusedRow = rows.length - focusedRow - 1;
           }
         }
-        if (showTotal) {
+        if (allowTotal && showTooltipTotal) {
           const totalRow = ['Total', formatter.format(total)];
           if (showPercentage) {
             totalRow.push(percentFormatter.format(1));

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -76,6 +76,8 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   stack: StackType;
   timeCompare?: string[];
   tooltipTimeFormat?: string;
+  showTooltipTotal?: boolean;
+  showTooltipPercentage?: boolean;
   truncateXAxis: boolean;
   truncateYAxis: boolean;
   yAxisFormat?: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -210,9 +210,40 @@ const tooltipSortByMetricControl: ControlSetItem = {
   },
 };
 
+const tooltipTotalControl: ControlSetItem = {
+  name: 'showTooltipTotal',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Show total'),
+    renderTrigger: true,
+    default: true,
+    description: t('Whether to display the total value in the tooltip'),
+    visibility: ({ controls, form_data }: ControlPanelsContainerProps) =>
+      Boolean(controls?.rich_tooltip?.value) &&
+      form_data.viz_type !== 'mixed_timeseries',
+  },
+};
+
+const tooltipPercentageControl: ControlSetItem = {
+  name: 'showTooltipPercentage',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Show percentage'),
+    renderTrigger: true,
+    default: true,
+    description: t('Whether to display the percentage value in the tooltip'),
+    visibility: ({ controls, form_data }: ControlPanelsContainerProps) =>
+      Boolean(controls?.rich_tooltip?.value) &&
+      !controls?.contributionMode?.value &&
+      form_data.viz_type !== 'mixed_timeseries',
+  },
+};
+
 export const richTooltipSection: ControlSetRow[] = [
   [<ControlSubSectionHeader>{t('Tooltip')}</ControlSubSectionHeader>],
   [richTooltipControl],
+  [tooltipTotalControl],
+  [tooltipPercentageControl],
   [tooltipSortByMetricControl],
   [tooltipTimeFormatControl],
 ];


### PR DESCRIPTION
### SUMMARY
This PR fixes a problem with the new tooltip for timeseries charts where the percentages and totals were always displayed and users didn't have the option to hide them. Having the ability to hide that information is important given that you might have metrics that are not percentage-friendly or you might want to simplify what's displayed.

Fixes https://github.com/apache/superset/issues/28832

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/cf13a7b9-ce0d-4955-8d86-90015910c4fa

### TESTING INSTRUCTIONS
Check the video for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
