### PR TITLE
docs: adding notes about using uv instead of raw pip

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -46,6 +46,7 @@ assists people when migrating to a new version.
 - [25166](https://github.com/apache/superset/pull/25166) Changed the default configuration of `UPLOAD_FOLDER` from `/app/static/uploads/` to `/static/uploads/`. It also removed the unused `IMG_UPLOAD_FOLDER` and `IMG_UPLOAD_URL` configuration options.
 - [30284](https://github.com/apache/superset/pull/30284) Deprecated GLOBAL_ASYNC_QUERIES_REDIS_CONFIG in favor of the new GLOBAL_ASYNC_QUERIES_CACHE_BACKEND configuration. To leverage Redis Sentinel, set CACHE_TYPE to RedisSentinelCache, or use RedisCache for standalone Redis
 - [31961](https://github.com/apache/superset/pull/31961) Upgraded React from version 16.13.1 to 17.0.2. If you are using custom frontend extensions or plugins, you may need to update them to be compatible with React 17.
+- [31260](https://github.com/apache/superset/pull/31260) Docker images now use `uv pip install` instead of `pip install` to manage the python envrionment. Most docker-based deployments will be affected, whether you derive one of the published images, or have custom bootstrap script that install python libraries (drivers)
 
 ### Potential Downtime
 

--- a/docs/docs/installation/kubernetes.mdx
+++ b/docs/docs/installation/kubernetes.mdx
@@ -160,7 +160,7 @@ The following example installs the drivers for BigQuery and Elasticsearch, allow
 ```yaml
 bootstrapScript: |
   #!/bin/bash
-  pip install .[postgres] \
+  uv pip install .[postgres] \
     .[bigquery] \
     .[elasticsearch] &&\
   if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi


### PR DESCRIPTION
Since the last release, we moved to using `uv` instead of `pip` and related packages. This can break deployments using our docker files that rely on `pip` for say installing drivers or custom libraries. Adding a note in UPDATING.md. This PR should be cherried in 5.0 branch
