### PR TITLE
chore(legacy-plugin-chart-map-box / legacy-preset-deckgl): Bump react-map-gl to v7

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -7495,6 +7495,37 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "license": "MIT"
+    },
     "node_modules/@math.gl/core": {
       "version": "3.5.3",
       "license": "MIT",
@@ -17051,7 +17082,6 @@
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17324,7 +17354,6 @@
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18697,6 +18726,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
       }
     },
     "node_modules/cacache": {
@@ -25560,7 +25608,6 @@
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -27352,7 +27399,6 @@
     },
     "node_modules/get-value": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29867,7 +29913,6 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -30113,7 +30158,6 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -46151,6 +46195,7 @@
     "node_modules/react-map-gl": {
       "version": "6.1.19",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@types/geojson": "^7946.0.7",
@@ -46172,6 +46217,7 @@
     "node_modules/react-map-gl/node_modules/viewport-mercator-project": {
       "version": "7.0.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/web-mercator": "^3.5.5"
       }
@@ -49295,7 +49341,6 @@
     },
     "node_modules/set-value": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -49831,6 +49876,24 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -49841,6 +49904,23 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sort-object-keys": {
@@ -50216,7 +50296,6 @@
     },
     "node_modules/split-string": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.0"
@@ -50227,7 +50306,6 @@
     },
     "node_modules/split-string/node_modules/extend-shallow": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assign-symbols": "^1.0.0",
@@ -50239,7 +50317,6 @@
     },
     "node_modules/split-string/node_modules/is-extendable": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
@@ -52227,6 +52304,21 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/ua-parser-js": {
       "version": "0.7.33",
       "funding": [
@@ -52397,7 +52489,6 @@
     },
     "node_modules/union-value": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
@@ -57945,14 +58036,14 @@
       "dependencies": {
         "@math.gl/web-mercator": "^4.1.0",
         "prop-types": "^15.8.1",
-        "react-map-gl": "^6.1.19",
+        "react-map-gl": "^7.1.7",
         "supercluster": "^8.0.1"
       },
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^15 || ^16"
+        "react": "*"
       }
     },
     "plugins/legacy-plugin-chart-map-box/node_modules/@math.gl/core": {
@@ -57983,6 +58074,30 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+    },
+    "plugins/legacy-plugin-chart-map-box/node_modules/react-map-gl": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.7.tgz",
+      "integrity": "sha512-mwjc0obkBJOXCcoXQr3VoLqmqwo9vS4bXfbGsdxXzEgVCv/PM0v+1QggL7W0d/ccIy+VCjbXNlGij+PENz6VNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1",
+        "@types/mapbox-gl": ">=1.0.0"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
     },
     "plugins/legacy-plugin-chart-map-box/node_modules/supercluster": {
       "version": "8.0.1",
@@ -58115,7 +58230,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/geojson-extent": "^1.0.1",
-        "@math.gl/web-mercator": "^3.2.2",
+        "@math.gl/web-mercator": "^4.1.0",
         "@types/d3-array": "^2.0.0",
         "bootstrap-slider": "^11.0.2",
         "d3-array": "^1.2.4",
@@ -58140,9 +58255,9 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
-        "react-map-gl": "^6.1.19"
+        "react": "*",
+        "react-dom": "*",
+        "react-map-gl": "*"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers": {
@@ -58159,6 +58274,16 @@
         "@deck.gl/core": "^8.0.0",
         "@deck.gl/layers": "^8.0.0",
         "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto": {
@@ -58189,6 +58314,16 @@
         "@deck.gl/geo-layers": "^8.0.0",
         "@deck.gl/layers": "^8.0.0",
         "@loaders.gl/core": "^3.4.2"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto/node_modules/d3-array": {
@@ -58250,6 +58385,16 @@
         "mjolnir.js": "^2.7.0"
       }
     },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/core/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
+      }
+    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/extensions": {
       "version": "8.9.22",
       "license": "MIT",
@@ -58297,6 +58442,16 @@
         "@luma.gl/core": "^8.0.0"
       }
     },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/geo-layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
+      }
+    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/google-maps": {
       "version": "8.9.22",
       "license": "MIT",
@@ -58340,6 +58495,16 @@
         "@deck.gl/core": "^8.0.0",
         "@loaders.gl/core": "^3.4.2",
         "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/mapbox": {
@@ -58389,6 +58554,30 @@
         "@math.gl/types": "3.6.3",
         "gl-matrix": "^3.4.0"
       }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+      "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator/node_modules/@math.gl/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator/node_modules/@math.gl/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==",
+      "license": "MIT"
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@types/mapbox__geojson-extent": {
       "version": "1.0.3",
@@ -63675,6 +63864,31 @@
     "@mapbox/whoots-js": {
       "version": "3.1.0"
     },
+    "@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "requires": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "dependencies": {
+        "@mapbox/unitbezier": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+          "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="
+        },
+        "json-stringify-pretty-compact": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+          "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+        }
+      }
+    },
     "@math.gl/core": {
       "version": "3.5.3",
       "requires": {
@@ -68684,7 +68898,7 @@
       "requires": {
         "@math.gl/web-mercator": "^4.1.0",
         "prop-types": "^15.8.1",
-        "react-map-gl": "^6.1.19",
+        "react-map-gl": "^7.1.7",
         "supercluster": "^8.0.1"
       },
       "dependencies": {
@@ -68713,6 +68927,15 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
           "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+        },
+        "react-map-gl": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.7.tgz",
+          "integrity": "sha512-mwjc0obkBJOXCcoXQr3VoLqmqwo9vS4bXfbGsdxXzEgVCv/PM0v+1QggL7W0d/ccIy+VCjbXNlGij+PENz6VNg==",
+          "requires": {
+            "@maplibre/maplibre-gl-style-spec": "^19.2.1",
+            "@types/mapbox-gl": ">=1.0.0"
+          }
         },
         "supercluster": {
           "version": "8.0.1",
@@ -68861,7 +69084,7 @@
       "version": "file:plugins/legacy-preset-chart-deckgl",
       "requires": {
         "@mapbox/geojson-extent": "^1.0.1",
-        "@math.gl/web-mercator": "^3.2.2",
+        "@math.gl/web-mercator": "^4.1.0",
         "@types/d3-array": "^2.0.0",
         "@types/mapbox__geojson-extent": "^1.0.3",
         "@types/underscore": "^1.11.15",
@@ -68889,6 +69112,17 @@
             "@luma.gl/shadertools": "^8.5.20",
             "@math.gl/web-mercator": "^3.6.2",
             "d3-hexbin": "^0.2.1"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/carto": {
@@ -68912,6 +69146,15 @@
             "quadbin": "^0.1.9"
           },
           "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            },
             "d3-array": {
               "version": "3.2.4",
               "requires": {
@@ -68954,6 +69197,17 @@
             "gl-matrix": "^3.0.0",
             "math.gl": "^3.6.2",
             "mjolnir.js": "^2.7.0"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/extensions": {
@@ -68983,6 +69237,17 @@
             "@types/geojson": "^7946.0.8",
             "h3-js": "^3.7.0",
             "long": "^3.2.0"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/google-maps": {
@@ -69011,6 +69276,17 @@
             "@math.gl/polygon": "^3.6.2",
             "@math.gl/web-mercator": "^3.6.2",
             "earcut": "^2.2.4"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/mapbox": {
@@ -69042,6 +69318,29 @@
             "@babel/runtime": "^7.12.0",
             "@math.gl/types": "3.6.3",
             "gl-matrix": "^3.4.0"
+          }
+        },
+        "@math.gl/web-mercator": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+          "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+          "requires": {
+            "@math.gl/core": "4.1.0"
+          },
+          "dependencies": {
+            "@math.gl/core": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+              "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+              "requires": {
+                "@math.gl/types": "4.1.0"
+              }
+            },
+            "@math.gl/types": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+              "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="
+            }
           }
         },
         "@types/mapbox__geojson-extent": {
@@ -72524,8 +72823,7 @@
       "dev": true
     },
     "arr-union": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "array-buffer-byte-length": {
       "version": "1.0.1",
@@ -72703,8 +73001,7 @@
       "dev": true
     },
     "assign-symbols": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "ast-types": {
       "version": "0.16.1",
@@ -73633,6 +73930,23 @@
     "bytes": {
       "version": "3.0.0",
       "dev": true
+    },
+    "bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "requires": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "requires": {
+        "typewise-core": "^1.2"
+      }
     },
     "cacache": {
       "version": "18.0.4",
@@ -78185,7 +78499,6 @@
     },
     "extend-shallow": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -79375,8 +79688,7 @@
       }
     },
     "get-value": {
-      "version": "2.0.6",
-      "dev": true
+      "version": "2.0.6"
     },
     "getos": {
       "version": "3.2.1",
@@ -80983,8 +81295,7 @@
       "version": "2.2.2"
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "is-extglob": {
       "version": "2.1.1"
@@ -81122,7 +81433,6 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -90939,6 +91249,7 @@
     },
     "react-map-gl": {
       "version": "6.1.19",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@types/geojson": "^7946.0.7",
@@ -90952,6 +91263,7 @@
       "dependencies": {
         "viewport-mercator-project": {
           "version": "7.0.4",
+          "peer": true,
           "requires": {
             "@math.gl/web-mercator": "^3.5.5"
           }
@@ -92952,7 +93264,6 @@
     },
     "set-value": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -93331,6 +93642,16 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA=="
+    },
+    "sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w=="
+    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -93338,6 +93659,19 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "requires": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
       }
     },
     "sort-object-keys": {
@@ -93589,14 +93923,12 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       },
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
-          "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -93604,7 +93936,6 @@
         },
         "is-extendable": {
           "version": "1.0.1",
-          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -94906,6 +95237,19 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
+    "typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "requires": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg=="
+    },
     "ua-parser-js": {
       "version": "0.7.33"
     },
@@ -94996,7 +95340,6 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/package.json
@@ -28,14 +28,14 @@
   "dependencies": {
     "@math.gl/web-mercator": "^4.1.0",
     "prop-types": "^15.8.1",
-    "react-map-gl": "^6.1.19",
+    "react-map-gl": "^7.1.7",
     "supercluster": "^8.0.1"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "mapbox-gl": "*",
-    "react": "^15 || ^16"
+    "react": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/src/MapBox.jsx
@@ -125,7 +125,7 @@ class MapBox extends Component {
         mapStyle={mapStyle}
         width={width}
         height={height}
-        mapboxApiAccessToken={mapboxApiKey}
+        mapboxAccessToken={mapboxApiKey}
         onViewportChange={this.handleViewportChange}
         preserveDrawingBuffer
       >

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@mapbox/geojson-extent": "^1.0.1",
-    "@math.gl/web-mercator": "^3.2.2",
+    "@math.gl/web-mercator": "^4.1.0",
     "@types/d3-array": "^2.0.0",
     "bootstrap-slider": "^11.0.2",
     "d3-array": "^1.2.4",
@@ -50,9 +50,9 @@
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "mapbox-gl": "*",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-map-gl": "^6.1.19"
+    "react": "*",
+    "react-dom": "*",
+    "react-map-gl": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -222,7 +222,7 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
         layers={getLayers()}
         setControlValue={props.setControlValue}
         mapStyle={props.formData.mapbox_style}
-        mapboxApiAccessToken={props.mapboxApiKey}
+        mapboxAccessToken={props.mapboxApiKey}
         width={props.width}
         height={props.height}
       />

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/DeckGLContainer.tsx
@@ -43,7 +43,7 @@ export type DeckGLContainerProps = {
   viewport: Viewport;
   setControlValue?: (control: string, value: JsonValue) => void;
   mapStyle?: string;
-  mapboxApiAccessToken: string;
+  mapboxAccessToken: string;
   children?: ReactNode;
   width: number;
   height: number;
@@ -118,7 +118,7 @@ export const DeckGLContainer = memo(
             <StaticMap
               preserveDrawingBuffer
               mapStyle={props.mapStyle || 'light'}
-              mapboxApiAccessToken={props.mapboxApiAccessToken}
+              mapboxAccessToken={props.mapboxAccessToken}
             />
           </DeckGL>
           {children}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -134,7 +134,7 @@ const DeckMulti = (props: DeckMultiProps) => {
   return (
     <DeckGLContainerStyledWrapper
       ref={containerRef}
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
+      mapboxAccessToken={payload.data.mapboxApiKey}
       viewport={viewport || props.viewport}
       layers={layers}
       mapStyle={formData.mapbox_style}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/factory.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/factory.tsx
@@ -114,7 +114,7 @@ export function createDeckGLComponent(
     return (
       <DeckGLContainerStyledWrapper
         ref={containerRef}
-        mapboxApiAccessToken={payload.data.mapboxApiKey}
+        mapboxAccessToken={payload.data.mapboxApiKey}
         viewport={viewport}
         layers={[layer]}
         mapStyle={formData.mapbox_style}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Geojson/Geojson.tsx
@@ -213,7 +213,7 @@ const DeckGLGeoJson = (props: DeckGLGeoJsonProps) => {
   return (
     <DeckGLContainerStyledWrapper
       ref={containerRef}
-      mapboxApiAccessToken={payload.data.mapboxApiKey}
+      mapboxAccessToken={payload.data.mapboxApiKey}
       viewport={viewport}
       layers={[layer]}
       mapStyle={formData.mapbox_style}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
@@ -287,7 +287,7 @@ const DeckGLPolygon = (props: DeckGLPolygonProps) => {
         layers={getLayers()}
         setControlValue={setControlValue}
         mapStyle={formData.mapbox_style}
-        mapboxApiAccessToken={payload.data.mapboxApiKey}
+        mapboxAccessToken={payload.data.mapboxApiKey}
         width={props.width}
         height={props.height}
       />

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Screengrid/Screengrid.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Screengrid/Screengrid.tsx
@@ -150,7 +150,7 @@ const DeckGLScreenGrid = (props: DeckGLScreenGridProps) => {
         layers={getLayers()}
         setControlValue={setControlValue}
         mapStyle={formData.mapbox_style}
-        mapboxApiAccessToken={payload.data.mapboxApiKey}
+        mapboxAccessToken={payload.data.mapboxApiKey}
         width={props.width}
         height={props.height}
       />


### PR DESCRIPTION
Part of https://github.com/apache/superset/issues/30307

Upgrading the react-map-gl to v7, which is agnostic for maplibre/mapbox
Bumping the web-mercator of deckgl preset, so it's the same version as mapbox plugin.


