### PR TITLE
fix: install uv in docker-bootstrap

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -18,6 +18,9 @@
 
 set -eo pipefail
 
+# UV may not be installed in older images
+pip install uv
+
 # Make python interactive
 if [ "$DEV_MODE" == "true" ]; then
     echo "Reinstalling the app in editable mode"

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -121,6 +121,13 @@ Here various release tags, github SHA, and latest `master` can be referenced by 
 Refer to the docker-related documentation to learn more about existing tags you can point to
 from Docker Hub.
 
+:::note
+For option #2 and #3, we recommend checking out the release tag from the better repository
+(ie: `git checkout 4.0.0`) for more guaranteed results. This ensures that the `docker-compose.*.yml`
+configurations and that the mounted `docker/` scripts are in sync with the image you are
+looking to fire up.
+:::
+
 ## `docker compose` tips & configuration
 
 :::caution


### PR DESCRIPTION
closes https://github.com/apache/superset/issues/31510

When using docker-compose-non-dev.yml or docker-compose.yml, we mount the `docker/` directory in the container. This means we use the logic in the docker-related scripts from whatever branch the user has checked out locally into the container, and. Since `uv` was introduced recently, older images don't have it, and the script fail.

Here to unblock I'm adding `pip install uv` to the bootstrap script, which should enable things to run.

Moving forward, it'd be better if docker-compose would NOT mount the `docker/` directory, and instead use the `docker/` directory from the image. This would ensure that the scripts are always in sync with the image. This is a bit more involved, so I'm going with the simpler fix for now. This also requires having the right entrypoints / CMD instruciton set IN the image. Unclear how whether it's setup ok in older releases, would require pulling each release branch and looking into the entrypoints/CMD instructions in their respective Dockerfiles.
