### PR TITLE
fix(OAuth): Remove masked_encrypted_extra from DB update properties

### DIFF
--- a/superset/commands/database/update.py
+++ b/superset/commands/database/update.py
@@ -72,7 +72,7 @@ class UpdateDatabaseCommand(BaseCommand):
             self._properties["encrypted_extra"] = (
                 self._model.db_engine_spec.unmask_encrypted_extra(
                     self._model.encrypted_extra,
-                    self._properties["masked_encrypted_extra"],
+                    self._properties.pop("masked_encrypted_extra"),
                 )
             )
 


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/31777 implemented changes to the DB update, but did not remove the ``masked_encrypted_extra`` from the DB properties, which is required (``encrypted_extra`` is sent instead).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added unit test covering this requirement.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
