### PR TITLE
fix(daos/tag): prevent non-unique tags getting created along with unique ones

### DIFF
--- a/superset/daos/tag.py
+++ b/superset/daos/tag.py
@@ -57,9 +57,6 @@ class TagDAO(BaseDAO[Tag]):
         for name in clean_tag_names:
             type_ = TagType.custom
             tag = TagDAO.get_by_name(name, type_)
-            tagged_objects.append(
-                TaggedObject(object_id=object_id, object_type=object_type, tag=tag)
-            )
 
             # Check if the association already exists
             existing_tagged_object = (

--- a/tests/integration_tests/tags/dao_tests.py
+++ b/tests/integration_tests/tags/dao_tests.py
@@ -146,6 +146,15 @@ class TestTagsDAO(SupersetTestCase):
         # check if tag exists
         assert db.session.query(Tag).filter(Tag.name == "example tag 1").first()
 
+        # test that a combination of non-unique and unique tags
+        # can be added.
+        TagDAO.create_custom_tagged_objects(
+            object_type=ObjectType.dashboard.name,
+            object_id=1,
+            tag_names=["example tag 1", "example tag 2"],
+        )
+        assert db.session.query(Tag).filter(Tag.name == "example tag 2").first()
+
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @pytest.mark.usefixtures("with_tagging_system_feature")
     @pytest.mark.usefixtures("create_tags")


### PR DESCRIPTION


<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(daos/tag): prevent non-unique tags getting created along with unique ones

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #30895

Unconditionally add a tag object before checking its uniqueness can fail the API call with payload combining non-unique and unique tags. This PR is to fix it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Unit test extended.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
