### PR TITLE
feat: WiP support for python 3.12

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -28,8 +28,7 @@ runs:
         if [ "${{ inputs.python-version }}" = "current" ]; then
           echo "PYTHON_VERSION=3.11.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
-          # TODO: set to 3.12 when libs are ready - seemed hard on 12/17/24
-          echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=3.12" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "previous" ]; then
           echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
         else

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -57,7 +57,7 @@ runs:
           elif [ "${{ inputs.requirements-type }}" = "base" ]; then
             REQS=requirements/base.txt
           fi
-          uv pip install --only-binary :all: --verbose --system -r $REQS
+          uv pip install --verbose --system -r $REQS
           echo "Done with uv pip install"
 
           uv pip install --system -e .

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -44,21 +44,14 @@ runs:
         if [ "${{ inputs.install-superset }}" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
 
-          if [ "${{ env.PYTHON_VERSION }}" = "nextooooooo" ]; then
-            # No wheel in 3.11 for numpy
-            sudo apt-get -y install build-essential
-          fi
-
           pip install --upgrade pip setuptools wheel uv
-          echo "Done with pip install"
 
           if [ "${{ inputs.requirements-type }}" = "dev" ]; then
             REQS=requirements/development.txt
           elif [ "${{ inputs.requirements-type }}" = "base" ]; then
             REQS=requirements/base.txt
           fi
-          uv pip install --verbose --system -r $REQS
-          echo "Done with uv pip install"
+          uv pip install --system -r $REQS
 
           uv pip install --system -e .
         fi

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -26,11 +26,12 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.python-version }}" = "current" ]; then
-          echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=3.11.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
+          # TODO: set to 3.12 when libs are ready - seemed hard on 12/17/24
           echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "previous" ]; then
-          echo "PYTHON_VERSION=3.9" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
         else
           echo "PYTHON_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV
         fi
@@ -43,6 +44,12 @@ runs:
       run: |
         if [ "${{ inputs.install-superset }}" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
+
+          if [ "${{ env.PYTHON_VERSION }}" = "next" ]; then
+            # No wheel in 3.11 for numpy
+            sudo apt-get -y install build-essential
+          fi
+
           pip install --upgrade pip setuptools wheel uv
 
           if [ "${{ inputs.requirements-type }}" = "dev" ]; then

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -44,7 +44,7 @@ runs:
         if [ "${{ inputs.install-superset }}" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
 
-          if [ "${{ env.PYTHON_VERSION }}" = "next" ]; then
+          if [ "${{ env.PYTHON_VERSION }}" = "nextooooooo" ]; then
             # No wheel in 3.11 for numpy
             sudo apt-get -y install build-essential
           fi

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -28,7 +28,7 @@ runs:
         if [ "${{ inputs.python-version }}" = "current" ]; then
           echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
-          echo "PYTHON_VERSION=3.12" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=3.12.7" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "previous" ]; then
           echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
         else
@@ -50,12 +50,14 @@ runs:
           fi
 
           pip install --upgrade pip setuptools wheel uv
+          echo "Done with pip install"
 
           if [ "${{ inputs.requirements-type }}" = "dev" ]; then
             uv pip install --system -r requirements/development.txt
           elif [ "${{ inputs.requirements-type }}" = "base" ]; then
             uv pip install --system -r requirements/base.txt
           fi
+          echo "Done with uv pip install"
 
           uv pip install --system -e .
         fi

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -53,10 +53,11 @@ runs:
           echo "Done with pip install"
 
           if [ "${{ inputs.requirements-type }}" = "dev" ]; then
-            uv pip install --system -r requirements/development.txt
+            REQS=requirements/development.txt
           elif [ "${{ inputs.requirements-type }}" = "base" ]; then
-            uv pip install --system -r requirements/base.txt
+            REQS=requirements/base.txt
           fi
+          uv pip install --only-binary :all: --verbose --system -r $REQS
           echo "Done with uv pip install"
 
           uv pip install --system -e .

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -26,7 +26,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.python-version }}" = "current" ]; then
-          echo "PYTHON_VERSION=3.11.11" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
           echo "PYTHON_VERSION=3.12" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "previous" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # Node stage to deal with static asset construction
 ######################################################################
-ARG PY_VER=3.10-slim-bookworm
+ARG PY_VER=3.11-slim-bookworm
 
 # If BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
 ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <2.1",
+    "pandas[excel]>=2.0.3, <3",
     "bottleneck",
     # --------------------------
     "parsedatetime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <3",
+    # upper bounding at 2.2 as df.to_sql changes sqlalchemy type compatibility
+    "pandas[excel]>=2.0.3, <2.2",
     "bottleneck",
     # --------------------------
     "parsedatetime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ dependencies = [
     #https://github.com/tobymao/sqlglot/blob/main/CHANGELOG.md#v25250---2024-10-14
     "sqlglot>=25.24.0,<25.25.0",
     "sqlparse>=0.5.0",
-    "tabulate>=0.8.9, <0.9",
+    # newer pandas needs 0.9+
+    "tabulate>=0.9.0, <1.0",
     "typing-extensions>=4, <5",
     "waitress; sys_platform == 'win32'",
     "wtforms>=2.3.3, <4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    # "Programming Language :: Python :: 3.12", # not just yet ...
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "backoff>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,15 @@ name = "apache-superset"
 description = "A modern, enterprise-ready business intelligence web application"
 readme = "README.md"
 dynamic = ["version", "scripts", "entry-points"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file="LICENSE.txt" }
 authors = [
     { name = "Apache Software Foundation", email = "dev@superset.apache.org" },
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    # "Programming Language :: Python :: 3.12", # not just yet ...
 ]
 dependencies = [
     "backoff>=1.8.0",
@@ -67,7 +67,7 @@ dependencies = [
     "markdown>=3.0",
     "msgpack>=1.0.0, <1.1",
     "nh3>=0.2.11, <0.3",
-    "numpy==1.23.5",
+    "numpy>1.23.5, <2",
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
@@ -275,8 +275,8 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.9
-target-version = "py39"
+# Assume Python 3.10
+target-version = "py310"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "markdown>=3.0",
     "msgpack>=1.0.0, <1.1",
     "nh3>=0.2.11, <0.3",
-    "numpy>1.23.5, <2",
+    "numpy>=1.23.5, <2",
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,8 +23,3 @@ numexpr>=2.9.0
 # 5.0.0 has a sensitive deprecation used in other libs
 # -> https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#500-2024-10-31
 async_timeout>=4.0.0,<5.0.0
-
-# playwright requires greenlet==3.0.3
-# submitted a PR to relax deps in 11/2024
-# https://github.com/microsoft/playwright-python/pull/2669
-greenlet==3.0.3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,3 +23,6 @@ numexpr>=2.9.0
 # 5.0.0 has a sensitive deprecation used in other libs
 # -> https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#500-2024-10-31
 async_timeout>=4.0.0,<5.0.0
+
+# needed for python 3.12 support
+openapi-schema-validator>=0.6.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -174,9 +174,13 @@ jinja2==3.1.4
 jsonpath-ng==1.7.0
     # via apache-superset (pyproject.toml)
 jsonschema==4.23.0
-    # via flask-appbuilder
-jsonschema-specifications==2024.10.1
-    # via jsonschema
+    # via
+    #   flask-appbuilder
+    #   openapi-schema-validator
+jsonschema-specifications==2023.12.1
+    # via
+    #   jsonschema
+    #   openapi-schema-validator
 kombu==5.4.2
     # via celery
 korean-lunar-calendar==0.3.1
@@ -222,6 +226,8 @@ numpy==1.26.4
     #   pyarrow
 odfpy==1.4.1
     # via pandas
+openapi-schema-validator==0.6.2
+    # via -r requirements/base.in
 openpyxl==3.1.5
     # via pandas
 ordered-set==4.1.0
@@ -315,6 +321,8 @@ requests==2.32.2
     #   shillelagh
 requests-cache==1.2.0
     # via shillelagh
+rfc3339-validator==0.1.4
+    # via openapi-schema-validator
 rich==13.9.4
     # via flask-limiter
 rpds-py==0.22.3
@@ -335,6 +343,7 @@ six==1.16.0
     # via
     #   prison
     #   python-dateutil
+    #   rfc3339-validator
     #   url-normalize
     #   wtforms-json
 slack-sdk==3.33.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -146,7 +146,6 @@ google-auth==2.36.0
     # via shillelagh
 greenlet==3.0.3
     # via
-    #   -r requirements/base.in
     #   apache-superset (pyproject.toml)
     #   shillelagh
 gunicorn==23.0.0
@@ -215,7 +214,7 @@ nh3==0.2.19
     # via apache-superset (pyproject.toml)
 numexpr==2.10.2
     # via -r requirements/base.in
-numpy==1.23.5
+numpy==1.26.4
     # via
     #   apache-superset (pyproject.toml)
     #   bottleneck

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -241,8 +241,9 @@ packaging==24.2
     #   limits
     #   marshmallow
     #   marshmallow-sqlalchemy
+    #   python-calamine
     #   shillelagh
-pandas==2.0.3
+pandas==2.2.3
     # via apache-superset (pyproject.toml)
 paramiko==3.5.0
     # via
@@ -285,6 +286,8 @@ pyopenssl==24.2.1
     # via shillelagh
 pyparsing==3.2.0
     # via apache-superset (pyproject.toml)
+python-calamine==0.3.1
+    # via pandas
 python-dateutil==2.9.0.post0
     # via
     #   apache-superset (pyproject.toml)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,9 +9,7 @@ apispec==6.3.0
 apsw==3.46.0.0
     # via shillelagh
 async-timeout==4.0.3
-    # via
-    #   -r requirements/base.in
-    #   redis
+    # via -r requirements/base.in
 attrs==24.2.0
     # via
     #   cattrs
@@ -92,8 +90,6 @@ email-validator==2.2.0
     # via flask-appbuilder
 et-xmlfile==2.0.0
     # via openpyxl
-exceptiongroup==1.2.2
-    # via cattrs
 flask==2.3.3
     # via
     #   apache-superset (pyproject.toml)
@@ -359,10 +355,8 @@ typing-extensions==4.12.2
     # via
     #   apache-superset (pyproject.toml)
     #   alembic
-    #   cattrs
     #   flask-limiter
     #   limits
-    #   rich
     #   shillelagh
 tzdata==2024.2
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -370,7 +370,7 @@ sqlparse==0.5.2
     # via apache-superset (pyproject.toml)
 sshtunnel==0.4.0
     # via apache-superset (pyproject.toml)
-tabulate==0.8.10
+tabulate==0.9.0
     # via apache-superset (pyproject.toml)
 typing-extensions==4.12.2
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ attrs==24.2.0
     # via
     #   cattrs
     #   jsonschema
+    #   referencing
     #   requests-cache
 babel==2.16.0
     # via flask-babel
@@ -172,8 +173,10 @@ jinja2==3.1.4
     #   flask-babel
 jsonpath-ng==1.7.0
     # via apache-superset (pyproject.toml)
-jsonschema==4.17.3
+jsonschema==4.23.0
     # via flask-appbuilder
+jsonschema-specifications==2024.10.1
+    # via jsonschema
 kombu==5.4.2
     # via celery
 korean-lunar-calendar==0.3.1
@@ -276,8 +279,6 @@ pyopenssl==24.2.1
     # via shillelagh
 pyparsing==3.2.0
     # via apache-superset (pyproject.toml)
-pyrsistent==0.20.0
-    # via jsonschema
 python-dateutil==2.9.0.post0
     # via
     #   apache-superset (pyproject.toml)
@@ -304,6 +305,10 @@ pyyaml==6.0.2
     #   apispec
 redis==4.6.0
     # via apache-superset (pyproject.toml)
+referencing==0.35.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.2
     # via
     #   requests-cache
@@ -312,6 +317,10 @@ requests-cache==1.2.0
     # via shillelagh
 rich==13.9.4
     # via flask-limiter
+rpds-py==0.22.3
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via google-auth
 selenium==3.141.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -241,9 +241,8 @@ packaging==24.2
     #   limits
     #   marshmallow
     #   marshmallow-sqlalchemy
-    #   python-calamine
     #   shillelagh
-pandas==2.2.3
+pandas==2.1.4
     # via apache-superset (pyproject.toml)
 paramiko==3.5.0
     # via
@@ -286,8 +285,6 @@ pyopenssl==24.2.1
     # via shillelagh
 pyparsing==3.2.0
     # via apache-superset (pyproject.toml)
-python-calamine==0.3.1
-    # via pandas
 python-dateutil==2.9.0.post0
     # via
     #   apache-superset (pyproject.toml)

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -448,7 +448,7 @@ nh3==0.2.19
     #   apache-superset
 nodeenv==1.8.0
     # via pre-commit
-numpy==1.23.5
+numpy==1.26.4
     # via
     #   -c requirements/base.txt
     #   apache-superset

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -797,7 +797,7 @@ sshtunnel==0.4.0
     #   apache-superset
 statsd==4.0.1
     # via apache-superset
-tabulate==0.8.10
+tabulate==0.9.0
     # via
     #   -c requirements/base.txt
     #   apache-superset

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -18,10 +18,6 @@ apsw==3.46.0.0
     # via
     #   -c requirements/base.txt
     #   shillelagh
-async-timeout==4.0.3
-    # via
-    #   -c requirements/base.txt
-    #   redis
 attrs==24.2.0
     # via
     #   -c requirements/base.txt
@@ -172,11 +168,6 @@ et-xmlfile==2.0.0
     # via
     #   -c requirements/base.txt
     #   openpyxl
-exceptiongroup==1.2.2
-    # via
-    #   -c requirements/base.txt
-    #   cattrs
-    #   pytest
 filelock==3.12.2
     # via virtualenv
 flask==2.3.3
@@ -789,10 +780,6 @@ tabulate==0.8.10
     # via
     #   -c requirements/base.txt
     #   apache-superset
-tomli==2.2.1
-    # via
-    #   coverage
-    #   pytest
 tqdm==4.67.1
     # via
     #   cmdstanpy
@@ -804,10 +791,8 @@ typing-extensions==4.12.2
     #   -c requirements/base.txt
     #   alembic
     #   apache-superset
-    #   cattrs
     #   flask-limiter
     #   limits
-    #   rich
     #   shillelagh
 tzdata==2024.2
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -492,10 +492,9 @@ packaging==24.2
     #   marshmallow-sqlalchemy
     #   matplotlib
     #   pytest
-    #   python-calamine
     #   shillelagh
     #   sqlalchemy-bigquery
-pandas==2.2.3
+pandas==2.1.4
     # via
     #   -c requirements/base.txt
     #   apache-superset
@@ -633,10 +632,6 @@ pytest-cov==6.0.0
     # via apache-superset
 pytest-mock==3.10.0
     # via apache-superset
-python-calamine==0.3.1
-    # via
-    #   -c requirements/base.txt
-    #   pandas
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/base.txt

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -492,9 +492,10 @@ packaging==24.2
     #   marshmallow-sqlalchemy
     #   matplotlib
     #   pytest
+    #   python-calamine
     #   shillelagh
     #   sqlalchemy-bigquery
-pandas==2.0.3
+pandas==2.2.3
     # via
     #   -c requirements/base.txt
     #   apache-superset
@@ -632,6 +633,10 @@ pytest-cov==6.0.0
     # via apache-superset
 pytest-mock==3.10.0
     # via apache-superset
+python-calamine==0.3.1
+    # via
+    #   -c requirements/base.txt
+    #   pandas
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/base.txt

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -368,15 +368,15 @@ jsonschema==4.23.0
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder
-    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-spec==0.1.3
+jsonschema-path==0.3.3
     # via openapi-spec-validator
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2023.12.1
     # via
     #   -c requirements/base.txt
     #   jsonschema
+    #   openapi-schema-validator
 kiwisolver==1.4.7
     # via matplotlib
 kombu==5.4.2
@@ -463,9 +463,11 @@ odfpy==1.4.1
     # via
     #   -c requirements/base.txt
     #   pandas
-openapi-schema-validator==0.4.3
-    # via openapi-spec-validator
-openapi-spec-validator==0.5.5
+openapi-schema-validator==0.6.2
+    # via
+    #   -c requirements/base.txt
+    #   openapi-spec-validator
+openapi-spec-validator==0.7.1
     # via apache-superset
 openpyxl==3.1.5
     # via
@@ -514,7 +516,7 @@ parsedatetime==2.6
     #   -c requirements/base.txt
     #   apache-superset
 pathable==0.4.3
-    # via jsonschema-spec
+    # via jsonschema-path
 pgsanity==0.2.9
     # via
     #   -c requirements/base.txt
@@ -671,7 +673,7 @@ pyyaml==6.0.2
     #   -c requirements/base.txt
     #   apache-superset
     #   apispec
-    #   jsonschema-spec
+    #   jsonschema-path
     #   pre-commit
 redis==4.6.0
     # via
@@ -681,6 +683,7 @@ referencing==0.35.1
     # via
     #   -c requirements/base.txt
     #   jsonschema
+    #   jsonschema-path
     #   jsonschema-specifications
 requests==2.32.2
     # via
@@ -688,6 +691,7 @@ requests==2.32.2
     #   docker
     #   google-api-core
     #   google-cloud-bigquery
+    #   jsonschema-path
     #   pydruid
     #   pyhive
     #   requests-cache
@@ -701,7 +705,9 @@ requests-cache==1.2.0
 requests-oauthlib==2.0.0
     # via google-auth-oauthlib
 rfc3339-validator==0.1.4
-    # via openapi-schema-validator
+    # via
+    #   -c requirements/base.txt
+    #   openapi-schema-validator
 rich==13.9.4
     # via
     #   -c requirements/base.txt
@@ -802,7 +808,6 @@ typing-extensions==4.12.2
     #   alembic
     #   apache-superset
     #   flask-limiter
-    #   jsonschema-spec
     #   limits
     #   shillelagh
 tzdata==2024.2

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -23,6 +23,7 @@ attrs==24.2.0
     #   -c requirements/base.txt
     #   cattrs
     #   jsonschema
+    #   referencing
     #   requests-cache
 babel==2.16.0
     # via
@@ -363,15 +364,19 @@ jsonpath-ng==1.7.0
     # via
     #   -c requirements/base.txt
     #   apache-superset
-jsonschema==4.17.3
+jsonschema==4.23.0
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-spec==0.1.6
+jsonschema-spec==0.1.3
     # via openapi-spec-validator
+jsonschema-specifications==2024.10.1
+    # via
+    #   -c requirements/base.txt
+    #   jsonschema
 kiwisolver==1.4.7
     # via matplotlib
 kombu==5.4.2
@@ -458,9 +463,9 @@ odfpy==1.4.1
     # via
     #   -c requirements/base.txt
     #   pandas
-openapi-schema-validator==0.4.4
+openapi-schema-validator==0.4.3
     # via openapi-spec-validator
-openapi-spec-validator==0.5.6
+openapi-spec-validator==0.5.5
     # via apache-superset
 openpyxl==3.1.5
     # via
@@ -616,10 +621,6 @@ pyparsing==3.2.0
     #   -c requirements/base.txt
     #   apache-superset
     #   matplotlib
-pyrsistent==0.20.0
-    # via
-    #   -c requirements/base.txt
-    #   jsonschema
 pytest==7.4.4
     # via
     #   apache-superset
@@ -676,13 +677,17 @@ redis==4.6.0
     # via
     #   -c requirements/base.txt
     #   apache-superset
+referencing==0.35.1
+    # via
+    #   -c requirements/base.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.2
     # via
     #   -c requirements/base.txt
     #   docker
     #   google-api-core
     #   google-cloud-bigquery
-    #   jsonschema-spec
     #   pydruid
     #   pyhive
     #   requests-cache
@@ -701,6 +706,11 @@ rich==13.9.4
     # via
     #   -c requirements/base.txt
     #   flask-limiter
+rpds-py==0.22.3
+    # via
+    #   -c requirements/base.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -c requirements/base.txt
@@ -792,6 +802,7 @@ typing-extensions==4.12.2
     #   alembic
     #   apache-superset
     #   flask-limiter
+    #   jsonschema-spec
     #   limits
     #   shillelagh
 tzdata==2024.2

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -83,7 +83,7 @@ def append_charts(position: dict[str, Any], charts: set[Slice]) -> dict[str, Any
             "parents": ["ROOT_ID", "GRID_ID"],
         }
 
-    for chart_hash, chart in zip(chart_hashes, charts):
+    for chart_hash, chart in zip(chart_hashes, charts, strict=False):
         position[chart_hash] = {
             "children": [],
             "id": chart_hash,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1903,6 +1903,7 @@ class SqlaTable(
             for method, perms in zip(
                 (SqlaTable.perm, SqlaTable.schema_perm, SqlaTable.catalog_perm),
                 (permissions, schema_perms, catalog_perms),
+                strict=False,
             )
             if perms
         ]

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -440,7 +440,7 @@ class HiveEngineSpec(PrestoEngineSpec):
             # table is not partitioned
             return None
         if values is not None and columns is not None:
-            for col_name, value in zip(col_names, values):
+            for col_name, value in zip(col_names, values, strict=False):
                 for clm in columns:
                     if clm.get("name") == col_name:
                         query = query.where(Column(col_name) == value)

--- a/superset/db_engine_specs/ocient.py
+++ b/superset/db_engine_specs/ocient.py
@@ -348,7 +348,9 @@ class OcientEngineSpec(BaseEngineSpec):
                 rows = [
                     tuple(
                         sanitize_func(val)
-                        for sanitize_func, val in zip(sanitization_functions, row)
+                        for sanitize_func, val in zip(
+                            sanitization_functions, row, strict=False
+                        )
                     )
                     for row in rows
                 ]

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -545,7 +545,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
             column.get("column_name"): column.get("type") for column in columns or []
         }
 
-        for col_name, value in zip(col_names, values):
+        for col_name, value in zip(col_names, values, strict=False):
             col_type = column_type_by_name.get(col_name)
 
             if isinstance(col_type, str):
@@ -1240,7 +1240,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
                     if isinstance(values, str):
                         values = cast(Optional[list[Any]], destringify(values))
                         row[name] = values
-                    for value, col in zip(values or [], expanded):
+                    for value, col in zip(values or [], expanded, strict=False):
                         row[col["column_name"]] = value
 
         data = [
@@ -1271,7 +1271,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
 
             metadata["partitions"] = {
                 "cols": sorted(indexes[0].get("column_names", [])),
-                "latest": dict(zip(col_names, latest_parts)),
+                "latest": dict(zip(col_names, latest_parts, strict=False)),
                 "partitionQuery": cls._partition_query(
                     table=table,
                     indexes=indexes,

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -131,7 +131,7 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
             # uses the max size for redshift nvarchar(65335)
             # the default object and string types create a varchar(256)
             col_name: NVARCHAR(length=65535)
-            for col_name, type in zip(df.columns, df.dtypes)
+            for col_name, type in zip(df.columns, df.dtypes, strict=False)
             if isinstance(type, pd.StringDtype)
         }
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -111,7 +111,7 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                         }
                     )
                 ),
-                "latest": dict(zip(col_names, latest_parts)),
+                "latest": dict(zip(col_names, latest_parts, strict=False)),
                 "partitionQuery": cls._partition_query(
                     table=table,
                     indexes=indexes,

--- a/superset/extensions/metadb.py
+++ b/superset/extensions/metadb.py
@@ -412,7 +412,7 @@ class SupersetShillelaghAdapter(Adapter):
             connection = engine.connect()
             rows = connection.execute(query)
             for i, row in enumerate(rows):
-                data = dict(zip(self.columns, row))
+                data = dict(zip(self.columns, row, strict=False))
                 data["rowid"] = data[self._rowid] if self._rowid else i
                 yield data
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1971,7 +1971,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         self.make_orderby_compatible(select_exprs, orderby_exprs)
 
-        for col, (orig_col, ascending) in zip(orderby_exprs, orderby):  # noqa: B007
+        for col, (orig_col, ascending) in zip(orderby_exprs, orderby, strict=False):  # noqa: B007
             if not db_engine_spec.allows_alias_in_orderby and isinstance(col, Label):
                 # if engine does not allow using SELECT alias in ORDER BY
                 # revert to the underlying column

--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -123,7 +123,9 @@ class SupersetResultSet:
             # fix cursor descriptor with the deduped names
             deduped_cursor_desc = [
                 tuple([column_name, *list(description)[1:]])  # noqa: C409
-                for column_name, description in zip(column_names, cursor_description)
+                for column_name, description in zip(
+                    column_names, cursor_description, strict=False
+                )
             ]
 
             # generate numpy structured array dtype

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -56,7 +56,7 @@ def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
 def apply_column_types(
     df: pd.DataFrame, column_types: list[GenericDataType]
 ) -> pd.DataFrame:
-    for column, column_type in zip(df.columns, column_types):
+    for column, column_type in zip(df.columns, column_types, strict=False):
         if column_type == GenericDataType.NUMERIC:
             try:
                 df[column] = pd.to_numeric(df[column])

--- a/superset/utils/mock_data.py
+++ b/superset/utils/mock_data.py
@@ -221,8 +221,11 @@ def get_column_objects(columns: list[ColumnInfo]) -> list[Column]:
 def generate_data(columns: list[ColumnInfo], num_rows: int) -> list[dict[str, Any]]:
     keys = [column["name"] for column in columns]
     return [
-        dict(zip(keys, row))
-        for row in zip(*[generate_column_data(column, num_rows) for column in columns])
+        dict(zip(keys, row, strict=False))
+        for row in zip(
+            *[generate_column_data(column, num_rows) for column in columns],
+            strict=False,
+        )
     ]
 
 

--- a/superset/utils/pandas_postprocessing/compare.py
+++ b/superset/utils/pandas_postprocessing/compare.py
@@ -59,7 +59,7 @@ def compare(  # pylint: disable=too-many-arguments
     if len(source_columns) == 0:
         return df
 
-    for s_col, c_col in zip(source_columns, compare_columns):
+    for s_col, c_col in zip(source_columns, compare_columns, strict=False):
         s_df = df.loc[:, [s_col]]
         s_df.rename(columns={s_col: "__intermediate"}, inplace=True)
         c_df = df.loc[:, [c_col]]

--- a/superset/utils/pandas_postprocessing/geography.py
+++ b/superset/utils/pandas_postprocessing/geography.py
@@ -40,7 +40,7 @@ def geohash_decode(
     try:
         lonlat_df = DataFrame()
         lonlat_df["latitude"], lonlat_df["longitude"] = zip(
-            *df[geohash].apply(geohash_lib.decode)
+            *df[geohash].apply(geohash_lib.decode), strict=False
         )
         return _append_columns(
             df, lonlat_df, {"latitude": latitude, "longitude": longitude}
@@ -109,7 +109,7 @@ def geodetic_parse(
             geodetic_df["latitude"],
             geodetic_df["longitude"],
             geodetic_df["altitude"],
-        ) = zip(*df[geodetic].apply(_parse_location))
+        ) = zip(*df[geodetic].apply(_parse_location), strict=False)
         columns = {"latitude": latitude, "longitude": longitude}
         if altitude:
             columns["altitude"] = altitude

--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -71,7 +71,7 @@ def histogram(
 
     if len(groupby) == 0:
         # without grouping
-        hist_dict = dict(zip(bin_edges_str, hist_values(df[column])))
+        hist_dict = dict(zip(bin_edges_str, hist_values(df[column]), strict=False))
         histogram_df = DataFrame(hist_dict, index=[0])
     else:
         # with grouping

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1779,6 +1779,7 @@ class MapboxViz(BaseViz):
                     df[self.form_data.get("all_columns_y")],
                     metric_col,
                     point_radius_col,
+                    strict=False,
                 )
             ],
         }
@@ -1902,6 +1903,7 @@ class BaseDeckGLViz(BaseViz):
                 zip(
                     pd.to_numeric(df[spatial.get("lonCol")], errors="coerce"),
                     pd.to_numeric(df[spatial.get("latCol")], errors="coerce"),
+                    strict=False,
                 )
             )
         elif spatial.get("type") == "delimited":

--- a/tests/integration_tests/core_tests.py
+++ b/tests/integration_tests/core_tests.py
@@ -673,7 +673,9 @@ class TestCore(SupersetTestCase):
                 count_ds = series["values"]
             if series["key"] == "COUNT(name)":
                 count_name = series["values"]
-        for expected, actual_ds, actual_name in zip(resp["data"], count_ds, count_name):
+        for expected, actual_ds, actual_name in zip(
+            resp["data"], count_ds, count_name, strict=False
+        ):
             assert expected["count_name"] == actual_name["y"]
             assert expected["count_ds"] == actual_ds["y"]
 

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -87,7 +87,7 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
         inspector.bind.execute.return_value.fetchall = mock.Mock(return_value=[row])
         results = PrestoEngineSpec.get_columns(inspector, Table("", ""))
         assert len(expected_results) == len(results)
-        for expected_result, result in zip(expected_results, results):
+        for expected_result, result in zip(expected_results, results, strict=False):
             assert expected_result[0] == result["column_name"]
             assert expected_result[1] == str(result["type"])
 
@@ -191,7 +191,9 @@ class TestPrestoDbEngineSpec(TestDbEngineSpec):
                 "label": 'column."quoted.nested obj"',
             },
         ]
-        for actual_result, expected_result in zip(actual_results, expected_results):
+        for actual_result, expected_result in zip(
+            actual_results, expected_results, strict=False
+        ):
             assert actual_result.element.name == expected_result["column_name"]
             assert actual_result.name == expected_result["label"]
 

--- a/tests/integration_tests/dict_import_export_tests.py
+++ b/tests/integration_tests/dict_import_export_tests.py
@@ -80,7 +80,8 @@ class TestDictImportExport(SupersetTestCase):
             "id": id,
             "params": json.dumps(params),
             "columns": [
-                {"column_name": c, "uuid": u} for c, u in zip(cols_names, cols_uuids)
+                {"column_name": c, "uuid": u}
+                for c, u in zip(cols_names, cols_uuids, strict=False)
             ],
             "metrics": [{"metric_name": c, "expression": ""} for c in metric_names],
         }
@@ -88,7 +89,7 @@ class TestDictImportExport(SupersetTestCase):
         table = SqlaTable(
             id=id, schema=schema, table_name=name, params=json.dumps(params)
         )
-        for col_name, uuid in zip(cols_names, cols_uuids):
+        for col_name, uuid in zip(cols_names, cols_uuids, strict=False):
             table.columns.append(TableColumn(column_name=col_name, uuid=uuid))
         for metric_name in metric_names:
             table.metrics.append(SqlMetric(metric_name=metric_name, expression=""))

--- a/tests/integration_tests/import_export_tests.py
+++ b/tests/integration_tests/import_export_tests.py
@@ -153,7 +153,7 @@ class TestImportExport(SupersetTestCase):
         assert len(expected_dash.slices) == len(actual_dash.slices)
         expected_slices = sorted(expected_dash.slices, key=lambda s: s.slice_name or "")
         actual_slices = sorted(actual_dash.slices, key=lambda s: s.slice_name or "")
-        for e_slc, a_slc in zip(expected_slices, actual_slices):
+        for e_slc, a_slc in zip(expected_slices, actual_slices, strict=False):
             self.assert_slice_equals(e_slc, a_slc)
         if check_position:
             assert expected_dash.position_json == actual_dash.position_json
@@ -212,7 +212,7 @@ class TestImportExport(SupersetTestCase):
         """
         expected_slices = sorted(expected_dash.slices, key=lambda s: s.slice_name or "")
         actual_slices = sorted(actual_dash.slices, key=lambda s: s.slice_name or "")
-        for e_slc, a_slc in zip(expected_slices, actual_slices):
+        for e_slc, a_slc in zip(expected_slices, actual_slices, strict=False):
             params = a_slc.params_dict
             assert e_slc.datasource.name == params["datasource_name"]
             assert e_slc.datasource.schema == params["schema"]

--- a/tests/unit_tests/sql_parse_tests.py
+++ b/tests/unit_tests/sql_parse_tests.py
@@ -1507,7 +1507,7 @@ def test_insert_rls_as_subquery(
             else candidate_table.table
         )
         for left, right in zip(
-            candidate_table_name.split(".")[::-1], table.split(".")[::-1]
+            candidate_table_name.split(".")[::-1], table.split(".")[::-1], strict=False
         ):
             if left != right:
                 return None
@@ -1719,7 +1719,9 @@ def test_insert_rls_in_predicate(
         Return the RLS ``condition`` if ``candidate`` matches ``table``.
         """
         # compare ignoring schema
-        for left, right in zip(str(candidate).split(".")[::-1], table.split(".")[::-1]):
+        for left, right in zip(
+            str(candidate).split(".")[::-1], table.split(".")[::-1], strict=False
+        ):
             if left != right:
                 return None
         return condition


### PR DESCRIPTION
Gave supporting `3.12` a shot while deprecating `3.9`, made some progress but hit some blockers. Keeping this PR open to keep tabs on what's blocking at this time.

`pandas==2.0.3` does not support py3.12, so bumped to latest, hit some issues, found some worrisome changes apparently in `pandas>=2.2.0` related to them no supporting `dtype` arg of type `sqlalchemy` in `df.to_sql()`, so reverter to the highest under 2.2, and seems there are issues there. Pandas folks not respecting semver it seems but given the API surface pandas have, gonna be have to evolve that lib without breaking a million things.

Python wizards, help is very welcome to help get this through