### PR TITLE
refactor: Removes legacy CSS template endpoint

### DIFF
--- a/superset-frontend/src/dashboard/components/CssEditor/CssEditor.test.tsx
+++ b/superset-frontend/src/dashboard/components/CssEditor/CssEditor.test.tsx
@@ -38,7 +38,7 @@ const templates = [
   { template_name: 'Template C', css: 'background-color: yellow;' },
 ];
 
-fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {
+fetchMock.get('glob:*/api/v1/css_template*', {
   result: templates,
 });
 

--- a/superset-frontend/src/dashboard/components/CssEditor/index.tsx
+++ b/superset-frontend/src/dashboard/components/CssEditor/index.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Key, ReactNode, PureComponent } from 'react';
+import rison from 'rison';
 import { AntdDropdown } from 'src/components';
 import { Menu } from 'src/components/Menu';
 import Button from 'src/components/Button';
@@ -73,8 +74,8 @@ class CssEditor extends PureComponent<CssEditorProps, CssEditorState> {
 
   componentDidMount() {
     AceCssEditor.preload();
-
-    SupersetClient.get({ endpoint: '/csstemplateasyncmodelview/api/read' })
+    const query = rison.encode({ columns: ['template_name', 'css'] });
+    SupersetClient.get({ endpoint: `/api/v1/css_template/?q=${query}` })
       .then(({ json }) => {
         const templates = json.result.map(
           (row: { template_name: string; css: string }) => ({

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -165,10 +165,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.api import Api
         from superset.views.chart.views import SliceAsync, SliceModelView
         from superset.views.core import Superset
-        from superset.views.css_templates import (
-            CssTemplateAsyncModelView,
-            CssTemplateModelView,
-        )
+        from superset.views.css_templates import CssTemplateModelView
         from superset.views.dashboard.views import (
             Dashboard,
             DashboardModelView,
@@ -297,7 +294,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # Setup views with no menu
         #
         appbuilder.add_view_no_menu(Api)
-        appbuilder.add_view_no_menu(CssTemplateAsyncModelView)
         appbuilder.add_view_no_menu(Dashboard)
         appbuilder.add_view_no_menu(DashboardModelViewAsync)
         appbuilder.add_view_no_menu(Datasource)

--- a/superset/views/css_templates.py
+++ b/superset/views/css_templates.py
@@ -15,18 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 from flask_appbuilder.api import expose
-from flask_appbuilder.baseviews import expose_api
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import (
-    has_access,
-    has_access_api,
-    permission_name,
-)
+from flask_appbuilder.security.decorators import has_access
 
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models import core as models
 from superset.superset_typing import FlaskResponse
-from superset.views.base import DeleteMixin, deprecated, SupersetModelView
+from superset.views.base import DeleteMixin, SupersetModelView
 
 
 class CssTemplateModelView(  # pylint: disable=too-many-ancestors
@@ -43,20 +38,3 @@ class CssTemplateModelView(  # pylint: disable=too-many-ancestors
     @has_access
     def list(self) -> FlaskResponse:
         return super().render_app_template()
-
-
-class CssTemplateAsyncModelView(  # pylint: disable=too-many-ancestors
-    CssTemplateModelView
-):
-    include_route_methods = RouteMethod.API_READ
-    class_permission_name = "CssTemplate"
-    method_permission_name = MODEL_VIEW_RW_METHOD_PERMISSION_MAP
-
-    list_columns = ["template_name", "css"]
-
-    @expose_api(name="read", url="/api/read", methods=["GET"])
-    @has_access_api
-    @permission_name("list")
-    @deprecated(eol_version="5.0.0")
-    def api_read(self) -> FlaskResponse:
-        return super().api_read()


### PR DESCRIPTION
### SUMMARY
As part of the 5.0 proposals, this PR executes the [90 - Remove old CSS templates views and endpoints](https://github.com/orgs/apache/projects/345/views/1?filterQuery=assignee%3A%22michael-s-molina%22&pane=issue&itemId=62405820&issue=apache%7Csuperset%7C28401).

I didn't add anything to `UPDATING.md` given that the removed endpoint was not under  `api/v1`.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
