### PR TITLE
fix: Load cached DB metadata as DatasourceName and add catalog to schema_list cache key

### DIFF
--- a/superset/commands/database/tables.py
+++ b/superset/commands/database/tables.py
@@ -32,6 +32,7 @@ from superset.daos.database import DatabaseDAO
 from superset.exceptions import SupersetException
 from superset.extensions import db, security_manager
 from superset.models.core import Database
+from superset.utils.core import DatasourceName
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,8 @@ class TablesDatabaseCommand(BaseCommand):
                 catalog=self._catalog_name,
                 schema=self._schema_name,
                 datasource_names=sorted(
-                    self._model.get_all_table_names_in_schema(
+                    DatasourceName(*datasource_name)
+                    for datasource_name in self._model.get_all_table_names_in_schema(
                         catalog=self._catalog_name,
                         schema=self._schema_name,
                         force=self._force,
@@ -74,7 +76,8 @@ class TablesDatabaseCommand(BaseCommand):
                 catalog=self._catalog_name,
                 schema=self._schema_name,
                 datasource_names=sorted(
-                    self._model.get_all_view_names_in_schema(
+                    DatasourceName(*datasource_name)
+                    for datasource_name in self._model.get_all_view_names_in_schema(
                         catalog=self._catalog_name,
                         schema=self._schema_name,
                         force=self._force,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -83,7 +83,7 @@ from superset.superset_typing import (
 )
 from superset.utils import cache as cache_util, core as utils, json
 from superset.utils.backports import StrEnum
-from superset.utils.core import DatasourceName, get_username
+from superset.utils.core import get_username
 from superset.utils.oauth2 import get_oauth2_access_token, OAuth2ClientConfigSchema
 
 config = app.config
@@ -798,7 +798,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         self,
         catalog: str | None,
         schema: str,
-    ) -> set[DatasourceName]:
+    ) -> set[tuple[str, str, str | None]]:
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -814,7 +814,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
-                    DatasourceName(table, schema, catalog)
+                    (table, schema, catalog)
                     for table in self.db_engine_spec.get_table_names(
                         database=self,
                         inspector=inspector,
@@ -832,7 +832,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         self,
         catalog: str | None,
         schema: str,
-    ) -> set[DatasourceName]:
+    ) -> set[tuple[str, str, str | None]]:
         """Parameters need to be passed as keyword arguments.
 
         For unused parameters, they are referenced in
@@ -848,7 +848,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
-                    DatasourceName(view, schema, catalog)
+                    (view, schema, catalog)
                     for view in self.db_engine_spec.get_view_names(
                         database=self,
                         inspector=inspector,
@@ -873,7 +873,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
             yield sqla.inspect(engine)
 
     @cache_util.memoized_func(
-        key="db:{self.id}:schema_list",
+        key="db:{self.id}:catalog:{catalog}:schema_list",
         cache=cache_manager.cache,
     )
     def get_all_schema_names(


### PR DESCRIPTION
### SUMMARY
The `get_all_table_names_in_schema` and `get_all_view_names_in_schema` methods might return data from cache (if `force` isn't set to `True`). Metadata is serialized before getting cached, so currently if cached results are returned, the logic would throw an error as it would try to access these as `DatasourceName` named tuples directly.

This PR changes the logic so that the result of these methods are then loaded as `DatasourceName`s, so that cached results can be used properly.

I also added the catalog name to the `schema_list` cache key.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
An error is displayed when trying to load cached table list:
![image](https://github.com/user-attachments/assets/33a78164-ba53-42c0-8e43-5ae4f7f4e4d0)


**After**
List loads properly.

### TESTING INSTRUCTIONS
1. Create a DB connection.
2. Set a cache timeout for table metadata.
3. Load tables from a schema.
4. Refresh the browser.
5. The list should load properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
