### PR TITLE
docs(intro): broaden link to installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Want to add support for your datastore or data engine? Read more [here](https://
 
 ## Installation and Configuration
 
-[Extended documentation for Superset](https://superset.apache.org/docs/installation/docker-compose)
+Try out Superset's [quickstart](https://superset.apache.org/docs/quickstart/) guide or learn about [the options for production deployments](https://superset.apache.org/docs/installation/architecture/).
 
 ## Get Involved
 


### PR DESCRIPTION
### SUMMARY
This page currently sends users directly to docker compose to install, where they are greeted by warnings. Instead this will send them to either the quickstart page (which uses docker) or to the first page to learn about production installs.

### TESTING INSTRUCTIONS
I viewed the page in preview mode. Click the links to make sure they work.
