### PR TITLE
fix(helm): Add common labels for init job pods

### DIFF
--- a/helm/superset/templates/init-job.yaml
+++ b/helm/superset/templates/init-job.yaml
@@ -37,6 +37,12 @@ spec:
       {{- if .Values.init.podAnnotations }}
       annotations: {{- toYaml .Values.init.podAnnotations | nindent 8 }}
       {{- end }}
+      labels:
+        app: {{ template "superset.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.extraLabels }}
+          {{- toYaml .Values.extraLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if or (.Values.serviceAccount.create) (.Values.serviceAccountName) }}
       serviceAccountName: {{ template "superset.serviceAccountName" . }}


### PR DESCRIPTION
Add two common labels for the init-job pods, similar to other deployments.

In our environment, we need to define NetworkPolicies to control network traffic. Without labels on the init-job pods, I cannot whitelist any network traffic for them.