### PR TITLE
chore(backend): replace insecure `shortid` usage for native filter migration with native `uuid` Python implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ dependencies = [
     "redis>=4.6.0, <5.0",
     "selenium>=4.14.0, <5.0",
     "shillelagh[gsheetsapi]>=1.2.18, <2.0",
-    "shortid",
     "sshtunnel>=0.4.0, <0.5",
     "simplejson>=3.15.0",
     "slack_sdk>=3.19.0, <4",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -329,8 +329,6 @@ selenium==4.27.1
     # via apache-superset (pyproject.toml)
 shillelagh==1.2.18
     # via apache-superset (pyproject.toml)
-shortid==0.1.2
-    # via apache-superset (pyproject.toml)
 simplejson==3.19.3
     # via apache-superset (pyproject.toml)
 six==1.16.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -738,10 +738,6 @@ shillelagh==1.2.18
     # via
     #   -c requirements/base.txt
     #   apache-superset
-shortid==0.1.2
-    # via
-    #   -c requirements/base.txt
-    #   apache-superset
 simplejson==3.19.3
     # via
     #   -c requirements/base.txt

--- a/superset/migrations/shared/native_filters.py
+++ b/superset/migrations/shared/native_filters.py
@@ -48,7 +48,6 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
     :see: convert_filter_scopes
     """
 
-    short_id = f"{shortid()}"[:9]
     default_filters = json.loads(json_metadata.get("default_filters") or "{}")
     filter_scopes = json_metadata.get("filter_scopes", {})
     filter_box_ids = {filter_box.id for filter_box in filter_boxes}
@@ -81,6 +80,7 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
 
         for field, filter_scope in filter_scope_by_key_and_field[key].items():
             default = default_filters.get(key, {}).get(field)
+            short_id = f"{shortid()}"[:9]
 
             fltr: dict[str, Any] = {
                 "cascadeParentIds": [],

--- a/superset/migrations/shared/native_filters.py
+++ b/superset/migrations/shared/native_filters.py
@@ -74,6 +74,7 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
         }
 
     # Construct the native filters.
+    unique_short_ids = set()
     for filter_box in filter_boxes:
         key = str(filter_box.id)
         params = json.loads(filter_box.params or "{}")
@@ -81,6 +82,15 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
         for field, filter_scope in filter_scope_by_key_and_field[key].items():
             default = default_filters.get(key, {}).get(field)
             short_id = f"{shortid()}"[:9]
+
+            # Ensure uniqueness due to UUIDv4 truncation increasing
+            # collision chance to infinitesimally small amount.
+            while True:
+                if short_id not in unique_short_ids:
+                    unique_short_ids.add(short_id)
+                    break
+                else:
+                    short_id = f"{shortid()}"[:9]
 
             fltr: dict[str, Any] = {
                 "cascadeParentIds": [],

--- a/superset/migrations/shared/native_filters.py
+++ b/superset/migrations/shared/native_filters.py
@@ -18,11 +18,10 @@ from collections import defaultdict
 from textwrap import dedent
 from typing import Any
 
-from shortid import ShortId
-
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils import json
+from superset.utils.core import shortid
 from superset.utils.dashboard_filter_scopes_converter import convert_filter_scopes
 
 
@@ -49,7 +48,7 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
     :see: convert_filter_scopes
     """
 
-    shortid = ShortId()
+    short_id = f"{shortid()}"[:9]
     default_filters = json.loads(json_metadata.get("default_filters") or "{}")
     filter_scopes = json_metadata.get("filter_scopes", {})
     filter_box_ids = {filter_box.id for filter_box in filter_boxes}
@@ -85,7 +84,7 @@ def convert_filter_scopes_to_native_filters(  # pylint: disable=invalid-name,too
 
             fltr: dict[str, Any] = {
                 "cascadeParentIds": [],
-                "id": f"NATIVE_FILTER-{shortid.generate()}",
+                "id": f"NATIVE_FILTER-{short_id}",
                 "scope": {
                     "rootPath": filter_scope["scope"],
                     "excluded": [


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(backend): replace insecure `shortid` usage for native filter migration with native `uuid` Python implementation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Pypi package `shortid` is based on [a deprecated npm module `shortid`](https://github.com/dylang/shortid?tab=readme-ov-file) so a migration is very much anticipated. Luckily, there is a native Python implementation in place already in place so I decided to use it to swap around.

Other examples ([1](https://github.com/apache/superset/blob/master/superset-frontend/spec/fixtures/mockNativeFilters.ts#L60), [2](https://github.com/apache/superset/blob/master/tests/integration_tests/migrations/fc3a3a8ff221_migrate_filter_sets_to_new_format__tests.py#L176)) shows that the native filter's generated ID has 9 chars whilst [`shortid()` gives out 12 chars](https://github.com/apache/superset/blob/master/superset/utils/core.py#L1377) so I truncated to 9 chars to ensure status quo.

<img width="748" alt="image" src="https://github.com/user-attachments/assets/ce7a4eee-e46a-4c0e-a8b1-0b72d12aaf09" />


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
N/A

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
