### PR TITLE
fix(sqllab): tab layout truncated

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/style/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/style/index.tsx
@@ -27,6 +27,7 @@ export {
   ThemeProvider,
   CacheProvider as EmotionCacheProvider,
   withTheme,
+  type SerializedStyles,
 } from '@emotion/react';
 export { default as createEmotionCache } from '@emotion/cache';
 

--- a/superset-frontend/src/components/ErrorBoundary/index.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/index.tsx
@@ -24,6 +24,7 @@ export interface ErrorBoundaryProps {
   children: ReactNode;
   onError?: (error: Error, info: ErrorInfo) => void;
   showMessage?: boolean;
+  className?: string;
 }
 
 interface ErrorBoundaryState {
@@ -51,14 +52,16 @@ export default class ErrorBoundary extends Component<
 
   render() {
     const { error, info } = this.state;
+    const { showMessage, className } = this.props;
     if (error) {
       const firstLine = error.toString().split('\n')[0];
-      if (this.props.showMessage) {
+      if (showMessage) {
         return (
           <ErrorAlert
             errorType={t('Unexpected error')}
             message={firstLine}
             descriptionDetails={info?.componentStack}
+            className={className}
           />
         );
       }

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -35,6 +35,7 @@ export interface ErrorAlertProps {
   children?: React.ReactNode; // Additional content to show in the modal
   closable?: boolean; // Show close button, default true
   showIcon?: boolean; // Show icon, default true
+  className?: string;
 }
 
 const ErrorAlert: React.FC<ErrorAlertProps> = ({
@@ -49,6 +50,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
   children,
   closable = true,
   showIcon = true,
+  className,
 }) => {
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(
     !descriptionDetailsCollapsed,
@@ -66,7 +68,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
     const color =
       type === 'warning' ? theme.colors.warning.base : theme.colors.error.base;
     return (
-      <div style={{ cursor: 'pointer' }}>
+      <div className={className} style={{ cursor: 'pointer' }}>
         <span style={{ color }}>{icon} </span>
         {errorType}
       </div>
@@ -100,13 +102,13 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
       )}
     </div>
   );
-
   const renderAlert = (closable: boolean) => (
     <Alert
       description={renderDescription()}
       type={type}
       showIcon
       closable={closable}
+      className={className}
     >
       <strong>{errorType}</strong>
       {message && (

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -25,6 +25,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
+import { css } from '@superset-ui/core';
 import { GlobalStyles } from 'src/GlobalStyles';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
@@ -83,12 +84,19 @@ const App = () => (
         {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
           <Route path={path} key={path}>
             <Suspense fallback={<Fallback />}>
-              <Layout.Content>
-                <div style={{ padding: '16px' }}>
-                  <ErrorBoundary>
-                    <Component user={bootstrapData.user} {...props} />
-                  </ErrorBoundary>
-                </div>
+              <Layout.Content
+                css={css`
+                  display: flex;
+                  flex-direction: column;
+                `}
+              >
+                <ErrorBoundary
+                  css={css`
+                    margin: 16px;
+                  `}
+                >
+                  <Component user={bootstrapData.user} {...props} />
+                </ErrorBoundary>
               </Layout.Content>
             </Suspense>
           </Route>


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/pull/31858#pullrequestreview-2567399027

In #31858, unnecessary space was created on all pages due to the div with added padding.
|Before|After|
|--|--|
|![Screenshot_2025-01-27_at_6_20_03 PM](https://github.com/user-attachments/assets/12c2dfec-ac2d-4a4c-8f9a-7cf1c0cea5f2)|![Screenshot_2025-01-27_at_6_19_44 PM](https://github.com/user-attachments/assets/a776daf8-60b0-4a27-b741-166ca25bfbf1)

The intention of this padding was to provide [space for the alert container](https://github.com/apache/superset/pull/31858#issuecomment-2593398152). To resolve this issue, I removed the div and added margin to the ErrorBoundary in the App container instead. 

![Screenshot 2025-01-27 at 6 03 47 PM](https://github.com/user-attachments/assets/b26db8f7-7857-4cbd-ae71-bc61873fc027)
Additionally, the Layout.Content component caused issues with the full page height, resulting in improper rendering of the SQL Lab tab. This was fixed by adding `display:flex`.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|Before|After|
|--|--|
|![Screenshot 2025-01-27 at 6 20 26 PM](https://github.com/user-attachments/assets/cb3c95f5-2eec-4dbf-8df9-1ba36950504c)|![Screenshot 2025-01-27 at 6 20 10 PM](https://github.com/user-attachments/assets/d36af505-2346-4ab8-b6d4-1dc65d3b09c5)|
|![Screenshot 2025-01-27 at 6 19 44 PM](https://github.com/user-attachments/assets/b2bde732-ca73-46a7-8e33-080ad35d08e9)|![Screenshot 2025-01-27 at 6 20 03 PM](https://github.com/user-attachments/assets/bfc1addc-2c55-4292-ab89-08960b457954)|

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
