### PR TITLE
fix(explore): Styling issue in Search Metrics input field

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/index.tsx
@@ -100,6 +100,7 @@ const DatasourceContainer = styled.div`
       color: ${theme.colors.grayscale.light1};
     }
     .form-control.input-md {
+      display: inline-flex;
       width: calc(100% - ${theme.gridUnit * 8}px);
       height: ${theme.gridUnit * 8}px;
       margin: ${theme.gridUnit * 2}px auto;


### PR DESCRIPTION

### SUMMARY
Following upgrade of Input component to antd 5, the "Search Metrics & Columns" field in Explore had some broken styles

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="316" alt="image" src="https://github.com/user-attachments/assets/1573a80b-7643-4dcf-a0be-ab4de713c9ba" />

<img width="310" alt="image" src="https://github.com/user-attachments/assets/19170a1f-b74d-4be0-9b69-8abe2d659793" />


After:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/fe1bb607-f3b0-41bc-90a4-f5227677481b" />

<img width="311" alt="image" src="https://github.com/user-attachments/assets/6e88f8c6-4968-4214-bbbb-8034d8049995" />


### TESTING INSTRUCTIONS
Open Explore, verify that Search Metrics & Columns input looks good - the placeholder should be centered, the input text and clear button should be aligned

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
