### PR TITLE
fix(trino): db session error in handle cursor

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=consider-using-transaction
 from __future__ import annotations
 
 import contextlib
@@ -216,7 +215,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
         if tracking_url := cls.get_tracking_url(cursor):
             query.tracking_url = tracking_url
 
-        db.session.commit()
+        db.session.commit()  # pylint: disable=consider-using-transaction
 
         # if query cancelation was requested prior to the handle_cursor call, but
         # the query was still executed, trigger the actual query cancelation now
@@ -309,7 +308,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
     def prepare_cancel_query(cls, query: Query) -> None:
         if QUERY_CANCEL_KEY not in query.extra:
             query.set_extra_json_key(QUERY_EARLY_CANCEL_KEY, True)
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
 
     @classmethod
     def cancel_query(cls, cursor: Cursor, query: Query, cancel_query_id: str) -> bool:


### PR DESCRIPTION
### SUMMARY
In the thread execution function, the query is referenced, and since it occupies the session within the thread scope, it became impossible to perform session transactions related to the query in the handle_cursor that runs separately.
This resulted in errors for multi-statement queries. This commit changes the code to ensure that the database object is only referenced in the thread, thereby separating the session scope.
Additionally, it resolves the issue where handle_cursor would skip sleep when a multi-statement is executing, allowing access before execution.

```
2024-11-25 18:35:16,271:DEBUG:superset.db_engine_specs.trino:Query 18151072: Handling cursor
2024-11-25 18:35:16,271:DEBUG:superset.db_engine_specs.trino:Query 18151072: queryId 20241125_183516_08494_6vvqw found in cursor
2024-11-25 18:35:16,273:DEBUG:superset.sql_lab:Query 18151072: This session is in 'prepared' state; no further SQL can be emitted within this transaction.
2024-11-25 18:35:16,277:INFO:backoff:Backing off get_query(...) for 0.9s (superset.sql_lab.SqlLabException: Failed at getting query)
2024-11-25 18:35:16,277:ERROR:superset.sqllab.sql_json_executer:Query 18151072 failed unexpectedly
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/base.py", line 1094, in _commit_impl
    self.engine.dialect.do_commit(self.connection)
  File "/usr/local/lib/python3.10/dist-packages/sqlalchemy/engine/default.py", line 686, in do_commit
    dbapi_connection.commit()
MySQLdb.OperationalError: (2013, 'Lost connection to MySQL server during query')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/srv/superset-internal/apache-superset/superset/sql_lab.py", line 302, in execute_sql_statement
    db_engine_spec.execute_with_cursor(cursor, sql, query)
  File "/srv/superset-internal/apache-superset/superset/db_engine_specs/trino.py", line 269, in execute_with_cursor
    cls.handle_cursor(cursor, query)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No error thrown

### TESTING INSTRUCTIONS
Run a multi-statement query in trino db, such like `select 1; select 2;`


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
