### PR TITLE
feat(pivot table): Add feature flag to allow HTML rendering in pivot tables

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -48,6 +48,7 @@ const d3Formatted: [string, string][] = [
   ',.3f',
   '+,',
   '$,.2f',
+  ' ,.2f',
 ].map(fmt => [fmt, `${fmt} (${getNumberFormatter(fmt).preview()})`]);
 
 // input choices & options

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -48,7 +48,6 @@ const d3Formatted: [string, string][] = [
   ',.3f',
   '+,',
   '$,.2f',
-  ' ,.2f',
 ].map(fmt => [fmt, `${fmt} (${getNumberFormatter(fmt).preview()})`]);
 
 // input choices & options

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -27,6 +27,7 @@ export enum FeatureFlag {
   AlertReportTabs = 'ALERT_REPORT_TABS',
   AlertReportSlackV2 = 'ALERT_REPORT_SLACK_V2',
   AllowFullCsvExport = 'ALLOW_FULL_CSV_EXPORT',
+  AllowPivotTableHtml = 'ALLOW_PIVOT_TABLE_HTML',
   AvoidColorsCollision = 'AVOID_COLORS_COLLISION',
   ChartPluginsExperimental = 'CHART_PLUGINS_EXPERIMENTAL',
   ConfirmDashboardDiff = 'CONFIRM_DASHBOARD_DIFF',

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -155,7 +155,7 @@ export default function PivotTableChart(props: PivotTableProps) {
     dateFormatters,
     onContextMenu,
     timeGrainSqla,
-    allowRenderHtml,
+    allowRenderHtml = isFeatureEnabled(FeatureFlag.AllowPivotTableHtml),
   } = props;
 
   const theme = useTheme();

--- a/superset/config.py
+++ b/superset/config.py
@@ -512,6 +512,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Allow users to export full CSV of table viz type.
     # This could cause the server to run out of memory or compute.
     "ALLOW_FULL_CSV_EXPORT": False,
+    # Allow pivot table to render html formated in cells
+    "ALLOW_PIVOT_TABLE_HTML": False,
     "ALLOW_ADHOC_SUBQUERY": False,
     "USE_ANALAGOUS_COLORS": False,
     # Apply RLS rules to SQL Lab queries. This requires parsing and manipulating the


### PR DESCRIPTION
### SUMMARY
After analyzing the source code, a variable is set to `true` by default in the Table chart (`superset/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx`) but not in the Pivot Table (`superset/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx`). The variable in question is `allowRenderHtml` in the function `export default function TableChart<D extends DataRecord = DataRecord>` or `export default function PivotTableChart(props: PivotTableProps)`.

The goal is to make this value configurable via a feature flag. Therefore, a new feature flag needs to be declared in the file `superset/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts` as follows:
`AllowPivotTableHtml = 'ALLOW_PIVOT_TABLE_HTML'`.

Then, retrieve this feature flag in the source code of the Pivot Table like this:
`allowRenderHtml = isFeatureEnabled(FeatureFlag.AllowPivotTableHtml)`

Finally, declare the new feature flag in the superset_config.py file and set it to true as follows:
```
FEATURE_FLAGS = {
    "ALLOW_PIVOT_TABLE_HTML": True,
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Capture d'écran 17 12 2024 à 15 03 50 PM](https://github.com/user-attachments/assets/13cb9e43-b87b-4d58-9aa5-d3ac838722aa)
![Capture d'écran 17 12 2024 à 15 04 10 PM](https://github.com/user-attachments/assets/fa25808c-e592-4191-8823-75690e2c652f)


### TESTING INSTRUCTIONS
Set the feature flag ALLOW_PIVOT_TABLE_HTML to "True" in your superset_config.py and look if your html is formated or not in the Pivot Table.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: ALLOW_PIVOT_TABLE_HTML
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
