### PR TITLE
feat(Timeseries): Respect time grain

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -594,13 +594,13 @@ export default function transformProps(
       minInterval:
         xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
           ? TIMEGRAIN_TO_TIMESTAMP[
-              timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+                (formData.extraFormData.time_grain_sqla ?? timeGrainSqla) as keyof typeof TIMEGRAIN_TO_TIMESTAMP
             ]
           : 0,
       maxInterval:
         xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
           ? TIMEGRAIN_TO_TIMESTAMP[
-              timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+                (formData.extraFormData.time_grain_sqla ?? timeGrainSqla) as keyof typeof TIMEGRAIN_TO_TIMESTAMP
             ]
           : undefined,
       ...getMinAndMaxFromBounds(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -543,11 +543,11 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(tooltipTimeFormat, timeGrainSqla)
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat)
+      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
       : String;
 
   const addYAxisTitleOffset = !!(yAxisTitle || yAxisTitleSecondary);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -219,10 +219,7 @@ export default function transformProps(
     showQueryIdentifiers = false,
     metrics = [],
     metricsB = [],
-  }: EchartsMixedTimeseriesFormData = {
-    ...DEFAULT_FORM_DATA,
-    ...formData,
-  };
+  }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
 
   const refs: Refs = {};
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -23,6 +23,7 @@ import {
   AxisType,
   buildCustomFormatters,
   CategoricalColorNamespace,
+  convertKeysToCamelCase,
   CurrencyFormatter,
   ensureIsArray,
   getCustomFormatter,
@@ -219,7 +220,11 @@ export default function transformProps(
     showQueryIdentifiers = false,
     metrics = [],
     metricsB = [],
-  }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
+  }: EchartsMixedTimeseriesFormData = {
+    ...DEFAULT_FORM_DATA,
+    ...formData,
+    ...convertKeysToCamelCase(formData.extraFormData),
+  };
 
   const refs: Refs = {};
   const colorScale = CategoricalColorNamespace.getScale(colorScheme as string);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -23,7 +23,6 @@ import {
   AxisType,
   buildCustomFormatters,
   CategoricalColorNamespace,
-  convertKeysToCamelCase,
   CurrencyFormatter,
   ensureIsArray,
   getCustomFormatter,
@@ -223,7 +222,6 @@ export default function transformProps(
   }: EchartsMixedTimeseriesFormData = {
     ...DEFAULT_FORM_DATA,
     ...formData,
-    ...convertKeysToCamelCase(formData.extraFormData),
   };
 
   const refs: Refs = {};
@@ -548,11 +546,17 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat, timeGrainSqla)
+      ? getTooltipTimeFormatter(
+          tooltipTimeFormat,
+          formData.extraFormData.time_grain_sqla ?? timeGrainSqla,
+        )
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
+      ? getXAxisFormatter(
+          xAxisTimeFormat,
+          formData.extraFormData.time_grain_sqla ?? timeGrainSqla,
+        )
       : String;
 
   const addYAxisTitleOffset = !!(yAxisTitle || yAxisTitleSecondary);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -542,13 +542,13 @@ export default function transformProps(
     minInterval:
       xAxisType === AxisType.Time && timeGrainSqla && !forceMaxInterval
         ? TIMEGRAIN_TO_TIMESTAMP[
-            timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+              (formData.extraFormData.time_grain_sqla ?? timeGrainSqla) as keyof typeof TIMEGRAIN_TO_TIMESTAMP
           ]
         : 0,
     maxInterval:
       xAxisType === AxisType.Time && timeGrainSqla && forceMaxInterval
         ? TIMEGRAIN_TO_TIMESTAMP[
-            timeGrainSqla as keyof typeof TIMEGRAIN_TO_TIMESTAMP
+              (formData.extraFormData.time_grain_sqla ?? timeGrainSqla) as keyof typeof TIMEGRAIN_TO_TIMESTAMP
           ]
         : undefined,
     ...getMinAndMaxFromBounds(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -204,7 +204,7 @@ export default function transformProps(
   }: EchartsTimeseriesFormData = {
     ...DEFAULT_FORM_DATA,
     ...formData,
-    ...convertKeysToCamelCase(formData.extra_form_data),
+    ...convertKeysToCamelCase(formData.extraFormData),
   };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -200,10 +200,7 @@ export default function transformProps(
     yAxisTitlePosition,
     zoomable,
     stackDimension,
-  }: EchartsTimeseriesFormData = {
-    ...DEFAULT_FORM_DATA,
-    ...formData,
-  };
+  }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
   const labelMap: { [key: string]: string[] } = Object.entries(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -39,7 +39,6 @@ import {
   t,
   TimeseriesChartDataResponseResult,
   NumberFormats,
-  convertKeysToCamelCase,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import {
@@ -204,7 +203,6 @@ export default function transformProps(
   }: EchartsTimeseriesFormData = {
     ...DEFAULT_FORM_DATA,
     ...formData,
-    ...convertKeysToCamelCase(formData.extraFormData),
   };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
@@ -485,11 +483,17 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat, timeGrainSqla)
+      ? getTooltipTimeFormatter(
+          tooltipTimeFormat,
+          formData.extraFormData.time_grain_sqla ?? timeGrainSqla,
+        )
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
+      ? getXAxisFormatter(
+          xAxisTimeFormat,
+          formData.extraFormData.time_grain_sqla ?? timeGrainSqla,
+        )
       : xAxisDataType === GenericDataType.Numeric
         ? getNumberFormatter(xAxisNumberFormat)
         : String;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -39,6 +39,7 @@ import {
   t,
   TimeseriesChartDataResponseResult,
   NumberFormats,
+  convertKeysToCamelCase,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import {
@@ -200,8 +201,11 @@ export default function transformProps(
     yAxisTitlePosition,
     zoomable,
     stackDimension,
-  }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
-
+  }: EchartsTimeseriesFormData = {
+    ...DEFAULT_FORM_DATA,
+    ...formData,
+    ...convertKeysToCamelCase(formData.extra_form_data),
+  };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
   const labelMap: { [key: string]: string[] } = Object.entries(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -481,11 +481,11 @@ export default function transformProps(
 
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getTooltipTimeFormatter(tooltipTimeFormat)
+      ? getTooltipTimeFormatter(tooltipTimeFormat, timeGrainSqla)
       : String;
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
-      ? getXAxisFormatter(xAxisTimeFormat)
+      ? getXAxisFormatter(xAxisTimeFormat, timeGrainSqla)
       : xAxisDataType === GenericDataType.Numeric
         ? getNumberFormatter(xAxisNumberFormat)
         : String;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -29,6 +29,7 @@ import {
   SMART_DATE_ID,
   SMART_DATE_VERBOSE_ID,
   TimeFormatter,
+  TimeGranularity,
   ValueFormatter,
 } from '@superset-ui/core';
 
@@ -76,24 +77,40 @@ export const getYAxisFormatter = (
 
 export function getTooltipTimeFormatter(
   format?: string,
+  timeGrain?: TimeGranularity,
 ): TimeFormatter | StringConstructor {
+  if (
+    timeGrain === TimeGranularity.QUARTER ||
+    timeGrain === TimeGranularity.MONTH ||
+    timeGrain === TimeGranularity.YEAR
+  ) {
+    return getTimeFormatter(undefined, timeGrain);
+  }
   if (format === SMART_DATE_ID) {
-    return getSmartDateVerboseFormatter();
+    return getTimeFormatter(SMART_DATE_DETAILED_ID, timeGrain);
   }
   if (format) {
-    return getTimeFormatter(format);
+    return getTimeFormatter(format, timeGrain);
   }
   return String;
 }
 
 export function getXAxisFormatter(
   format?: string,
+  timeGrain?: TimeGranularity,
 ): TimeFormatter | StringConstructor | undefined {
+  if (
+    timeGrain === TimeGranularity.QUARTER ||
+    timeGrain === TimeGranularity.MONTH ||
+    timeGrain === TimeGranularity.YEAR
+  ) {
+    return getTimeFormatter(undefined, timeGrain);
+  }
   if (format === SMART_DATE_ID || !format) {
     return undefined;
   }
   if (format) {
-    return getTimeFormatter(format);
+    return getTimeFormatter(format, timeGrain);
   }
   return String;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -38,8 +38,8 @@ export const getSmartDateDetailedFormatter = () =>
 
 export const getSmartDateFormatter = () => getTimeFormatter(SMART_DATE_ID);
 
-export const getSmartDateVerboseFormatter = () =>
-  getTimeFormatter(SMART_DATE_VERBOSE_ID);
+export const getSmartDateVerboseFormatter = (timeGrain?: TimeGranularity) =>
+  getTimeFormatter(SMART_DATE_VERBOSE_ID, timeGrain);
 
 export const getPercentFormatter = (format?: string) =>
   getNumberFormatter(
@@ -87,7 +87,7 @@ export function getTooltipTimeFormatter(
     return getTimeFormatter(undefined, timeGrain);
   }
   if (format === SMART_DATE_ID) {
-    return getTimeFormatter(SMART_DATE_VERBOSE_ID, timeGrain);
+    return getSmartDateVerboseFormatter(timeGrain);
   }
   if (format) {
     return getTimeFormatter(format, timeGrain);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -87,7 +87,7 @@ export function getTooltipTimeFormatter(
     return getTimeFormatter(undefined, timeGrain);
   }
   if (format === SMART_DATE_ID) {
-    return getTimeFormatter(SMART_DATE_DETAILED_ID, timeGrain);
+    return getTimeFormatter(SMART_DATE_VERBOSE_ID, timeGrain);
   }
   if (format) {
     return getTimeFormatter(format, timeGrain);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -402,7 +402,7 @@ describe('should add the correct time formatter for the xAxis', () => {
   it('should work for years', () => {
     const formatter = getXAxisFormatter(TimeGranularity.YEAR);
     expect(formatter).toBeDefined();
-    expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+    expect(formatter(1610000000000)).toEqual('2021');
   });
 });
 
@@ -476,6 +476,6 @@ describe('should add the correct time formatter for the tooltip', () => {
   it('should work for years', () => {
     const formatter = getTooltipFormatter(TimeGranularity.YEAR);
     expect(formatter).toBeDefined();
-    expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+    expect(formatter(1610000000000)).toEqual('2021');
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -400,7 +400,7 @@ describe('should add the correct time formatter for the xAxis', () => {
   });
 
   it('should work for years', () => {
-    const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+    const formatter = getXAxisFormatter(TimeGranularity.YEAR);
     expect(formatter).toBeDefined();
     expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
   });
@@ -474,7 +474,7 @@ describe('should add the correct time formatter for the tooltip', () => {
   });
 
   it('should work for years', () => {
-    const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+    const formatter = getTooltipFormatter(TimeGranularity.YEAR);
     expect(formatter).toBeDefined();
     expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -16,8 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps, VizType } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/ui';
+import {
+  ChartProps,
+  TimeFormatter,
+  TimeGranularity,
+  VizType,
+} from '@superset-ui/core';
 import {
   LegendOrientation,
   LegendType,
@@ -28,6 +33,7 @@ import {
   EchartsMixedTimeseriesFormData,
   EchartsMixedTimeseriesProps,
 } from '../../src/MixedTimeseries/types';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 const formData: EchartsMixedTimeseriesFormData = {
   annotationLayers: [],
@@ -321,4 +327,155 @@ test('legend margin: right orientation sets grid.right correctly', () => {
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
   expect((transformed.echartOptions.grid as any).right).toEqual(270);
+});
+
+describe('should add the correct time formatter for the xAxis', () => {
+  const getXAxisFormatter = (timeGrainSqla: TimeGranularity) => {
+    const updatedChartPropsConfig = {
+      ...chartPropsConfig,
+      formData: {
+        ...chartPropsConfig.formData,
+        time_grain_sqla: timeGrainSqla,
+        xAxisTimeFormat: '%Y-%m-%d',
+      },
+      queriesData: [
+        {
+          data: chartPropsConfig.queriesData[0].data,
+          label_map: chartPropsConfig.queriesData[0].label_map,
+          colnames: ['Boy', 'Girl', 'ds'],
+          coltypes: [
+            GenericDataType.String,
+            GenericDataType.String,
+            GenericDataType.Temporal,
+          ],
+        },
+        {
+          data: chartPropsConfig.queriesData[1].data,
+          label_map: chartPropsConfig.queriesData[1].label_map,
+          colnames: ['Boy', 'Girl', 'ds'],
+          coltypes: [
+            GenericDataType.String,
+            GenericDataType.String,
+            GenericDataType.Temporal,
+          ],
+        },
+      ],
+    };
+    const { echartOptions } = transformProps(
+      new ChartProps(updatedChartPropsConfig) as EchartsMixedTimeseriesProps,
+    );
+    const xAxis = echartOptions.xAxis as {
+      axisLabel: { formatter: TimeFormatter };
+    };
+    return xAxis.axisLabel.formatter;
+  };
+
+  it('should work for days', () => {
+    const formatter = getXAxisFormatter(TimeGranularity.DAY);
+    expect(formatter(1610000000000)).toEqual(
+      expect.stringMatching('2021-01-07'),
+    );
+  });
+
+  it('should work for weeks', () => {
+    const formatter = getXAxisFormatter(TimeGranularity.WEEK);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(
+      expect.stringMatching('2021-01-07 — 2021-01-13'),
+    );
+  });
+
+  it('should work for months', () => {
+    const formatter = getXAxisFormatter(TimeGranularity.MONTH);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('Jan'));
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+  });
+
+  it('should work for quarters', () => {
+    const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('Q1'));
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+  });
+
+  it('should work for years', () => {
+    const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+  });
+});
+
+describe('should add the correct time formatter for the tooltip', () => {
+  const getTooltipFormatter = (timeGrainSqla: TimeGranularity) => {
+    const updatedChartPropsConfig = {
+      ...chartPropsConfig,
+      formData: {
+        ...chartPropsConfig.formData,
+        time_grain_sqla: timeGrainSqla,
+        tooltipTimeFormat: '%Y-%m-%d',
+      },
+      queriesData: [
+        {
+          data: chartPropsConfig.queriesData[0].data,
+          label_map: chartPropsConfig.queriesData[0].label_map,
+          colnames: ['Boy', 'Girl', 'ds'],
+          coltypes: [
+            GenericDataType.String,
+            GenericDataType.String,
+            GenericDataType.Temporal,
+          ],
+        },
+        {
+          data: chartPropsConfig.queriesData[1].data,
+          label_map: chartPropsConfig.queriesData[1].label_map,
+          colnames: ['Boy', 'Girl', 'ds'],
+          coltypes: [
+            GenericDataType.String,
+            GenericDataType.String,
+            GenericDataType.Temporal,
+          ],
+        },
+      ],
+    };
+
+    return transformProps(
+      new ChartProps(updatedChartPropsConfig) as EchartsMixedTimeseriesProps,
+    ).xValueFormatter;
+  };
+
+  it('should work for days', () => {
+    const formatter = getTooltipFormatter(TimeGranularity.DAY);
+    expect(formatter(1610000000000)).toEqual(
+      expect.stringMatching('2021-01-07'),
+    );
+  });
+
+  it('should work for weeks', () => {
+    const formatter = getTooltipFormatter(TimeGranularity.WEEK);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(
+      expect.stringMatching('2021-01-07 — 2021-01-13'),
+    );
+  });
+
+  it('should work for months', () => {
+    const formatter = getTooltipFormatter(TimeGranularity.MONTH);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('Jan'));
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+  });
+
+  it('should work for quarters', () => {
+    const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('Q1'));
+    expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+  });
+
+  it('should work for years', () => {
+    const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+    expect(formatter).toBeDefined();
+    expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -690,7 +690,7 @@ describe('Does transformProps transform series correctly', () => {
     it('should work for years', () => {
       const formatter = getXAxisFormatter(TimeGranularity.YEAR);
       expect(formatter).toBeDefined();
-      expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+      expect(formatter(1610000000000)).toEqual('2021');
     });
   });
 
@@ -753,7 +753,7 @@ describe('Does transformProps transform series correctly', () => {
     it('should work for years', () => {
       const formatter = getTooltipFormatter(TimeGranularity.YEAR);
       expect(formatter).toBeDefined();
-      expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+      expect(formatter(1610000000000)).toEqual('2021');
     });
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -688,7 +688,7 @@ describe('Does transformProps transform series correctly', () => {
     });
 
     it('should work for years', () => {
-      const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+      const formatter = getXAxisFormatter(TimeGranularity.YEAR);
       expect(formatter).toBeDefined();
       expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
     });
@@ -751,7 +751,7 @@ describe('Does transformProps transform series correctly', () => {
     });
 
     it('should work for years', () => {
-      const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+      const formatter = getTooltipFormatter(TimeGranularity.YEAR);
       expect(formatter).toBeDefined();
       expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -25,11 +25,14 @@ import {
   FormulaAnnotationLayer,
   IntervalAnnotationLayer,
   SqlaFormData,
+  TimeFormatter,
+  TimeGranularity,
   TimeseriesAnnotationLayer,
 } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/ui';
 import { EchartsTimeseriesChartProps } from '../../src/types';
 import transformProps from '../../src/Timeseries/transformProps';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 const formData: SqlaFormData = {
   colorScheme: 'bnbColors',
@@ -622,6 +625,135 @@ describe('Does transformProps transform series correctly', () => {
       '1 year ago, foo2, bar2': ['foo2', 'bar2'],
       'foo1, bar1': ['foo1', 'bar1'],
       'foo2, bar2': ['foo2', 'bar2'],
+    });
+  });
+
+  describe('should add the correct time formatter for the xAxis', () => {
+    const getXAxisFormatter = (timeGrainSqla: TimeGranularity) => {
+      const updatedChartPropsConfig = {
+        ...chartPropsConfig,
+        formData: {
+          ...chartPropsConfig.formData,
+          time_grain_sqla: timeGrainSqla,
+          xAxisTimeFormat: '%Y-%m-%d',
+        },
+        queriesData: [
+          {
+            data: chartPropsConfig.queriesData[0].data,
+            colnames: ['San Francisco', 'New York', '__timestamp'],
+            coltypes: [
+              GenericDataType.String,
+              GenericDataType.String,
+              GenericDataType.Temporal,
+            ],
+          },
+        ],
+      };
+      const { echartOptions } = transformProps(
+        new ChartProps(updatedChartPropsConfig) as EchartsTimeseriesChartProps,
+      );
+      const xAxis = echartOptions.xAxis as {
+        axisLabel: { formatter: TimeFormatter };
+      };
+      return xAxis.axisLabel.formatter;
+    };
+
+    it('should work for days', () => {
+      const formatter = getXAxisFormatter(TimeGranularity.DAY);
+      expect(formatter(1610000000000)).toEqual(
+        expect.stringMatching('2021-01-07'),
+      );
+    });
+
+    it('should work for weeks', () => {
+      const formatter = getXAxisFormatter(TimeGranularity.WEEK);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(
+        expect.stringMatching('2021-01-07 — 2021-01-13'),
+      );
+    });
+
+    it('should work for months', () => {
+      const formatter = getXAxisFormatter(TimeGranularity.MONTH);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('Jan'));
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+    });
+
+    it('should work for quarters', () => {
+      const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('Q1'));
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+    });
+
+    it('should work for years', () => {
+      const formatter = getXAxisFormatter(TimeGranularity.QUARTER);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
+    });
+  });
+
+  describe('should add the correct time formatter for the tooltip', () => {
+    const getTooltipFormatter = (timeGrainSqla: TimeGranularity) => {
+      const updatedChartPropsConfig = {
+        ...chartPropsConfig,
+        formData: {
+          ...chartPropsConfig.formData,
+          time_grain_sqla: timeGrainSqla,
+          tooltipTimeFormat: '%Y-%m-%d',
+        },
+        queriesData: [
+          {
+            data: chartPropsConfig.queriesData[0].data,
+            colnames: ['San Francisco', 'New York', '__timestamp'],
+            coltypes: [
+              GenericDataType.String,
+              GenericDataType.String,
+              GenericDataType.Temporal,
+            ],
+          },
+        ],
+      };
+
+      return transformProps(
+        new ChartProps(updatedChartPropsConfig) as EchartsTimeseriesChartProps,
+      ).xValueFormatter;
+    };
+
+    it('should work for days', () => {
+      const formatter = getTooltipFormatter(TimeGranularity.DAY);
+      expect(formatter(1610000000000)).toEqual(
+        expect.stringMatching('2021-01-07'),
+      );
+    });
+
+    it('should work for weeks', () => {
+      const formatter = getTooltipFormatter(TimeGranularity.WEEK);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(
+        expect.stringMatching('2021-01-07 — 2021-01-13'),
+      );
+    });
+
+    it('should work for months', () => {
+      const formatter = getTooltipFormatter(TimeGranularity.MONTH);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('Jan'));
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+    });
+
+    it('should work for quarters', () => {
+      const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('Q1'));
+      expect(formatter(1610000000000)).toEqual(expect.stringContaining('2021'));
+    });
+
+    it('should work for years', () => {
+      const formatter = getTooltipFormatter(TimeGranularity.QUARTER);
+      expect(formatter).toBeDefined();
+      expect(formatter(1610000000000)).toEqual(expect.stringMatching('2021'));
     });
   });
 });


### PR DESCRIPTION
## **User description**
### SUMMARY
Respect time grain in timeseries and mixed timeseries chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="2394" alt="image" src="https://github.com/user-attachments/assets/31f89bdd-cfd9-48c3-8841-5d24946e4a65" />

#### AFTER
<img width="3018" alt="image" src="https://github.com/user-attachments/assets/580d8320-62d3-4627-8640-95c1643dc366" />

### TESTING INSTRUCTIONS
Create a Timeseries or MixedTimeseries chart and use the time grain Quarter.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Respect time grain for x-axis and tooltip date formatting in Timeseries and MixedTimeseries charts**

### What Changed
- X-axis labels and tooltip date strings now honor the chart's selected time grain (day, week, month, quarter, year), showing appropriate ranges and concise labels (for example: weekly ranges, "Jan 2021" for months, "Q1 2021" for quarters, "2021" for years).
- Time grain overrides supplied to the chart (for example, via dashboard/extra form overrides) are applied to both x-axis and tooltip formatting.
- The SMART_DATE verbose formatter now produces verbose date strings that match the selected time grain.
- Unit tests added for Timeseries and MixedTimeseries to validate formatting across days, weeks, months, quarters, and years.

### Impact
`✅ Clearer time labels for weekly/monthly/quarterly/yearly charts`
`✅ Consistent tooltip dates with configured time grain`
`✅ Fewer incorrect date displays when dashboards override time grain`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
