### PR TITLE
fix(popover): refactor toggle and close handlers for controlled components

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopoverTrigger.tsx
@@ -72,26 +72,33 @@ const ColumnSelectPopoverTrigger = ({
     setPopoverLabel(initialPopoverLabel);
   }, [initialPopoverLabel, popoverVisible]);
 
-  const togglePopover = useCallback((visible: boolean) => {
-    setPopoverVisible(visible);
-  }, []);
+  const handleTogglePopover = useCallback(
+    (visible: boolean) => {
+      if (isControlledComponent) {
+        props.togglePopover!(visible);
+      } else {
+        setPopoverVisible(visible);
+      }
 
-  const closePopover = useCallback(() => {
-    setPopoverVisible(false);
-  }, []);
+      if (!visible) {
+        setPopoverLabel(initialPopoverLabel);
+        setHasCustomLabel(false);
+      }
+    },
+    [initialPopoverLabel, isControlledComponent, props.togglePopover],
+  );
 
-  const { visible, handleTogglePopover, handleClosePopover } =
-    isControlledComponent
-      ? {
-          visible: props.visible,
-          handleTogglePopover: props.togglePopover!,
-          handleClosePopover: props.closePopover!,
-        }
-      : {
-          visible: popoverVisible,
-          handleTogglePopover: togglePopover,
-          handleClosePopover: closePopover,
-        };
+  const handleClosePopover = useCallback(() => {
+    if (isControlledComponent) {
+      props.closePopover!();
+    } else {
+      setPopoverVisible(false);
+    }
+    setPopoverLabel(initialPopoverLabel);
+    setHasCustomLabel(false);
+  }, [initialPopoverLabel, isControlledComponent, props.closePopover]);
+
+  const visible = isControlledComponent ? props.visible! : popoverVisible;
 
   const getCurrentTab = useCallback((tab: string) => {
     setIsTitleEditDisabled(tab !== editableTitleTab);


### PR DESCRIPTION
### SUMMARY
Fixes #25592

Added clearing of popoverLabel and hasCustomLabel states. Merged handlers that works with toggle/close from props and locally implemented in component to work with new column selectors and edit existing ones.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="661" alt="Screenshot 2025-01-10 о 18 27 31" src="https://github.com/user-attachments/assets/1439783f-561f-4919-8754-8d57cd6a44b9" />


### TESTING INSTRUCTIONS
1. On the chart table agregattion edit page
2. Add new column with custom title
3. Open new popover to add column
4. Check that column name in popover is default ('My Column')

### ADDITIONAL INFORMATION
- [x] Has associated issue: #25592
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `handleTogglePopover` and `handleClosePopover` functions to better accommodate controlled components within `ColumnSelectPopoverTrigger`.

### Why are these changes being made?

The changes ensure that `ColumnSelectPopoverTrigger` handles both controlled and uncontrolled component cases by delegating toggle and close functionality to external handlers when needed, enhancing flexibility and ensuring consistent behavior across different component states. This approach also consolidates logic, making maintenance easier, though it introduces dependency on the existence of externally provided handlers for controlled components.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->