### PR TITLE
refactor(Name_column): Make 'Name' column of Saved Query page into links

### DIFF
--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -296,6 +296,11 @@ function SavedQueryList({
       {
         accessor: 'label',
         Header: t('Name'),
+        Cell: ({
+          row: {
+            original: { id, label },
+          },
+        }: any) => <Link to={`/sqllab?savedQueryId=${id}`}>{label}</Link>,
       },
       {
         accessor: 'description',


### PR DESCRIPTION
<!---
Fixes #31011
refactor(Name column): Make 'Name' column of Saved Query page into links
-->

### SUMMARY
This change updates the "Name" column on the Saved Query page to render the query names as clickable links. These links redirect users to SQL Lab with the respective saved query preloaded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![links](https://github.com/user-attachments/assets/be57b53b-6dbb-43dc-8697-e78b2257b618)

### TESTING INSTRUCTIONS
1. Navigate to the Saved Queries page in the application.
2. Ensure you have at least one saved query in the list. If not, create a new query and save it.
3. Check that the **Name** column now displays query names as clickable links.
4. Click on any query name in the **Name** column.
   - Verify that the link redirects you to SQL Lab with the corresponding saved query loaded.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [x] Has associated issue: Fixes #31011
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
