### PR TITLE
Fix: this.props overwrite config in TextAreaControl

### DIFF
--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -97,6 +97,7 @@ class TextAreaControl extends Component {
 
       return (
         <TextAreaEditor
+          {...this.props}
           mode={this.props.language}
           style={style}
           minLines={minLines}
@@ -105,7 +106,6 @@ class TextAreaControl extends Component {
           defaultValue={this.props.initialValue}
           readOnly={this.props.readOnly}
           key={this.props.name}
-          {...this.props}
           onChange={this.onAreaEditorChange.bind(this)}
         />
       );


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
this.props overwrite config in TextAreaControl, in that case inModal state has the same style as not modal

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
