### PR TITLE
fix: check for column before adding in migrations

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -21,6 +21,7 @@ from collections.abc import Iterator
 from typing import Any, Callable, Optional, Union
 from uuid import uuid4
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import inspect
 from sqlalchemy.dialects.mysql.base import MySQLDialect
@@ -182,3 +183,17 @@ def has_table(table_name: str) -> bool:
     table_exists = insp.has_table(table_name)
 
     return table_exists
+
+
+def add_column_if_not_exists(table_name: str, column: sa.Column) -> None:
+    """
+    Adds a column to a table if it does not already exist.
+
+    :param table_name: Name of the table.
+    :param column: SQLAlchemy Column object.
+    """
+    if not table_has_column(table_name, column.name):
+        print(f"Adding column '{column.name}' to table '{table_name}'.\n")
+        op.add_column(table_name, column)
+    else:
+        print(f"Column '{column.name}' already exists in table '{table_name}'.\n")

--- a/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
+++ b/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
@@ -24,7 +24,7 @@ Create Date: 2024-04-01 22:44:40.386543
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.utils import table_has_column
+from superset.migrations.shared.utils import add_column_if_not_exists
 
 # revision identifiers, used by Alembic.
 revision = "c22cb5c2e546"
@@ -32,11 +32,10 @@ down_revision = "678eefb4ab44"
 
 
 def upgrade():
-    if not table_has_column("user_attribute", "avatar_url"):
-        op.add_column(
-            "user_attribute",
-            sa.Column("avatar_url", sa.String(length=100), nullable=True),
-        )
+    add_column_if_not_exists(
+        "user_attribute",
+        sa.Column("avatar_url", sa.String(length=100), nullable=True),
+    )
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
+++ b/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
@@ -24,15 +24,19 @@ Create Date: 2024-04-01 22:44:40.386543
 import sqlalchemy as sa
 from alembic import op
 
+from superset.migrations.shared.utils import table_has_column
+
 # revision identifiers, used by Alembic.
 revision = "c22cb5c2e546"
 down_revision = "678eefb4ab44"
 
 
 def upgrade():
-    op.add_column(
-        "user_attribute", sa.Column("avatar_url", sa.String(length=100), nullable=True)
-    )
+    if not table_has_column("user_attribute", "avatar_url"):
+        op.add_column(
+            "user_attribute",
+            sa.Column("avatar_url", sa.String(length=100), nullable=True),
+        )
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -25,7 +25,7 @@ Create Date: 2024-04-11 15:41:34.663989
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.utils import table_has_column
+from superset.migrations.shared.utils import add_column_if_not_exists
 
 # revision identifiers, used by Alembic.
 revision = "5f57af97bc3f"
@@ -36,11 +36,10 @@ tables = ["tables", "query", "saved_query", "tab_state", "table_schema"]
 
 def upgrade():
     for table in tables:
-        if not table_has_column(table, "catalog"):
-            op.add_column(
-                table,
-                sa.Column("catalog", sa.String(length=256), nullable=True),
-            )
+        add_column_if_not_exists(
+            table,
+            sa.Column("catalog", sa.String(length=256), nullable=True),
+        )
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -25,6 +25,8 @@ Create Date: 2024-04-11 15:41:34.663989
 import sqlalchemy as sa
 from alembic import op
 
+from superset.migrations.shared.utils import table_has_column
+
 # revision identifiers, used by Alembic.
 revision = "5f57af97bc3f"
 down_revision = "d60591c5515f"
@@ -34,10 +36,11 @@ tables = ["tables", "query", "saved_query", "tab_state", "table_schema"]
 
 def upgrade():
     for table in tables:
-        op.add_column(
-            table,
-            sa.Column("catalog", sa.String(length=256), nullable=True),
-        )
+        if not table_has_column(table, "catalog"):
+            op.add_column(
+                table,
+                sa.Column("catalog", sa.String(length=256), nullable=True),
+            )
 
 
 def downgrade():

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -29,6 +29,7 @@ from superset.migrations.shared.catalogs import (
     downgrade_catalog_perms,
     upgrade_catalog_perms,
 )
+from superset.migrations.shared.utils import table_has_column
 
 # revision identifiers, used by Alembic.
 revision = "58d051681a3b"
@@ -36,14 +37,16 @@ down_revision = "4a33124c18ad"
 
 
 def upgrade():
-    op.add_column(
-        "tables",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-    )
-    op.add_column(
-        "slices",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-    )
+    if not table_has_column("tables", "catalog_perm"):
+        op.add_column(
+            "tables",
+            sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+        )
+    if not table_has_column("slices", "catalog_perm"):
+        op.add_column(
+            "slices",
+            sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+        )
     upgrade_catalog_perms(engines={"postgresql"})
 
 

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -29,7 +29,7 @@ from superset.migrations.shared.catalogs import (
     downgrade_catalog_perms,
     upgrade_catalog_perms,
 )
-from superset.migrations.shared.utils import table_has_column
+from superset.migrations.shared.utils import add_column_if_not_exists
 
 # revision identifiers, used by Alembic.
 revision = "58d051681a3b"
@@ -37,16 +37,14 @@ down_revision = "4a33124c18ad"
 
 
 def upgrade():
-    if not table_has_column("tables", "catalog_perm"):
-        op.add_column(
-            "tables",
-            sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-        )
-    if not table_has_column("slices", "catalog_perm"):
-        op.add_column(
-            "slices",
-            sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
-        )
+    add_column_if_not_exists(
+        "tables",
+        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+    )
+    add_column_if_not_exists(
+        "slices",
+        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+    )
     upgrade_catalog_perms(engines={"postgresql"})
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pr will add checks to some migration scripts to check if the column already exists in the table before trying to create it.

Fixes: https://github.com/apache/superset/issues/31144
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
