### PR TITLE
fix: Use clickhouse sqlglot dialect for YDB

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -91,6 +91,7 @@ SQLGLOT_DIALECTS = {
     "teradatasql": Dialects.TERADATA,
     "trino": Dialects.TRINO,
     "vertica": Dialects.POSTGRES,
+    "yql": Dialects.CLICKHOUSE,
 }
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Superset uses sqlglot to parse queries. It is not obvious in what cases it performs parsing and in what cases it doesnt, but we see an error where we are not able to use backticks and slashes in SQL Lab while creating datasets.
For example, query like

```
SELECT * FROM `prefix/some_name`
```

will fail because no sqlglot dialect is defined for YDB.

To have an ability to use db's with slashes we can use clickhouse's sqlglot dialect until we make our own.

Fixes https://github.com/apache/superset/issues/31322

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/31322
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
