### PR TITLE
fix(Datasource): handle undefined datasource_type in fetchSyncedColumns

### DIFF
--- a/superset-frontend/src/components/Datasource/utils.js
+++ b/superset-frontend/src/components/Datasource/utils.js
@@ -121,7 +121,7 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
 
 export async function fetchSyncedColumns(datasource) {
   const params = {
-    datasource_type: datasource.type,
+    datasource_type: datasource.type || datasource.datasource_type,
     database_name:
       datasource.database?.database_name || datasource.database?.name,
     catalog_name: datasource.catalog,


### PR DESCRIPTION
### SUMMARY
Sync columns from source is not working on dataset edit columns page. This fixes that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
