### PR TITLE
fix: No virtual environment when running Docker translation compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ FROM python-base AS python-translation-compiler
 # Install Python dependencies using docker/pip-install.sh
 COPY requirements/translations.txt requirements/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    /app/docker/pip-install.sh --requires-build-essential -r requirements/translations.txt
+    . /app/.venv/bin/activate && /app/docker/pip-install.sh --requires-build-essential -r requirements/translations.txt
 
 COPY superset/translations/ /app/translations_mo/
 RUN if [ "$BUILD_TRANSLATIONS" = "true" ]; then \


### PR DESCRIPTION
### SUMMARY
This PR fixes the following error triggered by the Docker translation compiler step:

```
failed to solve: process "/bin/sh -c /app/docker/pip-install.sh --requires-build-essential 
-r requirements/translations.txt" did not complete successfully: exit code: 2
```

The root cause can be verified in the Docker build logs:
```
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` 
to install into a non-virtual environment
```

This PR makes sure that the virtual environment created by

```
RUN uv venv /app/.venv
```

is activated before invoking `pip-install.sh`.

### TESTING INSTRUCTIONS
Run `docker compose build` and check that the process runs successfully.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
