### PR TITLE
fix(sqllab): Remove update_saved_query_exec_info to reduce lag

### DIFF
--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -278,7 +278,7 @@ const SavedQueries = ({
                 url={`/sqllab?savedQueryId=${q.id}`}
                 title={q.label}
                 imgFallbackURL="/static/assets/images/empty-query.svg"
-                description={t('Ran %s', q.changed_on_delta_humanized)}
+                description={t('Modified %s', q.changed_on_delta_humanized)}
                 cover={
                   q?.sql?.length && showThumbnails && featureFlag ? (
                     <QueryContainer>

--- a/superset/daos/query.py
+++ b/superset/daos/query.py
@@ -36,25 +36,6 @@ class QueryDAO(BaseDAO[Query]):
     base_filter = QueryFilter
 
     @staticmethod
-    def update_saved_query_exec_info(query_id: int) -> None:
-        """
-        Propagates query execution info back to saved query if applicable
-
-        :param query_id: The query id
-        :return:
-        """
-        query = db.session.query(Query).get(query_id)
-        related_saved_queries = (
-            db.session.query(SavedQuery)
-            .filter(SavedQuery.database == query.database)
-            .filter(SavedQuery.sql == query.sql)
-        ).all()
-        if related_saved_queries:
-            for saved_query in related_saved_queries:
-                saved_query.rows = query.rows
-                saved_query.last_run = datetime.now()
-
-    @staticmethod
     def save_metadata(query: Query, payload: dict[str, Any]) -> None:
         # pull relevant data from payload and store in extra_json
         columns = payload.get("columns", {})

--- a/superset/sqllab/sql_json_executer.py
+++ b/superset/sqllab/sql_json_executer.py
@@ -95,7 +95,6 @@ class SynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             data = self._get_sql_results_with_timeout(
                 execution_context, rendered_query, log_params
             )
-            self._query_dao.update_saved_query_exec_info(query_id)
             execution_context.set_execution_result(data)
         except SupersetTimeoutException:
             raise
@@ -200,5 +199,4 @@ class ASynchronousSqlJsonExecutor(SqlJsonExecutorBase):
             query.status = QueryStatus.FAILED
             query.error_message = message
             raise SupersetErrorException(error) from ex
-        self._query_dao.update_saved_query_exec_info(query_id)
         return SqlJsonExecutionStatus.QUERY_IS_RUNNING

--- a/tests/integration_tests/sqllab_tests.py
+++ b/tests/integration_tests/sqllab_tests.py
@@ -17,7 +17,6 @@
 # isort:skip_file
 """Unit tests for Sql Lab"""
 
-from datetime import datetime
 from textwrap import dedent
 
 import pytest
@@ -26,7 +25,6 @@ from parameterized import parameterized
 from unittest import mock
 import prison
 
-from freezegun import freeze_time
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable  # noqa: F401
 from superset.db_engine_specs import BaseEngineSpec
@@ -34,7 +32,7 @@ from superset.db_engine_specs.hive import HiveEngineSpec
 from superset.db_engine_specs.presto import PrestoEngineSpec
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import SupersetErrorException
-from superset.models.sql_lab import Query, SavedQuery
+from superset.models.sql_lab import Query
 from superset.result_set import SupersetResultSet
 from superset.sqllab.limiting_factor import LimitingFactor
 from superset.sql_lab import (
@@ -155,34 +153,6 @@ class TestSqlLab(SupersetTestCase):
                 }
             ]
         }
-
-    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_sql_json_to_saved_query_info(self):
-        """
-        SQLLab: Test SQLLab query execution info propagation to saved queries
-        """
-        self.login(ADMIN_USERNAME)
-
-        sql_statement = "SELECT * FROM birth_names LIMIT 10"
-        examples_db_id = get_example_database().id
-        saved_query = SavedQuery(db_id=examples_db_id, sql=sql_statement)
-        db.session.add(saved_query)
-        db.session.commit()
-
-        with freeze_time(datetime.now().isoformat(timespec="seconds")):
-            self.run_sql(sql_statement, "1")
-            saved_query_ = (
-                db.session.query(SavedQuery)
-                .filter(
-                    SavedQuery.db_id == examples_db_id, SavedQuery.sql == sql_statement
-                )
-                .one_or_none()
-            )
-            assert saved_query_.rows is not None
-            assert saved_query_.last_run == datetime.now()
-        # Rollback changes
-        db.session.delete(saved_query_)
-        db.session.commit()
 
     @parameterized.expand([CtasMethod.TABLE, CtasMethod.VIEW])
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")


### PR DESCRIPTION
### SUMMARY
Currently, there is a significant bottleneck when executing queries in sqllab due to the delay in `update_saved_query_exec_info`. 

![Superset](https://github.com/user-attachments/assets/3e1512cd-87c9-48b7-9163-acdb285ef042)

![392578130-07d5b578-3beb-4797-a982-49ab524572bb_png__1197×268_](https://github.com/user-attachments/assets/03524ab7-904a-40ba-8bf8-89673339febe)

According to #11391, the information obtained during the `update_saved_query_exec_info` was added for display on the homepage, but it has been confirmed that the recently changed_date is actually being used.

To facilitate smoother execution of sqllab queries, this commit removes the `update_saved_query_exec_info` part. Additionally, it changed the displayed label (from `ran` to `modified`) on the homepage to reflect the actual data.

### TESTING INSTRUCTIONS

CI and specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
