### PR TITLE
feat(Handlebars): formatNumber and group helpers

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -28029,6 +28029,14 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/handlebars-group-by": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-group-by/-/handlebars-group-by-1.0.1.tgz",
+      "integrity": "sha512-qwVVDVAJMBKdmnQU8jcEXGOu+4/2YJX1RP3pUw6Ee9t6gdkxt+dJEWDudSFTgqb35KXrktw/Nn/Dp3Rx5muHpg==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
@@ -58568,6 +58576,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "^4.7.8",
+        "handlebars-group-by": "^1.0.1",
         "just-handlebars-helpers": "^1.0.19"
       },
       "devDependencies": {
@@ -69177,6 +69186,7 @@
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.7",
         "handlebars": "^4.7.8",
+        "handlebars-group-by": "*",
         "jest": "^29.7.0",
         "just-handlebars-helpers": "^1.0.19"
       },
@@ -79828,6 +79838,11 @@
           "version": "0.6.1"
         }
       }
+    },
+    "handlebars-group-by": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/handlebars-group-by/-/handlebars-group-by-1.0.1.tgz",
+      "integrity": "sha512-qwVVDVAJMBKdmnQU8jcEXGOu+4/2YJX1RP3pUw6Ee9t6gdkxt+dJEWDudSFTgqb35KXrktw/Nn/Dp3Rx5muHpg=="
     },
     "har-schema": {
       "version": "2.0.0",

--- a/superset-frontend/plugins/plugin-chart-handlebars/package.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "handlebars": "^4.7.8",
+    "handlebars-group-by": "^1.0.1",
     "just-handlebars-helpers": "^1.0.19"
   },
   "peerDependencies": {

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
@@ -22,6 +22,7 @@ import moment from 'moment';
 import { useMemo, useState } from 'react';
 import { isPlainObject } from 'lodash';
 import Helpers from 'just-handlebars-helpers';
+import HandlebarsGroupBy from 'handlebars-group-by';
 
 export interface HandlebarsViewerProps {
   templateSource: string;
@@ -88,4 +89,15 @@ Handlebars.registerHelper('stringify', (obj: any, obj2: any) => {
   return isPlainObject(obj) ? JSON.stringify(obj) : String(obj);
 });
 
+Handlebars.registerHelper(
+  'formatNumber',
+  function (number: any, locale: string = 'en-US') {
+    if (typeof number !== 'number') {
+      return number;
+    }
+    return number.toLocaleString(locale);
+  },
+);
+
 Helpers.registerHelpers(Handlebars);
+HandlebarsGroupBy.register(Handlebars);

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/components/Handlebars/HandlebarsViewer.tsx
@@ -91,7 +91,7 @@ Handlebars.registerHelper('stringify', (obj: any, obj2: any) => {
 
 Handlebars.registerHelper(
   'formatNumber',
-  function (number: any, locale: string = 'en-US') {
+  function (number: any, locale = 'en-US') {
     if (typeof number !== 'number') {
       return number;
     }

--- a/superset-frontend/plugins/plugin-chart-handlebars/types/external.d.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/types/external.d.ts
@@ -22,3 +22,4 @@ declare module '*.png' {
 }
 declare module '*.jpg';
 declare module 'just-handlebars-helpers';
+declare module 'handlebars-group-by';


### PR DESCRIPTION
### SUMMARY
This PR adds two new helpers to the Handlebars chart:
* `formatNumber`: allows using `number.toLocaleString(locale)` to format numbers as needed.
* `group` (via the [handlebars-group-by module](https://github.com/shannonmoeller/handlebars-group-by)): Allows grouping data.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Example using both helpers:
![image](https://github.com/user-attachments/assets/a9e983e2-ac0e-4b2e-9281-751d3768b40b)

### TESTING INSTRUCTIONS
1. Create a Handlebars chart using the `cleaned_sales_data` dataset.
2. Use `year` and `deal_size` as dimensions and create any metric with the `test_metric` label.
3. Use below Handlebars template:
```
{{#group data by="year"}}
<h3>Year: {{ value }}</h3>
<ul>
{{#each items}}
	<li>{{ deal_size }} deals: {{ formatNumber test_metric "de-DE"}}</li>
{{/each}}
</ul>
{{/group}}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
