### PR TITLE
fix(sunburst): Fix sunburst chart cross-filter logic

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -39,7 +39,6 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
     width,
     echartOptions,
     setDataMask,
-    labelMap,
     selectedValues,
     formData,
     onContextMenu,
@@ -52,45 +51,47 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
   const getCrossFilterDataMask = useCallback(
     (treePathInfo: TreePathInfo[]) => {
       const treePath = extractTreePathInfo(treePathInfo);
-      const name = treePath.join(',');
-      const selected = Object.values(selectedValues);
-      let values: string[];
-      if (selected.includes(name)) {
-        values = selected.filter(v => v !== name);
-      } else {
-        values = [name];
+      const joinedThreePath = treePath.join(',');
+      const value = treePath[treePath.length - 1];
+
+      const isCurrentValueSelected =
+        Object.values(selectedValues).includes(joinedThreePath);
+
+      if (!columns?.length || isCurrentValueSelected) {
+        return {
+          dataMask: {
+            extraFormData: {
+              filters: [],
+            },
+            filterState: {
+              value: null,
+              selectedValues: [],
+            },
+          },
+          isCurrentValueSelected,
+        };
       }
-      const labels = values.map(value => labelMap[value]);
 
       return {
         dataMask: {
           extraFormData: {
-            filters:
-              values.length === 0 || !columns
-                ? []
-                : columns.slice(0, treePath.length).map((col, idx) => {
-                    const val = labels.map(v => v[idx]);
-                    if (val === null || val === undefined)
-                      return {
-                        col,
-                        op: 'IS NULL' as const,
-                      };
-                    return {
-                      col,
-                      op: 'IN' as const,
-                      val: val as (string | number | boolean)[],
-                    };
-                  }),
+            filters: [
+              {
+                col: columns[treePath.length - 1],
+                op: '==' as const,
+                val: value,
+              },
+            ],
           },
           filterState: {
-            value: labels.length ? labels : null,
-            selectedValues: values.length ? values : null,
+            value,
+            selectedValues: [joinedThreePath],
           },
         },
-        isCurrentValueSelected: selected.includes(name),
+        isCurrentValueSelected,
       };
     },
-    [columns, labelMap, selectedValues],
+    [columns, selectedValues],
   );
 
   const handleChange = useCallback(
@@ -101,7 +102,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
 
       setDataMask(getCrossFilterDataMask(treePathInfo).dataMask);
     },
-    [emitCrossFilters, setDataMask, getCrossFilterDataMask],
+    [emitCrossFilters, columns?.length, setDataMask, getCrossFilterDataMask],
   );
 
   const eventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -51,11 +51,11 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
   const getCrossFilterDataMask = useCallback(
     (treePathInfo: TreePathInfo[]) => {
       const treePath = extractTreePathInfo(treePathInfo);
-      const joinedThreePath = treePath.join(',');
+      const joinedTreePath = treePath.join(',');
       const value = treePath[treePath.length - 1];
 
       const isCurrentValueSelected =
-        Object.values(selectedValues).includes(joinedThreePath);
+        Object.values(selectedValues).includes(joinedTreePath);
 
       if (!columns?.length || isCurrentValueSelected) {
         return {
@@ -85,7 +85,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
           },
           filterState: {
             value,
-            selectedValues: [joinedThreePath],
+            selectedValues: [joinedTreePath],
           },
         },
         isCurrentValueSelected,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR resolves an issue where the Sunburst chart's cross-filtering did not work properly for hierarchies with more than two levels. Previously, only the first and last hierarchies allowed cross-filtering, whereas any interactions with the middle hierarchies let to an error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![bevore](https://github.com/user-attachments/assets/9060d5e5-2826-4040-a63f-c1964fd33a7f)

After:
![after](https://github.com/user-attachments/assets/aafbae4b-14f5-48bb-afcb-f030abd60dfd)


### TESTING INSTRUCTIONS
Create a sunburst chart with more than two hierarchies.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
