### PR TITLE
chore(tests): Changing the logic for an intermittent tag test

### DIFF
--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -487,8 +487,19 @@ class TestTagApi(SupersetTestCase):
 
     @pytest.mark.usefixtures("create_tags")
     def test_delete_favorite_tag_not_found(self):
+        """
+        Tag API: Test trying to remove an unexisting tag from the list
+        of user favorites returns 404.
+        """
         self.login(ADMIN_USERNAME)
-        uri = "api/v1/tag/123/favorites/"  # noqa: F541
+
+        # Fetch all existing tag IDs
+        existing_ids = [tag_id for (tag_id,) in db.session.query(Tag.id).all()]
+
+        # Get an ID not in use
+        non_existent_id = max(existing_ids, default=0) + 1
+
+        uri = f"api/v1/tag/{non_existent_id}/favorites/"  # noqa: F541
         rv = self.client.delete(uri, follow_redirects=True)
 
         assert rv.status_code == 404


### PR DESCRIPTION
### SUMMARY
Updating the logic for this particular test as it's been failing on an un-related PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Test logic is still the same -- just added logic to ensure it uses an ID that's not in use yet.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
