### PR TITLE
feat: add a few docker-compose env vars to control the build + docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ x-common-build: &common-build
     - apache/superset-cache:3.10-slim-bookworm
   args:
     DEV_MODE: "true"
+    INCLUDE_CHROMIUM: ${INCLUDE_CHROMIUM:false}
+    INCLUDE_FIREFOX: ${INCLUDE_FIREFOX:false}
+    BUILD_TRANSLATIONS: ${BUILD_TRANSLATIONS:false}
 
 services:
   nginx:
@@ -157,6 +160,7 @@ services:
         # and build it on startup while firing docker-frontend.sh in dev mode, where
         # it'll mount and watch local files and rebuild as you update them
         DEV_MODE: "true"
+        BUILD_TRANSLATIONS: ${BUILD_TRANSLATIONS:false}
     environment:
       # set this to false if you have perf issues running the npm i; npm run dev in-docker
       # if you do so, you have to run this manually on the host, which should perform better!

--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -72,6 +72,18 @@ documentation.
 configured to be secure.
 :::
 
+### Supported environment variables
+
+Affecting the Docker build process:
+- **INCLUDE_FIREFOX (default=false):** whether to include the Firefox headless browser in the build
+- **INCLUDE_CHROMIUM (default=false):** whether to include the Firefox headless browser in the build
+- **BUILD_TRANSLATIONS(default=false):** whether to compile the translations from the .po files available
+
+For more env vars that affect your configuration, see this
+[superset_config.py](https://github.com/apache/superset/blob/master/docker/pythonpath_dev/superset_config.py)
+used in the `docker compose` context to assign env vars to the superset configuration.
+
+
 ### Nuking the postgres database
 
 At times, it's possible to end up with your development database in a bad state, it's


### PR DESCRIPTION
Living in docker/compose over the past few days, I figure it'll be good to attach build
args to env vars so it's easy to turn things on and off.

As part of this, I'm turning off installing chromium in the build as in most cases developers
won't be working on something that requires it. If you need though, it's
easy to set an env var to switch it on.

Should speed up the local builds a little and make images significantly
smaller locally.

