### PR TITLE
chore(ci): fix ephemeral env null issue number

### DIFF
--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -190,8 +190,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: superset-ci
           IMAGE_TAG: apache/superset:${{ needs.ephemeral-env-label.outputs.sha }}-ci
+          PR_NUMBER: ${{ github.event.inputs.issue_number || github.event.pull_request.number }}
         run: |
-          docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-ci
+          docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER-ci
           docker push -a $ECR_REGISTRY/$ECR_REPOSITORY
 
   ephemeral-env-up:
@@ -222,11 +223,12 @@ jobs:
       - name: Check target image exists in ECR
         id: check-image
         continue-on-error: true
+        PR_NUMBER: ${{ github.event.inputs.issue_number || github.event.pull_request.number }}
         run: |
           aws ecr describe-images \
           --registry-id $(echo "${{ steps.login-ecr.outputs.registry }}" | grep -Eo "^[0-9]+") \
           --repository-name superset-ci \
-          --image-ids imageTag=pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-ci
+          --image-ids imageTag=pr-$PR_NUMBER-ci
 
       - name: Fail on missing container image
         if: steps.check-image.outcome == 'failure'
@@ -236,7 +238,7 @@ jobs:
           script: |
             const errMsg = '@${{ github.event.comment.user.login }} Container image not yet published for this PR. Please try again when build is complete.';
             github.rest.issues.createComment({
-              issue_number: ${{ github.event.inputs.issue_number || github.event.issue.number }},
+              issue_number: ${{ github.event.inputs.issue_number || github.event.pull_request.number }},
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: errMsg
@@ -249,7 +251,7 @@ jobs:
         with:
           task-definition: .github/workflows/ecs-task-definition.json
           container-name: superset-ci
-          image: ${{ steps.login-ecr.outputs.registry }}/superset-ci:pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-ci
+          image: ${{ steps.login-ecr.outputs.registry }}/superset-ci:pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-ci
 
       - name: Update env vars in the Amazon ECS task definition
         run: |
@@ -258,29 +260,30 @@ jobs:
       - name: Describe ECS service
         id: describe-services
         run: |
-          echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> $GITHUB_OUTPUT
+          echo "active=$(aws ecs describe-services --cluster superset-ci --services pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-service | jq '.services[] | select(.status == "ACTIVE") | any')" >> $GITHUB_OUTPUT
       - name: Create ECS service
         id: create-service
         if: steps.describe-services.outputs.active != 'true'
         env:
           ECR_SUBNETS: subnet-0e15a5034b4121710,subnet-0e8efef4a72224974
           ECR_SECURITY_GROUP: sg-092ff3a6ae0574d91
+          PR_NUMBER: ${{ github.event.inputs.issue_number || github.event.pull_request.number }}
         run: |
           aws ecs create-service \
           --cluster superset-ci \
-          --service-name pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-service \
+          --service-name pr-$PR_NUMBER-service \
           --task-definition superset-ci \
           --launch-type FARGATE \
           --desired-count 1 \
           --platform-version LATEST \
           --network-configuration "awsvpcConfiguration={subnets=[$ECR_SUBNETS],securityGroups=[$ECR_SECURITY_GROUP],assignPublicIp=ENABLED}" \
-          --tags key=pr,value=${{ github.event.inputs.issue_number || github.event.issue.number }} key=github_user,value=${{ github.actor }}
+          --tags key=pr,value=$PR_NUMBER key=github_user,value=${{ github.actor }}
       - name: Deploy Amazon ECS task definition
         id: deploy-task
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-service
+          service: pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-service
           cluster: superset-ci
           wait-for-service-stability: true
           wait-for-minutes: 10
@@ -288,7 +291,7 @@ jobs:
       - name: List tasks
         id: list-tasks
         run: |
-          echo "task=$(aws ecs list-tasks --cluster superset-ci --service-name pr-${{ github.event.inputs.issue_number || github.event.issue.number }}-service | jq '.taskArns | first')" >> $GITHUB_OUTPUT
+          echo "task=$(aws ecs list-tasks --cluster superset-ci --service-name pr-${{ github.event.inputs.issue_number || github.event.pull_request.number }}-service | jq '.taskArns | first')" >> $GITHUB_OUTPUT
       - name: Get network interface
         id: get-eni
         run: |


### PR DESCRIPTION
### SUMMARY

Fixes issue number being evaluated as null on ephemeral envs workflow

ex:
```
Run docker tag $IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:pr--ci
```

pr--ci should be pr-<PR_NUMBER>-ci

Unfortunately we can only test after merging

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
