### PR TITLE
chore: refactor for uplifting react-error-boundary to v5

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -45379,13 +45379,6 @@
         "react-dom": ">= 16.3.0"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "1.2.5",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.0.0-beta.1"
-      }
-    },
     "node_modules/react-hot-loader": {
       "version": "4.13.1",
       "license": "MIT",
@@ -55666,7 +55659,7 @@
         "lodash": "^4.17.21",
         "math-expression-evaluator": "^1.3.8",
         "pretty-ms": "^9.2.0",
-        "react-error-boundary": "^1.2.5",
+        "react-error-boundary": "^5.0.0",
         "react-markdown": "^8.0.7",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
@@ -56104,6 +56097,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/superset-ui-core/node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "packages/superset-ui-core/node_modules/remark-gfm": {
@@ -66521,7 +66526,7 @@
         "lodash": "^4.17.21",
         "math-expression-evaluator": "^1.3.8",
         "pretty-ms": "^9.2.0",
-        "react-error-boundary": "^1.2.5",
+        "react-error-boundary": "^5.0.0",
         "react-markdown": "^8.0.7",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
@@ -66805,6 +66810,14 @@
             "micromark-util-symbol": "^1.0.0",
             "micromark-util-types": "^1.0.0",
             "uvu": "^0.5.0"
+          }
+        },
+        "react-error-boundary": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+          "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5"
           }
         },
         "remark-gfm": {
@@ -90604,10 +90617,6 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.8.1"
       }
-    },
-    "react-error-boundary": {
-      "version": "1.2.5",
-      "requires": {}
     },
     "react-hot-loader": {
       "version": "4.13.1",

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.21",
     "math-expression-evaluator": "^1.3.8",
     "pretty-ms": "^9.2.0",
-    "react-error-boundary": "^1.2.5",
+    "react-error-boundary": "^5.0.0",
     "react-markdown": "^8.0.7",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -25,7 +25,8 @@ import {
   Fragment,
 } from 'react';
 
-import ErrorBoundary, {
+import {
+  ErrorBoundary,
   ErrorBoundaryProps,
   FallbackProps,
 } from 'react-error-boundary';
@@ -46,7 +47,9 @@ const defaultProps = {
   enableNoResults: true,
 };
 
-export type FallbackPropsWithDimension = FallbackProps & Partial<Dimension>;
+export type FallbackPropsWithDimension = FallbackProps & {
+  componentStack?: string;
+} & Partial<Dimension>;
 
 export type WrapperProps = Dimension & {
   children: ReactNode;

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/FallbackComponent.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/FallbackComponent.test.tsx
@@ -24,7 +24,7 @@ import { ThemeProvider, supersetTheme } from '../../../src/style';
 
 import FallbackComponent from '../../../src/chart/components/FallbackComponent';
 
-const renderWithTheme = (props: FallbackProps) =>
+const renderWithTheme = (props: FallbackProps & { componentStack?: string }) =>
   render(
     <ThemeProvider theme={supersetTheme}>
       <FallbackComponent {...props} />
@@ -38,23 +38,34 @@ test('renders error and stack trace', () => {
   const { getByText } = renderWithTheme({
     componentStack: STACK_TRACE,
     error: ERROR,
+    resetErrorBoundary: jest.fn(),
   });
   expect(getByText('Error: CaffeineOverLoadException')).toBeInTheDocument();
   expect(getByText('Error at line 1: x.drink(coffee)')).toBeInTheDocument();
 });
 
 test('renders error only', () => {
-  const { getByText } = renderWithTheme({ error: ERROR });
+  const { getByText } = renderWithTheme({
+    error: ERROR,
+    resetErrorBoundary: jest.fn(),
+  });
   expect(getByText('Error: CaffeineOverLoadException')).toBeInTheDocument();
 });
 
 test('renders stacktrace only', () => {
-  const { getByText } = renderWithTheme({ componentStack: STACK_TRACE });
+  const { getByText } = renderWithTheme({
+    componentStack: STACK_TRACE,
+    error: undefined,
+    resetErrorBoundary: jest.fn(),
+  });
   expect(getByText('Unknown Error')).toBeInTheDocument();
   expect(getByText('Error at line 1: x.drink(coffee)')).toBeInTheDocument();
 });
 
 test('renders when nothing is given', () => {
-  const { getByText } = renderWithTheme({});
+  const { getByText } = renderWithTheme({
+    error: undefined,
+    resetErrorBoundary: jest.fn(),
+  });
   expect(getByText('Unknown Error')).toBeInTheDocument();
 });

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
@@ -20,7 +20,7 @@
 import { ReactElement } from 'react';
 import mockConsole, { RestoreConsole } from 'jest-mock-console';
 import { triggerResizeObserver } from 'resize-observer-polyfill';
-import ErrorBoundary from 'react-error-boundary';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import {
   promiseTimeout,
@@ -165,7 +165,7 @@ describe('SuperChart', () => {
       const inactiveErrorHandler = jest.fn();
       const activeErrorHandler = jest.fn();
       mount(
-        <ErrorBoundary onError={activeErrorHandler}>
+        <ErrorBoundary onError={activeErrorHandler} fallbackRender={() => null}>
           <SuperChart
             disableErrorBoundary
             chartType={ChartKeys.BUGGY}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `componentStack` attribute in `FallbackProps` type has been removed in [v3](https://github.com/bvaughn/react-error-boundary/releases/tag/v3.0.0) but since there's a need to render the stack trace as a React component, I decided to extend the type with removed attribute to avoid breaking backwards.

Fixes #31671
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
CI and `npm run build` passed with colors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
