### PR TITLE
feat(doris): add catalog support for Apache Doris

### DIFF
--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -251,7 +251,7 @@ class DorisEngineSpec(MySQLEngineSpec):
         if uri.database and "." in uri.database:
             current_catalog, _ = uri.database.split(".", 1)
         else:
-            current_catalog = uri.database
+            current_catalog = "internal"
 
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -22,11 +22,13 @@ from urllib import parse
 
 from flask_babel import gettext as __
 from sqlalchemy import Float, Integer, Numeric, String, TEXT, types
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql.type_api import TypeEngine
 
 from superset.db_engine_specs.mysql import MySQLEngineSpec
 from superset.errors import SupersetErrorType
+from superset.models.core import Database
 from superset.utils.core import GenericDataType
 
 # Regular expressions to catch custom errors
@@ -111,6 +113,7 @@ class DorisEngineSpec(MySQLEngineSpec):
     )
     encryption_parameters = {"ssl": "0"}
     supports_dynamic_schema = True
+    supports_catalog = supports_dynamic_catalog = True
 
     column_type_mappings = (  # type: ignore
         (
@@ -245,16 +248,44 @@ class DorisEngineSpec(MySQLEngineSpec):
         catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> tuple[URL, dict[str, Any]]:
-        database = uri.database
-        if schema and database:
-            schema = parse.quote(schema, safe="")
-            if "." in database:
-                database = database.split(".")[0] + "." + schema
-            else:
-                database = "internal." + schema
-            uri = uri.set(database=database)
+        if uri.database and "." in uri.database:
+            current_catalog, _ = uri.database.split(".", 1)
+        else:
+            current_catalog = uri.database
 
+        # In Apache Doris, each catalog has an information_schema for BI tool
+        # compatibility. See: https://github.com/apache/doris/pull/28919
+        adjusted_database = ".".join(
+            [catalog or current_catalog or "", "information_schema"]
+        ).rstrip(".")
+
+        uri = uri.set(database=adjusted_database)
         return uri, connect_args
+
+    @classmethod
+    def get_default_catalog(cls, database: Database) -> Optional[str]:
+        """
+        Return the default catalog.
+        """
+        if database.url_object.database is None:
+            return None
+
+        return database.url_object.database.split(".")[0]
+
+    @classmethod
+    def get_catalog_names(
+        cls,
+        database: Database,
+        inspector: Inspector,
+    ) -> set[str]:
+        """
+        Get all catalogs.
+        For Doris, the SHOW CATALOGS command returns multiple columns:
+        CatalogId, CatalogName, Type, IsCurrent, CreateTime, LastUpdateTime, Comment
+        We need to extract just the CatalogName column.
+        """
+        result = inspector.bind.execute("SHOW CATALOGS")
+        return {row.CatalogName for row in result}
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -258,7 +258,7 @@ class DorisEngineSpec(MySQLEngineSpec):
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919
         schema = schema or "information_schema"
-        database = ".".join([catalog or "", schema])
+        database = ".".join([catalog, schema])
         uri = uri.set(database=database)
         return uri, connect_args
 

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -257,7 +257,10 @@ class DorisEngineSpec(MySQLEngineSpec):
 
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919
-        adjusted_database = ".".join([catalog or "", "information_schema"])
+        if schema:
+            adjusted_database = ".".join([catalog or "", schema])
+        else:
+            adjusted_database = ".".join([catalog or "", "information_schema"])
         uri = uri.set(database=adjusted_database)
         return uri, connect_args
 

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -257,11 +257,9 @@ class DorisEngineSpec(MySQLEngineSpec):
 
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919
-        if schema:
-            adjusted_database = ".".join([catalog or "", schema])
-        else:
-            adjusted_database = ".".join([catalog or "", "information_schema"])
-        uri = uri.set(database=adjusted_database)
+        schema = schema or "information_schema"
+        database = ".".join([catalog or "", schema])
+        uri = uri.set(database=database)
         return uri, connect_args
 
     @classmethod

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -258,7 +258,7 @@ class DorisEngineSpec(MySQLEngineSpec):
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919
         schema = schema or "information_schema"
-        database = ".".join([catalog, schema])
+        database = ".".join([catalog or "", schema])
         uri = uri.set(database=database)
         return uri, connect_args
 

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -248,17 +248,16 @@ class DorisEngineSpec(MySQLEngineSpec):
         catalog: Optional[str] = None,
         schema: Optional[str] = None,
     ) -> tuple[URL, dict[str, Any]]:
-        if uri.database and "." in uri.database:
-            current_catalog, _ = uri.database.split(".", 1)
+        if catalog:
+            pass
+        elif uri.database and "." in uri.database:
+            catalog, _ = uri.database.split(".", 1)
         else:
-            current_catalog = "internal"
+            catalog = "internal"
 
         # In Apache Doris, each catalog has an information_schema for BI tool
         # compatibility. See: https://github.com/apache/doris/pull/28919
-        adjusted_database = ".".join(
-            [catalog or current_catalog or "", "information_schema"]
-        ).rstrip(".")
-
+        adjusted_database = ".".join([catalog or "", "information_schema"])
         uri = uri.set(database=adjusted_database)
         return uri, connect_args
 

--- a/tests/unit_tests/db_engine_specs/test_doris.py
+++ b/tests/unit_tests/db_engine_specs/test_doris.py
@@ -86,25 +86,25 @@ def test_get_column_spec(
         (
             "doris://user:password@host/db1",
             {"param1": "some_value"},
-            "db1",
+            "internal.information_schema",
             {"param1": "some_value"},
         ),
         (
             "pydoris://user:password@host/db1",
             {"param1": "some_value"},
-            "db1",
+            "internal.information_schema",
             {"param1": "some_value"},
         ),
         (
             "doris://user:password@host/catalog1.db1",
             {"param1": "some_value"},
-            "catalog1.db1",
+            "catalog1.information_schema",
             {"param1": "some_value"},
         ),
         (
             "pydoris://user:password@host/catalog1.db1",
             {"param1": "some_value"},
-            "catalog1.db1",
+            "catalog1.information_schema",
             {"param1": "some_value"},
         ),
     ],
@@ -121,6 +121,11 @@ def test_adjust_engine_params(
     returned_url, returned_connect_args = DorisEngineSpec.adjust_engine_params(
         url, connect_args
     )
+    # # Update expected schema to include .information_schema
+    # if return_schema not in ".":
+    #     expected_schema = f"{return_schema}.information_schema"
+    # else:
+    #     expected_schema = return_schema
     assert returned_url.database == return_schema
     assert returned_connect_args == return_connect_args
 


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add catalog for apache doris
In Apache Doris, in order to be compatible with different BI tools, we have information_schema for each catalog. When no catalog is specified, the default catalog is internal. This feature corresponds to this PR of Doris, https://github.com/apache/doris/pull/28919
<img width="329" alt="image" src="https://github.com/user-attachments/assets/a7e2a230-b94f-42c0-bcda-ccb09a1199b6" />

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
