### PR TITLE
fix: code scanning alert no. 1203: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/superset/utils/hashing.py
+++ b/superset/utils/hashing.py
@@ -20,8 +20,8 @@ from typing import Any, Callable, Optional
 from superset.utils import json
 
 
-def md5_sha_from_str(val: str) -> str:
-    return hashlib.md5(val.encode("utf-8")).hexdigest()
+def sha256_from_str(val: str) -> str:
+    return hashlib.sha256(val.encode("utf-8")).hexdigest()
 
 
 def md5_sha_from_dict(
@@ -33,4 +33,4 @@ def md5_sha_from_dict(
         obj, sort_keys=True, ignore_nan=ignore_nan, default=default, allow_nan=True
     )
 
-    return md5_sha_from_str(json_data)
+    return sha256_from_str(json_data)

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -805,7 +805,7 @@ class TestUtils(SupersetTestCase):
 
     def test_ssl_certificate_file_creation(self):
         path = create_ssl_cert_file(ssl_certificate)
-        expected_filename = md5_sha_from_str(ssl_certificate)
+        expected_filename = sha256_from_str(ssl_certificate)
         assert expected_filename in path
         assert os.path.exists(path)
 


### PR DESCRIPTION
Fixes [https://github.com/apache/superset/security/code-scanning/1203](https://github.com/apache/superset/security/code-scanning/1203)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger cryptographic hash function. In this case, SHA-256 is a suitable replacement as it is a strong and widely accepted cryptographic hash function.

- Replace the `hashlib.md5` function with `hashlib.sha256` in the `md5_sha_from_str` function.
- Ensure that the rest of the code that relies on this function continues to work as expected with the new hash function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
