### PR TITLE
chore: remove numba and llvmlite deps as they are large and we don't use them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ dependencies = [
     "nh3>=0.2.11, <0.3",
     "numpy==1.23.5",
     "packaging",
-    "pandas[excel,performance]>=2.0.3, <2.1",
+    # --------------------------
+    # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
+    "pandas[excel]>=2.0.3, <2.1",
+    "bottleneck",
+    # --------------------------
     "parsedatetime",
     "paramiko>=3.4.0",
     "pgsanity",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,7 +35,7 @@ billiard==4.2.1
 blinker==1.9.0
     # via flask
 bottleneck==1.4.2
-    # via pandas
+    # via apache-superset
 brotli==1.1.0
     # via flask-compress
 cachelib==0.9.0
@@ -194,8 +194,6 @@ korean-lunar-calendar==0.3.1
     # via holidays
 limits==3.13.0
     # via flask-limiter
-llvmlite==0.43.0
-    # via numba
 mako==1.3.6
     # via
     #   alembic
@@ -224,17 +222,12 @@ msgspec==0.18.6
     # via flask-session
 nh3==0.2.19
     # via apache-superset
-numba==0.60.0
-    # via pandas
 numexpr==2.10.2
-    # via
-    #   -r requirements/base.in
-    #   pandas
+    # via -r requirements/base.in
 numpy==1.23.5
     # via
     #   apache-superset
     #   bottleneck
-    #   numba
     #   numexpr
     #   pandas
     #   pyarrow
@@ -254,7 +247,7 @@ packaging==24.2
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   shillelagh
-pandas[excel,performance]==2.0.3
+pandas[excel]==2.0.3
     # via apache-superset
 paramiko==3.5.0
     # via


### PR DESCRIPTION
After realizing llvmlite is about 200mb and numba 25mb, looked to see if we need this.

Apparently they come from pandas[performance], but numba is never user unless we tell pandas to use it explicitely in specific calls
<img width="789" alt="Screenshot 2024-12-13 at 4 46 40 PM" src="https://github.com/user-attachments/assets/01b0f086-072b-4e15-88fa-bba7d0670031" />

