### PR TITLE
fix(explore/data-table-pane): intuitive caret icons to expand/collapse data table pane

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -158,12 +158,12 @@ export const DataTablesPane = ({
 
   const CollapseButton = useMemo(() => {
     const caretIcon = panelOpen ? (
-      <Icons.CaretUp
+      <Icons.CaretDown
         iconColor={theme.colors.grayscale.base}
         aria-label={t('Collapse data panel')}
       />
     ) : (
-      <Icons.CaretDown
+      <Icons.CaretUp
         iconColor={theme.colors.grayscale.base}
         aria-label={t('Expand data panel')}
       />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(explore/data-table-pane): intuitive caret icons to expand/collapse data table pane

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The caret icons shown in the footer's data table pane is quite confusing: it should be `up` when someone needs to expand the pane and vice versa for collapse case.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
<img width="891" alt="image" src="https://github.com/user-attachments/assets/60630840-7335-49ea-8ef0-c9d10c329c25" />
<img width="891" alt="image" src="https://github.com/user-attachments/assets/5ee41c09-b450-4021-a7f4-cd5c5bc602ad" />

After
<img width="875" alt="image" src="https://github.com/user-attachments/assets/4bd6dc75-848d-4b5a-810f-ec4de6b07242" />
<img width="875" alt="image" src="https://github.com/user-attachments/assets/55825dec-207e-48f4-803c-a9f8ba881448" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Setup dev Superset
2. Go to any Pivot table
3. Expand/collapse the data table pane in the bottom right direction to see the caret icon

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
