### PR TITLE
docs: Removed mentioning of .env-non-dev in docker/README.md

### DIFF
--- a/.github/workflows/superset-docs-verify.yml
+++ b/.github/workflows/superset-docs-verify.yml
@@ -28,7 +28,6 @@ jobs:
           linksToSkip: >-
             ^https://github.com/apache/(superset|incubator-superset)/(pull|issue)/\d+,
             http://localhost:8088/,
-            docker/.env-non-dev,
             http://127.0.0.1:3000/,
             http://localhost:9001/,
             https://charts.bitnami.com/bitnami,

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,7 @@ Don't forget to reload the page to take the new frontend into account though.
 
 ## Production
 
-It is possible to run Superset in non-development mode by using [`docker-compose-non-dev.yml`](../docker-compose-non-dev.yml). This file excludes the volumes needed for development and uses [`./docker/.env-non-dev`](./.env-non-dev) which sets the variable `SUPERSET_ENV` to `production`.
+It is possible to run Superset in non-development mode by using [`docker-compose-non-dev.yml`](../docker-compose-non-dev.yml). This file excludes the volumes needed for development.
 
 ## Resource Constraints
 


### PR DESCRIPTION
### SUMMARY
Even though `.env-non-dev` (not to be confused with `.env-local`) is mentioned in `docker/README.md`, it's not mentioned or used anywhere else in the repo, except it's being excluded from the `linkinator` job inside [`superset-docs-verify.yml`](https://github.com/apache/superset/blob/master/.github/workflows/superset-docs-verify.yml#L31).

The sentence "`docker-compose-non-dev.yml` uses `.env-non-dev` which sets the variable `SUPERSET_ENV` to `production`" is misleading because `docker-compose-non-dev.yml` **doesn't** use `.env-non-dev` and `.env-non-dev` **doesn't** set env var to anything because `.env-non-dev` **doesn't even exist**.

So I went ahead and removed it.

### TESTING INSTRUCTIONS
1. clone repo
2. run `cd superset; grep -rin env-non-dev`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
