### PR TITLE
fix(fe/explore): prevent runtime error when editing Dataset-origin Chart with empty title 

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -167,7 +167,7 @@ export const ExploreChartHeader = ({
     <>
       <PageHeaderWithActions
         editableTitleProps={{
-          title: sliceName,
+          title: sliceName ?? '',
           canEdit:
             !slice ||
             canOverwrite ||


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix(fe/explore): prevent runtime error when editing Dataset-origin Chart with empty title 

Prevent a runtime error page when editable title is given a non-string content to display

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before

https://github.com/user-attachments/assets/316d43e2-4c61-47b9-b95f-d30b99e24bab

After

https://github.com/user-attachments/assets/0e3971ce-745a-47c3-bd5d-473061e8c0a0


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Go to `Dataset`
- Get into some example Datasets
- Click on the empty editable title
- Click away
- Crash

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
