### PR TITLE
fix: d3.count doesn't exist

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.tsx
@@ -20,7 +20,6 @@ import { ReactNode } from 'react';
 import {
   ascending as d3ascending,
   quantile as d3quantile,
-  count as d3count,
   sum as d3sum,
   mean as d3mean,
   min as d3min,
@@ -90,7 +89,6 @@ const percentiles = {
 /* Supported d3-array functions */
 const d3functions: Record<string, any> = {
   sum: d3sum,
-  count: d3count,
   min: d3min,
   max: d3max,
   mean: d3mean,


### PR DESCRIPTION
Quick fast follow on https://github.com/apache/superset/pull/31830

