### PR TITLE
fix(E2E): Fix flaky Dashboard list delete test

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard_list/list.test.ts
@@ -40,11 +40,25 @@ function openMenu() {
   cy.get('[aria-label="more-vert"]').first().click();
 }
 
-function confirmDelete() {
+function confirmDelete(bulk = false) {
+  interceptDelete();
+  interceptBulkDelete();
+
   // Wait for modal dialog to be present and visible
   cy.get('[role="dialog"][aria-modal="true"]').should('be.visible');
-  cy.getBySel('delete-modal-input').should('be.visible').clear().type('DELETE');
+  cy.getBySel('delete-modal-input')
+    .should('be.visible')
+    .then($input => {
+      cy.wrap($input).clear();
+      cy.wrap($input).type('DELETE');
+    });
   cy.getBySel('modal-confirm-button').should('be.visible').click();
+
+  if (bulk) {
+    cy.wait('@bulkDelete');
+  } else {
+    cy.wait('@delete');
+  }
 }
 
 describe('Dashboards list', () => {
@@ -159,7 +173,6 @@ describe('Dashboards list', () => {
     });
 
     it('should bulk delete correctly', () => {
-      interceptBulkDelete();
       toggleBulkSelect();
 
       // bulk deletes in card-view
@@ -169,8 +182,7 @@ describe('Dashboards list', () => {
       cy.getBySel('styled-card').eq(0).contains('1 - Sample dashboard').click();
       cy.getBySel('styled-card').eq(1).contains('2 - Sample dashboard').click();
       cy.getBySel('bulk-select-action').eq(0).contains('Delete').click();
-      confirmDelete();
-      cy.wait('@bulkDelete');
+      confirmDelete(true);
       cy.getBySel('styled-card')
         .eq(0)
         .should('not.contain', '1 - Sample dashboard');
@@ -185,8 +197,7 @@ describe('Dashboards list', () => {
       cy.get('[data-test="table-row"] input[type="checkbox"]').eq(0).click();
       cy.get('[data-test="table-row"] input[type="checkbox"]').eq(1).click();
       cy.getBySel('bulk-select-action').eq(0).contains('Delete').click();
-      confirmDelete();
-      cy.wait('@bulkDelete');
+      confirmDelete(true);
       cy.getBySel('table-row')
         .eq(0)
         .should('not.contain', '3 - Sample dashboard');
@@ -195,31 +206,36 @@ describe('Dashboards list', () => {
         .should('not.contain', '4 - Sample dashboard');
     });
 
-    it('should delete correctly', () => {
-      interceptDelete();
+    it('should delete correctly in list mode', () => {
+      // deletes in list-view
+      setGridMode('list');
 
+      cy.getBySel('table-row')
+        .eq(0)
+        .contains('4 - Sample dashboard')
+        .should('exist');
+      cy.getBySel('dashboard-list-trash-icon').eq(0).click();
+      confirmDelete();
+      cy.getBySel('table-row')
+        .eq(0)
+        .should('not.contain', '4 - Sample dashboard');
+    });
+
+    it('should delete correctly in card mode', () => {
       // deletes in card-view
       setGridMode('card');
       orderAlphabetical();
 
-      cy.getBySel('styled-card').eq(0).contains('1 - Sample dashboard');
+      cy.getBySel('styled-card')
+        .eq(0)
+        .contains('1 - Sample dashboard')
+        .should('exist');
       openMenu();
       cy.getBySel('dashboard-card-option-delete-button').click();
       confirmDelete();
-      cy.wait('@delete');
       cy.getBySel('styled-card')
         .eq(0)
         .should('not.contain', '1 - Sample dashboard');
-
-      // deletes in list-view
-      setGridMode('list');
-      cy.getBySel('table-row').eq(0).contains('2 - Sample dashboard');
-      cy.getBySel('dashboard-list-trash-icon').eq(0).click();
-      confirmDelete();
-      cy.wait('@delete');
-      cy.getBySel('table-row')
-        .eq(0)
-        .should('not.contain', '2 - Sample dashboard');
     });
 
     it('should edit correctly', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes an issue for which the modal to delete a Dashboard from the list wasn't appearing in the E2E test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N.A.

### TESTING INSTRUCTIONS
CI should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
