### PR TITLE
refactor: Remove CSV upload size limit and related validation

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -849,9 +849,6 @@ CSV_EXTENSIONS = {"csv", "tsv", "txt"}
 COLUMNAR_EXTENSIONS = {"parquet", "zip"}
 ALLOWED_EXTENSIONS = {*EXCEL_EXTENSIONS, *CSV_EXTENSIONS, *COLUMNAR_EXTENSIONS}
 
-# Optional maximum file size in bytes when uploading a CSV
-CSV_UPLOAD_MAX_SIZE = None
-
 # CSV Options: key/value pairs that will be passed as argument to DataFrame.to_csv
 # method.
 # note: index option should not be overridden

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 import inspect
-import os
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -1233,16 +1232,6 @@ class CSVUploadPostSchema(BaseUploadPostSchema):
                     "Invalid JSON format for column_data_types"
                 ) from ex
         return data
-
-    @validates("file")
-    def validate_file_size(self, file: FileStorage) -> None:
-        file.flush()
-        size = os.fstat(file.fileno()).st_size
-        if (
-            current_app.config["CSV_UPLOAD_MAX_SIZE"] is not None
-            and size > current_app.config["CSV_UPLOAD_MAX_SIZE"]
-        ):
-            raise ValidationError([_("File size exceeds the maximum allowed size.")])
 
 
 class ExcelUploadPostSchema(BaseUploadPostSchema):

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -1090,32 +1090,6 @@ def test_csv_upload_validation(
     assert response.json == expected_response
 
 
-def test_csv_upload_file_size_validation(
-    mocker: MockerFixture,
-    client: Any,
-    full_api_access: None,
-) -> None:
-    """
-    Test CSV Upload validation fails.
-    """
-    _ = mocker.patch.object(UploadCommand, "run")
-    current_app.config["CSV_UPLOAD_MAX_SIZE"] = 5
-    response = client.post(
-        "/api/v1/database/1/csv_upload/",
-        data={
-            "file": (create_csv_file(), "out.csv"),
-            "table_name": "table1",
-            "delimiter": ",",
-        },
-        content_type="multipart/form-data",
-    )
-    assert response.status_code == 400
-    assert response.json == {
-        "message": {"file": ["File size exceeds the maximum allowed size."]}
-    }
-    current_app.config["CSV_UPLOAD_MAX_SIZE"] = None
-
-
 @pytest.mark.parametrize(
     "filename",
     [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR removes CSV upload size validation according to [#28400](https://github.com/apache/superset/issues/28400)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
