### PR TITLE
docs(docker-compose): remove extra backticks

### DIFF
--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -43,7 +43,6 @@ Note that there are 3 major ways we support to run `docker compose`:
   `export TAG=4.0.0-dev` or `export TAG=3.0.0-dev`, with `latest-dev` being the default.
   That's because The `dev` builds happen to package the `psycopg2-binary` required to connect
   to the Postgres database launched as part of the `docker compose` builds.
-``
 
 More on these two approaches after setting up the requirements for either.
 


### PR DESCRIPTION
removes unnecessary backticks 