### PR TITLE
chore: replace `imp` built-in module usage for future Python3.12 usage

### DIFF
--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -18,7 +18,7 @@
 """Unit tests for Superset"""
 
 from datetime import datetime
-import importlib.util
+from importlib.util import find_spec
 from contextlib import contextmanager
 from typing import Any, Union, Optional
 from unittest.mock import Mock, patch, MagicMock
@@ -258,7 +258,7 @@ class SupersetTestCase(TestCase):
     @staticmethod
     def is_module_installed(module_name: str) -> bool:
         try:
-            spec = importlib.util.find_spec(module_name)
+            spec = find_spec(module_name)
             return spec is not None
         except ImportError:
             return False

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -260,7 +260,7 @@ class SupersetTestCase(TestCase):
         try:
             spec = find_spec(module_name)
             return spec is not None
-        except ImportError:
+        except (ModuleNotFoundError, ValueError, TypeError, ImportError):
             return False
 
     def get_or_create(self, cls, criteria, **kwargs):

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -18,7 +18,7 @@
 """Unit tests for Superset"""
 
 from datetime import datetime
-import imp
+import importlib.util
 from contextlib import contextmanager
 from typing import Any, Union, Optional
 from unittest.mock import Mock, patch, MagicMock
@@ -256,10 +256,10 @@ class SupersetTestCase(TestCase):
         return db.session.query(SqlaTable).filter_by(id=table_id).one()
 
     @staticmethod
-    def is_module_installed(module_name):
+    def is_module_installed(module_name: str) -> bool:
         try:
-            imp.find_module(module_name)
-            return True
+            spec = importlib.util.find_spec(module_name)
+            return spec is not None
         except ImportError:
             return False
 


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(test/integration): replace `imp` built-in module usage for future Python3.12 usage

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`imp` module is deprecated in Python 3.4 and removed in Python3.12. This replacement will help with extending Superset support for Python3.12 in the future

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
This should pass CI checks

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
