### PR TITLE
fix(tags): clean up bulk create api and schema

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -100,8 +100,13 @@
                           "QUERY_SECURITY_ACCESS_ERROR",
                           "MISSING_OWNERSHIP_ERROR",
                           "USER_ACTIVITY_SECURITY_ACCESS_ERROR",
+                          "DASHBOARD_SECURITY_ACCESS_ERROR",
+                          "CHART_SECURITY_ACCESS_ERROR",
+                          "OAUTH2_REDIRECT",
+                          "OAUTH2_REDIRECT_ERROR",
                           "BACKEND_TIMEOUT_ERROR",
                           "DATABASE_NOT_FOUND_ERROR",
+                          "TABLE_NOT_FOUND_ERROR",
                           "MISSING_TEMPLATE_PARAMS_ERROR",
                           "INVALID_TEMPLATE_PARAMS_ERROR",
                           "RESULTS_BACKEND_NOT_CONFIGURED_ERROR",
@@ -112,12 +117,14 @@
                           "RESULTS_BACKEND_ERROR",
                           "ASYNC_WORKERS_ERROR",
                           "ADHOC_SUBQUERY_NOT_ALLOWED_ERROR",
+                          "INVALID_SQL_ERROR",
+                          "RESULT_TOO_LARGE_ERROR",
                           "GENERIC_COMMAND_ERROR",
                           "GENERIC_BACKEND_ERROR",
                           "INVALID_PAYLOAD_FORMAT_ERROR",
                           "INVALID_PAYLOAD_SCHEMA_ERROR",
-                          "REPORT_NOTIFICATION_ERROR",
-                          "RESULT_TOO_LARGE_ERROR"
+                          "MARSHMALLOW_ERROR",
+                          "REPORT_NOTIFICATION_ERROR"
                         ],
                         "type": "string"
                       },
@@ -125,7 +132,11 @@
                         "type": "object"
                       },
                       "level": {
-                        "enum": ["info", "warning", "error"],
+                        "enum": [
+                          "info",
+                          "warning",
+                          "error"
+                        ],
                         "type": "string"
                       },
                       "message": {
@@ -207,7 +218,12 @@
         "properties": {
           "annotationType": {
             "description": "Type of annotation layer",
-            "enum": ["FORMULA", "INTERVAL", "EVENT", "TIME_SERIES"],
+            "enum": [
+              "FORMULA",
+              "INTERVAL",
+              "EVENT",
+              "TIME_SERIES"
+            ],
             "type": "string"
           },
           "color": {
@@ -238,7 +254,12 @@
           },
           "opacity": {
             "description": "Opacity of layer",
-            "enum": ["", "opacityLow", "opacityMedium", "opacityHigh"],
+            "enum": [
+              "",
+              "opacityLow",
+              "opacityMedium",
+              "opacityHigh"
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -265,12 +286,22 @@
           },
           "sourceType": {
             "description": "Type of source for annotation data",
-            "enum": ["", "line", "NATIVE", "table"],
+            "enum": [
+              "",
+              "line",
+              "NATIVE",
+              "table"
+            ],
             "type": "string"
           },
           "style": {
             "description": "Line style. Only applies to time-series annotations",
-            "enum": ["dashed", "dotted", "solid", "longDashed"],
+            "enum": [
+              "dashed",
+              "dotted",
+              "solid",
+              "longDashed"
+            ],
             "type": "string"
           },
           "timeColumn": {
@@ -292,7 +323,12 @@
             "type": "number"
           }
         },
-        "required": ["name", "show", "showMarkers", "value"],
+        "required": [
+          "name",
+          "show",
+          "showMarkers",
+          "value"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get": {
@@ -359,7 +395,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User1": {
@@ -373,7 +412,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.post": {
@@ -390,7 +432,9 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.put": {
@@ -440,7 +484,9 @@
             "type": "string"
           }
         },
-        "required": ["layer"],
+        "required": [
+          "layer"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get.AnnotationLayer": {
@@ -459,13 +505,13 @@
       "AnnotationRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
+            "$ref": "#/components/schemas/AnnotationRestApi.get_list.User1"
           },
           "end_dttm": {
             "format": "date-time",
@@ -502,7 +548,9 @@
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get_list.User1": {
@@ -515,7 +563,9 @@
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.post": {
@@ -547,7 +597,11 @@
             "type": "string"
           }
         },
-        "required": ["end_dttm", "short_descr", "start_dttm"],
+        "required": [
+          "end_dttm",
+          "short_descr",
+          "start_dttm"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.put": {
@@ -581,6 +635,37 @@
         },
         "type": "object"
       },
+      "AppleHealthResponseSchema": {
+        "properties": {
+          "cache_message": {
+            "description": "Human readable status message for the cache connection",
+            "type": "string"
+          },
+          "cache_status": {
+            "description": "The status of the cache",
+            "enum": [
+              "NA",
+              "HEALTHY",
+              "ERROR"
+            ],
+            "type": "string"
+          },
+          "metastore_message": {
+            "description": "Human readable status message for the metastore connection",
+            "type": "string"
+          },
+          "metastore_status": {
+            "description": "The status of the metastore",
+            "enum": [
+              "NA",
+              "HEALTHY",
+              "ERROR"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "AvailableDomainsSchema": {
         "properties": {
           "domains": {
@@ -592,10 +677,136 @@
         },
         "type": "object"
       },
+      "CSVMetadataUploadFilePostSchema": {
+        "properties": {
+          "delimiter": {
+            "description": "The delimiter of the CSV file",
+            "type": "string"
+          },
+          "file": {
+            "description": "The file to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "header_row": {
+            "description": "Row containing the headers to use as column names(0 is first line of data). Leave empty if there is no header row.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "CSVUploadPostSchema": {
+        "properties": {
+          "already_exists": {
+            "default": "fail",
+            "description": "What to do if the table already exists accepts: fail, replace, append",
+            "enum": [
+              "fail",
+              "replace",
+              "append"
+            ],
+            "type": "string"
+          },
+          "column_data_types": {
+            "description": "A dictionary with column names and their data types if you need to change the defaults. Example: {'user_id':'int'}. Check Python Pandas library for supported data types",
+            "type": "string"
+          },
+          "column_dates": {
+            "description": "A list of column names that should be parsed as dates. Example: date,timestamp",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "columns_read": {
+            "description": "A List of the column names that should be read",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dataframe_index": {
+            "description": "Write dataframe index as a column.",
+            "type": "boolean"
+          },
+          "day_first": {
+            "description": "DD/MM format dates, international and European format",
+            "type": "boolean"
+          },
+          "decimal_character": {
+            "description": "Character to recognize as decimal point. Default is '.'",
+            "type": "string"
+          },
+          "delimiter": {
+            "description": "The delimiter of the CSV file",
+            "type": "string"
+          },
+          "file": {
+            "description": "The CSV file to upload",
+            "format": "text/csv",
+            "type": "string"
+          },
+          "header_row": {
+            "description": "Row containing the headers to use as column names(0 is first line of data). Leave empty if there is no header row.",
+            "type": "integer"
+          },
+          "index_column": {
+            "description": "Column to use as the row labels of the dataframe. Leave empty if no index column",
+            "type": "string"
+          },
+          "index_label": {
+            "description": "Index label for index column.",
+            "type": "string"
+          },
+          "null_values": {
+            "description": "A list of strings that should be treated as null. Examples: '' for empty strings, 'None', 'N/A',Warning: Hive database supports only a single value",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rows_to_read": {
+            "description": "Number of rows to read from the file. If None, reads all rows.",
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "schema": {
+            "description": "The schema to upload the data file to.",
+            "type": "string"
+          },
+          "skip_blank_lines": {
+            "description": "Skip blank lines in the CSV file.",
+            "type": "boolean"
+          },
+          "skip_initial_space": {
+            "description": "Skip spaces after delimiter.",
+            "type": "boolean"
+          },
+          "skip_rows": {
+            "description": "Number of rows to skip at start of file.",
+            "type": "integer"
+          },
+          "table_name": {
+            "description": "The name of the table to be created/appended",
+            "maxLength": 10000,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "table_name"
+        ],
+        "type": "object"
+      },
       "CacheInvalidationRequestSchema": {
         "properties": {
           "datasource_uids": {
-            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasouce_uid` ",
+            "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasource_uid` ",
             "items": {
               "type": "string"
             },
@@ -643,6 +854,18 @@
         },
         "type": "object"
       },
+      "CatalogsResponseSchema": {
+        "properties": {
+          "result": {
+            "items": {
+              "description": "A database catalog name",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "ChartCacheScreenshotResponseSchema": {
         "properties": {
           "cache_key": {
@@ -675,7 +898,9 @@
             "type": "string"
           }
         },
-        "required": ["chart_id"],
+        "required": [
+          "chart_id"
+        ],
         "type": "object"
       },
       "ChartCacheWarmUpResponseSchema": {
@@ -711,7 +936,14 @@
         "properties": {
           "aggregate": {
             "description": "Aggregation operator.Only required for simple expression types.",
-            "enum": ["AVG", "COUNT", "COUNT_DISTINCT", "MAX", "MIN", "SUM"],
+            "enum": [
+              "AVG",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "MAX",
+              "MIN",
+              "SUM"
+            ],
             "type": "string"
           },
           "column": {
@@ -719,7 +951,10 @@
           },
           "expressionType": {
             "description": "Simple or SQL metric",
-            "enum": ["SIMPLE", "SQL"],
+            "enum": [
+              "SIMPLE",
+              "SQL"
+            ],
             "example": "SQL",
             "type": "string"
           },
@@ -753,7 +988,9 @@
             "type": "string"
           }
         },
-        "required": ["expressionType"],
+        "required": [
+          "expressionType"
+        ],
         "type": "object"
       },
       "ChartDataAggregateOptionsSchema": {
@@ -818,16 +1055,25 @@
           },
           "percentiles": {
             "description": "Upper and lower percentiles for percentile whisker type.",
-            "example": [1, 99]
+            "example": [
+              1,
+              99
+            ]
           },
           "whisker_type": {
             "description": "Whisker type. Any numpy function will work.",
-            "enum": ["tukey", "min/max", "percentile"],
+            "enum": [
+              "tukey",
+              "min/max",
+              "percentile"
+            ],
             "example": "tukey",
             "type": "string"
           }
         },
-        "required": ["whisker_type"],
+        "required": [
+          "whisker_type"
+        ],
         "type": "object"
       },
       "ChartDataColumn": {
@@ -849,12 +1095,17 @@
         "properties": {
           "orientation": {
             "description": "Should cell values be calculated across the row or column.",
-            "enum": ["row", "column"],
+            "enum": [
+              "row",
+              "column"
+            ],
             "example": "row",
             "type": "string"
           }
         },
-        "required": ["orientation"],
+        "required": [
+          "orientation"
+        ],
         "type": "object"
       },
       "ChartDataDatasource": {
@@ -866,7 +1117,6 @@
           "type": {
             "description": "Datasource type",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -876,7 +1126,9 @@
             "type": "string"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "ChartDataExtras": {
@@ -885,14 +1137,25 @@
             "description": "HAVING clause to be added to aggregate queries using AND operator.",
             "type": "string"
           },
+          "instant_time_comparison_range": {
+            "description": "This is only set using the new time comparison controls that is made available in some plugins behind the experimental feature flag.",
+            "nullable": true,
+            "type": "string"
+          },
           "relative_end": {
             "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "relative_start": {
             "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "time_grain_sqla": {
@@ -916,12 +1179,7 @@
               "1969-12-28T00:00:00Z/P1W",
               "1969-12-29T00:00:00Z/P1W",
               "P1W/1970-01-03T00:00:00Z",
-              "P1W/1970-01-04T00:00:00Z",
-              "PT2H",
-              "PT4H",
-              "PT8H",
-              "PT10H",
-              "PT12H"
+              "P1W/1970-01-04T00:00:00Z"
             ],
             "example": "P1D",
             "nullable": true,
@@ -959,6 +1217,7 @@
               ">=",
               "<=",
               "LIKE",
+              "NOT LIKE",
               "ILIKE",
               "IS NULL",
               "IS NOT NULL",
@@ -973,11 +1232,18 @@
           },
           "val": {
             "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
-            "example": ["China", "France", "Japan"],
+            "example": [
+              "China",
+              "France",
+              "Japan"
+            ],
             "nullable": true
           }
         },
-        "required": ["col", "op"],
+        "required": [
+          "col",
+          "op"
+        ],
         "type": "object"
       },
       "ChartDataGeodeticParseOptionsSchema": {
@@ -999,7 +1265,11 @@
             "type": "string"
           }
         },
-        "required": ["geodetic", "latitude", "longitude"],
+        "required": [
+          "geodetic",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashDecodeOptionsSchema": {
@@ -1017,7 +1287,11 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashEncodeOptionsSchema": {
@@ -1035,7 +1309,11 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataPivotOptionsSchema": {
@@ -1099,8 +1377,10 @@
               "geodetic_parse",
               "geohash_decode",
               "geohash_encode",
+              "histogram",
               "pivot",
               "prophet",
+              "rank",
               "rename",
               "resample",
               "rolling",
@@ -1127,12 +1407,17 @@
                   }
                 }
               },
-              "groupby": ["country", "gender"]
+              "groupby": [
+                "country",
+                "gender"
+              ]
             },
             "type": "object"
           }
         },
-        "required": ["operation"],
+        "required": [
+          "operation"
+        ],
         "type": "object"
       },
       "ChartDataProphetOptionsSchema": {
@@ -1174,12 +1459,7 @@
               "1969-12-28T00:00:00Z/P1W",
               "1969-12-29T00:00:00Z/P1W",
               "P1W/1970-01-03T00:00:00Z",
-              "P1W/1970-01-04T00:00:00Z",
-              "PT2H",
-              "PT4H",
-              "PT8H",
-              "PT10H",
-              "PT12H"
+              "P1W/1970-01-04T00:00:00Z"
             ],
             "example": "P1D",
             "type": "string"
@@ -1193,7 +1473,11 @@
             "example": false
           }
         },
-        "required": ["confidence_interval", "periods", "time_grain"],
+        "required": [
+          "confidence_interval",
+          "periods",
+          "time_grain"
+        ],
         "type": "object"
       },
       "ChartDataQueryContextSchema": {
@@ -1221,7 +1505,11 @@
             "type": "array"
           },
           "result_format": {
-            "enum": ["csv", "json", "xlsx"]
+            "enum": [
+              "csv",
+              "json",
+              "xlsx"
+            ]
           },
           "result_type": {
             "enum": [
@@ -1338,8 +1626,14 @@
           "orderby": {
             "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.",
             "example": [
-              ["my_col_1", false],
-              ["my_col_2", true]
+              [
+                "my_col_1",
+                false
+              ],
+              [
+                "my_col_2",
+                true
+              ]
             ],
             "items": {},
             "nullable": true,
@@ -1604,7 +1898,7 @@
             "type": "boolean"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get.User"
+            "$ref": "#/components/schemas/ChartDataRestApi.get.AppleUser"
           },
           "params": {
             "nullable": true,
@@ -1636,6 +1930,26 @@
         },
         "type": "object"
       },
+      "ChartDataRestApi.get.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "ChartDataRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
@@ -1664,26 +1978,14 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
-        "type": "object"
-      },
-      "ChartDataRestApi.get.User": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
         "type": "object"
       },
       "ChartDataRestApi.get_list": {
@@ -1701,7 +2003,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -1716,7 +2018,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
           },
           "created_by_name": {
             "readOnly": true
@@ -1767,10 +2069,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.AppleUser"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartDataRestApi.get_list.AppleUser1"
           },
           "params": {
             "nullable": true,
@@ -1804,6 +2106,46 @@
         },
         "type": "object"
       },
+      "ChartDataRestApi.get_list.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "ChartDataRestApi.get_list.AppleUser1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "ChartDataRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
@@ -1828,7 +2170,9 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.Tag": {
@@ -1842,7 +2186,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -1861,7 +2210,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User1": {
@@ -1878,38 +2230,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartDataRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartDataRestApi.get_list.User3": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.post": {
@@ -1948,7 +2272,6 @@
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -1988,7 +2311,7 @@
             "type": "string"
           },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modifiedstate.",
             "nullable": true,
             "type": "boolean"
           },
@@ -2000,13 +2323,21 @@
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.put": {
@@ -2041,7 +2372,6 @@
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -2082,7 +2412,7 @@
             "type": "string"
           },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modifiedstate.",
             "nullable": true,
             "type": "boolean"
           },
@@ -2095,13 +2425,18 @@
           },
           "tags": {
             "items": {
-              "$ref": "#/components/schemas/Tag"
+              "description": "Tags to be associated with the chart",
+              "type": "integer"
             },
             "type": "array"
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2182,14 +2517,21 @@
             "type": "integer"
           }
         },
-        "required": ["rolling_type", "window"],
+        "required": [
+          "rolling_type",
+          "window"
+        ],
         "type": "object"
       },
       "ChartDataSelectOptionsSchema": {
         "properties": {
           "columns": {
             "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
-            "example": ["country", "gender", "age"],
+            "example": [
+              "country",
+              "gender",
+              "age"
+            ],
             "items": {
               "type": "string"
             },
@@ -2197,7 +2539,9 @@
           },
           "exclude": {
             "description": "Columns to exclude from selection.",
-            "example": ["my_temp_column"],
+            "example": [
+              "my_temp_column"
+            ],
             "items": {
               "type": "string"
             },
@@ -2242,7 +2586,9 @@
             "type": "object"
           }
         },
-        "required": ["columns"],
+        "required": [
+          "columns"
+        ],
         "type": "object"
       },
       "ChartEntityResponseSchema": {
@@ -2372,7 +2718,7 @@
             "type": "boolean"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartRestApi.get.User"
+            "$ref": "#/components/schemas/ChartRestApi.get.AppleUser"
           },
           "params": {
             "nullable": true,
@@ -2404,6 +2750,26 @@
         },
         "type": "object"
       },
+      "ChartRestApi.get.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "ChartRestApi.get.Dashboard": {
         "properties": {
           "dashboard_title": {
@@ -2432,26 +2798,14 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
-        "type": "object"
-      },
-      "ChartRestApi.get.User": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
         "type": "object"
       },
       "ChartRestApi.get_list": {
@@ -2469,7 +2823,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -2484,7 +2838,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
           },
           "created_by_name": {
             "readOnly": true
@@ -2535,10 +2889,10 @@
             "type": "string"
           },
           "last_saved_by": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.AppleUser"
           },
           "owners": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ChartRestApi.get_list.AppleUser1"
           },
           "params": {
             "nullable": true,
@@ -2572,6 +2926,46 @@
         },
         "type": "object"
       },
+      "ChartRestApi.get_list.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "ChartRestApi.get_list.AppleUser1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "ChartRestApi.get_list.Dashboard": {
         "properties": {
           "dashboard_title": {
@@ -2596,7 +2990,9 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.Tag": {
@@ -2610,7 +3006,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -2629,7 +3030,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User1": {
@@ -2646,38 +3050,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartRestApi.get_list.User3": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.post": {
@@ -2716,7 +3092,6 @@
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -2756,7 +3131,7 @@
             "type": "string"
           },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modifiedstate.",
             "nullable": true,
             "type": "boolean"
           },
@@ -2768,13 +3143,21 @@
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.put": {
@@ -2809,7 +3192,6 @@
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -2850,7 +3232,7 @@
             "type": "string"
           },
           "query_context_generation": {
-            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modfiedstate.",
+            "description": "The query context generation represents whether the query_contextis user generated or not so that it does not update user modifiedstate.",
             "nullable": true,
             "type": "boolean"
           },
@@ -2863,13 +3245,18 @@
           },
           "tags": {
             "items": {
-              "$ref": "#/components/schemas/Tag"
+              "description": "Tags to be associated with the chart",
+              "type": "integer"
             },
             "type": "array"
           },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2878,10 +3265,78 @@
         },
         "type": "object"
       },
+      "ColumnarMetadataUploadFilePostSchema": {
+        "properties": {
+          "file": {
+            "description": "The file to upload",
+            "format": "binary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "ColumnarUploadPostSchema": {
+        "properties": {
+          "already_exists": {
+            "default": "fail",
+            "description": "What to do if the table already exists accepts: fail, replace, append",
+            "enum": [
+              "fail",
+              "replace",
+              "append"
+            ],
+            "type": "string"
+          },
+          "columns_read": {
+            "description": "A List of the column names that should be read",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dataframe_index": {
+            "description": "Write dataframe index as a column.",
+            "type": "boolean"
+          },
+          "file": {
+            "description": "The Columnar file to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "index_label": {
+            "description": "Index label for index column.",
+            "type": "string"
+          },
+          "schema": {
+            "description": "The schema to upload the data file to.",
+            "type": "string"
+          },
+          "table_name": {
+            "description": "The name of the table to be created/appended",
+            "maxLength": 10000,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "table_name"
+        ],
+        "type": "object"
+      },
       "CssTemplateRestApi.get": {
         "properties": {
-          "created_by": {
+          "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get.User"
+          },
+          "changed_on_delta_humanized": {
+            "readOnly": true
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/CssTemplateRestApi.get.User1"
           },
           "css": {
             "nullable": true,
@@ -2912,19 +3367,42 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "CssTemplateRestApi.get.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
+            "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -2960,7 +3438,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User1": {
@@ -2977,7 +3458,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.post": {
@@ -3008,31 +3492,21 @@
         },
         "type": "object"
       },
-      "DashboardNativeFiltersConfigUpdateSchema": {
+      "DashboardCacheScreenshotResponseSchema": {
         "properties": {
-          "deleted": {
-            "description": "List of filter ids to delete",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
+          "cache_key": {
+            "description": "The cache key",
+            "type": "string"
           },
-          "modified": {
-            "description": "List of filter objects to update",
-            "items": {
-              "type": "object"
-            },
-            "type": "array"
+          "dashboard_url": {
+            "description": "The url to render the dashboard",
+            "type": "string"
           },
-          "reordered": {
-            "description": "List of filter ids in the new order",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
+          "image_url": {
+            "description": "The url to fetch the screenshot",
+            "type": "string"
           }
         },
-        "required": ["deleted", "modified", "reordered"],
         "type": "object"
       },
       "DashboardCopySchema": {
@@ -3057,16 +3531,27 @@
             "type": "string"
           }
         },
-        "required": ["json_metadata"],
+        "required": [
+          "json_metadata"
+        ],
         "type": "object"
       },
       "DashboardDatasetSchema": {
         "properties": {
+          "always_filter_main_dttm": {
+            "type": "boolean"
+          },
           "cache_timeout": {
             "type": "integer"
           },
           "column_formats": {
             "type": "object"
+          },
+          "column_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "column_types": {
             "items": {
@@ -3077,12 +3562,6 @@
           "columns": {
             "items": {
               "type": "object"
-            },
-            "type": "array"
-          },
-          "column_names": {
-            "items": {
-              "type": "string"
             },
             "type": "array"
           },
@@ -3139,6 +3618,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "normalize_columns": {
+            "type": "boolean"
           },
           "offset": {
             "type": "integer"
@@ -3233,6 +3715,12 @@
             },
             "type": "array"
           },
+          "created_by": {
+            "$ref": "#/components/schemas/User"
+          },
+          "created_on_delta_humanized": {
+            "type": "string"
+          },
           "css": {
             "description": "Override CSS for the dashboard.",
             "type": "string"
@@ -3276,7 +3764,7 @@
           },
           "tags": {
             "items": {
-              "$ref": "#/components/schemas/Tag1"
+              "$ref": "#/components/schemas/Tag"
             },
             "type": "array"
           },
@@ -3340,7 +3828,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User2"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -3352,7 +3840,7 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
           },
           "created_on_delta_humanized": {
             "readOnly": true
@@ -3377,7 +3865,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/DashboardRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DashboardRestApi.get_list.AppleUser"
           },
           "position_json": {
             "nullable": true,
@@ -3410,6 +3898,26 @@
         },
         "type": "object"
       },
+      "DashboardRestApi.get_list.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
       "DashboardRestApi.get_list.Role": {
         "properties": {
           "id": {
@@ -3420,7 +3928,9 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.Tag": {
@@ -3434,7 +3944,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -3453,7 +3968,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.User1": {
@@ -3470,24 +3988,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "DashboardRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.post": {
@@ -3626,12 +4130,23 @@
             "minLength": 0,
             "nullable": true,
             "type": "string"
+          },
+          "tags": {
+            "items": {
+              "description": "Tags to be associated with the dashboard",
+              "nullable": true,
+              "type": "integer"
+            },
+            "type": "array"
           }
         },
         "type": "object"
       },
       "Database": {
         "properties": {
+          "allow_multi_catalog": {
+            "type": "boolean"
+          },
           "allows_cost_estimate": {
             "type": "boolean"
           },
@@ -3719,15 +4234,14 @@
             "type": "string"
           },
           "engine_information": {
-            "additionalProperties": {},
-            "type": "object"
+            "$ref": "#/components/schemas/EngineInformation"
           },
           "expose_in_sqllab": {
             "description": "Expose this database to SQLLab",
             "type": "boolean"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -3943,7 +4457,9 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list": {
@@ -3964,6 +4480,9 @@
             "nullable": true,
             "type": "boolean"
           },
+          "allow_multi_catalog": {
+            "readOnly": true
+          },
           "allow_run_async": {
             "nullable": true,
             "type": "boolean"
@@ -3980,6 +4499,9 @@
           "backend": {
             "readOnly": true
           },
+          "changed_by": {
+            "$ref": "#/components/schemas/DatabaseRestApi.get_list.User"
+          },
           "changed_on": {
             "format": "date-time",
             "nullable": true,
@@ -3989,13 +4511,16 @@
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/DatabaseRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatabaseRestApi.get_list.User1"
           },
           "database_name": {
             "maxLength": 250,
             "type": "string"
           },
           "disable_data_preview": {
+            "readOnly": true
+          },
+          "disable_drill_to_detail": {
             "readOnly": true
           },
           "engine_information": {
@@ -4026,7 +4551,9 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list.User": {
@@ -4040,7 +4567,27 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "DatabaseRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.post": {
@@ -4073,7 +4620,10 @@
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4100,7 +4650,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -4151,7 +4701,9 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.put": {
@@ -4184,7 +4736,10 @@
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4212,7 +4767,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -4327,7 +4882,10 @@
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4347,7 +4905,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
             "type": "string"
           },
           "impersonate_user": {
@@ -4397,7 +4955,10 @@
           },
           "configuration_method": {
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4416,7 +4977,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
             "type": "string"
           },
           "id": {
@@ -4446,7 +5007,10 @@
             "type": "string"
           }
         },
-        "required": ["configuration_method", "engine"],
+        "required": [
+          "configuration_method",
+          "engine"
+        ],
         "type": "object"
       },
       "Dataset": {
@@ -4636,7 +5200,10 @@
             "type": "string"
           }
         },
-        "required": ["db_name", "table_name"],
+        "required": [
+          "db_name",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetCacheWarmUpResponseSchema": {
@@ -4730,7 +5297,9 @@
             "type": "string"
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetColumnsRestApi.get": {
@@ -4776,7 +5345,10 @@
             "type": "string"
           }
         },
-        "required": ["base_model_id", "table_name"],
+        "required": [
+          "base_model_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetMetricRestApi.get": {
@@ -4864,7 +5436,10 @@
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
         "type": "object"
       },
       "DatasetRelatedChart": {
@@ -4943,12 +5518,21 @@
       },
       "DatasetRestApi.get": {
         "properties": {
+          "always_filter_main_dttm": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "cache_timeout": {
             "nullable": true,
             "type": "integer"
           },
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -5034,6 +5618,10 @@
           "name": {
             "readOnly": true
           },
+          "normalize_columns": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "offset": {
             "nullable": true,
             "type": "integer"
@@ -5042,7 +5630,7 @@
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get.AppleUser"
           },
           "schema": {
             "maxLength": 255,
@@ -5077,11 +5665,39 @@
             "readOnly": true
           }
         },
-        "required": ["columns", "database", "metrics", "table_name"],
+        "required": [
+          "columns",
+          "database",
+          "metrics",
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.Database": {
         "properties": {
+          "allow_multi_catalog": {
+            "readOnly": true
+          },
           "backend": {
             "readOnly": true
           },
@@ -5093,7 +5709,9 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.SqlMetric": {
@@ -5151,7 +5769,10 @@
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.TableColumn": {
@@ -5229,7 +5850,9 @@
             "type": "string"
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User": {
@@ -5243,7 +5866,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User1": {
@@ -5252,35 +5878,26 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "type": "integer"
-          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "DatasetRestApi.get.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list": {
         "properties": {
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
           },
           "changed_by_name": {
             "readOnly": true
@@ -5319,7 +5936,7 @@
             "readOnly": true
           },
           "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User"
+            "$ref": "#/components/schemas/DatasetRestApi.get_list.AppleUser"
           },
           "schema": {
             "maxLength": 255,
@@ -5335,7 +5952,30 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get_list.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.Database": {
@@ -5348,7 +5988,9 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.User": {
@@ -5365,25 +6007,24 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "DatasetRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.post": {
         "properties": {
+          "always_filter_main_dttm": {
+            "default": false,
+            "type": "boolean"
+          },
+          "catalog": {
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
           "database": {
             "type": "integer"
           },
@@ -5393,6 +6034,10 @@
           },
           "is_managed_externally": {
             "nullable": true,
+            "type": "boolean"
+          },
+          "normalize_columns": {
+            "default": false,
             "type": "boolean"
           },
           "owners": {
@@ -5417,14 +6062,27 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.put": {
         "properties": {
+          "always_filter_main_dttm": {
+            "default": false,
+            "type": "boolean"
+          },
           "cache_timeout": {
             "nullable": true,
             "type": "integer"
+          },
+          "catalog": {
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
           },
           "columns": {
             "items": {
@@ -5479,6 +6137,10 @@
             },
             "type": "array"
           },
+          "normalize_columns": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "offset": {
             "nullable": true,
             "type": "integer"
@@ -5514,6 +6176,11 @@
       },
       "Datasource": {
         "properties": {
+          "catalog": {
+            "description": "Datasource catalog",
+            "nullable": true,
+            "type": "string"
+          },
           "database_name": {
             "description": "Datasource name",
             "type": "string"
@@ -5525,7 +6192,6 @@
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -5539,7 +6205,9 @@
             "type": "string"
           }
         },
-        "required": ["datasource_type"],
+        "required": [
+          "datasource_type"
+        ],
         "type": "object"
       },
       "DistincResponseSchema": {
@@ -5575,7 +6243,9 @@
             "type": "array"
           }
         },
-        "required": ["allowed_domains"],
+        "required": [
+          "allowed_domains"
+        ],
         "type": "object"
       },
       "EmbeddedDashboardResponseSchema": {
@@ -5638,8 +6308,34 @@
         },
         "type": "object"
       },
+      "EngineInformation": {
+        "properties": {
+          "disable_ssh_tunneling": {
+            "description": "SSH tunnel is not available to the database",
+            "type": "boolean"
+          },
+          "supports_dynamic_catalog": {
+            "description": "The database supports multiple catalogs in a single connection",
+            "type": "boolean"
+          },
+          "supports_file_upload": {
+            "description": "Users can upload files to the database",
+            "type": "boolean"
+          },
+          "supports_oauth2": {
+            "description": "The database supports OAuth2",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "EstimateQueryCostSchema": {
         "properties": {
+          "catalog": {
+            "description": "The database catalog",
+            "nullable": true,
+            "type": "string"
+          },
           "database_id": {
             "description": "The database id",
             "type": "integer"
@@ -5658,11 +6354,124 @@
             "type": "object"
           }
         },
-        "required": ["database_id", "sql"],
+        "required": [
+          "database_id",
+          "sql"
+        ],
+        "type": "object"
+      },
+      "ExcelMetadataUploadFilePostSchema": {
+        "properties": {
+          "file": {
+            "description": "The file to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "header_row": {
+            "description": "Row containing the headers to use as column names(0 is first line of data). Leave empty if there is no header row.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "type": "object"
+      },
+      "ExcelUploadPostSchema": {
+        "properties": {
+          "already_exists": {
+            "default": "fail",
+            "description": "What to do if the table already exists accepts: fail, replace, append",
+            "enum": [
+              "fail",
+              "replace",
+              "append"
+            ],
+            "type": "string"
+          },
+          "column_dates": {
+            "description": "A list of column names that should be parsed as dates. Example: date,timestamp",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "columns_read": {
+            "description": "A List of the column names that should be read",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dataframe_index": {
+            "description": "Write dataframe index as a column.",
+            "type": "boolean"
+          },
+          "decimal_character": {
+            "description": "Character to recognize as decimal point. Default is '.'",
+            "type": "string"
+          },
+          "file": {
+            "description": "The Excel file to upload",
+            "format": "binary",
+            "type": "string"
+          },
+          "header_row": {
+            "description": "Row containing the headers to use as column names(0 is first line of data). Leave empty if there is no header row.",
+            "type": "integer"
+          },
+          "index_column": {
+            "description": "Column to use as the row labels of the dataframe. Leave empty if no index column",
+            "type": "string"
+          },
+          "index_label": {
+            "description": "Index label for index column.",
+            "type": "string"
+          },
+          "null_values": {
+            "description": "A list of strings that should be treated as null. Examples: '' for empty strings, 'None', 'N/A',Warning: Hive database supports only a single value",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rows_to_read": {
+            "description": "Number of rows to read from the file. If None, reads all rows.",
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "schema": {
+            "description": "The schema to upload the data file to.",
+            "type": "string"
+          },
+          "sheet_name": {
+            "description": "Strings used for sheet names (default is the first sheet).",
+            "type": "string"
+          },
+          "skip_rows": {
+            "description": "Number of rows to skip at start of file.",
+            "type": "integer"
+          },
+          "table_name": {
+            "description": "The name of the table to be created/appended",
+            "maxLength": 10000,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "table_name"
+        ],
         "type": "object"
       },
       "ExecutePayloadSchema": {
         "properties": {
+          "catalog": {
+            "nullable": true,
+            "type": "string"
+          },
           "client_id": {
             "nullable": true,
             "type": "string"
@@ -5718,7 +6527,10 @@
             "type": "string"
           }
         },
-        "required": ["database_id", "sql"],
+        "required": [
+          "database_id",
+          "sql"
+        ],
         "type": "object"
       },
       "ExploreContextSchema": {
@@ -5756,7 +6568,9 @@
             "type": "array"
           }
         },
-        "required": ["formData"],
+        "required": [
+          "formData"
+        ],
         "type": "object"
       },
       "FormDataPostSchema": {
@@ -5772,7 +6586,6 @@
           "datasource_type": {
             "description": "The datasource type",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -5786,7 +6599,11 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "FormDataPutSchema": {
@@ -5802,7 +6619,6 @@
           "datasource_type": {
             "description": "The datasource type",
             "enum": [
-              "sl_table",
               "table",
               "dataset",
               "query",
@@ -5816,7 +6632,11 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "GetFavStarIdsSchema": {
@@ -5833,9 +6653,24 @@
       },
       "GetOrCreateDatasetSchema": {
         "properties": {
+          "always_filter_main_dttm": {
+            "default": false,
+            "type": "boolean"
+          },
+          "catalog": {
+            "description": "The catalog the table belongs to",
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
           "database_id": {
             "description": "ID of database table belongs to",
             "type": "integer"
+          },
+          "normalize_columns": {
+            "default": false,
+            "type": "boolean"
           },
           "schema": {
             "description": "The schema the table belongs to",
@@ -5853,7 +6688,10 @@
             "type": "string"
           }
         },
-        "required": ["database_id", "table_name"],
+        "required": [
+          "database_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "GuestTokenCreate": {
@@ -5874,7 +6712,557 @@
             "$ref": "#/components/schemas/User2"
           }
         },
-        "required": ["resources", "rls"],
+        "required": [
+          "resources",
+          "rls"
+        ],
+        "type": "object"
+      },
+      "IASLoginTokenRequestSchema": {
+        "properties": {
+          "access_token": {
+            "description": "IAS Access token. Can be requested by adding `token` to the `responseTypes`.",
+            "nullable": true,
+            "type": "string"
+          },
+          "client_id": {
+            "description": "IAS client id. Only needed if `refresh_token` is provided.",
+            "nullable": true,
+            "type": "string"
+          },
+          "client_secret": {
+            "description": "IAS client secret. Only needed if `refresh_token` and `client_id` is provided.",
+            "nullable": true,
+            "type": "string"
+          },
+          "id_token": {
+            "description": "IAS ID token. Can be requested by adding `id_token` to the `responseTypes`. The following scopes should be added:`iam:ds:groups`, `corpds:ds:username`, `corpds:ds:firstName`, `corpds:ds:lastName`, `corpds:ds:email`, `corpds:ds:uidNumber`, `iam:ds:explicitgroups`.",
+            "type": "string"
+          },
+          "refresh_token": {
+            "description": "IAS refresh token. This can be requested by adding `offline` to `scopes`. To be able to refresh the token, the IAS `client_id` and `client_secret` need to be added, as the same client needs to be used for refreshing as logging in.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id_token"
+        ],
+        "type": "object"
+      },
+      "IASLoginTokenResponseSchema": {
+        "properties": {
+          "access_token": {
+            "description": "Access that can be used access the Superset API",
+            "type": "string"
+          },
+          "refresh_token": {
+            "description": "Refresh token that can be used to refresh the `access_token`",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token"
+        ],
+        "type": "object"
+      },
+      "IASProfileResponse": {
+        "properties": {
+          "client_id": {
+            "description": "The client id",
+            "type": "string"
+          },
+          "profile": {
+            "description": "The IAS profile",
+            "type": "string"
+          },
+          "scope": {
+            "description": "The scope of the client",
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_id",
+          "profile"
+        ],
+        "type": "object"
+      },
+      "IASProfilesResponseSchema": {
+        "properties": {
+          "result": {
+            "description": "A list of all available IAS profiles",
+            "items": {
+              "$ref": "#/components/schemas/IASProfileResponse"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "IASTokenResponse": {
+        "properties": {
+          "access_token": {
+            "description": "The access token",
+            "type": "string"
+          },
+          "has_client_credentials": {
+            "description": "Are the original client credentials available or not",
+            "type": "boolean"
+          },
+          "has_refresh_token": {
+            "description": "Is there a refresh token available or not",
+            "type": "boolean"
+          },
+          "ias_profile": {
+            "description": "The IAS profile",
+            "type": "string"
+          },
+          "id_token": {
+            "description": "The id token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "has_client_credentials",
+          "has_refresh_token",
+          "ias_profile",
+          "id_token"
+        ],
+        "type": "object"
+      },
+      "IASTokensResponseSchema": {
+        "properties": {
+          "result": {
+            "description": "A list of all requested tokens",
+            "items": {
+              "$ref": "#/components/schemas/IASTokenResponse"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ImportV1Database": {
+        "properties": {
+          "allow_csv_upload": {
+            "type": "boolean"
+          },
+          "allow_ctas": {
+            "type": "boolean"
+          },
+          "allow_cvas": {
+            "type": "boolean"
+          },
+          "allow_dml": {
+            "type": "boolean"
+          },
+          "allow_run_async": {
+            "type": "boolean"
+          },
+          "cache_timeout": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "database_name": {
+            "type": "string"
+          },
+          "expose_in_sqllab": {
+            "type": "boolean"
+          },
+          "external_url": {
+            "nullable": true,
+            "type": "string"
+          },
+          "extra": {
+            "$ref": "#/components/schemas/ImportV1DatabaseExtra"
+          },
+          "impersonate_user": {
+            "type": "boolean"
+          },
+          "is_managed_externally": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "password": {
+            "nullable": true,
+            "type": "string"
+          },
+          "sqlalchemy_uri": {
+            "type": "string"
+          },
+          "ssh_tunnel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatabaseSSHTunnel"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "database_name",
+          "sqlalchemy_uri",
+          "uuid",
+          "version"
+        ],
+        "type": "object"
+      },
+      "ImportV1DatabaseExtra": {
+        "properties": {
+          "allow_multi_catalog": {
+            "type": "boolean"
+          },
+          "allows_virtual_table_explore": {
+            "type": "boolean"
+          },
+          "cancel_query_on_windows_unload": {
+            "type": "boolean"
+          },
+          "cost_estimate_enabled": {
+            "type": "boolean"
+          },
+          "disable_data_preview": {
+            "type": "boolean"
+          },
+          "disable_drill_to_detail": {
+            "type": "boolean"
+          },
+          "engine_params": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "metadata_cache_timeout": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "metadata_params": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "schemas_allowed_for_csv_upload": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "version": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseCatalog": {
+        "properties": {
+          "database_id": {
+            "description": "The numerical id of the database",
+            "type": "integer"
+          },
+          "database_name": {
+            "description": "The name of the database",
+            "type": "string"
+          },
+          "id": {
+            "description": "The numerical id of the catalog",
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the catalog",
+            "type": "string"
+          },
+          "sqlalchemy_uri": {
+            "description": "The SQLAlchemy URI",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseConnectRequestSchema": {
+        "properties": {
+          "catalogs": {
+            "description": "A list of catalogs to connect to. If empty or undefined, connect all available catalogs.",
+            "example": [
+              "my_catalog"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "database_names": {
+            "description": "Custom catalog-database name mappings. If undefined, the default naming convention will be used",
+            "example": {
+              "my_catalog": "my_database"
+            },
+            "nullable": true,
+            "type": "object"
+          },
+          "dry_run": {
+            "description": "Should the task be executed in dry run mode. Useful for testing.",
+            "example": false,
+            "type": "boolean"
+          },
+          "engine_type": {
+            "description": "The type of the engine (only trino is currently supported)",
+            "enum": [
+              "trino"
+            ],
+            "example": "trino",
+            "type": "string"
+          },
+          "engine_url": {
+            "description": "The URL to the engine",
+            "example": "https://myengine.corp.apple.com",
+            "type": "string"
+          },
+          "environment": {
+            "description": "Prod or Int",
+            "enum": [
+              "int",
+              "prod"
+            ],
+            "example": "int",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the Lakehouse (subject to change over time). If left undefined, use lakehouse id",
+            "example": "My Lakehouse",
+            "nullable": true,
+            "type": "string"
+          },
+          "superset_url": {
+            "description": "The URL of the Superset instance connecting to",
+            "example": "http://localhost:8088",
+            "type": "string"
+          }
+        },
+        "required": [
+          "engine_type",
+          "engine_url",
+          "environment",
+          "superset_url"
+        ],
+        "type": "object"
+      },
+      "LakehouseConnectResponseSchema": {
+        "properties": {
+          "task_id": {
+            "description": "The id of the connection task",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseConnectResultResponseSchema": {
+        "properties": {
+          "existing_catalogs": {
+            "description": "A list of connected catalogs before the connect operation",
+            "items": {
+              "description": "Catalogs",
+              "items": {
+                "$ref": "#/components/schemas/LakehouseCatalog"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "lakehouse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LakehouseGetResponseSchema"
+              }
+            ],
+            "description": "The connected Lakehouse",
+            "nullable": true
+          },
+          "message": {
+            "description": "A message to provide additional context on what has happened",
+            "type": "string"
+          },
+          "new_catalogs": {
+            "description": "A list of newly connected catalogs after the connect operation",
+            "items": {
+              "description": "Catalogs",
+              "items": {
+                "$ref": "#/components/schemas/LakehouseCatalog"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "The status of the task",
+            "enum": [
+              "scheduled",
+              "running",
+              "completed",
+              "failed",
+              "reconnect_failed",
+              "cancelled"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "lakehouse"
+        ],
+        "type": "object"
+      },
+      "LakehouseConnectStatusResponseSchema": {
+        "properties": {
+          "message": {
+            "description": "A message to provide additional context on what has happened",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the task",
+            "enum": [
+              "scheduled",
+              "running",
+              "completed",
+              "failed",
+              "reconnect_failed",
+              "cancelled"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseDatasetListResponseSchema": {
+        "properties": {
+          "name": {
+            "description": "The name of the dataset",
+            "type": "string"
+          },
+          "schema": {
+            "description": "The schema",
+            "nullable": true,
+            "type": "string"
+          },
+          "sql": {
+            "description": "The virtual dataset query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "sql"
+        ],
+        "type": "object"
+      },
+      "LakehouseDatasetRequestSchema": {
+        "properties": {
+          "catalog": {
+            "description": "The catalog. If left empty, uses an arbitrary connected catalog.",
+            "nullable": true,
+            "type": "string"
+          },
+          "lakehouse_id": {
+            "description": "Deprecated, not used for anything",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the dataset to be created",
+            "type": "string"
+          },
+          "overwrite": {
+            "default": false,
+            "description": "Should the virtual dataset be overwritten if it already exists",
+            "type": "boolean"
+          },
+          "schema": {
+            "description": "The schema",
+            "nullable": true,
+            "type": "string"
+          },
+          "sql": {
+            "description": "The virtual dataset query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "sql"
+        ],
+        "type": "object"
+      },
+      "LakehouseDatasetResponseSchema": {
+        "properties": {
+          "url": {
+            "description": "The url for exploring the virtual dataset",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "LakehouseDisconnectResponseSchema": {
+        "properties": {
+          "lakehouse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LakehouseGetResponseSchema"
+              }
+            ],
+            "description": "A list of disconnected lakehouses"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseGetListResponseSchema": {
+        "properties": {
+          "lakehouses": {
+            "description": "A list of connected lakehouses",
+            "items": {
+              "$ref": "#/components/schemas/LakehouseGetResponseSchema"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LakehouseGetResponseSchema": {
+        "properties": {
+          "catalogs": {
+            "description": "A list of connected catalogs",
+            "items": {
+              "description": "Catalogs",
+              "items": {
+                "$ref": "#/components/schemas/LakehouseCatalog"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "engine_url": {
+            "description": "The URL uf the engine",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique id of the Lakehouse",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "superset_url": {
+            "description": "The URL uf the Superset instance",
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "LogRestApi.get": {
@@ -5911,7 +7299,7 @@
             "type": "integer"
           },
           "user": {
-            "$ref": "#/components/schemas/LogRestApi.get.User"
+            "$ref": "#/components/schemas/LogRestApi.get.AppleUser"
           },
           "user_id": {
             "nullable": true,
@@ -5920,14 +7308,16 @@
         },
         "type": "object"
       },
-      "LogRestApi.get.User": {
+      "LogRestApi.get.AppleUser": {
         "properties": {
           "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["username"],
+        "required": [
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.get_list": {
@@ -5964,7 +7354,7 @@
             "type": "integer"
           },
           "user": {
-            "$ref": "#/components/schemas/LogRestApi.get_list.User"
+            "$ref": "#/components/schemas/LogRestApi.get_list.AppleUser"
           },
           "user_id": {
             "nullable": true,
@@ -5973,14 +7363,16 @@
         },
         "type": "object"
       },
-      "LogRestApi.get_list.User": {
+      "LogRestApi.get_list.AppleUser": {
         "properties": {
           "username": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["username"],
+        "required": [
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.post": {
@@ -6159,7 +7551,10 @@
             "readOnly": true
           }
         },
-        "required": ["client_id", "database"],
+        "required": [
+          "client_id",
+          "database"
+        ],
         "type": "object"
       },
       "QueryRestApi.get.Database": {
@@ -6340,7 +7735,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -6372,6 +7770,9 @@
       },
       "RLSRestApi.get_list": {
         "properties": {
+          "changed_by": {
+            "$ref": "#/components/schemas/User"
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
@@ -6385,7 +7786,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -6428,7 +7832,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -6458,7 +7865,13 @@
             "type": "array"
           }
         },
-        "required": ["clause", "filter_type", "name", "roles", "tables"],
+        "required": [
+          "clause",
+          "filter_type",
+          "name",
+          "roles",
+          "tables"
+        ],
         "type": "object"
       },
       "RLSRestApi.put": {
@@ -6474,7 +7887,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -6648,7 +8064,10 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.get_list": {
@@ -6692,7 +8111,10 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.post": {
@@ -6718,15 +8140,27 @@
           },
           "type": {
             "description": "The recipient type, check spec for valid options",
-            "enum": ["Email", "Slack"],
+            "enum": [
+              "Email",
+              "Slack",
+              "SlackV2"
+            ],
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportRecipientConfigJSON": {
         "properties": {
+          "bccTarget": {
+            "type": "string"
+          },
+          "ccTarget": {
+            "type": "string"
+          },
           "target": {
             "type": "string"
           }
@@ -6766,6 +8200,11 @@
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.Database"
           },
           "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "email_subject": {
+            "maxLength": 255,
             "nullable": true,
             "type": "string"
           },
@@ -6810,7 +8249,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get.User"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get.AppleUser"
           },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get.ReportRecipients"
@@ -6846,7 +8285,32 @@
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ReportScheduleRestApi.get.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Dashboard": {
@@ -6872,7 +8336,9 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.ReportRecipients": {
@@ -6889,7 +8355,9 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Slice": {
@@ -6910,23 +8378,6 @@
         },
         "type": "object"
       },
-      "ReportScheduleRestApi.get.User": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
       "ReportScheduleRestApi.get_list": {
         "properties": {
           "active": {
@@ -6934,7 +8385,7 @@
             "type": "boolean"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
           },
           "changed_on": {
             "format": "date-time",
@@ -6949,7 +8400,7 @@
             "type": "integer"
           },
           "created_by": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -6997,7 +8448,7 @@
             "type": "string"
           },
           "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
+            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.AppleUser"
           },
           "recipients": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
@@ -7011,7 +8462,32 @@
             "type": "string"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ReportScheduleRestApi.get_list.AppleUser": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.ReportRecipients": {
@@ -7024,7 +8500,9 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User": {
@@ -7038,7 +8516,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User1": {
@@ -7047,29 +8528,15 @@
             "maxLength": 64,
             "type": "string"
           },
-          "id": {
-            "type": "integer"
-          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ReportScheduleRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.post": {
@@ -7088,7 +8555,11 @@
           },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
-            "enum": ["charts", "dashboards", "alerts_reports"]
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports"
+            ]
           },
           "crontab": {
             "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
@@ -7113,6 +8584,12 @@
           "description": {
             "description": "Use a nice description to give context to this Alert/Report",
             "example": "Daily sales dashboard to marketing",
+            "nullable": true,
+            "type": "string"
+          },
+          "email_subject": {
+            "description": "The report schedule subject line",
+            "example": "[Report]  Report name: Dashboard or chart name",
             "nullable": true,
             "type": "string"
           },
@@ -7155,7 +8632,12 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PNG", "CSV", "TEXT"],
+            "enum": [
+              "PDF",
+              "PNG",
+              "CSV",
+              "TEXT"
+            ],
             "type": "string"
           },
           "selected_tabs": {
@@ -7268,6 +8750,7 @@
               "America/Cayman",
               "America/Chicago",
               "America/Chihuahua",
+              "America/Ciudad_Juarez",
               "America/Coral_Harbour",
               "America/Cordoba",
               "America/Costa_Rica",
@@ -7620,8 +9103,9 @@
               "Europe/Istanbul",
               "Europe/Jersey",
               "Europe/Kaliningrad",
-              "Europe/Kyiv",
+              "Europe/Kiev",
               "Europe/Kirov",
+              "Europe/Kyiv",
               "Europe/Lisbon",
               "Europe/Ljubljana",
               "Europe/London",
@@ -7772,7 +9256,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -7780,17 +9267,24 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator"],
+            "enum": [
+              "not null",
+              "operator"
+            ],
             "type": "string"
           },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "description": "If an alert is staled at a working state, how long until it's state is reset to error",
             "example": 3600,
             "minimum": 1,
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.put": {
@@ -7809,7 +9303,11 @@
           },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
-            "enum": ["charts", "dashboards", "alerts_reports"],
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports"
+            ],
             "nullable": true
           },
           "crontab": {
@@ -7837,6 +9335,12 @@
             "nullable": true,
             "type": "string"
           },
+          "email_subject": {
+            "description": "The report schedule subject line",
+            "example": "[Report]  Report name: Dashboard or chart name",
+            "nullable": true,
+            "type": "string"
+          },
           "extra": {
             "type": "object"
           },
@@ -7852,7 +9356,7 @@
           "log_retention": {
             "description": "How long to keep the logs around for this report (in days)",
             "example": 90,
-            "minimum": 1,
+            "minimum": 0,
             "type": "integer"
           },
           "name": {
@@ -7875,7 +9379,12 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PNG", "CSV", "TEXT"],
+            "enum": [
+              "PDF",
+              "PNG",
+              "CSV",
+              "TEXT"
+            ],
             "type": "string"
           },
           "sql": {
@@ -7982,6 +9491,7 @@
               "America/Cayman",
               "America/Chicago",
               "America/Chihuahua",
+              "America/Ciudad_Juarez",
               "America/Coral_Harbour",
               "America/Cordoba",
               "America/Costa_Rica",
@@ -8334,8 +9844,9 @@
               "Europe/Istanbul",
               "Europe/Jersey",
               "Europe/Kaliningrad",
-              "Europe/Kyiv",
+              "Europe/Kiev",
               "Europe/Kirov",
+              "Europe/Kyiv",
               "Europe/Lisbon",
               "Europe/Ljubljana",
               "Europe/London",
@@ -8486,7 +9997,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -8494,12 +10008,15 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator"],
+            "enum": [
+              "not null",
+              "operator"
+            ],
             "nullable": true,
             "type": "string"
           },
           "working_timeout": {
-            "description": "If an alert is staled at a working state, how long until it's state is reseted to error",
+            "description": "If an alert is staled at a working state, how long until it's state is reset to error",
             "example": 3600,
             "minimum": 1,
             "nullable": true,
@@ -8514,10 +10031,15 @@
             "type": "string"
           },
           "type": {
-            "enum": ["dashboard"]
+            "enum": [
+              "dashboard"
+            ]
           }
         },
-        "required": ["id", "type"],
+        "required": [
+          "id",
+          "type"
+        ],
         "type": "object"
       },
       "RlsRule": {
@@ -8529,7 +10051,9 @@
             "type": "integer"
           }
         },
-        "required": ["clause"],
+        "required": [
+          "clause"
+        ],
         "type": "object"
       },
       "Roles": {
@@ -8554,13 +10078,52 @@
         },
         "type": "object"
       },
+      "SQLLabBootstrapSchema": {
+        "properties": {
+          "active_tab": {
+            "$ref": "#/components/schemas/TabState"
+          },
+          "databases": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ImportV1Database"
+            },
+            "type": "object"
+          },
+          "queries": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/QueryResult"
+            },
+            "type": "object"
+          },
+          "tab_state_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "SavedQueryRestApi.get": {
         "properties": {
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "changed_by": {
+            "$ref": "#/components/schemas/SavedQueryRestApi.get.User"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/SavedQueryRestApi.get.User"
+            "$ref": "#/components/schemas/SavedQueryRestApi.get.User1"
           },
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get.Database"
@@ -8606,7 +10169,9 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get.User": {
@@ -8623,16 +10188,52 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "SavedQueryRestApi.get.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list": {
         "properties": {
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "changed_by": {
+            "$ref": "#/components/schemas/SavedQueryRestApi.get_list.User"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/SavedQueryRestApi.get_list.User"
+            "$ref": "#/components/schemas/SavedQueryRestApi.get_list.User1"
           },
           "created_on": {
             "format": "date-time",
@@ -8696,7 +10297,9 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list.Tag": {
@@ -8710,7 +10313,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -8729,16 +10337,48 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "SavedQueryRestApi.get_list.User1": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.post": {
         "properties": {
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
           "db_id": {
             "nullable": true,
             "type": "integer"
           },
           "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "extra_json": {
             "nullable": true,
             "type": "string"
           },
@@ -8765,11 +10405,20 @@
       },
       "SavedQueryRestApi.put": {
         "properties": {
+          "catalog": {
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
           "db_id": {
             "nullable": true,
             "type": "integer"
           },
           "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "extra_json": {
             "nullable": true,
             "type": "string"
           },
@@ -8895,6 +10544,106 @@
       "StopQuerySchema": {
         "properties": {
           "client_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Tab": {
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/Tab"
+            },
+            "type": "array"
+          },
+          "parents": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TabState": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "autorun": {
+            "type": "boolean"
+          },
+          "database_id": {
+            "type": "integer"
+          },
+          "extra_json": {
+            "type": "object"
+          },
+          "hide_left_bar": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "latest_query": {
+            "$ref": "#/components/schemas/QueryResult"
+          },
+          "query_limit": {
+            "type": "integer"
+          },
+          "saved_query": {
+            "nullable": true,
+            "type": "object"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "sql": {
+            "type": "string"
+          },
+          "table_schemas": {
+            "items": {
+              "$ref": "#/components/schemas/Table"
+            },
+            "type": "array"
+          },
+          "user_id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "Table": {
+        "properties": {
+          "database_id": {
+            "type": "integer"
+          },
+          "description": {
+            "type": "string"
+          },
+          "expanded": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "tab_state_id": {
+            "type": "integer"
+          },
+          "table": {
             "type": "string"
           }
         },
@@ -9070,6 +10819,23 @@
         },
         "type": "object"
       },
+      "TabsPayloadSchema": {
+        "properties": {
+          "all_tabs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "tab_tree": {
+            "items": {
+              "$ref": "#/components/schemas/Tab"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "Tag": {
         "properties": {
           "id": {
@@ -9079,21 +10845,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
-          }
-        },
-        "type": "object"
-      },
-      "Tag1": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -9112,16 +10869,75 @@
         },
         "type": "object"
       },
+      "TagObject": {
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "objects_to_tag": {
+            "description": "Objects to tag",
+            "items": {},
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagPostBulkResponseObject": {
+        "properties": {
+          "objects_skipped": {
+            "description": "Objects to tag",
+            "items": {},
+            "type": "array"
+          },
+          "objects_tagged": {
+            "description": "Objects to tag",
+            "items": {},
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagPostBulkResponseSchema": {
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/TagPostBulkResponseObject"
+          }
+        },
+        "type": "object"
+      },
+      "TagPostBulkSchema": {
+        "properties": {
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagObject"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "TagRestApi.get": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/TagRestApi.get.User1"
+            "$ref": "#/components/schemas/TagRestApi.get.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/TagRestApi.get.User"
+            "$ref": "#/components/schemas/TagRestApi.get.User1"
+          },
+          "created_on_delta_humanized": {
+            "readOnly": true
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
           },
           "id": {
             "type": "integer"
@@ -9132,12 +10948,34 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "TagRestApi.get.User": {
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "TagRestApi.get.User1": {
         "properties": {
           "active": {
             "nullable": true,
@@ -9154,7 +10992,7 @@
             "type": "string"
           },
           "email": {
-            "maxLength": 64,
+            "maxLength": 320,
             "type": "string"
           },
           "fail_login_count": {
@@ -9191,33 +11029,31 @@
             "type": "string"
           }
         },
-        "required": ["email", "first_name", "last_name", "username"],
-        "type": "object"
-      },
-      "TagRestApi.get.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "TagRestApi.get_list": {
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/TagRestApi.get_list.User1"
+            "$ref": "#/components/schemas/TagRestApi.get_list.User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
           },
           "created_by": {
-            "$ref": "#/components/schemas/TagRestApi.get_list.User"
+            "$ref": "#/components/schemas/TagRestApi.get_list.User1"
+          },
+          "created_on_delta_humanized": {
+            "readOnly": true
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
           },
           "id": {
             "type": "integer"
@@ -9228,7 +11064,12 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
@@ -9244,7 +11085,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.get_list.User1": {
@@ -9258,15 +11102,25 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.post": {
         "properties": {
-          "tags": {
-            "items": {
-              "type": "string"
-            },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "objects_to_tag": {
+            "description": "Objects to tag",
+            "items": {},
             "type": "array"
           }
         },
@@ -9274,8 +11128,18 @@
       },
       "TagRestApi.put": {
         "properties": {
-          "id": {
-            "type": "integer"
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "objects_to_tag": {
+            "description": "Objects to tag",
+            "items": {},
+            "type": "array"
           }
         },
         "type": "object"
@@ -9298,6 +11162,18 @@
           "name": {
             "type": "string"
           },
+          "owners": {
+            "items": {
+              "$ref": "#/components/schemas/User1"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagGetResponseSchema"
+            },
+            "type": "array"
+          },
           "type": {
             "type": "string"
           },
@@ -9314,7 +11190,9 @@
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object"
       },
       "TemporaryCachePutSchema": {
@@ -9324,7 +11202,36 @@
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "UploadFileMetadata": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UploadFileMetadataItem"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "UploadFileMetadataItem": {
+        "properties": {
+          "column_names": {
+            "description": "A list of columns names in the sheet",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sheet_name": {
+            "description": "The name of the sheet",
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "User": {
@@ -9400,6 +11307,10 @@
       },
       "ValidateSQLRequest": {
         "properties": {
+          "catalog": {
+            "nullable": true,
+            "type": "string"
+          },
           "schema": {
             "nullable": true,
             "type": "string"
@@ -9413,7 +11324,9 @@
             "type": "object"
           }
         },
-        "required": ["sql"],
+        "required": [
+          "sql"
+        ],
         "type": "object"
       },
       "ValidateSQLResponse": {
@@ -9437,7 +11350,14 @@
         "properties": {
           "op": {
             "description": "The operation to compare with a threshold to apply to the SQL output\n",
-            "enum": ["<", "<=", ">", ">=", "==", "!="],
+            "enum": [
+              "<",
+              "<=",
+              ">",
+              ">=",
+              "==",
+              "!="
+            ],
             "type": "string"
           },
           "threshold": {
@@ -9460,11 +11380,25 @@
             "type": "array"
           }
         },
-        "required": ["type", "values"],
+        "required": [
+          "type",
+          "values"
+        ],
+        "type": "object"
+      },
+      "database_catalogs_query_schema": {
+        "properties": {
+          "force": {
+            "type": "boolean"
+          }
+        },
         "type": "object"
       },
       "database_schemas_query_schema": {
         "properties": {
+          "catalog": {
+            "type": "string"
+          },
           "force": {
             "type": "boolean"
           }
@@ -9473,6 +11407,9 @@
       },
       "database_tables_query_schema": {
         "properties": {
+          "catalog_name": {
+            "type": "string"
+          },
           "force": {
             "type": "boolean"
           },
@@ -9480,7 +11417,9 @@
             "type": "string"
           }
         },
-        "required": ["schema_name"],
+        "required": [
+          "schema_name"
+        ],
         "type": "object"
       },
       "delete_tags_schema": {
@@ -9613,7 +11552,11 @@
                   ]
                 }
               },
-              "required": ["col", "opr", "value"],
+              "required": [
+                "col",
+                "opr",
+                "value"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -9636,7 +11579,10 @@
             "type": "string"
           },
           "order_direction": {
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "type": "string"
           },
           "page": {
@@ -9644,6 +11590,12 @@
           },
           "page_size": {
             "type": "integer"
+          },
+          "select_columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -9694,7 +11646,9 @@
             "type": "number"
           }
         },
-        "required": ["last_updated_ms"],
+        "required": [
+          "last_updated_ms"
+        ],
         "type": "object"
       },
       "screenshot_query_schema": {
@@ -9723,7 +11677,9 @@
             "type": "string"
           }
         },
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "type": "object"
       },
       "thumbnail_query_schema": {
@@ -9757,6 +11713,7 @@
   "paths": {
     "/api/v1/advanced_data_type/convert": {
       "get": {
+        "description": "Returns an AdvancedDataTypeResponse object populated with the passed in args.",
         "parameters": [
           {
             "content": {
@@ -9787,6 +11744,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -9799,13 +11759,14 @@
             "jwt": []
           }
         ],
-        "summary": "Returns a AdvancedDataTypeResponse object populated with the passed in args.",
-        "tags": ["Advanced Data Type"]
+        "summary": "Return an AdvancedDataTypeResponse",
+        "tags": [
+          "Advanced Data Type"
+        ]
       }
     },
     "/api/v1/advanced_data_type/types": {
       "get": {
-        "description": "Returns a list of available advanced data types.",
         "responses": {
           "200": {
             "content": {
@@ -9828,6 +11789,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -9840,12 +11804,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Advanced Data Type"]
+        "summary": "Return a list of available advanced data types",
+        "tags": [
+          "Advanced Data Type"
+        ]
       }
     },
     "/api/v1/annotation_layer/": {
       "delete": {
-        "description": "Deletes multiple annotation layers in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -9893,10 +11859,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Delete multiple annotation layers in a bulk operation",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -9998,10 +11967,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get a list of annotation layers",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "post": {
-        "description": "Create an Annotation layer",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10050,7 +12021,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Create an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/_info": {
@@ -10134,7 +12108,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/related/{column_name}": {
@@ -10189,12 +12166,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}": {
       "delete": {
-        "description": "Delete Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10237,10 +12216,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Delete annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
-        "description": "Get an Annotation layer",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -10335,10 +12317,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "put": {
-        "description": "Update an Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10398,12 +12382,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Update an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}/annotation/": {
       "delete": {
-        "description": "Deletes multiple annotation in a bulk operation.",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10460,10 +12446,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Bulk delete annotation layers",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
-        "description": "Get a list of Annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of annotation layers, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "description": "The annotation layer id for this annotation",
@@ -10535,10 +12524,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get a list of annotation layers",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "post": {
-        "description": "Create an Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10598,12 +12589,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Create an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       }
     },
     "/api/v1/annotation_layer/{pk}/annotation/{annotation_id}": {
       "delete": {
-        "description": "Delete Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10655,10 +12648,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Delete annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "get": {
-        "description": "Get an Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10731,10 +12726,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Get an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
       },
       "put": {
-        "description": "Update an Annotation layer",
         "parameters": [
           {
             "description": "The annotation layer pk for this annotation",
@@ -10803,12 +12800,48 @@
             "jwt": []
           }
         ],
-        "tags": ["Annotation Layers"]
+        "summary": "Update an annotation layer",
+        "tags": [
+          "Annotation Layers"
+        ]
+      }
+    },
+    "/api/v1/apple/health": {
+      "get": {
+        "description": "Endpoint for checking the health status of the metastore and cache",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleHealthResponseSchema"
+                }
+              }
+            },
+            "description": "The"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get the health status of the metastore and cache",
+        "tags": [
+          "Apple"
+        ]
       }
     },
     "/api/v1/assets/export/": {
       "get": {
-        "description": "Returns a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.",
+        "description": "Gets a ZIP file with all the Superset assets (databases, datasets, charts, dashboards, saved queries) as YAML files.",
         "responses": {
           "200": {
             "content": {
@@ -10836,7 +12869,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Import/export"]
+        "summary": "Export all assets",
+        "tags": [
+          "Import/export"
+        ]
       }
     },
     "/api/v1/assets/import/": {
@@ -10908,7 +12944,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Import/export"]
+        "summary": "Import multiple assets",
+        "tags": [
+          "Import/export"
+        ]
       }
     },
     "/api/v1/async_event/": {
@@ -10981,12 +13020,14 @@
             "jwt": []
           }
         ],
-        "tags": ["AsyncEventsRestApi"]
+        "summary": "Read off of the Redis events stream",
+        "tags": [
+          "AsyncEventsRestApi"
+        ]
       }
     },
     "/api/v1/available_domains/": {
       "get": {
-        "description": "Get all available domains",
         "responses": {
           "200": {
             "content": {
@@ -11015,12 +13056,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Available Domains"]
+        "summary": "Get all available domains",
+        "tags": [
+          "Available Domains"
+        ]
       }
     },
     "/api/v1/cachekey/invalidate": {
       "post": {
-        "description": "Takes a list of datasources, finds the associated cache records and invalidates them and removes the database records",
+        "description": "Takes a list of datasources, finds and invalidates the associated cache records and removes the database records.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -11048,12 +13092,14 @@
             "jwt": []
           }
         ],
-        "tags": ["CacheRestApi"]
+        "summary": "Invalidate cache records and remove the database records",
+        "tags": [
+          "CacheRestApi"
+        ]
       }
     },
     "/api/v1/chart/": {
       "delete": {
-        "description": "Deletes multiple Charts in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -11104,10 +13150,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Bulk delete charts",
+        "tags": [
+          "Charts"
+        ]
       },
       "get": {
-        "description": "Get a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Gets a list of charts, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -11209,10 +13258,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get a list of charts",
+        "tags": [
+          "Charts"
+        ]
       },
       "post": {
-        "description": "Create a new Chart.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -11264,12 +13315,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Create a new chart",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/_info": {
       "get": {
-        "description": "Several metadata information about chart API endpoints.",
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -11348,7 +13402,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/data": {
@@ -11401,7 +13458,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Return payload data response for the given query",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/data/{cache_key}": {
@@ -11449,12 +13509,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Return payload data response for the given query",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/export/": {
       "get": {
-        "description": "Exports multiple charts and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -11498,12 +13560,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Download multiple charts as YAML files",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user",
         "parameters": [
           {
             "content": {
@@ -11546,7 +13610,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Check favorited charts for current user",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/import/": {
@@ -11622,7 +13689,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Import chart(s) with associated datasets and databases",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/related/{column_name}": {
@@ -11678,7 +13748,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/warm_up_cache": {
@@ -11721,13 +13794,14 @@
             "jwt": []
           }
         ],
-        "summary": "Warms up the cache for the chart",
-        "tags": ["Charts"]
+        "summary": "Warm up the cache for the chart",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}": {
       "delete": {
-        "description": "Deletes a Chart.",
         "parameters": [
           {
             "in": "path",
@@ -11775,10 +13849,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Delete a chart",
+        "tags": [
+          "Charts"
+        ]
       },
       "get": {
-        "description": "Get a chart detail information.",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -11873,10 +13950,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get a chart detail information",
+        "tags": [
+          "Charts"
+        ]
       },
       "put": {
-        "description": "Changes a Chart.",
         "parameters": [
           {
             "in": "path",
@@ -11941,12 +14020,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Update a chart",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/cache_screenshot/": {
       "get": {
-        "description": "Compute and cache a screenshot.",
         "parameters": [
           {
             "in": "path",
@@ -11997,7 +14078,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Compute and cache a screenshot",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/data/": {
@@ -12074,12 +14158,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Return payload data response for a chart",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/favorites/": {
       "delete": {
-        "description": "Remove the chart from the user favorite list",
         "parameters": [
           {
             "in": "path",
@@ -12121,10 +14207,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Remove the chart from the user favorite list",
+        "tags": [
+          "Charts"
+        ]
       },
       "post": {
-        "description": "Marks the chart as favorite for the current user",
         "parameters": [
           {
             "in": "path",
@@ -12166,12 +14254,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Mark the chart as favorite for the current user",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/screenshot/{digest}/": {
       "get": {
-        "description": "Get a computed screenshot from cache.",
         "parameters": [
           {
             "in": "path",
@@ -12220,7 +14310,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get a computed screenshot from cache",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/chart/{pk}/thumbnail/{digest}/": {
@@ -12277,12 +14370,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Charts"]
+        "summary": "Get chart thumbnail",
+        "tags": [
+          "Charts"
+        ]
       }
     },
     "/api/v1/css_template/": {
       "delete": {
-        "description": "Deletes multiple css templates in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -12330,10 +14425,13 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Bulk delete CSS templates",
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "get": {
-        "description": "Get a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of CSS templates, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -12435,10 +14533,12 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Get a list of CSS templates",
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "post": {
-        "description": "Create a CSS template",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12487,7 +14587,10 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Create a CSS template",
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/_info": {
@@ -12571,7 +14674,10 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/related/{column_name}": {
@@ -12626,12 +14732,14 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Get related fields data",
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/css_template/{pk}": {
       "delete": {
-        "description": "Delete CSS template",
         "parameters": [
           {
             "in": "path",
@@ -12673,10 +14781,13 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Delete a CSS template",
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "get": {
-        "description": "Get a CSS template",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -12771,10 +14882,12 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Get a CSS template",
+        "tags": [
+          "CSS Templates"
+        ]
       },
       "put": {
-        "description": "Update a CSS template",
         "parameters": [
           {
             "in": "path",
@@ -12833,12 +14946,14 @@
             "jwt": []
           }
         ],
-        "tags": ["CSS Templates"]
+        "summary": "Update a CSS template",
+        "tags": [
+          "CSS Templates"
+        ]
       }
     },
     "/api/v1/dashboard/": {
       "delete": {
-        "description": "Deletes multiple Dashboards in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -12889,10 +15004,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Bulk delete dashboards",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "get": {
-        "description": "Get a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Gets a list of dashboards, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -12994,10 +15112,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get a list of dashboards",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "post": {
-        "description": "Create a new Dashboard.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13046,12 +15166,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Create a new dashboard",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/_info": {
       "get": {
-        "description": "Several metadata information about dashboard API endpoints.",
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -13130,12 +15253,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/export/": {
       "get": {
-        "description": "Exports multiple Dashboards and downloads them as YAML files.",
         "parameters": [
           {
             "content": {
@@ -13181,12 +15306,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Download multiple dashboards as YAML files",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user",
         "parameters": [
           {
             "content": {
@@ -13229,7 +15356,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Check favorited dashboards for current user",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/import/": {
@@ -13305,12 +15435,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Import dashboard(s) with associated charts/datasets/databases",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/permalink/{key}": {
       "get": {
-        "description": "Retrives dashboard state associated with a permanent link.",
         "parameters": [
           {
             "in": "path",
@@ -13359,7 +15491,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Permanent Link"]
+        "summary": "Get dashboard's permanent link state",
+        "tags": [
+          "Dashboard Permanent Link"
+        ]
       }
     },
     "/api/v1/dashboard/related/{column_name}": {
@@ -13415,12 +15550,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}": {
       "get": {
-        "description": "Get a dashboard detail information.",
         "parameters": [
           {
             "description": "Either the id of the dashboard, or its slug",
@@ -13466,12 +15603,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get a dashboard detail information",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/charts": {
       "get": {
-        "description": "Get the chart definitions for a given dashboard",
         "parameters": [
           {
             "in": "path",
@@ -13519,73 +15658,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
-      }
-    },
-    "/api/v1/dashboard/{id_or_slug}/filters/": {
-      "put": {
-        "description": "Update the filters for a given dashboard",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id_or_slug",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DashboardNativeFiltersConfigUpdateSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successfully updated the filters"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": ["Dashboards"]
+        "summary": "Get a dashboard's chart definitions.",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/copy/": {
@@ -13651,8 +15727,10 @@
             "jwt": []
           }
         ],
-        "summary": "Makes a copy of an existing dashboard",
-        "tags": ["Dashboards"]
+        "summary": "Create a copy of an existing dashboard",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/datasets": {
@@ -13706,12 +15784,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get dashboard's datasets",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{id_or_slug}/embedded": {
       "delete": {
-        "description": "Removes a dashboard's embedded configuration.",
         "parameters": [
           {
             "description": "The dashboard id or slug",
@@ -13751,10 +15831,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Delete a dashboard's embedded configuration",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "get": {
-        "description": "Returns the dashboard's embedded configuration",
         "parameters": [
           {
             "description": "The dashboard id or slug",
@@ -13794,10 +15876,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get the dashboard's embedded configuration",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "post": {
-        "description": "Sets a dashboard's embedded configuration.",
         "parameters": [
           {
             "description": "The dashboard id or slug",
@@ -13848,7 +15932,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Set a dashboard's embedded configuration",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "put": {
         "description": "Sets a dashboard's embedded configuration.",
@@ -13902,12 +15989,70 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{id_or_slug}/tabs": {
+      "get": {
+        "description": "Returns a list of a dashboard's tabs and dashboard's nested tree structure for associated tabs.",
+        "parameters": [
+          {
+            "description": "Either the id of the dashboard, or its slug",
+            "in": "path",
+            "name": "id_or_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "items": {
+                        "$ref": "#/components/schemas/TabsPayloadSchema"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard tabs"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get dashboard's tabs",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}": {
       "delete": {
-        "description": "Deletes a Dashboard.",
         "parameters": [
           {
             "in": "path",
@@ -13955,10 +16100,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Delete a dashboard",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "put": {
-        "description": "Changes a Dashboard.",
         "parameters": [
           {
             "in": "path",
@@ -14026,12 +16173,70 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Update a dashboard",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{pk}/cache_dashboard_screenshot/": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardScreenshotPostSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardCacheScreenshotResponseSchema"
+                }
+              }
+            },
+            "description": "Dashboard async result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Compute and cache a screenshot",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/favorites/": {
       "delete": {
-        "description": "Remove the dashboard from the user favorite list",
         "parameters": [
           {
             "in": "path",
@@ -14073,10 +16278,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Remove the dashboard from the user favorite list",
+        "tags": [
+          "Dashboards"
+        ]
       },
       "post": {
-        "description": "Marks the dashboard as favorite for the current user",
         "parameters": [
           {
             "in": "path",
@@ -14118,12 +16325,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Mark the dashboard as favorite for the current user",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/filter_state": {
       "post": {
-        "description": "Stores a new value.",
         "parameters": [
           {
             "in": "path",
@@ -14186,12 +16395,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "summary": "Create a dashboard's filter state",
+        "tags": [
+          "Dashboard Filter State"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/filter_state/{key}": {
       "delete": {
-        "description": "Deletes a value.",
         "parameters": [
           {
             "in": "path",
@@ -14249,10 +16460,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "summary": "Delete a dashboard's filter state value",
+        "tags": [
+          "Dashboard Filter State"
+        ]
       },
       "get": {
-        "description": "Retrives a value.",
         "parameters": [
           {
             "in": "path",
@@ -14309,10 +16522,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "summary": "Get a dashboard's filter state value",
+        "tags": [
+          "Dashboard Filter State"
+        ]
       },
       "put": {
-        "description": "Updates an existing value.",
         "parameters": [
           {
             "in": "path",
@@ -14386,12 +16601,83 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Filter State"]
+        "summary": "Update a dashboard's filter state value",
+        "tags": [
+          "Dashboard Filter State"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{pk}/filters": {
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardNativeFiltersConfigUpdateSchema"
+              }
+            }
+          },
+          "description": "Native filters configuration",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard native filters updated"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Update native filters configuration for a dashboard.",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/permalink": {
       "post": {
-        "description": "Stores a new permanent link.",
         "parameters": [
           {
             "in": "path",
@@ -14451,12 +16737,71 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboard Permanent Link"]
+        "summary": "Create a new dashboard's permanent link",
+        "tags": [
+          "Dashboard Permanent Link"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{pk}/screenshot/{digest}/": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "digest",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "image/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Dashboard thumbnail image"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get a computed screenshot from cache",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/dashboard/{pk}/thumbnail/{digest}/": {
       "get": {
-        "description": "Compute async or get already computed dashboard thumbnail from cache.",
+        "description": "Computes async or get already computed dashboard thumbnail from cache.",
         "parameters": [
           {
             "in": "path",
@@ -14535,12 +16880,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Dashboards"]
+        "summary": "Get dashboard's thumbnail",
+        "tags": [
+          "Dashboards"
+        ]
       }
     },
     "/api/v1/database/": {
       "get": {
-        "description": "Get a list of models",
+        "description": "Gets a list of databases, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -14642,10 +16990,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get a list of databases",
+        "tags": [
+          "Database"
+        ]
       },
       "post": {
-        "description": "Create a new Database.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -14694,7 +17044,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Create a new database",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/_info": {
@@ -14778,12 +17131,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/available/": {
       "get": {
-        "description": "Get names of databases currently available",
         "responses": {
           "200": {
             "content": {
@@ -14857,12 +17212,170 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get names of databases currently available",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/columnar_metadata/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ColumnarMetadataUploadFilePostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/UploadFileMetadata"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Columnar upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload a Columnar file and returns file metadata",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/csv_metadata/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CSVMetadataUploadFilePostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/UploadFileMetadata"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Columnar upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload an CSV file and returns file metadata",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/excel_metadata/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ExcelMetadataUploadFilePostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/UploadFileMetadata"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Columnar upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload an Excel file and returns file metadata",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/export/": {
       "get": {
-        "description": "Download database(s) and associated dataset(s) as a zip file",
         "parameters": [
           {
             "content": {
@@ -14903,7 +17416,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Download database(s) and associated dataset(s) as a zip file",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/import/": {
@@ -14979,12 +17495,137 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Import database(s) with associated datasets",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/oauth2/": {
+      "get": {
+        "description": "-> Receive and store personal access tokens from OAuth for user-level authorization",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "A dummy self-closing HTML page"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Receive personal access tokens from OAuth2",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/related/{column_name}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "column_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_related_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelatedResponseSchema"
+                }
+              }
+            },
+            "description": "Related column data"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get related fields data",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/test_connection/": {
       "post": {
-        "description": "Tests a database connection",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15027,12 +17668,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Test a database connection",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/validate_parameters/": {
       "post": {
-        "description": "Validates parameters used to connect to a database",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15075,12 +17718,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Validate database connection parameters",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}": {
       "delete": {
-        "description": "Deletes a Database.",
         "parameters": [
           {
             "in": "path",
@@ -15128,10 +17773,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Delete a database",
+        "tags": [
+          "Database"
+        ]
       },
       "get": {
-        "description": "Get a database",
         "parameters": [
           {
             "description": "The database id",
@@ -15172,10 +17819,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get a database",
+        "tags": [
+          "Database"
+        ]
       },
       "put": {
-        "description": "Changes a Database.",
         "parameters": [
           {
             "in": "path",
@@ -15240,7 +17889,134 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Change a database",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/catalogs/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/database_catalogs_query_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogsResponseSchema"
+                }
+              }
+            },
+            "description": "A List of all catalogs from the database"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get all catalogs from a database",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/columnar_upload/": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ColumnarUploadPostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Columnar upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload a Columnar file to a database table",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/connection": {
@@ -15286,12 +18062,143 @@
           }
         ],
         "summary": "Get a database connection info",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/csv_upload/": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CSVUploadPostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "CSV upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload a CSV file to a database table",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/excel_upload/": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ExcelUploadPostSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Excel upload response"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Upload an Excel file to a database table",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/function_names/": {
       "get": {
-        "description": "Get function names supported by a database",
         "parameters": [
           {
             "in": "path",
@@ -15328,12 +18235,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get function names supported by a database",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/related_objects/": {
       "get": {
-        "description": "Get charts and dashboards count associated to a database",
         "parameters": [
           {
             "in": "path",
@@ -15370,12 +18279,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get charts and dashboards count associated to a database",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/schemas/": {
       "get": {
-        "description": "Get all schemas from a database",
         "parameters": [
           {
             "description": "The database id",
@@ -15427,7 +18338,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get all schemas from a database",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/schemas_access_for_file_upload/": {
@@ -15469,12 +18383,13 @@
           }
         ],
         "summary": "The list of the database schemas where to upload information",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/select_star/{table_name}/": {
       "get": {
-        "description": "Get database select star for table",
         "parameters": [
           {
             "description": "The database id",
@@ -15536,12 +18451,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get database select star for table",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database select star for table",
         "parameters": [
           {
             "description": "The database id",
@@ -15603,12 +18520,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get database select star for table",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/ssh_tunnel/": {
       "delete": {
-        "description": "Deletes a SSH Tunnel.",
         "parameters": [
           {
             "in": "path",
@@ -15656,12 +18575,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Delete a SSH tunnel",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/table/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Get database table metadata",
         "parameters": [
           {
             "description": "The database id",
@@ -15723,12 +18644,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Database"]
+        "summary": "Get database table metadata",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/": {
       "get": {
-        "description": "Response depends on each DB engine spec normally focused on partitions",
+        "description": "Response depends on each DB engine spec normally focused on partitions.",
         "parameters": [
           {
             "description": "The database id",
@@ -15791,7 +18715,151 @@
           }
         ],
         "summary": "Get table extra metadata",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/table_metadata/": {
+      "get": {
+        "description": "Metadata associated with the table (columns, indexes, etc.)",
+        "parameters": [
+          {
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Table name",
+            "in": "query",
+            "name": "table",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional table schema, if not passed default schema will be used",
+            "in": "query",
+            "name": "schema",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional table catalog, if not passed default catalog will be used",
+            "in": "query",
+            "name": "catalog",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
+                }
+              }
+            },
+            "description": "Table metadata information"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get table metadata",
+        "tags": [
+          "Database"
+        ]
+      }
+    },
+    "/api/v1/database/{pk}/table_metadata/extra/": {
+      "get": {
+        "description": "Extra metadata associated with the table (partitions, description, etc.)",
+        "parameters": [
+          {
+            "description": "The database id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Table name",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional table schema, if not passed the schema configured in the database will be used",
+            "in": "query",
+            "name": "schema",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional table catalog, if not passed the catalog configured in the database will be used",
+            "in": "query",
+            "name": "catalog",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
+                }
+              }
+            },
+            "description": "Table extra metadata information"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get table extra metadata",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/tables/": {
@@ -15863,12 +18931,14 @@
           }
         ],
         "summary": "Get a list of tables for given database",
-        "tags": ["Database"]
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/database/{pk}/validate_sql/": {
       "post": {
-        "description": "Validates arbitrary SQL.",
+        "description": "Validates that arbitrary SQL is acceptable for the given database.",
         "parameters": [
           {
             "in": "path",
@@ -15928,13 +18998,14 @@
             "jwt": []
           }
         ],
-        "summary": "Validates that arbitrary sql is acceptable for the given database",
-        "tags": ["Database"]
+        "summary": "Validate arbitrary SQL",
+        "tags": [
+          "Database"
+        ]
       }
     },
     "/api/v1/dataset/": {
       "delete": {
-        "description": "Deletes multiple Datasets in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -15988,10 +19059,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Bulk delete datasets",
+        "tags": [
+          "Datasets"
+        ]
       },
       "get": {
-        "description": "Get a list of models",
+        "description": "Gets a list of datasets, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -16093,10 +19167,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get a list of datasets",
+        "tags": [
+          "Datasets"
+        ]
       },
       "post": {
-        "description": "Create a new Dataset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -16145,7 +19221,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Create a new dataset",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/_info": {
@@ -16229,7 +19308,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/distinct/{column_name}": {
@@ -16284,12 +19366,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/duplicate": {
       "post": {
-        "description": "Duplicates a Dataset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -16344,12 +19428,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Duplicate a dataset",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/export/": {
       "get": {
-        "description": "Exports multiple datasets and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -16392,7 +19478,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Download multiple datasets as YAML files",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/get_or_create/": {
@@ -16447,7 +19536,9 @@
           }
         ],
         "summary": "Retrieve a table by name, or create it if it does not exist",
-        "tags": ["Datasets"]
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/import/": {
@@ -16531,7 +19622,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Import dataset(s) with associated databases",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/related/{column_name}": {
@@ -16586,7 +19680,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/warm_up_cache": {
@@ -16629,13 +19726,14 @@
             "jwt": []
           }
         ],
-        "summary": "Warms up the cache for each chart powered by the given table",
-        "tags": ["Datasets"]
+        "summary": "Warm up the cache for each chart powered by the given table",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}": {
       "delete": {
-        "description": "Deletes a Dataset",
         "parameters": [
           {
             "in": "path",
@@ -16683,12 +19781,16 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Delete a dataset",
+        "tags": [
+          "Datasets"
+        ]
       },
       "get": {
-        "description": "Get an item model",
+        "description": "Get a dataset by ID",
         "parameters": [
           {
+            "description": "The dataset ID",
             "in": "path",
             "name": "pk",
             "required": true,
@@ -16706,6 +19808,14 @@
             },
             "in": "query",
             "name": "q"
+          },
+          {
+            "description": "Should Jinja macros from sql, metrics and columns be rendered and included in the response",
+            "in": "query",
+            "name": "include_rendered_sql",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -16714,60 +19824,25 @@
               "application/json": {
                 "schema": {
                   "properties": {
-                    "description_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
                     "id": {
                       "description": "The item id",
                       "type": "string"
                     },
-                    "label_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.get"
-                    },
-                    "show_columns": {
-                      "description": "A list of columns",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "show_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "Show Item Details",
-                      "type": "string"
                     }
                   },
                   "type": "object"
                 }
               }
             },
-            "description": "Item from Model"
+            "description": "Dataset object has been returned."
           },
           "400": {
             "$ref": "#/components/responses/400"
           },
           "401": {
             "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
           },
           "422": {
             "$ref": "#/components/responses/422"
@@ -16781,10 +19856,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get a dataset",
+        "tags": [
+          "Datasets"
+        ]
       },
       "put": {
-        "description": "Changes a Dataset",
         "parameters": [
           {
             "in": "path",
@@ -16856,12 +19933,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Update a dataset",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/column/{column_id}": {
       "delete": {
-        "description": "Delete a Dataset column",
         "parameters": [
           {
             "description": "The dataset pk for this column",
@@ -16919,12 +19998,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Delete a dataset column",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/metric/{metric_id}": {
       "delete": {
-        "description": "Delete a Dataset metric",
         "parameters": [
           {
             "description": "The dataset pk for this column",
@@ -16982,12 +20063,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Delete a dataset metric",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/refresh": {
       "put": {
-        "description": "Refreshes and updates columns of a dataset",
         "parameters": [
           {
             "in": "path",
@@ -17035,12 +20118,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Refresh and update columns of a dataset",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/dataset/{pk}/related_objects": {
       "get": {
-        "description": "Get charts and dashboards count associated to a dataset",
         "parameters": [
           {
             "in": "path",
@@ -17077,7 +20162,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Datasets"]
+        "summary": "Get charts and dashboards count associated to a dataset",
+        "tags": [
+          "Datasets"
+        ]
       }
     },
     "/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/": {
@@ -17168,12 +20256,13 @@
           }
         ],
         "summary": "Get possible values for a datasource column",
-        "tags": ["Datasources"]
+        "tags": [
+          "Datasources"
+        ]
       }
     },
     "/api/v1/embedded_dashboard/{uuid}": {
       "get": {
-        "description": "Get a report schedule log",
         "parameters": [
           {
             "description": "The embedded configuration uuid",
@@ -17216,12 +20305,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Embedded Dashboard"]
+        "summary": "Get a report schedule log",
+        "tags": [
+          "Embedded Dashboard"
+        ]
       }
     },
     "/api/v1/explore/": {
       "get": {
-        "description": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.<br/><br/>\\nThe information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
+        "description": "Assembles Explore related information (form_data, slice, dataset) in a single endpoint.<br/><br/> The information can be assembled from:<br/> - The cache using a form_data_key<br/> - The metadata database using a permalink_key<br/> - Build from scratch using dataset or slice identifiers.",
         "parameters": [
           {
             "in": "query",
@@ -17291,13 +20383,14 @@
             "jwt": []
           }
         ],
-        "summary": "Assembles Explore related information (form_data, slice, dataset)\\n in a single endpoint.",
-        "tags": ["Explore"]
+        "summary": "Assemble Explore related information in a single endpoint",
+        "tags": [
+          "Explore"
+        ]
       }
     },
     "/api/v1/explore/form_data": {
       "post": {
-        "description": "Stores a new form_data.",
         "parameters": [
           {
             "in": "query",
@@ -17352,12 +20445,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "summary": "Create a new form_data",
+        "tags": [
+          "Explore Form Data"
+        ]
       }
     },
     "/api/v1/explore/form_data/{key}": {
       "delete": {
-        "description": "Deletes a form_data.",
         "parameters": [
           {
             "description": "The form_data key.",
@@ -17407,10 +20502,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "summary": "Delete a form_data",
+        "tags": [
+          "Explore Form Data"
+        ]
       },
       "get": {
-        "description": "Retrives a form_data.",
         "parameters": [
           {
             "in": "path",
@@ -17459,10 +20556,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "summary": "Get a form_data",
+        "tags": [
+          "Explore Form Data"
+        ]
       },
       "put": {
-        "description": "Updates an existing form_data.",
         "parameters": [
           {
             "in": "path",
@@ -17528,12 +20627,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Form Data"]
+        "summary": "Update an existing form_data",
+        "tags": [
+          "Explore Form Data"
+        ]
       }
     },
     "/api/v1/explore/permalink": {
       "post": {
-        "description": "Stores a new permanent link.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -17583,12 +20684,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Permanent Link"]
+        "summary": "Create a new permanent link",
+        "tags": [
+          "Explore Permanent Link"
+        ]
       }
     },
     "/api/v1/explore/permalink/{key}": {
       "get": {
-        "description": "Retrives chart state associated with a permanent link.",
         "parameters": [
           {
             "in": "path",
@@ -17637,12 +20740,672 @@
             "jwt": []
           }
         ],
-        "tags": ["Explore Permanent Link"]
+        "summary": "Get chart's permanent link state",
+        "tags": [
+          "Explore Permanent Link"
+        ]
+      }
+    },
+    "/api/v1/ias/login_token": {
+      "post": {
+        "description": "Endpoint for exchanging IAS tokens for Superset API tokens. IAS Tokens should be requested from the `acssuperset` IAS application, typically using [client credential flow](https://docs.aci.apple.com/ias/tutorials/client_credentials/index.html). At a minimum, an `id_token` needs to be provided, but by providing a `refresh_token` Superset will be able to automatically refresh the token after the initial one expires. However, to be able to refresh the token, `client_id` and `client_secret` must be provided, as the token needs to be refreshed with the same client that was used for logging in. Unless `refresh_token`, `client_id` and `client_secret` are provided, a `refresh_token` will not be returned.\\nThe following scope should be requested in the token request: `offline openid iam:ds:groups corpds:ds:username corpds:ds:firstName corpds:ds:lastName corpds:ds:email iam:ds:explicitgroups`",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IASLoginTokenRequestSchema"
+              }
+            }
+          },
+          "description": "Payload containing IAS tokens.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IASLoginTokenResponseSchema"
+                }
+              }
+            },
+            "description": "Query result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "tags": [
+          "IAS"
+        ]
+      }
+    },
+    "/api/v1/ias/profiles": {
+      "get": {
+        "description": "Endpoint for retrieving available IAS profiles.",
+        "parameters": [
+          {
+            "description": "The name of the IAS profile",
+            "in": "query",
+            "name": "profile",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IASProfilesResponseSchema"
+                }
+              }
+            },
+            "description": "IAS Tokens"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "IAS"
+        ]
+      }
+    },
+    "/api/v1/ias/tokens": {
+      "get": {
+        "description": "Endpoint for retrieving IAS tokens for the logged in user. If no token is provided, all tokens are returned.",
+        "parameters": [
+          {
+            "description": "The name of the IAS profile",
+            "in": "query",
+            "name": "profile",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IASTokensResponseSchema"
+                }
+              }
+            },
+            "description": "IAS Tokens"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "IAS"
+        ]
+      }
+    },
+    "/api/v1/ias/tokens/{pk}": {
+      "get": {
+        "description": "Endpoint for retrieving IAS tokens for a specific user. If no token is provided, all tokens are returned. Only Admin users are able to view other users' tokens.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The name of the IAS profile",
+            "in": "query",
+            "name": "profile",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IASTokensResponseSchema"
+                }
+              }
+            },
+            "description": "IAS Tokens"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "tags": [
+          "IAS"
+        ]
+      }
+    },
+    "/api/v1/lakehouse": {
+      "get": {
+        "description": "Disconnect a Lakehouse.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseGetListResponseSchema"
+                }
+              }
+            },
+            "description": "Lakehouse has been deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get a list of all connected Lakehouses",
+        "tags": [
+          "Lakehouse"
+        ]
+      }
+    },
+    "/api/v1/lakehouse/{lakehouse_id}": {
+      "delete": {
+        "description": "Disconnect a Lakehouse.",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseDisconnectResponseSchema"
+                }
+              }
+            },
+            "description": "Lakehouse has been deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Disconnect a Lakehouse and all catalogs",
+        "tags": [
+          "Lakehouse"
+        ]
+      },
+      "get": {
+        "description": "Get information regarding a connected Lakehouse",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseGetResponseSchema"
+                }
+              }
+            },
+            "description": "Lakehouses"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get information about a specific Lakehouse",
+        "tags": [
+          "Lakehouse"
+        ]
+      },
+      "post": {
+        "description": "Endpoint for connecting a Lakehouse and associated catalogs to the ACS Superset instance.",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LakehouseConnectRequestSchema"
+              }
+            }
+          },
+          "description": "Payload containing connection parameters.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseConnectResponseSchema"
+                }
+              }
+            },
+            "description": "The connection task has been scheduled."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Schedule a task to connect a Lakehouse and catalogs",
+        "tags": [
+          "Lakehouse"
+        ]
+      }
+    },
+    "/api/v1/lakehouse/{lakehouse_id}/dataset": {
+      "get": {
+        "description": "Endpoint for listing all virtual datasets on a Lakehouse",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The catalog. Leave empty for all catalogs",
+            "in": "query",
+            "name": "catalog",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The schema. Leave empty for all schemas",
+            "in": "query",
+            "name": "schema",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseDatasetListResponseSchema"
+                }
+              }
+            },
+            "description": "All virtual datasets satisfying the query params."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get a list of virtual datasets",
+        "tags": [
+          "Lakehouse"
+        ]
+      },
+      "post": {
+        "description": "Endpoint for creating a virtual dataset from a query",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LakehouseDatasetRequestSchema"
+              }
+            }
+          },
+          "description": "Payload containing virtual dataset parameters.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseDatasetResponseSchema"
+                }
+              }
+            },
+            "description": "The virtual dataset has been created."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Create a virtual dataset out of a query",
+        "tags": [
+          "Lakehouse"
+        ]
+      }
+    },
+    "/api/v1/lakehouse/{lakehouse_id}/task/{task_id}/cancel": {
+      "post": {
+        "description": "Endpoint for cancelling a scheduled connection request.",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The id of the connection task",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseConnectStatusResponseSchema"
+                }
+              }
+            },
+            "description": "The status of the task."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Cancel a running task",
+        "tags": [
+          "Lakehouse"
+        ]
+      }
+    },
+    "/api/v1/lakehouse/{lakehouse_id}/task/{task_id}/result": {
+      "get": {
+        "description": "Endpoint for retrieving the payload of a scheduled connection request.",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The id of the connection task",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseConnectResultResponseSchema"
+                }
+              }
+            },
+            "description": "The status of the task."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get the payload of a completed connection task",
+        "tags": [
+          "Lakehouse"
+        ]
+      }
+    },
+    "/api/v1/lakehouse/{lakehouse_id}/task/{task_id}/status": {
+      "get": {
+        "description": "Endpoint for checking what the status of a scheduled connection request is.",
+        "parameters": [
+          {
+            "description": "The unique id of the lakehouse",
+            "in": "path",
+            "name": "lakehouse_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The id of the connection task",
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LakehouseConnectStatusResponseSchema"
+                }
+              }
+            },
+            "description": "The status of the task."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Check the status of a connection task",
+        "tags": [
+          "Lakehouse"
+        ]
       }
     },
     "/api/v1/log/": {
       "get": {
-        "description": "Get a list of models",
+        "description": "Gets a list of logs, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -17744,7 +21507,10 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "summary": "Get a list of logs",
+        "tags": [
+          "LogRestApi"
+        ]
       },
       "post": {
         "requestBody": {
@@ -17795,7 +21561,9 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
     "/api/v1/log/recent_activity/": {
@@ -17852,7 +21620,9 @@
           }
         ],
         "summary": "Get recent activity data for a user",
-        "tags": ["LogRestApi"]
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
     "/api/v1/log/{pk}": {
@@ -17952,12 +21722,15 @@
             "jwt": []
           }
         ],
-        "tags": ["LogRestApi"]
+        "summary": "Get a log detail information",
+        "tags": [
+          "LogRestApi"
+        ]
       }
     },
     "/api/v1/me/": {
       "get": {
-        "description": "Returns the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
+        "description": "Gets the user object corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -17978,12 +21751,15 @@
             "$ref": "#/components/responses/401"
           }
         },
-        "tags": ["Current User"]
+        "summary": "Get the user object",
+        "tags": [
+          "Current User"
+        ]
       }
     },
     "/api/v1/me/roles/": {
       "get": {
-        "description": "Returns the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
+        "description": "Gets the user roles corresponding to the agent making the request, or returns a 401 error if the user is unauthenticated.",
         "responses": {
           "200": {
             "content": {
@@ -18004,7 +21780,10 @@
             "$ref": "#/components/responses/401"
           }
         },
-        "tags": ["Current User"]
+        "summary": "Get the user roles",
+        "tags": [
+          "Current User"
+        ]
       }
     },
     "/api/v1/menu/": {
@@ -18063,12 +21842,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Menu"]
+        "tags": [
+          "Menu"
+        ]
       }
     },
     "/api/v1/query/": {
       "get": {
-        "description": "Get a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
+        "description": "Gets a list of queries, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -18170,7 +21951,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get a list of queries",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/distinct/{column_name}": {
@@ -18225,7 +22009,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/related/{column_name}": {
@@ -18280,7 +22067,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/stop": {
@@ -18331,7 +22121,9 @@
           }
         ],
         "summary": "Manually stop a query with client_id",
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/updated_since": {
@@ -18388,12 +22180,14 @@
           }
         ],
         "summary": "Get a list of queries that changed after last_updated_ms",
-        "tags": ["Queries"]
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/query/{pk}": {
       "get": {
-        "description": "Get query detail information.",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -18488,12 +22282,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get query detail information",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/report/": {
       "delete": {
-        "description": "Deletes multiple report schedules in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -18544,10 +22340,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Bulk delete report schedules",
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "get": {
-        "description": "Get a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of report schedules, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -18649,10 +22448,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get a list of report schedules",
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "post": {
-        "description": "Create a report schedule",
         "requestBody": {
           "content": {
             "application/json": {
@@ -18704,7 +22505,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Create a report schedule",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/_info": {
@@ -18788,7 +22592,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/related/{column_name}": {
@@ -18843,12 +22650,84 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Report Schedules"
+        ]
+      }
+    },
+    "/api/v1/report/slack_channels/": {
+      "get": {
+        "description": "Get slack channels",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_slack_channels_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Slack channels"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get slack channels",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}": {
       "delete": {
-        "description": "Delete a report schedule",
         "parameters": [
           {
             "description": "The report schedule pk",
@@ -18894,10 +22773,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Delete a report schedule",
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "get": {
-        "description": "Get a report schedule",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -18992,10 +22874,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get a report schedule",
+        "tags": [
+          "Report Schedules"
+        ]
       },
       "put": {
-        "description": "Update a report schedule",
         "parameters": [
           {
             "description": "The Report Schedule pk",
@@ -19061,12 +22945,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Update a report schedule",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}/log/": {
       "get": {
-        "description": "Get a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of report schedule logs, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "description": "The report schedule id for these logs",
@@ -19138,12 +23025,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get a list of report schedule logs",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/report/{pk}/log/{log_id}": {
       "get": {
-        "description": "Get a report schedule log",
         "parameters": [
           {
             "description": "The report schedule pk for log",
@@ -19216,12 +23105,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Report Schedules"]
+        "summary": "Get a report schedule log",
+        "tags": [
+          "Report Schedules"
+        ]
       }
     },
     "/api/v1/rowlevelsecurity/": {
       "delete": {
-        "description": "Deletes multiple RLS rules in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -19272,10 +23163,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Bulk delete RLS rules",
+        "tags": [
+          "Row Level Security"
+        ]
       },
       "get": {
-        "description": "Get a list of models",
+        "description": "Gets a list of RLS, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -19377,10 +23271,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Get a list of RLS",
+        "tags": [
+          "Row Level Security"
+        ]
       },
       "post": {
-        "description": "Create a new RLS Rule",
         "requestBody": {
           "content": {
             "application/json": {
@@ -19432,7 +23328,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Create a new RLS rule",
+        "tags": [
+          "Row Level Security"
+        ]
       }
     },
     "/api/v1/rowlevelsecurity/_info": {
@@ -19516,7 +23415,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Row Level Security"
+        ]
       }
     },
     "/api/v1/rowlevelsecurity/related/{column_name}": {
@@ -19571,7 +23473,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Row Level Security"
+        ]
       }
     },
     "/api/v1/rowlevelsecurity/{pk}": {
@@ -19617,7 +23522,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Delete an RLS",
+        "tags": [
+          "Row Level Security"
+        ]
       },
       "get": {
         "description": "Get an item model",
@@ -19715,10 +23623,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Get an RLS",
+        "tags": [
+          "Row Level Security"
+        ]
       },
       "put": {
-        "description": "Updates an RLS Rule",
         "parameters": [
           {
             "description": "The Rule pk",
@@ -19784,12 +23694,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Row Level Security"]
+        "summary": "Update an RLS rule",
+        "tags": [
+          "Row Level Security"
+        ]
       }
     },
     "/api/v1/saved_query/": {
       "delete": {
-        "description": "Deletes multiple saved queries in a bulk operation.",
         "parameters": [
           {
             "content": {
@@ -19837,10 +23749,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Bulk delete saved queries",
+        "tags": [
+          "Queries"
+        ]
       },
       "get": {
-        "description": "Get a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "description": "Gets a list of saved queries, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
         "parameters": [
           {
             "content": {
@@ -19942,10 +23857,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get a list of saved queries",
+        "tags": [
+          "Queries"
+        ]
       },
       "post": {
-        "description": "Create a saved query",
         "requestBody": {
           "content": {
             "application/json": {
@@ -19994,7 +23911,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Create a saved query",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/_info": {
@@ -20078,7 +23998,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/distinct/{column_name}": {
@@ -20133,12 +24056,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/export/": {
       "get": {
-        "description": "Exports multiple saved queries and downloads them as YAML files",
         "parameters": [
           {
             "content": {
@@ -20182,7 +24107,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Download multiple saved queries as YAML files",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/import/": {
@@ -20258,7 +24186,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Import saved queries with associated databases",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/related/{column_name}": {
@@ -20313,12 +24244,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/saved_query/{pk}": {
       "delete": {
-        "description": "Delete saved query",
         "parameters": [
           {
             "in": "path",
@@ -20360,10 +24293,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Delete a saved query",
+        "tags": [
+          "Queries"
+        ]
       },
       "get": {
-        "description": "Get a saved query",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -20458,10 +24394,12 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Get a saved query",
+        "tags": [
+          "Queries"
+        ]
       },
       "put": {
-        "description": "Update a saved query",
         "parameters": [
           {
             "in": "path",
@@ -20520,12 +24458,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Queries"]
+        "summary": "Update a saved query",
+        "tags": [
+          "Queries"
+        ]
       }
     },
     "/api/v1/security/csrf_token/": {
       "get": {
-        "description": "Fetch the CSRF token",
         "responses": {
           "200": {
             "content": {
@@ -20554,12 +24494,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Security"]
+        "summary": "Get the CSRF token",
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/guest_token/": {
       "post": {
-        "description": "Fetches a guest token",
         "requestBody": {
           "content": {
             "application/json": {
@@ -20602,7 +24544,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Security"]
+        "summary": "Get a guest token",
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/login": {
@@ -20620,7 +24565,10 @@
                   },
                   "provider": {
                     "description": "Choose an authentication provider",
-                    "enum": ["db", "ldap"],
+                    "enum": [
+                      "db",
+                      "ldap"
+                    ],
                     "example": "db",
                     "type": "string"
                   },
@@ -20670,7 +24618,9 @@
             "$ref": "#/components/responses/500"
           }
         },
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
       }
     },
     "/api/v1/security/refresh": {
@@ -20705,7 +24655,47 @@
             "jwt_refresh": []
           }
         ],
-        "tags": ["Security"]
+        "tags": [
+          "Security"
+        ]
+      }
+    },
+    "/api/v1/sqllab/": {
+      "get": {
+        "description": "Assembles SQLLab bootstrap data (active_tab, databases, queries, tab_state_ids) in a single endpoint. The data can be assembled from the current user's id.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SQLLabBootstrapSchema"
+                }
+              }
+            },
+            "description": "Returns the initial bootstrap data for SqlLab"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Get the bootstrap data for SqlLab page",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/estimate/": {
@@ -20755,13 +24745,14 @@
             "jwt": []
           }
         ],
-        "summary": "Estimates the SQL query execution cost",
-        "tags": ["SQL Lab"]
+        "summary": "Estimate the SQL query execution cost",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/execute/": {
       "post": {
-        "description": "Starts the execution of a SQL query",
         "requestBody": {
           "content": {
             "application/json": {
@@ -20815,7 +24806,10 @@
             "jwt": []
           }
         ],
-        "tags": ["SQL Lab"]
+        "summary": "Execute a SQL query",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/export/{client_id}/": {
@@ -20863,8 +24857,63 @@
             "jwt": []
           }
         ],
-        "summary": "Exports the SQL query results to a CSV",
-        "tags": ["SQL Lab"]
+        "summary": "Export the SQL query results to a CSV",
+        "tags": [
+          "SQL Lab"
+        ]
+      }
+    },
+    "/api/v1/sqllab/format_sql/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormatQueryPayloadSchema"
+              }
+            }
+          },
+          "description": "SQL query",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Format SQL result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Format SQL code",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/sqllab/results/": {
@@ -20917,13 +24966,15 @@
             "jwt": []
           }
         ],
-        "summary": "Gets the result of a SQL query execution",
-        "tags": ["SQL Lab"]
+        "summary": "Get the result of a SQL query execution",
+        "tags": [
+          "SQL Lab"
+        ]
       }
     },
     "/api/v1/tag/": {
       "delete": {
-        "description": "Deletes multiple Tags. This will remove all tagged objects with this tag",
+        "description": "Bulk deletes tags. This will remove all tagged objects with this tag.",
         "parameters": [
           {
             "content": {
@@ -20974,7 +25025,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Bulk delete tags",
+        "tags": [
+          "Tags"
+        ]
       },
       "get": {
         "description": "Get a list of tags, use Rison or JSON query parameters for filtering, sorting, pagination and  for selecting specific columns and metadata.",
@@ -21079,9 +25133,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Get a list of tags",
+        "tags": [
+          "Tags"
+        ]
       },
       "post": {
+        "description": "Create a new Tag",
         "requestBody": {
           "content": {
             "application/json": {
@@ -21090,7 +25148,7 @@
               }
             }
           },
-          "description": "Model schema",
+          "description": "Tag schema",
           "required": true
         },
         "responses": {
@@ -21100,7 +25158,7 @@
                 "schema": {
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "number"
                     },
                     "result": {
                       "$ref": "#/components/schemas/TagRestApi.post"
@@ -21110,7 +25168,7 @@
                 }
               }
             },
-            "description": "Item inserted"
+            "description": "Tag added"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -21130,12 +25188,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Create a tag",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/_info": {
       "get": {
-        "description": "Several metadata information about tag API endpoints.",
+        "description": "Get metadata information about this API resource",
         "parameters": [
           {
             "content": {
@@ -21214,12 +25275,66 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Get metadata information about tag API endpoints",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/tag/bulk_create": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagPostBulkSchema"
+              }
+            }
+          },
+          "description": "Tag schema",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagPostBulkResponseSchema"
+                }
+              }
+            },
+            "description": "Bulk created tags and tagged objects"
+          },
+          "302": {
+            "description": "Redirects to the current digest"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "summary": "Bulk create tags and tagged objects",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/favorite_status/": {
       "get": {
-        "description": "Check favorited dashboards for current user",
+        "description": "Get favorited tags for current user",
         "parameters": [
           {
             "content": {
@@ -21262,12 +25377,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/get_objects/": {
       "get": {
-        "description": "Gets all objects associated with a Tag.",
         "parameters": [
           {
             "in": "path",
@@ -21318,7 +25434,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Get all objects associated with a tag",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/related/{column_name}": {
@@ -21373,12 +25492,15 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Get related fields data",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/{object_type}/{object_id}/": {
       "post": {
-        "description": "Add tags to an object..",
+        "description": "Adds tags to an object. Creates new tags if they do not already exist.",
         "parameters": [
           {
             "in": "path",
@@ -21442,12 +25564,14 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Add tags to an object",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/{object_type}/{object_id}/{tag}/": {
       "delete": {
-        "description": "Deletes a Tagged Object.",
         "parameters": [
           {
             "in": "path",
@@ -21511,7 +25635,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Delete a tagged object",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/{pk}": {
@@ -21557,10 +25684,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Delete a tag",
+        "tags": [
+          "Tags"
+        ]
       },
       "get": {
-        "description": "Get a tag detail information.",
+        "description": "Get an item model",
         "parameters": [
           {
             "in": "path",
@@ -21655,9 +25785,13 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Get a tag detail information",
+        "tags": [
+          "Tags"
+        ]
       },
       "put": {
+        "description": "Changes a Tag.",
         "parameters": [
           {
             "in": "path",
@@ -21676,7 +25810,7 @@
               }
             }
           },
-          "description": "Model schema",
+          "description": "Chart schema",
           "required": true
         },
         "responses": {
@@ -21685,6 +25819,9 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "id": {
+                      "type": "number"
+                    },
                     "result": {
                       "$ref": "#/components/schemas/TagRestApi.put"
                     }
@@ -21693,13 +25830,16 @@
                 }
               }
             },
-            "description": "Item changed"
+            "description": "Tag changed"
           },
           "400": {
             "$ref": "#/components/responses/400"
           },
           "401": {
             "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
           },
           "404": {
             "$ref": "#/components/responses/404"
@@ -21716,7 +25856,10 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "summary": "Update a tag",
+        "tags": [
+          "Tags"
+        ]
       }
     },
     "/api/v1/tag/{pk}/favorites/": {
@@ -21766,7 +25909,9 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "tags": [
+          "Tags"
+        ]
       },
       "post": {
         "description": "Marks the tag as favorite for the current user",
@@ -21814,7 +25959,40 @@
             "jwt": []
           }
         ],
-        "tags": ["Tags"]
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/api/v1/user/{user_id}/avatar.png": {
+      "get": {
+        "description": "Gets the avatar URL for the user with the given ID, or returns a 401 error if the user is unauthenticated.",
+        "parameters": [
+          {
+            "description": "The ID of the user",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "301": {
+            "description": "A redirect to the user's avatar URL"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "summary": "Get the user avatar",
+        "tags": [
+          "User"
+        ]
       }
     },
     "/api/{version}/_openapi": {
@@ -21853,7 +26031,9 @@
             "jwt": []
           }
         ],
-        "tags": ["OpenApi"]
+        "tags": [
+          "OpenApi"
+        ]
       }
     }
   },

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -47,6 +47,7 @@ from superset.tags.schemas import (
     openapi_spec_methods_override,
     TaggedObjectEntityResponseSchema,
     TagGetResponseSchema,
+    TagPostBulkResponseSchema,
     TagPostBulkSchema,
     TagPostSchema,
     TagPutSchema,
@@ -132,6 +133,8 @@ class TagRestApi(BaseSupersetModelRestApi):
     openapi_spec_component_schemas = (
         TagGetResponseSchema,
         TaggedObjectEntityResponseSchema,
+        TagPostBulkResponseSchema,
+        TagPostBulkSchema,
     )
     apispec_parameter_schemas = {
         "delete_tags_schema": delete_tags_schema,
@@ -211,40 +214,21 @@ class TagRestApi(BaseSupersetModelRestApi):
         """Bulk create tags and tagged objects
         ---
         post:
-          summary: Get all objects associated with a tag
-          parameters:
-          - in: path
-            schema:
-              type: integer
-            name: tag_id
+          summary: Bulk create tags and tagged objects
           requestBody:
             description: Tag schema
             required: true
             content:
               application/json:
                 schema:
-                  type: object
-                  properties:
-                    tags:
-                      description: list of tag names to add to object
-                      type: array
-                      items:
-                        type: string
-                    objects_to_tag:
-                      description: list of object names to add to object
-                      type: array
-                      items:
-                        type: array
+                  $ref: '#/components/schemas/TagPostBulkSchema'
           responses:
             200:
-              description: Tag added to favorites
+              description: Bulk created tags and tagged objects
               content:
                 application/json:
                   schema:
-                    type: object
-                    properties:
-                      result:
-                        type: object
+                    $ref: '#/components/schemas/TagPostBulkResponseSchema'
             302:
               description: Redirects to the current digest
             400:
@@ -267,6 +251,7 @@ class TagRestApi(BaseSupersetModelRestApi):
                 tagged_item: dict[str, Any] = self.add_model_schema.load(
                     {
                         "name": tag.get("name"),
+                        "description": tag.get("description"),
                         "objects_to_tag": tag.get("objects_to_tag"),
                     }
                 )

--- a/superset/tags/schemas.py
+++ b/superset/tags/schemas.py
@@ -53,21 +53,41 @@ class TaggedObjectEntityResponseSchema(Schema):
     changed_on = fields.DateTime()
     created_by = fields.Nested(UserSchema(exclude=["username"]))
     creator = fields.String()
-    tags = fields.List(fields.Nested(TagGetResponseSchema))
-    owners = fields.List(fields.Nested(UserSchema))
+    tags = fields.List(fields.Nested(TagGetResponseSchema()))
+    owners = fields.List(fields.Nested(UserSchema()))
+
+
+objects_to_tag_field = fields.List(
+    fields.Tuple(
+        (
+            fields.String(metadata={"description": "type of resource"}),
+            fields.Int(validate=Range(min=1), metadata={"description": "resource id"}),
+        ),
+    ),
+    metadata={
+        "description": "Objects to tag",
+    },
+    required=False,
+)
 
 
 class TagObjectSchema(Schema):
     name = fields.String(validate=Length(min=1))
     description = fields.String(required=False, allow_none=True)
-    objects_to_tag = fields.List(
-        fields.Tuple((fields.String(), fields.Int(validate=Range(min=1)))),
-        required=False,
-    )
+    objects_to_tag = objects_to_tag_field
 
 
 class TagPostBulkSchema(Schema):
-    tags = fields.List(fields.Nested(TagObjectSchema))
+    tags = fields.List(fields.Nested(TagObjectSchema()))
+
+
+class TagPostBulkResponseObjectSchema(Schema):
+    objects_tagged = objects_to_tag_field
+    objects_skipped = objects_to_tag_field
+
+
+class TagPostBulkResponseSchema(Schema):
+    result = fields.Nested(TagPostBulkResponseObjectSchema())
 
 
 class TagPostSchema(TagObjectSchema):


### PR DESCRIPTION
### SUMMARY
While working on tags I noticed that the bulk create API spec had multiple issues. This cleans up most of the issues I noticed. The OAS3 schema is also regenerated by running `superset update-api-docs`. However, the whole `tags` resource is pretty funky (including the data model and the related enums), so I would almost suggest doing a big refactor on it at some point.

### BEFORE
The description, request type, and the 200 response are wrong:
![image](https://github.com/user-attachments/assets/47348e6a-485b-4ae0-b185-f81d94b27333)

### AFTER
Now they are in line with what the method actually expects/returns. Note that the tuple types are shown as "string" - this appears to be a limitation of Marshmallow:
![image](https://github.com/user-attachments/assets/f6bc53e3-4627-40ac-bd7c-84e4aa64ba61)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
