### PR TITLE
chore(legacy-preset-deckgl): bump web-mercator in

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -58115,7 +58115,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/geojson-extent": "^1.0.1",
-        "@math.gl/web-mercator": "^3.2.2",
+        "@math.gl/web-mercator": "^4.1.0",
         "@types/d3-array": "^2.0.0",
         "bootstrap-slider": "^11.0.2",
         "d3-array": "^1.2.4",
@@ -58161,6 +58161,16 @@
         "@luma.gl/core": "^8.0.0"
       }
     },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
+      }
+    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto": {
       "version": "8.9.22",
       "license": "MIT",
@@ -58189,6 +58199,16 @@
         "@deck.gl/geo-layers": "^8.0.0",
         "@deck.gl/layers": "^8.0.0",
         "@loaders.gl/core": "^3.4.2"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/carto/node_modules/d3-array": {
@@ -58250,6 +58270,16 @@
         "mjolnir.js": "^2.7.0"
       }
     },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/core/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
+      }
+    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/extensions": {
       "version": "8.9.22",
       "license": "MIT",
@@ -58297,6 +58327,16 @@
         "@luma.gl/core": "^8.0.0"
       }
     },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/geo-layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
+      }
+    },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/google-maps": {
       "version": "8.9.22",
       "license": "MIT",
@@ -58340,6 +58380,16 @@
         "@deck.gl/core": "^8.0.0",
         "@loaders.gl/core": "^3.4.2",
         "@luma.gl/core": "^8.0.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/layers/node_modules/@math.gl/web-mercator": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "gl-matrix": "^3.4.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/mapbox": {
@@ -58389,6 +58439,30 @@
         "@math.gl/types": "3.6.3",
         "gl-matrix": "^3.4.0"
       }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+      "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator/node_modules/@math.gl/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "plugins/legacy-preset-chart-deckgl/node_modules/@math.gl/web-mercator/node_modules/@math.gl/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==",
+      "license": "MIT"
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/@types/mapbox__geojson-extent": {
       "version": "1.0.3",
@@ -68861,7 +68935,7 @@
       "version": "file:plugins/legacy-preset-chart-deckgl",
       "requires": {
         "@mapbox/geojson-extent": "^1.0.1",
-        "@math.gl/web-mercator": "^3.2.2",
+        "@math.gl/web-mercator": "^4.1.0",
         "@types/d3-array": "^2.0.0",
         "@types/mapbox__geojson-extent": "^1.0.3",
         "@types/underscore": "^1.11.15",
@@ -68889,6 +68963,17 @@
             "@luma.gl/shadertools": "^8.5.20",
             "@math.gl/web-mercator": "^3.6.2",
             "d3-hexbin": "^0.2.1"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/carto": {
@@ -68912,6 +68997,15 @@
             "quadbin": "^0.1.9"
           },
           "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            },
             "d3-array": {
               "version": "3.2.4",
               "requires": {
@@ -68954,6 +69048,17 @@
             "gl-matrix": "^3.0.0",
             "math.gl": "^3.6.2",
             "mjolnir.js": "^2.7.0"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/extensions": {
@@ -68983,6 +69088,17 @@
             "@types/geojson": "^7946.0.8",
             "h3-js": "^3.7.0",
             "long": "^3.2.0"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/google-maps": {
@@ -69011,6 +69127,17 @@
             "@math.gl/polygon": "^3.6.2",
             "@math.gl/web-mercator": "^3.6.2",
             "earcut": "^2.2.4"
+          },
+          "dependencies": {
+            "@math.gl/web-mercator": {
+              "version": "3.6.3",
+              "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
+              "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
+              "requires": {
+                "@babel/runtime": "^7.12.0",
+                "gl-matrix": "^3.4.0"
+              }
+            }
           }
         },
         "@deck.gl/mapbox": {
@@ -69042,6 +69169,29 @@
             "@babel/runtime": "^7.12.0",
             "@math.gl/types": "3.6.3",
             "gl-matrix": "^3.4.0"
+          }
+        },
+        "@math.gl/web-mercator": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.1.0.tgz",
+          "integrity": "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==",
+          "requires": {
+            "@math.gl/core": "4.1.0"
+          },
+          "dependencies": {
+            "@math.gl/core": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+              "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+              "requires": {
+                "@math.gl/types": "4.1.0"
+              }
+            },
+            "@math.gl/types": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+              "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="
+            }
           }
         },
         "@types/mapbox__geojson-extent": {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@mapbox/geojson-extent": "^1.0.1",
-    "@math.gl/web-mercator": "^3.2.2",
+    "@math.gl/web-mercator": "^4.1.0",
     "@types/d3-array": "^2.0.0",
     "bootstrap-slider": "^11.0.2",
     "d3-array": "^1.2.4",


### PR DESCRIPTION
Part of https://github.com/apache/superset/issues/30307

Similar to:
- https://github.com/apache/superset/pull/30651

this pr updates the web-mercator deps in the deck preset to the same version as is used in the mapbox plugin