### PR TITLE
fix(be/utils): sync cache timeout for memoized function

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -109,7 +109,7 @@ def memoized_func(key: str, cache: Cache = cache_manager.cache) -> Callable[...,
     force means whether to force refresh the cache and is treated as False by default,
     except force = True is passed to the decorated function.
 
-    timeout of cache is set to 600 seconds by default,
+    timeout of cache is set to CACHE_DEFAULT_TIMEOUT seconds by default,
     except cache_timeout = {timeout in seconds} is passed to the decorated function.
 
     :param key: a callable function that takes function arguments and returns
@@ -121,7 +121,9 @@ def memoized_func(key: str, cache: Cache = cache_manager.cache) -> Callable[...,
         def wrapped_f(*args: Any, **kwargs: Any) -> Any:
             should_cache = kwargs.pop("cache", True)
             force = kwargs.pop("force", False)
-            cache_timeout = kwargs.pop("cache_timeout", 0)
+            cache_timeout = kwargs.pop(
+                "cache_timeout", app.config["CACHE_DEFAULT_TIMEOUT"]
+            )
 
             if not should_cache:
                 return f(*args, **kwargs)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(be/utils): sync cache timeout for memoized function

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #31841 

Originally the default cache timeout is set at 600 seconds ([commit](https://github.com/apache/superset/pull/6078/files#diff-37d71f62db96c3ce79a88a74f872cb930ac0e644f69e6d9fb8579113f3279fdbR46)) but currently it sits at zero aka never expired. This PR is to sync this default value to be similar to other caching, at `app.config('CACHE_DEFAULT_VALUE')` or 300 seconds.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #31841
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
