### PR TITLE
fix(api): /v1/me and /v1/me/roles access with JWT

### DIFF
--- a/superset/views/users/api.py
+++ b/superset/views/users/api.py
@@ -17,6 +17,7 @@
 from flask import g, redirect, Response
 from flask_appbuilder.api import expose, safe
 from flask_jwt_extended.exceptions import NoAuthorizationError
+from flask_jwt_extended.view_decorators import jwt_required
 from sqlalchemy.orm.exc import NoResultFound
 
 from superset import app, is_feature_enabled
@@ -38,6 +39,7 @@ class CurrentUserRestApi(BaseSupersetApi):
 
     @expose("/", methods=("GET",))
     @safe
+    @jwt_required(optional=True)
     def get_me(self) -> Response:
         """Get the user object corresponding to the agent making the request.
         ---
@@ -69,6 +71,7 @@ class CurrentUserRestApi(BaseSupersetApi):
 
     @expose("/roles/", methods=("GET",))
     @safe
+    @jwt_required(optional=True)
     def get_my_roles(self) -> Response:
         """Get the user roles corresponding to the agent making the request.
         ---


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows for using JWT for authorizing the `/me` and `/me/roles` APIs
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: https://github.com/apache/superset/issues/25876
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
