### PR TITLE
fix(translation): Dutch translations for Current datetime filter

### DIFF
--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -3056,9 +3056,8 @@ msgstr "Configuratie"
 msgid "Configure Advanced Time Range "
 msgstr "Configureer geavanceerd tijdbereik "
 
-#, fuzzy
 msgid "Configure Time Range: Current..."
-msgstr "Configureer Tijdbereik: Laatste..."
+msgstr "Configureer Tijdbereik: Huidige..."
 
 msgid "Configure Time Range: Last..."
 msgstr "Configureer Tijdbereik: Laatste..."
@@ -3366,29 +3365,23 @@ msgstr "Valuta voorvoegsel of achtervoegsel"
 msgid "Currency symbol"
 msgstr "Valuta symbool"
 
-#, fuzzy
 msgid "Current"
-msgstr "Valuta"
+msgstr "Huidig"
 
-#, fuzzy
 msgid "Current day"
-msgstr "Valuta"
+msgstr "Huidige dag"
 
-#, fuzzy
 msgid "Current month"
-msgstr "Valuta symbool"
+msgstr "Huidige maand"
 
-#, fuzzy
 msgid "Current quarter"
-msgstr "Voer huidige query uit"
+msgstr "Huidig kwartaal"
 
-#, fuzzy
 msgid "Current week"
-msgstr "Voer huidige query uit"
+msgstr "Huidige week"
 
-#, fuzzy
 msgid "Current year"
-msgstr "Valuta"
+msgstr "Huidig jaar"
 
 #, python-format
 msgid "Currently rendered: %s"


### PR DESCRIPTION
### SUMMARY
The translations mistook "current" for "currency" and other random values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
![image](https://github.com/user-attachments/assets/b87bff6c-30b3-44c6-9282-f32aacccddfb)
After
![image](https://github.com/user-attachments/assets/7d25b38e-fb71-4ce3-a3dc-f237af4a0c19)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Enable dutch in the config and switch to the language.
```
LANGUAGES = {
    'en': {'flag': 'us', 'name': 'English'},
    'nl_NL': {'flag': 'nl', 'name': 'Dutch'}
}
```
Open a datetime filter on a dashboard.

