### PR TITLE
feat(feature flag): Setting `TAGGING_SYSTEM` to True by default

### DIFF
--- a/RESOURCES/FEATURE_FLAGS.md
+++ b/RESOURCES/FEATURE_FLAGS.md
@@ -31,7 +31,6 @@ These features are considered **unfinished** and should only be used on developm
 - ENABLE_ADVANCED_DATA_TYPES
 - PRESTO_EXPAND_DATA
 - SHARE_QUERIES_VIA_KV_STORE
-- TAGGING_SYSTEM
 - CHART_PLUGINS_EXPERIMENTAL
 
 ## In Testing
@@ -65,6 +64,7 @@ These features flags are **safe for production**. They have been tested and will
 ### Flags on the path to feature launch and flag deprecation/removal
 
 - DASHBOARD_VIRTUALIZATION
+- TAGGING_SYSTEM
 
 ### Flags retained for runtime configuration
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,7 @@ assists people when migrating to a new version.
 
 ## Next
 
+- [32318](https://github.com/apache/superset/pull/32318) The `TAGGING_SYSTEM` feature flag is now set to True by default.
 - [31976](https://github.com/apache/superset/pull/31976) Removed the `DISABLE_LEGACY_DATASOURCE_EDITOR` feature flag. The previous value of the feature flag was `True` and now the feature is permanently removed.
 - [31959](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.
 - [31959](https://github.com/apache/superset/pull/31959) Removes the following endpoints from data uploads: `/api/v1/database/<id>/<file type>_upload` and `/api/v1/database/<file type>_metadata`, in favour of new one (Details on the PR). And simplifies permissions.

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard_list/list.test.ts
@@ -16,15 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DASHBOARD_LIST } from 'cypress/utils/urls';
 import { setGridMode, toggleBulkSelect } from 'cypress/utils';
+import { DASHBOARD_LIST } from 'cypress/utils/urls';
 import {
-  setFilter,
   interceptBulkDelete,
-  interceptUpdate,
   interceptDelete,
   interceptFav,
   interceptUnfav,
+  interceptUpdate,
+  setFilter,
 } from '../dashboard/utils';
 
 function orderAlphabetical() {
@@ -72,9 +72,10 @@ describe('Dashboards list', () => {
       cy.getBySel('listview-table').should('be.visible');
       cy.getBySel('sort-header').eq(1).contains('Name');
       cy.getBySel('sort-header').eq(2).contains('Status');
-      cy.getBySel('sort-header').eq(3).contains('Owners');
-      cy.getBySel('sort-header').eq(4).contains('Last modified');
-      cy.getBySel('sort-header').eq(5).contains('Actions');
+      cy.getBySel('sort-header').eq(3).contains('Tags');
+      cy.getBySel('sort-header').eq(4).contains('Owners');
+      cy.getBySel('sort-header').eq(5).contains('Last modified');
+      cy.getBySel('sort-header').eq(6).contains('Actions');
     });
 
     it('should sort correctly in list mode', () => {

--- a/superset/config.py
+++ b/superset/config.py
@@ -482,7 +482,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This feature flag is used by the download feature in the dashboard view.
     # It is dependent on ENABLE_DASHBOARD_SCREENSHOT_ENDPOINT being enabled.
     "ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT": False,
-    "TAGGING_SYSTEM": False,
+    "TAGGING_SYSTEM": True,
     "SQLLAB_BACKEND_PERSISTENCE": True,
     "LISTVIEWS_DEFAULT_CARD_VIEW": False,
     # When True, this escapes HTML (rather than rendering it) in Markdown components

--- a/tests/integration_tests/fixtures/tags.py
+++ b/tests/integration_tests/fixtures/tags.py
@@ -32,6 +32,9 @@ def with_tagging_system_feature():
         yield
         app.config["DEFAULT_FEATURE_FLAGS"]["TAGGING_SYSTEM"] = False
         clear_sqla_event_listeners()
+    else:
+        # Add yield when feature is already enabled
+        yield
 
 
 @pytest.fixture

--- a/tests/integration_tests/tagging_tests.py
+++ b/tests/integration_tests/tagging_tests.py
@@ -30,6 +30,7 @@ from superset.utils.database import get_main_database
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.tags import (
+    clear_sqla_event_listeners,
     with_tagging_system_feature,  # noqa: F401
 )
 
@@ -235,6 +236,8 @@ class TestTagging(SupersetTestCase):
         Test to make sure that when the TAGGING_SYSTEM
         feature flag is false, that no tags are created
         """
+        # We need to clear the event listeners when the feature is disabled
+        clear_sqla_event_listeners()
 
         # Remove all existing rows in the tagged_object table
         self.clear_tagged_object_table()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Following on the heels of https://github.com/apache/superset/pull/32317, and a discussion with @eschutho, we feel that this feature is ready for promotion to being on by default, whether this makes it into 5.0 or a subsequent minor. Again tagging @kgabryje @michael-s-molina @mistercrunch in case there are any concerns here preventing this change.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
