### PR TITLE
refactor: Removes Apply to all panels filters scope configuration

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/FilterScope.test.tsx
@@ -82,7 +82,6 @@ describe('FilterScope', () => {
   it('select tree values with 1 excluded', async () => {
     render(<MockModal />);
     fireEvent.click(screen.getByText('Scoping'));
-    fireEvent.click(screen.getByLabelText('Apply to specific panels'));
     expect(screen.getByRole('tree')).toBeInTheDocument();
     fireEvent.click(getTreeSwitcher(2));
     fireEvent.click(screen.getByText('CHART_ID2'));
@@ -99,7 +98,6 @@ describe('FilterScope', () => {
   it('select 1 value only', async () => {
     render(<MockModal />);
     fireEvent.click(screen.getByText('Scoping'));
-    fireEvent.click(screen.getByLabelText('Apply to specific panels'));
     expect(screen.getByRole('tree')).toBeInTheDocument();
     fireEvent.click(getTreeSwitcher(2));
     fireEvent.click(screen.getByText('CHART_ID2'));
@@ -124,7 +122,6 @@ describe('FilterScope', () => {
       />,
     );
     fireEvent.click(screen.getByText('Scoping'));
-    fireEvent.click(screen.getByLabelText('Apply to specific panels'));
 
     await waitFor(() => {
       expect(screen.getByRole('tree')).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/types.ts
@@ -19,11 +19,6 @@
 
 import { ReactNode } from 'react';
 
-export enum ScopingType {
-  All,
-  Specific,
-}
-
 /** UI Ant tree type */
 export type TreeItem = {
   children: TreeItem[];

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -190,8 +190,3 @@ export const getDefaultScopeValue = (
     ? [chartId, ...initiallyExcludedCharts]
     : initiallyExcludedCharts,
 });
-
-export const isScopingAll = (scope: NativeFilterScope, chartId?: number) =>
-  !scope ||
-  (scope.rootPath[0] === DASHBOARD_ROOT_ID &&
-    !scope.excluded.filter(item => item !== chartId).length);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1353,7 +1353,6 @@ const FiltersConfigForm = (
           forceUpdate={forceUpdate}
           filterScope={filterToEdit?.scope}
           formFilterScope={formFilter?.scope}
-          formScopingType={formFilter?.scoping}
           initiallyExcludedCharts={initiallyExcludedCharts}
         />
       </TabPane>


### PR DESCRIPTION
### SUMMARY
This PR implements the 5.0 proposal called [87 - Remove Apply to all panels filters scope configuration](https://github.com/orgs/apache/projects/345?pane=issue&itemId=84839864) to make it explicit which charts will be affected when setting filter scopes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/f6c07d75-40f7-4ca1-8fdc-384205c3b26c

### TESTING INSTRUCTIONS
Check that filter scopes continues to work as expected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
