### PR TITLE
feat: allowing print() statements to be unbuffered in docker

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# Allowing python to print() in docker
+PYTHONUNBUFFERED=1
 
 COMPOSE_PROJECT_NAME=superset
 DEV_MODE=true


### PR DESCRIPTION
I finally looked into something that's been bugging me for a while:
python print() statements not showing up in docker logs. Digging a bit,
turns out in non-interactive mode (aka docker environment), the print
statements are buffered, meaning they don't show up in logs until the
program exits. From what I read this is a legacy behavior around the
concern that printing is more expensive than writing to file. Anyhow,
created confusion for me trying to debug with prints in the past, I
would print, and to see the output I'd have to save a file, which - in
our dev environments - triggers flask to restart, and flush the buffer,
meaning prints aren't in-line with logger.info statements. Anyhow,
I learned to use logger instead of prints while debugging for that reason.
Another byproduct of that is buffer growth, which can explain at least a
bit of memory leak in our environments. Everything you print stays
in-memory until the interpreted exits - minimal, but could see potential
issues with that. In any case solution is as simple as setting
PYTHONUNBUFFERED=1 in our docker containers to solve. Seems like a no
brainer.

