### PR TITLE
fix(DatePicker): Increase z-index over Modal

### DIFF
--- a/superset-frontend/src/GlobalStyles.tsx
+++ b/superset-frontend/src/GlobalStyles.tsx
@@ -47,7 +47,8 @@ export const GlobalStyles = () => (
       .ant-dropdown,
       .ant-select-dropdown,
       .antd5-modal-wrap,
-      .antd5-modal-mask {
+      .antd5-modal-mask,
+      .antd5-picker-dropdown {
         z-index: ${theme.zIndex.max} !important;
       }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes the z-index of the DatePicker to be over Modal. 

### NOTE
z-indexes should use vanilla Ant Design wherever possible. These custom styles will need to be removed as soon as the [migration to Ant Design 5](https://github.com/apache/superset/issues/29268) is complete.

### BEFORE
<img width="1229" alt="Screenshot 2025-01-31 at 14 53 27" src="https://github.com/user-attachments/assets/0fab5826-34ea-427e-a3ee-0eb5e348ab02" />

### AFTER
<img width="1232" alt="Screenshot 2025-01-31 at 14 54 01" src="https://github.com/user-attachments/assets/553f89ca-4cde-493e-a6c2-1289862a3006" />


### TESTING INSTRUCTIONS
1. Open the DatePicker from within a Modal
2. The DatePicker should be above the Modal

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
