### PR TITLE
fix: Filter null child names in treeBuilder utility

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -98,7 +98,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Show Null Values'),
-              default: false,
+              default: true,
               renderTrigger: true,
               description: t('Whether to display null values'),
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -100,7 +100,7 @@ const config: ControlPanelConfig = {
               label: t('Show Null Values'),
               default: true,
               renderTrigger: true,
-              description: t('Whether to display null values'),
+              description: t('Whether to display entries with null values in the hierarchy'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -100,7 +100,9 @@ const config: ControlPanelConfig = {
               label: t('Show Null Values'),
               default: true,
               renderTrigger: true,
-              description: t('Whether to display entries with null values in the hierarchy'),
+              description: t(
+                'Whether to display entries with null values in the hierarchy',
+              ),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -94,6 +94,18 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'show_null_values',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show Null Values'),
+              default: false,
+              renderTrigger: true,
+              description: t('Whether to display null values'),
+            },
+          },
+        ],
+        [
+          {
             name: 'label_type',
             config: {
               type: 'SelectControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -186,6 +186,7 @@ export default function transformProps(
     showLabels,
     showLabelsThreshold,
     showTotal,
+    showNullValues,
     sliceId,
   } = formData;
   const {
@@ -251,6 +252,7 @@ export default function transformProps(
     columnLabels,
     metricLabel,
     secondaryMetricLabel,
+    !showNullValues,
   );
   const totalValue = treeData.reduce(
     (result, treeNode) => result + treeNode.value,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -74,9 +74,10 @@ export function treeBuilder(
               0,
             )
           : metricValue;
+        const validChildren = children.filter(child => child.name !== null);
         result.push({
           name,
-          children,
+          children: validChildren,
           value: metricValue,
           secondaryValue,
           groupBy: curGroupBy,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -36,6 +36,7 @@ export function treeBuilder(
   groupBy: string[],
   metric: string,
   secondaryMetric?: string,
+  filterNullNames?: boolean,
 ): TreeNode[] {
   const [curGroupBy, ...restGroupby] = groupBy;
   const curData = _groupBy(data, curGroupBy);
@@ -63,6 +64,7 @@ export function treeBuilder(
           restGroupby,
           metric,
           secondaryMetric,
+          filterNullNames,
         );
         const metricValue = children.reduce(
           (prev, cur) => prev + (cur.value as number),
@@ -74,7 +76,9 @@ export function treeBuilder(
               0,
             )
           : metricValue;
-        const validChildren = children.filter(child => child.name !== null);
+        const validChildren = filterNullNames
+          ? children.filter(child => child.name !== null)
+          : children;
         result.push({
           name,
           children: validChildren,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -271,4 +271,244 @@ describe('test treeBuilder', () => {
       },
     ]);
   });
+
+  it('include null values', () => {
+    const tree = treeBuilder(
+      [
+        ...data,
+        {
+          foo: 'a-2',
+          bar: null,
+          count: 2,
+          count2: 3,
+        },
+      ],
+      ['foo', 'bar'],
+      'count',
+    );
+    expect(tree).toEqual([
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'a',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'a-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'a',
+            secondaryValue: 2,
+            value: 2,
+          },
+          {
+            groupBy: 'bar',
+            name: null,
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'a-2',
+        secondaryValue: 4,
+        value: 4,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'b',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'b-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'b',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'b-2',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'c',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'c-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'c',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'c-2',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'd',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'd-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+    ]);
+  });
+
+  it('filter null values', () => {
+    const tree = treeBuilder(
+      [
+        ...data,
+        {
+          foo: 'a-2',
+          bar: null,
+          count: 2,
+          count2: 3,
+        },
+      ],
+      ['foo', 'bar'],
+      'count',
+      undefined,
+      true,
+    );
+    expect(tree).toEqual([
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'a',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'a-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'a',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'a-2',
+        secondaryValue: 4,
+        value: 4,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'b',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'b-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'b',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'b-2',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'c',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'c-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'c',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'c-2',
+        secondaryValue: 2,
+        value: 2,
+      },
+      {
+        children: [
+          {
+            groupBy: 'bar',
+            name: 'd',
+            secondaryValue: 2,
+            value: 2,
+          },
+        ],
+        groupBy: 'foo',
+        name: 'd-1',
+        secondaryValue: 2,
+        value: 2,
+      },
+    ]);
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -272,7 +272,7 @@ describe('test treeBuilder', () => {
     ]);
   });
 
-  it('include null values', () => {
+  test('include null values', () => {
     const tree = treeBuilder(
       [
         ...data,
@@ -394,7 +394,7 @@ describe('test treeBuilder', () => {
     ]);
   });
 
-  it('filter null values', () => {
+  test('filter null values', () => {
     const tree = treeBuilder(
       [
         ...data,


### PR DESCRIPTION
### SUMMARY
This update modifies the treeBuilder utility to filter out null child names. This ensures that the echart sunburst chart does not display null children as <Null>.
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
<img width="993" alt="image" src="https://github.com/user-attachments/assets/0242690e-2c00-4cb5-b0e9-dce191082ede" />


After:
<img width="943" alt="image" src="https://github.com/user-attachments/assets/9fdadc10-9a76-4fbb-b8fa-929159f31681" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a sunburst diagram with multiple hierarchies and some null values.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
