### PR TITLE
fix(sqllab): Missing allowHTML props in ResultTableExtension

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -134,13 +134,14 @@ export interface SQLFormExtensionProps {
   startQuery: (ctasArg?: any, ctas_method?: any) => void;
 }
 
-export interface SQLResultTableExtentionProps {
+export interface SQLResultTableExtensionProps {
   queryId: string;
   orderedColumnKeys: string[];
   data: Record<string, unknown>[];
   height: number;
   filterText?: string;
   expandedColumns?: string[];
+  allowHTML?: boolean;
 }
 
 /**
@@ -223,7 +224,7 @@ export type Extensions = Partial<{
   'database.delete.related': ComponentType<DatabaseDeleteRelatedExtensionProps>;
   'dataset.delete.related': ComponentType<DatasetDeleteRelatedExtensionProps>;
   'sqleditor.extension.form': ComponentType<SQLFormExtensionProps>;
-  'sqleditor.extension.resultTable': ComponentType<SQLResultTableExtentionProps>;
+  'sqleditor.extension.resultTable': ComponentType<SQLResultTableExtensionProps>;
   'dashboard.slice.header': ComponentType<SliceHeaderExtension>;
   'sqleditor.extension.customAutocomplete': (
     args: CustomAutoCompleteArgs,


### PR DESCRIPTION
### SUMMARY
As titled.

### TESTING INSTRUCTIONS
CI 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
