### PR TITLE
fix: typo in plugin-chart-echats controls

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -306,7 +306,7 @@ export const truncateXAxis: ControlSetItem = {
     default: DEFAULT_FORM_DATA.truncateXAxis,
     renderTrigger: true,
     description: t(
-      'Truncate X Axis. Can be overridden by specifying a min or max bound. Only applicable for numercal X axis.',
+      'Truncate X Axis. Can be overridden by specifying a min or max bound. Only applicable for numerical X axis.',
     ),
   },
 };

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -12140,7 +12140,7 @@ msgstr "اقتطاع المحور X"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "قم باقتطاع المحور X. يمكن تجاوزه عن طريق تحديد حد أدنى أو حد أقصى. ينطبق "
 "فقط على المحور X الرقمي."

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -12482,7 +12482,7 @@ msgstr "X-Achse abschneiden"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "X-Achse abschneiden. Kann durch Angabe einer Minimal- oder Maximalgrenze "
 "außer Kraft gesetzt werden. Nur anwendbar für numerische X-Achsen."

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -11222,7 +11222,7 @@ msgstr ""
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -12536,7 +12536,7 @@ msgstr "Truncar el eje Y"
 #, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "Truncar el eje Y. Puede ser sobreescrito al especificar un límite máximo "
 "o mínimo"

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -13309,7 +13309,7 @@ msgstr "Trier les métriques"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "Marquer une colonne comme temporelle dans le modal «Modifier la source de"
 " données»"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -12026,7 +12026,7 @@ msgstr "Mostra metrica"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -11590,7 +11590,7 @@ msgstr "X 軸の切り詰め"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr "X 軸を切り詰めます。最小値または最大値の境界を指定することでオーバーライドできます。数値 X 軸にのみ適用されます。"
 
 msgid "Truncate Y Axis"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -11884,7 +11884,7 @@ msgstr "메트릭"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -11210,7 +11210,7 @@ msgstr ""
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -12325,7 +12325,7 @@ msgstr "X-as Afkappen"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "X-as afkappen. Kan worden overschreven door het specificeren van een min "
 "of max grens. Alleen van toepassing op numerieke X assen."

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -12226,7 +12226,7 @@ msgstr "Selecione métrica"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -12428,7 +12428,7 @@ msgstr "Truncar Eixo Y"
 #, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "Truncar Eixo Y. Pode ser substituído pela especificação de um limite "
 "mínimo ou máximo."

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -12187,7 +12187,7 @@ msgstr "Ограничить ось X"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr "Ограничивает ось X. Применимо только к числовой оси."
 
 msgid "Truncate Y Axis"

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -11313,7 +11313,7 @@ msgstr ""
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -12174,7 +12174,7 @@ msgstr "Prireži X-os"
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "Prireži X-os. Če določite spodnjo ali zgornjo mejo, preprečite "
 "prirezovanje. Deluje samo za numerično X os."

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -11286,7 +11286,7 @@ msgstr ""
 
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 
 msgid "Truncate Y Axis"

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -12299,7 +12299,7 @@ msgstr "Укорочення y вісь"
 #, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr ""
 "Укоротився вісь. Можна перекрити, вказавши мінімальну або максимальну "
 "межу."

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -12032,7 +12032,7 @@ msgstr "截断X轴"
 #, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr "截断X轴。可以通过指定最小或最大界限来重写。"
 
 msgid "Truncate Y Axis"

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -12046,7 +12046,7 @@ msgstr "截斷 X 軸"
 #, fuzzy
 msgid ""
 "Truncate X Axis. Can be overridden by specifying a min or max bound. Only"
-" applicable for numercal X axis."
+" applicable for numerical X axis."
 msgstr "截斷 X 軸。可以通過指定最小或最大界限來重寫。"
 
 msgid "Truncate Y Axis"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Basic typo fix

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="348" alt="Screenshot 2025-01-01 at 18 01 49" src="https://github.com/user-attachments/assets/0511568f-4392-471b-bfed-5fefc8d8300d" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
