### PR TITLE
chore: migrating easy-to-migrate AntD vanilla components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.swp
 __pycache__
 
+.aider*
 .local
 .cache
 .bento*

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -26,24 +26,23 @@ export { default as Select } from './Select/Select';
 export { default as AsyncSelect } from './Select/AsyncSelect';
 export { default as Button } from './Button';
 export { default as Card } from './Card';
-/*
- * Components that don't conflict with the ones in src/components.
- * As Superset progresses to support full theming, this list should
- * decrease in favor of the components defined in src/components.
- */
+
+// Vanilla Ant Design components from v5
 export {
   AutoComplete,
   Col,
   Grid,
+  Layout,
   Row,
   Skeleton,
   Tag,
   Tree,
   TreeSelect,
   Typography,
-  Upload,
-} from 'antd';
-export { Layout } from 'antd-v5';
+} from 'antd-v5';
+
+// Vanilla Ant Design components from v4 that require migration
+export { Upload } from 'antd';
 
 /*
  * Components that conflict with the ones in src/components.


### PR DESCRIPTION
Pushing these easy-to-migrate components, hoping to get through a CI run, and that we can fire up an ephemeral environment and make is easier to do a manual review.
