### PR TITLE
fix: update virtual dataset updated message to show the count

### DIFF
--- a/superset-frontend/src/components/Datasource/utils.js
+++ b/superset-frontend/src/components/Datasource/utils.js
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Children, cloneElement } from 'react';
-import { nanoid } from 'nanoid';
 import { SupersetClient, tn } from '@superset-ui/core';
+import { nanoid } from 'nanoid';
+import { Children, cloneElement } from 'react';
 import rison from 'rison';
 
 export function recurseReactClone(children, type, propExtender) {
@@ -92,27 +92,36 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
   if (columnChanges.modified.length) {
     addSuccessToast(
       tn(
-        'Modified 1 column in the virtual dataset',
-        'Modified %s columns in the virtual dataset',
+        'Modified %(count) column in the virtual dataset',
+        'Modified %(count) columns in the virtual dataset',
         columnChanges.modified.length,
+        {
+          count: columnChanges.modified.length,
+        },
       ),
     );
   }
   if (columnChanges.removed.length) {
     addSuccessToast(
       tn(
-        'Removed 1 column from the virtual dataset',
-        'Removed %s columns from the virtual dataset',
+        'Removed %(count) column from the virtual dataset',
+        'Removed %(count) columns from the virtual dataset',
         columnChanges.removed.length,
+        {
+          count: columnChanges.removed.length,
+        },
       ),
     );
   }
   if (columnChanges.added.length) {
     addSuccessToast(
       tn(
-        'Added 1 new column to the virtual dataset',
-        'Added %s new columns to the virtual dataset',
+        'Added %(count) new column to the virtual dataset',
+        'Added %(count) new columns to the virtual dataset',
         columnChanges.added.length,
+        {
+          count: columnChanges.added.length,
+        },
       ),
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently when we update a virtual dataset, we show a message with the string placeholder of `%s` This will attempt to show the proper number of columns when updating a virtual dataset.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
