### PR TITLE
fix(embedded): Hide anchor links in embedded mode

### DIFF
--- a/superset-frontend/src/dashboard/components/AnchorLink/index.tsx
+++ b/superset-frontend/src/dashboard/components/AnchorLink/index.tsx
@@ -64,7 +64,7 @@ export default function AnchorLink({
   }, [id, scrollIntoView]);
 
   return (
-    <span className="anchor-link-container" id={id}>
+    <span className="anchor-link-container" id={id} data-test="anchor-link">
       {showShortLinkButton && dashboardId && (
         <URLShortLinkButton
           anchorLinkId={id}

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   parentComponent: componentShape.isRequired,
   index: PropTypes.number.isRequired,
   editMode: PropTypes.bool.isRequired,
+  embeddedMode: PropTypes.bool.isRequired,
 
   // redux
   handleComponentDrop: PropTypes.func.isRequired,
@@ -166,6 +167,7 @@ class Header extends PureComponent {
       index,
       handleComponentDrop,
       editMode,
+      embeddedMode,
     } = this.props;
 
     const headerStyle = headerStyleOptions.find(
@@ -234,7 +236,7 @@ class Header extends PureComponent {
                   onSaveTitle={this.handleChangeText}
                   showTooltip={false}
                 />
-                {!editMode && (
+                {!editMode && !embeddedMode &&(
                   <AnchorLink id={component.id} dashboardId={dashboardId} />
                 )}
               </HeaderStyles>

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
@@ -236,7 +236,7 @@ class Header extends PureComponent {
                   onSaveTitle={this.handleChangeText}
                   showTooltip={false}
                 />
-                {!editMode && !embeddedMode &&(
+                {!editMode && !embeddedMode && (
                   <AnchorLink id={component.id} dashboardId={dashboardId} />
                 )}
               </HeaderStyles>

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.test.jsx
@@ -45,6 +45,7 @@ describe('Header', () => {
     parentComponent: newComponentFactory(DASHBOARD_GRID_TYPE),
     index: 0,
     editMode: false,
+    embeddedMode: false,
     filters: {},
     handleComponentDrop() {},
     deleteComponent() {},
@@ -118,4 +119,19 @@ describe('Header', () => {
 
     expect(deleteComponent.callCount).toBe(1);
   });
+
+  it('should render the AnchorLink in view mode', () => {
+    const wrapper = setup();
+    expect(wrapper.find('AnchorLink')).toExist();
+  });
+
+  it('should not render the AnchorLink in edit mode', () => {
+    const wrapper = setup({ editMode: true });
+    expect(wrapper.find('AnchorLink')).not.toExist();
+  });
+
+  it('should not render the AnchorLink in embedded mode', () => {
+    const wrapper = setup({ embeddedMode: true });
+    expect(wrapper.find('AnchorLink')).not.toExist();
+  })
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.test.jsx
@@ -133,5 +133,5 @@ describe('Header', () => {
   it('should not render the AnchorLink in embedded mode', () => {
     const wrapper = setup({ embeddedMode: true });
     expect(wrapper.find('AnchorLink')).not.toExist();
-  })
+  });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -52,6 +52,7 @@ const propTypes = {
   onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
   canEdit: PropTypes.bool.isRequired,
+  embeddedMode: PropTypes.bool,
 
   // grid related
   availableColumnCount: PropTypes.number,
@@ -282,6 +283,7 @@ class Tab extends PureComponent {
       isHighlighted,
       onDropPositionChange,
       onDragTab,
+      embeddedMode,
     } = this.props;
 
     return (
@@ -313,7 +315,7 @@ class Tab extends PureComponent {
               showTooltip={false}
               editing={editMode && isFocused}
             />
-            {!editMode && (
+            {!editMode && !embeddedMode && (
               <AnchorLink
                 id={component.id}
                 dashboardId={this.props.dashboardId}

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
@@ -409,12 +409,12 @@ test('Render tab content with no children, editMode: true, canEdit: true', () =>
 test('AnchorLink renders in view mode', () => {
   const props = createProps();
   props.renderType = 'RENDER_TAB';
-  
+
   render(<Tab {...props} />, {
     useRedux: true,
     useDnd: true,
   });
-  
+
   expect(screen.queryByTestId('anchor-link')).toBeInTheDocument();
 });
 
@@ -422,12 +422,12 @@ test('AnchorLink does not render in edit mode', () => {
   const props = createProps();
   props.editMode = true;
   props.renderType = 'RENDER_TAB';
-  
+
   render(<Tab {...props} />, {
     useRedux: true,
     useDnd: true,
   });
-  
+
   expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
 });
 
@@ -435,11 +435,11 @@ test('AnchorLink does not render in embedded mode', () => {
   const props = createProps();
   props.embeddedMode = true;
   props.renderType = 'RENDER_TAB';
-  
+
   render(<Tab {...props} />, {
     useRedux: true,
     useDnd: true,
   });
-  
+
   expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.test.tsx
@@ -90,6 +90,7 @@ const createProps = () => ({
     type: 'TABS',
   },
   editMode: false,
+  embeddedMode: false,
   undoLength: 0,
   redoLength: 0,
   filters: {},
@@ -403,4 +404,42 @@ test('Render tab content with no children, editMode: true, canEdit: true', () =>
   expect(
     screen.getByRole('link', { name: 'create a new chart' }),
   ).toHaveAttribute('href', '/chart/add?dashboard_id=23');
+});
+
+test('AnchorLink renders in view mode', () => {
+  const props = createProps();
+  props.renderType = 'RENDER_TAB';
+  
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+  });
+  
+  expect(screen.queryByTestId('anchor-link')).toBeInTheDocument();
+});
+
+test('AnchorLink does not render in edit mode', () => {
+  const props = createProps();
+  props.editMode = true;
+  props.renderType = 'RENDER_TAB';
+  
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+  });
+  
+  expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
+});
+
+test('AnchorLink does not render in embedded mode', () => {
+  const props = createProps();
+  props.embeddedMode = true;
+  props.renderType = 'RENDER_TAB';
+  
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+  });
+  
+  expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -80,6 +80,7 @@ function mapStateToProps(
     dashboardId: dashboardInfo.id,
     dashboardInfo,
     fullSizeChartId: dashboardState.fullSizeChartId,
+    embeddedMode: !dashboardInfo?.userId,
   };
 
   // rows and columns need more data about their child dimensions


### PR DESCRIPTION
### SUMMARY
The `Tab` and `Header` UI elements in the dashboard have an `AnchorLink`. These are currently visible in embedded mode. Embedded users are external that don't have access to the instance directly, so these links should not be visible.

This PR hides `AnchorLinks` in embedded mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
![image](https://github.com/user-attachments/assets/7bf7fa68-1b67-4693-a481-5fd59e526ebe)

**After**
![image](https://github.com/user-attachments/assets/0848a87f-9eb0-4f58-83cf-d246326a9583)


### TESTING INSTRUCTIONS
Tests added. For manual testing:
1. Create a dashboard containing at least a header and a tab.
2. Load this dashboard in embedded mode.
3. Validate the `AnchorLinks` are not visible.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
