### PR TITLE
feat(viz: country-map): Add support for region normalization to country map

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/transformProps.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/transformProps.js
@@ -29,7 +29,7 @@ export default function transformProps(chartProps) {
   return {
     width,
     height,
-    data: queriesData[0].data,
+    rawData: queriesData[0].data,
     country: selectCountry ? String(selectCountry).toLowerCase() : null,
     linearColorScheme,
     numberFormat,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates country map to normalize the region input. Right now the ISO format is expected but we needed to support using data that did not confirm to the ISO format. This will read from the loaded country geojson file and creates lookups of abbreviation and region names that map to the ISO format.
| Region ISO input     | Region Name input | Region Abbreviation input | Normalized input
| ---      | ---       | ---     |---     |
| US-AK | Alaska         | AK | US-AK
| IT-AO     | Aoste        | AO | IT-AO
| FR-GF | Guyane française | GF | FR-GF

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
