### PR TITLE
clean

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     container_name: superset_nginx
     restart: unless-stopped
     ports:
-      - "80:80"
+      - "8081:80"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -91,7 +91,7 @@ services:
     command: ["/app/docker/docker-bootstrap.sh", "app"]
     restart: unless-stopped
     ports:
-      - 8088:8088
+      - 8089:8088
     extra_hosts:
       - "host.docker.internal:host-gateway"
     user: *superset-user

--- a/superset-frontend/cypress-base/cypress.config.ts
+++ b/superset-frontend/cypress-base/cypress.config.ts
@@ -33,7 +33,7 @@ export default eyesPlugin(
     video: false,
     viewportWidth: 1280,
     viewportHeight: 1024,
-    projectId: 'ud5x2f',
+    projectId: 'j7nqyu',
     retries: {
       runMode: 2,
       openMode: 0,
@@ -68,7 +68,7 @@ export default eyesPlugin(
         // eslint-disable-next-line global-require,import/extensions
         return config;
       },
-      baseUrl: 'http://localhost:8088',
+      baseUrl: 'http://localhost:8089',
       excludeSpecPattern: [],
       specPattern: [
         'cypress/e2e/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
update ports and cypress project id

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the port mappings in `docker-compose.yml` for the Nginx and app services and adjust the project ID and base URL in `cypress.config.ts`.

### Why are these changes being made?
These changes are being made to accommodate a port conflict and ensure the app runs on non-default ports, preventing interference with services using port 80 and 8088. The updates in the Cypress configuration, including the project ID and base URL, reflect these new settings, ensuring integration tests still target the correct addresses.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->