### PR TITLE
feat: adds a github action to auto label draft prs

### DIFF
--- a/.github/actions/change-detector/label-draft-pr.yml
+++ b/.github/actions/change-detector/label-draft-pr.yml
@@ -1,0 +1,19 @@
+name: Label Draft PRs
+description: "Add `review:draft` label to pull requests that are opened as a draft or converted to a draft"
+on:
+  pull_request:
+    types:
+      - opened
+      - converted_to_draft
+jobs:
+  label-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Add `review:draft` Label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "review:draft"

--- a/.github/actions/change-detector/label-draft-pr.yml
+++ b/.github/actions/change-detector/label-draft-pr.yml
@@ -1,5 +1,4 @@
 name: Label Draft PRs
-description: "Add `review:draft` label to pull requests that are opened as a draft or converted to a draft"
 on:
   pull_request:
     types:
@@ -9,10 +8,15 @@ jobs:
   label-draft:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
+      - name: Check if the PR is a draft
+        id: check-draft
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const isDraft = context.payload.pull_request.draft;
+            core.setOutput('isDraft', isDraft);
       - name: Add `review:draft` Label
+        if: steps.check-draft.outputs.isDraft == 'true'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a github action that will auto-label a pr with `review:draft` either when a PR is created as a draft or if a PR gets converted to a draft.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
