### PR TITLE
fix: Filters badge disappeared

### DIFF
--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -175,10 +175,10 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
       setDashboardIndicators(indicatorsInitialState);
     } else if (prevChartStatus !== 'success') {
       if (
-        chart?.queriesResponse?.rejected_filters !==
-          prevChart?.queriesResponse?.rejected_filters ||
-        chart?.queriesResponse?.applied_filters !==
-          prevChart?.queriesResponse?.applied_filters ||
+        chart?.queriesResponse?.[0]?.rejected_filters !==
+          prevChart?.queriesResponse?.[0]?.rejected_filters ||
+        chart?.queriesResponse?.[0]?.applied_filters !==
+          prevChart?.queriesResponse?.[0]?.applied_filters ||
         dashboardFilters !== prevDashboardFilters ||
         datasources !== prevDatasources
       ) {
@@ -215,10 +215,10 @@ export const FiltersBadge = ({ chartId }: FiltersBadgeProps) => {
       setNativeIndicators(indicatorsInitialState);
     } else if (prevChartStatus !== 'success') {
       if (
-        chart?.queriesResponse?.rejected_filters !==
-          prevChart?.queriesResponse?.rejected_filters ||
-        chart?.queriesResponse?.applied_filters !==
-          prevChart?.queriesResponse?.applied_filters ||
+        chart?.queriesResponse?.[0]?.rejected_filters !==
+          prevChart?.queriesResponse?.[0]?.rejected_filters ||
+        chart?.queriesResponse?.[0]?.applied_filters !==
+          prevChart?.queriesResponse?.[0]?.applied_filters ||
         nativeFilters !== prevNativeFilters ||
         chartLayoutItems !== prevChartLayoutItems ||
         dataMask !== prevDataMask ||

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -55,7 +55,7 @@ export interface ChartState {
   latestQueryFormData: Partial<QueryFormData>;
   sliceFormData: QueryFormData | null;
   queryController: AbortController | null;
-  queriesResponse: QueryData | null;
+  queriesResponse: QueryData[] | null;
   triggerQuery: boolean;
 }
 


### PR DESCRIPTION
### SUMMARY
Fix filters badge not appearring after adding a native filter

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![image](https://github.com/user-attachments/assets/ddb1fcbd-363a-4fca-a60d-cd1731cf2a64)

After:

![image](https://github.com/user-attachments/assets/da783a41-e7ea-4039-98a6-3f3e023843b8)


### TESTING INSTRUCTIONS
1. Add a native filter and set some value
2. Verify that the charts in scope of that filter have a filters badge

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
