### PR TITLE
fix(date_parser): fixed bug for advanced time range filter

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -162,9 +162,9 @@ def get_relative_base(unit: str, relative_start: str | None = None) -> str:
     granular_units = {"second", "minute", "hour"}
     broad_units = {"day", "week", "month", "quarter", "year"}
 
-    if unit in granular_units:
+    if unit.lower() in granular_units:
         return "now"
-    elif unit in broad_units:
+    elif unit.lower() in broad_units:
         return "today"
     else:
         raise ValueError(f"Unknown unit: {unit}")
@@ -268,9 +268,9 @@ def handle_modifier_and_unit(
     """
     base_expression = handle_scope_and_unit(scope, delta, unit, relative_base)
 
-    if modifier in ["start of", "beginning of"]:
+    if modifier.lower() in ["start of", "beginning of"]:
         return handle_start_of(base_expression, unit)
-    elif modifier == "end of":
+    elif modifier.lower() == "end of":
         return handle_end_of(base_expression, unit)
     else:
         raise ValueError(f"Unknown modifier: {modifier}")
@@ -302,11 +302,11 @@ def handle_scope_and_unit(scope: str, delta: str, unit: str, relative_base: str)
         - Example: "last 2 weeks" → `DATEADD(DATETIME('today'), -2, week)`.
     """
     _delta = int(delta) if delta else 1
-    if scope == "this":
+    if scope.lower() == "this":
         return f"DATETIME('{relative_base}')"
-    elif scope in ["last", "prior"]:
+    elif scope.lower() in ["last", "prior"]:
         return f"DATEADD(DATETIME('{relative_base}'), -{_delta}, {unit})"
-    elif scope == "next":
+    elif scope.lower() == "next":
         return f"DATEADD(DATETIME('{relative_base}'), {_delta}, {unit})"
     else:
         raise ValueError(f"Invalid scope: {scope}")
@@ -412,20 +412,17 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
             (
                 r"^(start of|beginning of|end of)\s+(this|last|next|prior)\s+([0-9]+)?\s*(day|week|month|quarter|year)s?$",  # pylint: disable=line-too-long,useless-suppression  # noqa: E501
                 lambda modifier, scope, delta, unit: handle_modifier_and_unit(
-                    modifier.lower(),
-                    scope.lower(),
+                    modifier,
+                    scope,
                     delta,
-                    unit.lower,
-                    get_relative_base(unit.lower(), relative_start),
+                    unit,
+                    get_relative_base(unit, relative_start),
                 ),
             ),
             (
                 r"^(this|last|next|prior)\s+([0-9]+)?\s*(second|minute|day|week|month|quarter|year)s?$",
                 lambda scope, delta, unit: handle_scope_and_unit(
-                    scope.lower(),
-                    delta,
-                    unit.lower(),
-                    get_relative_base(unit.lower(), relative_start),
+                    scope, delta, unit, get_relative_base(unit, relative_start)
                 ),
             ),
             (

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -199,7 +199,7 @@ def handle_scope_and_unit(scope: str, delta: str, unit: str, relative_base: str)
     _delta = int(delta) if delta else 1
     if scope.lower() == "this":
         return f"DATETIME('{relative_base}')"
-    elif scope.lower() == "last":
+    elif scope.lower() in ["last", "prior"]:
         return f"DATEADD(DATETIME('{relative_base}'), -{_delta}, {unit})"
     elif scope.lower() == "next":
         return f"DATEADD(DATETIME('{relative_base}'), {_delta}, {unit})"
@@ -305,7 +305,7 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     if time_range and separator in time_range:
         time_range_lookup = [
             (
-                r"^(start of|beginning of|end of)\s+(this|last|next)\s+([0-9]+)?\s*(day|week|month|quarter|year)s?$",  # pylint: disable=line-too-long,useless-suppression
+                r"^(start of|beginning of|end of)\s+(this|last|next|prior)\s+([0-9]+)?\s*(day|week|month|quarter|year)s?$",  # pylint: disable=line-too-long,useless-suppression  # noqa: E501
                 lambda modifier, scope, delta, unit: handle_modifier_and_unit(
                     modifier,
                     scope,
@@ -315,7 +315,7 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
                 ),
             ),
             (
-                r"^(this|last|next)\s+([0-9]+)?\s*(second|minute|day|week|month|quarter|year)s?$",
+                r"^(this|last|next|prior)\s+([0-9]+)?\s*(second|minute|day|week|month|quarter|year)s?$",
                 lambda scope, delta, unit: handle_scope_and_unit(
                     scope, delta, unit, get_relative_base(unit, relative_start)
                 ),

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -269,9 +269,9 @@ def handle_modifier_and_unit(
     base_expression = handle_scope_and_unit(scope, delta, unit, relative_base)
 
     if modifier.lower() in ["start of", "beginning of"]:
-        return handle_start_of(base_expression, unit)
+        return handle_start_of(base_expression, unit.lower())
     elif modifier.lower() == "end of":
-        return handle_end_of(base_expression, unit)
+        return handle_end_of(base_expression, unit.lower())
     else:
         raise ValueError(f"Unknown modifier: {modifier}")
 

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -166,8 +166,7 @@ def get_relative_base(unit: str, relative_start: str | None = None) -> str:
         return "now"
     elif unit.lower() in broad_units:
         return "today"
-    else:
-        raise ValueError(f"Unknown unit: {unit}")
+    raise ValueError(f"Unknown unit: {unit}")
 
 
 def handle_start_of(base_expression: str, unit: str) -> str:

--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -409,7 +409,10 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     if time_range and separator in time_range:
         time_range_lookup = [
             (
-                r"^(start of|beginning of|end of)\s+(this|last|next|prior)\s+([0-9]+)?\s*(day|week|month|quarter|year)s?$",  # pylint: disable=line-too-long,useless-suppression  # noqa: E501
+                r"^(start of|beginning of|end of)\s+"
+                r"(this|last|next|prior)\s+"
+                r"([0-9]+)?\s*"
+                r"(day|week|month|quarter|year)s?$",  # Matches phrases like "start of next month" # pylint: disable=line-too-long,useless-suppression  # noqa: E501
                 lambda modifier, scope, delta, unit: handle_modifier_and_unit(
                     modifier,
                     scope,
@@ -419,13 +422,15 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
                 ),
             ),
             (
-                r"^(this|last|next|prior)\s+([0-9]+)?\s*(second|minute|day|week|month|quarter|year)s?$",
+                r"^(this|last|next|prior)\s+"
+                r"([0-9]+)?\s*"
+                r"(second|minute|day|week|month|quarter|year)s?$",  # Matches "next 5 days" or "last 2 weeks" # pylint: disable=line-too-long,useless-suppression  # noqa: E501
                 lambda scope, delta, unit: handle_scope_and_unit(
                     scope, delta, unit, get_relative_base(unit, relative_start)
                 ),
             ),
             (
-                r"^(DATETIME.*|DATEADD.*|DATETRUNC.*|LASTDAY.*|HOLIDAY.*)$",
+                r"^(DATETIME.*|DATEADD.*|DATETRUNC.*|LASTDAY.*|HOLIDAY.*)$",  # Matches date-related keywords # pylint: disable=line-too-long,useless-suppression  # noqa: E501
                 lambda text: text,
             ),
         ]

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -100,12 +100,36 @@ def test_get_since_until() -> None:
     expected = None, datetime(2016, 11, 7, 9, 28, 10)
     assert result == expected
 
+    result = get_since_until(" : prior 2 minutes")
+    expected = None, datetime(2016, 11, 7, 9, 28, 10)
+    assert result == expected
+
     result = get_since_until(" : next 2 minutes")
     expected = None, datetime(2016, 11, 7, 9, 32, 10)
     assert result == expected
 
     result = get_since_until("start of this month : ")
     expected = datetime(2016, 11, 1), None
+    assert result == expected
+
+    result = get_since_until("start of next month : ")
+    expected = datetime(2016, 12, 1), None
+    assert result == expected
+
+    result = get_since_until("end of this month : ")
+    expected = datetime(2016, 11, 30), None
+    assert result == expected
+
+    result = get_since_until("end of next month : ")
+    expected = datetime(2016, 12, 31), None
+    assert result == expected
+
+    result = get_since_until("beginning of next year : ")
+    expected = datetime(2017, 1, 1), None
+    assert result == expected
+
+    result = get_since_until("beginning of last year : ")
+    expected = datetime(2015, 1, 1), None
     assert result == expected
 
     result = get_since_until("2018-01-01T00:00:00 : 2018-12-31T23:59:59")

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -92,6 +92,18 @@ def test_get_since_until() -> None:
     expected = datetime(2016, 11, 6), datetime(2016, 11, 8)
     assert result == expected
 
+    result = get_since_until(" : now")
+    expected = None, datetime(2016, 11, 7, 9, 30, 10)
+    assert result == expected
+
+    result = get_since_until(" : last 2 minutes")
+    expected = None, datetime(2016, 11, 7, 9, 28, 10)
+    assert result == expected
+
+    result = get_since_until(" : next 2 minutes")
+    expected = None, datetime(2016, 11, 7, 9, 32, 10)
+    assert result == expected
+
     result = get_since_until("2018-01-01T00:00:00 : 2018-12-31T23:59:59")
     expected = datetime(2018, 1, 1), datetime(2018, 12, 31, 23, 59, 59)
     assert result == expected

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -104,6 +104,10 @@ def test_get_since_until() -> None:
     expected = None, datetime(2016, 11, 7, 9, 32, 10)
     assert result == expected
 
+    result = get_since_until("start of this month : ")
+    expected = datetime(2016, 11, 1), None
+    assert result == expected
+
     result = get_since_until("2018-01-01T00:00:00 : 2018-12-31T23:59:59")
     expected = datetime(2018, 1, 1), datetime(2018, 12, 31, 23, 59, 59)
     assert result == expected


### PR DESCRIPTION
Fixes #30592

### SUMMARY
Fixed bug where Advanced Time Range filter showed wrong dates for queries like "last 2 minutes" , "start of next month", "end of next month" etc

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE -> "Last 2 minutes"
![image](https://github.com/user-attachments/assets/38d8254f-1502-43d5-a006-47416c694c3e)

#### AFTER -> "Last 2 minutes"
![image](https://github.com/user-attachments/assets/9b5439ba-2536-447b-ba90-636fd65f1e95)

#### BEFORE -> "Start of this month"
![image](https://github.com/user-attachments/assets/d7204f5d-d3ff-4b34-86fa-edda769b8213)

#### AFTER -> "Start of this month"
![image](https://github.com/user-attachments/assets/2ac05776-79f0-43fa-b8ee-9807493cead5)

#### BEFORE -> "End of next month"
![image](https://github.com/user-attachments/assets/1de2267c-eba4-4fa7-9775-a2d1af4064c7)

#### AFTER -> "End of next month"
![image](https://github.com/user-attachments/assets/6b0e2639-60e1-4451-a9cf-34215b28993d)

#### BEFORE -> "Prior 2 minutes"
![image](https://github.com/user-attachments/assets/52ac8502-5db3-4434-84a0-6760194fd339)

#### AFTER -> "Prior 2 minutes"
![image](https://github.com/user-attachments/assets/76e1d875-9e6e-42c3-8797-a503b11bb5e0)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
