### PR TITLE
fix: pass string to `process_template`

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -26,7 +26,7 @@ from typing import Any, cast, TYPE_CHECKING
 
 import sqlparse
 from flask_babel import gettext as __
-from jinja2 import nodes
+from jinja2 import nodes, Template
 from sqlalchemy import and_
 from sqlparse import keywords
 from sqlparse.lexer import Lexer
@@ -999,10 +999,13 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
             node.fields = nodes.TemplateData.fields
             node.data = "NULL"
 
+    # re-render template back into a string
+    rendered_template = Template(template).render()
+
     return (
         tables
         | ParsedQuery(
-            sql_statement=processor.process_template(template),
+            sql_statement=processor.process_template(rendered_template),
             engine=database.db_engine_spec.engine,
         ).tables
     )

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1888,12 +1888,15 @@ SELECT * FROM t"""
     ],
 )
 def test_extract_tables_from_jinja_sql(
-    engine: str, macro: str, expected: set[Table]
+    mocker: MockerFixture,
+    engine: str,
+    macro: str,
+    expected: set[Table],
 ) -> None:
     assert (
         extract_tables_from_jinja_sql(
             sql=f"'{{{{ {engine}.{macro} }}}}'",
-            database=mock.Mock(),
+            database=mocker.Mock(),
         )
         == expected
     )
@@ -1904,11 +1907,14 @@ def test_extract_tables_from_jinja_sql(
     {"ENABLE_TEMPLATE_PROCESSING": False},
     clear=True,
 )
-def test_extract_tables_from_jinja_sql_disabled() -> None:
+def test_extract_tables_from_jinja_sql_disabled(mocker: MockerFixture) -> None:
     """
     Test the function when the feature flag is disabled.
     """
+    database = mocker.Mock()
+    database.db_engine_spec.engine = "mssql"
+
     assert extract_tables_from_jinja_sql(
         sql="SELECT 1 FROM t",
-        database=mock.Mock(),
+        database=database,
     ) == {Table("t")}

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -17,7 +17,7 @@
 # pylint: disable=invalid-name, redefined-outer-name, too-many-lines
 
 from typing import Optional
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 import sqlparse
@@ -1893,7 +1893,22 @@ def test_extract_tables_from_jinja_sql(
     assert (
         extract_tables_from_jinja_sql(
             sql=f"'{{{{ {engine}.{macro} }}}}'",
-            database=Mock(),
+            database=mock.Mock(),
         )
         == expected
     )
+
+
+@mock.patch.dict(
+    "superset.extensions.feature_flag_manager._feature_flags",
+    {"ENABLE_TEMPLATE_PROCESSING": False},
+    clear=True,
+)
+def test_extract_tables_from_jinja_sql_disabled() -> None:
+    """
+    Test the function when the feature flag is disabled.
+    """
+    assert extract_tables_from_jinja_sql(
+        sql="SELECT 1 FROM t",
+        database=mock.Mock(),
+    ) == {Table("t")}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When extracting tables from a Jinja template we're passing a `jinja2.nodes.Template` object to the `process_template` method, but it expects a string.  This can cause errors depending on the `ENABLE_TEMPLATE_PROCESSING` feature flag and the SQL dialect.

This PR fixes the logic to re-render the modified template before passing it as a string to `process_template`.

(Note that a `jinja2.nodes.Template` is an internal object, different from a `jinja2.environment.Template`.)

**Why wasn't this caught before?**

This only happens when `ENABLE_TEMPLATE_PROCESSING` is off. When the feature flag is ON we use the `JinjaTemplateProcessor`, which parses the string passed to `process_template` using `env.from_string`. Despite the name, `env.from_string` **also works** on `jinja2.nodes.Template` objects, so the template is rendered correctly and `process_template` returns valid SQL.

When the feature flag is OFF we use the `NoOpTemplateProcessor` to extract tables, which just returns `str(sql)` in its `process_template`. This converts the `jinja2.nodes.Template` into a string that can't be parsed correctly _most of the time_:

```
Template(body=[Output(nodes=[TemplateData(data='SELECT 1 FROM t')])])
```

Confusingly, the string above **is a valid SQL expression depending on the dialect**:

```python
>>> import sqlglot
>>> sqlglot.parse("Template(body=[Output(nodes=[TemplateData(data='SELECT 1 FROM t')])])")
[Anonymous(
  this=Template,
  expressions=[
    EQ(
      this=Column(
        this=Identifier(this=body, quoted=False)),
      expression=Array(
        expressions=[
          Anonymous(
            this=Output,
            expressions=[
              EQ(
                this=Column(
                  this=Identifier(this=nodes, quoted=False)),
                expression=Array(
                  expressions=[
                    Anonymous(
                      this=TemplateData,
                      expressions=[
                        EQ(
                          this=Column(
                            this=Identifier(this=data, quoted=False)),
                          expression=Literal(this=SELECT 1 FROM t, is_string=True))])]))])]))])]
>>> sqlglot.parse("Template(body=[Output(nodes=[TemplateData(data='SELECT 1 FROM t')])])", "tsql")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/beto/.pyenv/versions/superset/lib/python3.11/site-packages/sqlglot/__init__.py", line 102, in parse
    return Dialect.get_or_raise(read or dialect).parse(sql, **opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/beto/.pyenv/versions/superset/lib/python3.11/site-packages/sqlglot/dialects/dialect.py", line 919, in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/beto/.pyenv/versions/superset/lib/python3.11/site-packages/sqlglot/parser.py", line 1398, in parse
    return self._parse(
           ^^^^^^^^^^^^
  File "/Users/beto/.pyenv/versions/superset/lib/python3.11/site-packages/sqlglot/parser.py", line 1470, in _parse
    self.raise_error("Invalid expression / Unexpected token")
  File "/Users/beto/.pyenv/versions/superset/lib/python3.11/site-packages/sqlglot/parser.py", line 1511, in raise_error
    raise error
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 68.
  Template(body=[Output(nodes=[TemplateData(data='SELECT 1 FROM t')])])
```

Fixes https://github.com/apache/superset/issues/31307 and https://github.com/apache/superset/issues/31183.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

I added a unit test capturing the bug. It failed before this fix.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
