### PR TITLE
fix(Slack): Fix Slack recipients migration to V2

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -149,7 +149,14 @@ class BaseReportState:
                         exact_match=True,
                     )
                     if len(channels_list) != len(channels):
-                        raise UpdateFailedError("Not all channels could be found")
+                        missing_channels = set(channels_list) - {
+                            channel["name"] for channel in channels
+                        }
+                        msg = (
+                            "Could not find the following channels: "
+                            f"{', '.join(missing_channels)}"
+                        )
+                        raise UpdateFailedError(msg)
                     channel_ids = ", ".join(channel["id"] for channel in channels)
                     recipient.recipient_config_json = json.dumps(
                         {

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -72,7 +72,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.tasks.utils import get_executor
 from superset.utils import json
-from superset.utils.core import get_recipients_list, HeaderDataType, override_user
+from superset.utils.core import HeaderDataType, override_user, recipients_string_to_list
 from superset.utils.csv import get_chart_csv_data, get_chart_dataframe
 from superset.utils.decorators import logs_context, transaction
 from superset.utils.pdf import build_pdf_from_screenshots
@@ -137,18 +137,19 @@ class BaseReportState:
                 if recipient.type == ReportRecipientType.SLACK:
                     recipient.type = ReportRecipientType.SLACKV2
                     slack_recipients = json.loads(recipient.recipient_config_json)
+                    # V1 method allowed to use leading `#` in the channel name
+                    channel_names = (slack_recipients["target"] or "").replace("#", "")
                     # we need to ensure that existing reports can also fetch
                     # ids from private channels
-                    channels_list = get_recipients_list(slack_recipients["target"])
-                    channels_list = [channel.lstrip("#") for channel in channels_list]
                     channels = get_channels_with_search(
-                        search_string=channels_list,
+                        search_string=channel_names,
                         types=[
                             SlackChannelTypes.PRIVATE,
                             SlackChannelTypes.PUBLIC,
                         ],
                         exact_match=True,
                     )
+                    channels_list = recipients_string_to_list(channel_names)
                     if len(channels_list) != len(channels):
                         missing_channels = set(channels_list) - {
                             channel["name"] for channel in channels
@@ -158,7 +159,7 @@ class BaseReportState:
                             f"{', '.join(missing_channels)}"
                         )
                         raise UpdateFailedError(msg)
-                    channel_ids = ", ".join(channel["id"] for channel in channels)
+                    channel_ids = ",".join(channel["id"] for channel in channels)
                     recipient.recipient_config_json = json.dumps(
                         {
                             "target": channel_ids,
@@ -168,7 +169,7 @@ class BaseReportState:
             # Revert to v1 to preserve configuration (requires manual fix)
             recipient.type = ReportRecipientType.SLACK
             msg = f"Failed to update slack recipients to v2: {str(ex)}"
-            logger.error(msg, exc_info=True)
+            logger.exception(msg)
             raise UpdateFailedError(msg) from ex
 
     def create_log(self, error_message: Optional[str] = None) -> None:
@@ -568,33 +569,32 @@ class BaseReportState:
         for recipient in recipients:
             notification = create_notification(recipient, notification_content)
             try:
-                if app.config["ALERT_REPORTS_NOTIFICATION_DRY_RUN"]:
-                    logger.info(
-                        "Would send notification for alert %s, to %s. "
-                        "ALERT_REPORTS_NOTIFICATION_DRY_RUN is enabled, "
-                        "set it to False to send notifications.",
-                        self._report_schedule.name,
-                        recipient.recipient_config_json,
-                    )
-                else:
-                    notification.send()
-            except SlackV1NotificationError as ex:
-                # The slack notification should be sent with the v2 api
-                logger.info("Attempting to upgrade the report to Slackv2: %s", str(ex))
                 try:
+                    if app.config["ALERT_REPORTS_NOTIFICATION_DRY_RUN"]:
+                        logger.info(
+                            "Would send notification for alert %s, to %s. "
+                            "ALERT_REPORTS_NOTIFICATION_DRY_RUN is enabled, "
+                            "set it to False to send notifications.",
+                            self._report_schedule.name,
+                            recipient.recipient_config_json,
+                        )
+                    else:
+                        notification.send()
+                except SlackV1NotificationError as ex:
+                    # The slack notification should be sent with the v2 api
+                    logger.info(
+                        "Attempting to upgrade the report to Slackv2: %s", str(ex)
+                    )
                     self.update_report_schedule_slack_v2()
                     recipient.type = ReportRecipientType.SLACKV2
                     notification = create_notification(recipient, notification_content)
                     notification.send()
-                except (UpdateFailedError, NotificationParamException) as mig_err:
-                    notification_errors.append(
-                        SupersetError(
-                            message=mig_err.message,
-                            error_type=SupersetErrorType.REPORT_NOTIFICATION_ERROR,
-                            level=ErrorLevel.ERROR,
-                        )
-                    )
-            except (NotificationError, SupersetException) as ex:
+            except (
+                UpdateFailedError,
+                NotificationParamException,
+                NotificationError,
+                SupersetException,
+            ) as ex:
                 # collect errors but keep processing them
                 notification_errors.append(
                     SupersetError(

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -139,15 +139,21 @@ class BaseReportState:
                     slack_recipients = json.loads(recipient.recipient_config_json)
                     # we need to ensure that existing reports can also fetch
                     # ids from private channels
+                    current_target_count = slack_recipients["target"].split(",")
+                    channels = get_channels_with_search(
+                        slack_recipients["target"],
+                        types=[
+                            SlackChannelTypes.PRIVATE,
+                            SlackChannelTypes.PUBLIC,
+                        ],
+                        exact_match=True,
+                    )
+                    if len(current_target_count) != len(channels):
+                        raise UpdateFailedError("Not all channels could be found")
+                    channel_ids = ", ".join(channel["id"] for channel in channels)
                     recipient.recipient_config_json = json.dumps(
                         {
-                            "target": get_channels_with_search(
-                                slack_recipients["target"],
-                                types=[
-                                    SlackChannelTypes.PRIVATE,
-                                    SlackChannelTypes.PUBLIC,
-                                ],
-                            )
+                            "target": channel_ids,
                         }
                     )
         except Exception as ex:

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -72,7 +72,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.tasks.utils import get_executor
 from superset.utils import json
-from superset.utils.core import HeaderDataType, override_user
+from superset.utils.core import get_recipients_list, HeaderDataType, override_user
 from superset.utils.csv import get_chart_csv_data, get_chart_dataframe
 from superset.utils.decorators import logs_context, transaction
 from superset.utils.pdf import build_pdf_from_screenshots
@@ -139,16 +139,16 @@ class BaseReportState:
                     slack_recipients = json.loads(recipient.recipient_config_json)
                     # we need to ensure that existing reports can also fetch
                     # ids from private channels
-                    current_target_count = slack_recipients["target"].split(",")
+                    channels_list = get_recipients_list(slack_recipients["target"])
                     channels = get_channels_with_search(
-                        slack_recipients["target"],
+                        search_string=channels_list,
                         types=[
                             SlackChannelTypes.PRIVATE,
                             SlackChannelTypes.PUBLIC,
                         ],
                         exact_match=True,
                     )
-                    if len(current_target_count) != len(channels):
+                    if len(channels_list) != len(channels):
                         raise UpdateFailedError("Not all channels could be found")
                     channel_ids = ", ".join(channel["id"] for channel in channels)
                     recipient.recipient_config_json = json.dumps(

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -51,6 +51,7 @@ from superset.reports.schemas import (
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
 )
+from superset.utils.core import get_recipients_list
 from superset.utils.slack import get_channels_with_search
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
@@ -574,7 +575,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         """
         try:
             params = kwargs.get("rison", {})
-            search_string = params.get("search_string")
+            search_string = get_recipients_list(params.get("search_string"))
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
             channels = get_channels_with_search(

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -574,7 +574,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         """
         try:
             params = kwargs.get("rison", {})
-            search_string = [params.get("search_string", "").strip()]
+            search_string = params.get("search_string")
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
             channels = get_channels_with_search(

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -51,7 +51,6 @@ from superset.reports.schemas import (
     ReportSchedulePostSchema,
     ReportSchedulePutSchema,
 )
-from superset.utils.core import get_recipients_list
 from superset.utils.slack import get_channels_with_search
 from superset.views.base_api import (
     BaseSupersetModelRestApi,
@@ -575,7 +574,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         """
         try:
             params = kwargs.get("rison", {})
-            search_string = get_recipients_list(params.get("search_string"))
+            search_string = [params.get("search_string", "").strip()]
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
             channels = get_channels_with_search(

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -43,7 +43,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.reports.notifications.slack_mixin import SlackMixin
 from superset.utils import json
-from superset.utils.core import get_recipients_list
+from superset.utils.core import recipients_string_to_list
 from superset.utils.decorators import statsd_gauge
 from superset.utils.slack import (
     get_slack_client,
@@ -70,7 +70,7 @@ class SlackNotification(SlackMixin, BaseNotification):  # pylint: disable=too-fe
         """
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
-        return ",".join(get_recipients_list(recipient_str))
+        return ",".join(recipients_string_to_list(recipient_str))
 
     def _get_inline_files(
         self,

--- a/superset/reports/notifications/slack.py
+++ b/superset/reports/notifications/slack.py
@@ -43,7 +43,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.reports.notifications.slack_mixin import SlackMixin
 from superset.utils import json
-from superset.utils.core import get_email_address_list
+from superset.utils.core import get_recipients_list
 from superset.utils.decorators import statsd_gauge
 from superset.utils.slack import (
     get_slack_client,
@@ -70,7 +70,7 @@ class SlackNotification(SlackMixin, BaseNotification):  # pylint: disable=too-fe
         """
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
-        return ",".join(get_email_address_list(recipient_str))
+        return ",".join(get_recipients_list(recipient_str))
 
     def _get_inline_files(
         self,

--- a/superset/reports/notifications/slackv2.py
+++ b/superset/reports/notifications/slackv2.py
@@ -42,7 +42,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.reports.notifications.slack_mixin import SlackMixin
 from superset.utils import json
-from superset.utils.core import get_recipients_list
+from superset.utils.core import recipients_string_to_list
 from superset.utils.decorators import statsd_gauge
 from superset.utils.slack import get_slack_client
 
@@ -64,7 +64,7 @@ class SlackV2Notification(SlackMixin, BaseNotification):  # pylint: disable=too-
         """  # noqa: E501
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
-        return get_recipients_list(recipient_str)
+        return recipients_string_to_list(recipient_str)
 
     def _get_inline_files(
         self,

--- a/superset/reports/notifications/slackv2.py
+++ b/superset/reports/notifications/slackv2.py
@@ -42,7 +42,7 @@ from superset.reports.notifications.exceptions import (
 )
 from superset.reports.notifications.slack_mixin import SlackMixin
 from superset.utils import json
-from superset.utils.core import get_email_address_list
+from superset.utils.core import get_recipients_list
 from superset.utils.decorators import statsd_gauge
 from superset.utils.slack import get_slack_client
 
@@ -64,7 +64,7 @@ class SlackV2Notification(SlackMixin, BaseNotification):  # pylint: disable=too-
         """  # noqa: E501
         recipient_str = json.loads(self._recipient.recipient_config_json)["target"]
 
-        return get_email_address_list(recipient_str)
+        return get_recipients_list(recipient_str)
 
     def _get_inline_files(
         self,

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Union
 from croniter import croniter
 from flask import current_app
 from flask_babel import gettext as _
-from marshmallow import fields, Schema, validate, validates, validates_schema
+from marshmallow import EXCLUDE, fields, Schema, validate, validates, validates_schema
 from marshmallow.validate import Length, Range, ValidationError
 from pytz import all_timezones
 
@@ -399,3 +399,17 @@ class ReportSchedulePutSchema(Schema):
                     max=max_width,
                 )
             )
+
+
+class SlackChannelSchema(Schema):
+    """
+    Schema to load Slack channels, set to ignore any fields not used by Superset.
+    """
+
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.String()
+    name = fields.String()
+    is_member = fields.Boolean()
+    is_private = fields.Boolean()

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -700,7 +700,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
         'test@example.com', 'foo', '<b>Foo</b> bar',['/dev/null'], dryrun=True)
     """
     smtp_mail_from = config["SMTP_MAIL_FROM"]
-    smtp_mail_to = get_recipients_list(to)
+    smtp_mail_to = recipients_string_to_list(to)
 
     msg = MIMEMultipart(mime_subtype)
     msg["Subject"] = subject
@@ -711,14 +711,14 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
 
     recipients = smtp_mail_to
     if cc:
-        smtp_mail_cc = get_recipients_list(cc)
+        smtp_mail_cc = recipients_string_to_list(cc)
         msg["Cc"] = ", ".join(smtp_mail_cc)
         recipients = recipients + smtp_mail_cc
 
     smtp_mail_bcc = []
     if bcc:
         # don't add bcc in header
-        smtp_mail_bcc = get_recipients_list(bcc)
+        smtp_mail_bcc = recipients_string_to_list(bcc)
         recipients = recipients + smtp_mail_bcc
 
     msg["Date"] = formatdate(localtime=True)
@@ -811,7 +811,7 @@ def send_mime_email(
     smtp.quit()
 
 
-def get_recipients_list(address_string: str | None) -> list[str]:
+def recipients_string_to_list(address_string: str | None) -> list[str]:
     """
     Returns the list of target recipients for alerts and reports.
 

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -700,7 +700,7 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
         'test@example.com', 'foo', '<b>Foo</b> bar',['/dev/null'], dryrun=True)
     """
     smtp_mail_from = config["SMTP_MAIL_FROM"]
-    smtp_mail_to = get_email_address_list(to)
+    smtp_mail_to = get_recipients_list(to)
 
     msg = MIMEMultipart(mime_subtype)
     msg["Subject"] = subject
@@ -711,14 +711,14 @@ def send_email_smtp(  # pylint: disable=invalid-name,too-many-arguments,too-many
 
     recipients = smtp_mail_to
     if cc:
-        smtp_mail_cc = get_email_address_list(cc)
+        smtp_mail_cc = get_recipients_list(cc)
         msg["Cc"] = ", ".join(smtp_mail_cc)
         recipients = recipients + smtp_mail_cc
 
     smtp_mail_bcc = []
     if bcc:
         # don't add bcc in header
-        smtp_mail_bcc = get_email_address_list(bcc)
+        smtp_mail_bcc = get_recipients_list(bcc)
         recipients = recipients + smtp_mail_bcc
 
     msg["Date"] = formatdate(localtime=True)
@@ -811,7 +811,13 @@ def send_mime_email(
     smtp.quit()
 
 
-def get_email_address_list(address_string: str) -> list[str]:
+def get_recipients_list(address_string: str | None) -> list[str]:
+    """
+    Returns the list of target recipients for alerts and reports.
+
+    Strips values and converts a comma/semicolon separated
+    string into a list.
+    """
     address_string_list: list[str] = []
     if isinstance(address_string, str):
         address_string_list = re.split(r",|\s|;", address_string)

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -48,7 +48,7 @@ def get_slack_client() -> WebClient:
 
 
 def get_channels_with_search(
-    search_string: str = "",
+    search_string: list[str] | None = None,
     limit: int = 999,
     types: Optional[list[SlackChannelTypes]] = None,
     exact_match: bool = False,
@@ -80,25 +80,20 @@ def get_channels_with_search(
 
         # The search string can be multiple channels separated by commas
         if search_string:
-            search_array = [
-                search.strip().lower()
-                for search in (search_string.split(",") if search_string else [])
-            ]
-
             channels = [
                 channel
                 for channel in channels
                 if any(
                     (
-                        search == channel["name"].lower()
-                        or search == channel["id"].lower()
+                        search.lower() == channel["name"].lower()
+                        or search.lower() == channel["id"].lower()
                         if exact_match
                         else (
-                            search in channel["name"].lower()
-                            or search in channel["id"].lower()
+                            search.lower() in channel["name"].lower()
+                            or search.lower() in channel["id"].lower()
                         )
                     )
-                    for search in search_array
+                    for search in search_string
                 )
             ]
         return channels

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -25,6 +25,7 @@ from slack_sdk.errors import SlackApiError
 
 from superset import feature_flag_manager
 from superset.exceptions import SupersetException
+from superset.reports.schemas import SlackChannelSchema
 from superset.utils.backports import StrEnum
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def get_channels_with_search(
     limit: int = 999,
     types: Optional[list[SlackChannelTypes]] = None,
     exact_match: bool = False,
-) -> list[str]:
+) -> list[SlackChannelSchema]:
     """
     The slack api is paginated but does not include search, so we need to fetch
     all channels and filter them ourselves
@@ -60,7 +61,8 @@ def get_channels_with_search(
 
     try:
         client = get_slack_client()
-        channels = []
+        channel_schema = SlackChannelSchema()
+        channels: list[SlackChannelSchema] = []
         cursor = None
         extra_params = {}
         extra_params["types"] = ",".join(types) if types else None
@@ -69,7 +71,9 @@ def get_channels_with_search(
             response = client.conversations_list(
                 limit=limit, cursor=cursor, exclude_archived=True, **extra_params
             )
-            channels.extend(response.data["channels"])
+            channels.extend(
+                channel_schema.load(channel) for channel in response.data["channels"]
+            )
             cursor = response.data.get("response_metadata", {}).get("next_cursor")
             if not cursor:
                 break
@@ -77,7 +81,7 @@ def get_channels_with_search(
         # The search string can be multiple channels separated by commas
         if search_string:
             search_array = [
-                search.lower()
+                search.strip().lower()
                 for search in (search_string.split(",") if search_string else [])
             ]
 

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -27,6 +27,7 @@ from superset import feature_flag_manager
 from superset.exceptions import SupersetException
 from superset.reports.schemas import SlackChannelSchema
 from superset.utils.backports import StrEnum
+from superset.utils.core import recipients_string_to_list
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ def get_slack_client() -> WebClient:
 
 
 def get_channels_with_search(
-    search_string: list[str] | None = None,
+    search_string: str = "",
     limit: int = 999,
     types: Optional[list[SlackChannelTypes]] = None,
     exact_match: bool = False,
@@ -80,6 +81,7 @@ def get_channels_with_search(
 
         # The search string can be multiple channels separated by commas
         if search_string:
+            search_array = recipients_string_to_list(search_string)
             channels = [
                 channel
                 for channel in channels
@@ -93,7 +95,7 @@ def get_channels_with_search(
                             or search.lower() in channel["id"].lower()
                         )
                     )
-                    for search in search_string
+                    for search in search_array
                 )
             ]
         return channels

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1455,23 +1455,23 @@ def test_slack_chart_report_schedule_fails_to_converts_to_v2(
         },
     ]
 
-    with freeze_time("2020-01-01T00:00:00Z"):
+    with pytest.raises(ReportScheduleSystemErrorsException):
         AsyncExecuteReportScheduleCommand(
             TEST_ID, report_schedule.id, datetime.utcnow()
         ).run()
 
-        # Assert failuer with proper log
-        expected_message = (
-            "Failed to update slack recipients to v2: "
-            "Could not find the following channels: my_member_ID"
-        )
-        assert_log(ReportState.ERROR, error_message=expected_message)
+    # Assert failuer with proper log
+    expected_message = (
+        "Failed to update slack recipients to v2: "
+        "Could not find the following channels: my_member_ID"
+    )
+    assert_log(ReportState.ERROR, error_message=expected_message)
 
-        # Assert that previous configuration was kept for manual correction
-        assert report_schedule.recipients[0].recipient_config_json == json.dumps(
-            {"target": "#slack_channel,my_member_ID"}
-        )
-        assert report_schedule.recipients[0].type == ReportRecipientType.SLACK
+    # Assert that previous configuration was kept for manual correction
+    assert report_schedule.recipients[0].recipient_config_json == json.dumps(
+        {"target": "#slack_channel,my_member_ID"}
+    )
+    assert report_schedule.recipients[0].type == ReportRecipientType.SLACK
 
     cleanup_report_schedule(report_schedule)
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1324,7 +1324,7 @@ def test_slack_chart_report_schedule_converts_to_v2(
     get_channels_with_search_mock.return_value = [
         {
             "id": channel_id,
-            "name": "Channel 1",
+            "name": "slack_channel",
             "is_member": True,
             "is_private": False,
         },

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1486,7 +1486,6 @@ def test_slack_chart_report_schedule_v2(
     screenshot_mock,
     slack_client_mock,
     slack_should_use_v2_api_mock,
-    get_channels_with_search_mock,
     create_report_slack_chart,
 ):
     """

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1509,10 +1509,6 @@ def test_slack_chart_report_schedule_v2(
 
             # Assert logs are correct
             assert_log(ReportState.SUCCESS)
-            # this will send a warning
-            assert statsd_mock.call_args_list[0] == call(
-                "reports.slack.send.warning", 1
-            )
             assert statsd_mock.call_args_list[1] == call("reports.slack.send.ok", 1)
 
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1509,7 +1509,7 @@ def test_slack_chart_report_schedule_v2(
 
             # Assert logs are correct
             assert_log(ReportState.SUCCESS)
-            assert statsd_mock.call_args_list[1] == call("reports.slack.send.ok", 1)
+            assert statsd_mock.call_args_list[0] == call("reports.slack.send.ok", 1)
 
 
 @pytest.mark.usefixtures(

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -1476,9 +1476,7 @@ def test_slack_chart_report_schedule_fails_to_converts_to_v2(
     cleanup_report_schedule(report_schedule)
 
 
-@pytest.mark.usefixtures(
-    "load_birth_names_dashboard_with_slices", "create_report_slack_chartv2"
-)
+@pytest.mark.usefixtures("create_report_slack_chartv2")
 @patch("superset.reports.notifications.slack.should_use_v2_api", return_value=True)
 @patch("superset.reports.notifications.slackv2.get_slack_client")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -1486,7 +1484,7 @@ def test_slack_chart_report_schedule_v2(
     screenshot_mock,
     slack_client_mock,
     slack_should_use_v2_api_mock,
-    create_report_slack_chart,
+    create_report_slack_chartv2,
 ):
     """
     ExecuteReport Command: Test chart slack report schedule using Slack v2.
@@ -1497,7 +1495,7 @@ def test_slack_chart_report_schedule_v2(
     with freeze_time("2020-01-01T00:00:00Z"):
         with patch.object(current_app.config["STATS_LOGGER"], "gauge") as statsd_mock:
             AsyncExecuteReportScheduleCommand(
-                TEST_ID, create_report_slack_chart.id, datetime.utcnow()
+                TEST_ID, create_report_slack_chartv2.id, datetime.utcnow()
             ).run()
 
             assert (

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -131,12 +131,11 @@ def create_report_notification(
         ]
 
     if slack_channel:
+        type = (
+            ReportRecipientType.SLACKV2 if use_slack_v2 else ReportRecipientType.SLACK
+        )
         recipient = ReportRecipients(
-            type=(
-                ReportRecipientType.SLACKV2
-                if use_slack_v2
-                else ReportRecipientType.SLACK
-            ),
+            type=type,
             recipient_config_json=json.dumps(
                 {
                     "target": slack_channel,

--- a/tests/integration_tests/reports/utils.py
+++ b/tests/integration_tests/reports/utils.py
@@ -119,6 +119,7 @@ def create_report_notification(
     owners: Optional[list[User]] = None,
     ccTarget: Optional[str] = None,  # noqa: N803
     bccTarget: Optional[str] = None,  # noqa: N803
+    use_slack_v2: bool = False,
 ) -> ReportSchedule:
     if not owners:
         owners = [
@@ -131,7 +132,11 @@ def create_report_notification(
 
     if slack_channel:
         recipient = ReportRecipients(
-            type=ReportRecipientType.SLACK,
+            type=(
+                ReportRecipientType.SLACKV2
+                if use_slack_v2
+                else ReportRecipientType.SLACK
+            ),
             recipient_config_json=json.dumps(
                 {
                     "target": slack_channel,

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -52,7 +52,7 @@ from superset.utils.core import (
     GenericDataType,
     get_form_data_token,
     as_list,
-    get_recipients_list,
+    recipients_string_to_list,
     get_stacktrace,
     merge_extra_filters,
     merge_extra_form_data,
@@ -809,12 +809,12 @@ class TestUtils(SupersetTestCase):
         assert expected_filename in path
         assert os.path.exists(path)
 
-    def test_get_recipients_list(self):
-        assert get_recipients_list("a@a") == ["a@a"]
-        assert get_recipients_list(" a@a ") == ["a@a"]
-        assert get_recipients_list("a@a\n") == ["a@a"]
-        assert get_recipients_list(",a@a;") == ["a@a"]
-        assert get_recipients_list(",a@a; b@b c@c a-c@c; d@d, f@f") == [
+    def test_recipients_string_to_list(self):
+        assert recipients_string_to_list("a@a") == ["a@a"]
+        assert recipients_string_to_list(" a@a ") == ["a@a"]
+        assert recipients_string_to_list("a@a\n") == ["a@a"]
+        assert recipients_string_to_list(",a@a;") == ["a@a"]
+        assert recipients_string_to_list(",a@a; b@b c@c a-c@c; d@d, f@f") == [
             "a@a",
             "b@b",
             "c@c",

--- a/tests/integration_tests/utils_tests.py
+++ b/tests/integration_tests/utils_tests.py
@@ -52,7 +52,7 @@ from superset.utils.core import (
     GenericDataType,
     get_form_data_token,
     as_list,
-    get_email_address_list,
+    get_recipients_list,
     get_stacktrace,
     merge_extra_filters,
     merge_extra_form_data,
@@ -809,12 +809,12 @@ class TestUtils(SupersetTestCase):
         assert expected_filename in path
         assert os.path.exists(path)
 
-    def test_get_email_address_list(self):
-        assert get_email_address_list("a@a") == ["a@a"]
-        assert get_email_address_list(" a@a ") == ["a@a"]
-        assert get_email_address_list("a@a\n") == ["a@a"]
-        assert get_email_address_list(",a@a;") == ["a@a"]
-        assert get_email_address_list(",a@a; b@b c@c a-c@c; d@d, f@f") == [
+    def test_get_recipients_list(self):
+        assert get_recipients_list("a@a") == ["a@a"]
+        assert get_recipients_list(" a@a ") == ["a@a"]
+        assert get_recipients_list("a@a\n") == ["a@a"]
+        assert get_recipients_list(",a@a;") == ["a@a"]
+        assert get_recipients_list(",a@a; b@b c@c a-c@c; d@d, f@f") == [
             "a@a",
             "b@b",
             "c@c",

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -24,9 +24,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from superset.app import SupersetApp
+from superset.commands.exceptions import UpdateFailedError
 from superset.commands.report.execute import BaseReportState
 from superset.dashboards.permalink.types import DashboardPermalinkState
 from superset.reports.models import (
+    ReportRecipients,
     ReportRecipientType,
     ReportSchedule,
     ReportScheduleType,
@@ -480,3 +482,78 @@ def test_screenshot_width_calculation(
                     f"Test {test_id}: Expected width {expected_width}, "
                     f"but got {kwargs['window_size'][0]}"
                 )
+
+
+def test_update_recipient_to_slack_v2(mocker: MockerFixture):
+    """
+    Test converting a Slack recipient to Slack v2 format.
+    """
+    mocker.patch(
+        "superset.commands.report.execute.get_channels_with_search",
+        return_value=[
+            {
+                "id": "abc124f",
+                "name": "Channel 1",
+                "is_member": True,
+                "is_private": False,
+            },
+            {
+                "id": "blah_!channel_2",
+                "name": "Channel 2",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+    )
+    mock_report_schedule = ReportSchedule(
+        recipients=[
+            ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json=json.dumps({"target": "Channel 1, Channel 2"}),
+            ),
+        ],
+    )
+
+    mock_cmmd: BaseReportState = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+    mock_cmmd.update_report_schedule_slack_v2()
+
+    assert (
+        mock_cmmd._report_schedule.recipients[0].recipient_config_json
+        == '{"target": "abc124f, blah_!channel_2"}'
+    )
+    assert mock_cmmd._report_schedule.recipients[0].type == ReportRecipientType.SLACKV2
+
+
+def test_update_recipient_to_slack_v2_missing_channels(mocker: MockerFixture):
+    """
+    Test converting a Slack recipient to Slack v2 format raises an error
+    in case it can't find all channels.
+    """
+    mocker.patch(
+        "superset.commands.report.execute.get_channels_with_search",
+        return_value=[
+            {
+                "id": "blah_!channel_2",
+                "name": "Channel 2",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+    )
+    mock_report_schedule = ReportSchedule(
+        name="Test Report",
+        recipients=[
+            ReportRecipients(
+                type=ReportRecipientType.SLACK,
+                recipient_config_json=json.dumps({"target": "Channel 1, Channel 2"}),
+            ),
+        ],
+    )
+
+    mock_cmmd: BaseReportState = BaseReportState(
+        mock_report_schedule, "January 1, 2021", "execution_id_example"
+    )
+    with pytest.raises(UpdateFailedError):
+        mock_cmmd.update_report_schedule_slack_v2()

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -493,13 +493,13 @@ def test_update_recipient_to_slack_v2(mocker: MockerFixture):
         return_value=[
             {
                 "id": "abc124f",
-                "name": "Channel 1",
+                "name": "channel-1",
                 "is_member": True,
                 "is_private": False,
             },
             {
                 "id": "blah_!channel_2",
-                "name": "Channel 2",
+                "name": "Channel_2",
                 "is_member": True,
                 "is_private": False,
             },
@@ -509,7 +509,7 @@ def test_update_recipient_to_slack_v2(mocker: MockerFixture):
         recipients=[
             ReportRecipients(
                 type=ReportRecipientType.SLACK,
-                recipient_config_json=json.dumps({"target": "Channel 1, Channel 2"}),
+                recipient_config_json=json.dumps({"target": "Channel-1, Channel_2"}),
             ),
         ],
     )

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -521,7 +521,7 @@ def test_update_recipient_to_slack_v2(mocker: MockerFixture):
 
     assert (
         mock_cmmd._report_schedule.recipients[0].recipient_config_json
-        == '{"target": "abc124f, blah_!channel_2"}'
+        == '{"target": "abc124f,blah_!channel_2"}'
     )
     assert mock_cmmd._report_schedule.recipients[0].type == ReportRecipientType.SLACKV2
 

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -60,7 +60,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string=[])
+        result = get_channels_with_search(search_string="")
         assert result == [{"name": "general", "id": "C12345"}]
 
     def test_handle_exact_match_search_string_single_channel(self, mocker):
@@ -81,7 +81,7 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call the function with a search string that matches a single channel
-        result = get_channels_with_search(search_string=["general"], exact_match=True)
+        result = get_channels_with_search(search_string="general", exact_match=True)
 
         # Assert that the result is a list with a single channel dictionary
         assert result == [{"name": "general", "id": "C12345"}]
@@ -102,7 +102,7 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string=["general", "random"], exact_match=True
+            search_string="general,random", exact_match=True
         )
         assert result == [
             {"name": "general", "id": "C12345"},
@@ -124,7 +124,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string=["general", "random"])
+        result = get_channels_with_search(search_string="general,random")
         assert result == [
             {"name": "general", "id": "C12345"},
             {"name": "general2", "id": "C13454"},

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -60,7 +60,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="")
+        result = get_channels_with_search(search_string=[])
         assert result == [{"name": "general", "id": "C12345"}]
 
     def test_handle_exact_match_search_string_single_channel(self, mocker):
@@ -81,7 +81,7 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call the function with a search string that matches a single channel
-        result = get_channels_with_search(search_string="general", exact_match=True)
+        result = get_channels_with_search(search_string=["general"], exact_match=True)
 
         # Assert that the result is a list with a single channel dictionary
         assert result == [{"name": "general", "id": "C12345"}]
@@ -102,7 +102,7 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string="general,random", exact_match=True
+            search_string=["general", "random"], exact_match=True
         )
         assert result == [
             {"name": "general", "id": "C12345"},
@@ -124,7 +124,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="general,random")
+        result = get_channels_with_search(search_string=["general", "random"])
         assert result == [
             {"name": "general", "id": "C12345"},
             {"name": "general2", "id": "C13454"},
@@ -153,7 +153,12 @@ The server responded with: missing scope: channels:read"""
     def test_filter_channels_by_specified_types(self, mocker):
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345", "type": "public"},
+                {
+                    "id": "C12345",
+                    "name": "general",
+                    "is_member": False,
+                    "is_private": False,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -164,7 +169,14 @@ The server responded with: missing scope: channels:read"""
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(types=["public"])
-        assert result == [{"name": "general", "id": "C12345", "type": "public"}]
+        assert result == [
+            {
+                "id": "C12345",
+                "name": "general",
+                "is_member": False,
+                "is_private": False,
+            }
+        ]
 
     def test_handle_pagination_multiple_pages(self, mocker):
         mock_data_page1 = {


### PR DESCRIPTION
### SUMMARY
This PR fixes a few things with the Slack method migration from V1 to V2 (required as Slack is fully deprecating `files.upload()` in March):
* `get_channels_with_search` was returning a list of dictionaries (one per channel found) and we were dumping this directly in the `target` configuration for a report. The `target` field expects a comma-separated list of channels IDs for the V2 approach.
* I've added a schema that drops any additional fields from each channels to reduce information (some organizations could have thousands of channels).
* Enforcing `exact_match` search during the migration to avoid for example migrating a report from `other-channel` to `another-channel`.
* Stripping channel names before the search to account for `one-channel, second-channel`. Also removing leading `#` to channel names that were supported with the V1 method.
* Considering that V1 is reaching EOL and won't work anymore, if the bot has the required scopes for the migration to V2 but the migration fails, the execution now fails with an error that should notify owners for manual fix. The channel names are preserved in the form to make the process easier. Before this PR, the execution was logged as `SUCCESS` even though the notification was not sent, so this seems more appropriate.

One known issue is that the V1 integration allowed sending reports as a DM (by using the **Member ID**), and this is no longer possible with V2. The V2 APIs consider a DM as a conversation as well, so the bot would need to parse all Workspace members + public channels + private channels to support this, which would definitely hit the Slack rate limit (20+ requests per minute). We can revisit this once we have a better strategy to avoid rate limits.

Fixes https://github.com/apache/superset/issues/31936

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Report form when the migration failed**
![image](https://github.com/user-attachments/assets/bb669d73-5237-45d0-9f43-e03a8223e2db)

**Execution logs when the migration failed**
![image](https://github.com/user-attachments/assets/50a1bea3-3eed-4da2-9154-8b2a1401c19c)

### TESTING INSTRUCTIONS
Added testing.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/31936
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
