### PR TITLE
fix: don't include chromium on ephemeral envs

### DIFF
--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -155,7 +155,8 @@ jobs:
           supersetbot docker \
             --preset ci \
             --platform  linux/amd64 \
-            --context-ref "$RELEASE"
+            --context-ref "$RELEASE" \
+            --extra-flags "--build-arg INCLUDE_CHROMIUM=false"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
While working on another PR, I noticed that often docker builds fail while installing chromium, and it appears to be the container running out of memory.

Well turns out we don't need a headless browser for ephemeral envs, so passing a flag to prevent that step.

