### PR TITLE
fix(cfg): fix borked `/v1/security/*token` API endpoints by disabling verify sub claim in JWT to be string type in PyJWT >= 2.10

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1920,7 +1920,7 @@ CATALOGS_SIMPLIFIED_MIGRATION: bool = False
 # TODO: remove this variable once pyjwt resolved the issue.
 # https://github.com/jpadilla/pyjwt/issues/1017
 # https://github.com/dpgaspar/Flask-AppBuilder/issues/2287
-JWT_VERIFY_SUB = False
+JWT_VERIFY_SUB: bool = False
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *

--- a/superset/config.py
+++ b/superset/config.py
@@ -1915,6 +1915,12 @@ EXTRA_DYNAMIC_QUERY_FILTERS: ExtraDynamicQueryFilters = {}
 # connection via the UI (without downtime).
 CATALOGS_SIMPLIFIED_MIGRATION: bool = False
 
+# Configure JWT subsystem to not enforce that the sub claim is a string
+# Set this variable to avoid breaking `/api/security` endpoints
+# TODO: remove this variable once pyjwt resolved the issue.
+# https://github.com/jpadilla/pyjwt/issues/1017
+# https://github.com/dpgaspar/Flask-AppBuilder/issues/2287
+JWT_VERIFY_SUB = False
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(cfg): fix borked /v1/security/*token API endpoints by disabling verify sub claim in JWT to be string type in PyJWT >= 2.10

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #32241 #32257 by adding a sane default config while waiting for upstream packages to resolve breakages.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/4f863797-bdb7-4de3-9fbd-1a3d026c93dc" />


After
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/13733348-126f-4568-b363-f2430ebb1d54" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Run Superset's Flask server
2.  Call API `/api/v1/security/csrf_token` with proper Authorization header.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
