### PR TITLE
fix: Update 'Last modified' time when modifying RLS rules

### DIFF
--- a/superset/row_level_security/schemas.py
+++ b/superset/row_level_security/schemas.py
@@ -78,7 +78,7 @@ class RLSListSchema(Schema):
     tables = fields.List(fields.Nested(TablesSchema))
     clause = fields.String(metadata={"description": "clause_description"})
     changed_on_delta_humanized = fields.Function(
-        RowLevelSecurityFilter.created_on_delta_humanized
+        RowLevelSecurityFilter.changed_on_delta_humanized
     )
     group_key = fields.String(metadata={"description": "group_key_description"})
     description = fields.String(metadata={"description": "description_description"})


### PR DESCRIPTION
Fixes #32050

### SUMMARY
This PR fixes an issue where the Last modified field does not update when a Row Level Security (RLS) rule is changed. The issue occurs because the modification timestamp is not being updated in the database when an RLS rule is altered.

### CHANGES  
- Ensure the **Last modified** field is updated when an RLS rule is **created or edited**.  

## STEPS TO REPRODUCE  
1. Navigate to **Settings → Row Level Security**.  
2. Create a new RLS rule by clicking the **"+ Rule"** button in the top-right corner.  
3. Observe the **Last modified** field.  
4. Modify the rule and save the changes.  
5. The **Last modified** field should reflect the latest update.  


### BEFORE/AFTER SCREENSHOTS
#### Before
![Screenshot 2025-02-12 at 1 58 13 AM](https://github.com/user-attachments/assets/31ee2d03-c546-42ac-beb0-c1045b52b21a)

#### After
![Screenshot 2025-02-12 at 1 57 18 AM](https://github.com/user-attachments/assets/6c04cd51-bac8-49d1-bc92-4074e4184ba0)





