### PR TITLE
chore: rename `apply_post_process`

### DIFF
--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -17,12 +17,11 @@
 """
 Functions to reproduce the client post-processing of data on charts.
 
-Some text-based charts (pivot tables and t-test table) perform post-processing of the data
-in JavaScript. When sending the data to users in reports we want to show the same data
-they would see on Explore.
+Some text-based charts (pivot tables and t-test table) perform post-processing of the
+data in JavaScript. When sending the data to users in reports we want to show the same
+data they would see on Explore.
 
-In order to do that, we reproduce the post-processing in Python
-for these chart types.
+In order to do that, we reproduce the post-processing in Python for these chart types.
 """
 
 from io import StringIO

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -15,12 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Functions to reproduce the post-processing of data on text charts.
+Functions to reproduce the client post-processing of data on charts.
 
-Some text-based charts (pivot tables and t-test table) perform
-post-processing of the data in JavaScript. When sending the data
-to users in reports we want to show the same data they would see
-on Explore.
+Some text-based charts (pivot tables and t-test table) perform post-processing of the data
+in JavaScript. When sending the data to users in reports we want to show the same data
+they would see on Explore.
 
 In order to do that, we reproduce the post-processing in Python
 for these chart types.
@@ -298,7 +297,7 @@ post_processors = {
 
 
 @event_logger.log_this
-def apply_post_process(  # noqa: C901
+def apply_client_processing(  # noqa: C901
     result: dict[Any, Any],
     form_data: Optional[dict[str, Any]] = None,
     datasource: Optional[Union["BaseDatasource", "Query"]] = None,

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -28,8 +28,8 @@ from marshmallow import ValidationError
 from superset import is_feature_enabled, security_manager
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.charts.api import ChartRestApi
+from superset.charts.client_processing import apply_client_processing
 from superset.charts.data.query_context_cache_loader import QueryContextCacheLoader
-from superset.charts.post_processing import apply_post_process
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.commands.chart.data.create_async_job_command import (
     CreateAsyncChartDataJobCommand,
@@ -356,7 +356,7 @@ class ChartDataRestApi(ChartRestApi):
         # This is needed for sending reports based on text charts that do the
         # post-processing of data, eg, the pivot table.
         if result_type == ChartDataResultType.POST_PROCESSED:
-            result = apply_post_process(result, form_data, datasource)
+            result = apply_client_processing(result, form_data, datasource)
 
         if result_format in ChartDataResultFormat.table_like():
             # Verify user has permission to export file

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -190,8 +190,8 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             return isinstance(metric, str) or is_adhoc_metric(metric)
 
         self.metrics = metrics and [
-            x if is_str_or_adhoc(x) else x["label"]
-            for x in metrics  # type: ignore
+            x if is_str_or_adhoc(x) else x["label"]  # type: ignore
+            for x in metrics
         ]
 
     def _set_post_processing(

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -33,6 +33,7 @@ from superset.exceptions import (
     QueryClauseValidationException,
     QueryObjectValidationError,
 )
+from superset.extensions import event_logger
 from superset.sql_parse import sanitize_clause
 from superset.superset_typing import Column, Metric, OrderBy
 from superset.utils import json, pandas_postprocessing
@@ -189,8 +190,8 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             return isinstance(metric, str) or is_adhoc_metric(metric)
 
         self.metrics = metrics and [
-            x if is_str_or_adhoc(x) else x["label"]  # type: ignore
-            for x in metrics
+            x if is_str_or_adhoc(x) else x["label"]
+            for x in metrics  # type: ignore
         ]
 
     def _set_post_processing(
@@ -417,6 +418,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
 
         return md5_sha_from_dict(cache_dict, default=json_int_dttm_ser, ignore_nan=True)
 
+    @event_logger.log_this
     def exec_post_processing(self, df: DataFrame) -> DataFrame:
         """
         Perform post processing operations on DataFrame.

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -418,7 +418,6 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
 
         return md5_sha_from_dict(cache_dict, default=json_int_dttm_ser, ignore_nan=True)
 
-    @event_logger.log_this
     def exec_post_processing(self, df: DataFrame) -> DataFrame:
         """
         Perform post processing operations on DataFrame.
@@ -430,19 +429,20 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                  is incorrect
         """
         logger.debug("post_processing: \n %s", pformat(self.post_processing))
-        for post_process in self.post_processing:
-            operation = post_process.get("operation")
-            if not operation:
-                raise InvalidPostProcessingError(
-                    _("`operation` property of post processing object undefined")
-                )
-            if not hasattr(pandas_postprocessing, operation):
-                raise InvalidPostProcessingError(
-                    _(
-                        "Unsupported post processing operation: %(operation)s",
-                        type=operation,
+        with event_logger.log_context(f"{self.__class__.__name__}.post_processing"):
+            for post_process in self.post_processing:
+                operation = post_process.get("operation")
+                if not operation:
+                    raise InvalidPostProcessingError(
+                        _("`operation` property of post processing object undefined")
                     )
-                )
-            options = post_process.get("options", {})
-            df = getattr(pandas_postprocessing, operation)(df, **options)
-        return df
+                if not hasattr(pandas_postprocessing, operation):
+                    raise InvalidPostProcessingError(
+                        _(
+                            "Unsupported post processing operation: %(operation)s",
+                            type=operation,
+                        )
+                    )
+                options = post_process.get("options", {})
+                df = getattr(pandas_postprocessing, operation)(df, **options)
+            return df

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -21,7 +21,7 @@ import pytest
 from flask_babel import lazy_gettext as _
 from sqlalchemy.orm.session import Session
 
-from superset.charts.post_processing import apply_post_process, pivot_df, table
+from superset.charts.client_processing import apply_client_processing, pivot_df, table
 from superset.common.chart_data import ChartDataResultFormat
 from superset.utils.core import GenericDataType
 
@@ -1841,16 +1841,16 @@ def test_table():
     )
 
 
-def test_apply_post_process_no_form_invalid_viz_type():
+def test_apply_client_processing_no_form_invalid_viz_type():
     """
     Test with invalid viz type. It should just return the result
     """
     result = {"foo": "bar"}
     form_data = {"viz_type": "baz"}
-    assert apply_post_process(result, form_data) == result
+    assert apply_client_processing(result, form_data) == result
 
 
-def test_apply_post_process_without_result_format():
+def test_apply_client_processing_without_result_format():
     """
     A query without result_format should raise an exception
     """
@@ -1858,12 +1858,12 @@ def test_apply_post_process_without_result_format():
     form_data = {"viz_type": "pivot_table_v2"}
 
     with pytest.raises(Exception) as ex:  # noqa: PT011
-        apply_post_process(result, form_data)
+        apply_client_processing(result, form_data)
 
     assert ex.match("Result format foo not supported") is True  # noqa: E712
 
 
-def test_apply_post_process_json_format():
+def test_apply_client_processing_json_format():
     """
     It should be able to process json results
     """
@@ -1944,7 +1944,7 @@ def test_apply_post_process_json_format():
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [
             {
                 "result_format": ChartDataResultFormat.JSON,
@@ -1966,7 +1966,7 @@ def test_apply_post_process_json_format():
     }
 
 
-def test_apply_post_process_csv_format():
+def test_apply_client_processing_csv_format():
     """
     It should be able to process csv results
     """
@@ -2042,7 +2042,7 @@ COUNT(is_software_dev)
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [
             {
                 "result_format": ChartDataResultFormat.CSV,
@@ -2056,7 +2056,7 @@ COUNT(is_software_dev)
     }
 
 
-def test_apply_post_process_csv_format_empty_string():
+def test_apply_client_processing_csv_format_empty_string():
     """
     It should be able to process csv results with no data
     """
@@ -2122,13 +2122,13 @@ def test_apply_post_process_csv_format_empty_string():
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [{"result_format": ChartDataResultFormat.CSV, "data": ""}]
     }
 
 
 @pytest.mark.parametrize("data", [None, "", "\n"])
-def test_apply_post_process_csv_format_no_data(data):
+def test_apply_client_processing_csv_format_no_data(data):
     """
     It should be able to process csv results with no data
     """
@@ -2194,12 +2194,12 @@ def test_apply_post_process_csv_format_no_data(data):
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [{"result_format": ChartDataResultFormat.CSV, "data": data}]
     }
 
 
-def test_apply_post_process_csv_format_no_data_multiple_queries():
+def test_apply_client_processing_csv_format_no_data_multiple_queries():
     """
     It should be able to process csv results multiple queries if one query has no data
     """
@@ -2276,7 +2276,7 @@ COUNT(is_software_dev)
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [
             {"result_format": ChartDataResultFormat.CSV, "data": ""},
             {
@@ -2291,7 +2291,7 @@ COUNT(is_software_dev)
     }
 
 
-def test_apply_post_process_json_format_empty_string():
+def test_apply_client_processing_json_format_empty_string():
     """
     It should be able to process json results with no data
     """
@@ -2357,12 +2357,12 @@ def test_apply_post_process_json_format_empty_string():
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [{"result_format": ChartDataResultFormat.JSON, "data": ""}]
     }
 
 
-def test_apply_post_process_json_format_data_is_none():
+def test_apply_client_processing_json_format_data_is_none():
     """
     It should be able to process json results with no data
     """
@@ -2428,12 +2428,12 @@ def test_apply_post_process_json_format_data_is_none():
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data) == {
+    assert apply_client_processing(result, form_data) == {
         "queries": [{"result_format": ChartDataResultFormat.JSON, "data": None}]
     }
 
 
-def test_apply_post_process_verbose_map(session: Session):
+def test_apply_client_processing_verbose_map(session: Session):
     from superset import db
     from superset.connectors.sqla.models import SqlaTable, SqlMetric
     from superset.models.core import Database
@@ -2487,7 +2487,7 @@ def test_apply_post_process_verbose_map(session: Session):
         "result_type": "results",
     }
 
-    assert apply_post_process(result, form_data, datasource=sqla_table) == {
+    assert apply_client_processing(result, form_data, datasource=sqla_table) == {
         "queries": [
             {
                 "result_format": ChartDataResultFormat.JSON,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We have a function called `apply_post_process` that replicates the post-processing done in Javascript by different visualization types. This is needed for reports; for example, when sending a pivot table as a text we need to replicate the pivoting logic in Python, so that the report matches what the visualization shows.

The name is somewhat confusing, since we already have the concept of post-processing in visualizations. To make the difference more evident I renamed the method to `apply_client_processing`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
