### PR TITLE
feat(sqllab): giving the query history pane a facelift

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -421,7 +421,7 @@ export function postStopQuery(query) {
     })
       .then(() => dispatch(stopQuery(query)))
       .then(() => dispatch(addSuccessToast(t('Query was stopped.'))))
-      .catch(() => dispatch(addDangerToast(t('Failed at stopping query.'))));
+      .catch(() => dispatch(addDangerToast(t('Failed to stop query.'))));
   };
 }
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -384,7 +384,6 @@ export function runQueryFromSqlEditor(
   ctas,
   ctasMethod,
 ) {
-  console.log('YOYO', queryEditor);
   return function (dispatch, getState) {
     const qe = getUpToDateQuery(getState(), queryEditor, queryEditor.id);
     const query = {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -384,6 +384,7 @@ export function runQueryFromSqlEditor(
   ctas,
   ctasMethod,
 ) {
+  console.log('YOYO', queryEditor);
   return function (dispatch, getState) {
     const qe = getUpToDateQuery(getState(), queryEditor, queryEditor.id);
     const query = {
@@ -421,9 +422,7 @@ export function postStopQuery(query) {
     })
       .then(() => dispatch(stopQuery(query)))
       .then(() => dispatch(addSuccessToast(t('Query was stopped.'))))
-      .catch(() =>
-        dispatch(addDangerToast(t('Failed at stopping query. %s', query.id))),
-      );
+      .catch(() => dispatch(addDangerToast(t('Failed at stopping query.'))));
   };
 }
 

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -35,6 +35,7 @@ import TableView from 'src/components/TableView';
 import Button from 'src/components/Button';
 import { fDuration } from 'src/utils/dates';
 import Icons from 'src/components/Icons';
+import Label from 'src/components/Label';
 import { Tooltip } from 'src/components/Tooltip';
 import { SqlLabRootState } from 'src/SqlLab/types';
 import ModalTrigger from 'src/components/ModalTrigger';
@@ -125,49 +126,52 @@ const QueryTable = ({
     const statusAttributes = {
       success: {
         config: {
-          icon: <Icons.Check iconColor={theme.colors.success.base} />,
+          icon: <Icons.CheckOutlined iconColor={theme.colors.success.base} />,
+          //icon: <Icons.Edit iconSize="xl" />,
           label: t('Success'),
         },
       },
       failed: {
         config: {
-          icon: <Icons.XSmall iconColor={theme.colors.error.base} />,
+          icon: <Icons.CloseOutlined iconColor={theme.colors.error.base} />,
           label: t('Failed'),
         },
       },
       stopped: {
         config: {
-          icon: <Icons.XSmall iconColor={theme.colors.error.base} />,
+          icon: <Icons.CloseOutlined iconColor={theme.colors.error.base} />,
           label: t('Failed'),
         },
       },
       running: {
         config: {
-          icon: <Icons.Running iconColor={theme.colors.primary.base} />,
+          icon: <Icons.LoadingOutlined iconColor={theme.colors.primary.base} />,
           label: t('Running'),
         },
       },
       fetching: {
         config: {
-          icon: <Icons.Queued iconColor={theme.colors.primary.base} />,
+          icon: (
+            <Icons.HourglassOutlined iconColor={theme.colors.primary.base} />
+          ),
           label: t('Fetching'),
         },
       },
       timed_out: {
         config: {
-          icon: <Icons.Offline iconColor={theme.colors.grayscale.light1} />,
+          icon: <Icons.Clock iconColor={theme.colors.error.base} />,
           label: t('Offline'),
         },
       },
       scheduled: {
         config: {
-          icon: <Icons.Queued iconColor={theme.colors.grayscale.base} />,
+          icon: <Icons.Clock iconColor={theme.colors.warning.base} />,
           label: t('Scheduled'),
         },
       },
       pending: {
         config: {
-          icon: <Icons.Queued iconColor={theme.colors.grayscale.base} />,
+          icon: <Icons.Clock iconColor={theme.colors.warning.base} />,
           label: t('Scheduled'),
         },
       },
@@ -187,16 +191,14 @@ const QueryTable = ({
         const status = statusAttributes[state] || statusAttributes.error;
 
         if (q.endDttm) {
-          q.duration = fDuration(q.startDttm, q.endDttm);
+          q.duration = (
+            <Label
+              style={{ 'font-family': theme.typography.families.monospace }}
+            >
+              {fDuration(q.startDttm, q.endDttm)}
+            </Label>
+          );
         }
-        const time = moment(q.startDttm).format().split('T');
-        q.time = (
-          <div>
-            <span>
-              {time[0]} <br /> {time[1]}
-            </span>
-          </div>
-        );
         q.user = (
           <Button
             buttonSize="small"
@@ -215,7 +217,11 @@ const QueryTable = ({
             {q.db}
           </Button>
         );
-        q.started = moment(q.startDttm).format('L HH:mm:ss');
+        q.started = (
+          <Label style={{ 'font-family': theme.typography.families.monospace }}>
+            {moment(q.startDttm).format('L HH:mm:ss')}
+          </Label>
+        );
         q.querylink = (
           <Button
             buttonSize="small"
@@ -241,9 +247,9 @@ const QueryTable = ({
             <ModalTrigger
               className="ResultsModal"
               triggerNode={
-                <Label type="info" className="pointer">
+                <Button buttonSize="xsmall" buttonStyle="tertiary">
                   {t('View')}
-                </Label>
+                </Button>
               }
               modalTitle={t('Data preview')}
               beforeOpen={() => openAsyncResults(query, displayLimit)}
@@ -275,9 +281,7 @@ const QueryTable = ({
             <ProgressBar percent={parseInt(progress.toFixed(0), 10)} striped />
           );
         q.state = (
-          <Tooltip title={status.config.label} placement="bottom">
-            <span>{status.config.icon}</span>
-          </Tooltip>
+          <Tooltip title={status.config.label}>{status.config.icon}</Tooltip>
         );
         q.actions = (
           <div>
@@ -287,6 +291,7 @@ const QueryTable = ({
                 'Overwrite text in the editor with a query on this table',
               )}
               placement="top"
+              className="pointer"
             >
               <Icons.Edit iconSize="xl" />
             </StyledTooltip>
@@ -294,6 +299,7 @@ const QueryTable = ({
               onClick={() => openQueryInNewTab(query)}
               tooltip={t('Run query in a new tab')}
               placement="top"
+              className="pointer"
             >
               <Icons.PlusCircleOutlined iconSize="xl" css={verticalAlign} />
             </StyledTooltip>
@@ -301,6 +307,7 @@ const QueryTable = ({
               <StyledTooltip
                 tooltip={t('Remove query from log')}
                 onClick={() => dispatch(removeQuery(query))}
+                className="pointer"
               >
                 <Icons.Trash iconSize="xl" />
               </StyledTooltip>

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -126,58 +126,95 @@ const QueryTable = ({
     const statusAttributes = {
       success: {
         config: {
-          icon: <Icons.CheckOutlined iconColor={theme.colors.success.base} />,
+          icon: (
+            <Icons.CheckOutlined
+              iconColor={theme.colors.success.base}
+              iconSize="m"
+            />
+          ),
           //icon: <Icons.Edit iconSize="xl" />,
           label: t('Success'),
         },
       },
       failed: {
         config: {
-          icon: <Icons.CloseOutlined iconColor={theme.colors.error.base} />,
+          icon: (
+            <Icons.CloseOutlined
+              iconColor={theme.colors.error.base}
+              iconSize="m"
+            />
+          ),
           label: t('Failed'),
         },
       },
       stopped: {
         config: {
-          icon: <Icons.CloseOutlined iconColor={theme.colors.error.base} />,
+          icon: (
+            <Icons.CloseOutlined
+              iconColor={theme.colors.error.base}
+              iconSize="m"
+            />
+          ),
           label: t('Failed'),
         },
       },
       running: {
         config: {
-          icon: <Icons.LoadingOutlined iconColor={theme.colors.primary.base} />,
+          icon: (
+            <Icons.LoadingOutlined
+              iconColor={theme.colors.primary.base}
+              iconSize="m"
+            />
+          ),
           label: t('Running'),
         },
       },
       fetching: {
         config: {
           icon: (
-            <Icons.HourglassOutlined iconColor={theme.colors.primary.base} />
+            <Icons.LoadingOutlined
+              iconColor={theme.colors.primary.base}
+              iconSize="m"
+            />
           ),
           label: t('Fetching'),
         },
       },
       timed_out: {
         config: {
-          icon: <Icons.Clock iconColor={theme.colors.error.base} />,
+          icon: (
+            <Icons.Clock iconColor={theme.colors.error.base} iconSize="m" />
+          ),
           label: t('Offline'),
         },
       },
       scheduled: {
         config: {
-          icon: <Icons.Clock iconColor={theme.colors.warning.base} />,
+          icon: (
+            <Icons.LoadingOutlined
+              iconColor={theme.colors.warning.base}
+              iconSize="m"
+            />
+          ),
           label: t('Scheduled'),
         },
       },
       pending: {
         config: {
-          icon: <Icons.Clock iconColor={theme.colors.warning.base} />,
+          icon: (
+            <Icons.LoadingOutlined
+              iconColor={theme.colors.warning.base}
+              iconSize="m"
+            />
+          ),
           label: t('Scheduled'),
         },
       },
       error: {
         config: {
-          icon: <Icons.Error iconColor={theme.colors.error.base} />,
+          icon: (
+            <Icons.Error iconColor={theme.colors.error.base} iconSize="m" />
+          ),
           label: t('Unknown Status'),
         },
       },
@@ -192,11 +229,7 @@ const QueryTable = ({
 
         if (q.endDttm) {
           q.duration = (
-            <Label
-              style={{ 'font-family': theme.typography.families.monospace }}
-            >
-              {fDuration(q.startDttm, q.endDttm)}
-            </Label>
+            <Label monospace={true}>{fDuration(q.startDttm, q.endDttm)}</Label>
           );
         }
         q.user = (
@@ -218,7 +251,7 @@ const QueryTable = ({
           </Button>
         );
         q.started = (
-          <Label style={{ 'font-family': theme.typography.families.monospace }}>
+          <Label monospace={true}>
             {moment(q.startDttm).format('L HH:mm:ss')}
           </Label>
         );

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -136,7 +136,7 @@ const QueryTable = ({
               iconSize="m"
             />
           ),
-          //icon: <Icons.Edit iconSize="xl" />,
+          // icon: <Icons.Edit iconSize="xl" />,
           label: t('Success'),
         },
       },
@@ -233,7 +233,7 @@ const QueryTable = ({
 
         if (q.endDttm) {
           q.duration = (
-            <Label monospace={true}>{fDuration(q.startDttm, q.endDttm)}</Label>
+            <Label monospace>{fDuration(q.startDttm, q.endDttm)}</Label>
           );
         }
         q.user = (
@@ -255,9 +255,7 @@ const QueryTable = ({
           </Button>
         );
         q.started = (
-          <Label monospace={true}>
-            {moment(q.startDttm).format('L HH:mm:ss')}
-          </Label>
+          <Label monospace>{moment(q.startDttm).format('L HH:mm:ss')}</Label>
         );
         q.querylink = (
           <Button

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useMemo } from 'react';
+import { useMemo, ReactNode } from 'react';
 import moment from 'moment';
 import Card from 'src/components/Card';
 import ProgressBar from 'src/components/ProgressBar';
-import Label from 'src/components/Label';
 import { t, useTheme, QueryResponse } from '@superset-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -45,11 +44,16 @@ import HighlightedSql from '../HighlightedSql';
 import { StaticPosition, verticalAlign, StyledTooltip } from './styles';
 
 interface QueryTableQuery
-  extends Omit<QueryResponse, 'state' | 'sql' | 'progress' | 'results'> {
+  extends Omit<
+    QueryResponse,
+    'state' | 'sql' | 'progress' | 'results' | 'duration' | 'started'
+  > {
   state?: Record<string, any>;
   sql?: Record<string, any>;
   progress?: Record<string, any>;
   results?: Record<string, any>;
+  duration?: ReactNode;
+  started?: ReactNode;
 }
 
 interface QueryTableProps {

--- a/superset-frontend/src/components/Icons/Icons.stories.tsx
+++ b/superset-frontend/src/components/Icons/Icons.stories.tsx
@@ -44,10 +44,19 @@ const IconBlock = styled.div`
   flex-direction: column;
   align-items: center;
   padding: ${({ theme }) => theme.gridUnit * 2}px;
+
+  span {
+    margin-top: ${({ theme }) =>
+      2 * theme.gridUnit}px; // Add spacing between icon and name
+    font-size: ${({ theme }) =>
+      theme.typography.sizes.m}; // Optional: adjust font size for elegance
+    color: ${({ theme }) =>
+      theme.colors.grayscale.base}; // Optional: subtle color for the name
+  }
 `;
 
 export const InteractiveIcons = ({
-  showNames,
+  showNames = true,
   ...rest
 }: IconType & { showNames: boolean }) => (
   <IconSet>
@@ -56,7 +65,7 @@ export const InteractiveIcons = ({
       return (
         <IconBlock key={k}>
           <IconComponent {...rest} />
-          {showNames && k}
+          {showNames && <span>{k}</span>}
         </IconBlock>
       );
     })}

--- a/superset-frontend/src/components/Label/Label.stories.tsx
+++ b/superset-frontend/src/components/Label/Label.stories.tsx
@@ -55,9 +55,13 @@ export const LabelGallery = () => (
 );
 
 export const InteractiveLabel = (args: any) => {
-  const { hasOnClick, label, ...rest } = args;
+  const { hasOnClick, label, monospace, ...rest } = args;
   return (
-    <Label onClick={hasOnClick ? action('clicked') : undefined} {...rest}>
+    <Label
+      onClick={hasOnClick ? action('clicked') : undefined}
+      monospace={monospace}
+      {...rest}
+    >
       {label}
     </Label>
   );
@@ -66,4 +70,5 @@ export const InteractiveLabel = (args: any) => {
 InteractiveLabel.args = {
   hasOnClick: true,
   label: 'Example',
+  monospace: true,
 };

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -46,12 +46,20 @@ export interface LabelProps extends HTMLAttributes<HTMLSpanElement> {
   style?: CSSProperties;
   children?: ReactNode;
   role?: string;
+  monospace?: boolean;
 }
 
 export default function Label(props: LabelProps) {
   const theme = useTheme();
   const { colors, transitionTiming } = theme;
-  const { type = 'default', onClick, children, ...rest } = props;
+  const {
+    type = 'default',
+    monospace = false,
+    style,
+    onClick,
+    children,
+    ...rest
+  } = props;
   const {
     alert,
     primary,
@@ -88,6 +96,9 @@ export default function Label(props: LabelProps) {
       baseColor = secondary;
     } else {
       baseColor = primary;
+    }
+    if (monospace) {
+      style.fontFamily = theme.typography.families.monospace;
     }
 
     backgroundColor = baseColor.base;

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -97,40 +97,41 @@ export default function Label(props: LabelProps) {
     } else {
       baseColor = primary;
     }
-    if (monospace) {
-      style.fontFamily = theme.typography.families.monospace;
-    }
-
     backgroundColor = baseColor.base;
     backgroundColorHover = onClick ? baseColor.dark1 : baseColor.base;
     borderColor = onClick ? baseColor.dark1 : 'transparent';
     borderColorHover = onClick ? baseColor.dark2 : 'transparent';
+  }
+  const css = {
+    transition: `background-color ${transitionTiming}s`,
+    whiteSpace: 'nowrap',
+    cursor: onClick ? 'pointer' : 'default',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    backgroundColor,
+    borderColor,
+    borderRadius: 21,
+    padding: '0.35em 0.8em',
+    lineHeight: 1,
+    color,
+    maxWidth: '100%',
+    '&:hover': {
+      backgroundColor: backgroundColorHover,
+      borderColor: borderColorHover,
+      opacity: 1,
+    },
+  };
+  if (monospace) {
+    css.fontFamily = theme.typography.families.monospace;
   }
 
   return (
     <Tag
       onClick={onClick}
       role={onClick ? 'button' : undefined}
+      style={style}
       {...rest}
-      css={{
-        transition: `background-color ${transitionTiming}s`,
-        whiteSpace: 'nowrap',
-        cursor: onClick ? 'pointer' : 'default',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        backgroundColor,
-        borderColor,
-        borderRadius: 21,
-        padding: '0.35em 0.8em',
-        lineHeight: 1,
-        color,
-        maxWidth: '100%',
-        '&:hover': {
-          backgroundColor: backgroundColorHover,
-          borderColor: borderColorHover,
-          opacity: 1,
-        },
-      }}
+      css={css}
     >
       {children}
     </Tag>

--- a/superset-frontend/src/components/Label/index.tsx
+++ b/superset-frontend/src/components/Label/index.tsx
@@ -122,7 +122,7 @@ export default function Label(props: LabelProps) {
     },
   };
   if (monospace) {
-    css.fontFamily = theme.typography.families.monospace;
+    css['font-family'] = theme.typography.families.monospace;
   }
 
   return (


### PR DESCRIPTION
Fixing some styling and UI components in the query history pane in SQL Lab

* using label with monospace for timestamps
* set mouse to pointer on clickable icons
* using consistent icon size 
* make the View clickable a button instead of label

### before
<img width="1313" alt="Screenshot 2024-12-05 at 7 04 25 PM" src="https://github.com/user-attachments/assets/c564c690-2afb-447e-b1a6-eb58e144611f">

### after
<img width="1336" alt="Screenshot 2024-12-05 at 7 03 00 PM" src="https://github.com/user-attachments/assets/458ac915-c480-4c18-9a1c-b73bf3597220">


