### PR TITLE
chore(bug report template): bump Superset versions to reflect 4.1.1 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -41,8 +41,8 @@ body:
       label: Superset version
       options:
         - master / latest-dev
-        - "4.1.0"
-        - "3.1.3"
+        - "4.1.1"
+        - "4.0.2"
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
Updated the bug report template to reflect latest release.

### SUMMARY
Bumped latest release from 4.1.0 -> 4.1.1, also bumped prior release from 3.1.3 -> 4.0.2.
