### PR TITLE
fix: GHA frontend builds fail when frontends hasn't changed

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -19,7 +19,8 @@ env:
 jobs:
   frontend-build:
     runs-on: ubuntu-24.04
-    should-run: ${{ steps.check.outputs.frontend }}
+    outputs:
+      should-run: ${{ steps.check.outputs.frontend }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   frontend-build:
     runs-on: ubuntu-24.04
+    should-run: ${{ steps.check.outputs.frontend }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -57,7 +58,7 @@ jobs:
 
   sharded-jest-tests:
     needs: frontend-build
-    if: needs.frontend-build.result == 'success'
+    if: needs.frontend-build.outputs.should-run == 'true'
     strategy:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
@@ -89,7 +90,7 @@ jobs:
 
   report-coverage:
     needs: [sharded-jest-tests]
-    if: needs.frontend-build.result == 'success'
+    if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Download Coverage Artifacts
@@ -115,7 +116,7 @@ jobs:
 
   core-cover:
     needs: frontend-build
-    if: needs.frontend-build.result == 'success'
+    if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Download Docker Image Artifact
@@ -133,7 +134,7 @@ jobs:
 
   lint-frontend:
     needs: frontend-build
-    if: needs.frontend-build.result == 'success'
+    if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Download Docker Image Artifact
@@ -156,7 +157,7 @@ jobs:
 
   validate-frontend:
     needs: frontend-build
-    if: needs.frontend-build.result == 'success'
+    if: needs.frontend-build.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Download Docker Image Artifact


### PR DESCRIPTION
I just merged https://github.com/apache/superset/pull/31490 and realized it fails when no frontend changes are found. It will run the first workflow and fail on subsequent.

This PR makes it such that the first workflow emits an output to tell the other workflows to skip if needed.

To test it, I had to remove the regex in `scripts/change_detector.py` that looks whether the specific GHA I'm altering here has been changed and it skipped as expected:

<img width="772" alt="Screenshot 2025-01-07 at 5 15 52 PM" src="https://github.com/user-attachments/assets/cb81e3d7-f217-4ea8-979a-17f67b399892" />

... and reenabled the rule after testing
