### PR TITLE
fix(oauth): Handle updates to the OAuth config

### DIFF
--- a/superset/commands/database/update.py
+++ b/superset/commands/database/update.py
@@ -44,6 +44,7 @@ from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.db_engine_specs.base import GenericDBException
 from superset.exceptions import OAuth2RedirectError
 from superset.models.core import Database
+from superset.utils import json
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
@@ -66,21 +67,22 @@ class UpdateDatabaseCommand(BaseCommand):
 
         self.validate()
 
-        # unmask ``encrypted_extra``
-        self._properties["encrypted_extra"] = (
-            self._model.db_engine_spec.unmask_encrypted_extra(
-                self._model.encrypted_extra,
-                self._properties.pop("masked_encrypted_extra", "{}"),
+        if "masked_encrypted_extra" in self._properties:
+            # unmask ``encrypted_extra``
+            self._properties["encrypted_extra"] = (
+                self._model.db_engine_spec.unmask_encrypted_extra(
+                    self._model.encrypted_extra,
+                    self._properties["masked_encrypted_extra"],
+                )
             )
-        )
+
+            # Depending on the changes to the OAuth2 configuration we may need to purge
+            # existing personal tokens.
+            self._handle_oauth2()
 
         # if the database name changed we need to update any existing permissions,
         # since they're name based
         original_database_name = self._model.database_name
-
-        # Depending on the changes to the OAuth2 configuration we may need to purge
-        # existing personal tokens.
-        self._handle_oauth2()
 
         database = DatabaseDAO.update(self._model, self._properties)
         database.set_sqlalchemy_uri(database.sqlalchemy_uri)
@@ -99,11 +101,16 @@ class UpdateDatabaseCommand(BaseCommand):
         if not self._model:
             return
 
+        if self._properties["encrypted_extra"] is None:
+            self._model.purge_oauth2_tokens()
+            return
+
         current_config = self._model.get_oauth2_config()
         if not current_config:
             return
 
-        new_config = self._properties["encrypted_extra"].get("oauth2_client_info", {})
+        encrypted_extra = json.loads(self._properties["encrypted_extra"])
+        new_config = encrypted_extra.get("oauth2_client_info", {})
 
         # Keys that require purging personal tokens because they probably are no longer
         # valid. For example, if the scope has changed the existing tokens are still

--- a/tests/unit_tests/commands/databases/update_test.py
+++ b/tests/unit_tests/commands/databases/update_test.py
@@ -399,8 +399,8 @@ def test_remove_oauth_config_purges_tokens(
         "find_permission_view_menu",
     )
     find_permission_view_menu.side_effect = [
-        None,  # schema1 has no permissions
-        "[my_db].[schema2]",  # second schema already exists
+        None,
+        "[my_db].[schema2]",
     ]
     add_permission_view_menu = mocker.patch.object(
         security_manager,
@@ -435,8 +435,8 @@ def test_update_other_fields_dont_affect_oauth(
         "find_permission_view_menu",
     )
     find_permission_view_menu.side_effect = [
-        None,  # schema1 has no permissions
-        "[my_db].[schema2]",  # second schema already exists
+        None,
+        "[my_db].[schema2]",
     ]
     add_permission_view_menu = mocker.patch.object(
         security_manager,


### PR DESCRIPTION
### SUMMARY
The `masked_encrypted_extra` value is passed as a string during the database update API call. The code was currently throwing an error when trying to `.get()` a key from it (as it wasn't loaded as a `dict`).

This PR fixes this issue, and also perform a few modifications:
* Avoids validating OAuth changes if `masked_encrypted_extra` is not part of the API payload.
* Purges OAuth tokens in case the connection configuration is removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Unit tests added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the handling of OAuth2 updates in the database update command to properly manage `encrypted_extra` masking and ensure personal OAuth2 tokens are purged when necessary, including added unit tests for these changes.

### Why are these changes being made?

These changes improve the robustness of database updates involving OAuth2 configurations by accurately unmasking `encrypted_extra`, ensuring existing tokens are purged when changes occur, and adding comprehensive tests to prevent regression. This approach ensures that personal tokens remain valid according to the latest configuration, enhancing security and maintaining updated permissions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->