### PR TITLE
fix: oauth2 trino

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -62,9 +62,7 @@ except ImportError:
 class CustomTrinoAuthErrorMeta(type):
     def __instancecheck__(cls, instance: object) -> bool:
         logger.info("is this being called?")
-        return isinstance(
-            instance, HttpError
-        ) and "error 401: b'Invalid credentials'" in str(instance)
+        return isinstance(instance, HttpError) and "error 401" in str(instance)
 
 
 class TrinoAuthError(HttpError, metaclass=CustomTrinoAuthErrorMeta):


### PR DESCRIPTION
fix(trino): compare only error code for oauth2 auth

### SUMMARY
I guess this message "invalid credentials" is specific for google oauth2 server (or the one that was used to develop the feature), there is a ([link](https://www.cubebackup.com/docs/faq/invalid-credential-error/#:~:text=This%20error%20usually%20happens%20when,Domain%20and%20Domain%20administrator%20correctly.)) I found that makes me think so. With the change applied it started to work good with [identity server 4](https://identityserver4.readthedocs.io/), and I guess this comparison makes it impossible for people to use oauth2 right now, for example [here](https://github.com/apache/superset/issues/20300#issuecomment-2239175914).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
This is how it looks with the change applied.
<img width="1505" alt="Screenshot 2025-01-27 at 05 43 52" src="https://github.com/user-attachments/assets/613fbcad-9ed6-440e-971c-7b076e10ecfe" />

### TESTING INSTRUCTIONS
There is an example of how I configured oauth2 for trino. 
P.S.: I didn't copy other configuration except for the part need to make oauth work.

```
configOverrides:
  enable_oauth: |
    DATABASE_OAUTH2_REDIRECT_URI = "https://{hostname}/api/v1/database/oauth2/"
    DATABASE_OAUTH2_CLIENTS = {
      "Trino": {
        "id": "trino",
        "secret": os.getenv("SUPERSET_OAUTH_CLIENT_SECRET"),
        "scope": "openid email profile offline_access trino",
        "redirect_uri": "https://{hostname}/api/v1/database/oauth2/",
        "authorization_request_uri": "https://{hostname}/connect/authorize",
        "token_request_uri": "https://{hostname}/connect/token"
      }
    }
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
- [x] Fixes #30081
