### PR TITLE
fix: Tooltip covers the date selector in native filters

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -207,7 +207,6 @@ const DescriptionToolTip = ({ description }: { description: string }) => (
         textOverflow: 'ellipsis',
         whiteSpace: 'normal',
       }}
-      getPopupContainer={trigger => trigger.parentElement as HTMLElement}
     >
       <i
         className="fa fa-info-circle text-muted"

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -379,11 +379,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       }
       destroyTooltipOnHide
     >
-      <Tooltip
-        placement="top"
-        title={tooltipTitle}
-        getPopupContainer={trigger => trigger.parentElement as HTMLElement}
-      >
+      <Tooltip placement="top" title={tooltipTitle}>
         <DateLabel
           name={name}
           aria-labelledby={`filter-name-${props.name}`}
@@ -400,11 +396,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
 
   const modalContent = (
     <>
-      <Tooltip
-        placement="top"
-        title={tooltipTitle}
-        getPopupContainer={trigger => trigger.parentElement as HTMLElement}
-      >
+      <Tooltip placement="top" title={tooltipTitle}>
         <DateLabel
           name={name}
           aria-labelledby={`filter-name-${props.name}`}


### PR DESCRIPTION
### SUMMARY
After upgrading the Tooltip component to antd5, tooltips were covering the date selector in horizontal native filters bar and preventing clicking on the filter.
This PR fixes it by removing `getPopupContainer` prop from Tooltip, which was introduced in https://github.com/apache/superset/pull/24617 to fix an issue with tooltip position when user scrolls the page.
Apparently Antd v5 fixed this behaviour and we no longer need to pass `getPopupContainer`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/a7b21916-3ee3-427e-abc4-46b59ec40629

After:

https://github.com/user-attachments/assets/6a2b734f-4c5d-4156-b558-027c4506b879

### TESTING INSTRUCTIONS
1. Add a date native filter
2. Set a date
3. Verify that the tooltip is not covering the filter control and that its placement doesn't change when you scroll
4. Make sure that it works as expected both in horizontal and vertical filter bar

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
