### PR TITLE
chore(config): remove deprecated AVOID_COLORS_COLLISION flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     hooks:
       - id: eslint
         name: eslint
-        entry: bash -c 'cd superset-frontend && npm run eslint -- $(echo "$@" | sed "s|superset-frontend/||g")'
+        entry: bash -c 'cd superset-frontend && npm run eslint'
         language: system
         pass_filenames: true
         files: \.(js|jsx|ts|tsx)$

--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -97,7 +97,6 @@ These features flags currently default to True and **will be removed in a future
 
 [//]: # "PLEASE KEEP THE LIST SORTED ALPHABETICALLY"
 
-- AVOID_COLORS_COLLISION
 - DRILL_TO_DETAIL
 - ENABLE_JAVASCRIPT_CONTROLS
 - KV_STORE

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,8 +24,8 @@ assists people when migrating to a new version.
 
 ## Next
 
-- [31959](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.
-- [31959](https://github.com/apache/superset/pull/31959) Removes the following endpoints from data uploads: /api/v1/database/<id>/<file type>\_upload and /api/v1/database/<file type>\_metadata, in favour of new one (Details on the PR). And simplifies permissions.
+- [32000](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.
+- [31959](https://github.com/apache/superset/pull/31959) Removes the following endpoints from data uploads: `/api/v1/database/<id>/<file type>_upload` and `/api/v1/database/<file type>_metadata`, in favour of new one (Details on the PR). And simplifies permissions.
 - [31895](https://github.com/apache/superset/pull/31895): The `AVOID_COLORS_COLLISION` flag (previously deprecated) has been removed, and this is now the default behavior.
 - [31844](https://github.com/apache/superset/pull/31844) The `ALERT_REPORTS_EXECUTE_AS` and `THUMBNAILS_EXECUTE_AS` config parameters have been renamed to `ALERT_REPORTS_EXECUTORS` and `THUMBNAILS_EXECUTORS` respectively. A new config flag `CACHE_WARMUP_EXECUTORS` has also been introduced to be able to control which user is used to execute cache warmup tasks. Finally, the config flag `THUMBNAILS_SELENIUM_USER` has been removed. To use a fixed executor for async tasks, use the new `FixedExecutor` class. See the config and docs for more info on setting up different executor profiles.
 - [31894](https://github.com/apache/superset/pull/31894) Domain sharding is deprecated in favor of HTTP2. The `SUPERSET_WEBSERVER_DOMAINS` configuration will be removed in the next major version (6.0)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -25,7 +25,8 @@ assists people when migrating to a new version.
 ## Next
 
 - [31959](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.
-- [31959](https://github.com/apache/superset/pull/31959) Removes the following endpoints from data uploads: /api/v1/database/<id>/<file type>_upload and /api/v1/database/<file type>_metadata, in favour of new one (Details on the PR). And simplifies permissions.
+- [31959](https://github.com/apache/superset/pull/31959) Removes the following endpoints from data uploads: /api/v1/database/<id>/<file type>\_upload and /api/v1/database/<file type>\_metadata, in favour of new one (Details on the PR). And simplifies permissions.
+- [31895](https://github.com/apache/superset/pull/31895): The `AVOID_COLORS_COLLISION` flag (previously deprecated) has been removed, and this is now the default behavior.
 - [31844](https://github.com/apache/superset/pull/31844) The `ALERT_REPORTS_EXECUTE_AS` and `THUMBNAILS_EXECUTE_AS` config parameters have been renamed to `ALERT_REPORTS_EXECUTORS` and `THUMBNAILS_EXECUTORS` respectively. A new config flag `CACHE_WARMUP_EXECUTORS` has also been introduced to be able to control which user is used to execute cache warmup tasks. Finally, the config flag `THUMBNAILS_SELENIUM_USER` has been removed. To use a fixed executor for async tasks, use the new `FixedExecutor` class. See the config and docs for more info on setting up different executor profiles.
 - [31894](https://github.com/apache/superset/pull/31894) Domain sharding is deprecated in favor of HTTP2. The `SUPERSET_WEBSERVER_DOMAINS` configuration will be removed in the next major version (6.0)
 - [31794](https://github.com/apache/superset/pull/31794) Removed the previously deprecated `DASHBOARD_CROSS_FILTERS` feature flag
@@ -45,7 +46,6 @@ assists people when migrating to a new version.
 - [25166](https://github.com/apache/superset/pull/25166) Changed the default configuration of `UPLOAD_FOLDER` from `/app/static/uploads/` to `/static/uploads/`. It also removed the unused `IMG_UPLOAD_FOLDER` and `IMG_UPLOAD_URL` configuration options.
 - [30284](https://github.com/apache/superset/pull/30284) Deprecated GLOBAL_ASYNC_QUERIES_REDIS_CONFIG in favor of the new GLOBAL_ASYNC_QUERIES_CACHE_BACKEND configuration. To leverage Redis Sentinel, set CACHE_TYPE to RedisSentinelCache, or use RedisCache for standalone Redis
 - [31961](https://github.com/apache/superset/pull/31961) Upgraded React from version 16.13.1 to 17.0.2. If you are using custom frontend extensions or plugins, you may need to update them to be compatible with React 17.
-
 
 ### Potential Downtime
 

--- a/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/CategoricalColorScale.ts
@@ -142,11 +142,7 @@ class CategoricalColorScale extends ExtensibleFunction {
       if (isFeatureEnabled(FeatureFlag.UseAnalogousColors)) {
         this.incrementColorRange();
       }
-      if (
-        // feature flag to be deprecated (will become standard behaviour)
-        isFeatureEnabled(FeatureFlag.AvoidColorsCollision) &&
-        this.isColorUsed(color)
-      ) {
+      if (this.isColorUsed(color)) {
         // fallback to least used color
         color = this.getNextAvailableColor(cleanedValue, color);
       }

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -27,7 +27,6 @@ export enum FeatureFlag {
   AlertReportTabs = 'ALERT_REPORT_TABS',
   AlertReportSlackV2 = 'ALERT_REPORT_SLACK_V2',
   AllowFullCsvExport = 'ALLOW_FULL_CSV_EXPORT',
-  AvoidColorsCollision = 'AVOID_COLORS_COLLISION',
   ChartPluginsExperimental = 'CHART_PLUGINS_EXPERIMENTAL',
   ConfirmDashboardDiff = 'CONFIRM_DASHBOARD_DIFF',
   DashboardVirtualization = 'DASHBOARD_VIRTUALIZATION',

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -199,11 +199,7 @@ describe('CategoricalColorScale', () => {
       const returnedColor = scale.getColor(value, sliceId);
       expect(returnedColor).toBe(expectedColor);
     });
-    it('conditionally calls getNextAvailableColor', () => {
-      window.featureFlags = {
-        [FeatureFlag.AvoidColorsCollision]: true,
-      };
-
+    it('calls getNextAvailableColor', () => {
       scale.getColor('testValue1');
       scale.getColor('testValue2');
       scale.getColor('testValue1');
@@ -216,14 +212,6 @@ describe('CategoricalColorScale', () => {
       );
 
       getNextAvailableColorSpy.mockClear();
-
-      window.featureFlags = {
-        [FeatureFlag.AvoidColorsCollision]: false,
-      };
-
-      scale.getColor('testValue3');
-
-      expect(getNextAvailableColorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -141,7 +141,6 @@ describe('CategoricalColorScale', () => {
       expect(c3).not.toBe(c1);
     });
     it('recycles colors when number of items exceed available colors', () => {
-      const colorSet: { [key: string]: number } = {};
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);
       const colors = [
         scale.getColor('pig'),
@@ -151,17 +150,7 @@ describe('CategoricalColorScale', () => {
         scale.getColor('donkey'),
         scale.getColor('goat'),
       ];
-      colors.forEach(color => {
-        if (colorSet[color]) {
-          colorSet[color] += 1;
-        } else {
-          colorSet[color] = 1;
-        }
-      });
-      expect(Object.keys(colorSet)).toHaveLength(3);
-      ['blue', 'red', 'green'].forEach(color => {
-        expect(colorSet[color]).toBe(2);
-      });
+      expect(colors).toEqual(['blue', 'red', 'green', 'blue', 'red', 'green']);
     });
     it('get analogous colors when number of items exceed available colors', () => {
       window.featureFlags = {
@@ -318,9 +307,10 @@ describe('CategoricalColorScale', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);
       scale.getColor('cat');
       scale.getColor('dog');
+      scale.getColor('pet');
 
-      // Since 'green' hasn't been used, it's considered the least used.
-      expect(scale.getNextAvailableColor('fish', 'blue')).toBe('green');
+      // All colors used equally, so the function should return the current color
+      expect(scale.getNextAvailableColor('fish', 'blue')).toBe('blue');
     });
 
     it('returns the least used color among all', () => {
@@ -332,25 +322,6 @@ describe('CategoricalColorScale', () => {
       scale.getColor('teddy'); // red
       // All colors used, so the function should return least used
       expect(scale.getNextAvailableColor('darling', 'red')).toBe('green');
-    });
-
-    it('returns the least used color accurately even when some colors are used more frequently', () => {
-      const scale = new CategoricalColorScale([
-        'blue',
-        'red',
-        'green',
-        'yellow',
-      ]);
-      scale.getColor('cat'); // blue
-      scale.getColor('dog'); // red
-      scale.getColor('frog'); // green
-      scale.getColor('fish'); // yellow
-      scale.getColor('goat'); // blue
-      scale.getColor('horse'); // red
-      scale.getColor('pony'); // green
-
-      // Yellow is the least used color, so it should be returned.
-      expect(scale.getNextAvailableColor('pony', 'blue')).toBe('yellow');
     });
     it('does not return adjacent colors if a non-adjacent color is equally used', () => {
       const scale = new CategoricalColorScale(['blue', 'red', 'green']);
@@ -389,18 +360,6 @@ describe('CategoricalColorScale', () => {
 
       // "green" has never been used, so usageCount for "green" should fallback to 0
       expect(scale.getNextAvailableColor('label2', 'red')).toBe('green');
-    });
-    it('handles a color with an explicit usage count of 0', () => {
-      const scale = new CategoricalColorScale(['blue', 'red', 'green']);
-
-      // Mock or override getColorUsageCount to return 0 for "blue"
-      jest.spyOn(scale, 'getColorUsageCount').mockImplementation(color => {
-        if (color === 'blue') return 0; // Explicitly return 0 for "blue"
-        return 1; // Return 1 for other colors
-      });
-
-      // "blue" should still be a valid option with a usage count of 0
-      expect(scale.getNextAvailableColor('label1', 'red')).toBe('blue');
     });
   });
 

--- a/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
+++ b/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
@@ -62,11 +62,7 @@ const BackgroundStyleOption = styled.div`
           ${theme.colors.text.label} 25%,
           transparent 25%
         ),
-        linear-gradient(
-          -45deg,
-          ${theme.colors.text.label} 25%,
-          transparent 25%
-        ),
+        linear-gradient(-45deg, ${theme.colors.text.label} 25%, transparent 25%),
         linear-gradient(45deg, transparent 75%, ${theme.colors.text.label} 75%),
         linear-gradient(-45deg, transparent 75%, ${theme.colors.text.label} 75%);
       background-size: ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;

--- a/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
+++ b/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
@@ -62,7 +62,11 @@ const BackgroundStyleOption = styled.div`
           ${theme.colors.text.label} 25%,
           transparent 25%
         ),
-        linear-gradient(-45deg, ${theme.colors.text.label} 25%, transparent 25%),
+        linear-gradient(
+          -45deg,
+          ${theme.colors.text.label} 25%,
+          transparent 25%
+        ),
         linear-gradient(45deg, transparent 75%, ${theme.colors.text.label} 75%),
         linear-gradient(-45deg, transparent 75%, ${theme.colors.text.label} 75%);
       background-size: ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;

--- a/superset/config.py
+++ b/superset/config.py
@@ -536,7 +536,6 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Users must check whether the DB engine supports SSH Tunnels
     # otherwise enabling this flag won't have any effect on the DB.
     "SSH_TUNNELING": False,
-    "AVOID_COLORS_COLLISION": True,
     # Do not show user info in the menu
     "MENU_HIDE_USER_INFO": False,
     # Allows users to add a ``superset://`` DB that can query across databases. This is


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Removing the previously deprecated AVOID_COLORS_COLLISION flag, and bring in its behavior full-time.
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
