### PR TITLE
fix(docker): Docker python-translation-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,14 @@ ARG PY_VER=3.11-slim-bookworm
 # If BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
 ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
 
+# Include translations in the final build
+ARG BUILD_TRANSLATIONS="false"
+
 ######################################################################
 # superset-node-ci used as a base for building frontend assets and CI
 ######################################################################
 FROM --platform=${BUILDPLATFORM} node:20-bullseye-slim AS superset-node-ci
-ARG BUILD_TRANSLATIONS="false" # Include translations in the final build
+ARG BUILD_TRANSLATIONS
 ENV BUILD_TRANSLATIONS=${BUILD_TRANSLATIONS}
 ARG DEV_MODE="false"           # Skip frontend build in dev mode
 ENV DEV_MODE=${DEV_MODE}
@@ -121,6 +124,9 @@ ENV PATH="/app/.venv/bin:${PATH}"
 # Python translation compiler layer
 ######################################################################
 FROM python-base AS python-translation-compiler
+
+ARG BUILD_TRANSLATIONS
+ENV BUILD_TRANSLATIONS=${BUILD_TRANSLATIONS}
 
 # Install Python dependencies using docker/pip-install.sh
 COPY requirements/translations.txt requirements/


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR fix the Docker compiler python translation build.
The build didn't run, this step was just passed, because BUILD_TRANSLATIONS flag was not set into python-translation-compiler layer.

fixes: https://github.com/apache/superset/issues/32161

### TESTING INSTRUCTIONS
Set BUILD_TRANSLATIONS to "true"
run `docker build` and check into folder superset/translations/xx/LC_MESSAGES
With this fix, .mo files are available.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/32161
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
