### PR TITLE
fix: Changing language doesn't affect echarts charts

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -238,7 +238,9 @@ module.exports = {
       rules: {
         'import/no-extraneous-dependencies': [
           'error',
-          { devDependencies: true },
+          {
+            "devDependencies": ["**/*.test.js", "**/*.spec.js"]
+          },
         ],
         'no-only-tests/no-only-tests': 'error',
         'max-classes-per-file': 0,

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -239,7 +239,7 @@ module.exports = {
         'import/no-extraneous-dependencies': [
           'error',
           {
-            "devDependencies": ["**/*.test.tsx", "**/*.test.jsx", "**/*.test.ts"]
+            "devDependencies": ["**/*.test.tsx", "**/*.test.js", "**/*.test.jsx", "**/*.test.ts", "**/*.stories.tsx", "**/*.fixtures.ts"]
           },
         ],
         'no-only-tests/no-only-tests': 'error',

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -239,7 +239,7 @@ module.exports = {
         'import/no-extraneous-dependencies': [
           'error',
           {
-            "devDependencies": ["**/*.test.js", "**/*.spec.js"]
+            "devDependencies": ["**/*.test.tsx", "**/*.test.jsx", "**/*.test.ts"]
           },
         ],
         'no-only-tests/no-only-tests': 'error',

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -238,9 +238,7 @@ module.exports = {
       rules: {
         'import/no-extraneous-dependencies': [
           'error',
-          {
-            "devDependencies": ["**/*.test.tsx", "**/*.test.js", "**/*.test.jsx", "**/*.test.ts", "**/*.stories.tsx", "**/*.fixtures.ts"]
-          },
+          { devDependencies: true },
         ],
         'no-only-tests/no-only-tests': 'error',
         'max-classes-per-file': 0,

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@types/react-redux": "^7.1.34",
+    "@types/react-redux": "^7.1.10",
     "d3-array": "^1.2.0",
     "dayjs": "^1.11.13",
     "lodash": "^4.17.21"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@types/react-redux": "^7.1.10",
     "d3-array": "^1.2.0",
-    "dayjs": "^1.11.13",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "dayjs": "^1.11.13"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -24,16 +24,17 @@
     "lib"
   ],
   "dependencies": {
+    "@types/react-redux": "^7.1.34",
     "d3-array": "^1.2.0",
-    "lodash": "^4.17.21",
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "echarts": "*",
     "memoize-one": "*",
-    "react": "^17.0.2"
+    "react": "^16.13.1"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -23,11 +23,13 @@
     "esm",
     "lib"
   ],
+  "devDependencies": {
+    "@types/react-redux": "^7.1.10"
+  },
   "dependencies": {
     "d3-array": "^1.2.0",
     "lodash": "^4.17.21",
-    "dayjs": "^1.11.13",
-    "@types/react-redux": "^7.1.10"
+    "dayjs": "^1.11.13"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -33,7 +33,9 @@
     "@superset-ui/core": "*",
     "echarts": "*",
     "memoize-one": "*",
-    "react": "^17.0.2",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
     "@types/react-redux": "^7.1.10"
   },
   "publishConfig": {

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -24,7 +24,6 @@
     "lib"
   ],
   "dependencies": {
-    "@types/react-redux": "^7.1.10",
     "d3-array": "^1.2.0",
     "lodash": "^4.17.21",
     "dayjs": "^1.11.13"
@@ -34,7 +33,8 @@
     "@superset-ui/core": "*",
     "echarts": "*",
     "memoize-one": "*",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "@types/react-redux": "^7.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "d3-array": "^1.2.0",
     "lodash": "^4.17.21",
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "@types/react-redux": "^7.1.10"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
@@ -34,9 +35,6 @@
     "echarts": "*",
     "memoize-one": "*",
     "react": "^17.0.2"
-  },
-  "devDependencies": {
-    "@types/react-redux": "^7.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -23,13 +23,11 @@
     "esm",
     "lib"
   ],
-  "devDependencies": {
-    "@types/react-redux": "^7.1.10"
-  },
   "dependencies": {
     "d3-array": "^1.2.0",
     "lodash": "^4.17.21",
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "@types/react-redux": "^7.1.10"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",

--- a/superset-frontend/plugins/plugin-chart-echarts/package.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/package.json
@@ -34,7 +34,7 @@
     "@superset-ui/core": "*",
     "echarts": "*",
     "memoize-one": "*",
-    "react": "^16.13.1"
+    "react": "^17.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -63,14 +63,14 @@ import {
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
 
-// Define this interface here to avoid creating a dependency back to superset-frontend, 
+// Define this interface here to avoid creating a dependency back to superset-frontend,
 // and to appease the compiler.
 // ref: superset-frontend/src/explore/types
 interface ExplorePageState {
   common: {
     locale: string;
   };
-};
+}
 
 const Styles = styled.div<EchartsStylesProps>`
   height: ${({ height }) => height};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -27,8 +27,10 @@ import {
   Ref,
 } from 'react';
 
+import { useSelector } from 'react-redux';
+
 import { styled } from '@superset-ui/core';
-import { use, init, EChartsType } from 'echarts/core';
+import { use, init, EChartsType, registerLocale } from 'echarts/core';
 import {
   SankeyChart,
   PieChart,
@@ -60,6 +62,15 @@ import {
 } from 'echarts/components';
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
+
+// Define this interface here to avoid creating a dependency back to superset-frontend, 
+// and to appease the compiler.
+// ref: superset-frontend/src/explore/types
+interface ExplorePageState {
+  common: {
+    locale: string;
+  };
+};
 
 const Styles = styled.div<EchartsStylesProps>`
   height: ${({ height }) => height};
@@ -123,24 +134,52 @@ function Echart(
     getEchartInstance: () => chartRef.current,
   }));
 
+  const locale = useSelector(
+    (state: ExplorePageState) => state?.common?.locale ?? 'en',
+  ).toUpperCase();
+
+  const handleSizeChange = useCallback(
+    ({ width, height }: { width: number; height: number }) => {
+      if (chartRef.current) {
+        chartRef.current.resize({ width, height });
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
-    if (!divRef.current) return;
-    if (!chartRef.current) {
-      chartRef.current = init(divRef.current);
-    }
+    const loadLocaleAndInitChart = async () => {
+      if (!divRef.current) return;
 
-    Object.entries(eventHandlers || {}).forEach(([name, handler]) => {
-      chartRef.current?.off(name);
-      chartRef.current?.on(name, handler);
-    });
+      const lang = await import(`echarts/lib/i18n/lang${locale}`).catch(e => {
+        console.error(`Locale ${locale} not supported in ECharts`, e);
+      });
+      if (lang?.default) {
+        registerLocale(locale, lang.default);
+      }
 
-    Object.entries(zrEventHandlers || {}).forEach(([name, handler]) => {
-      chartRef.current?.getZr().off(name);
-      chartRef.current?.getZr().on(name, handler);
-    });
+      if (!chartRef.current) {
+        chartRef.current = init(divRef.current, null, { locale });
+      }
 
-    chartRef.current.setOption(echartOptions, true);
-  }, [echartOptions, eventHandlers, zrEventHandlers]);
+      Object.entries(eventHandlers || {}).forEach(([name, handler]) => {
+        chartRef.current?.off(name);
+        chartRef.current?.on(name, handler);
+      });
+
+      Object.entries(zrEventHandlers || {}).forEach(([name, handler]) => {
+        chartRef.current?.getZr().off(name);
+        chartRef.current?.getZr().on(name, handler);
+      });
+
+      chartRef.current.setOption(echartOptions, true);
+
+      // did mount
+      handleSizeChange({ width, height });
+    };
+
+    loadLocaleAndInitChart();
+  }, [echartOptions, eventHandlers, zrEventHandlers, locale]);
 
   // highlighting
   useEffect(() => {
@@ -158,22 +197,7 @@ function Echart(
       });
     }
     previousSelection.current = currentSelection;
-  }, [currentSelection]);
-
-  const handleSizeChange = useCallback(
-    ({ width, height }: { width: number; height: number }) => {
-      if (chartRef.current) {
-        chartRef.current.resize({ width, height });
-      }
-    },
-    [],
-  );
-
-  // did mount
-  useEffect(() => {
-    handleSizeChange({ width, height });
-    return () => chartRef.current?.dispose();
-  }, []);
+  }, [currentSelection, chartRef.current]);
 
   useLayoutEffect(() => {
     handleSizeChange({ width, height });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -64,8 +64,7 @@ import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
 
 // Define this interface here to avoid creating a dependency back to superset-frontend,
-// and to appease the compiler.
-// ref: superset-frontend/src/explore/types
+// TODO: to move the type to @superset-ui/core
 interface ExplorePageState {
   common: {
     locale: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -62,6 +62,7 @@ import {
 } from 'echarts/components';
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
+import { DEFAULT_LOCALE } from '../constants';
 
 // Define this interface here to avoid creating a dependency back to superset-frontend,
 // TODO: to move the type to @superset-ui/core
@@ -134,7 +135,7 @@ function Echart(
   }));
 
   const locale = useSelector(
-    (state: ExplorePageState) => state?.common?.locale ?? 'en',
+    (state: ExplorePageState) => state?.common?.locale ?? DEFAULT_LOCALE,
   ).toUpperCase();
 
   const handleSizeChange = useCallback(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -121,3 +121,5 @@ export const TOOLTIP_POINTER_MARGIN = 10;
 // If no satisfactory position can be found, how far away
 // from the edge of the window should the tooltip be kept
 export const TOOLTIP_OVERFLOW_MARGIN = 5;
+
+export const DEFAULT_LOCALE = 'en'

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -122,4 +122,4 @@ export const TOOLTIP_POINTER_MARGIN = 10;
 // from the edge of the window should the tooltip be kept
 export const TOOLTIP_OVERFLOW_MARGIN = 5;
 
-export const DEFAULT_LOCALE = 'en'
+export const DEFAULT_LOCALE = 'en';


### PR DESCRIPTION
### SUMMARY
this is to propagate the current locale up to the echarts configuration.

fixes: #30131 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
switch the locale and verify that charts have the correct locale (for example in months name and in buttons)