### PR TITLE
fix(import): ensure charts and datasets overwrite on report import

### DIFF
--- a/superset/commands/dashboard/importers/v1/__init__.py
+++ b/superset/commands/dashboard/importers/v1/__init__.py
@@ -86,7 +86,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
         database_ids: dict[str, int] = {}
         for file_name, config in configs.items():
             if file_name.startswith("databases/") and config["uuid"] in database_uuids:
-                database = import_database(config, overwrite=False)
+                database = import_database(config, overwrite=overwrite)
                 database_ids[str(database.uuid)] = database.id
 
         # import datasets with the correct parent ref
@@ -97,7 +97,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 and config["database_uuid"] in database_ids
             ):
                 config["database_id"] = database_ids[config["database_uuid"]]
-                dataset = import_dataset(config, overwrite=False)
+                dataset = import_dataset(config, overwrite=overwrite)
                 dataset_info[str(dataset.uuid)] = {
                     "datasource_id": dataset.id,
                     "datasource_type": dataset.datasource_type,
@@ -121,7 +121,7 @@ class ImportDashboardsCommand(ImportModelsCommand):
                 if "query_context" in config:
                     config["query_context"] = None
 
-                chart = import_chart(config, overwrite=False)
+                chart = import_chart(config, overwrite=overwrite)
                 charts.append(chart)
                 chart_ids[str(chart.uuid)] = chart.id
 

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -289,6 +289,11 @@ class Slice(  # pylint: disable=too-many-public-methods
     def get_query_context(self) -> QueryContext | None:
         if self.query_context:
             try:
+                query_context = json.loads(self.query_context)
+                query_context["datasource"] = {
+                    "type": self.datasource_type,
+                    "id": self.datasource_id,
+                }
                 return self.get_query_context_factory().create(
                     **json.loads(self.query_context)
                 )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, when importing a report in Superset, charts and datasets were not being overwritten, unlike when they were imported separately. 

This update fixes the issue by ensuring the overwrite parameter is correctly passed to the import_database, import_dataset, and import_chart functions. Now, when importing a report, charts and datasets will be properly updated, eliminating the need for manual re-importing.

Additionally, query_context handling in slice.py has been improved to correctly pass the datasource to QueryContextFactory.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
