### PR TITLE
fix(issue #31927): TimeGrain.WEEK_STARTING_MONDAY

### DIFF
--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -91,7 +91,7 @@ class SqliteEngineSpec(BaseEngineSpec):
         TimeGrain.WEEK_STARTING_SUNDAY: "DATETIME({col}, 'start of day', \
             -strftime('%w', {col}) || ' days')",
         TimeGrain.WEEK_STARTING_MONDAY: "DATETIME({col}, 'start of day', '-' || \
-            ((strftime('%w', {col}) + 6) % 7) || ' days')"
+            ((strftime('%w', {col}) + 6) % 7) || ' days')",
     }
     # not sure why these are different
     _time_grain_expressions.update(

--- a/superset/db_engine_specs/sqlite.py
+++ b/superset/db_engine_specs/sqlite.py
@@ -88,12 +88,10 @@ class SqliteEngineSpec(BaseEngineSpec):
         TimeGrain.YEAR: "DATETIME({col}, 'start of year')",
         TimeGrain.WEEK_ENDING_SATURDAY: "DATETIME({col}, 'start of day', 'weekday 6')",
         TimeGrain.WEEK_ENDING_SUNDAY: "DATETIME({col}, 'start of day', 'weekday 0')",
-        TimeGrain.WEEK_STARTING_SUNDAY: (
-            "DATETIME({col}, 'start of day', 'weekday 0', '-7 days')"
-        ),
-        TimeGrain.WEEK_STARTING_MONDAY: (
-            "DATETIME({col}, 'start of day', 'weekday 1', '-7 days')"
-        ),
+        TimeGrain.WEEK_STARTING_SUNDAY: "DATETIME({col}, 'start of day', \
+            -strftime('%w', {col}) || ' days')",
+        TimeGrain.WEEK_STARTING_MONDAY: "DATETIME({col}, 'start of day', '-' || \
+            ((strftime('%w', {col}) + 6) % 7) || ' days')"
     }
     # not sure why these are different
     _time_grain_expressions.update(


### PR DESCRIPTION
### SUMMARY
Fixes [#31927](https://github.com/apache/superset/issues/31927)

Time grain 'Week starting Monday' doesn't select the proper date time range. I also found that 'Week starting Sunday' didn't work either and I'm adding the fix for it too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
- Pre-fix 'Week starting Monday' with incorrect numbers:
![prefix-monday](https://github.com/user-attachments/assets/436274ac-27c6-4093-8a31-496ff808d903)

- Pre-fix 'Week ending Sunday' with correct numbers:
![prefix-sunday](https://github.com/user-attachments/assets/fa9ceeea-5651-4641-9c26-e0bb216c8b55)

- Post-fix 'Week starting Monday' with correct numbers: 
![postfix-monday](https://github.com/user-attachments/assets/a8086cea-c30b-44ba-a74e-726aede5b012)

### TESTING INSTRUCTIONS

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: [#31927](https://github.com/apache/superset/issues/31927)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
