### PR TITLE
fix(histogram): axis margin padding consistent with other graphs

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
@@ -27,6 +27,7 @@ import {
   formatSelectOptionsForRange,
   dndGroupByControl,
   columnsByType,
+  sections,
 } from '@superset-ui/chart-controls';
 import { showLegendControl, showValueControl } from '../controls';
 
@@ -104,35 +105,37 @@ const config: ControlPanelConfig = {
         ],
       ],
     },
+    sections.titleControls,
     {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
+
         ['color_scheme'],
         [showValueControl],
         [showLegendControl],
-        [
-          {
-            name: 'x_axis_title',
-            config: {
-              type: 'TextControl',
-              label: t('X Axis Title'),
-              renderTrigger: true,
-              default: '',
-            },
-          },
-        ],
-        [
-          {
-            name: 'y_axis_title',
-            config: {
-              type: 'TextControl',
-              label: t('Y Axis Title'),
-              renderTrigger: true,
-              default: '',
-            },
-          },
-        ],
+        // [
+        //   {
+        //     name: 'x_axis_title',
+        //     config: {
+        //       type: 'TextControl',
+        //       label: t('X Axis Title'),
+        //       renderTrigger: true,
+        //       default: '',
+        //     },
+        //   },
+        // ],
+        // [
+        //   {
+        //     name: 'y_axis_title',
+        //     config: {
+        //       type: 'TextControl',
+        //       label: t('Y Axis Title'),
+        //       renderTrigger: true,
+        //       default: '',
+        //     },
+        //   },
+        // ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
@@ -114,28 +114,6 @@ const config: ControlPanelConfig = {
         ['color_scheme'],
         [showValueControl],
         [showLegendControl],
-        // [
-        //   {
-        //     name: 'x_axis_title',
-        //     config: {
-        //       type: 'TextControl',
-        //       label: t('X Axis Title'),
-        //       renderTrigger: true,
-        //       default: '',
-        //     },
-        //   },
-        // ],
-        // [
-        //   {
-        //     name: 'y_axis_title',
-        //     config: {
-        //       type: 'TextControl',
-        //       label: t('Y Axis Title'),
-        //       renderTrigger: true,
-        //       default: '',
-        //     },
-        //   },
-        // ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
@@ -110,7 +110,6 @@ const config: ControlPanelConfig = {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-
         ['color_scheme'],
         [showValueControl],
         [showLegendControl],


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Newly introduced histogram graph did not have the ability to adjust x & y axis padding under the customize tab, leading to inconsistent display of chart relative to the rest. It now matches the standard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="959" alt="Screenshot 2024-12-06 at 9 16 13 AM" src="https://github.com/user-attachments/assets/4e068dbf-2a67-47c2-a599-4fc80e2d099e">

Before
<img width="312" alt="Screenshot 2024-12-07 at 1 16 53 AM" src="https://github.com/user-attachments/assets/2502fe78-e08c-4129-be5e-2bea2a424046">

After
<img width="318" alt="Screenshot 2024-12-07 at 1 17 25 AM" src="https://github.com/user-attachments/assets/4a736ddb-be5d-4cd9-beaa-8425f5201ece">


### TESTING INSTRUCTIONS
Deploy code and create histogram graph. Select options under `customize tab` to adjust axis padding

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: `Inconsistent Default Padding for Different Charts #31033`
- [ ] Required feature flags:
- [x ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
