### PR TITLE
chore: add eslint to pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["current", "next", "previous"]
+        python-version: ["current", "previous"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["current", "previous"]
+        python-version: ["current", "next", "previous"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v4
@@ -41,6 +41,8 @@ jobs:
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
+          # Skip eslint as it requires `npm ci` and is executed in another job
+          export SKIP=eslint
           pre-commit run --all-files
           if [ $? -ne 0 ] || ! git diff --quiet --exit-code; then
             echo "❌ Pre-commit check failed."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,14 @@ repos:
       - id: trailing-whitespace
         exclude: ^.*\.(snap)
         args: ["--markdown-linebreak-ext=md"]
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: bash -c 'cd superset-frontend && npm run eslint -- $(echo "$@" | sed "s|superset-frontend/||g")'
+        language: system
+        pass_filenames: true
+        files: \.(js|jsx|ts|tsx)$
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8 # Use the sha or tag you want to point at
     hooks:


### PR DESCRIPTION
Chiseling at https://github.com/apache/superset/pull/31590 and bringing what's atomically committable out of there.

This simply adds eslint checks to pre-commit. Note that:
- it requires having run `npm i` in superset-frontend
- it's set up to NOT run in CI as part of the pre-commit validation workflow, since we run eslint more formally in another workflow

Why doing this? Currently it's common to forget to run `npm run lint` prior to committing/pushing, so people can waste time waiting for CI to fail where it could be caught easily. It's nice to have pre-commit do the check itself because it will only evaluate the files that have changed, making it much faster than running a full lint run against all files.

