### PR TITLE
feat(dropdown accessibility): Wrap dropdown triggers with buttons for accessibility

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -873,7 +873,9 @@ const SqlEditor: FC<Props> = ({
                 dropdownRender={() => renderDropdown()}
                 trigger={['click']}
               >
-                <Icons.MoreHoriz iconColor={theme.colors.grayscale.base} />
+                <Button buttonSize="xsmall" type="link" showMarginRight={false}>
+                  <Icons.MoreHoriz iconColor={theme.colors.grayscale.base} />
+                </Button>
               </Dropdown>
             </div>
           </>

--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -30,7 +30,7 @@ import {
 import AutoSizer from 'react-virtualized-auto-sizer';
 import Icons from 'src/components/Icons';
 import type { SqlLabRootState } from 'src/SqlLab/types';
-import { Skeleton, AntdBreadcrumb as Breadcrumb } from 'src/components';
+import { Skeleton, AntdBreadcrumb as Breadcrumb, Button } from 'src/components';
 import { Dropdown } from 'src/components/Dropdown';
 import FilterableTable from 'src/components/FilterableTable';
 import Tabs from 'src/components/Tabs';
@@ -324,11 +324,13 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
           )}
           trigger={['click']}
         >
-          <Icons.DownSquareOutlined
-            iconSize="m"
-            style={{ marginTop: 2, marginLeft: 4 }}
-            aria-label={t('Table actions')}
-          />
+          <Button buttonSize="xsmall" type="link">
+            <Icons.DownSquareOutlined
+              iconSize="m"
+              style={{ marginTop: 2, marginLeft: 4 }}
+              aria-label={t('Table actions')}
+            />
+          </Button>
         </Dropdown>
       </Title>
       {isMetadataRefreshing ? (

--- a/superset-frontend/src/components/GridTable/HeaderMenu.tsx
+++ b/superset-frontend/src/components/GridTable/HeaderMenu.tsx
@@ -97,8 +97,8 @@ const HeaderMenu: React.FC<Params> = ({
       <Dropdown
         placement="bottomLeft"
         trigger={['click']}
-        onVisibleChange={onVisibleChange}
-        overlay={
+        onOpenChange={onVisibleChange}
+        dropdownRender={() => (
           <Menu style={{ width: 250 }} mode="vertical">
             <IconMenuItem
               onClick={() => {
@@ -170,7 +170,7 @@ const HeaderMenu: React.FC<Params> = ({
               {t('Reset columns')}
             </IconMenuItem>
           </Menu>
-        }
+        )}
       />
     );
   }
@@ -179,8 +179,8 @@ const HeaderMenu: React.FC<Params> = ({
     <Dropdown
       placement="bottomRight"
       trigger={['click']}
-      onVisibleChange={onVisibleChange}
-      overlay={
+      onOpenChange={onVisibleChange}
+      dropdownRender={() => (
         <Menu style={{ width: 180 }} mode="vertical">
           <IconMenuItem
             onClick={() => {
@@ -239,7 +239,7 @@ const HeaderMenu: React.FC<Params> = ({
           </IconMenuItem>
           {unHideAction}
         </Menu>
-      }
+      )}
     />
   );
 };

--- a/superset-frontend/src/components/GridTable/HeaderMenu.tsx
+++ b/superset-frontend/src/components/GridTable/HeaderMenu.tsx
@@ -97,8 +97,8 @@ const HeaderMenu: React.FC<Params> = ({
       <Dropdown
         placement="bottomLeft"
         trigger={['click']}
-        onOpenChange={onVisibleChange}
-        dropdownRender={() => (
+        onVisibleChange={onVisibleChange}
+        overlay={
           <Menu style={{ width: 250 }} mode="vertical">
             <IconMenuItem
               onClick={() => {
@@ -170,7 +170,7 @@ const HeaderMenu: React.FC<Params> = ({
               {t('Reset columns')}
             </IconMenuItem>
           </Menu>
-        )}
+        }
       />
     );
   }
@@ -179,8 +179,8 @@ const HeaderMenu: React.FC<Params> = ({
     <Dropdown
       placement="bottomRight"
       trigger={['click']}
-      onOpenChange={onVisibleChange}
-      dropdownRender={() => (
+      onVisibleChange={onVisibleChange}
+      overlay={
         <Menu style={{ width: 180 }} mode="vertical">
           <IconMenuItem
             onClick={() => {
@@ -239,7 +239,7 @@ const HeaderMenu: React.FC<Params> = ({
           </IconMenuItem>
           {unHideAction}
         </Menu>
-      )}
+      }
     />
   );
 };

--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -29,6 +29,7 @@ import { Menu } from 'src/components/Menu';
 import FaveStar from 'src/components/FaveStar';
 import FacePile from 'src/components/FacePile';
 import { handleChartDelete, CardStyles } from 'src/views/CRUD/utils';
+import Button from 'src/components/Button';
 
 interface ChartCardProps {
   chart: Chart;
@@ -172,8 +173,10 @@ export default function ChartCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown dropdownRender={() => menu}>
-              <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+            <Dropdown dropdownRender={() => menu} trigger={['click', 'hover']}>
+              <Button buttonSize="xsmall" type="link">
+                <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+              </Button>
             </Dropdown>
           </ListViewCard.Actions>
         }

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -34,6 +34,7 @@ import { PublishedLabel } from 'src/components/Label';
 import FacePile from 'src/components/FacePile';
 import FaveStar from 'src/components/FaveStar';
 import { Dashboard } from 'src/views/CRUD/types';
+import { Button } from 'src/components';
 
 interface DashboardCardProps {
   isChart?: boolean;
@@ -179,8 +180,10 @@ function DashboardCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown dropdownRender={() => menu}>
-              <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+            <Dropdown dropdownRender={() => menu} trigger={['hover', 'click']}>
+              <Button buttonSize="xsmall" type="link">
+                <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+              </Button>
             </Dropdown>
           </ListViewCard.Actions>
         }

--- a/superset-frontend/src/features/home/SavedQueries.test.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.test.tsx
@@ -104,7 +104,7 @@ describe('SavedQueries', () => {
   it('renders a submenu with clickable tables and buttons', async () => {
     expect(wrapper.find(SubMenu)).toExist();
     expect(wrapper.find('[role="tab"]')).toHaveLength(1);
-    expect(wrapper.find('button')).toHaveLength(2);
+    expect(wrapper.find('button')).toHaveLength(5);
     clickTab(0);
     await waitForComponentToPaint(wrapper);
     expect(fetchMock.calls(/saved_query\/\?q/)).toHaveLength(2);

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -42,6 +42,7 @@ import {
 import SubMenu from './SubMenu';
 import EmptyState from './EmptyState';
 import { WelcomeTable } from './types';
+import { Button } from 'src/components';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 
@@ -315,10 +316,15 @@ const SavedQueries = ({
                         e.preventDefault();
                       }}
                     >
-                      <Dropdown dropdownRender={() => renderMenu(q)}>
-                        <Icons.MoreVert
-                          iconColor={theme.colors.grayscale.base}
-                        />
+                      <Dropdown
+                        dropdownRender={() => renderMenu(q)}
+                        trigger={['click', 'hover']}
+                      >
+                        <Button buttonSize="xsmall" type="link">
+                          <Icons.MoreVert
+                            iconColor={theme.colors.grayscale.base}
+                          />
+                        </Button>
                       </Dropdown>
                     </ListViewCard.Actions>
                   </QueryData>

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { styled, SupersetClient, t, useTheme } from '@superset-ui/core';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
@@ -39,10 +39,10 @@ import {
   PAGE_SIZE,
   shortenSQL,
 } from 'src/views/CRUD/utils';
+import { Button } from 'src/components';
 import SubMenu from './SubMenu';
 import EmptyState from './EmptyState';
 import { WelcomeTable } from './types';
-import { Button } from 'src/components';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 
@@ -192,33 +192,36 @@ const SavedQueries = ({
       filters: getFilterValues(tab, WelcomeTable.SavedQueries, user),
     });
 
-  const renderMenu = (query: Query) => (
-    <Menu>
-      {canEdit && (
-        <Menu.Item>
-          <Link to={`/sqllab?savedQueryId=${query.id}`}>{t('Edit')}</Link>
-        </Menu.Item>
-      )}
-      <Menu.Item
-        onClick={() => {
-          if (query.id) {
-            copyQueryLink(query.id, addDangerToast, addSuccessToast);
-          }
-        }}
-      >
-        {t('Share')}
-      </Menu.Item>
-      {canDelete && (
+  const renderMenu = useCallback(
+    (query: Query) => (
+      <Menu>
+        {canEdit && (
+          <Menu.Item>
+            <Link to={`/sqllab?savedQueryId=${query.id}`}>{t('Edit')}</Link>
+          </Menu.Item>
+        )}
         <Menu.Item
           onClick={() => {
-            setQueryDeleteModal(true);
-            setCurrentlyEdited(query);
+            if (query.id) {
+              copyQueryLink(query.id, addDangerToast, addSuccessToast);
+            }
           }}
         >
-          {t('Delete')}
+          {t('Share')}
         </Menu.Item>
-      )}
-    </Menu>
+        {canDelete && (
+          <Menu.Item
+            onClick={() => {
+              setQueryDeleteModal(true);
+              setCurrentlyEdited(query);
+            }}
+          >
+            {t('Delete')}
+          </Menu.Item>
+        )}
+      </Menu>
+    ),
+    [],
   );
 
   if (loading) return <LoadingCards cover={showThumbnails} />;

--- a/superset-frontend/src/features/tags/TagCard.tsx
+++ b/superset-frontend/src/features/tags/TagCard.tsx
@@ -26,6 +26,7 @@ import ListViewCard from 'src/components/ListViewCard';
 import Icons from 'src/components/Icons';
 import { Tag } from 'src/views/CRUD/types';
 import { deleteTags } from 'src/features/tags/tags';
+import { Button } from 'src/components';
 
 interface TagCardProps {
   tag: Tag;
@@ -108,8 +109,10 @@ function TagCard({
               e.preventDefault();
             }}
           >
-            <Dropdown dropdownRender={() => menu}>
-              <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+            <Dropdown dropdownRender={() => menu} trigger={['click', 'hover']}>
+              <Button buttonSize="xsmall" type="link">
+                <Icons.MoreVert iconColor={theme.colors.grayscale.base} />
+              </Button>
             </Dropdown>
           </ListViewCard.Actions>
         }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While migrating the dropdown i realized some dropdown triggers are just icons, which are not keyboard navigation friendly. This PR aims to fix that by wrapping those with Buttons.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Test keyboard navigation on dropdowns in explore page.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
