### PR TITLE
feat: use npm run dev-server in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,10 @@ services:
       BUILD_SUPERSET_FRONTEND_IN_DOCKER: true
       NPM_RUN_PRUNE: false
       SCARF_ANALYTICS: "${SCARF_ANALYTICS:-}"
+      # configuring the dev-server to use the host.docker.internal to connect to the backend
+      superset: "http://host.docker.internal:8088"
+    ports:
+      - "127.0.0.1:9000:9000"  # exposing the dynamic webpack dev server
     container_name: superset_node
     command: ["/app/docker/docker-frontend.sh"]
     env_file:

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -36,7 +36,9 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
     npm install
 
     echo "Start webpack dev server"
-    npm run dev
+    # start the webpack dev server, serving dynamically at http://localhost:9000
+    # it proxies to the backend served at http://localhost:8088
+    npm run dev-server
 
 else
     echo "Skipping frontend build steps - YOU NEED TO RUN IT MANUALLY ON THE HOST!"

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -528,20 +528,7 @@ if (isDevMode) {
       const { afterEmit } = getCompilerHooks(devServer.compiler);
       afterEmit.tap('ManifestPlugin', manifest => {
         proxyConfig = getProxyConfig(manifest);
-
-        // Update the proxy configuration
-        if (devServer.proxy) {
-          // Instead of trying to find and remove the old middleware,
-          // let webpack-dev-server handle the proxy configuration update
-          devServer.proxy = [() => proxyConfig];
-
-          // Force webpack-dev-server to update its middleware stack
-          if (typeof devServer.invalidate === 'function') {
-            devServer.invalidate();
-          }
-        }
       });
-
       return middlewares;
     },
     historyApiFallback: true,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -522,23 +522,17 @@ Object.entries(packageConfig.dependencies).forEach(([pkg, relativeDir]) => {
 console.log(''); // pure cosmetic new line
 
 if (isDevMode) {
-  config.devServer = {
-    setupMiddleware: (middlewares, devServer) => {
-      // load proxy config when manifest updates
-      const { afterEmit } = getCompilerHooks(devServer.compiler);
-      afterEmit.tap('ManifestPlugin', manifest => {
-        proxyConfig = getProxyConfig(manifest);
-      });
+  // Set up manifest hook outside of devServer config
+  const { afterEmit } = getCompilerHooks(compiler);
+  afterEmit.tap('ManifestPlugin', manifest => {
+    proxyConfig = getProxyConfig(manifest);
+  });
 
-      return middlewares;
-    },
+  config.devServer = {
     historyApiFallback: true,
     hot: true,
     port: devserverPort,
-    proxy: [
-      // functions are called for every request
-      () => proxyConfig,
-    ],
+    proxy: [() => proxyConfig],
     client: {
       overlay: {
         errors: true,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -524,25 +524,19 @@ console.log(''); // pure cosmetic new line
 let proxyConfig = getProxyConfig();
 
 if (isDevMode) {
+  const { afterEmit } = getCompilerHooks(devServer.compiler);
+
   config.devServer = {
-    setupMiddlewares: (middlewares, devServer) => {
-      // load proxy config when manifest updates
-      const { afterEmit } = getCompilerHooks(devServer.compiler);
+    onBeforeSetupMiddleware(devServer) {
+      // Tap into manifest updates
       afterEmit.tap('ManifestPlugin', manifest => {
         proxyConfig = getProxyConfig(manifest);
       });
-
-      return middlewares; // Make sure to return the middlewares
     },
     historyApiFallback: true,
     hot: true,
     port: devserverPort,
-    // Only serves bundled files from webpack-dev-server
-    // and proxy everything else to Superset backend
-    proxy: [
-      // functions are called for every request
-      () => proxyConfig,
-    ],
+    proxy: [() => proxyConfig],
     client: {
       overlay: {
         errors: true,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -525,12 +525,14 @@ let proxyConfig = getProxyConfig();
 
 if (isDevMode) {
   config.devServer = {
-    onBeforeSetupMiddleware(devServer) {
+    setupMiddlewares: (middlewares, devServer) => {
       // load proxy config when manifest updates
       const { afterEmit } = getCompilerHooks(devServer.compiler);
       afterEmit.tap('ManifestPlugin', manifest => {
         proxyConfig = getProxyConfig(manifest);
       });
+
+      return middlewares; // Make sure to return the middlewares
     },
     historyApiFallback: true,
     hot: true,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -529,6 +529,7 @@ if (isDevMode) {
       afterEmit.tap('ManifestPlugin', manifest => {
         proxyConfig = getProxyConfig(manifest);
       });
+
       return middlewares;
     },
     historyApiFallback: true,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -522,10 +522,16 @@ Object.entries(packageConfig.dependencies).forEach(([pkg, relativeDir]) => {
 console.log(''); // pure cosmetic new line
 
 if (isDevMode) {
-  // Set up manifest hook outside of devServer config
-  const { afterEmit } = getCompilerHooks(compiler);
-  afterEmit.tap('ManifestPlugin', manifest => {
-    proxyConfig = getProxyConfig(manifest);
+  let proxyConfig = getProxyConfig();
+  // Set up a plugin to handle manifest updates
+  config.plugins = config.plugins || [];
+  config.plugins.push({
+    apply: compiler => {
+      const { afterEmit } = getCompilerHooks(compiler);
+      afterEmit.tap('ManifestPlugin', manifest => {
+        proxyConfig = getProxyConfig(manifest);
+      });
+    },
   });
 
   config.devServer = {

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -24,12 +24,12 @@ const yargs = require('yargs');
 const parsedArgs = yargs.argv;
 
 const parsedEnvArg = () => {
+  let envArgs = {};
   if (parsedArgs.env) {
-    return yargs(parsedArgs.env).argv;
+    envArgs = yargs(parsedArgs.env).argv;
   }
-  return {};
+  return { ...process.env, ...envArgs };
 };
-
 const { supersetPort = 8088, superset: supersetUrl = null } = parsedEnvArg();
 const backend = (supersetUrl || `http://localhost:${supersetPort}`).replace(
   '//+$/',


### PR DESCRIPTION
This configures docker to serve the interactive/dynamic webpack server at `localhost:9000`, and configures it to connect to the backend serve in another container at port 8088. It offers the convenience to auto-webpack and auto-refresh the pages as code is altered/saved.

