### PR TITLE
feat: Adds helper functions for migrations

### DIFF
--- a/superset/migrations/shared/constraints.py
+++ b/superset/migrations/shared/constraints.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from alembic import op
-from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
 from sqlalchemy.engine.reflection import Inspector
 
-from superset.migrations.shared.utils import has_table
 from superset.utils.core import generic_find_fk_constraint_name
 
 
@@ -73,23 +71,3 @@ def redefine(
             ondelete=on_delete,
             onupdate=on_update,
         )
-
-
-def drop_fks_for_table(table_name: str) -> None:
-    """
-    Drop all foreign key constraints for a table if it exist and the database
-    is not sqlite.
-
-    :param table_name: The table name to drop foreign key constraints for
-    """
-    connection = op.get_bind()
-    inspector = Inspector.from_engine(connection)
-
-    if isinstance(connection.dialect, SQLiteDialect):
-        return  # sqlite doesn't like constraints
-
-    if has_table(table_name):
-        foreign_keys = inspector.get_foreign_keys(table_name)
-
-        for fk in foreign_keys:
-            op.drop_constraint(fk["name"], table_name, type_="foreignkey")

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -23,13 +23,22 @@ from uuid import uuid4
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import inspect
+from sqlalchemy import Column, inspect
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.dialects.sqlite.base import SQLiteDialect  # noqa: E402
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import Query, Session
+from sqlalchemy.sql.schema import SchemaItem
 
 from superset.utils import json
+
+GREEN = "\033[32m"
+RESET = "\033[0m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+LRED = "\033[91m"
 
 logger = logging.getLogger(__name__)
 
@@ -185,15 +194,200 @@ def has_table(table_name: str) -> bool:
     return table_exists
 
 
-def add_column_if_not_exists(table_name: str, column: sa.Column) -> None:
+def drop_fks_for_table(table_name: str) -> None:
     """
-    Adds a column to a table if it does not already exist.
+    Drop all foreign key constraints for a table if it exist and the database
+    is not sqlite.
 
-    :param table_name: Name of the table.
-    :param column: SQLAlchemy Column object.
+    :param table_name: The table name to drop foreign key constraints for
     """
-    if not table_has_column(table_name, column.name):
-        print(f"Adding column '{column.name}' to table '{table_name}'.\n")
-        op.add_column(table_name, column)
-    else:
-        print(f"Column '{column.name}' already exists in table '{table_name}'.\n")
+    connection = op.get_bind()
+    inspector = Inspector.from_engine(connection)
+
+    if isinstance(connection.dialect, SQLiteDialect):
+        return  # sqlite doesn't like constraints
+
+    if has_table(table_name):
+        foreign_keys = inspector.get_foreign_keys(table_name)
+
+        for fk in foreign_keys:
+            op.drop_constraint(fk["name"], table_name, type_="foreignkey")
+
+
+logger = logging.getLogger("alembic")
+
+
+def create_table(table_name: str, *columns: SchemaItem) -> None:
+    """
+    Creates a database table with the specified name and columns.
+
+    This function checks if a table with the given name already exists in the database.
+    If the table exists, it logs an informational message and skips the creation process.
+    Otherwise, it proceeds to create a new table using the provided name and schema columns.
+
+    :param table_name: The name of the table to be created.
+    :param columns: A variable number of arguments representing the schema just like when calling alembic's method create_table()
+    """
+
+    if has_table(table_name=table_name):
+        logger.info(f"Table {LRED}{table_name}{RESET} already exists Skipping...")
+        return
+
+    logger.info(f"Creating table {GREEN}{table_name}{RESET}...")
+    op.create_table(table_name, *columns)
+    logger.info(f"Table {GREEN}{table_name}{RESET} created")
+
+
+def drop_table(table_name: str) -> None:
+    """
+    Drops a database table with the specified name.
+
+    This function checks if a table with the given name exists in the database.
+    If the table does not exist, it logs an informational message and skips the dropping process.
+    If the table exists, it first attempts to drop all foreign key constraints associated with the table
+    (handled by `drop_fks_for_table`) and then proceeds to drop the table.
+
+    :param table_name: The name of the table to be dropped.
+    """
+
+    if not has_table(table_name=table_name):
+        logger.info(f"Table {GREEN}{table_name}{RESET} doesn't exist Skipping...")
+        return
+
+    logger.info(f"Dropping table {GREEN}{table_name}{RESET}...")
+    drop_fks_for_table(table_name)
+    op.drop_table(table_name=table_name)
+    logger.info(f"Table {GREEN}{table_name}{RESET} dropped")
+
+
+def batch_operation(
+    callable: Callable[[int, int], None], count: int, batch_size: int
+) -> None:
+    for offset in range(0, count, batch_size):
+        percentage = (offset / count) * 100 if count else 0
+        logger.info(f"Progress: {offset:,}/{count:,} ({percentage:.2f}%)")
+        callable(offset, min(offset + batch_size, count))
+
+    logger.info(f"Progress: {count:,}/{count:,} (100%)")
+    logger.info(
+        f"End: {callable.__name__} batch operation {GREEN}succesfully{RESET} executed"
+    )
+
+
+def add_columns(table_name: str, columns: list[Column]) -> None:
+    """
+    Adds new columns to an existing database table.
+
+    For each column on columns list variable, it checks if the column already exists in the table. If a column already exists, it logs an informational
+    message and skips the addition of that column. Otherwise, it proceeds to add the new column to the table.
+
+    The operation is performed within a batch operation context which allows a more performant approach
+
+    :param table_name: The name of the table to which the columns will be added.
+    :param columns: A list of SQLAlchemy Column objects that define the name, type, and other attributes of the columns to be added.
+    """
+
+    cols_to_add = []
+    for col in columns:
+        if table_has_column(table_name=table_name, column_name=col.name):
+            logger.info(
+                f"Column {LRED}{col.name}{RESET} already present on table {LRED}{table_name}{RESET} Skipping..."
+            )
+        else:
+            cols_to_add.append(col)
+
+    with op.batch_alter_table(table_name) as batch_op:
+        for col in cols_to_add:
+            logger.info(
+                f"Adding column {GREEN}{col.name}{RESET} to table {GREEN}{table_name}{RESET}"
+            )
+            batch_op.add_column(col)
+
+
+def drop_columns(table_name: str, columns: list[str]) -> None:
+    """
+    Drops specified columns from an existing database table.
+
+    For each column, it first checks if the column exists in the table. If a column does not exist, it logs an informational
+    message and skips the dropping of that column. Otherwise, it proceeds to remove the column from the table.
+
+    The operation is performed within a batch operation context which allows a more performant approach
+
+    :param table_name: The name of the table from which the columns will be removed.
+    :param columns: A list of column names to be dropped.
+    """
+
+    cols_to_drop = []
+    for col in columns:
+        if not table_has_column(table_name=table_name, column_name=col):
+            logger.info(
+                f"Column {LRED}{col}{RESET} is not present on table {LRED}{table_name}{RESET} Skipping..."
+            )
+        else:
+            cols_to_drop.append(col)
+
+    with op.batch_alter_table(table_name) as batch_op:
+        for col in cols_to_drop:
+            logger.info(
+                f"Dropping column {GREEN}{col}{RESET} from table {GREEN}{table_name}{RESET}"
+            )
+            batch_op.drop_column(col)
+
+
+def create_index(table_name: str, index_name: str, columns: list[Column]) -> None:
+    """
+    Creates an index on specified columns of an existing database table.
+
+    This function checks if an index with the given name already exists on the specified table.
+    If so, it logs an informational message and skips the index creation process.
+    Otherwise, it proceeds to create a new index with the specified name on the given columns of the table.
+
+    The operation is performed within a batch operation context which allows a more performant approach
+
+    :param table_name: The name of the table on which the index will be created.
+    :param index_name: The name of the index to be created.
+    :param columns: A list of column names (as strings) that the index will cover. This list should contain
+                    the names of existing columns in the table.
+    """
+
+    if table_has_index(table=table_name, index=index_name):
+        logger.info(
+            f"Table {LRED}{table_name}{RESET} already has index {LRED}{index_name}{RESET} Skipping..."
+        )
+        return
+
+    logger.info(
+        f"Creating index {GREEN}{index_name}{RESET} on table {GREEN}{table_name}{RESET}"
+    )
+
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.create_index(index_name=index_name, columns=columns)
+
+
+def drop_index(table_name: str, index_name: str) -> None:
+    """
+    Drops an index from an existing database table.
+
+    Before attempting to drop the index, this function checks if an index with the given name
+    exists on the specified table. If not, it logs an informational message and skips the index
+      dropping process. If the index exists, it proceeds with the removal operation.
+
+    The operation is performed within a batch operation context which allows a more performant approach
+
+
+    :param table_name: The name of the table from which the index will be dropped.
+    :param index_name: The name of the index to be dropped.
+    """
+
+    if not table_has_index(table=table_name, index=index_name):
+        logger.info(
+            f"Table {LRED}{table_name}{RESET} doesn't have index {LRED}{index_name}{RESET} Skipping..."
+        )
+        return
+
+    logger.info(
+        f"Dropping index {GREEN}{index_name}{RESET} from table {GREEN}{table_name}{RESET}"
+    )
+
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.drop_index(index_name=index_name)

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -228,12 +228,12 @@ def create_table(table_name: str, *columns: SchemaItem) -> None:
     """
 
     if has_table(table_name=table_name):
-        logger.info(f"Table {LRED}{table_name}{RESET} already exists Skipping...")
+        logger.info(f"Table {LRED}{table_name}{RESET} already exists. Skipping...")
         return
 
     logger.info(f"Creating table {GREEN}{table_name}{RESET}...")
     op.create_table(table_name, *columns)
-    logger.info(f"Table {GREEN}{table_name}{RESET} created")
+    logger.info(f"Table {GREEN}{table_name}{RESET} created.")
 
 
 def drop_table(table_name: str) -> None:
@@ -249,13 +249,13 @@ def drop_table(table_name: str) -> None:
     """
 
     if not has_table(table_name=table_name):
-        logger.info(f"Table {GREEN}{table_name}{RESET} doesn't exist Skipping...")
+        logger.info(f"Table {GREEN}{table_name}{RESET} doesn't exist. Skipping...")
         return
 
     logger.info(f"Dropping table {GREEN}{table_name}{RESET}...")
     drop_fks_for_table(table_name)
     op.drop_table(table_name=table_name)
-    logger.info(f"Table {GREEN}{table_name}{RESET} dropped")
+    logger.info(f"Table {GREEN}{table_name}{RESET} dropped.")
 
 
 def batch_operation(
@@ -268,11 +268,18 @@ def batch_operation(
     that performs the operation on each batch. The function logs the progress of the operation as it processes
     through the batches.
 
+    If count is set to 0 or lower, it logs an informational message and skips the batch process.
+
     :param callable: A callable function that takes two integer arguments:
     the start index and the end index of the current batch.
     :param count: The total number of items to process.
     :param batch_size: The number of items to process in each batch.
     """
+    if count <= 0:
+        logger.info(
+            f"No records to process in batch {LRED}(count <= 0){RESET} for callable {LRED}other_callable_example{RESET}. Skipping..."
+        )
+        return
     for offset in range(0, count, batch_size):
         percentage = (offset / count) * 100 if count else 0
         logger.info(f"Progress: {offset:,}/{count:,} ({percentage:.2f}%)")
@@ -280,7 +287,7 @@ def batch_operation(
 
     logger.info(f"Progress: {count:,}/{count:,} (100%)")
     logger.info(
-        f"End: {GREEN}{callable.__name__}{RESET} batch operation {GREEN}succesfully{RESET} executed"
+        f"End: {GREEN}{callable.__name__}{RESET} batch operation {GREEN}succesfully{RESET} executed."
     )
 
 
@@ -288,7 +295,7 @@ def add_columns(table_name: str, *columns: Column) -> None:
     """
     Adds new columns to an existing database table.
 
-    If a column already exists, it logs an informational.
+    If a column already exists, it logs an informational message and skips the adding process.
     Otherwise, it proceeds to add the new column to the table.
 
     The operation is performed using Alembic's batch_alter_table.
@@ -301,7 +308,7 @@ def add_columns(table_name: str, *columns: Column) -> None:
     for col in columns:
         if table_has_column(table_name=table_name, column_name=col.name):
             logger.info(
-                f"Column {LRED}{col.name}{RESET} already present on table {LRED}{table_name}{RESET} Skipping..."
+                f"Column {LRED}{col.name}{RESET} already present on table {LRED}{table_name}{RESET}. Skipping..."
             )
         else:
             cols_to_add.append(col)
@@ -309,7 +316,7 @@ def add_columns(table_name: str, *columns: Column) -> None:
     with op.batch_alter_table(table_name) as batch_op:
         for col in cols_to_add:
             logger.info(
-                f"Adding column {GREEN}{col.name}{RESET} to table {GREEN}{table_name}{RESET}"
+                f"Adding column {GREEN}{col.name}{RESET} to table {GREEN}{table_name}{RESET}..."
             )
             batch_op.add_column(col)
 
@@ -318,7 +325,7 @@ def drop_columns(table_name: str, *columns: str) -> None:
     """
     Drops specified columns from an existing database table.
 
-    If a column does not exist, it logs an informational.
+    If a column does not exist, it logs an informational message and skips the dropping process.
     Otherwise, it proceeds to remove the column from the table.
 
     The operation is performed using Alembic's batch_alter_table.
@@ -331,7 +338,7 @@ def drop_columns(table_name: str, *columns: str) -> None:
     for col in columns:
         if not table_has_column(table_name=table_name, column_name=col):
             logger.info(
-                f"Column {LRED}{col}{RESET} is not present on table {LRED}{table_name}{RESET} Skipping..."
+                f"Column {LRED}{col}{RESET} is not present on table {LRED}{table_name}{RESET}. Skipping..."
             )
         else:
             cols_to_drop.append(col)
@@ -339,7 +346,7 @@ def drop_columns(table_name: str, *columns: str) -> None:
     with op.batch_alter_table(table_name) as batch_op:
         for col in cols_to_drop:
             logger.info(
-                f"Dropping column {GREEN}{col}{RESET} from table {GREEN}{table_name}{RESET}"
+                f"Dropping column {GREEN}{col}{RESET} from table {GREEN}{table_name}{RESET}..."
             )
             batch_op.drop_column(col)
 
@@ -348,7 +355,7 @@ def create_index(table_name: str, index_name: str, *columns: str) -> None:
     """
     Creates an index on specified columns of an existing database table.
 
-    If the index already exists, it logs an informational.
+    If the index already exists, it logs an informational message and skips the creation process.
     Otherwise, it proceeds to create a new index with the specified name on the given columns of the table.
 
     :param table_name: The name of the table on which the index will be created.
@@ -358,7 +365,7 @@ def create_index(table_name: str, index_name: str, *columns: str) -> None:
 
     if table_has_index(table=table_name, index=index_name):
         logger.info(
-            f"Table {LRED}{table_name}{RESET} already has index {LRED}{index_name}{RESET} Skipping..."
+            f"Table {LRED}{table_name}{RESET} already has index {LRED}{index_name}{RESET}. Skipping..."
         )
         return
 
@@ -373,7 +380,7 @@ def drop_index(table_name: str, index_name: str) -> None:
     """
     Drops an index from an existing database table.
 
-    If the index does not exists, it logs an informational.
+    If the index does not exists, it logs an informational message and skips the dropping process.
     Otherwise, it proceeds with the removal operation.
 
     :param table_name: The name of the table from which the index will be dropped.
@@ -382,12 +389,12 @@ def drop_index(table_name: str, index_name: str) -> None:
 
     if not table_has_index(table=table_name, index=index_name):
         logger.info(
-            f"Table {LRED}{table_name}{RESET} doesn't have index {LRED}{index_name}{RESET} Skipping..."
+            f"Table {LRED}{table_name}{RESET} doesn't have index {LRED}{index_name}{RESET}. Skipping..."
         )
         return
 
     logger.info(
-        f"Dropping index {GREEN}{index_name}{RESET} from table {GREEN}{table_name}{RESET}"
+        f"Dropping index {GREEN}{index_name}{RESET} from table {GREEN}{table_name}{RESET}..."
     )
 
     op.drop_index(table_name=table_name, index_name=index_name)

--- a/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
+++ b/superset/migrations/versions/2024-03-20_16-02_678eefb4ab44_add_access_token_table.py
@@ -30,7 +30,7 @@ import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 from sqlalchemy_utils import EncryptedType  # noqa: E402
 
-from superset.migrations.shared.constraints import drop_fks_for_table  # noqa: E402
+from superset.migrations.shared.utils import drop_fks_for_table  # noqa: E402
 
 
 def upgrade():

--- a/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
+++ b/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
@@ -24,7 +24,7 @@ Create Date: 2024-04-01 22:44:40.386543
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.utils import add_column_if_not_exists
+from superset.migrations.shared.utils import add_columns, drop_columns
 
 # revision identifiers, used by Alembic.
 revision = "c22cb5c2e546"
@@ -32,11 +32,11 @@ down_revision = "678eefb4ab44"
 
 
 def upgrade():
-    add_column_if_not_exists(
+    add_columns(
         "user_attribute",
-        sa.Column("avatar_url", sa.String(length=100), nullable=True),
+        [sa.Column("avatar_url", sa.String(length=100), nullable=True)],
     )
 
 
 def downgrade():
-    op.drop_column("user_attribute", "avatar_url")
+    drop_columns("user_attribute", ["avatar_url"])

--- a/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
+++ b/superset/migrations/versions/2024-04-01_22-44_c22cb5c2e546_user_attr_avatar_url.py
@@ -22,7 +22,6 @@ Create Date: 2024-04-01 22:44:40.386543
 """
 
 import sqlalchemy as sa
-from alembic import op
 
 from superset.migrations.shared.utils import add_columns, drop_columns
 
@@ -34,9 +33,9 @@ down_revision = "678eefb4ab44"
 def upgrade():
     add_columns(
         "user_attribute",
-        [sa.Column("avatar_url", sa.String(length=100), nullable=True)],
+        sa.Column("avatar_url", sa.String(length=100), nullable=True),
     )
 
 
 def downgrade():
-    drop_columns("user_attribute", ["avatar_url"])
+    drop_columns("user_attribute", "avatar_url")

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -23,7 +23,6 @@ Create Date: 2024-04-11 15:41:34.663989
 """
 
 import sqlalchemy as sa
-from alembic import op
 
 from superset.migrations.shared.utils import add_columns, drop_columns
 
@@ -36,9 +35,9 @@ tables = ["tables", "query", "saved_query", "tab_state", "table_schema"]
 
 def upgrade():
     for table in tables:
-        add_columns(table, [sa.Column("catalog", sa.String(length=256), nullable=True)])
+        add_columns(table, sa.Column("catalog", sa.String(length=256), nullable=True))
 
 
 def downgrade():
     for table in reversed(tables):
-        drop_columns(table, ["catalog"])
+        drop_columns(table, "catalog")

--- a/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
+++ b/superset/migrations/versions/2024-04-11_15-41_5f57af97bc3f_add_catalog_column.py
@@ -25,7 +25,7 @@ Create Date: 2024-04-11 15:41:34.663989
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.utils import add_column_if_not_exists
+from superset.migrations.shared.utils import add_columns, drop_columns
 
 # revision identifiers, used by Alembic.
 revision = "5f57af97bc3f"
@@ -36,12 +36,9 @@ tables = ["tables", "query", "saved_query", "tab_state", "table_schema"]
 
 def upgrade():
     for table in tables:
-        add_column_if_not_exists(
-            table,
-            sa.Column("catalog", sa.String(length=256), nullable=True),
-        )
+        add_columns(table, [sa.Column("catalog", sa.String(length=256), nullable=True)])
 
 
 def downgrade():
     for table in reversed(tables):
-        op.drop_column(table, "catalog")
+        drop_columns(table, ["catalog"])

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -23,7 +23,6 @@ Create Date: 2024-05-01 10:52:31.458433
 """
 
 import sqlalchemy as sa
-from alembic import op
 
 from superset.migrations.shared.catalogs import (
     downgrade_catalog_perms,
@@ -38,15 +37,15 @@ down_revision = "4a33124c18ad"
 
 def upgrade():
     add_columns(
-        "tables", [sa.Column("catalog_perm", sa.String(length=1000), nullable=True)]
+        "tables", sa.Column("catalog_perm", sa.String(length=1000), nullable=True)
     )
     add_columns(
-        "slices", [sa.Column("catalog_perm", sa.String(length=1000), nullable=True)]
+        "slices", sa.Column("catalog_perm", sa.String(length=1000), nullable=True)
     )
     upgrade_catalog_perms(engines={"postgresql"})
 
 
 def downgrade():
     downgrade_catalog_perms(engines={"postgresql"})
-    drop_columns("slices", ["catalog_perm"])
-    drop_columns("tables", ["catalog_perm"])
+    drop_columns("slices", "catalog_perm")
+    drop_columns("tables", "catalog_perm")

--- a/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
+++ b/superset/migrations/versions/2024-05-01_10-52_58d051681a3b_add_catalog_perm_to_tables.py
@@ -29,7 +29,7 @@ from superset.migrations.shared.catalogs import (
     downgrade_catalog_perms,
     upgrade_catalog_perms,
 )
-from superset.migrations.shared.utils import add_column_if_not_exists
+from superset.migrations.shared.utils import add_columns, drop_columns
 
 # revision identifiers, used by Alembic.
 revision = "58d051681a3b"
@@ -37,18 +37,16 @@ down_revision = "4a33124c18ad"
 
 
 def upgrade():
-    add_column_if_not_exists(
-        "tables",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+    add_columns(
+        "tables", [sa.Column("catalog_perm", sa.String(length=1000), nullable=True)]
     )
-    add_column_if_not_exists(
-        "slices",
-        sa.Column("catalog_perm", sa.String(length=1000), nullable=True),
+    add_columns(
+        "slices", [sa.Column("catalog_perm", sa.String(length=1000), nullable=True)]
     )
     upgrade_catalog_perms(engines={"postgresql"})
 
 
 def downgrade():
     downgrade_catalog_perms(engines={"postgresql"})
-    op.drop_column("slices", "catalog_perm")
-    op.drop_column("tables", "catalog_perm")
+    drop_columns("slices", ["catalog_perm"])
+    drop_columns("tables", ["catalog_perm"])

--- a/superset/migrations/versions/2024-05-24_11-31_02f4f7811799_remove_sl_dataset_columns_table.py
+++ b/superset/migrations/versions/2024-05-24_11-31_02f4f7811799_remove_sl_dataset_columns_table.py
@@ -25,8 +25,7 @@ Create Date: 2024-05-24 11:31:57.115586
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "02f4f7811799"

--- a/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
+++ b/superset/migrations/versions/2024-08-13_15-17_39549add7bfc_remove_sl_table_columns_table.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:17:23.273168
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "39549add7bfc"

--- a/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-23_38f4144e8558_remove_sl_dataset_tables.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:23:28.768963
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "38f4144e8558"

--- a/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
+++ b/superset/migrations/versions/2024-08-13_15-27_e53fd48cc078_remove_sl_dataset_users.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:27:11.589886
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "e53fd48cc078"

--- a/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
+++ b/superset/migrations/versions/2024-08-13_15-29_a6b32d2d07b1_remove_sl_columns.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:29:33.135672
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "a6b32d2d07b1"

--- a/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
+++ b/superset/migrations/versions/2024-08-13_15-31_007a1abffe7e_remove_sl_tables.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:31:31.478017
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "007a1abffe7e"

--- a/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
+++ b/superset/migrations/versions/2024-08-13_15-33_48cbb571fa3a_remove_sl_datasets.py
@@ -25,8 +25,7 @@ Create Date: 2024-08-13 15:33:14.551012
 import sqlalchemy as sa
 from alembic import op
 
-from superset.migrations.shared.constraints import drop_fks_for_table
-from superset.migrations.shared.utils import has_table
+from superset.migrations.shared.utils import drop_fks_for_table, has_table
 
 # revision identifiers, used by Alembic.
 revision = "48cbb571fa3a"


### PR DESCRIPTION
### SUMMARY

This PR aims to implement helper functions that will provide standard interfaces for the most used methods found in the migrations for the past 2 years, which are: create and drop tables, add and drop columns, create and drop indexes. Another objective to make logging standard among migrations by providing more human readable logs and displaying the same type of information.

These new functions will apply some validations before executing such as: 
- When adding/dropping a column, does this column already exist on the table? 
- Does the index to be created is already present on the table? 

These types of validations will make the migrations more resilient. The added helper functions and their logs are:

```
def create_table(table_name: str, *columns: SchemaItem) -> None:

INFO [alembic] Creating table temp_table…
INFO [alembic] Table temp_table created
```

```
def drop_table(table_name: str) -> None:

INFO  [alembic] Dropping table temp_table...
INFO  [alembic] Table temp_table dropped
```

```
def add_columns(table_name: str, *columns: Column) -> None:

INFO [alembic] Adding column new_id on table temp_table
INFO [alembic] Column id already present on table temp_table Skipping…
```

```
def drop_columns(table_name: str, *columns: str) -> None:

INFO  [alembic] Column address is not present on table temp_table Skipping...
INFO  [alembic] Dropping column new_id from table temp_table
```

```
def create_index(table_name: str, index_name: str, *columns: str) -> None:

INFO [alembic] Creating index my_index on table temp_table
INFO [alembic] Table temp_table already has index my_index Skipping…
```

```
def drop_index(table_name: str, index_name: str) -> None:

INFO  [alembic] Dropping index my_index from table temp_table
INFO  [alembic] Table temp_table doesn't have index other_index Skipping...
```

There’s also a new method for executing database operations in batch. This function will receive a `Callable`, the `count` and `batch_size` as the parameters. When executing, the `Callable` will receive the offset and limit for the current processed batch.

```
def batch_operation(callable: Callable[[int, int], None], count: int, batch_size: int) -> None:

INFO [alembic] Progress: 0/100,000 (0.00%)
INFO [alembic] Progress: 25,000/100,000 (25.00%)
INFO [alembic] Progress: 50,000/100,000 (50.00%)
INFO [alembic] Progress: 75.000/100,000 (75.00%)
INFO [alembic] Progress: 100,000/100,000 (100%)
INFO [alembic] End: callable_example batch operation successfully executed
```

### TESTING INSTRUCTIONS
Execute the migrations using `superset db upgrade` and superset db downgrade` commands and make sure everything works as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
