### PR TITLE
fix(sqllab): duplicate error message

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -42,7 +42,6 @@ import {
   css,
   getNumberFormatter,
   getExtensionsRegistry,
-  ErrorLevel,
   ErrorTypeEnum,
 } from '@superset-ui/core';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
@@ -559,16 +558,7 @@ const ResultSet = ({
   }
 
   if (query.state === QueryState.Failed) {
-    const errors = [];
-    if (query.errorMessage) {
-      errors.push({
-        error_type: ErrorTypeEnum.GENERIC_DB_ENGINE_ERROR,
-        extra: {},
-        level: 'error' as ErrorLevel,
-        message: query.errorMessage,
-      });
-    }
-    errors.push(...(query.extra?.errors || []), ...(query.errors || []));
+    const errors = [...(query.extra?.errors || []), ...(query.errors || [])];
 
     return (
       <ResultlessStyles>

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -532,6 +532,12 @@ export const failedQueryWithErrors = {
       level: 'error',
       extra: null,
     },
+    {
+      message: 'Something else wrong',
+      error_type: 'TEST_ERROR',
+      level: 'error',
+      extra: null,
+    },
   ],
   id: 'ryhMUZCGb',
   progress: 0,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Small fix for error messages in SQL Lab being duplicated.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="1728" alt="Screenshot 2024-12-09 at 10 58 54 AM" src="https://github.com/user-attachments/assets/7ef426e2-180b-4fdd-8e8d-bf4da57e687f">

After:

<img width="1728" alt="Screenshot 2024-12-09 at 10 58 19 AM" src="https://github.com/user-attachments/assets/3037f28f-faf0-48cf-9134-d1713823dcc9">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
