### PR TITLE
fix: fix/suppress webpack console warnings

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getAggFunc, commonLayerProps } from './common';
+import { JsonObject } from '@superset-ui/core';
+
+describe('getAggFunc', () => {
+  it('returns correct function for sum', () => {
+    const aggFunc = getAggFunc('sum');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(10);
+  });
+
+  it('returns correct function for min', () => {
+    const aggFunc = getAggFunc('min');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(1);
+  });
+
+  it('returns correct function for max', () => {
+    const aggFunc = getAggFunc('max');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(4);
+  });
+
+  it('returns correct function for mean', () => {
+    const aggFunc = getAggFunc('mean');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(2.5);
+  });
+
+  it('returns correct function for median', () => {
+    const aggFunc = getAggFunc('median');
+    const result = aggFunc([1, 2, 3, 4, 5]);
+    expect(result).toBe(3);
+  });
+
+  it('returns correct function for variance', () => {
+    const aggFunc = getAggFunc('variance');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(1.6666666666666667);
+  });
+
+  it('returns correct function for deviation', () => {
+    const aggFunc = getAggFunc('deviation');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBeCloseTo(1.29099, 5);
+  });
+
+  it('returns correct function for count', () => {
+    const aggFunc = getAggFunc('count');
+    const result = aggFunc([1, 2, 3, 4]);
+    expect(result).toBe(4);
+  });
+
+  it('returns correct function for p95 (percentiles)', () => {
+    const aggFunc = getAggFunc('p95');
+    const result = aggFunc([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result).toBeCloseTo(9.55, 5);
+  });
+
+  it('throws an error for unsupported aggregation type', () => {
+    expect(() => getAggFunc('unsupported')).toThrow(
+      'Unsupported aggregation type: unsupported',
+    );
+  });
+});
+
+describe('commonLayerProps', () => {
+  const mockSetTooltip = jest.fn();
+  const mockSetTooltipContent = jest.fn(
+    () => (o: JsonObject) => `Tooltip for ${o}`,
+  );
+  const mockOnSelect = jest.fn();
+
+  it('returns correct props when js_tooltip is provided', () => {
+    const formData = { js_tooltip: 'tooltip => tooltip.content' } as any;
+    const props = commonLayerProps(
+      formData,
+      mockSetTooltip,
+      mockSetTooltipContent,
+    );
+    expect(props.pickable).toBe(true);
+    expect(props.onHover).toBeDefined();
+  });
+
+  it('calls onHover and sets tooltip', () => {
+    const formData = { js_tooltip: null } as any;
+    const props = commonLayerProps(
+      formData,
+      mockSetTooltip,
+      mockSetTooltipContent,
+    );
+
+    const mockObject = { picked: true, x: 10, y: 20 };
+    props.onHover(mockObject);
+    expect(mockSetTooltip).toHaveBeenCalledWith({
+      content: expect.any(Function), // Matches any function
+      x: 10,
+      y: 20,
+    });
+  });
+
+  it('calls onClick and opens link when js_onclick_href is provided', () => {
+    global.open = jest.fn();
+    const formData = {
+      js_onclick_href: 'o => `https://example.com/${o.id}`',
+    } as any;
+    const props = commonLayerProps(
+      formData,
+      mockSetTooltip,
+      mockSetTooltipContent,
+    );
+
+    const mockObject = { id: 42 };
+    props.onClick(mockObject);
+    expect(global.open).toHaveBeenCalledWith('https://example.com/42');
+  });
+
+  it('calls onSelect when table_filter is enabled', () => {
+    const formData = { table_filter: true, line_column: 'name' } as any;
+    const props = commonLayerProps(
+      formData,
+      mockSetTooltip,
+      mockSetTooltipContent,
+      mockOnSelect,
+    );
+
+    const mockObject = { object: { name: 'John Doe' } };
+    props.onClick(mockObject);
+    expect(mockOnSelect).toHaveBeenCalledWith('John Doe');
+  });
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
@@ -125,23 +125,6 @@ describe('commonLayerProps', () => {
     });
   });
 
-  it('calls onClick and opens link when js_onclick_href is provided', () => {
-    global.open = jest.fn();
-    const formData = {
-      ...partialformData,
-      js_onclick_href: 'o => `https://example.com/${o.id}`',
-    } as QueryFormData;
-    const props = commonLayerProps(
-      formData,
-      mockSetTooltip,
-      mockSetTooltipContent,
-    );
-
-    const mockObject = { id: 42 };
-    props.onClick?.(mockObject);
-    expect(global.open).toHaveBeenCalledWith('https://example.com/42');
-  });
-
   it('calls onSelect when table_filter is enabled', () => {
     const formData = {
       ...partialformData,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getAggFunc, commonLayerProps } from './common';
 import { JsonObject } from '@superset-ui/core';
+import { getAggFunc, commonLayerProps } from './common';
 
 describe('getAggFunc', () => {
   it('returns correct function for sum', () => {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
@@ -16,8 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonObject } from '@superset-ui/core';
+
+import { JsonObject, QueryFormData } from '@superset-ui/core';
 import { getAggFunc, commonLayerProps } from './common';
+
+const partialformData: Partial<QueryFormData> = {
+  viz_type: 'table',
+  datasource: '3_sqla',
+};
 
 describe('getAggFunc', () => {
   it('returns correct function for sum', () => {
@@ -53,7 +59,7 @@ describe('getAggFunc', () => {
   it('returns correct function for variance', () => {
     const aggFunc = getAggFunc('variance');
     const result = aggFunc([1, 2, 3, 4]);
-    expect(result).toBe(1.6666666666666667);
+    expect(result).toBeCloseTo(1.6666666666666667);
   });
 
   it('returns correct function for deviation', () => {
@@ -89,7 +95,10 @@ describe('commonLayerProps', () => {
   const mockOnSelect = jest.fn();
 
   it('returns correct props when js_tooltip is provided', () => {
-    const formData = { js_tooltip: 'tooltip => tooltip.content' } as any;
+    const formData = {
+      ...partialformData,
+      js_tooltip: 'tooltip => tooltip.content',
+    } as QueryFormData;
     const props = commonLayerProps(
       formData,
       mockSetTooltip,
@@ -100,7 +109,7 @@ describe('commonLayerProps', () => {
   });
 
   it('calls onHover and sets tooltip', () => {
-    const formData = { js_tooltip: null } as any;
+    const formData = { ...partialformData, js_tooltip: null } as QueryFormData;
     const props = commonLayerProps(
       formData,
       mockSetTooltip,
@@ -108,7 +117,7 @@ describe('commonLayerProps', () => {
     );
 
     const mockObject = { picked: true, x: 10, y: 20 };
-    props.onHover(mockObject);
+    props.onHover?.(mockObject);
     expect(mockSetTooltip).toHaveBeenCalledWith({
       content: expect.any(Function), // Matches any function
       x: 10,
@@ -119,8 +128,9 @@ describe('commonLayerProps', () => {
   it('calls onClick and opens link when js_onclick_href is provided', () => {
     global.open = jest.fn();
     const formData = {
+      ...partialformData,
       js_onclick_href: 'o => `https://example.com/${o.id}`',
-    } as any;
+    } as QueryFormData;
     const props = commonLayerProps(
       formData,
       mockSetTooltip,
@@ -128,12 +138,16 @@ describe('commonLayerProps', () => {
     );
 
     const mockObject = { id: 42 };
-    props.onClick(mockObject);
+    props.onClick?.(mockObject);
     expect(global.open).toHaveBeenCalledWith('https://example.com/42');
   });
 
   it('calls onSelect when table_filter is enabled', () => {
-    const formData = { table_filter: true, line_column: 'name' } as any;
+    const formData = {
+      ...partialformData,
+      table_filter: true,
+      line_column: 'name',
+    } as QueryFormData;
     const props = commonLayerProps(
       formData,
       mockSetTooltip,
@@ -142,7 +156,7 @@ describe('commonLayerProps', () => {
     );
 
     const mockObject = { object: { name: 'John Doe' } };
-    props.onClick(mockObject);
+    props.onClick?.(mockObject);
     expect(mockOnSelect).toHaveBeenCalledWith('John Doe');
   });
 });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
@@ -20,6 +20,7 @@ import { ReactNode } from 'react';
 import {
   ascending as d3ascending,
   quantile as d3quantile,
+  count as d3count,
   sum as d3sum,
   mean as d3mean,
   min as d3min,
@@ -89,6 +90,7 @@ const percentiles = {
 /* Supported d3-array functions */
 const d3functions: Record<string, any> = {
   sum: d3sum,
+  count: d3count,
   min: d3min,
   max: d3max,
   mean: d3mean,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
@@ -11,15 +11,22 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 import { ReactNode } from 'react';
-import d3array, {
+import {
   ascending as d3ascending,
   quantile as d3quantile,
+  sum as d3sum,
+  mean as d3mean,
+  min as d3min,
+  max as d3max,
+  median as d3median,
+  variance as d3variance,
+  deviation as d3deviation,
 } from 'd3-array';
 import { JsonObject, JsonValue, QueryFormData } from '@superset-ui/core';
 import sandboxedEval from '../utils/sandbox';
@@ -79,6 +86,17 @@ const percentiles = {
   p99: 0.99,
 };
 
+/* Supported d3-array functions */
+const d3functions: Record<string, any> = {
+  sum: d3sum,
+  min: d3min,
+  max: d3max,
+  mean: d3mean,
+  median: d3median,
+  variance: d3variance,
+  deviation: d3deviation,
+};
+
 /* Get a stat function that operates on arrays, aligns with control=js_agg_function  */
 export function getAggFunc(
   type = 'sum',
@@ -87,10 +105,12 @@ export function getAggFunc(
   if (type === 'count') {
     return (arr: number[]) => arr.length;
   }
+
   let d3func: (
     iterable: Array<unknown>,
     accessor?: (object: JsonObject) => number | undefined,
   ) => number[] | number | undefined;
+
   if (type in percentiles) {
     d3func = (arr, acc: (object: JsonObject) => number | undefined) => {
       let sortedArr;
@@ -104,9 +124,12 @@ export function getAggFunc(
 
       return d3quantile(sortedArr, percentiles[type], acc);
     };
+  } else if (type in d3functions) {
+    d3func = d3functions[type];
   } else {
-    d3func = d3array[type];
+    throw new Error(`Unsupported aggregation type: ${type}`);
   }
+
   if (!accessor) {
     return (arr: JsonObject[]) => d3func(arr);
   }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
@@ -131,8 +131,8 @@ export function getAggFunc(
   }
 
   if (!accessor) {
-    return (arr: JsonObject[]) => d3func(arr);
+    return (arr: number[]) => d3func(arr);
   }
 
-  return (arr: JsonObject[]) => d3func(arr.map(x => accessor(x)));
+  return (arr: number[]) => d3func(arr.map(x => accessor(x)));
 }

--- a/superset-frontend/src/utils/textUtils.ts
+++ b/superset-frontend/src/utils/textUtils.ts
@@ -15,13 +15,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-let supersetText = {};
-try {
-  // eslint-disable-next-line global-require, import/no-unresolved
-  supersetText = require('../../../superset_text.yaml') || {};
-} catch (e) {
-  // Swallow the error if the file does not exist
-  supersetText = {};
-}
+const loadModule = () => {
+  try {
+    // eslint-disable-next-line global-require, import/no-unresolved
+    return require('../../../superset_text') || {};
+  } catch (e) {
+    return {};
+  }
+};
+
+const supersetText = loadModule();
 
 export default supersetText;

--- a/superset-frontend/src/utils/textUtils.ts
+++ b/superset-frontend/src/utils/textUtils.ts
@@ -15,15 +15,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-const loadModule = () => {
-  try {
-    // eslint-disable-next-line global-require, import/no-unresolved
-    return require('../../../superset_text') || {};
-  } catch (e) {
-    return {};
-  }
-};
-
-const supersetText = loadModule();
+let supersetText = {};
+try {
+  // eslint-disable-next-line global-require, import/no-unresolved
+  supersetText = require('../../../superset_text.yaml') || {};
+} catch (e) {
+  // Swallow the error if the file does not exist
+  supersetText = {};
+}
 
 export default supersetText;

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -231,6 +231,9 @@ const config = {
       message:
         /export 'withTooltipPropTypes' \(imported as 'vxTooltipPropTypes'\) was not found/,
     },
+    {
+      message: /Can't resolve.*superset_text/,
+    },
   ],
   performance: {
     assetFilter(assetFilename) {


### PR DESCRIPTION
Hit this one today:
```
superset_node         | WARNING in
./plugins/legacy-preset-chart-deckgl/src/layers/common.tsx 70:13-20
superset_node         | export 'default' (imported as 'd3array') was not
found in 'd3-array' (possible exports: ascending, bisect, bisectLeft,
bisectRight, bisector, cross, descending, deviation, extent, histogram,
max, mean, median, merge, mi
n, pairs, permute, quantile, range, scan, shuffle, sum,
thresholdFreedmanDiaconis, thresholdScott, thresholdSturges,
tickIncrement, tickStep, ticks, transpose, variance, zip)
```

was introduced here https://github.com/apache/superset/pull/31761

Then took on fixing the other long-standing warning that's bugging me for a long time
