### PR TITLE
chore: pin greenlet in base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ dependencies = [
     "flask-wtf>=1.1.0, <2.0",
     "func_timeout",
     "geopy",
+    # playwright requires greenlet==3.0.3
+    # submitted a PR to relax deps in 11/2024
+    # https://github.com/microsoft/playwright-python/pull/2669
+    "greenlet==3.0.3",
     "gunicorn>=22.0.0; sys_platform != 'win32'",
     "hashids>=1.3.1, <2",
     # known issue with holidays 0.26.0 and above related to prophet lib #25017
@@ -182,10 +186,6 @@ development = [
     "docker",
     "flask-testing",
     "freezegun",
-    # playwright requires greenlet==3.0.3
-    # submitted a PR to relax deps in 11/2024
-    # https://github.com/microsoft/playwright-python/pull/2669
-    "greenlet==3.0.3",
     "grpcio>=1.55.3",
     "openapi-spec-validator",
     "parameterized",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,8 +155,8 @@ google-auth==2.36.0
     # via shillelagh
 greenlet==3.0.3
     # via
+    #   apache-superset
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset
 hashids==1.3.1


### PR DESCRIPTION
Greenlet is used by base deps, and should be pinned at that level, otherwise @supersetbot will try and upgrade...
