### PR TITLE
feat: Mutate SQL query executed by alerts

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -20,6 +20,7 @@ import logging
 from operator import eq, ge, gt, le, lt, ne
 from timeit import default_timer
 from typing import Any
+from uuid import UUID
 
 import numpy as np
 import pandas as pd
@@ -40,6 +41,7 @@ from superset.reports.models import ReportSchedule, ReportScheduleValidatorType
 from superset.tasks.utils import get_executor
 from superset.utils import json
 from superset.utils.core import override_user
+from superset.utils.decorators import logs_context
 from superset.utils.retries import retry_call
 
 logger = logging.getLogger(__name__)
@@ -52,8 +54,9 @@ OPERATOR_FUNCTIONS = {">=": ge, ">": gt, "<=": le, "<": lt, "==": eq, "!=": ne}
 
 
 class AlertCommand(BaseCommand):
-    def __init__(self, report_schedule: ReportSchedule):
+    def __init__(self, report_schedule: ReportSchedule, execution_id: UUID):
         self._report_schedule = report_schedule
+        self._execution_id = execution_id
         self._result: float | None = None
 
     def run(self) -> bool:
@@ -135,6 +138,13 @@ class AlertCommand(BaseCommand):
             self._report_schedule.validator_type == ReportScheduleValidatorType.OPERATOR
         )
 
+    def _get_alert_metadata_from_object(self) -> dict[str, Any]:
+        return {
+            "report_schedule_id": self._report_schedule.id,
+            "execution_id": self._execution_id,
+        }
+
+    @logs_context(context_func=_get_alert_metadata_from_object)
     def _execute_query(self) -> pd.DataFrame:
         """
         Executes the actual alert SQL query template
@@ -151,6 +161,13 @@ class AlertCommand(BaseCommand):
             limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
                 rendered_sql, ALERT_SQL_LIMIT
             )
+
+            if app.config["MUTATE_ALERT_QUERY"]:
+                limited_rendered_sql = (
+                    self._report_schedule.database.mutate_sql_based_on_config(
+                        limited_rendered_sql
+                    )
+                )
 
             executor, username = get_executor(  # pylint: disable=unused-variable
                 executor_types=app.config["ALERT_REPORTS_EXECUTE_AS"],

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -698,7 +698,7 @@ class ReportNotTriggeredErrorState(BaseReportState):
         try:
             # If it's an alert check if the alert is triggered
             if self._report_schedule.type == ReportScheduleType.ALERT:
-                if not AlertCommand(self._report_schedule).run():
+                if not AlertCommand(self._report_schedule, self._execution_id).run():
                     self.update_report_schedule_and_log(ReportState.NOOP)
                     return
             self.send()
@@ -782,7 +782,7 @@ class ReportSuccessState(BaseReportState):
                 return
             self.update_report_schedule_and_log(ReportState.WORKING)
             try:
-                if not AlertCommand(self._report_schedule).run():
+                if not AlertCommand(self._report_schedule, self._execution_id).run():
                     self.update_report_schedule_and_log(ReportState.NOOP)
                     return
             except Exception as ex:

--- a/superset/config.py
+++ b/superset/config.py
@@ -1380,6 +1380,10 @@ def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument  # noqa: 
 MUTATE_AFTER_SPLIT = False
 
 
+# Boolean config that determines if alert SQL queries should also be mutated or not.
+MUTATE_ALERT_QUERY = False
+
+
 # This allows for a user to add header data to any outgoing emails. For example,
 # if you need to include metadata in the header or you want to change the specifications
 # of the email title, header, or sender.


### PR DESCRIPTION
### SUMMARY
This PR adds a new config `MUTATE_ALERT_QUERY` that determines if SQL queries executed to validate the alert condition should be mutated via the `SQL_QUERY_MUTATOR` config.

It also leverages the ``logs_context`` decorator to pass the `report_schedule_id` and `execution_id` (that can then be retrieved in the mutator function if desired).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added tests. For manual testing:
1. Make sure you have a `SQL_QUERY_MUTATOR` method defined in your config.
2. Update this method to add the `report_schedule_id` and `execution_id` as comments in the SQL.
3. Set `MUTATE_ALERT_QUERY` to `True` in the config.
4. Schedule an alert.
5. Validate in the target DB logs that a) the query was mutated and b) both `report_schedule_id` and `execution_id` are added to the query.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
