### PR TITLE
fix: Download as PDF fails due to cache error

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1127,6 +1127,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 dashboard_url=dashboard_url,
                 thumb_size=thumb_size,
                 window_size=window_size,
+                cache_key=cache_key,
                 force=force,
             )
             return build_response(202)

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import base64
 import logging
 from datetime import datetime
 from enum import Enum
@@ -64,7 +65,7 @@ class StatusValues(Enum):
 
 
 class ScreenshotCachePayloadType(TypedDict):
-    image: bytes | None
+    image: str | None
     timestamp: str
     status: str
 
@@ -83,14 +84,16 @@ class ScreenshotCachePayload:
     @classmethod
     def from_dict(cls, payload: ScreenshotCachePayloadType) -> ScreenshotCachePayload:
         return cls(
-            image=payload["image"],
+            image=base64.b64decode(payload["image"]) if payload["image"] else None,
             status=StatusValues(payload["status"]),
             timestamp=payload["timestamp"],
         )
 
     def to_dict(self) -> ScreenshotCachePayloadType:
         return {
-            "image": self._image,
+            "image": base64.b64encode(self._image).decode("utf-8")
+            if self._image
+            else None,
             "timestamp": self._timestamp,
             "status": self.status.value,
         }


### PR DESCRIPTION
### SUMMARY
When backend generation of dashboard PDF and PNG exports is enabled, the screenshot generation would fail. The reason for that was that we didn't pass a correct cache_ley to the compute method. Additionally, this PR implements converting the image bytes to a string to make it compatible with Redis cache backend.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Enable feature flags: THUMBNAILS, ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS, ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT
2. Make sure that THUMBNAIL_CACHE_CONFIG is set to a proper cache backend - by default we use a no-op NullCache, so try something like Redis
3. Go to a dashboard and click Download -> Export to PDF
4. Verify that the PDF contains a dashboard screenshot
5. Do it again - this time it should be quicker as the screenshot should be cached

Example of a redis config:

```
THUMBNAIL_CACHE_CONFIG = {
    "CACHE_TYPE": "redis",
    "CACHE_DEFAULT_TIMEOUT": 60 * 60,
    "CACHE_KEY_PREFIX": 'development_superset_thumbs_',
    "CACHE_REDIS_URL": "redis://%s:%s/0" % (REDIS_HOST, REDIS_PORT),
}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
