### PR TITLE
fix: docker builds in forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,16 +77,12 @@ jobs:
           fi
 
           supersetbot docker \
-            --push \
+            --load \
             --preset ${{ matrix.build_preset }} \
             --context "$EVENT" \
             --context-ref "$RELEASE" $FORCE_LATEST \
             --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
             $PLATFORM_ARG
-
-      - name: Docker pull
-        if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
-        run:  docker pull apache/superset:GHA-${GITHUB_RUN_ID}
 
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
@@ -96,6 +92,10 @@ jobs:
           echo "IMAGE: $IMAGE_ID"
           docker images $IMAGE_ID
           docker history $IMAGE_ID
+
+      - name: Docker push
+        if: secrets.DOCKERHUB_TOKEN && steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
+        run:  docker push apache/superset:GHA-${GITHUB_RUN_ID}
 
       - name: docker-compose sanity check
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && (matrix.build_preset == 'dev' || matrix.build_preset == 'lean')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,10 +101,6 @@ jobs:
           docker images $IMAGE_TAG
           docker history $IMAGE_TAG
 
-      - name: Docker push
-        if: secrets.DOCKERHUB_TOKEN && steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
-        run:  docker push apache/superset:GHA-${GITHUB_RUN_ID}
-
       - name: docker-compose sanity check
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && (matrix.build_preset == 'dev' || matrix.build_preset == 'lean')
         shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
     env:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      IMAGE_TAG: apache/superset:GHA-${{ github.run_id }}
 
     steps:
 
@@ -72,26 +73,33 @@ jobs:
           # Single platform builds in pull_request context to speed things up
           if [ "${{ github.event_name }}" = "push" ]; then
             PLATFORM_ARG="--platform linux/arm64 --platform linux/amd64"
+            # can only --load images in single-platform builds
+            PUSH_OR_LOAD="--push"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             PLATFORM_ARG="--platform linux/amd64"
+            PUSH_OR_LOAD="--load"
           fi
 
           supersetbot docker \
-            --load \
+            $PUSH_OR_LOAD \
             --preset ${{ matrix.build_preset }} \
             --context "$EVENT" \
             --context-ref "$RELEASE" $FORCE_LATEST \
             --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
             $PLATFORM_ARG
 
+      # in the context of push (using multi-platform build), we need to pull the image locally
+      - name: Docker pull
+        if: github.event_name == "push" && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
+        run:  docker pull $IMAGE_TAG
+
       - name: Print docker stats
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         run: |
-          IMAGE_ID=$(docker images --filter "label=sha=${{ github.sha }}" --format "{{.ID}}" | head -n 1)
           echo "SHA: ${{ github.sha }}"
-          echo "IMAGE: $IMAGE_ID"
-          docker images $IMAGE_ID
-          docker history $IMAGE_ID
+          echo "IMAGE: $IMAGE_TAG"
+          docker images $IMAGE_TAG
+          docker history $IMAGE_TAG
 
       - name: Docker push
         if: secrets.DOCKERHUB_TOKEN && steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,7 +90,7 @@ jobs:
 
       # in the context of push (using multi-platform build), we need to pull the image locally
       - name: Docker pull
-        if: github.event_name == "push" && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
+        if: github.event_name == 'push' && (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker)
         run:  docker pull $IMAGE_TAG
 
       - name: Print docker stats

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      IMAGE_TAG: apache/superset:GHA-${{ github.run_id }}
+      IMAGE_TAG: apache/superset:GHA-${{ matrix.build_preset }}-${{ github.run_id }}
 
     steps:
 
@@ -85,7 +85,7 @@ jobs:
             --preset ${{ matrix.build_preset }} \
             --context "$EVENT" \
             --context-ref "$RELEASE" $FORCE_LATEST \
-            --extra-flags "--build-arg INCLUDE_CHROMIUM=false" \
+            --extra-flags "--build-arg INCLUDE_CHROMIUM=false --tag $IMAGE_TAG" \
             $PLATFORM_ARG
 
       # in the context of push (using multi-platform build), we need to pull the image locally
@@ -106,6 +106,7 @@ jobs:
         shell: bash
         run: |
           export SUPERSET_BUILD_TARGET=${{ matrix.build_preset }}
+          # This should reuse the CACHED image built in the previous steps
           docker compose build superset-init --build-arg DEV_MODE=false --build-arg INCLUDE_CHROMIUM=false
           docker compose up superset-init --exit-code-from superset-init
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -12,8 +12,8 @@
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations under
-# the License.
+# specific language governing permissions and limitations
+# under the License.
 """The main config file for Superset
 
 All configuration in this file can be overridden by providing a superset_config

--- a/superset/config.py
+++ b/superset/config.py
@@ -12,8 +12,8 @@
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# specific language governing permissions and limitations under
+# the License.
 """The main config file for Superset
 
 All configuration in this file can be overridden by providing a superset_config


### PR DESCRIPTION
Recently observed an issue where the GHA for docker builds fails when the PR is opened from a fork (as opposed to the main repo itself). This is related to the fact that the job tried to push the image to dockerhub, and doesn't have the creds `${{ secrets.DOCKERHUB_TOKEN }}` in that context.

Now there are some intricacies here:
- we should only push images on `push` events on the main branch (we don't need to publish images for every PR)
- we can only `--load` when building single-platform manifests, docker will just fail if you try and load the image from the wrong platform, --load is just not supported for multi-platform builds
- so, in push-to-master context, we simply multi-platform builds to docker hub, and then `docker pull` right after so that we can use the image in subsequent steps