### PR TITLE
chore(fe): correct typing for sheetsColumnNames

### DIFF
--- a/superset-frontend/src/features/databases/UploadDataModel/index.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/index.tsx
@@ -137,11 +137,6 @@ interface UploadInfo {
   column_data_types: string;
 }
 
-interface SheetColumnNames {
-  sheet_name: string;
-  column_names: string[];
-}
-
 const defaultUploadInfo: UploadInfo = {
   table_name: '',
   schema: '',
@@ -225,8 +220,8 @@ const UploadDataModal: FunctionComponent<UploadDataModalProps> = ({
   const [columns, setColumns] = useState<string[]>([]);
   const [sheetNames, setSheetNames] = useState<string[]>([]);
   const [sheetsColumnNames, setSheetsColumnNames] = useState<
-    SheetColumnNames[]
-  >([]);
+    Record<string, string[]>
+  >({});
   const [delimiter, setDelimiter] = useState<string>(',');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [currentSchema, setCurrentSchema] = useState<string | undefined>();
@@ -334,7 +329,7 @@ const UploadDataModal: FunctionComponent<UploadDataModalProps> = ({
     setDelimiter(',');
     setPreviewUploadedFile(true);
     setFileLoading(false);
-    setSheetsColumnNames([]);
+    setSheetsColumnNames({});
     form.resetFields();
   };
 
@@ -408,10 +403,10 @@ const UploadDataModal: FunctionComponent<UploadDataModalProps> = ({
           const { allSheetNames, sheetColumnNamesMap } = items.reduce(
             (
               acc: {
-                allSheetNames: any[];
+                allSheetNames: string[];
                 sheetColumnNamesMap: Record<string, string[]>;
               },
-              item: { sheet_name: any; column_names: any },
+              item: { sheet_name: string; column_names: string[] },
             ) => {
               acc.allSheetNames.push(item.sheet_name);
               acc.sheetColumnNamesMap[item.sheet_name] = item.column_names;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(fe): correct typing for sheetsColumnNames

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix a typing issue during Typescript migration to v5 as this should go first. No change to existing behavior

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before and After

https://github.com/user-attachments/assets/2a585cdf-9de0-4584-b801-5aafebea44ed


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
