### PR TITLE
fix(sunburst): Use metric label from verbose map

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -188,7 +188,11 @@ export default function transformProps(
     showTotal,
     sliceId,
   } = formData;
-  const { currencyFormats = {}, columnFormats = {} } = datasource;
+  const {
+    currencyFormats = {},
+    columnFormats = {},
+    verboseMap = {},
+  } = datasource;
   const refs: Refs = {};
   const primaryValueFormatter = getValueFormatter(
     metric,
@@ -334,8 +338,10 @@ export default function transformProps(
           secondaryValueFormatter,
           colorByCategory,
           totalValue,
-          metricLabel,
-          secondaryMetricLabel,
+          metricLabel: verboseMap[metricLabel] || metricLabel,
+          secondaryMetricLabel: secondaryMetricLabel
+            ? verboseMap[secondaryMetricLabel] || secondaryMetricLabel
+            : undefined,
         }),
     },
     series: [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Use metric labels from verbose map.

### TESTING INSTRUCTIONS
Create a sunburst chart with saved columns as primary or secondary metric.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
