### PR TITLE
fix(firebolt): allow backslach escape for single quotes

### DIFF
--- a/superset/sql/dialects/firebolt.py
+++ b/superset/sql/dialects/firebolt.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from sqlglot import exp, generator, parser
+from sqlglot import exp, generator, parser, tokens
 from sqlglot.dialects.dialect import Dialect
 from sqlglot.helper import csv
 from sqlglot.tokens import TokenType
@@ -83,6 +83,9 @@ class FireboltOld(Firebolt):
     The main difference is that `UNNEST` is an operator like `JOIN`, instead of a
     function.
     """
+
+    class Tokenizer(tokens.Tokenizer):
+        STRING_ESCAPES = ["'", "\\"]
 
     class Parser(Firebolt.Parser):
         TABLE_ALIAS_TOKENS = Firebolt.Parser.TABLE_ALIAS_TOKENS - {TokenType.UNNEST}

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1164,3 +1164,24 @@ def test_firebolt_old() -> None:
   *
 FROM t1 UNNEST(col1 AS foo)"""
     )
+
+
+def test_firebolt_old_escape_string() -> None:
+    """
+    Test the dialect for the old Firebolt syntax.
+    """
+    from superset.sql.dialects import FireboltOld
+    from superset.sql.parse import SQLGLOT_DIALECTS
+
+    SQLGLOT_DIALECTS["firebolt"] = FireboltOld
+
+    # both '' and \' are valid escape sequences
+    sql = r"SELECT 'foo''bar', 'foo\'bar'"
+
+    # but they normalize to ''
+    assert (
+        SQLStatement(sql, "firebolt").format()
+        == """SELECT
+  'foo''bar',
+  'foo''bar'"""
+    )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix for the Firebolt dialect (old), which accepts `\'` for escaping single quotes, meaning both are valid:

```sql
SELECT 'She''s my inspiration';
SELECT 'She\'s my inspiration';
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added a test.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
