### PR TITLE
fix(docs): add custom editUrl path for intro page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -203,7 +203,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 
+          editUrl:
           ({versionDocsDirPath, docPath}) => {
             if (docPath === 'intro.md') {
               return 'https://github.com/apache/superset/edit/master/README.md'

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -203,13 +203,18 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/apache/superset/edit/master/docs',
+          editUrl: 
+          ({versionDocsDirPath, docPath}) => {
+            if (docPath === 'intro.md') {
+              return 'https://github.com/apache/superset/edit/master/README.md'
+            }
+            return `https://github.com/apache/superset/edit/master/docs/${versionDocsDirPath}/${docPath}`
+          }
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
-          editUrl:
-            'https://github.com/facebook/docusaurus/edit/main/website/blog/',
+          editUrl: 'https://github.com/facebook/docusaurus/edit/main/website/blog/',
         },
         theme: {
           customCss: require.resolve('./src/styles/custom.css'),


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#### Problem
At issue is a broken link on the main docs intro page (https://superset.apache.org/docs/intro). This bug was introduced after a previous PR:  [docs: various improvements across the docs](https://github.com/apache/superset/pull/28285), which removed the intro.md file from the superset/docs/docs subdirectory after deeming it redundant. This change had the unintended consequence of breaking the link for the "Edit this page on GitHub" button on the main docs/intro site page. This is because the docusaurus.config.js is currently configured to return a path of 'https://github.com/apache/superset/edit/master/docs/' + docPath. While this works fine for the other sidebar items that are still housed in the docs/docs subdirectory, it needs updating for the intro page, which is currently built from the main repo README.md file.

#### Solution
Add a custom editURL function to the docusaurus.config.js file so that the intro page will now properly redirect to the main repo README.md file, and the remaining sidebar links will remain unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Link Location:
![Screen Shot 2024-11-19 at 11 25 44 PM](https://github.com/user-attachments/assets/f488c6e6-5772-49cf-ade9-693ef21e4da2)

Before:
![Screen Shot 2024-11-19 at 11 26 13 PM](https://github.com/user-attachments/assets/c6756c3b-c7b5-4130-b701-35c42406fc4b)

After:
![Screen Shot 2024-12-07 at 1 09 11 AM](https://github.com/user-attachments/assets/b215dcf4-294a-45e9-b44d-4cb7fda59df2)

### TESTING INSTRUCTIONS
Change the docusaurus.config.js file as suggested and check that the intro page link is working correctly. Verify that all other page links continue working as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #30985
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
