### PR TITLE
fix(Pivot Table): Fix column width to respect currency config

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -51,6 +51,7 @@ const Styles = styled.div<PivotTableStylesProps>`
       width: ${
         typeof width === 'string' ? parseInt(width, 10) : width - margin * 2
       }px;
+      white-space: nowrap;
  `}
 `;
 


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/31377.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
<img width="674" alt="image" src="https://github.com/user-attachments/assets/0c151271-7a57-498e-b70a-6bd50bfd0d86" />

**After**
![image](https://github.com/user-attachments/assets/f6cb1537-1ccc-4ba2-8bc3-a7a9c96dc300)

### TESTING INSTRUCTIONS
1. Create a Pivot table using the `cleaned_sales_data` dataset.
2. Create a metric at the dataset level and apply a currency config.
3. Set `country` as a **column**, `product_line` as a **row** and use the metric created in the previous step.
4. Validate that the column width respects the currency config. 

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/issues/31377
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
