### PR TITLE
docs: clarify port configuration for Cypress

### DIFF
--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -228,31 +228,35 @@ npm run test -- path/to/file.js
 For e2e testing, we recommend that you use a `docker compose` backend
 
 ```bash
-CYPRESS_CONFIG=true docker compose up
+CYPRESS_CONFIG=true docker compose up --build
 ```
-Cypress will start and expose a Cypress-ready backend on port `8081`.  Note that
-it's a different port than the default port for the backend (`8088`).
+`docker compose` will get to work and expose a Cypress-ready Superset app.
+This app uses a different database schema (`superset_cypress`) to keep it isolated from
+your other dev environmen(s)t, a specific set of examples, and a set of configurations that
+aligns with the expectations within the end-to-end tests.  Also note that it's served on a
+different port than the default port for the backend (`8088`).
 
-In another terminal, let's get ready to execute some Cypress commands.
-
-First, tell cypress to connect to the Cypress-ready Superset backend.
+Now in another terminal, let's get ready to execute some Cypress commands. First, tell cypress
+to connect to the Cypress-ready Superset backend.
 
 ```
 CYPRESS_BASE_URL=http://localhost:8081
 ```
 
 ```bash
-cd superset-frontend
-npm run build-instrumented
-
-cd cypress-base
+# superset-frontend/cypress-base is the base folder for everything Cypress-related
+# It's essentially its own npm app, with its own dependencies, configurations and utilities
+cd superset-frontend/cypress-base
 npm install
 
-# run tests via headless Chrome browser (requires Chrome 64+)
-npm run cypress-run-chrome
-
 # use interactive mode to run tests, while keeping memory usage contained
+# this will fire up an interactive Cypress UI
+# as you alter the code, the tests will re-run automatically, and you can visualize each
+# and every step for debugging purposes
 npx cypress open --config numTestsKeptInMemory=5
+
+# to run the test suite on the command line using chrome (same as CI)
+npm run cypress-run-chrome
 
 # run tests from a specific file
 npm run cypress-run-chrome -- --spec cypress/e2e/explore/link.test.ts

--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -230,8 +230,16 @@ For e2e testing, we recommend that you use a `docker compose` backend
 ```bash
 CYPRESS_CONFIG=true docker compose up
 ```
+Cypress will start and expose a Cypress-ready backend on port `8081`.  Note that
+it's a different port than the default port for the backend (`8088`).
 
-In another terminal, prepare the frontend and run Cypress tests:
+In another terminal, let's get ready to execute some Cypress commands.
+
+First, tell cypress to connect to the Cypress-ready Superset backend.
+
+```
+CYPRESS_BASE_URL=http://localhost:8081
+```
 
 ```bash
 cd superset-frontend
@@ -243,8 +251,8 @@ npm install
 # run tests via headless Chrome browser (requires Chrome 64+)
 npm run cypress-run-chrome
 
-# use interactive mode to run tests, while keeping memory usage contained (default is 50!)
-npx cypress open --config numTestsKeptInMemory=3
+# use interactive mode to run tests, while keeping memory usage contained
+npx cypress open --config numTestsKeptInMemory=5
 
 # run tests from a specific file
 npm run cypress-run-chrome -- --spec cypress/e2e/explore/link.test.ts
@@ -255,9 +263,6 @@ npm run cypress-run-chrome -- --spec cypress/e2e/dashboard/index.test.js --confi
 # to open the cypress ui
 npm run cypress-debug
 
-# to point cypress to a url other than the default (http://localhost:8088) set the environment variable before running the script
-# e.g., CYPRESS_BASE_URL="http://localhost:9000"
-CYPRESS_BASE_URL=<your url> npm run cypress open
 ```
 
 See [`superset-frontend/cypress_build.sh`](https://github.com/apache/superset/blob/master/superset-frontend/cypress_build.sh).


### PR DESCRIPTION
Adjusting the docs to clarify port 8081 should be used when running Cypress
