### PR TITLE
feat(viz/echart): allow enforcing line style for Timeseries chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -30,6 +30,7 @@ import {
   sharedControls,
 } from '@superset-ui/chart-controls';
 
+import { EchartsTimeseriesLineStyle } from '../../types';
 import {
   DEFAULT_FORM_DATA,
   TIME_SERIES_DESCRIPTION_TEXT,
@@ -72,6 +73,26 @@ const config: ControlPanelConfig = {
         ...seriesOrderSection,
         ['color_scheme'],
         ['time_shift_color'],
+        [
+          {
+            name: 'overrideLineStyle',
+            config: {
+              type: 'SelectControl',
+              label: t('Override line style'),
+              renderTrigger: true,
+              default: null,
+              choices: [
+                [null, t('None')],
+                [EchartsTimeseriesLineStyle.Solid, t('Solid')],
+                [EchartsTimeseriesLineStyle.Dashed, t('Dashed')],
+                [EchartsTimeseriesLineStyle.Dotted, t('Dotted')],
+              ],
+              description: t(
+                'Force apply line style to all series (solid, dotted, dashed or none)',
+              ),
+            },
+          },
+        ],
         ...showValueSection,
         [
           {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -88,6 +88,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   orientation: OrientationType.Vertical,
   sort_series_type: 'sum',
   sort_series_ascending: false,
+  overrideLineStyle: null,
 };
 
 export const TIME_SERIES_DESCRIPTION_TEXT: string = t(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -234,6 +234,7 @@ export default function transformProps(
     onlyTotal,
     opacity,
     orientation,
+    overrideLineStyle,
     percentageThreshold,
     richTooltip,
     seriesType,
@@ -420,6 +421,10 @@ export default function transformProps(
 
       lineStyle.opacity = OpacityEnum.DerivedSeries;
       lineSymbol = visibleSymbols[patternIndex % visibleSymbols.length];
+    }
+
+    if (overrideLineStyle) {
+      lineStyle.type = overrideLineStyle;
     }
 
     // Calculate min/max from data for horizontal bar charts

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -51,6 +51,12 @@ export enum EchartsTimeseriesSeriesType {
   End = 'end',
 }
 
+export enum EchartsTimeseriesLineStyle {
+  Solid = 'solid',
+  Dashed = 'dashed',
+  Dotted = 'dotted',
+}
+
 export type EchartsTimeseriesFormData = QueryFormData & {
   annotationLayers: AnnotationLayer[];
   area: boolean;
@@ -99,6 +105,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   percentageThreshold: number;
   colorByPrimaryAxis?: boolean;
   orientation?: OrientationType;
+  overrideLineStyle: EchartsTimeseriesLineStyle | null;
 } & LegendFormData &
   TitleFormData;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -32,7 +32,10 @@ import {
   TimeGranularity,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
-import { EchartsTimeseriesChartProps } from '../../src/types';
+import {
+  EchartsTimeseriesChartProps,
+  EchartsTimeseriesLineStyle,
+} from '../../src/types';
 import type { SeriesOption } from 'echarts';
 import transformProps from '../../src/Timeseries/transformProps';
 import {
@@ -615,6 +618,7 @@ describe('Does transformProps transform series correctly', () => {
     label: { show: boolean; formatter: labelFormatterType };
     data: seriesDataType[];
     name: string;
+    lineStyle: { type: EchartsTimeseriesLineStyle };
   };
 
   const formData: SqlaFormData = {
@@ -810,6 +814,23 @@ describe('Does transformProps transform series correctly', () => {
       '1 year ago, foo2, bar2': ['foo2', 'bar2'],
       'foo1, bar1': ['foo1', 'bar1'],
       'foo2, bar2': ['foo2', 'bar2'],
+    });
+  });
+
+  test('should apply line style for all series when an overrideLineStyle is chosen', () => {
+    const chartProps = createTestChartProps({
+      formData: {
+        ...formData,
+        overrideLineStyle: EchartsTimeseriesLineStyle.Dashed,
+      },
+      queriesData,
+    });
+
+    const transformedSeries = transformProps(chartProps).echartOptions
+      .series as seriesType[];
+
+    transformedSeries.forEach(series => {
+      expect(series.lineStyle.type).toEqual(EchartsTimeseriesLineStyle.Dashed);
     });
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(viz/echart): allow enforcing line style for Timeseries chart

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow users to enforce a line style for their Timeseries chart such as `dotted` or `dashed`. Interesting [feature request from a Slack user](https://apache-superset.slack.com/archives/C016B3LG5B4/p1739262387047549)

Demo

https://github.com/user-attachments/assets/cf34f724-a998-4bd4-9d5d-93b57652e97c


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
