### PR TITLE
fix: handlebars html and css templates reset on dataset update

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/handlebarTemplate.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/handlebarTemplate.tsx
@@ -65,6 +65,7 @@ export const handlebarsTemplateControlSetItem: ControlSetItem = {
 </ul>`,
     isInt: false,
     renderTrigger: true,
+    valueKey: null,
 
     validators: [validateNonEmpty],
     mapStateToProps: ({ controls }) => ({

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/style.tsx
@@ -75,6 +75,7 @@ export const styleControlSetItem: ControlSetItem = {
     description: t('CSS applied to the chart'),
     isInt: false,
     renderTrigger: true,
+    valueKey: null,
 
     validators: [],
     mapStateToProps: ({ controls }) => ({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

Fixes #32049 

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is sharedControls.entity included in the config of the handlebarsTemplateControlSetItem and styleControlSetItem. The "valueKey" property from this sharedConfig is used in the exploreReducer in UPDATE_FORM_DATA_BY_DATASOURCE action to reset the control values that are related to a column. If I understand it correctly, the handlebars templates are not column related drag and drop controls. There might be other reasons (based on the comment in dndControls.tsx:45) to have the sharedControls.entity config included, so I just unset the "valueKey" property to exclude the handlebars templates control values from the reset on datasource update.

"It also seems that the textarea "blinks" going back and forth between states."
After the fix I do not experience the "blinks" anymore. Let me know if it is still an issue.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #32049 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
