### PR TITLE
feat: Fix explore dynamic height issues by adding style to ErrorAlertBoundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ docker/*local*
 # Jest test report
 test-report.html
 superset/static/stats/statistics.html
+.aider*

--- a/superset-frontend/src/components/ErrorBoundary/index.tsx
+++ b/superset-frontend/src/components/ErrorBoundary/index.tsx
@@ -24,6 +24,7 @@ export interface ErrorBoundaryProps {
   children: ReactNode;
   onError?: (error: Error, info: ErrorInfo) => void;
   showMessage?: boolean;
+  style?: React.CSSProperties;
 }
 
 interface ErrorBoundaryState {
@@ -59,6 +60,7 @@ export default class ErrorBoundary extends Component<
             errorType={t('Unexpected error')}
             message={firstLine}
             descriptionDetails={info?.componentStack}
+            style={this.props.style}
           />
         );
       }

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.tsx
@@ -35,6 +35,7 @@ export interface ErrorAlertProps {
   children?: React.ReactNode; // Additional content to show in the modal
   closable?: boolean; // Show close button, default true
   showIcon?: boolean; // Show icon, default true
+  style?: React.CSSProperties;
 }
 
 const ErrorAlert: React.FC<ErrorAlertProps> = ({
@@ -49,6 +50,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
   children,
   closable = true,
   showIcon = true,
+  style,
 }) => {
   const [isDescriptionVisible, setIsDescriptionVisible] = useState(
     !descriptionDetailsCollapsed,
@@ -107,6 +109,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
       type={type}
       showIcon
       closable={closable}
+      style={style}
     >
       <strong>{errorType}</strong>
       {message && (

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -29,6 +29,7 @@ import { GlobalStyles } from 'src/GlobalStyles';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import { Layout } from 'src/components';
+import { useTheme } from '@superset-ui/core';
 import Menu from 'src/features/home/Menu';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';
@@ -69,34 +70,36 @@ const LocationPathnameLogger = () => {
   return <></>;
 };
 
-const App = () => (
-  <Router>
-    <ScrollToTop />
-    <LocationPathnameLogger />
-    <RootContextProviders>
-      <GlobalStyles />
-      <Menu
-        data={bootstrapData.common.menu_data}
-        isFrontendRoute={isFrontendRoute}
-      />
-      <Switch>
-        {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
-          <Route path={path} key={path}>
-            <Suspense fallback={<Fallback />}>
-              <Layout.Content>
-                <div style={{ padding: '16px' }}>
-                  <ErrorBoundary>
+const App = () => {
+  const theme = useTheme();
+
+  return (
+    <Router>
+      <ScrollToTop />
+      <LocationPathnameLogger />
+      <RootContextProviders>
+        <GlobalStyles />
+        <Menu
+          data={bootstrapData.common.menu_data}
+          isFrontendRoute={isFrontendRoute}
+        />
+        <Switch>
+          {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
+            <Route path={path} key={path}>
+              <Suspense fallback={<Fallback />}>
+                <Layout.Content>
+                  <ErrorBoundary style={{ margin: theme.sizeUnit * 4 }}>
                     <Component user={bootstrapData.user} {...props} />
                   </ErrorBoundary>
-                </div>
-              </Layout.Content>
-            </Suspense>
-          </Route>
-        ))}
-      </Switch>
-      <ToastContainer />
-    </RootContextProviders>
-  </Router>
-);
+                </Layout.Content>
+              </Suspense>
+            </Route>
+          ))}
+        </Switch>
+        <ToastContainer />
+      </RootContextProviders>
+    </Router>
+  );
+};
 
 export default hot(App);

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -28,7 +28,6 @@ import { bindActionCreators } from 'redux';
 import { GlobalStyles } from 'src/GlobalStyles';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
-import { Layout } from 'src/components';
 import Menu from 'src/features/home/Menu';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -83,11 +83,9 @@ const App = () => (
         {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
           <Route path={path} key={path}>
             <Suspense fallback={<Fallback />}>
-              <Layout.Content>
-                <ErrorBoundary style={{ margin: '16px' }}>
-                  <Component user={bootstrapData.user} {...props} />
-                </ErrorBoundary>
-              </Layout.Content>
+              <ErrorBoundary style={{ margin: '16px' }}>
+                <Component user={bootstrapData.user} {...props} />
+              </ErrorBoundary>
             </Suspense>
           </Route>
         ))}

--- a/superset-frontend/src/views/App.tsx
+++ b/superset-frontend/src/views/App.tsx
@@ -29,7 +29,6 @@ import { GlobalStyles } from 'src/GlobalStyles';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import Loading from 'src/components/Loading';
 import { Layout } from 'src/components';
-import { useTheme } from '@superset-ui/core';
 import Menu from 'src/features/home/Menu';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import ToastContainer from 'src/components/MessageToasts/ToastContainer';
@@ -70,36 +69,32 @@ const LocationPathnameLogger = () => {
   return <></>;
 };
 
-const App = () => {
-  const theme = useTheme();
-
-  return (
-    <Router>
-      <ScrollToTop />
-      <LocationPathnameLogger />
-      <RootContextProviders>
-        <GlobalStyles />
-        <Menu
-          data={bootstrapData.common.menu_data}
-          isFrontendRoute={isFrontendRoute}
-        />
-        <Switch>
-          {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
-            <Route path={path} key={path}>
-              <Suspense fallback={<Fallback />}>
-                <Layout.Content>
-                  <ErrorBoundary style={{ margin: theme.sizeUnit * 4 }}>
-                    <Component user={bootstrapData.user} {...props} />
-                  </ErrorBoundary>
-                </Layout.Content>
-              </Suspense>
-            </Route>
-          ))}
-        </Switch>
-        <ToastContainer />
-      </RootContextProviders>
-    </Router>
-  );
-};
+const App = () => (
+  <Router>
+    <ScrollToTop />
+    <LocationPathnameLogger />
+    <RootContextProviders>
+      <GlobalStyles />
+      <Menu
+        data={bootstrapData.common.menu_data}
+        isFrontendRoute={isFrontendRoute}
+      />
+      <Switch>
+        {routes.map(({ path, Component, props = {}, Fallback = Loading }) => (
+          <Route path={path} key={path}>
+            <Suspense fallback={<Fallback />}>
+              <Layout.Content>
+                <ErrorBoundary style={{ margin: '16px' }}>
+                  <Component user={bootstrapData.user} {...props} />
+                </ErrorBoundary>
+              </Layout.Content>
+            </Suspense>
+          </Route>
+        ))}
+      </Switch>
+      <ToastContainer />
+    </RootContextProviders>
+  </Router>
+);
 
 export default hot(App);


### PR DESCRIPTION
Recently brought in an intricate issue while trying to style the ErrorBoundary. Somehow was triggering a loop of auto-height-expanding in the Explore app.

Another related issue was around introducing `Layout.Content` in the App.tsx file, was creating issues with SQL Lab rendering the tab-content.

Here my solution is to pass a css prop to the boundary, which carries through to the `Alert` component. Here styling the boundary object ultimately styles the Alert, while passing the style props through ErrorAlert.

Could implement full emotion interface with `className` and `css` but decided to go minimalist and only pass what we need (`style`)
<img width="976" alt="Screenshot 2025-01-27 at 7 28 28 PM" src="https://github.com/user-attachments/assets/dce66107-36b3-4207-952a-22a908561e93" />

