### PR TITLE
feat: make CI against 'next' python version not-required

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,16 +75,13 @@ github:
           - dependency-review
           - frontend-build
           - pre-commit (current)
-          - pre-commit (next)
           - pre-commit (previous)
           - test-mysql
           - test-postgres (current)
-          - test-postgres (next)
           - test-postgres-hive
           - test-postgres-presto
           - test-sqlite
           - unit-tests (current)
-          - unit-tests (next)
 
       required_pull_request_reviews:
         dismiss_stale_reviews: false


### PR DESCRIPTION
As discussed in
https://github.com/apache/superset/pull/31503#issuecomment-2575869833,
let's make the CI checks against the `next` version of python optional.

This PR needs to get through as policies that live on `master` in
`.asf.yml` are applied to ongoing PRs. After this is merged, I'll add
the solution described in https://github.com/apache/superset/pull/31503,
that should mark the related failing jobs as `neutral`, which should
show as grey in the GitHub UI.
