### PR TITLE
feat(chart): download CSV chart contents from S3 for Athena charts

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1522,6 +1522,9 @@
               "post_processed",
               "drill_detail"
             ]
+          },
+          "result_location": {
+            "enum": ["superset", "s3"]
           }
         },
         "type": "object"

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -67,5 +67,6 @@ export default function buildQueryContext(
     form_data: formData,
     result_format: formData.result_format || 'json',
     result_type: formData.result_type || 'full',
+    result_location: formData.result_location || 'superset',
   };
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -162,6 +162,8 @@ export interface QueryContext {
   result_type: string;
   /** Response format */
   result_format: string;
+  /** Response query location */
+  result_location: string;
   queries: QueryObject[];
   form_data?: QueryFormData;
 }

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -180,6 +180,7 @@ export interface BaseFormData extends TimeRange, FormDataResidual {
   force?: boolean;
   result_format?: string;
   result_type?: string;
+  result_location?: string;
   annotation_layers?: AnnotationLayer[];
   url_params?: Record<string, string>;
   custom_params?: Record<string, string>;

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -33,6 +33,7 @@ export enum FeatureFlag {
   DashboardVirtualization = 'DASHBOARD_VIRTUALIZATION',
   DashboardRbac = 'DASHBOARD_RBAC',
   DatapanelClosedByDefault = 'DATAPANEL_CLOSED_BY_DEFAULT',
+  DownloadCSVFromS3 = 'DOWNLOAD_CSV_FROM_S3',
   /** @deprecated */
   DrillToDetail = 'DRILL_TO_DETAIL',
   DrillBy = 'DRILL_BY',

--- a/superset-frontend/packages/superset-ui-core/test/chart/models/ChartPlugin.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/models/ChartPlugin.test.tsx
@@ -48,6 +48,7 @@ describe('ChartPlugin', () => {
     force: false,
     result_format: 'json',
     result_type: 'full',
+    result_location: 'superset',
   });
 
   const controlPanel = { abc: 1 };

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -50,6 +50,7 @@ type SliceHeaderProps = SliceHeaderControlsProps & {
   formData: object;
   width: number;
   height: number;
+  databaseBackend?: string;
 };
 
 const annotationsLoading = t('Annotation layers are still loading.');
@@ -162,6 +163,7 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
       formData,
       width,
       height,
+      databaseBackend,
     },
     ref,
   ) => {
@@ -295,6 +297,7 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
                   formData={formData}
                   exploreUrl={exploreUrl}
                   crossFiltersEnabled={isCrossFiltersEnabled}
+                  databaseBackend={databaseBackend}
                 />
               )}
             </>

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -88,6 +88,7 @@ const createProps = (viz_type = VizType.Sunburst) =>
       viz_type: VizType.Sunburst,
     },
     exploreUrl: '/explore',
+    databaseBackend: 'sqlite',
     defaultOpen: true,
   }) as SliceHeaderControlsProps;
 

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -134,6 +134,7 @@ export interface SliceHeaderControlsProps {
   exportFullCSV?: (sliceId: number) => void;
   exportXLSX?: (sliceId: number) => void;
   exportFullXLSX?: (sliceId: number) => void;
+  downloadCSVFromS3?: (sliceId: number) => void;
   handleToggleFullSize: () => void;
 
   addDangerToast: (message: string) => void;
@@ -215,6 +216,10 @@ const SliceHeaderControls = (
         }
         break;
       case MenuKeys.ExportCsv:
+        if (isFeatureEnabled(FeatureFlag.DownloadCSVFromS3) && props.databaseBackend === 'awsathena') {
+          props.downloadCSVFromS3?.(props.slice.slice_id);
+          break;
+        }
         // eslint-disable-next-line no-unused-expressions
         props.exportCSV?.(props.slice.slice_id);
         break;
@@ -226,6 +231,10 @@ const SliceHeaderControls = (
         props.handleToggleFullSize();
         break;
       case MenuKeys.ExportFullCsv:
+        if (isFeatureEnabled(FeatureFlag.DownloadCSVFromS3) && props.databaseBackend === 'awsathena') {
+          props.downloadCSVFromS3?.(props.slice.slice_id);
+          break;
+        }
         // eslint-disable-next-line no-unused-expressions
         props.exportFullCSV?.(props.slice.slice_id);
         break;

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/types.ts
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/types.ts
@@ -39,6 +39,7 @@ export interface SliceHeaderControlsProps {
   isDescriptionExpanded?: boolean;
   formData: QueryFormData;
   exploreUrl: string;
+  databaseBackend: string;
 
   forceRefresh: (sliceId: number, dashboardId: number) => void;
   logExploreChart?: (sliceId: number) => void;
@@ -49,6 +50,7 @@ export interface SliceHeaderControlsProps {
   exportFullCSV?: (sliceId: number) => void;
   exportXLSX?: (sliceId: number) => void;
   exportFullXLSX?: (sliceId: number) => void;
+  downloadCSVFromS3?: (sliceId: number) => void;
   handleToggleFullSize: () => void;
 
   addDangerToast: (message: string) => void;

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -31,6 +31,7 @@ import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
   LOG_ACTIONS_EXPLORE_DASHBOARD_CHART,
   LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART,
+  LOG_ACTIONS_EXPORT_CSV_FROM_S3,
   LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART,
   LOG_ACTIONS_FORCE_REFRESH_CHART,
 } from 'src/logger/LogUtils';
@@ -376,6 +377,33 @@ const Chart = props => {
     ],
   );
 
+  const exportFromS3 = useCallback(
+    (format = 'csv') => {
+      const logAction = LOG_ACTIONS_EXPORT_CSV_FROM_S3;
+    
+      boundActionCreators.logEvent(logAction, {
+        slice_id: this.props.slice.slice_id,
+        is_cached: this.props.isCached,
+      });
+      exportChart({
+        formData: { ...formData, row_limit: props.maxRows },
+        resultType: 'full',
+        resultFormat: format,
+        resultLocation: 's3',
+        force: true,
+        ownState: props.ownState,
+      });
+    },
+    [
+      slice.slice_id,
+      props.isCached,
+      formData,
+      props.maxRows,
+      props.ownState,
+      boundActionCreators.logEvent,
+    ],
+  );
+
   const exportCSV = useCallback(
     (isFullCSV = false) => {
       exportTable('csv', isFullCSV);
@@ -390,6 +418,10 @@ const Chart = props => {
   const exportPivotCSV = useCallback(() => {
     exportTable('csv', false, true);
   }, [exportTable]);
+
+  const downloadCSVFromS3 = useCallback(() => {
+    exportFromS3('csv');
+  }, [exportFromS3]);
 
   const exportXLSX = useCallback(() => {
     exportTable('xlsx', false);
@@ -453,6 +485,7 @@ const Chart = props => {
         exportPivotCSV={exportPivotCSV}
         exportXLSX={exportXLSX}
         exportFullCSV={exportFullCSV}
+        downloadCSVFromS3={downloadCSVFromS3}
         exportFullXLSX={exportFullXLSX}
         updateSliceName={props.updateSliceName}
         sliceName={props.sliceName}
@@ -470,6 +503,7 @@ const Chart = props => {
         formData={formData}
         width={width}
         height={getHeaderHeight()}
+        databaseBackend={datasource.database?.backend}
       />
 
       {/*

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -243,6 +243,7 @@ export const exportChart = ({
   resultType = 'full',
   force = false,
   ownState = {},
+  resultLocation = 'superset',
 }) => {
   let url;
   let payload;
@@ -265,6 +266,7 @@ export const exportChart = ({
       ownState,
       parseMethod,
     });
+    payload.result_location = resultLocation === 's3' ? 's3' : 'superset';
   }
 
   SupersetClient.postForm(url, { form_data: safeStringify(payload) });

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -36,6 +36,7 @@ export const LOG_ACTIONS_EXPORT_CSV_DASHBOARD_CHART =
   'export_csv_dashboard_chart';
 export const LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART =
   'export_xlsx_dashboard_chart';
+export const LOG_ACTIONS_EXPORT_CSV_FROM_S3 = 'export_csv_from_s3';
 export const LOG_ACTIONS_CHANGE_DASHBOARD_FILTER = 'change_dashboard_filter';
 export const LOG_ACTIONS_DATASET_CREATION_EMPTY_CANCELLATION =
   'dataset_creation_empty_cancellation';

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -25,7 +25,7 @@ from marshmallow import EXCLUDE, fields, post_load, Schema, validate
 from marshmallow.validate import Length, Range
 
 from superset import app
-from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType, ChartDataResultLocation
 from superset.db_engine_specs.base import builtin_time_grains
 from superset.utils import pandas_postprocessing, schema as utils
 from superset.utils.core import (
@@ -1380,6 +1380,7 @@ class ChartDataQueryContextSchema(Schema):
 
     result_type = fields.Enum(ChartDataResultType, by_value=True)
     result_format = fields.Enum(ChartDataResultFormat, by_value=True)
+    result_location = fields.Enum(ChartDataResultLocation, by_value=True)
 
     form_data = fields.Raw(allow_none=True, required=False)
 
@@ -1498,6 +1499,11 @@ class ChartDataResponseResult(Schema):
     )
     to_dttm = fields.Integer(
         metadata={"description": "End timestamp of time range"},
+        required=False,
+        allow_none=True,
+    )
+    output_location = fields.String(
+        metadata={"description": "S3 location of query execution"},
         required=False,
         allow_none=True,
     )

--- a/superset/common/chart_data.py
+++ b/superset/common/chart_data.py
@@ -44,3 +44,11 @@ class ChartDataResultType(StrEnum):
     TIMEGRAINS = "timegrains"
     POST_PROCESSED = "post_processed"
     DRILL_DETAIL = "drill_detail"
+
+class ChartDataResultLocation(StrEnum):
+    """
+    Chart data response location
+    """
+
+    SUPERSET = "superset"
+    S3 = "s3"

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -107,7 +107,6 @@ def _get_full(
     if datasource.database.db_engine_spec.supports_remote_download(query_context.result_location):
         # Generate presigned URL for output CSV
         presigned_output_location = generate_presigned_url(payload["output_location"])
-        logger.info("ATHENA OUTPUT LOCATION PRESIGNED %s", presigned_output_location)
         return {
             "output_location": presigned_output_location,
         }

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -21,11 +21,12 @@ from typing import Any, Callable, TYPE_CHECKING
 
 from flask_babel import _
 
-from superset import app
-from superset.common.chart_data import ChartDataResultType
+from superset import app, feature_flag_manager
+from superset.common.chart_data import ChartDataResultType, ChartDataResultLocation
 from superset.common.db_query_status import QueryStatus
 from superset.connectors.sqla.models import BaseDatasource
 from superset.exceptions import QueryObjectValidationError
+from superset.utils.aws import generate_presigned_url
 from superset.utils.core import (
     extract_column_dtype,
     extract_dataframe_dtypes,
@@ -101,6 +102,16 @@ def _get_full(
     datasource = _get_datasource(query_context, query_obj)
     result_type = query_obj.result_type or query_context.result_type
     payload = query_context.get_df_payload(query_obj, force_cached=force_cached)
+    presigned_output_location = None
+
+    if datasource.database.db_engine_spec.supports_remote_download(query_context.result_location):
+        # Generate presigned URL for output CSV
+        presigned_output_location = generate_presigned_url(payload["output_location"])
+        logger.info("ATHENA OUTPUT LOCATION PRESIGNED %s", presigned_output_location)
+        return {
+            "output_location": presigned_output_location,
+        }
+    
     df = payload["df"]
     status = payload["status"]
     if status != QueryStatus.FAILED:
@@ -109,6 +120,7 @@ def _get_full(
         payload["coltypes"] = extract_dataframe_dtypes(df, datasource)
         payload["data"] = query_context.get_data(df, payload["coltypes"])
         payload["result_format"] = query_context.result_format
+        payload["output_location"] = presigned_output_location
     del payload["df"]
 
     applied_time_columns, rejected_time_columns = get_time_filter_status(

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -21,7 +21,7 @@ from typing import Any, ClassVar, TYPE_CHECKING
 
 import pandas as pd
 
-from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType, ChartDataResultLocation
 from superset.common.query_context_processor import (
     CachedTimeOffset,
     QueryContextProcessor,
@@ -53,6 +53,7 @@ class QueryContext:
     form_data: dict[str, Any] | None
     result_type: ChartDataResultType
     result_format: ChartDataResultFormat
+    result_location: ChartDataResultLocations
     force: bool
     custom_cache_timeout: int | None
 
@@ -71,6 +72,7 @@ class QueryContext:
         form_data: dict[str, Any] | None,
         result_type: ChartDataResultType,
         result_format: ChartDataResultFormat,
+        result_location: ChartDataResultLocation,
         force: bool = False,
         custom_cache_timeout: int | None = None,
         cache_values: dict[str, Any],
@@ -79,6 +81,7 @@ class QueryContext:
         self.slice_ = slice_
         self.result_type = result_type
         self.result_format = result_format
+        self.result_location = result_location
         self.queries = queries
         self.form_data = form_data
         self.force = force

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from superset import app
-from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType, ChartDataResultLocation
 from superset.common.query_context import QueryContext
 from superset.common.query_object import QueryObject
 from superset.common.query_object_factory import QueryObjectFactory
@@ -52,6 +52,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         form_data: dict[str, Any] | None = None,
         result_type: ChartDataResultType | None = None,
         result_format: ChartDataResultFormat | None = None,
+        result_location: ChartDataResultLocation | None = None,
         force: bool = False,
         custom_cache_timeout: int | None = None,
     ) -> QueryContext:
@@ -65,6 +66,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
 
         result_type = result_type or ChartDataResultType.FULL
         result_format = result_format or ChartDataResultFormat.JSON
+        result_location = result_location or ChartDataResultLocation.SUPERSET
         queries_ = [
             self._process_query_object(
                 datasource_model_instance,
@@ -80,6 +82,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             "queries": queries,
             "result_type": result_type,
             "result_format": result_format,
+            "result_location": result_location,
         }
         return QueryContext(
             datasource=datasource_model_instance,
@@ -88,6 +91,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             form_data=form_data,
             result_type=result_type,
             result_format=result_format,
+            result_location=result_location,
             force=force,
             custom_cache_timeout=custom_cache_timeout,
             cache_values=cache_values,

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -201,6 +201,7 @@ class QueryContextProcessor:
             "from_dttm": query_obj.from_dttm,
             "to_dttm": query_obj.to_dttm,
             "label_map": label_map,
+            "output_location": cache.output_location,
         }
 
     def query_cache_key(self, query_obj: QueryObject, **kwargs: Any) -> str | None:
@@ -235,7 +236,7 @@ class QueryContextProcessor:
             # todo(hugh): add logic to manage all sip68 models here
             result = query_context.datasource.exc_query(query_object.to_dict())
         else:
-            result = query_context.datasource.query(query_object.to_dict())
+            result = query_context.datasource.query(query_object.to_dict(), query_context.result_location)
             query = result.query + ";\n\n"
 
         df = result.df

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -65,6 +65,7 @@ class QueryCacheManager:
         cache_dttm: str | None = None,
         cache_value: dict[str, Any] | None = None,
         sql_rowcount: int | None = None,
+        output_location: str | None = None,
     ) -> None:
         self.df = df
         self.query = query
@@ -81,6 +82,7 @@ class QueryCacheManager:
         self.cache_dttm = cache_dttm
         self.cache_value = cache_value
         self.sql_rowcount = sql_rowcount
+        self.output_location = "" if output_location is None else output_location
 
     # pylint: disable=too-many-arguments
     def set_query_result(
@@ -106,6 +108,7 @@ class QueryCacheManager:
             self.df = query_result.df
             self.sql_rowcount = query_result.sql_rowcount
             self.annotation_data = {} if annotation_data is None else annotation_data
+            self.output_location = getattr(query_result.df, "output_location", "")
 
             if self.status != QueryStatus.FAILED:
                 stats_logger.incr("loaded_from_source")
@@ -121,6 +124,7 @@ class QueryCacheManager:
                 "rejected_filter_columns": self.rejected_filter_columns,
                 "annotation_data": self.annotation_data,
                 "sql_rowcount": self.sql_rowcount,
+                "output_location": self.output_location,
             }
             if self.is_loaded and key and self.status != QueryStatus.FAILED:
                 self.set(
@@ -172,6 +176,7 @@ class QueryCacheManager:
                 query_cache.is_loaded = True
                 query_cache.is_cached = cache_value is not None
                 query_cache.sql_rowcount = cache_value.get("sql_rowcount", None)
+                query_cache.output_location = cache_value.get("output_location", None)
                 query_cache.cache_dttm = (
                     cache_value["dttm"] if cache_value is not None else None
                 )

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -72,6 +72,7 @@ from sqlalchemy.sql.selectable import Alias, TableClause
 
 from superset import app, db, is_feature_enabled, security_manager
 from superset.commands.dataset.exceptions import DatasetNotFoundError
+from superset.common.chart_data import ChartDataResultLocation
 from superset.common.db_query_status import QueryStatus
 from superset.connectors.sqla.utils import (
     get_columns_description,
@@ -1710,7 +1711,7 @@ class SqlaTable(
 
         return or_(*groups)
 
-    def query(self, query_obj: QueryObjectDict) -> QueryResult:
+    def query(self, query_obj: QueryObjectDict, result_location: ChartDataResultLocation = ChartDataResultLocation.SUPERSET) -> QueryResult:
         qry_start_dttm = datetime.now()
         query_str_ext = self.get_query_str_extended(query_obj)
         sql = query_str_ext.sql
@@ -1746,9 +1747,11 @@ class SqlaTable(
         try:
             df = self.database.get_df(
                 sql,
-                self.catalog,
-                self.schema or None,
+                catalog = self.catalog,
+                schema = self.schema or None,
                 mutator=assign_column_label,
+                result_location=result_location
+
             )
         except (SupersetErrorException, SupersetErrorsException):
             # SupersetError(s) exception should not be captured; instead, they should

--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
+import pandas as pd
 from datetime import datetime
 from re import Pattern
 from typing import Any, Optional
@@ -22,9 +23,12 @@ from typing import Any, Optional
 from flask_babel import gettext as __
 from sqlalchemy import types
 
+from superset import is_feature_enabled
+from superset.common.chart_data import ChartDataResultLocation
 from superset.constants import TimeGrain
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import SupersetErrorType
+from superset.utils.aws import run_query_and_get_s3_url
 
 SYNTAX_ERROR_REGEX = re.compile(
     ": mismatched input '(?P<syntax_error>.*?)'. Expecting: "
@@ -80,6 +84,18 @@ class AthenaEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return "from_unixtime({col})"
+
+    @classmethod
+    def supports_remote_download(cls, result_location: ChartDataResultLocation) -> bool:
+        return is_feature_enabled("DOWNLOAD_CSV_FROM_S3") and result_location == ChartDataResultLocation.S3
+
+    @classmethod
+    def get_remote_download_url(cls, query: list[str]) -> str:
+        if is_feature_enabled("DOWNLOAD_CSV_FROM_S3"):
+            s3_url = run_query_and_get_s3_url(query)
+            df = pd.DataFrame()
+            df.output_location = s3_url
+            return df
 
     @staticmethod
     def _mutate_label(label: str) -> str:

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -59,6 +59,7 @@ from sqlalchemy.types import TypeEngine
 from sqlparse.tokens import CTE
 
 from superset import db, sql_parse
+from superset.common.chart_data import ChartDataResultLocation
 from superset.constants import QUERY_CANCEL_KEY, TimeGrain as TimeGrainConstants
 from superset.databases.utils import get_table_metadata, make_url_safe
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -2507,3 +2508,23 @@ class BasicParametersMixin:
         )
         spec.components.schema(cls.__name__, schema=cls.parameters_schema)
         return spec.to_dict()["components"]["schemas"][cls.__name__]
+
+    @classmethod
+    def supports_remote_download(cls, location: ChartDataResultLocation) -> bool:
+        """
+        Return a boolean indicating whether the engine supports remote download.
+
+        :location: The location of the file to download
+        """
+        return False
+
+    @classmethod
+    def get_remote_download_url(cls, query: list[str]) -> str:
+        """
+        Return a URL to download the results of the query instead of processing raw data (Presto supports this).
+
+        :query: The query to be executed
+        :return: The URL for downloadable file location
+        """
+        return None
+

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -583,6 +583,7 @@ class QueryResult:  # pylint: disable=too-few-public-methods
         errors: Optional[list[dict[str, Any]]] = None,
         from_dttm: Optional[datetime] = None,
         to_dttm: Optional[datetime] = None,
+        output_location: Optional[str] = None,
     ) -> None:
         self.df = df
         self.query = query
@@ -595,6 +596,7 @@ class QueryResult:  # pylint: disable=too-few-public-methods
         self.errors = errors or []
         self.from_dttm = from_dttm
         self.to_dttm = to_dttm
+        self.output_location = output_location
         self.sql_rowcount = len(self.df.index) if not self.df.empty else 0
 
 

--- a/superset/utils/aws.py
+++ b/superset/utils/aws.py
@@ -1,0 +1,41 @@
+import boto3
+import os
+from datetime import datetime
+
+
+def generate_presigned_url(output_location: str) -> str:
+    s3_client = boto3.client('s3')
+    bucket_name, key = output_location.replace("s3://", "").split("/", 1)
+    timestamp = datetime.now().strftime("%Y%m%d__%H%M%S")
+    filename = f"{timestamp}.csv"
+    presigned_url = s3_client.generate_presigned_url(
+        'get_object',
+        Params={'Bucket': bucket_name, 'Key': key, 'ResponseContentDisposition': f'attachment; filename={filename}'},
+        ExpiresIn=3600
+    )
+    return presigned_url
+
+def run_query_and_get_s3_url(query):
+    REGION = os.getenv("SUPERSET_REGION")
+    WORKGROUP = os.getenv("SUPERSET_WORKGROUP")
+    DATABASE = os.getenv("SUPERSET_ATHENA_DB")
+    athena_client = boto3.client('athena', region_name=REGION)
+    
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={'Database': DATABASE},
+        WorkGroup=WORKGROUP,
+    )
+    
+    query_execution_id = response['QueryExecutionId']
+    
+    while True:
+        query_status = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+        status = query_status['QueryExecution']['Status']['State']
+        if status in ['SUCCEEDED', 'FAILED', 'CANCELLED']:
+            break
+    
+    if status == 'SUCCEEDED':
+        return query_status['QueryExecution']['ResultConfiguration']['OutputLocation']
+    else:
+        raise Exception(f"Query failed with status: {status}")

--- a/tests/unit_tests/common/test_time_shifts.py
+++ b/tests/unit_tests/common/test_time_shifts.py
@@ -18,7 +18,7 @@ from pandas import DataFrame, Series, Timestamp
 from pandas.testing import assert_frame_equal
 from pytest import fixture, mark  # noqa: PT013
 
-from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType, ChartDataResultLocation
 from superset.common.query_context import QueryContext
 from superset.common.query_context_processor import QueryContextProcessor
 from superset.connectors.sqla.models import BaseDatasource
@@ -33,6 +33,7 @@ query_context_processor = QueryContextProcessor(
         slice_=None,
         result_format=ChartDataResultFormat.CSV,
         cache_values={},
+        result_location=ChartDataResultLocation.SUPERSET,
     )
 )
 


### PR DESCRIPTION
### SUMMARY
Add a right click context menu option if the chart is an Athena table to download full chart contents directly from S3 bucket instead of through Superset

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/user-attachments/assets/dfd352c0-7862-4fe4-bffe-beeb02b0a53d)

### TESTING INSTRUCTIONS
Set required env vars
SUPERSET_REGION=<my_aws_region>
SUPERSET_WORKGROUP=<my_superset-workgroup>
SUPERSET_ATHENA_DB=<my_superset_db>

Enable feature flags
'DOWNLOAD_CSV_FROM_S3'
'SHOW_DEFAULT_CSV_OPTIONS'

Ensure Athena is set to automatically persist query results to S3 bucket in CSV format

Test download of chart through right click option.

### ADDITIONAL INFORMATION
- [x] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

No DB changes

resolves #31482