### PR TITLE
fix(api): loading viz_type from request params

### DIFF
--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -43,6 +43,16 @@ class CreateChartCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
+        # Extract viz_type from params if it exists
+        if 'params' in self._properties:
+            try:
+                import json
+                params = json.loads(self._properties['params'])
+                if 'viz_type' in params:
+                    self._properties['viz_type'] = params['viz_type']
+            except json.JSONDecodeError as ex:
+                exceptions.append(ex)
+
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:
         self.validate()

--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -43,15 +43,14 @@ class CreateChartCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
-        # Extract viz_type from params if it exists
-        if 'params' in self._properties:
+        if self._properties.get('params'):
             try:
                 import json
                 params = json.loads(self._properties['params'])
                 if 'viz_type' in params:
                     self._properties['viz_type'] = params['viz_type']
             except json.JSONDecodeError as ex:
-                exceptions.append(ex)
+                raise ex
 
     @transaction(on_error=partial(on_error, reraise=ChartCreateFailedError))
     def run(self) -> Model:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Previously, when passing `viz_type` via the API, it would default to table. This change allows us to send viz_type and have the charts respect it in the UI


### TESTING INSTRUCTIONS
Make an API request via python and send the following params

```bash
params = {
        "viz_type": "big_number",
        "groupby": columns,
        "metrics": metrics,
        "adhoc_filters": [
            {
                "expressionType": "SQL",
                "sqlExpression": where_clause,
                "clause": "WHERE",
            }
        ]
    }
```

The resulting chart would always be a table. No longer

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
