### PR TITLE
fix(security): bind  SavedQueryView list permission to read permission

### DIFF
--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -20,8 +20,8 @@ under the License.
 |                                                  |Admin|Alpha|Gamma|SQL_LAB|
 |--------------------------------------------------|---|---|---|---|
 | Permission/role description                      |Admins have all possible rights, including granting or revoking rights from other users and altering other people’s slices and dashboards.|Alpha users have access to all data sources, but they cannot grant or revoke access from other users. They are also limited to altering the objects that they own. Alpha users can add and alter data sources.|Gamma users have limited access. They can only consume data coming from data sources they have been given access to through another complementary role. They only have access to view the slices and dashboards made from data sources that they have access to. Currently Gamma users are not able to alter or add data sources. We assume that they are mostly content consumers, though they can create slices and dashboards.|The sql_lab role grants access to SQL Lab. Note that while Admin users have access to all databases by default, both Alpha and Gamma users need to be given access on a per database basis.||
-| can read on SavedQuery                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can write on SavedQuery                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| can read on SavedQuery                           |:heavy_check_mark:|O|O|:heavy_check_mark:|
+| can write on SavedQuery                          |:heavy_check_mark:|O|O|:heavy_check_mark:|
 | can read on CssTemplate                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can write on CssTemplate                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can read on ReportSchedule                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
@@ -191,7 +191,7 @@ under the License.
 | can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can export on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can import on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on SavedQuery                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| can export on SavedQuery                         |:heavy_check_mark:|O|O|:heavy_check_mark:|
 | can dashboard permalink on Superset              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can grant guest token on SecurityRestApi         |:heavy_check_mark:|O|O|O|
 | can read on AdvancedDataType                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|

--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -191,7 +191,7 @@ under the License.
 | can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can export on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can import on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on SavedQuery                         |:heavy_check_mark:|O|O|:heavy_check_mark:|
+| can export on SavedQuery                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 | can dashboard permalink on Superset              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can grant guest token on SecurityRestApi         |:heavy_check_mark:|O|O|O|
 | can read on AdvancedDataType                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -18,7 +18,7 @@
 import logging
 
 from flask import request, Response
-from flask_appbuilder import expose
+from flask_appbuilder import expose, permission_name
 from flask_appbuilder.security.decorators import has_access, has_access_api
 from flask_babel import gettext as __
 from sqlalchemy import and_
@@ -43,6 +43,7 @@ class SavedQueryView(BaseSupersetView):
 
     @expose("/list/")
     @has_access
+    @permission_name("read")
     def list(self) -> FlaskResponse:
         return super().render_app_template()
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The  `SavedQuery` View has mostly migrated to `read` and `write` permission
This migration [superset/migrations/versions/2020-11-20_14-24_e38177dbf641_security_converge_saved_queries.py](https://github.com/apache/superset/blob/master/superset/migrations/versions/2020-11-20_14-24_e38177dbf641_security_converge_saved_queries.py)  has moved the `list` permission to `read`. However, the views still bind to `list` permission, causing permission lacking if user access that view directly through the link instead of navigating through SPA.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
