### PR TITLE
feat: reduce some filter width in list views

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Base.ts
+++ b/superset-frontend/src/components/ListView/Filters/Base.ts
@@ -25,11 +25,17 @@ export interface BaseFilter {
   initialValue: any;
 }
 
-export const FilterContainer = styled.div`
+// Define the prop type to include `width`
+interface FilterContainerProps {
+  width?: number; // Optional width prop
+}
+
+// Update styled.div to accept props
+export const FilterContainer = styled.div<FilterContainerProps>`
   display: inline-flex;
   font-size: ${({ theme }) => theme.typography.sizes.s}px;
   align-items: center;
-  width: ${SELECT_WIDTH}px;
+  width: ${({ width }) => (width ? `${width}px` : `${SELECT_WIDTH}px`)};
 `;
 
 export type FilterHandler = {

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -47,6 +47,7 @@ function SelectFilter(
     initialValue,
     onSelect,
     selects = [],
+    width,
   }: SelectFilterProps,
   ref: RefObject<FilterHandler>,
 ) {
@@ -86,9 +87,9 @@ function SelectFilter(
     },
     [fetchSelects],
   );
-
+  const placeholder = t('Select...');
   return (
-    <FilterContainer>
+    <FilterContainer width={width}>
       {fetchSelects ? (
         <AsyncSelect
           allowClear
@@ -98,7 +99,8 @@ function SelectFilter(
           onChange={onChange}
           onClear={onClear}
           options={fetchAndFormatSelects}
-          placeholder={t('Select or type a value')}
+          placeholder={placeholder}
+          popupMatchSelectWidth={false}
           showSearch
           value={selectedOption}
         />
@@ -108,11 +110,12 @@ function SelectFilter(
           ariaLabel={typeof Header === 'string' ? Header : name || t('Filter')}
           data-test="filters-select"
           header={<FormLabel>{Header}</FormLabel>}
+          popupMatchSelectWidth={false}
           labelInValue
           onChange={onChange}
           onClear={onClear}
           options={selects}
-          placeholder={t('Select or type a value')}
+          placeholder={placeholder}
           showSearch
           value={selectedOption}
         />

--- a/superset-frontend/src/components/ListView/Filters/Select.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Select.tsx
@@ -37,6 +37,7 @@ interface SelectFilterProps extends BaseFilter {
   onSelect: (selected: SelectOption | undefined, isClear?: boolean) => void;
   paginate?: boolean;
   selects: Filter['selects'];
+  width?: number;
 }
 
 function SelectFilter(
@@ -100,7 +101,6 @@ function SelectFilter(
           onClear={onClear}
           options={fetchAndFormatSelects}
           placeholder={placeholder}
-          popupMatchSelectWidth={false}
           showSearch
           value={selectedOption}
         />
@@ -110,7 +110,6 @@ function SelectFilter(
           ariaLabel={typeof Header === 'string' ? Header : name || t('Filter')}
           data-test="filters-select"
           header={<FormLabel>{Header}</FormLabel>}
-          popupMatchSelectWidth={false}
           labelInValue
           onChange={onChange}
           onClear={onClear}

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -60,7 +60,6 @@ function UIFilters(
       });
     },
   }));
-
   return (
     <>
       {filters.map(
@@ -75,6 +74,7 @@ function UIFilters(
             selects,
             toolTipDescription,
             onFilterUpdate,
+            width,
           },
           index,
         ) => {
@@ -103,6 +103,7 @@ function UIFilters(
                 }}
                 paginate={paginate}
                 selects={selects}
+                width={width}
               />
             );
           }

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -59,6 +59,7 @@ export interface Filter {
     pageSize: number,
   ) => Promise<{ data: SelectOption[]; totalCount: number }>;
   paginate?: boolean;
+  width?: number;
 }
 
 export type Filters = Filter[];

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -601,7 +601,6 @@ const Select = forwardRef(
       }
       fireOnChange();
     };
-
     return (
       <StyledContainer headerPosition={headerPosition}>
         {header && (

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -562,6 +562,7 @@ function ChartList(props: ChartListProps) {
         { label: t('Yes'), value: true },
         { label: t('No'), value: false },
       ],
+      width: 100,
     }),
     [],
   );
@@ -600,6 +601,7 @@ function ChartList(props: ChartListProps) {
 
             return 0;
           }),
+        width: 150,
       },
       {
         Header: t('Dataset'),
@@ -669,6 +671,7 @@ function ChartList(props: ChartListProps) {
           { label: t('Yes'), value: true },
           { label: t('No'), value: false },
         ],
+        width: 100,
       },
       {
         Header: t('Modified by'),

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -647,6 +647,7 @@ function ChartList(props: ChartListProps) {
           props.user,
         ),
         paginate: true,
+        width: 150,
       },
       {
         Header: t('Dashboard'),

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -512,6 +512,7 @@ function DashboardList(props: DashboardListProps) {
         { label: t('Yes'), value: true },
         { label: t('No'), value: false },
       ],
+      width: 100,
     }),
     [],
   );
@@ -585,6 +586,7 @@ function DashboardList(props: DashboardListProps) {
           { label: t('Yes'), value: true },
           { label: t('No'), value: false },
         ],
+        width: 100,
       },
       {
         Header: t('Modified by'),

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -532,6 +532,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           { label: t('Virtual'), value: false },
           { label: t('Physical'), value: true },
         ],
+        width: 100,
       },
       {
         Header: t('Database'),
@@ -597,6 +598,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           { label: t('Yes'), value: true },
           { label: t('No'), value: false },
         ],
+        width: 100,
       },
       {
         Header: t('Modified by'),


### PR DESCRIPTION
Currently in our CRUD list views (dashboards, charts, datasets) we use a fixed width of 200px for all filters, regardless of their content. This leads to some filter rows overflowing depending on use screen width. Here I'm setting some of the filters to be thinner, preventing filters from wrapping into 2 rows.

In the future version of antd, we'll be able to shrink all filters to thinner width with `popupMatchSelectWidth={false}`, allowing for the dropdown width to be wider than the input box.

### before
<img width="1712" alt="Screenshot 2024-12-23 at 1 09 14 AM" src="https://github.com/user-attachments/assets/d57da533-ce9d-403a-89cd-c82a8a8c4000" />

### after
<img width="1705" alt="Screenshot 2024-12-23 at 1 04 27 AM" src="https://github.com/user-attachments/assets/3f7c5bcc-803b-421c-9fec-9af85ddd7dd1" />