### PR TITLE
fix: ephemeral CI fetching task ENI

### DIFF
--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Get network interface
         id: get-eni
         run: |
-          echo "eni=$(aws ecs describe-tasks --cluster superset-ci --tasks ${{ steps.list-tasks.outputs.task }} | jq '.tasks[0].attachments[0].details | map(select(.name==\"networkInterfaceId\"))[0].value')" >> $GITHUB_OUTPUT
+          echo "eni=$(aws ecs describe-tasks --cluster superset-ci --tasks ${{ steps.list-tasks.outputs.task }} | jq '.tasks[0].attachments[0].details | map(select(.name=="networkInterfaceId"))[0].value')" >> $GITHUB_OUTPUT
       - name: Get public IP
         id: get-ip
         run: |


### PR DESCRIPTION
### SUMMARY

Ephemeral env CI's is silently failing with:
```
Run echo "eni=$(aws ecs describe-tasks --cluster superset-ci --tasks "arn:aws:ecs:us-west-2:627197447938:task/superset-ci/94968e7ca06949c38960c3ef7ae1020c" | jq '.tasks[0].attachments[0].details | map(select(.name==\"networkInterfaceId\"))[0].value')" >> $GITHUB_OUTPUT
  echo "eni=$(aws ecs describe-tasks --cluster superset-ci --tasks "arn:aws:ecs:us-west-[2](https://github.com/apache/superset/actions/runs/13520809119/job/37779934056#step:13:2):627197447938:task/superset-ci/94968e7ca06949c38960c3ef7ae1020c" | jq '.tasks[0].attachments[0].details | map(select(.name==\"networkInterfaceId\"))[0].value')" >> $GITHUB_OUTPUT
jq: error: syntax error, unexpected INVALID_CHARACTER (Unix shell quoting issues?) at <top-level>, line 1:
.tasks[0].attachments[0].details | map(select(.name==\"networkInterfaceId\"))[0].value
```


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
