### PR TITLE
fix: remove sort values on stacked totals

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/getMetricLabel.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getMetricLabel.ts
@@ -23,7 +23,7 @@ export default function getMetricLabel(
   metric: QueryFormMetric,
   index?: number,
   queryFormMetrics?: QueryFormMetric[],
-  verboseMap: Record<string, string> = {},
+  verboseMap?: Record<string, string>,
 ): string {
   let label = '';
   if (isSavedMetric(metric)) {
@@ -37,5 +37,5 @@ export default function getMetricLabel(
   } else {
     label = metric.sqlExpression;
   }
-  return verboseMap[label] || label;
+  return verboseMap?.[label] || label;
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/getMetricLabel.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getMetricLabel.ts
@@ -19,17 +19,23 @@
 
 import { QueryFormMetric, isSavedMetric, isAdhocMetricSimple } from './types';
 
-export default function getMetricLabel(metric: QueryFormMetric): string {
+export default function getMetricLabel(
+  metric: QueryFormMetric,
+  index?: number,
+  queryFormMetrics?: QueryFormMetric[],
+  verboseMap: Record<string, string> = {},
+): string {
+  let label = '';
   if (isSavedMetric(metric)) {
-    return metric;
-  }
-  if (metric.label) {
-    return metric.label;
-  }
-  if (isAdhocMetricSimple(metric)) {
-    return `${metric.aggregate}(${
+    label = metric;
+  } else if (metric.label) {
+    ({ label } = metric);
+  } else if (isAdhocMetricSimple(metric)) {
+    label = `${metric.aggregate}(${
       metric.column.columnName || metric.column.column_name
     })`;
+  } else {
+    label = metric.sqlExpression;
   }
-  return metric.sqlExpression;
+  return verboseMap[label] || label;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -19,7 +19,6 @@
 /* eslint-disable camelcase */
 import { invert } from 'lodash';
 import {
-  AdhocMetric,
   AnnotationLayer,
   AxisType,
   buildCustomFormatters,
@@ -28,6 +27,7 @@ import {
   ensureIsArray,
   GenericDataType,
   getCustomFormatter,
+  getMetricLabel,
   getNumberFormatter,
   getXAxisLabel,
   isDefined,
@@ -293,16 +293,12 @@ export default function transformProps(
     stack,
   });
 
-  const metricMapFunc = (metric: string | AdhocMetric) => {
-    if (metric.hasOwnProperty('label')) {
-      return (metric as AdhocMetric).label;
-    }
-    return verboseMap[metric as string] || metric;
-  };
   const metricsLabels = metrics
-    .map(metricMapFunc)
+    .map(metric => getMetricLabel(metric, undefined, undefined, verboseMap))
     .filter((label): label is string => label !== undefined);
-  const metricsLabelsB = metricsB.map(metricMapFunc);
+  const metricsLabelsB = metricsB.map((metric: QueryFormMetric) =>
+    getMetricLabel(metric, undefined, undefined, verboseMap),
+  );
 
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedDataA,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -19,6 +19,7 @@
 /* eslint-disable camelcase */
 import { invert } from 'lodash';
 import {
+  AdhocMetric,
   AnnotationLayer,
   AxisType,
   buildCustomFormatters,
@@ -291,12 +292,24 @@ export default function transformProps(
   const showValueIndexesB = extractShowValueIndexes(rawSeriesB, {
     stack,
   });
+
+  const metricMapFunc = (metric: string | AdhocMetric) => {
+    if (metric.hasOwnProperty('label')) {
+      return (metric as AdhocMetric).label;
+    }
+    return verboseMap[metric as string] || metric;
+  };
+  const metricsLabels = metrics
+    .map(metricMapFunc)
+    .filter((label): label is string => label !== undefined);
+  const metricsLabelsB = metricsB.map(metricMapFunc);
+
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedDataA,
     {
       stack,
       percentageThreshold,
-      xAxisCol: xAxisLabel,
+      metricsLabels,
     },
   );
   const {
@@ -305,7 +318,7 @@ export default function transformProps(
   } = extractDataTotalValues(rebasedDataB, {
     stack: Boolean(stackB),
     percentageThreshold,
-    xAxisCol: xAxisLabel,
+    metricsLabels: metricsLabelsB,
   });
 
   annotationLayers

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -40,6 +40,7 @@ import {
   t,
   TimeseriesChartDataResponseResult,
   NumberFormats,
+  AdhocMetric,
 } from '@superset-ui/core';
 import {
   extractExtraMetrics,
@@ -192,6 +193,7 @@ export default function transformProps(
     yAxisTitlePosition,
     zoomable,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
+  console.error('formData', formData);
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
   const labelMap: { [key: string]: string[] } = Object.entries(
@@ -215,16 +217,26 @@ export default function transformProps(
   ) {
     xAxisLabel = verboseMap[xAxisLabel];
   }
+  const metricsLabels = metrics
+    .map(metric => {
+      if (metric.hasOwnProperty('label')) {
+        return (metric as AdhocMetric).label;
+      }
+      return verboseMap[metric as string] || metric;
+    })
+    .filter((label): label is string => label !== undefined);
   const isHorizontal = orientation === OrientationType.Horizontal;
+
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,
     {
       stack,
       percentageThreshold,
-      xAxisCol: xAxisLabel,
       legendState,
+      metricsLabels,
     },
   );
+  console.error('Threshold Values 229', thresholdValues);
   const extraMetricLabels = extractExtraMetrics(chartProps.rawFormData).map(
     getMetricLabel,
   );
@@ -296,7 +308,7 @@ export default function transformProps(
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
-
+    console.error('Threshold Values to transform series', thresholdValues);
     const transformedSeries = transformSeries(
       entry,
       colorScale,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -40,7 +40,6 @@ import {
   t,
   TimeseriesChartDataResponseResult,
   NumberFormats,
-  AdhocMetric,
 } from '@superset-ui/core';
 import {
   extractExtraMetrics,
@@ -217,12 +216,7 @@ export default function transformProps(
     xAxisLabel = verboseMap[xAxisLabel];
   }
   const metricsLabels = metrics
-    .map(metric => {
-      if (metric.hasOwnProperty('label')) {
-        return (metric as AdhocMetric).label;
-      }
-      return verboseMap[metric as string] || metric;
-    })
+    .map(metric => getMetricLabel(metric, undefined, undefined, verboseMap))
     .filter((label): label is string => label !== undefined);
   const isHorizontal = orientation === OrientationType.Horizontal;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -193,7 +193,6 @@ export default function transformProps(
     yAxisTitlePosition,
     zoomable,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
-  console.error('formData', formData);
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
   const labelMap: { [key: string]: string[] } = Object.entries(
@@ -236,7 +235,6 @@ export default function transformProps(
       metricsLabels,
     },
   );
-  console.error('Threshold Values 229', thresholdValues);
   const extraMetricLabels = extractExtraMetrics(chartProps.rawFormData).map(
     getMetricLabel,
   );
@@ -308,7 +306,6 @@ export default function transformProps(
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
-    console.error('Threshold Values to transform series', thresholdValues);
     const transformedSeries = transformSeries(
       entry,
       colorScale,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -332,9 +332,6 @@ export function transformSeries(
         if (!stack && isSelectedLegend) {
           return formatter(numericValue);
         }
-        console.error('numericValue', numericValue);
-        console.error('thresholdValues', thresholdValues);
-        console.error('thresholdValue', thresholdValues[dataIndex]);
         if (!onlyTotal) {
           if (
             numericValue >=

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -332,6 +332,9 @@ export function transformSeries(
         if (!stack && isSelectedLegend) {
           return formatter(numericValue);
         }
+        console.error('numericValue', numericValue);
+        console.error('thresholdValues', thresholdValues);
+        console.error('thresholdValue', thresholdValues[dataIndex]);
         if (!onlyTotal) {
           if (
             numericValue >=

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -60,8 +60,8 @@ export function extractDataTotalValues(
   opts: {
     stack: StackType;
     percentageThreshold: number;
-    xAxisCol: string;
     legendState?: LegendState;
+    metricsLabels: string[];
   },
 ): {
   totalStackedValues: number[];
@@ -69,23 +69,38 @@ export function extractDataTotalValues(
 } {
   const totalStackedValues: number[] = [];
   const thresholdValues: number[] = [];
-  const { stack, percentageThreshold, xAxisCol, legendState } = opts;
+  const { stack, percentageThreshold, legendState, metricsLabels } = opts;
+  console.error('extractDataTotalValues -> data', data);
   if (stack) {
     data.forEach(datum => {
       const values = Object.keys(datum).reduce((prev, curr) => {
-        if (curr === xAxisCol) {
+        console.error(
+          'metricsLabels.includes(curr)',
+          metricsLabels,
+          curr,
+          prev,
+        );
+        if (!metricsLabels.includes(curr)) {
           return prev;
         }
+        console.error('legendState', legendState);
         if (legendState && !legendState[curr]) {
           return prev;
         }
         const value = datum[curr] || 0;
+        console.error('prev -> value', prev + (value as number));
         return prev + (value as number);
       }, 0);
+      console.error('extractDataTotalValues -> values', values);
       totalStackedValues.push(values);
       thresholdValues.push(((percentageThreshold || 0) / 100) * values);
     });
   }
+  console.error(
+    'extractDataTotalValues -> totalStackedValues',
+    totalStackedValues,
+  );
+  console.error('extractDataTotalValues -> thresholdValues', thresholdValues);
   return {
     totalStackedValues,
     thresholdValues,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -70,37 +70,22 @@ export function extractDataTotalValues(
   const totalStackedValues: number[] = [];
   const thresholdValues: number[] = [];
   const { stack, percentageThreshold, legendState, metricsLabels } = opts;
-  console.error('extractDataTotalValues -> data', data);
   if (stack) {
     data.forEach(datum => {
       const values = Object.keys(datum).reduce((prev, curr) => {
-        console.error(
-          'metricsLabels.includes(curr)',
-          metricsLabels,
-          curr,
-          prev,
-        );
         if (!metricsLabels.includes(curr)) {
           return prev;
         }
-        console.error('legendState', legendState);
         if (legendState && !legendState[curr]) {
           return prev;
         }
         const value = datum[curr] || 0;
-        console.error('prev -> value', prev + (value as number));
         return prev + (value as number);
       }, 0);
-      console.error('extractDataTotalValues -> values', values);
       totalStackedValues.push(values);
       thresholdValues.push(((percentageThreshold || 0) / 100) * values);
     });
   }
-  console.error(
-    'extractDataTotalValues -> totalStackedValues',
-    totalStackedValues,
-  );
-  console.error('extractDataTotalValues -> thresholdValues', thresholdValues);
   return {
     totalStackedValues,
     thresholdValues,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -36,15 +36,25 @@ describe('EchartsTimeseries transformProps', () => {
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',
-    metric: 'sum__num',
+    metrics: ['sum__num'],
     groupby: ['foo', 'bar'],
     viz_type: 'my_viz',
   };
   const queriesData = [
     {
       data: [
-        { 'San Francisco': 1, 'New York': 2, __timestamp: 599616000000 },
-        { 'San Francisco': 3, 'New York': 4, __timestamp: 599916000000 },
+        {
+          'San Francisco': 1,
+          'New York': 2,
+          __timestamp: 599616000000,
+          sum__num: 4,
+        },
+        {
+          'San Francisco': 3,
+          'New York': 4,
+          __timestamp: 599916000000,
+          sum__num: 8,
+        },
       ],
     },
   ];
@@ -64,7 +74,7 @@ describe('EchartsTimeseries transformProps', () => {
         height: 600,
         echartOptions: expect.objectContaining({
           legend: expect.objectContaining({
-            data: ['San Francisco', 'New York'],
+            data: ['sum__num', 'San Francisco', 'New York'],
           }),
           series: expect.arrayContaining([
             expect.objectContaining({
@@ -101,7 +111,7 @@ describe('EchartsTimeseries transformProps', () => {
         height: 600,
         echartOptions: expect.objectContaining({
           legend: expect.objectContaining({
-            data: ['San Francisco', 'New York'],
+            data: ['sum__num', 'San Francisco', 'New York'],
           }),
           series: expect.arrayContaining([
             expect.objectContaining({
@@ -146,7 +156,7 @@ describe('EchartsTimeseries transformProps', () => {
         height: 600,
         echartOptions: expect.objectContaining({
           legend: expect.objectContaining({
-            data: ['San Francisco', 'New York', 'My Formula'],
+            data: ['sum__num', 'San Francisco', 'New York', 'My Formula'],
           }),
           series: expect.arrayContaining([
             expect.objectContaining({
@@ -274,7 +284,7 @@ describe('EchartsTimeseries transformProps', () => {
       expect.objectContaining({
         echartOptions: expect.objectContaining({
           legend: expect.objectContaining({
-            data: ['San Francisco', 'New York', 'My Line'],
+            data: ['sum__num', 'San Francisco', 'New York', 'My Line'],
           }),
           series: expect.arrayContaining([
             expect.objectContaining({
@@ -420,7 +430,7 @@ describe('Does transformProps transform series correctly', () => {
     colorScheme: 'bnbColors',
     datasource: '3__table',
     granularity_sqla: 'ds',
-    metric: 'sum__num',
+    metrics: ['sum__num'],
     groupby: ['foo', 'bar'],
     showValue: true,
     stack: true,
@@ -435,24 +445,28 @@ describe('Does transformProps transform series correctly', () => {
           'New York': 2,
           Boston: 1,
           __timestamp: 599616000000,
+          sum__num: 4,
         },
         {
           'San Francisco': 3,
           'New York': 4,
           Boston: 1,
           __timestamp: 599916000000,
+          sum__num: 8,
         },
         {
           'San Francisco': 5,
           'New York': 8,
           Boston: 6,
           __timestamp: 600216000000,
+          sum__num: 19,
         },
         {
           'San Francisco': 2,
           'New York': 7,
           Boston: 2,
           __timestamp: 600516000000,
+          sum__num: 11,
         },
       ],
     },
@@ -468,7 +482,7 @@ describe('Does transformProps transform series correctly', () => {
   const totalStackedValues = queriesData[0].data.reduce(
     (totals, currentStack) => {
       const total = Object.keys(currentStack).reduce((stackSum, key) => {
-        if (key === '__timestamp') return stackSum;
+        if (key === '__timestamp' || key === 'sum__num') return stackSum;
         return stackSum + currentStack[key as keyof typeof currentStack];
       }, 0);
       totals.push(total);
@@ -561,7 +575,6 @@ describe('Does transformProps transform series correctly', () => {
     const expectedThresholds = totalStackedValues.map(
       total => ((formData.percentageThreshold || 0) / 100) * total,
     );
-
     transformedSeries.forEach((series, seriesIndex) => {
       expect(series.label.show).toBe(true);
       series.data.forEach((value, dataIndex) => {
@@ -576,7 +589,6 @@ describe('Does transformProps transform series correctly', () => {
       });
     });
   });
-
   it('should not apply percentage threshold when showValue is true and stack is false', () => {
     const updatedChartPropsConfig = {
       ...chartPropsConfig,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a y axis sort is selected with a stacked bar chart with totals shown, the y axis column value was being added to the total. This pr checks that only the metrics are being used in calculating totals by passing in the list of metrics labels to the total calculation function, and only totaling the columns that are metrics, not the ones used in sorting.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/user-attachments/assets/e01469e1-096b-433e-903a-8259a022d3de)

After:
<img width="2323" alt="Screenshot 2024-12-06 at 4 54 10 PM" src="https://github.com/user-attachments/assets/8ebd321c-4ead-4fe6-974d-fc0b9df8f91e">


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a chart with one metric, and a sort value. Turn on stacked and show values. The sort value column should not be added to the total of the metric. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
