### PR TITLE
fix: Card component background color

### DIFF
--- a/superset-frontend/src/theme/index.ts
+++ b/superset-frontend/src/theme/index.ts
@@ -75,6 +75,7 @@ const baseConfig: ThemeConfig = {
     Card: {
       paddingLG: supersetTheme.gridUnit * 6,
       fontWeightStrong: supersetTheme.typography.weights.medium,
+      colorBgContainer: supersetTheme.colors.grayscale.light4,
     },
     Input: {
       colorBorder: supersetTheme.colors.secondary.light3,


### PR DESCRIPTION


### SUMMARY
After upgrading the Card component to antd 5, we forgot about the background color token, resulting in cards having blue-ish background color instead of gray.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/cbfa24ba-f764-4b6b-ba02-9f22da96a384" />

<img width="943" alt="image" src="https://github.com/user-attachments/assets/5810e1dd-9e10-469b-9734-16f74779fc33" />


After:

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/f5cf398a-3ed1-45e2-b504-93ee2a89b4dc" />

<img width="900" alt="image" src="https://github.com/user-attachments/assets/cdb9ca52-10b0-4001-9b37-ac20275ddb30" />


### TESTING INSTRUCTIONS
Verify that the card components in SQL Lab (the query in the Results tab) and Dataset edit -> Settings have gray backgrounds

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
