### PR TITLE
perf: Optimize dashboard grid components

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent.tsx
@@ -20,7 +20,7 @@ import { FC, Suspense } from 'react';
 import { DashboardComponentMetadata, JsonObject, t } from '@superset-ui/core';
 import backgroundStyleOptions from 'src/dashboard/util/backgroundStyleOptions';
 import cx from 'classnames';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { Draggable } from '../dnd/DragDroppable';
 import { COLUMN_TYPE, ROW_TYPE } from '../../util/componentTypes';
 import WithPopoverMenu from '../menu/WithPopoverMenu';
@@ -103,6 +103,7 @@ const DynamicComponent: FC<FilterSummaryType> = ({
       nativeFilters,
       dataMask,
     }),
+    shallowEqual,
   );
 
   return (

--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -16,10 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { createRef, PureComponent, Fragment } from 'react';
+import {
+  Fragment,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useMemo,
+  memo,
+} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { debounce } from 'lodash';
 import {
   css,
   FAST_DEBOUNCE,
@@ -46,6 +53,7 @@ import backgroundStyleOptions from 'src/dashboard/util/backgroundStyleOptions';
 import { BACKGROUND_TRANSPARENT } from 'src/dashboard/util/constants';
 import { EMPTY_CONTAINER_Z_INDEX } from 'src/dashboard/constants';
 import { isCurrentUserBot } from 'src/utils/isBot';
+import { useDebouncedEffect } from '../../../explore/exploreUtils';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -126,285 +134,301 @@ const emptyRowContentStyles = theme => css`
   color: ${theme.colors.text.label};
 `;
 
-class Row extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isFocused: false,
-      isInView: false,
-      hoverMenuHovered: false,
-    };
-    this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
-    this.handleUpdateMeta = this.handleUpdateMeta.bind(this);
-    this.handleChangeBackground = this.handleUpdateMeta.bind(
-      this,
-      'background',
-    );
-    this.handleChangeFocus = this.handleChangeFocus.bind(this);
-    this.handleMenuHover = this.handleMenuHover.bind(this);
-    this.setVerticalEmptyContainerHeight = debounce(
-      this.setVerticalEmptyContainerHeight.bind(this),
-      FAST_DEBOUNCE,
-    );
+const Row = props => {
+  const {
+    component: rowComponent,
+    parentComponent,
+    index,
+    availableColumnCount,
+    columnWidth,
+    occupiedColumnCount,
+    depth,
+    onResizeStart,
+    onResize,
+    onResizeStop,
+    handleComponentDrop,
+    editMode,
+    onChangeTab,
+    isComponentVisible,
+    updateComponents,
+    deleteComponent,
+    parentId,
+  } = props;
 
-    this.containerRef = createRef();
-    this.observerEnabler = null;
-    this.observerDisabler = null;
-  }
+  const [isFocused, setIsFocused] = useState(false);
+  const [isInView, setIsInView] = useState(false);
+  const [hoverMenuHovered, setHoverMenuHovered] = useState(false);
+  const [containerHeight, setContainerHeight] = useState(null);
+  const containerRef = useRef();
+  const isComponentVisibleRef = useRef(isComponentVisible);
+
+  useEffect(() => {
+    isComponentVisibleRef.current = isComponentVisible;
+  }, [isComponentVisible]);
 
   // if chart not rendered - render it if it's less than 1 view height away from current viewport
   // if chart rendered - remove it if it's more than 4 view heights away from current viewport
-  componentDidMount() {
+  useEffect(() => {
+    let observerEnabler;
+    let observerDisabler;
     if (
       isFeatureEnabled(FeatureFlag.DashboardVirtualization) &&
       !isCurrentUserBot()
     ) {
-      this.observerEnabler = new IntersectionObserver(
+      observerEnabler = new IntersectionObserver(
         ([entry]) => {
-          if (entry.isIntersecting && !this.state.isInView) {
-            this.setState({ isInView: true });
+          if (entry.isIntersecting && isComponentVisibleRef.current) {
+            setIsInView(true);
           }
         },
         {
           rootMargin: '100% 0px',
         },
       );
-      this.observerDisabler = new IntersectionObserver(
+      observerDisabler = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting && this.state.isInView) {
-            this.setState({ isInView: false });
+          if (!entry.isIntersecting && isComponentVisibleRef.current) {
+            setIsInView(false);
           }
         },
         {
           rootMargin: '400% 0px',
         },
       );
-      const element = this.containerRef.current;
+      const element = containerRef.current;
       if (element) {
-        this.observerEnabler.observe(element);
-        this.observerDisabler.observe(element);
-        this.setVerticalEmptyContainerHeight();
+        observerEnabler.observe(element);
+        observerDisabler.observe(element);
       }
     }
-  }
+    return () => {
+      observerEnabler?.disconnect();
+      observerDisabler?.disconnect();
+    };
+  }, []);
 
-  componentDidUpdate() {
-    this.setVerticalEmptyContainerHeight();
-  }
+  useDebouncedEffect(
+    () => {
+      const updatedHeight = containerRef.current?.clientHeight;
+      if (
+        editMode &&
+        containerRef.current &&
+        updatedHeight !== containerHeight
+      ) {
+        setContainerHeight(updatedHeight);
+      }
+    },
+    FAST_DEBOUNCE,
+    [editMode, containerHeight],
+  );
 
-  setVerticalEmptyContainerHeight() {
-    const { containerHeight } = this.state;
-    const { editMode } = this.props;
-    const updatedHeight = this.containerRef.current?.clientHeight;
-    if (
-      editMode &&
-      this.containerRef.current &&
-      updatedHeight !== containerHeight
-    ) {
-      this.setState({ containerHeight: updatedHeight });
-    }
-  }
+  const handleChangeFocus = useCallback(nextFocus => {
+    setIsFocused(Boolean(nextFocus));
+  }, []);
 
-  componentWillUnmount() {
-    this.observerEnabler?.disconnect();
-    this.observerDisabler?.disconnect();
-  }
-
-  handleChangeFocus(nextFocus) {
-    this.setState(() => ({ isFocused: Boolean(nextFocus) }));
-  }
-
-  handleUpdateMeta(metaKey, nextValue) {
-    const { updateComponents, component } = this.props;
-    if (nextValue && component.meta[metaKey] !== nextValue) {
-      updateComponents({
-        [component.id]: {
-          ...component,
-          meta: {
-            ...component.meta,
-            [metaKey]: nextValue,
+  const handleChangeBackground = useCallback(
+    nextValue => {
+      const metaKey = 'background';
+      if (nextValue && rowComponent.meta[metaKey] !== nextValue) {
+        updateComponents({
+          [rowComponent.id]: {
+            ...rowComponent,
+            meta: {
+              ...rowComponent.meta,
+              [metaKey]: nextValue,
+            },
           },
-        },
-      });
-    }
-  }
+        });
+      }
+    },
+    [updateComponents, rowComponent],
+  );
 
-  handleDeleteComponent() {
-    const { deleteComponent, component, parentId } = this.props;
-    deleteComponent(component.id, parentId);
-  }
+  const handleDeleteComponent = useCallback(() => {
+    deleteComponent(rowComponent.id, parentId);
+  }, [deleteComponent, rowComponent, parentId]);
 
-  handleMenuHover = hovered => {
+  const handleMenuHover = useCallback(hovered => {
     const { isHovered } = hovered;
-    this.setState(() => ({ hoverMenuHovered: isHovered }));
-  };
+    setHoverMenuHovered(isHovered);
+  }, []);
 
-  render() {
-    const {
-      component: rowComponent,
-      parentComponent,
-      index,
-      availableColumnCount,
-      columnWidth,
-      occupiedColumnCount,
-      depth,
-      onResizeStart,
-      onResize,
-      onResizeStop,
-      handleComponentDrop,
-      editMode,
-      onChangeTab,
-      isComponentVisible,
-    } = this.props;
-    const { containerHeight, hoverMenuHovered } = this.state;
+  const rowItems = useMemo(
+    () => rowComponent.children || [],
+    [rowComponent.children],
+  );
 
-    const rowItems = rowComponent.children || [];
-
-    const backgroundStyle = backgroundStyleOptions.find(
-      opt =>
-        opt.value === (rowComponent.meta.background || BACKGROUND_TRANSPARENT),
-    );
-    const remainColumnCount = availableColumnCount - occupiedColumnCount;
-
-    return (
-      <Draggable
-        component={rowComponent}
-        parentComponent={parentComponent}
-        orientation="row"
-        index={index}
-        depth={depth}
-        onDrop={handleComponentDrop}
+  const backgroundStyle = backgroundStyleOptions.find(
+    opt =>
+      opt.value === (rowComponent.meta.background || BACKGROUND_TRANSPARENT),
+  );
+  const remainColumnCount = availableColumnCount - occupiedColumnCount;
+  const renderChild = useCallback(
+    ({ dragSourceRef }) => (
+      <WithPopoverMenu
+        isFocused={isFocused}
+        onChangeFocus={handleChangeFocus}
+        disableClick
+        menuItems={[
+          <BackgroundStyleDropdown
+            id={`${rowComponent.id}-background`}
+            value={backgroundStyle.value}
+            onChange={handleChangeBackground}
+          />,
+        ]}
         editMode={editMode}
       >
-        {({ dragSourceRef }) => (
-          <WithPopoverMenu
-            isFocused={this.state.isFocused}
-            onChangeFocus={this.handleChangeFocus}
-            disableClick
-            menuItems={[
-              <BackgroundStyleDropdown
-                id={`${rowComponent.id}-background`}
-                value={backgroundStyle.value}
-                onChange={this.handleChangeBackground}
-              />,
-            ]}
-            editMode={editMode}
+        {editMode && (
+          <HoverMenu
+            onHover={handleMenuHover}
+            innerRef={dragSourceRef}
+            position="left"
           >
-            {editMode && (
-              <HoverMenu
-                onHover={this.handleMenuHover}
-                innerRef={dragSourceRef}
-                position="left"
-              >
-                <DragHandle position="left" />
-                <DeleteComponentButton onDelete={this.handleDeleteComponent} />
-                <IconButton
-                  onClick={this.handleChangeFocus}
-                  icon={<Icons.Cog iconSize="xl" />}
-                />
-              </HoverMenu>
-            )}
-            <GridRow
-              className={cx(
-                'grid-row',
-                rowItems.length === 0 && 'grid-row--empty',
-                hoverMenuHovered && 'grid-row--hovered',
-                backgroundStyle.className,
-              )}
-              data-test={`grid-row-${backgroundStyle.className}`}
-              ref={this.containerRef}
-              editMode={editMode}
-            >
-              {editMode && (
-                <Droppable
-                  {...(rowItems.length === 0
-                    ? {
-                        component: rowComponent,
-                        parentComponent: rowComponent,
-                        dropToChild: true,
-                      }
-                    : {
-                        component: rowItems[0],
-                        parentComponent: rowComponent,
-                      })}
-                  depth={depth}
-                  index={0}
-                  orientation="row"
-                  onDrop={handleComponentDrop}
-                  className={cx(
-                    'empty-droptarget',
-                    'empty-droptarget--vertical',
-                    rowItems.length > 0 && 'droptarget-side',
-                  )}
-                  editMode
-                  style={{
-                    height: rowItems.length > 0 ? containerHeight : '100%',
-                    ...(rowItems.length > 0 && { width: 16 }),
-                  }}
-                >
-                  {({ dropIndicatorProps }) =>
-                    dropIndicatorProps && <div {...dropIndicatorProps} />
-                  }
-                </Droppable>
-              )}
-              {rowItems.length === 0 && (
-                <div css={emptyRowContentStyles}>{t('Empty row')}</div>
-              )}
-              {rowItems.length > 0 &&
-                rowItems.map((componentId, itemIndex) => (
-                  <Fragment key={componentId}>
-                    <DashboardComponent
-                      key={componentId}
-                      id={componentId}
-                      parentId={rowComponent.id}
-                      depth={depth + 1}
-                      index={itemIndex}
-                      availableColumnCount={remainColumnCount}
-                      columnWidth={columnWidth}
-                      onResizeStart={onResizeStart}
-                      onResize={onResize}
-                      onResizeStop={onResizeStop}
-                      isComponentVisible={isComponentVisible}
-                      onChangeTab={onChangeTab}
-                      isInView={this.state.isInView}
-                    />
-                    {editMode && (
-                      <Droppable
-                        component={rowItems}
-                        parentComponent={rowComponent}
-                        depth={depth}
-                        index={itemIndex + 1}
-                        orientation="row"
-                        onDrop={handleComponentDrop}
-                        className={cx(
-                          'empty-droptarget',
-                          'empty-droptarget--vertical',
-                          remainColumnCount === 0 &&
-                            itemIndex === rowItems.length - 1 &&
-                            'droptarget-side',
-                        )}
-                        editMode
-                        style={{
-                          height: containerHeight,
-                          ...(remainColumnCount === 0 &&
-                            itemIndex === rowItems.length - 1 && { width: 16 }),
-                        }}
-                      >
-                        {({ dropIndicatorProps }) =>
-                          dropIndicatorProps && <div {...dropIndicatorProps} />
-                        }
-                      </Droppable>
-                    )}
-                  </Fragment>
-                ))}
-            </GridRow>
-          </WithPopoverMenu>
+            <DragHandle position="left" />
+            <DeleteComponentButton onDelete={handleDeleteComponent} />
+            <IconButton
+              onClick={handleChangeFocus}
+              icon={<Icons.Cog iconSize="xl" />}
+            />
+          </HoverMenu>
         )}
-      </Draggable>
-    );
-  }
-}
+        <GridRow
+          className={cx(
+            'grid-row',
+            rowItems.length === 0 && 'grid-row--empty',
+            hoverMenuHovered && 'grid-row--hovered',
+            backgroundStyle.className,
+          )}
+          data-test={`grid-row-${backgroundStyle.className}`}
+          ref={containerRef}
+          editMode={editMode}
+        >
+          {editMode && (
+            <Droppable
+              {...(rowItems.length === 0
+                ? {
+                    component: rowComponent,
+                    parentComponent: rowComponent,
+                    dropToChild: true,
+                  }
+                : {
+                    component: rowItems[0],
+                    parentComponent: rowComponent,
+                  })}
+              depth={depth}
+              index={0}
+              orientation="row"
+              onDrop={handleComponentDrop}
+              className={cx(
+                'empty-droptarget',
+                'empty-droptarget--vertical',
+                rowItems.length > 0 && 'droptarget-side',
+              )}
+              editMode
+              style={{
+                height: rowItems.length > 0 ? containerHeight : '100%',
+                ...(rowItems.length > 0 && { width: 16 }),
+              }}
+            >
+              {({ dropIndicatorProps }) =>
+                dropIndicatorProps && <div {...dropIndicatorProps} />
+              }
+            </Droppable>
+          )}
+          {rowItems.length === 0 && (
+            <div css={emptyRowContentStyles}>{t('Empty row')}</div>
+          )}
+          {rowItems.length > 0 &&
+            rowItems.map((componentId, itemIndex) => (
+              <Fragment key={componentId}>
+                <DashboardComponent
+                  key={componentId}
+                  id={componentId}
+                  parentId={rowComponent.id}
+                  depth={depth + 1}
+                  index={itemIndex}
+                  availableColumnCount={remainColumnCount}
+                  columnWidth={columnWidth}
+                  onResizeStart={onResizeStart}
+                  onResize={onResize}
+                  onResizeStop={onResizeStop}
+                  isComponentVisible={isComponentVisible}
+                  onChangeTab={onChangeTab}
+                  isInView={isInView}
+                />
+                {editMode && (
+                  <Droppable
+                    component={rowItems}
+                    parentComponent={rowComponent}
+                    depth={depth}
+                    index={itemIndex + 1}
+                    orientation="row"
+                    onDrop={handleComponentDrop}
+                    className={cx(
+                      'empty-droptarget',
+                      'empty-droptarget--vertical',
+                      remainColumnCount === 0 &&
+                        itemIndex === rowItems.length - 1 &&
+                        'droptarget-side',
+                    )}
+                    editMode
+                    style={{
+                      height: containerHeight,
+                      ...(remainColumnCount === 0 &&
+                        itemIndex === rowItems.length - 1 && { width: 16 }),
+                    }}
+                  >
+                    {({ dropIndicatorProps }) =>
+                      dropIndicatorProps && <div {...dropIndicatorProps} />
+                    }
+                  </Droppable>
+                )}
+              </Fragment>
+            ))}
+        </GridRow>
+      </WithPopoverMenu>
+    ),
+    [
+      backgroundStyle.className,
+      backgroundStyle.value,
+      columnWidth,
+      containerHeight,
+      depth,
+      editMode,
+      handleChangeBackground,
+      handleChangeFocus,
+      handleComponentDrop,
+      handleDeleteComponent,
+      handleMenuHover,
+      hoverMenuHovered,
+      isComponentVisible,
+      isFocused,
+      isInView,
+      onChangeTab,
+      onResize,
+      onResizeStart,
+      onResizeStop,
+      remainColumnCount,
+      rowComponent,
+      rowItems,
+    ],
+  );
+
+  return (
+    <Draggable
+      component={rowComponent}
+      parentComponent={parentComponent}
+      orientation="row"
+      index={index}
+      depth={depth}
+      onDrop={handleComponentDrop}
+      editMode={editMode}
+    >
+      {renderChild}
+    </Draggable>
+  );
+};
 
 Row.propTypes = propTypes;
 
-export default Row;
+export default memo(Row);

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { PureComponent, Fragment } from 'react';
+import { Fragment, useCallback, memo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { styled, t } from '@superset-ui/core';
 
 import { EmptyStateMedium } from 'src/components/EmptyState';
@@ -51,7 +50,6 @@ const propTypes = {
   onDragTab: PropTypes.func,
   onHoverTab: PropTypes.func,
   editMode: PropTypes.bool.isRequired,
-  canEdit: PropTypes.bool.isRequired,
   embeddedMode: PropTypes.bool,
 
   // grid related
@@ -65,7 +63,6 @@ const propTypes = {
   handleComponentDrop: PropTypes.func.isRequired,
   updateComponents: PropTypes.func.isRequired,
   setDirectPathToChild: PropTypes.func.isRequired,
-  setEditMode: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -102,62 +99,65 @@ const TitleDropIndicator = styled.div`
 const renderDraggableContent = dropProps =>
   dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />;
 
-class Tab extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.handleChangeText = this.handleChangeText.bind(this);
-    this.handleDrop = this.handleDrop.bind(this);
-    this.handleOnHover = this.handleOnHover.bind(this);
-    this.handleTopDropTargetDrop = this.handleTopDropTargetDrop.bind(this);
-    this.handleChangeTab = this.handleChangeTab.bind(this);
-  }
+const Tab = props => {
+  const dispatch = useDispatch();
+  const canEdit = useSelector(state => state.dashboardInfo.dash_edit_perm);
+  const handleChangeTab = useCallback(
+    ({ pathToTabIndex }) => {
+      props.setDirectPathToChild(pathToTabIndex);
+    },
+    [props.setDirectPathToChild],
+  );
 
-  handleChangeTab({ pathToTabIndex }) {
-    this.props.setDirectPathToChild(pathToTabIndex);
-  }
-
-  handleChangeText(nextTabText) {
-    const { updateComponents, component } = this.props;
-    if (nextTabText && nextTabText !== component.meta.text) {
-      updateComponents({
-        [component.id]: {
-          ...component,
-          meta: {
-            ...component.meta,
-            text: nextTabText,
+  const handleChangeText = useCallback(
+    nextTabText => {
+      const { updateComponents, component } = props;
+      if (nextTabText && nextTabText !== component.meta.text) {
+        updateComponents({
+          [component.id]: {
+            ...component,
+            meta: {
+              ...component.meta,
+              text: nextTabText,
+            },
           },
-        },
-      });
-    }
-  }
+        });
+      }
+    },
+    [props.updateComponents, props.component],
+  );
 
-  handleDrop(dropResult) {
-    this.props.handleComponentDrop(dropResult);
-    this.props.onDropOnTab(dropResult);
-  }
+  const handleDrop = useCallback(
+    dropResult => {
+      props.handleComponentDrop(dropResult);
+      props.onDropOnTab(dropResult);
+    },
+    [props.handleComponentDrop, props.onDropOnTab],
+  );
 
-  handleOnHover() {
-    this.props.onHoverTab();
-  }
+  const handleHoverTab = useCallback(() => {
+    props.onHoverTab?.();
+  }, [props.onHoverTab]);
 
-  handleTopDropTargetDrop(dropResult) {
-    if (dropResult) {
-      this.props.handleComponentDrop({
-        ...dropResult,
-        destination: {
-          ...dropResult.destination,
-          // force appending as the first child if top drop target
-          index: 0,
-        },
-      });
-    }
-  }
+  const handleTopDropTargetDrop = useCallback(
+    dropResult => {
+      if (dropResult) {
+        props.handleComponentDrop({
+          ...dropResult,
+          destination: {
+            ...dropResult.destination,
+            // force appending as the first child if top drop target
+            index: 0,
+          },
+        });
+      }
+    },
+    [props.handleComponentDrop],
+  );
 
-  shouldDropToChild(item) {
-    return item.type !== TAB_TYPE;
-  }
+  const shouldDropToChild = useCallback(item => item.type !== TAB_TYPE, []);
 
-  renderTabContent() {
+  const renderTabContent = useCallback(() => {
     const {
       component: tabComponent,
       depth,
@@ -168,10 +168,8 @@ class Tab extends PureComponent {
       onResizeStop,
       editMode,
       isComponentVisible,
-      canEdit,
-      setEditMode,
       dashboardId,
-    } = this.props;
+    } = props;
 
     const shouldDisplayEmptyState = tabComponent.children.length === 0;
     return (
@@ -185,8 +183,8 @@ class Tab extends PureComponent {
             depth={depth}
             onDrop={
               tabComponent.children.length === 0
-                ? this.handleTopDropTargetDrop
-                : this.handleDrop
+                ? handleTopDropTargetDrop
+                : handleDrop
             }
             editMode
             className={classNames({
@@ -225,7 +223,7 @@ class Tab extends PureComponent {
                   <span
                     role="button"
                     tabIndex={0}
-                    onClick={() => setEditMode(true)}
+                    onClick={() => dispatch(setEditMode(true))}
                   >
                     {t('edit mode')}
                   </span>
@@ -242,15 +240,15 @@ class Tab extends PureComponent {
               parentId={tabComponent.id}
               depth={depth} // see isValidChild.js for why tabs don't increment child depth
               index={componentIndex}
-              onDrop={this.handleDrop}
-              onHover={this.handleOnHover}
+              onDrop={handleDrop}
+              onHover={handleHoverTab}
               availableColumnCount={availableColumnCount}
               columnWidth={columnWidth}
               onResizeStart={onResizeStart}
               onResize={onResize}
               onResizeStop={onResizeStop}
               isComponentVisible={isComponentVisible}
-              onChangeTab={this.handleChangeTab}
+              onChangeTab={handleChangeTab}
             />
             {/* Make bottom of tab droppable */}
             {editMode && (
@@ -259,7 +257,7 @@ class Tab extends PureComponent {
                 orientation="column"
                 index={componentIndex + 1}
                 depth={depth}
-                onDrop={this.handleDrop}
+                onDrop={handleDrop}
                 editMode
                 className="empty-droptarget"
               >
@@ -270,21 +268,95 @@ class Tab extends PureComponent {
         ))}
       </div>
     );
-  }
+  }, [
+    dispatch,
+    props.component,
+    props.depth,
+    props.availableColumnCount,
+    props.columnWidth,
+    props.onResizeStart,
+    props.onResize,
+    props.onResizeStop,
+    props.editMode,
+    props.isComponentVisible,
+    props.dashboardId,
+    props.handleComponentDrop,
+    props.onDropOnTab,
+    props.setDirectPathToChild,
+    props.updateComponents,
+    handleHoverTab,
+    canEdit,
+    handleChangeTab,
+    handleChangeText,
+    handleDrop,
+    handleTopDropTargetDrop,
+    shouldDropToChild,
+  ]);
 
-  renderTab() {
+  const renderTabChild = useCallback(
+    ({ dropIndicatorProps, dragSourceRef, draggingTabOnTab }) => {
+      const {
+        component,
+        index,
+        editMode,
+        isFocused,
+        isHighlighted,
+        dashboardId,
+        embeddedMode,
+      } = props;
+      return (
+        <TabTitleContainer
+          isHighlighted={isHighlighted}
+          className="dragdroppable-tab"
+          ref={dragSourceRef}
+        >
+          <EditableTitle
+            title={component.meta.text}
+            defaultTitle={component.meta.defaultText}
+            placeholder={component.meta.placeholder}
+            canEdit={editMode && isFocused}
+            onSaveTitle={handleChangeText}
+            showTooltip={false}
+            editing={editMode && isFocused}
+          />
+          {!editMode && !embeddedMode && (
+            <AnchorLink
+              id={component.id}
+              dashboardId={dashboardId}
+              placement={index >= 5 ? 'left' : 'right'}
+            />
+          )}
+
+          {dropIndicatorProps && !draggingTabOnTab && (
+            <TitleDropIndicator
+              className={dropIndicatorProps.className}
+              data-test="title-drop-indicator"
+            />
+          )}
+        </TabTitleContainer>
+      );
+    },
+    [
+      props.component,
+      props.index,
+      props.editMode,
+      props.isFocused,
+      props.isHighlighted,
+      props.dashboardId,
+      handleChangeText,
+    ],
+  );
+
+  const renderTab = useCallback(() => {
     const {
       component,
       parentComponent,
       index,
       depth,
       editMode,
-      isFocused,
-      isHighlighted,
       onDropPositionChange,
       onDragTab,
-      embeddedMode,
-    } = this.props;
+    } = props;
 
     return (
       <DragDroppable
@@ -293,71 +365,32 @@ class Tab extends PureComponent {
         orientation="column"
         index={index}
         depth={depth}
-        onDrop={this.handleDrop}
-        onHover={this.handleOnHover}
+        onDrop={handleDrop}
+        onHover={handleHoverTab}
         onDropIndicatorChange={onDropPositionChange}
         onDragTab={onDragTab}
         editMode={editMode}
-        dropToChild={this.shouldDropToChild}
+        dropToChild={shouldDropToChild}
       >
-        {({ dropIndicatorProps, dragSourceRef, draggingTabOnTab }) => (
-          <TabTitleContainer
-            isHighlighted={isHighlighted}
-            className="dragdroppable-tab"
-            ref={dragSourceRef}
-          >
-            <EditableTitle
-              title={component.meta.text}
-              defaultTitle={component.meta.defaultText}
-              placeholder={component.meta.placeholder}
-              canEdit={editMode && isFocused}
-              onSaveTitle={this.handleChangeText}
-              showTooltip={false}
-              editing={editMode && isFocused}
-            />
-            {!editMode && !embeddedMode && (
-              <AnchorLink
-                id={component.id}
-                dashboardId={this.props.dashboardId}
-                placement={index >= 5 ? 'left' : 'right'}
-              />
-            )}
-            {dropIndicatorProps && !draggingTabOnTab && (
-              <TitleDropIndicator
-                className={dropIndicatorProps.className}
-                data-test="title-drop-indicator"
-              />
-            )}
-          </TabTitleContainer>
-        )}
+        {renderTabChild}
       </DragDroppable>
     );
-  }
+  }, [
+    props.component,
+    props.parentComponent,
+    props.index,
+    props.depth,
+    props.editMode,
+    handleDrop,
+    handleHoverTab,
+    shouldDropToChild,
+    renderTabChild,
+  ]);
 
-  render() {
-    const { renderType } = this.props;
-    return renderType === RENDER_TAB
-      ? this.renderTab()
-      : this.renderTabContent();
-  }
-}
+  return props.renderType === RENDER_TAB ? renderTab() : renderTabContent();
+};
 
 Tab.propTypes = propTypes;
 Tab.defaultProps = defaultProps;
 
-function mapStateToProps(state) {
-  return {
-    canEdit: state.dashboardInfo.dash_edit_perm,
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(
-    {
-      setEditMode,
-    },
-    dispatch,
-  );
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Tab);
+export default memo(Tab);

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.jsx
@@ -20,11 +20,10 @@ import { fireEvent, render } from 'spec/helpers/testing-library';
 
 import { AntdModal } from 'src/components';
 import fetchMock from 'fetch-mock';
-import { Tabs } from 'src/dashboard/components/gridComponents/Tabs';
+import Tabs from 'src/dashboard/components/gridComponents/Tabs';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
 import emptyDashboardLayout from 'src/dashboard/fixtures/emptyDashboardLayout';
 import { dashboardLayoutWithTabs } from 'spec/fixtures/mockDashboardLayout';
-import { getMockStore } from 'spec/fixtures/mockStore';
 import { nativeFilters } from 'spec/fixtures/mockNativeFilters';
 import { initialState } from 'src/SqlLab/fixtures';
 
@@ -81,17 +80,17 @@ const props = {
   nativeFilters: nativeFilters.filters,
 };
 
-const mockStore = getMockStore({
-  ...initialState,
-  dashboardLayout: dashboardLayoutWithTabs,
-  dashboardFilters: {},
-});
-
-function setup(overrideProps) {
+function setup(overrideProps, overrideState = {}) {
   return render(<Tabs {...props} {...overrideProps} />, {
     useDnd: true,
     useRouter: true,
-    store: mockStore,
+    useRedux: true,
+    initialState: {
+      ...initialState,
+      dashboardLayout: dashboardLayoutWithTabs,
+      dashboardFilters: {},
+      ...overrideState,
+    },
   });
 }
 
@@ -174,11 +173,7 @@ test('should direct display direct-link tab', () => {
   // display child in directPathToChild list
   const directPathToChild =
     dashboardLayoutWithTabs.present.ROW_ID2.parents.slice();
-  const directLinkProps = {
-    ...props,
-    directPathToChild,
-  };
-  const { getByRole } = setup(directLinkProps);
+  const { getByRole } = setup({}, { dashboardState: { directPathToChild } });
   expect(getByRole('tab', { selected: true })).toHaveTextContent('TAB_ID2');
 });
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tabs.test.tsx
@@ -25,7 +25,7 @@ import { Draggable } from 'src/dashboard/components/dnd/DragDroppable';
 import DeleteComponentButton from 'src/dashboard/components/DeleteComponentButton';
 import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFromPath';
 import emptyDashboardLayout from 'src/dashboard/fixtures/emptyDashboardLayout';
-import { Tabs } from './Tabs';
+import Tabs from './Tabs';
 
 jest.mock('src/dashboard/containers/DashboardComponent', () =>
   jest.fn(props => (

--- a/superset-frontend/src/dashboard/components/gridComponents/index.js
+++ b/superset-frontend/src/dashboard/components/gridComponents/index.js
@@ -35,7 +35,7 @@ import Divider from './Divider';
 import Header from './Header';
 import Row from './Row';
 import Tab from './Tab';
-import TabsConnected from './Tabs';
+import Tabs from './Tabs';
 import DynamicComponent from './DynamicComponent';
 
 export { default as ChartHolder } from './ChartHolder';
@@ -56,6 +56,6 @@ export const componentLookup = {
   [HEADER_TYPE]: Header,
   [ROW_TYPE]: Row,
   [TAB_TYPE]: Tab,
-  [TABS_TYPE]: TabsConnected,
+  [TABS_TYPE]: Tabs,
   [DYNAMIC_TYPE]: DynamicComponent,
 };

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -22,7 +22,7 @@ import { t, logging } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import { getDashboardPermalink } from 'src/utils/urlUtils';
 import { MenuKeys, RootState } from 'src/dashboard/types';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 interface ShareMenuItemProps {
   url?: string;
@@ -54,10 +54,13 @@ const ShareMenuItems = (props: ShareMenuItemProps) => {
     selectedKeys,
     ...rest
   } = props;
-  const { dataMask, activeTabs } = useSelector((state: RootState) => ({
-    dataMask: state.dataMask,
-    activeTabs: state.dashboardState.activeTabs,
-  }));
+  const { dataMask, activeTabs } = useSelector(
+    (state: RootState) => ({
+      dataMask: state.dataMask,
+      activeTabs: state.dashboardState.activeTabs,
+    }),
+    shallowEqual,
+  );
 
   async function generateUrl() {
     return getDashboardPermalink({

--- a/superset-frontend/src/utils/colorScheme.ts
+++ b/superset-frontend/src/utils/colorScheme.ts
@@ -19,9 +19,12 @@
 
 import {
   CategoricalColorNamespace,
+  ensureIsArray,
   getCategoricalSchemeRegistry,
   getLabelsColorMap,
 } from '@superset-ui/core';
+
+const EMPTY_ARRAY: string[] = [];
 
 /**
  * Force falsy namespace values to undefined to default to GLOBAL
@@ -41,7 +44,7 @@ export const getColorNamespace = (namespace?: string) => namespace || undefined;
  */
 export const enforceSharedLabelsColorsArray = (
   sharedLabelsColors: string[] | Record<string, string> | undefined,
-) => (Array.isArray(sharedLabelsColors) ? sharedLabelsColors : []);
+) => (Array.isArray(sharedLabelsColors) ? sharedLabelsColors : EMPTY_ARRAY);
 
 /**
  * Get labels shared across all charts in a dashboard.
@@ -67,7 +70,9 @@ export const getFreshSharedLabels = (
     .filter(([, count]) => count > 1)
     .map(([label]) => label);
 
-  return Array.from(new Set([...currentSharedLabels, ...duplicates]));
+  return Array.from(
+    new Set([...ensureIsArray(currentSharedLabels), ...duplicates]),
+  );
 };
 
 export const getSharedLabelsColorMapEntries = (


### PR DESCRIPTION
### SUMMARY
This PR supersedes https://github.com/apache/superset/pull/30958.
Related to PRs: https://github.com/apache/superset/pull/31241, https://github.com/apache/superset/pull/31242, https://github.com/apache/superset/pull/31243, https://github.com/apache/superset/pull/31244.

Optimizes grid components such as Tabs, Tab, Row, Column by memoizing props passed to children and improving Redux selectors, leading to decreased number of redundant rerenders

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
For detailed perf improvement results, see the details in PR https://github.com/apache/superset/pull/30958

### TESTING INSTRUCTIONS
No functional changes - the dashboard, native filters, cross filters, chart actions, etc. should work like before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
