### PR TITLE
fix: Histogram examples config

### DIFF
--- a/superset/examples/configs/charts/FCC New Coder Survey/Age_distribution_of_respondents.yaml
+++ b/superset/examples/configs/charts/FCC New Coder Survey/Age_distribution_of_respondents.yaml
@@ -18,23 +18,18 @@ slice_name: Age distribution of respondents
 viz_type: histogram_v2
 params:
   adhoc_filters: []
-  all_columns_x:
-    - age
+  column: age
   color_scheme: supersetColors
   datasource: 42__table
-  granularity_sqla: time_start
-  groupby: null
+  groupby: []
   label_colors: {}
   link_length: "25"
-  queryFields:
-    groupby: groupby
   row_limit: 10000
   slice_id: 1380
-  time_range: No filter
   url_params: {}
   viz_type: histogram_v2
-  x_axis_label: age
-  y_axis_label: count
+  x_axis_title: age
+  y_axis_title: count
 cache_timeout: null
 uuid: 5f1ea868-604e-f69d-a241-5daa83ff33be
 version: 1.0.0

--- a/superset/examples/configs/charts/FCC New Coder Survey/How_much_do_you_expect_to_earn_0_-_100k.yaml
+++ b/superset/examples/configs/charts/FCC New Coder Survey/How_much_do_you_expect_to_earn_0_-_100k.yaml
@@ -36,57 +36,13 @@ params:
       operator: <=
       sqlExpression: null
       subject: expected_earn
-  all_columns_x:
-    - expected_earn
+  column: expected_earn
   color_scheme: supersetColors
   datasource: 42__table
-  granularity_sqla: time_start
-  groupby: null
-  label_colors:
-    "0": "#FCC700"
-    "1": "#A868B7"
-    "15": "#3CCCCB"
-    "30": "#A38F79"
-    "45": "#8FD3E4"
-    <NULL>: "#5AC189"
-    Female: "#454E7C"
-    From Home: "#1FA8C9"
-    I: "#FEC0A1"
-    In an Office (with Other Developers): "#9EE5E5"
-    Less: "#ACE1C4"
-    Male: "#666666"
-    More: "#A1A6BD"
-    "No": "#666666"
-    No Answer: "#D3B3DA"
-    No Preference: "#D1C6BC"
-    No,: "#FF7F44"
-    No, not an ethnic minority: "#1FA8C9"
-    "No: Not Willing to": "#FDE380"
-    Ph.D.: "#FCC700"
-    Prefer: "#5AC189"
-    Prefer not to say: "#E04355"
-    "Yes": "#FF7F44"
-    Yes,: "#1FA8C9"
-    Yes, an ethnic minority: "#454E7C"
-    "Yes: Willing To": "#EFA1AA"
-    age: "#1FA8C9"
-    associate's degree: "#A868B7"
-    bachelor's degree: "#3CCCCB"
-    expected_earn: "#B2B2B2"
-    high school diploma or equivalent (GED): "#A38F79"
-    last_yr_income: "#E04355"
-    master's degree (non-professional): "#8FD3E4"
-    no high school (secondary school): "#A1A6BD"
-    professional degree (MBA, MD, JD, etc.): "#ACE1C4"
-    some college credit, no degree: "#FEC0A1"
-    some high school: "#B2B2B2"
-    trade, technical, or vocational training: "#EFA1AA"
+  groupby: []
   link_length: "10"
-  queryFields:
-    groupby: groupby
   row_limit: null
   slice_id: 1366
-  time_range: No filter
   url_params: {}
   viz_type: histogram_v2
 cache_timeout: null

--- a/superset/examples/configs/charts/FCC New Coder Survey/Last_Year_Income_Distribution.yaml
+++ b/superset/examples/configs/charts/FCC New Coder Survey/Last_Year_Income_Distribution.yaml
@@ -36,18 +36,13 @@ params:
       operator: <=
       sqlExpression: null
       subject: last_yr_income
-  all_columns_x:
-    - last_yr_income
+  column: last_yr_income
   color_scheme: supersetColors
   datasource: 42__table
-  granularity_sqla: time_start
   groupby: []
   label_colors: {}
   link_length: "10"
-  queryFields:
-    groupby: groupby
   row_limit: null
-  time_range: No filter
   url_params: {}
   viz_type: histogram_v2
 cache_timeout: null


### PR DESCRIPTION
### SUMMARY
This PR fixes the configuration for some Histogram v2 examples that were originally created for Histogram v1.

### TESTING INSTRUCTIONS
Load the examples and check that all charts of the FCC New Coder Survey 2018 dashboard load correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
