### PR TITLE
fix(export): charts csv export in dashboards

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -376,16 +376,13 @@ const Chart = props => {
     ],
   );
 
-  const exportCSV = useCallback(
-    (isFullCSV = false) => {
-      exportTable('csv', isFullCSV);
-    },
-    [exportTable],
-  );
+  const exportCSV = useCallback(() => {
+    exportTable('csv', false);
+  }, [exportTable]);
 
   const exportFullCSV = useCallback(() => {
-    exportCSV(true);
-  }, [exportCSV]);
+    exportTable('csv', true);
+  }, [exportTable]);
 
   const exportPivotCSV = useCallback(() => {
     exportTable('csv', false, true);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When doing a CSV export of a chart in a dashboard, it's always a fullCSV, instead of a "standard" export, even if parameter ALLOW_FULL_CSV_EXPORT is False

### BEFORE/AFTER SCREENSHOTS
Before: ROW_LIMIT set to 100, export is over 100000 lines
![image](https://github.com/user-attachments/assets/eabd2337-d9e2-48e6-9601-133f00026cce)

After: Before: ROW_LIMIT set to 100, export is 100 lines (101 here because of the header)
![image](https://github.com/user-attachments/assets/2e26ad3b-2253-4349-98f5-1269b315d454)


### TESTING INSTRUCTIONS
- open a dashboard
- do a CSV export of a chart with a request returning more than ROW_LIMIT

![image](https://github.com/user-attachments/assets/7bfb85cf-a6c4-44ba-ad9a-101bf9a1ebb5)
**number of lines is over the limit**

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
