### PR TITLE
fix: re-enable cypress checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.swp
 __pycache__
 
+.aider.*
 .local
 .cache
 .bento*

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -60,6 +60,7 @@ def run_cypress_for_test_file(
                 f"--browser {browser} "
                 f"--record --group {group_id} --tag {REPO},{GITHUB_EVENT_NAME} "
                 f"--ci-build-id {build_id} "
+                f"--wait-for-missing-groups "
                 f"-- {chrome_flags}"
             )
         else:

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -599,7 +599,7 @@ describe('Drill by modal', () => {
       ]);
     });
 
-    it.skip('Radar Chart', () => {
+    it('Radar Chart', () => {
       testEchart('radar', 'Radar Chart', [
         [182, 49],
         [423, 91],

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
@@ -335,7 +335,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe.skip('Bar Chart', () => {
+    describe('Bar Chart', () => {
       it('opens the modal with the correct filters', () => {
         interceptSamples();
 
@@ -373,7 +373,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe.skip('Area Chart', () => {
+    describe('Area Chart', () => {
       it('opens the modal with the correct filters', () => {
         testTimeChart('echarts_area');
       });
@@ -407,7 +407,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe.skip('World Map', () => {
+    describe('World Map', () => {
       it('opens the modal with the correct filters', () => {
         interceptSamples();
 
@@ -567,7 +567,7 @@ describe('Drill to detail modal', () => {
       });
     });
 
-    describe.skip('Radar Chart', () => {
+    describe('Radar Chart', () => {
       it('opens the modal with the correct filters', () => {
         interceptSamples();
 

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/horizontalFilterBar.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/horizontalFilterBar.test.ts
@@ -176,7 +176,7 @@ describe('Horizontal FilterBar', () => {
     validateFilterNameOnDashboard(testItems.topTenChart.filterColumn);
   });
 
-  it.skip('should spot changes in "more filters" and apply their values', () => {
+  it('should spot changes in "more filters" and apply their values', () => {
     cy.intercept(`/api/v1/chart/data?form_data=**`).as('chart');
     prepareDashboardFilters([
       { name: 'test_1', column: 'country_name', datasetId: 2 },
@@ -204,7 +204,7 @@ describe('Horizontal FilterBar', () => {
     );
   });
 
-  it.skip('should focus filter and open "more filters" programmatically', () => {
+  it('should focus filter and open "more filters" programmatically', () => {
     prepareDashboardFilters([
       { name: 'test_1', column: 'country_name', datasetId: 2 },
       { name: 'test_2', column: 'country_code', datasetId: 2 },
@@ -231,7 +231,7 @@ describe('Horizontal FilterBar', () => {
     cy.get('.ant-select-focused').should('be.visible');
   });
 
-  it.skip('should show tag count and one plain tag on focus and only count on blur in select ', () => {
+  it('should show tag count and one plain tag on focus and only count on blur in select ', () => {
     prepareDashboardFilters([
       { name: 'test_1', column: 'country_name', datasetId: 2 },
     ]);

--- a/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
@@ -28,7 +28,7 @@ describe('SqlLab query panel', () => {
     cy.visit('/sqllab');
   });
 
-  it.skip('supports entering and running a query', () => {
+  it('supports entering and running a query', () => {
     // row limit has to be < ~10 for us to be able to determine how many rows
     // are fetched below (because React _Virtualized_ does not render all rows)
     let clockTime = 0;

--- a/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/sqllab/query.test.ts
@@ -28,7 +28,7 @@ describe('SqlLab query panel', () => {
     cy.visit('/sqllab');
   });
 
-  it('supports entering and running a query', () => {
+  it.skip('supports entering and running a query', () => {
     // row limit has to be < ~10 for us to be able to determine how many rows
     // are fetched below (because React _Virtualized_ does not render all rows)
     let clockTime = 0;


### PR DESCRIPTION
I got a bit confused and reckless on https://github.com/apache/superset/pull/31858 while dealing with a sizable merge conflict, proceeded to disable many cypress tests, many of which are or may be flaky at times, but in this instance were probably triggered by some real issues in that PR. 

Renabling them all and will monitor PRs and master merges to re-disable the ones flaking as needed.

Note that prior to the PR issues I created on https://github.com/apache/superset/pull/31858, there were all sorts of cypress issues that we couldn't pinpoint to any particular merges, and that led a few of us to make to call to "disable all flaking tests" with the intent to fix or replace with unit tests:
<img width="851" alt="Screenshot 2025-01-27 at 9 41 17 PM" src="https://github.com/user-attachments/assets/35e0000a-c455-48d6-a771-00a2331c9570" />

Seems there are other new issues with the way we goup/report tests as well. Still needs weeding.