### PR TITLE
feat(ci): add step to scan built container image for vulnerabilities

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
           image-ref: ${{ env.IMAGE_TAG }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          ignore-unfixed: true
+          vuln-type: 'os'
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,7 @@ jobs:
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: $IMAGE_TAG
+          image-ref: ${{ env.IMAGE_TAG }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,10 +108,7 @@ jobs:
           image-ref: ${{ env.IMAGE_TAG }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: 1
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,6 +109,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           vuln-type: 'os'
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,6 +101,24 @@ jobs:
           docker images $IMAGE_TAG
           docker history $IMAGE_TAG
 
+      - name: Run Trivy container image vulnerabity scan
+        if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: $IMAGE_TAG
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && matrix.build_preset == 'lean'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
       - name: docker-compose sanity check
         if: (steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker) && (matrix.build_preset == 'dev' || matrix.build_preset == 'lean')
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ CMD ["/app/docker/entrypoints/run-server.sh"]
 EXPOSE ${SUPERSET_PORT}
 
 ######################################################################
-# Final lean image...
+# Final lean image....
 ######################################################################
 FROM python-common AS lean
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(ci): add step to scan built container image for vulnerabilities

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently we don't have observability over container image vulnerabilities or at least not the one I'm aware of. This PR is to add a Trivy-based container scan to (1) proactively patch container image-based vulnerabilities and (2) have a holistic view over the scene.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
