### PR TITLE
fix(Dashboard): Sync color configuration via dedicated endpoint

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -47,7 +47,7 @@ import { loadTags } from 'src/components/Tags/utils';
 import {
   applyColors,
   getColorNamespace,
-  getLabelsColorMapEntries,
+  getFreshLabelsColorMapEntries,
 } from 'src/utils/colorScheme';
 import getOwnerName from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
@@ -369,7 +369,7 @@ const PropertiesModal = ({
     dispatch(
       setDashboardMetadata({
         ...updatedDashboardMetadata,
-        map_label_colors: getLabelsColorMapEntries(customLabelColors),
+        map_label_colors: getFreshLabelsColorMapEntries(customLabelColors),
       }),
     );
 

--- a/superset-frontend/src/utils/colorScheme.ts
+++ b/superset-frontend/src/utils/colorScheme.ts
@@ -23,6 +23,8 @@ import {
   getCategoricalSchemeRegistry,
   getLabelsColorMap,
 } from '@superset-ui/core';
+import { intersection, omit, pick } from 'lodash';
+import { areObjectsEqual } from 'src/reduxUtils';
 
 const EMPTY_ARRAY: string[] = [];
 
@@ -91,20 +93,32 @@ export const getSharedLabelsColorMapEntries = (
  * @param customLabelsColor - the custom label colors in label_colors field
  * @returns all color entries except custom label colors
  */
-export const getLabelsColorMapEntries = (
+export const getFreshLabelsColorMapEntries = (
   customLabelsColor: Record<string, string> = {},
 ): Record<string, string> => {
   const labelsColorMapInstance = getLabelsColorMap();
   const allEntries = Object.fromEntries(labelsColorMapInstance.getColorMap());
 
   // custom label colors are applied and stored separetely via label_colors
-  // removing all instances of custom label colors from the entries
   Object.keys(customLabelsColor).forEach(label => {
     delete allEntries[label];
   });
 
   return allEntries;
 };
+
+/**
+ * Returns all dynamic labels and colors (excluding custom label colors).
+ *
+ * @param labelsColorMap - the labels color map
+ * @param customLabelsColor - the custom label colors in label_colors field
+ * @returns all color entries except custom label colors
+ */
+export const getDynamicLabelsColors = (
+  fullLabelsColors: Record<string, string>,
+  customLabelsColor: Record<string, string> = {},
+): Record<string, string> =>
+  omit(fullLabelsColors, Object.keys(customLabelsColor));
 
 export const getColorSchemeDomain = (colorScheme: string) =>
   getCategoricalSchemeRegistry().get(colorScheme)?.colors || [];
@@ -116,20 +130,29 @@ export const getColorSchemeDomain = (colorScheme: string) =>
  * @returns true if the labels color map is the same as fresh
  */
 export const isLabelsColorMapSynced = (
-  metadata: Record<string, any>,
+  storedLabelsColors: Record<string, any>,
+  freshLabelsColors: Record<string, any>,
+  customLabelColors: Record<string, string>,
 ): boolean => {
-  const storedLabelsColorMap = metadata.map_label_colors || {};
-  const customLabelColors = metadata.label_colors || {};
-  const freshColorMap = getLabelsColorMap().getColorMap();
-  const fullFreshColorMap = {
-    ...Object.fromEntries(freshColorMap),
-    ...customLabelColors,
-  };
+  const freshLabelsCount = Object.keys(freshLabelsColors).length;
 
-  const isSynced = Object.entries(fullFreshColorMap).every(
-    ([label, color]) =>
-      storedLabelsColorMap.hasOwnProperty(label) &&
-      storedLabelsColorMap[label] === color,
+  // still updating, pass
+  if (!freshLabelsCount) return true;
+
+  const commonKeys = intersection(
+    Object.keys(storedLabelsColors),
+    Object.keys(freshLabelsColors),
+  );
+
+  const comparableStoredLabelsColors = pick(storedLabelsColors, commonKeys);
+  const comparableFreshLabelsColors = pick(freshLabelsColors, commonKeys);
+
+  const isSynced = areObjectsEqual(
+    comparableStoredLabelsColors,
+    comparableFreshLabelsColors,
+    {
+      ignoreFields: Object.keys(customLabelColors),
+    },
   );
 
   return isSynced;
@@ -227,7 +250,7 @@ export const applyColors = (
   if (fresh) {
     // requires a new map all together
     applicableColorMapEntries = {
-      ...getLabelsColorMapEntries(customLabelsColor),
+      ...getFreshLabelsColorMapEntries(customLabelsColor),
     };
   }
   if (merge) {
@@ -235,7 +258,7 @@ export const applyColors = (
     // without overriding existing ones
     applicableColorMapEntries = {
       ...fullLabelsColor,
-      ...getLabelsColorMapEntries(customLabelsColor),
+      ...getFreshLabelsColorMapEntries(customLabelsColor),
     };
   }
 

--- a/superset/commands/dashboard/exceptions.py
+++ b/superset/commands/dashboard/exceptions.py
@@ -62,6 +62,10 @@ class DashboardNativeFiltersUpdateFailedError(UpdateFailedError):
     message = _("Dashboard native filters could not be patched.")
 
 
+class DashboardColorsConfigUpdateFailedError(UpdateFailedError):
+    message = _("Dashboard color configuration could not be updated.")
+
+
 class DashboardDeleteFailedError(DeleteFailedError):
     message = _("Dashboard could not be deleted.")
 

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -174,6 +174,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "csv_metadata": "csv_upload",
     "slack_channels": "write",
     "put_filters": "write",
+    "put_colors": "write",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -391,6 +391,24 @@ class DashboardDAO(BaseDAO[Dashboard]):
 
         return updated_configuration
 
+    @classmethod
+    def update_colors_config(
+        cls, dashboard: Dashboard, attributes: dict[str, Any]
+    ) -> None:
+        metadata = json.loads(dashboard.json_metadata or "{}")
+
+        for key in [
+            "color_scheme_domain",
+            "color_scheme",
+            "shared_label_colors",
+            "map_label_colors",
+            "label_colors",
+        ]:
+            if key in attributes:
+                metadata[key] = attributes[key]
+
+        dashboard.json_metadata = json.dumps(metadata)
+
     @staticmethod
     def add_favorite(dashboard: Dashboard) -> None:
         ids = DashboardDAO.favorited_ids([dashboard])

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -428,6 +428,15 @@ class DashboardNativeFiltersConfigUpdateSchema(BaseDashboardSchema):
     reordered = fields.List(fields.String(), allow_none=False)
 
 
+class DashboardColorsConfigUpdateSchema(BaseDashboardSchema):
+    color_namespace = fields.String(allow_none=True)
+    color_scheme = fields.String(allow_none=True)
+    map_label_colors = fields.Dict(allow_none=False)
+    shared_label_colors = SharedLabelsColorsField()
+    label_colors = fields.Dict(allow_none=False)
+    color_scheme_domain = fields.List(fields.String(), allow_none=False)
+
+
 class DashboardScreenshotPostSchema(Schema):
     dataMask = fields.Dict(
         keys=fields.Str(),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR introduces a new endpoint which purpose is to store color configurations for a dashboard. Dashboard color configurations might need syncing and persistence in the backend even when the user takes no action. For instance, new data might appear on the dashboard that needs to be synced with the color maps and persisted. Previously, these changes would be saved using the dashboard PUT endpoint, causing that the dashboard last modified date would show up as updated even though no change was made from the user perspective, causing confusion. Also, issues have surfaced where metadata that wasn't meant to be persisted yet would go along with the updated color metadata, causing unexpected behaviors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
1. Open a Dashboard
2. Make sure new data appeared (new dimensions or metrics)
3. Observe how a network request is made to store the color metadata when leaving the dashboard
4. Make sure the last modified date of the Dashboard hasn't changed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
