### PR TITLE
fix: docker-compose-image-tag fails to start

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   setup_matrix:
     runs-on: ubuntu-24.04
     outputs:
@@ -24,29 +25,6 @@ jobs:
           MATRIX_CONFIG=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo '["dev", "lean"]'; else echo '["dev", "lean", "py310", "websocket", "dockerize", "py311"]'; fi)
           echo "matrix_config=${MATRIX_CONFIG}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
-
-  docker-compose-image-tag:
-    needs: setup_matrix
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check for file changes
-        id: check
-        uses: ./.github/actions/change-detector/
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Docker Environment
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
-        uses: ./.github/actions/setup-docker
-        with:
-          dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          build: "false"
-          install-docker-compose: "true"
-      - name: docker-compose sanity check
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
-        shell: bash
-        run: |
-          docker compose --exit-code-from superset-init -f docker-compose-image-tag.yml up
 
   docker-build:
     name: docker-build
@@ -126,3 +104,25 @@ jobs:
           export SUPERSET_BUILD_TARGET=${{ matrix.build_preset }}
           docker compose build superset-init --build-arg DEV_MODE=false --build-arg INCLUDE_CHROMIUM=false
           docker compose up superset-init --exit-code-from superset-init
+
+  docker-compose-image-tag:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Docker Environment
+        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        uses: ./.github/actions/setup-docker
+        with:
+          dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          build: "false"
+          install-docker-compose: "true"
+      - name: docker-compose sanity check
+        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        shell: bash
+        run: |
+          docker compose --exit-code-from superset-init -f docker-compose-image-tag.yml up

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Docker Environment
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        if: steps.check.outputs.docker
         uses: ./.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
@@ -126,7 +126,7 @@ jobs:
           build: "false"
           install-docker-compose: "true"
       - name: docker-compose sanity check
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        if: steps.check.outputs.docker
         shell: bash
         run: |
-          docker compose --exit-code-from superset-init -f docker-compose-image-tag.yml up
+          docker compose -f docker-compose-image-tag.yml up --exit-code-from superset-init

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,11 @@ jobs:
     needs: setup_matrix
     runs-on: ubuntu-24.04
     steps:
+      - name: Check for file changes
+        id: check
+        uses: ./.github/actions/change-detector/
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Docker Environment
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,6 +108,10 @@ jobs:
   docker-compose-image-tag:
     runs-on: ubuntu-24.04
     steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Check for file changes
         id: check
         uses: ./.github/actions/change-detector/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,24 @@ jobs:
           echo "matrix_config=${MATRIX_CONFIG}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
 
+  docker-compose-image-tag:
+    needs: setup_matrix
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Docker Environment
+        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        uses: ./.github/actions/setup-docker
+        with:
+          dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          build: "false"
+          install-docker-compose: "true"
+      - name: docker-compose sanity check
+        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        shell: bash
+        run: |
+          docker compose --exit-code-from superset-init -f docker-compose-image-tag.yml up
+
   docker-build:
     name: docker-build
     needs: setup_matrix

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -18,13 +18,12 @@
 
 set -eo pipefail
 
-# UV may not be installed in older images
-pip install uv
-
 # Make python interactive
 if [ "$DEV_MODE" == "true" ]; then
-    echo "Reinstalling the app in editable mode"
-    uv pip install -e .
+    if command -v uv > /dev/null 2>&1; then
+      echo "Reinstalling the app in editable mode"
+      uv pip install -e .
+    fi
 fi
 REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
 # If Cypress run – overwrite the password for admin and export env variables
@@ -35,7 +34,13 @@ if [ "$CYPRESS_CONFIG" == "true" ]; then
 fi
 if [[ "$DATABASE_DIALECT" == postgres* ]] ; then
     echo "Installing postgres requirements"
-    uv pip install -e .[postgres]
+    if command -v uv > /dev/null 2>&1; then
+        # Use uv in newer images
+        uv pip install -e .[postgres]
+    else
+        # Use pip in older images
+        pip install -e .[postgres]
+    fi
 fi
 #
 # Make sure we have dev requirements installed

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -40,7 +40,7 @@ PATTERNS = {
     ],
     "docker": [
         r"^Dockerfile$",
-        r"^docker/",
+        r"^docker.*",
     ],
     "docs": [
         r"^docs/",

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -34,8 +34,7 @@ from superset.security import SupersetSecurityManager  # noqa: F401
 # All of the fields located here should be considered legacy. The correct way
 # to declare "global" dependencies is to define it in extensions.py,
 # then initialize it in app.create_app(). These fields will be removed
-# in subsequent PRs as things are migrated towards the factory
-# pattern
+# in subsequent PRs as things are migrated towards the factory pattern
 app: Flask = current_app
 cache = cache_manager.cache
 conf = LocalProxy(lambda: current_app.config)

--- a/superset/__init__.py
+++ b/superset/__init__.py
@@ -34,7 +34,8 @@ from superset.security import SupersetSecurityManager  # noqa: F401
 # All of the fields located here should be considered legacy. The correct way
 # to declare "global" dependencies is to define it in extensions.py,
 # then initialize it in app.create_app(). These fields will be removed
-# in subsequent PRs as things are migrated towards the factory pattern
+# in subsequent PRs as things are migrated towards the factory
+# pattern
 app: Flask = current_app
 cache = cache_manager.cache
 conf = LocalProxy(lambda: current_app.config)


### PR DESCRIPTION
Recently I did some work to use `uv pip install` in place of plain `pip` in our docker images. This made builds significantly faster, but broke compatibility between some docker compose setups.

The issue is around the fact that `docker-compose-image-tag` mounts the local, newer, docker bootstrap scripts into the image, and those have evolve to use `uv`, which isn't installed in the image.

One option would be to not mount the docker folder and use what's in the image, but I believe some of the script may have changed names or location, and `docker-compose-image-tag` specifies their location as it passes arguments to them.

In any case, and at least for now, I decided to simply conditionally use uv or plain pip in the docker scripts based on what's installed in the image.

Also added a CI step to make sure `docker compose -f docker-compose-image-tag.yml up` works.

Closes https://github.com/apache/superset/issues/31600
