### PR TITLE
feat(repo) Add OpenSSF Scorecard badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ under the License.
 [![Build Status](https://github.com/apache/superset/workflows/Python/badge.svg)](https://github.com/apache/superset/actions)
 [![PyPI version](https://badge.fury.io/py/apache-superset.svg)](https://badge.fury.io/py/apache-superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/apache/superset/badge)](https://scorecard.dev/viewer/?uri=github.com/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache-superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache-superset)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adds OpenSSF Scorecard badge to the README.md that links to the [OpenSSF's Scorecard Report for the repo](https://scorecard.dev/viewer/?uri=github.com/apache/superset). OpenSSF's Scorecard and GitHub Action has become a 

### TESTING INSTRUCTIONS

You're able to run the OpenSSF's scorecard tool that analyzes the repo for best practices and detected vulnerabilities.

`docker run -e GITHUB_AUTH_TOKEN=<generated_auth_token> gcr.io/openssf/scorecard:stable --repo=https://github.com/apache/superset`