### PR TITLE
fix: set `Rich tooltip` -> 'Show percentage' to false by default

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -230,7 +230,7 @@ const tooltipPercentageControl: ControlSetItem = {
     type: 'CheckboxControl',
     label: t('Show percentage'),
     renderTrigger: true,
-    default: true,
+    default: false,
     description: t('Whether to display the percentage value in the tooltip'),
     visibility: ({ controls, form_data }: ControlPanelsContainerProps) =>
       Boolean(controls?.rich_tooltip?.value) &&


### PR DESCRIPTION
Many users have reported that they prefer having the show percentage option in timeseries as false by default. While it's generally a good feature and many might want it, default should be lightweight and optimize for less clutter.


Open to input or debatting which default option is best, but given that many users reported it, and that it's a bit of a visual regression / change in some dashboard, I thought we'd switch it off.

### after 
<img width="845" alt="Screenshot 2025-02-10 at 1 46 42 PM" src="https://github.com/user-attachments/assets/014d1fde-dfe2-4572-a50a-8a6637a9dae5" />

