### PR TITLE
docs: incorrect psycopg2 package in k8s install instructions

### DIFF
--- a/docs/docs/installation/kubernetes.mdx
+++ b/docs/docs/installation/kubernetes.mdx
@@ -150,6 +150,9 @@ Superset requires a Python DB-API database driver and a SQLAlchemy
 dialect to be installed for each datastore you want to connect to.
 
 See [Install Database Drivers](/docs/configuration/databases) for more information.
+It is recommended that you refer to versions listed in
+[pyproject.toml](https://github.com/apache/superset/blob/master/pyproject.toml)
+instead of hard-coding them in your bootstrap script, as seen below.
 
 :::
 
@@ -157,9 +160,9 @@ The following example installs the drivers for BigQuery and Elasticsearch, allow
 ```yaml
 bootstrapScript: |
   #!/bin/bash
-  pip install psycopg2-binary==2.9.10 \
-    sqlalchemy-bigquery==1.6.1 \
-    elasticsearch-dbapi==0.2.5 &&\
+  pip install .[postgres] \
+    .[bigquery] \
+    .[elasticsearch] &&\
   if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
 ```
 

--- a/docs/docs/installation/kubernetes.mdx
+++ b/docs/docs/installation/kubernetes.mdx
@@ -157,7 +157,7 @@ The following example installs the drivers for BigQuery and Elasticsearch, allow
 ```yaml
 bootstrapScript: |
   #!/bin/bash
-  pip install psycopg2==2.9.6 \
+  pip install psycopg2-binary==2.9.10 \
     sqlalchemy-bigquery==1.6.1 \
     elasticsearch-dbapi==0.2.5 &&\
   if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The current Kubernetes installation instructions are subtly incorrect: if you use the bootstrapScript as it is, Superset may fail to start since psycopg2 source package can't be built without a C compiler. Luckily, an official binary package is available and seems to work with Superset's images.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
Follow the instructions to deploy Superset on Kubernetes with Helm. Use bootstrapScript to add some driver, e.g. Bigquery one should work.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
