### PR TITLE
fix(alerts&reports): tabs with userfriendly urls

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -207,7 +207,7 @@ class BaseReportState:
         if (
             dashboard_state := self._report_schedule.extra.get("dashboard")
         ) and feature_flag_manager.is_feature_enabled("ALERT_REPORT_TABS"):
-            return self._get_tab_url(dashboard_state,user_friendly=user_friendly)
+            return self._get_tab_url(dashboard_state, user_friendly=user_friendly)
 
         dashboard = self._report_schedule.dashboard
         dashboard_id_or_slug = (
@@ -234,7 +234,7 @@ class BaseReportState:
             if anchor := dashboard_state.get("anchor"):
                 try:
                     anchor_list: list[str] = json.loads(anchor)
-                    return self._get_tabs_urls(anchor_list,user_friendly=user_friendly)
+                    return self._get_tabs_urls(anchor_list, user_friendly=user_friendly)
                 except json.JSONDecodeError:
                     logger.debug("Anchor value is not a list, Fall back to single tab")
             return [self._get_tab_url(dashboard_state)]
@@ -254,7 +254,9 @@ class BaseReportState:
             )
         ]
 
-    def _get_tab_url(self, dashboard_state: DashboardPermalinkState, user_friendly: bool = False) -> str:
+    def _get_tab_url(
+        self, dashboard_state: DashboardPermalinkState, user_friendly: bool = False
+    ) -> str:
         """
         Get one tab url
         """
@@ -262,9 +264,15 @@ class BaseReportState:
             dashboard_id=str(self._report_schedule.dashboard.uuid),
             state=dashboard_state,
         ).run()
-        return get_url_path("Superset.dashboard_permalink", key=permalink_key,user_friendly=user_friendly)
+        return get_url_path(
+            "Superset.dashboard_permalink",
+            key=permalink_key,
+            user_friendly=user_friendly,
+        )
 
-    def _get_tabs_urls(self, tab_anchors: list[str], user_friendly: bool = False) -> list[str]:
+    def _get_tabs_urls(
+        self, tab_anchors: list[str], user_friendly: bool = False
+    ) -> list[str]:
         """
         Get multple tabs urls
         """
@@ -275,7 +283,8 @@ class BaseReportState:
                     "dataMask": None,
                     "activeTabs": None,
                     "urlParams": None,
-                },user_friendly=user_friendly
+                },
+                user_friendly=user_friendly,
             )
             for tab_anchor in tab_anchors
         ]

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -207,7 +207,7 @@ class BaseReportState:
         if (
             dashboard_state := self._report_schedule.extra.get("dashboard")
         ) and feature_flag_manager.is_feature_enabled("ALERT_REPORT_TABS"):
-            return self._get_tab_url(dashboard_state)
+            return self._get_tab_url(dashboard_state,user_friendly=user_friendly)
 
         dashboard = self._report_schedule.dashboard
         dashboard_id_or_slug = (
@@ -234,7 +234,7 @@ class BaseReportState:
             if anchor := dashboard_state.get("anchor"):
                 try:
                     anchor_list: list[str] = json.loads(anchor)
-                    return self._get_tabs_urls(anchor_list)
+                    return self._get_tabs_urls(anchor_list,user_friendly=user_friendly)
                 except json.JSONDecodeError:
                     logger.debug("Anchor value is not a list, Fall back to single tab")
             return [self._get_tab_url(dashboard_state)]
@@ -254,7 +254,7 @@ class BaseReportState:
             )
         ]
 
-    def _get_tab_url(self, dashboard_state: DashboardPermalinkState) -> str:
+    def _get_tab_url(self, dashboard_state: DashboardPermalinkState, user_friendly: bool = False) -> str:
         """
         Get one tab url
         """
@@ -262,9 +262,9 @@ class BaseReportState:
             dashboard_id=str(self._report_schedule.dashboard.uuid),
             state=dashboard_state,
         ).run()
-        return get_url_path("Superset.dashboard_permalink", key=permalink_key)
+        return get_url_path("Superset.dashboard_permalink", key=permalink_key,user_friendly=user_friendly)
 
-    def _get_tabs_urls(self, tab_anchors: list[str]) -> list[str]:
+    def _get_tabs_urls(self, tab_anchors: list[str], user_friendly: bool = False) -> list[str]:
         """
         Get multple tabs urls
         """
@@ -275,7 +275,7 @@ class BaseReportState:
                     "dataMask": None,
                     "activeTabs": None,
                     "urlParams": None,
-                }
+                },user_friendly=user_friendly
             )
             for tab_anchor in tab_anchors
         ]

--- a/superset/utils/pdf.py
+++ b/superset/utils/pdf.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from io import BytesIO
+import img2pdf
 
 from superset.commands.report.exceptions import ReportSchedulePdfFailedError
 
@@ -28,21 +28,11 @@ except ModuleNotFoundError:
 
 
 def build_pdf_from_screenshots(snapshots: list[bytes]) -> bytes:
-    images = []
-
-    for snap in snapshots:
-        img = Image.open(BytesIO(snap))
-        if img.mode == "RGBA":
-            img = img.convert("RGB")
-        images.append(img)
     logger.info("building pdf")
     try:
-        new_pdf = BytesIO()
-        images[0].save(new_pdf, "PDF", save_all=True, append_images=images[1:])
-        new_pdf.seek(0)
+        pdf_bytes = img2pdf.convert(snapshots)
     except Exception as ex:
         raise ReportSchedulePdfFailedError(
             f"Failed converting screenshots to pdf {str(ex)}"
         ) from ex
-
-    return new_pdf.read()
+    return pdf_bytes


### PR DESCRIPTION


### SUMMARY
Userfriendly urls do not work in current branch when tabs are used in alerts & reports.
This pr fixes that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Required feature flags: ALERT_REPORT_TABS
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
