### PR TITLE
fix(backend/async_events): allow user to configure username for Redis authentication in GLOBAL_ASYNC_QUERIES_CACHE_BACKEND

### DIFF
--- a/superset/async_events/cache_backend.py
+++ b/superset/async_events/cache_backend.py
@@ -97,7 +97,7 @@ class RedisCacheBackend(RedisCache):
         }
 
         # Handle username separately as it's optional for Redis authentication.
-        if configured_username := config.get("CACHE_REDIS_USER", ""):
+        if configured_username := config.get("CACHE_REDIS_USER"):
             kwargs["username"] = configured_username
 
         return cls(**kwargs)

--- a/superset/async_events/cache_backend.py
+++ b/superset/async_events/cache_backend.py
@@ -95,6 +95,10 @@ class RedisCacheBackend(RedisCache):
             "ssl_cert_reqs": config.get("CACHE_REDIS_SSL_CERT_REQS", "required"),
             "ssl_ca_certs": config.get("CACHE_REDIS_SSL_CA_CERTS", None),
         }
+
+        if configured_username := config.get("CACHE_REDIS_USER", ""):
+            kwargs["username"] = configured_username
+
         return cls(**kwargs)
 
 

--- a/superset/async_events/cache_backend.py
+++ b/superset/async_events/cache_backend.py
@@ -96,6 +96,7 @@ class RedisCacheBackend(RedisCache):
             "ssl_ca_certs": config.get("CACHE_REDIS_SSL_CA_CERTS", None),
         }
 
+        # Handle username separately as it's optional for Redis authentication.
         if configured_username := config.get("CACHE_REDIS_USER", ""):
             kwargs["username"] = configured_username
 


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Fixes #32353

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`redis-py` can accept [username](https://redis-py.readthedocs.io/en/stable/connections.html) used for authentication. This PR is to restore that functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
