### PR TITLE
feat: cache the frontend's bootstrap data

### DIFF
--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -29,5 +29,6 @@ export default function getBootstrapData(): BootstrapData {
       ? JSON.parse(dataBootstrap)
       : DEFAULT_BOOTSTRAP_DATA;
   }
-  return cachedBootstrapData;
+  // Add a fallback to ensure the returned value is always of type BootstrapData
+  return cachedBootstrapData ?? DEFAULT_BOOTSTRAP_DATA;
 }

--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -16,12 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import { BootstrapData } from 'src/types/bootstrapTypes';
 import { DEFAULT_BOOTSTRAP_DATA } from 'src/constants';
 
+let cachedBootstrapData: BootstrapData | null = null;
+
 export default function getBootstrapData(): BootstrapData {
-  const appContainer = document.getElementById('app');
-  const dataBootstrap = appContainer?.getAttribute('data-bootstrap');
-  return dataBootstrap ? JSON.parse(dataBootstrap) : DEFAULT_BOOTSTRAP_DATA;
+  if (cachedBootstrapData === null) {
+    const appContainer = document.getElementById('app');
+    const dataBootstrap = appContainer?.getAttribute('data-bootstrap');
+    cachedBootstrapData = dataBootstrap
+      ? JSON.parse(dataBootstrap)
+      : DEFAULT_BOOTSTRAP_DATA;
+  }
+  return cachedBootstrapData;
 }


### PR DESCRIPTION
While reviewing https://github.com/apache/superset/pull/30134 which seemed to make heavy use of `getBootstrapData`, I realized that it's used 21 times across the codebase, while it may be a fairly expensive operation (JSON.parse on an object that may be significant in size at times (?)).

Now it's easy to do module-level caching here and ensures that `JSON.parse` happens only once per SPA-load, but opening this as a DRAFT as we probably already store it in other places (didn't dig in, but it's probably stored in a redux store or component state somewhere...).

Tradeoff here is compute VS memory, and clearly we need this object in memory somewhere, but probably in most cases, already have it in the app's state somewhere. Ideally the app would read it once and make it available in its state, as opposed to different modules calling this function on-demand...

PR is more of a request for comments.

Grepping for calls ->
```
22:30 $ git grep "getBootstrapData("
spec/helpers/reducerIndex.ts:const bootstrapData = getBootstrapData();
src/SqlLab/actions/sqlLab.js:      ...getBootstrapData(),
src/SqlLab/components/ScheduleQueryButton/index.tsx:const bootstrapData = getBootstrapData();
src/SqlLab/components/SqlEditor/index.tsx:const bootstrapData = getBootstrapData();
src/SqlLab/components/TabbedSqlEditors/index.tsx:    const bootstrapData = getBootstrapData();
src/dashboard/components/Dashboard.jsx:    const bootstrapData = getBootstrapData();
src/dashboard/components/nativeFilters/utils.ts:  const bootstrapData = getBootstrapData();
src/embedded/api.tsx:const bootstrapData = getBootstrapData();
src/embedded/index.tsx:const bootstrapData = getBootstrapData();
src/explore/components/controls/VizTypeControl/index.tsx:const bootstrapData = getBootstrapData();
src/middleware/asyncEvent.ts:  config = appConfig || getBootstrapData().common.conf;
src/pages/ChartCreation/index.tsx:const bootstrapData = getBootstrapData();
src/pages/Home/index.tsx:const bootstrapData = getBootstrapData();
src/preamble.ts:const bootstrapData = getBootstrapData();
src/setup/setupClient.ts:const bootstrapData = getBootstrapData();
src/utils/getBootstrapData.ts:export default function getBootstrapData(): BootstrapData {
src/utils/hostNamesConfig.js:  const bootstrapData = getBootstrapData();
src/views/App.tsx:const bootstrapData = getBootstrapData();
src/views/RootContextProviders.tsx:const { common } = getBootstrapData();
src/views/menu.tsx:const bootstrapData = getBootstrapData();
src/views/store.ts:const bootstrapData = getBootstrapData();
```

Thinking about it, this PR is probably net-positive, but would say that that sprawling calls to `getBootstrapData()` across the codebase is an anti-pattern.