### PR TITLE
fix(filters modal): layout cleanup, simplification, fixes

### DIFF
--- a/superset-frontend/cypress-base/cypress/support/directories.ts
+++ b/superset-frontend/cypress-base/cypress/support/directories.ts
@@ -362,7 +362,7 @@ export const nativeFilters = {
   silentLoading: '.loading inline-centered css-101mkpk',
   filterConfigurationSections: {
     sectionHeader: '.ant-collapse-header',
-    displayedSection: 'div[style="height: 100%; overflow-y: auto;"]',
+    displayedSection: dataTestLocator('filter-configuration-tab'),
     collapseExpandButton: '.ant-collapse-arrow',
     checkedCheckbox: '.ant-checkbox-wrapper-checked',
     infoTooltip: '[aria-label="Show info tooltip"]',

--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -163,13 +163,6 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
     }
   }
 
-  // styling for Tabs component
-  // Aaron note 20-11-19: this seems to be exclusively here for the Edit Database modal.
-  // TODO: remove this as it is a special case.
-  .ant-tabs-top {
-    margin-top: -${({ theme }) => theme.gridUnit * 4}px;
-  }
-
   &.no-content-padding .ant-modal-body {
     padding: 0;
   }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigurePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigurePane.tsx
@@ -35,20 +35,14 @@ interface Props {
   removedFilters: Record<string, FilterRemoval>;
 }
 
-const Container = styled.div`
-  display: flex;
-  height: 100%;
-`;
-
 const ContentHolder = styled.div`
   flex-grow: 3;
   margin-left: ${({ theme }) => theme.gridUnit * -1 - 1};
 `;
 
-const TitlesContainer = styled.div`
+const FiltersListPane = styled(FilterTitlePane)`
   min-width: 300px;
   max-width: 300px;
-  border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
 `;
 
 const FilterConfigurePane: FC<Props> = ({
@@ -64,23 +58,21 @@ const FilterConfigurePane: FC<Props> = ({
   filters,
   removedFilters,
 }) => (
-  <Container>
-    <TitlesContainer>
-      <FilterTitlePane
-        currentFilterId={currentFilterId}
-        filters={filters}
-        removedFilters={removedFilters}
-        erroredFilters={erroredFilters}
-        getFilterTitle={getFilterTitle}
-        onChange={onChange}
-        onAdd={(type: NativeFilterType) => onAdd(type)}
-        onRearrange={onRearrange}
-        onRemove={(id: string) => onRemove(id)}
-        restoreFilter={restoreFilter}
-      />
-    </TitlesContainer>
+  <>
+    <FiltersListPane
+      currentFilterId={currentFilterId}
+      filters={filters}
+      removedFilters={removedFilters}
+      erroredFilters={erroredFilters}
+      getFilterTitle={getFilterTitle}
+      onChange={onChange}
+      onAdd={(type: NativeFilterType) => onAdd(type)}
+      onRearrange={onRearrange}
+      onRemove={(id: string) => onRemove(id)}
+      restoreFilter={restoreFilter}
+    />
     <ContentHolder>{children}</ContentHolder>
-  </Container>
+  </>
 );
 
 export default FilterConfigurePane;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
@@ -44,6 +44,7 @@ const TabsContainer = styled.div`
   flex-direction: column;
   padding: ${({ theme }) => theme.gridUnit * 3}px;
   padding-top: 2px;
+  border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
 `;
 
 const FilterTitlePane: FC<Props> = ({
@@ -79,25 +80,18 @@ const FilterTitlePane: FC<Props> = ({
   };
   return (
     <TabsContainer>
-      <div
-        css={{
-          height: '100%',
-          overflowY: 'auto',
-        }}
-      >
-        <FilterTitleContainer
-          ref={filtersContainerRef}
-          filters={filters}
-          currentFilterId={currentFilterId}
-          removedFilters={removedFilters}
-          getFilterTitle={getFilterTitle}
-          erroredFilters={erroredFilters}
-          onChange={onChange}
-          onRemove={onRemove}
-          onRearrange={onRearrange}
-          restoreFilter={restoreFilter}
-        />
-      </div>
+      <FilterTitleContainer
+        ref={filtersContainerRef}
+        filters={filters}
+        currentFilterId={currentFilterId}
+        removedFilters={removedFilters}
+        getFilterTitle={getFilterTitle}
+        erroredFilters={erroredFilters}
+        onChange={onChange}
+        onRemove={onRemove}
+        onRearrange={onRearrange}
+        restoreFilter={restoreFilter}
+      />
       <div
         css={{
           display: 'flex',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -821,6 +821,7 @@ const FiltersConfigForm = (
         tab={FilterTabs.configuration.name}
         key={FilterTabs.configuration.key}
         forceRender
+        data-test="filter-configuration-tab"
       >
         <StyledContainer>
           <StyledFormItem

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -241,19 +241,14 @@ const StyledCollapse = styled(Collapse)`
 `;
 
 const StyledTabs = styled(Tabs)`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   .ant-tabs-nav {
-    position: sticky;
-    top: 0;
-    background: ${({ theme }) => theme.colors.grayscale.light5};
-    z-index: 1;
+    margin-bottom: 0;
   }
-
-  .ant-tabs-nav-list {
-    padding: 0;
-  }
-
-  .ant-form-item-label {
-    padding-bottom: 0;
+  .ant-tabs-content-holder {
+    overflow-y: scroll;
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -66,6 +66,7 @@ const MIN_WIDTH = 880;
 const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
   min-width: ${MIN_WIDTH}px;
   width: ${({ expanded }) => (expanded ? '100%' : MIN_WIDTH)} !important;
+  height: 100vh;
 
   @media (max-width: ${MIN_WIDTH + MODAL_MARGIN * 2}px) {
     width: 100% !important;
@@ -74,35 +75,24 @@ const StyledModalWrapper = styled(StyledModal)<{ expanded: boolean }>`
 
   .ant-modal-body {
     padding: 0px;
+    flex-basis: 100vh;
   }
 
   ${({ expanded }) =>
     expanded &&
     css`
-      height: 100%;
-
       .ant-modal-body {
         flex: 1 1 auto;
-      }
-      .ant-modal-content {
-        height: 100%;
       }
     `}
 `;
 
-export const StyledModalBody = styled.div<{ expanded: boolean }>`
-  display: flex;
-  height: ${({ expanded }) => (expanded ? '100%' : '700px')};
-  flex-direction: row;
-  flex: 1;
-  .filters-list {
-    width: ${({ theme }) => theme.gridUnit * 50}px;
-    overflow: auto;
-  }
-`;
-
 export const StyledForm = styled(AntdForm)`
   width: 100%;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  display: flex;
 `;
 
 export const StyledExpandButtonWrapper = styled.div`
@@ -645,40 +635,35 @@ function FiltersConfigModal({
         const isDivider = id.startsWith(NATIVE_FILTER_DIVIDER_PREFIX);
         const isActive = currentFilterId === id;
         return (
-          <div
-            key={id}
-            style={{
-              height: '100%',
-              overflowY: 'auto',
-              display: isActive ? '' : 'none',
-            }}
-          >
-            {isDivider ? (
-              <DividerConfigForm
-                componentId={id}
-                divider={filterConfigMap[id] as Divider}
-              />
-            ) : (
-              <FiltersConfigForm
-                expanded={expanded}
-                ref={configFormRef}
-                form={form}
-                filterId={id}
-                filterToEdit={filterConfigMap[id] as Filter}
-                removedFilters={removedFilters}
-                restoreFilter={restoreFilter}
-                getAvailableFilters={getAvailableFilters}
-                key={id}
-                activeFilterPanelKeys={activeFilterPanelKey}
-                handleActiveFilterPanelChange={handleActiveFilterPanelChange}
-                isActive={isActive}
-                setErroredFilters={setErroredFilters}
-                validateDependencies={validateDependencies}
-                getDependencySuggestion={getDependencySuggestion}
-                onModifyFilter={handleModifyFilter}
-              />
-            )}
-          </div>
+          isActive && (
+            <>
+              {isDivider ? (
+                <DividerConfigForm
+                  componentId={id}
+                  divider={filterConfigMap[id] as Divider}
+                />
+              ) : (
+                <FiltersConfigForm
+                  expanded={expanded}
+                  ref={configFormRef}
+                  form={form}
+                  filterId={id}
+                  filterToEdit={filterConfigMap[id] as Filter}
+                  removedFilters={removedFilters}
+                  restoreFilter={restoreFilter}
+                  getAvailableFilters={getAvailableFilters}
+                  key={id}
+                  activeFilterPanelKeys={activeFilterPanelKey}
+                  handleActiveFilterPanelChange={handleActiveFilterPanelChange}
+                  isActive={isActive}
+                  setErroredFilters={setErroredFilters}
+                  validateDependencies={validateDependencies}
+                  getDependencySuggestion={getDependencySuggestion}
+                  onModifyFilter={handleModifyFilter}
+                />
+              )}
+            </>
+          )
         );
       }),
     [
@@ -741,28 +726,27 @@ function FiltersConfigModal({
       }
     >
       <ErrorBoundary>
-        <StyledModalBody expanded={expanded}>
-          <StyledForm
-            form={form}
-            onValuesChange={handleValuesChange}
-            layout="vertical"
+        <StyledForm
+          form={form}
+          onValuesChange={handleValuesChange}
+          layout="vertical"
+          className="test2"
+        >
+          <FilterConfigurePane
+            erroredFilters={erroredFilters}
+            onRemove={handleRemoveItem}
+            onAdd={addFilter}
+            onChange={handleTabChange}
+            getFilterTitle={getFilterTitle}
+            currentFilterId={currentFilterId}
+            removedFilters={removedFilters}
+            restoreFilter={restoreFilter}
+            onRearrange={handleRearrange}
+            filters={orderedFilters}
           >
-            <FilterConfigurePane
-              erroredFilters={erroredFilters}
-              onRemove={handleRemoveItem}
-              onAdd={addFilter}
-              onChange={handleTabChange}
-              getFilterTitle={getFilterTitle}
-              currentFilterId={currentFilterId}
-              removedFilters={removedFilters}
-              restoreFilter={restoreFilter}
-              onRearrange={handleRearrange}
-              filters={orderedFilters}
-            >
-              {formList}
-            </FilterConfigurePane>
-          </StyledForm>
-        </StyledModalBody>
+            {formList}
+          </FilterConfigurePane>
+        </StyledForm>
       </ErrorBoundary>
     </StyledModalWrapper>
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -635,35 +635,38 @@ function FiltersConfigModal({
         const isDivider = id.startsWith(NATIVE_FILTER_DIVIDER_PREFIX);
         const isActive = currentFilterId === id;
         return (
-          isActive && (
-            <>
-              {isDivider ? (
-                <DividerConfigForm
-                  componentId={id}
-                  divider={filterConfigMap[id] as Divider}
-                />
-              ) : (
-                <FiltersConfigForm
-                  expanded={expanded}
-                  ref={configFormRef}
-                  form={form}
-                  filterId={id}
-                  filterToEdit={filterConfigMap[id] as Filter}
-                  removedFilters={removedFilters}
-                  restoreFilter={restoreFilter}
-                  getAvailableFilters={getAvailableFilters}
-                  key={id}
-                  activeFilterPanelKeys={activeFilterPanelKey}
-                  handleActiveFilterPanelChange={handleActiveFilterPanelChange}
-                  isActive={isActive}
-                  setErroredFilters={setErroredFilters}
-                  validateDependencies={validateDependencies}
-                  getDependencySuggestion={getDependencySuggestion}
-                  onModifyFilter={handleModifyFilter}
-                />
-              )}
-            </>
-          )
+          <div
+            style={{
+              display: isActive ? '' : 'none',
+              height: '100%',
+            }}
+          >
+            {isDivider ? (
+              <DividerConfigForm
+                componentId={id}
+                divider={filterConfigMap[id] as Divider}
+              />
+            ) : (
+              <FiltersConfigForm
+                expanded={expanded}
+                ref={configFormRef}
+                form={form}
+                filterId={id}
+                filterToEdit={filterConfigMap[id] as Filter}
+                removedFilters={removedFilters}
+                restoreFilter={restoreFilter}
+                getAvailableFilters={getAvailableFilters}
+                key={id}
+                activeFilterPanelKeys={activeFilterPanelKey}
+                handleActiveFilterPanelChange={handleActiveFilterPanelChange}
+                isActive={isActive}
+                setErroredFilters={setErroredFilters}
+                validateDependencies={validateDependencies}
+                getDependencySuggestion={getDependencySuggestion}
+                onModifyFilter={handleModifyFilter}
+              />
+            )}
+          </div>
         );
       }),
     [

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -733,7 +733,6 @@ function FiltersConfigModal({
           form={form}
           onValuesChange={handleValuesChange}
           layout="vertical"
-          className="test2"
         >
           <FilterConfigurePane
             erroredFilters={erroredFilters}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The new Add Filter/Divider buttons were getting hidden when the browser window was too short. "But it's flexbox, that shouldn't happen" I said. Then I started looking at all the onion layers of styled divs with random heights and overrides. 

This PR cleans a bunch of junk up. There are fewer elements now, a few unnecessary overrides and styles are taken out, and things generally use more flexbox-native layouts. I could keep trimming until the cows come home, but I wanted to stop when the problem was fixed.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Video demo with narration:
https://github.com/user-attachments/assets/1ebaab79-71bc-40e5-975e-d09b77bf75e6



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
