### PR TITLE
fix: clickhouse-connect engine SSH parameter

### DIFF
--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -219,6 +219,10 @@ class ClickHouseParametersSchema(Schema):
         values=fields.Raw(),
         metadata={"description": __("Additional parameters")},
     )
+    ssh = fields.Boolean(
+        required=False,
+        metadata={"description": __("Use an ssh tunnel connection to the database")},
+    )
 
 
 try:
@@ -313,6 +317,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
         if not url_params.get("database"):
             url_params["database"] = "__default__"
         url_params.pop("encryption", None)
+        url_params.pop("ssh", None)
         return str(URL.create(f"{cls.engine}+{cls.default_driver}", **url_params))
 
     @classmethod

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -316,9 +316,18 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
             url_params["query"] = query
         if not url_params.get("database"):
             url_params["database"] = "__default__"
-        url_params.pop("encryption", None)
-        url_params.pop("ssh", None)
-        return str(URL.create(f"{cls.engine}+{cls.default_driver}", **url_params))
+
+        return str(
+            URL.create(
+                f"{cls.engine}+{cls.default_driver}",
+                username=url_params.get("username"),
+                password=url_params.get("password"),
+                host=url_params.get("host"),
+                port=url_params.get("port"),
+                database=url_params.get("database"),
+                query=url_params.get("query"),
+            )
+        )
 
     @classmethod
     def get_parameters_from_uri(


### PR DESCRIPTION
### SUMMARY
This adds the missing SSH parameter to the clickhouse-connect engine. 

Clickhouse engine makes copy of BasicParametersSchema instead of just inheriting from it. Maybe that's not ideal, but I decided to keep it like this and add the SSH parameter as well.

### TESTING INSTRUCTIONS
Add a new clickhouse database (with clickhouse-connect), the SSH option should show up and work.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
  - [x] Fixes #28114
- [x] Required feature flags: Change SSH_TUNNELING to True
- [ ] Changes UI - (not really but the SSH toggle will show up now)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
