### PR TITLE
chore(build): enforce eslint rule banning antd imports outside of core Superset components

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -331,7 +331,7 @@ module.exports = {
     'no-prototype-builtins': 0,
     'no-restricted-properties': 0,
     'no-restricted-imports': [
-      'warn',
+      'error',
       {
         paths: [
           {

--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -340,6 +340,11 @@ module.exports = {
               'Please import Ant components from the index of src/components',
           },
           {
+            name: 'antd-v5',
+            message:
+              'Please import Ant v5 components from the index of src/components',
+          },
+          {
             name: '@superset-ui/core',
             importNames: ['supersetTheme'],
             message:


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Does just what it says. First run seen here is the current state of the codebase. In the second run, I changed an import to see it fail.

This also bans unsafe memorization, which is nice.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/ca8e43c6-a3c0-4933-b4eb-07fb299d60ce" />


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
