### PR TITLE
chore(backend): remove unused deps `python-dotenv` and `bottleneck` + replace `simplejson` usage with built-in `json` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
       - id: mypy
         args: [--check-untyped-defs]
         additional_dependencies: [
-            types-simplejson,
             types-python-dateutil,
             types-requests,
             # types-redis 4.6.0.5 is failing mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
     "pandas[excel]>=2.0.3, <2.1",
-    "bottleneck",
     # --------------------------
     "parsedatetime",
     "paramiko>=3.4.0",
@@ -79,7 +78,6 @@ dependencies = [
     "polyline>=2.0.0, <3.0",
     "pyparsing>=3.0.6, <4",
     "python-dateutil",
-    "python-dotenv",
     "python-geohash",
     "pyarrow>=14.0.1, <15",
     "pyyaml>=6.0.0, <7.0.0",
@@ -88,7 +86,6 @@ dependencies = [
     "selenium>=4.14.0, <5.0",
     "shillelagh[gsheetsapi]>=1.2.18, <2.0",
     "sshtunnel>=0.4.0, <0.5",
-    "simplejson>=3.15.0",
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
     "sqlalchemy-utils>=0.38.3, <0.39",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,8 +27,6 @@ billiard==4.2.1
     # via celery
 blinker==1.9.0
     # via flask
-bottleneck==1.4.2
-    # via apache-superset (pyproject.toml)
 brotli==1.1.0
     # via flask-compress
 cachelib==0.9.0
@@ -220,7 +218,6 @@ numexpr==2.10.2
 numpy==1.26.4
     # via
     #   apache-superset (pyproject.toml)
-    #   bottleneck
     #   numexpr
     #   pandas
     #   pyarrow
@@ -298,8 +295,6 @@ python-dateutil==2.9.0.post0
     #   holidays
     #   pandas
     #   shillelagh
-python-dotenv==1.0.1
-    # via apache-superset (pyproject.toml)
 python-geohash==0.8.5
     # via apache-superset (pyproject.toml)
 pytz==2024.2
@@ -328,8 +323,6 @@ rsa==4.9
 selenium==4.27.1
     # via apache-superset (pyproject.toml)
 shillelagh==1.2.18
-    # via apache-superset (pyproject.toml)
-simplejson==3.19.3
     # via apache-superset (pyproject.toml)
 six==1.16.0
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -46,10 +46,6 @@ blinker==1.9.0
     # via
     #   -c requirements/base.txt
     #   flask
-bottleneck==1.4.2
-    # via
-    #   -c requirements/base.txt
-    #   apache-superset
 brotli==1.1.0
     # via
     #   -c requirements/base.txt
@@ -451,7 +447,6 @@ numpy==1.26.4
     # via
     #   -c requirements/base.txt
     #   apache-superset
-    #   bottleneck
     #   cmdstanpy
     #   contourpy
     #   db-dtypes
@@ -660,10 +655,6 @@ python-dateutil==2.9.0.post0
     #   pyhive
     #   shillelagh
     #   trino
-python-dotenv==1.0.1
-    # via
-    #   -c requirements/base.txt
-    #   apache-superset
 python-geohash==0.8.5
     # via
     #   -c requirements/base.txt
@@ -735,10 +726,6 @@ setuptools==75.6.0
     #   zope-event
     #   zope-interface
 shillelagh==1.2.18
-    # via
-    #   -c requirements/base.txt
-    #   apache-superset
-simplejson==3.19.3
     # via
     #   -c requirements/base.txt
     #   apache-superset

--- a/superset/utils/json.py
+++ b/superset/utils/json.py
@@ -16,17 +16,17 @@
 # under the License.
 import copy
 import decimal
+import json
 import logging
 import uuid
 from datetime import date, datetime, time, timedelta
+from json import JSONDecodeError
 from typing import Any, Callable, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
-import simplejson
 from flask_babel.speaklater import LazyString
 from jsonpath_ng import parse
-from simplejson import JSONDecodeError
 
 from superset.constants import PASSWORD_MASK
 from superset.utils.dates import datetime_to_epoch, EPOCH
@@ -35,7 +35,7 @@ logging.getLogger("MARKDOWN").setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-class DashboardEncoder(simplejson.JSONEncoder):
+class DashboardEncoder(json.JSONEncoder):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.sort_keys = True
@@ -49,7 +49,7 @@ class DashboardEncoder(simplejson.JSONEncoder):
         except Exception:  # pylint: disable=broad-except
             if isinstance(o, datetime):
                 return {"__datetime__": o.replace(microsecond=0).isoformat()}
-            return simplejson.JSONEncoder(sort_keys=True).default(o)
+            return json.JSONEncoder(sort_keys=True).default(o)
 
 
 def format_timedelta(time_delta: timedelta) -> str:
@@ -189,7 +189,7 @@ def dumps(  # pylint: disable=too-many-arguments
     sort_keys: bool = False,
     indent: Union[str, int, None] = None,
     separators: Union[tuple[str, str], None] = None,
-    cls: Union[type[simplejson.JSONEncoder], None] = None,
+    cls: Union[type[json.JSONEncoder], None] = None,
     encoding: Optional[str] = "utf-8",
 ) -> str:
     """
@@ -218,10 +218,10 @@ def dumps(  # pylint: disable=too-many-arguments
         "encoding": encoding,
     }
     try:
-        results_string = simplejson.dumps(obj, **dumps_kwargs)
+        results_string = json.dumps(obj, **dumps_kwargs)
     except UnicodeDecodeError:
         dumps_kwargs["encoding"] = None
-        results_string = simplejson.dumps(obj, **dumps_kwargs)
+        results_string = json.dumps(obj, **dumps_kwargs)
     return results_string
 
 
@@ -240,7 +240,7 @@ def loads(
     :param object_hook: function that will be called to decode objects values
     :returns: A Python object deserialized from string
     """
-    return simplejson.loads(
+    return json.loads(
         obj,
         encoding=encoding,
         allow_nan=allow_nan,


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(backend): remove unused deps `python-dotenv` and `bottleneck` + replace `simplejson` usage with built-in `json` module

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`python-dotenv` `bottleneck` are not used anywhere in the codebase at the moment. For `simplejson`, many popular Python libraries ([itsdangerous](https://github.com/pallets/itsdangerous/issues/146), [flask](https://github.com/pallets/flask/issues/3555) and [werkzeug](https://github.com/pallets/werkzeug/pull/1766)) have replaced them with native `json` implementation as Python2 complementary is not needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
All CI checks should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
