### PR TITLE
fix: code scanning alert no. 1226: Incomplete multi-character sanitization

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -84,7 +84,12 @@ export function safeHtmlSpan(possiblyHtmlString: string) {
 }
 
 export function removeHTMLTags(str: string): string {
-  return str.replace(/<[^>]*>/g, '');
+  let previous;
+  do {
+    previous = str;
+    str = str.replace(/<[^>]*>/g, '');
+  } while (str !== previous);
+  return str;
 }
 
 export function isJsonString(str: string): boolean {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -85,11 +85,12 @@ export function safeHtmlSpan(possiblyHtmlString: string) {
 
 export function removeHTMLTags(str: string): string {
   let previous;
+  let newstr = str;
   do {
-    previous = str;
-    str = str.replace(/<[^>]*>/g, '');
-  } while (str !== previous);
-  return str;
+    previous = newstr;
+    newstr = newstr.replace(/<[^>]*>/g, '');
+  } while (newstr !== previous);
+  return newstr;
 }
 
 export function isJsonString(str: string): boolean {


### PR DESCRIPTION
Fixes [https://github.com/apache/superset/security/code-scanning/1226](https://github.com/apache/superset/security/code-scanning/1226)

To fix the problem, we should ensure that all HTML tags are removed from the input string, even if they are nested or malformed. One way to achieve this is to repeatedly apply the regular expression replacement until no more replacements can be performed. This approach ensures that all instances of HTML tags are removed.

We will modify the `removeHTMLTags` function to apply the regular expression replacement in a loop until the input string no longer changes. This ensures that all HTML tags are removed, regardless of their structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
