### PR TITLE
refactor: Removes legacy dashboard endpoints

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -172,7 +172,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.dashboard.views import (
             Dashboard,
             DashboardModelView,
-            DashboardModelViewAsync,
         )
         from superset.views.database.views import DatabaseView
         from superset.views.datasource.views import DatasetEditor, Datasource
@@ -299,7 +298,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_view_no_menu(Api)
         appbuilder.add_view_no_menu(CssTemplateAsyncModelView)
         appbuilder.add_view_no_menu(Dashboard)
-        appbuilder.add_view_no_menu(DashboardModelViewAsync)
         appbuilder.add_view_no_menu(Datasource)
         appbuilder.add_view_no_menu(DatasetEditor)
         appbuilder.add_view_no_menu(EmbeddedView)

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -17,17 +17,12 @@
 import builtins
 from typing import Callable, Union
 
-from flask import g, redirect, request, Response
+from flask import g, redirect, Response
 from flask_appbuilder import expose
 from flask_appbuilder.actions import action
-from flask_appbuilder.baseviews import expose_api
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder.security.decorators import (
-    has_access,
-    has_access_api,
-    permission_name,
-)
-from flask_babel import gettext as __, lazy_gettext as _
+from flask_appbuilder.security.decorators import has_access
+from flask_babel import gettext as __
 from flask_login import AnonymousUserMixin, login_user
 
 from superset import db, event_logger, is_feature_enabled
@@ -39,8 +34,6 @@ from superset.views.base import (
     BaseSupersetView,
     common_bootstrap_payload,
     DeleteMixin,
-    deprecated,
-    generate_download_headers,
     SupersetModelView,
 )
 from superset.views.dashboard.mixin import DashboardMixin
@@ -61,20 +54,6 @@ class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pyl
         "download_dashboards",
     }
 
-    @expose_api(name="read", url="/api/read", methods=["GET"])
-    @has_access_api
-    @permission_name("list")
-    @deprecated(eol_version="5.0.0")
-    def api_read(self) -> FlaskResponse:
-        return super().api_read()
-
-    @expose_api(name="delete", url="/api/delete/<pk>", methods=["DELETE"])
-    @has_access_api
-    @permission_name("delete")
-    @deprecated(eol_version="5.0.0")
-    def api_delete(self, pk: int) -> FlaskResponse:
-        return super().delete(pk)
-
     @has_access
     @expose("/list/")
     def list(self) -> FlaskResponse:
@@ -89,22 +68,6 @@ class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pyl
             items = [items]
         ids = "".join(f"&id={d.id}" for d in items)
         return redirect(f"/dashboard/export_dashboards_form?{ids[1:]}")
-
-    @event_logger.log_this
-    @has_access
-    @expose("/export_dashboards_form")
-    @deprecated(eol_version="5.0.0")
-    def download_dashboards(self) -> FlaskResponse:
-        if request.args.get("action") == "go":
-            ids = set(request.args.getlist("id"))
-            return Response(
-                DashboardModel.export_dashboards(ids),
-                headers=generate_download_headers("json"),
-                mimetype="application/text",
-            )
-        return self.render_template(
-            "superset/export_dashboards.html", dashboards_url="/dashboard/list"
-        )
 
 
 class Dashboard(BaseSupersetView):
@@ -163,35 +126,3 @@ class Dashboard(BaseSupersetView):
                 bootstrap_data, default=json.pessimistic_json_iso_dttm_ser
             ),
         )
-
-
-class DashboardModelViewAsync(DashboardModelView):  # pylint: disable=too-many-ancestors
-    route_base = "/dashboardasync"
-    class_permission_name = "Dashboard"
-    method_permission_name = MODEL_VIEW_RW_METHOD_PERMISSION_MAP
-
-    include_route_methods = {RouteMethod.API_READ}
-
-    list_columns = [
-        "id",
-        "dashboard_link",
-        "creator",
-        "modified",
-        "dashboard_title",
-        "changed_on",
-        "url",
-        "changed_by_name",
-    ]
-    label_columns = {
-        "dashboard_link": _("Dashboard"),
-        "dashboard_title": _("Title"),
-        "creator": _("Creator"),
-        "modified": _("Modified"),
-    }
-
-    @expose_api(name="read", url="/api/read", methods=["GET"])
-    @has_access_api
-    @permission_name("list")
-    @deprecated(eol_version="5.0.0")
-    def api_read(self) -> FlaskResponse:
-        return super().api_read()


### PR DESCRIPTION
### SUMMARY
As part of the 5.0 proposals, this PR executes the [92 - Remove old Dashboard views and endpoints](https://github.com/orgs/apache/projects/345/views/1?pane=issue&itemId=62405956&issue=apache%7Csuperset%7C28402).

I didn't add anything to  `UPDATING.md` given that the removed endpoint was not under `api/v1`.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
