### PR TITLE
chore: Re-enable asnyc event API tests

### DIFF
--- a/tests/integration_tests/async_events/api_tests.py
+++ b/tests/integration_tests/async_events/api_tests.py
@@ -17,8 +17,6 @@
 from typing import Any, Optional, Type
 from unittest import mock
 
-import pytest
-
 from superset.async_events.cache_backend import (
     RedisCacheBackend,
     RedisSentinelCacheBackend,
@@ -26,11 +24,11 @@ from superset.async_events.cache_backend import (
 from superset.extensions import async_query_manager
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.constants import ADMIN_USERNAME
 from tests.integration_tests.test_app import app
 
 
-@pytest.skip(reason="Needs to investigate this test", allow_module_level=True)
 class TestAsyncEventApi(SupersetTestCase):
     UUID = "943c920-32a5-412a-977d-b8e47d36f5a4"
 
@@ -118,22 +116,26 @@ class TestAsyncEventApi(SupersetTestCase):
         }
         assert response == expected
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("uuid.uuid4", return_value=UUID)
     def test_events_redis_cache_backend(self, mock_uuid4):
         self.run_test_with_cache_backend(RedisCacheBackend, self._test_events_logic)
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @mock.patch("uuid.uuid4", return_value=UUID)
     def test_events_redis_sentinel_cache_backend(self, mock_uuid4):
         self.run_test_with_cache_backend(
             RedisSentinelCacheBackend, self._test_events_logic
         )
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     def test_events_no_login(self):
         app._got_first_request = False
         async_query_manager.init_app(app)
         rv = self.fetch_events()
         assert rv.status_code == 401
 
+    @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     def test_events_no_token(self):
         self.login(ADMIN_USERNAME)
         self.client.set_cookie(app.config["GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME"], "")


### PR DESCRIPTION
### SUMMARY
Follow up to https://github.com/apache/superset/pull/31791 to re-enable async event API tests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
