### PR TITLE
fix: master docker builds fail because of multi-platform builds can't --load

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,6 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             PLATFORM_ARG="--platform linux/amd64"
           fi
-          PLATFORM_ARG="--platform linux/arm64 --platform linux/amd64"
 
           supersetbot docker \
             --preset ${{ matrix.build_preset }} \
@@ -83,7 +82,7 @@ jobs:
             --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
             $PLATFORM_ARG
 
-      - name: Print docker stats
+      - name: Docker pull
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         run:  docker pull apache/superset:GHA-${GITHUB_RUN_ID}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             PLATFORM_ARG="--platform linux/amd64"
           fi
+          PLATFORM_ARG="--platform linux/arm64 --platform linux/amd64"
 
           supersetbot docker \
             --preset ${{ matrix.build_preset }} \
@@ -82,7 +83,9 @@ jobs:
             --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
             $PLATFORM_ARG
 
-          docker pull apache/superset:GHA-${GITHUB_RUN_ID}
+      - name: Print docker stats
+        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        run:  docker pull apache/superset:GHA-${GITHUB_RUN_ID}
 
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,8 @@ jobs:
             --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
             $PLATFORM_ARG
 
+          docker pull apache/superset:GHA-${GITHUB_RUN_ID}
+
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         run: |

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -34,7 +34,8 @@ from superset.security import SupersetSecurityManager  # noqa: F401
 # All of the fields located here should be considered legacy. The correct way
 # to declare "global" dependencies is to define it in extensions.py,
 # then initialize it in app.create_app(). These fields will be removed
-# in subsequent PRs as things are migrated towards the factory pattern
+# in subsequent PRs as things are migrated towards the factory
+# pattern
 app: Flask = current_app
 cache = cache_manager.cache
 conf = LocalProxy(lambda: current_app.config)


### PR DESCRIPTION
Fixing an issue in `master` related to the fact that we do multi-platform build on master and
not on PRs (PR succeeded, but failed on master since the --load directive doesn't work against multi-platform
here removing load and doing a `docker pull`)

NOTE: manually tested against multi-platform builds too so this should fix `master` too