### PR TITLE
feat(sunburst): Add node click functionality to sunburst chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/controlPanel.tsx
@@ -93,6 +93,18 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'node_click',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Node Click'),
+              default: false,
+              renderTrigger: true,
+              description: t('Whether to enable drill down by node clicking'),
+            },
+          },
+        ],
+        [
+          {
             name: 'label_type',
             config: {
               type: 'SelectControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -100,6 +100,7 @@ export function formatTooltip({
   totalValue,
   metricLabel,
   secondaryMetricLabel,
+  nodeClick,
 }: {
   params: CallbackDataParams & {
     treePathInfo: {
@@ -114,8 +115,14 @@ export function formatTooltip({
   totalValue: number;
   metricLabel: string;
   secondaryMetricLabel?: string;
+  nodeClick: boolean;
 }): string {
   const { data, treePathInfo = [] } = params;
+
+  if (nodeClick && treePathInfo.length <= 1) {
+    return t('Back to the parent node');
+  }
+
   const node = data as TreeNode;
   const formattedValue = primaryValueFormatter(node.value);
   const formattedSecondaryValue = secondaryValueFormatter?.(
@@ -186,6 +193,7 @@ export default function transformProps(
     showLabels,
     showLabelsThreshold,
     showTotal,
+    nodeClick,
     sliceId,
   } = formData;
   const { currencyFormats = {}, columnFormats = {} } = datasource;
@@ -336,13 +344,14 @@ export default function transformProps(
           totalValue,
           metricLabel,
           secondaryMetricLabel,
+          nodeClick,
         }),
     },
     series: [
       {
         type: 'sunburst',
         ...padding,
-        nodeClick: false,
+        nodeClick: nodeClick ? 'rootToNode' : false,
         emphasis: {
           focus: 'ancestor',
           label: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This feature introduces node click functionality to the sunburst chart. Users can now click on nodes to focus on one node, enhancing the interactivity and usability of the chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/1d3749db-b382-4bb1-b182-996f3a96facc" />
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/092f5f52-e0ef-4857-827b-4e5436daf76c" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a sunburst chart with multiple hierarchies.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
