### PR TITLE
fix: refactor(date picker): Migrate Date Picker to Ant Design 5

### DIFF
--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -114,8 +114,10 @@ export default function TimezoneSelector({
 
       const matchTimezoneToOptions = (timezone: string) =>
         TIMEZONE_OPTIONS.find(
-          option => option.offsets === getOffsetKey(timezone),
-        )?.value || DEFAULT_TIMEZONE.value;
+          option =>
+            option.offsets === getOffsetKey(timezone) &&
+            option.timezoneName === timezone,
+           )?.value || DEFAULT_TIMEZONE.value;
 
       const validTimezone = matchTimezoneToOptions(
         timezone || extendedDayjs.tz.guess(),

--- a/superset-frontend/src/components/TimezoneSelector/index.tsx
+++ b/superset-frontend/src/components/TimezoneSelector/index.tsx
@@ -117,7 +117,7 @@ export default function TimezoneSelector({
           option =>
             option.offsets === getOffsetKey(timezone) &&
             option.timezoneName === timezone,
-           )?.value || DEFAULT_TIMEZONE.value;
+        )?.value || DEFAULT_TIMEZONE.value;
 
       const validTimezone = matchTimezoneToOptions(
         timezone || extendedDayjs.tz.guess(),


### PR DESCRIPTION
This PR fixes timezone matching so that timezone returned from the database will be used and not the first one alphabetically.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
