### PR TITLE
refactor(theme): Move colors to lightConfig

### DIFF
--- a/superset-frontend/src/theme/light.ts
+++ b/superset-frontend/src/theme/light.ts
@@ -18,6 +18,7 @@
  */
 
 import { type MappingAlgorithm, theme } from 'antd-v5';
+import { ThemeConfig } from 'antd-v5/lib';
 import { theme as supersetTheme } from 'src/preamble';
 
 export const lightAlgorithm: MappingAlgorithm = seedToken => {
@@ -116,4 +117,71 @@ export const lightAlgorithm: MappingAlgorithm = seedToken => {
 
     lineWidthBold: supersetTheme.gridUnit / 2,
   };
+};
+
+export const lightConfig: ThemeConfig = {
+  token: {
+    colorBgBase: supersetTheme.colors.primary.light4,
+    colorError: supersetTheme.colors.error.base,
+    colorInfo: supersetTheme.colors.info.base,
+    colorLink: supersetTheme.colors.grayscale.dark1,
+    colorPrimary: supersetTheme.colors.primary.base,
+    colorSuccess: supersetTheme.colors.success.base,
+    colorTextBase: supersetTheme.colors.grayscale.dark2,
+    colorWarning: supersetTheme.colors.warning.base,
+  },
+  components: {
+    Alert: {
+      colorBgContainer: supersetTheme.colors.grayscale.light5,
+      colorBorder: supersetTheme.colors.grayscale.light3,
+      colorText: supersetTheme.colors.grayscale.dark1,
+    },
+    Card: {
+      colorBgContainer: supersetTheme.colors.grayscale.light4,
+    },
+    Divider: {
+      colorSplit: supersetTheme.colors.grayscale.light3,
+    },
+    Input: {
+      colorBorder: supersetTheme.colors.secondary.light3,
+      colorBgContainer: supersetTheme.colors.grayscale.light5,
+      activeShadow: `0 0 0 ${supersetTheme.gridUnit / 2}px ${
+        supersetTheme.colors.primary.light3
+      }`,
+    },
+    InputNumber: {
+      colorBorder: supersetTheme.colors.secondary.light3,
+      colorBgContainer: supersetTheme.colors.grayscale.light5,
+      activeShadow: `0 0 0 ${supersetTheme.gridUnit / 2}px ${
+        supersetTheme.colors.primary.light3
+      }`,
+    },
+    List: {
+      colorSplit: supersetTheme.colors.grayscale.light3,
+      colorText: supersetTheme.colors.grayscale.dark1,
+    },
+    Modal: {
+      colorBgMask: `${supersetTheme.colors.grayscale.dark2}73`,
+      contentBg: supersetTheme.colors.grayscale.light5,
+      titleColor: `${supersetTheme.colors.grayscale.dark2}D9`,
+      headerBg: supersetTheme.colors.grayscale.light4,
+    },
+    Tag: {
+      defaultBg: supersetTheme.colors.grayscale.light4,
+    },
+    Progress: {
+      fontSize: supersetTheme.typography.sizes.s,
+    },
+    Popover: {
+      colorBgElevated: supersetTheme.colors.grayscale.light5,
+    },
+    Slider: {
+      trackBgDisabled: supersetTheme.colors.grayscale.light1,
+      colorBgElevated: supersetTheme.colors.grayscale.light5,
+    },
+    Switch: {
+      colorPrimaryHover: supersetTheme.colors.primary.base,
+      colorTextTertiary: supersetTheme.colors.grayscale.light1,
+    },
+  },
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Current implementation of Ant Design theme is based on Superset having a single light theme. To enable theming capabilities colors need to be seperated to their own lightConfig. This pr aims to do that. After this, adding a dark mode can be done by copying the light theme and changing colors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the tests and visually check if there are any regressions.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
