### PR TITLE
fix(migrations): Handle no params in time comparison migration

### DIFF
--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -63,6 +63,8 @@ time_map = {
 
 
 def upgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
+    if not slice_params or not isinstance(slice_params, dict):
+        return {}
     params = deepcopy(slice_params)
 
     # Update time_comparison to time_compare
@@ -103,6 +105,8 @@ def upgrade():
         )
     ):
         try:
+            if not slc.params:  # Noop if there's no params on the slice
+                continue
             params = json.loads(slc.params)
             updated_slice_params = upgrade_comparison_params(params)
             slc.params = json.dumps(updated_slice_params)
@@ -119,6 +123,8 @@ def upgrade():
 
 
 def downgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
+    if not slice_params or not isinstance(slice_params, dict):
+        return {}
     params = deepcopy(slice_params)
     params["enable_time_comparison"] = False
 
@@ -199,6 +205,8 @@ def downgrade():
         )
     ):
         try:
+            if not slc.params:  # Noop if there's no params on the slice
+                continue
             params = json.loads(slc.params)
             updated_slice_params = downgrade_comparison_params(params)
             slc.params = json.dumps(updated_slice_params)

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -229,3 +229,15 @@ def test_downgrade_chart_params_other_than_custom_false():
     original_params = deepcopy(params_v2_other_than_custom_false)
     downgraded_params = downgrade_comparison_params(original_params)
     assert downgraded_params == params_v1_other_than_custom_false
+
+
+def test_upgrade_chart_params_empty():
+    """
+    Ensure that the migration does not fail when params is None or empty.
+    """
+    assert upgrade_comparison_params(None) == {}
+    assert upgrade_comparison_params({}) == {}
+    assert upgrade_comparison_params("") == {}
+    assert downgrade_comparison_params(None) == {}
+    assert downgrade_comparison_params({}) == {}
+    assert downgrade_comparison_params("") == {}


### PR DESCRIPTION
### SUMMARY
The time comparison migration doesn't handle slices that have no params, causing the migration to fail. This PR fixes that behavior and make the migration a noop for those slices.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Run the db upgrade on a DB that have slices with no params and are Tables and BugNumber with Time Comparison.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
