### PR TITLE
chore: Reduces the form_data_key length

### DIFF
--- a/superset/key_value/shared_entries.py
+++ b/superset/key_value/shared_entries.py
@@ -42,6 +42,7 @@ def set_shared_value(key: SharedKey, value: Any) -> None:
 def get_permalink_salt(key: SharedKey) -> str:
     salt = get_shared_value(key)
     if salt is None:
-        salt = random_key()
+        # Use a 48 bytes salt
+        salt = random_key(48)
         set_shared_value(key, value=salt)
     return salt

--- a/superset/key_value/utils.py
+++ b/superset/key_value/utils.py
@@ -31,7 +31,7 @@ from superset.utils.json import json_dumps_w_dates
 HASHIDS_MIN_LENGTH = 11
 
 
-def random_key(nbytes=8) -> str:
+def random_key(nbytes: int = 8) -> str:
     """
     Generate a random URL-safe string.
 

--- a/superset/key_value/utils.py
+++ b/superset/key_value/utils.py
@@ -31,8 +31,14 @@ from superset.utils.json import json_dumps_w_dates
 HASHIDS_MIN_LENGTH = 11
 
 
-def random_key() -> str:
-    return token_urlsafe(48)
+def random_key(nbytes=8) -> str:
+    """
+    Generate a random URL-safe string.
+
+    Args:
+        nbytes (int): Number of bytes to use for generating the key. Default is 8.
+    """
+    return token_urlsafe(nbytes)
 
 
 def get_filter(resource: KeyValueResource, key: Key) -> KeyValueFilter:


### PR DESCRIPTION
### SUMMARY
When the `form_data_key` was created, it was used to share state between Superset users and required a secure key length. When permalinks were introduced, the `form_data_key` role changed to only be used for holding and transferring temporary state for a user session and not more for sharing state between Superset users. This PR reduces the `form_data_key` length given that an 8 bytes key is sufficient for its new role.

As an example, this will be the diff:

```
form_data_key=yjxRBK8zEhgHTs2PhFKLpA3gja9yxkBRdVPP4xRtLFO2fipTttSpFjZEbizBbyhm

form_data_key=z6OiPvci1q0
```

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
