### PR TITLE
fix(clickhouse): get_parameters_from_uri failing when secure is true

### DIFF
--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -334,9 +334,9 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
         cls, uri: str, encrypted_extra: dict[str, Any] | None = None
     ) -> BasicParametersType:
         url = make_url_safe(uri)
-        query = url.query
+        query = dict(url.query)
         if "secure" in query:
-            encryption = url.query.get("secure") == "true"
+            encryption = query == "true"
             query.pop("secure")
         else:
             encryption = False
@@ -346,7 +346,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
             host=url.host,
             port=url.port,
             database="" if url.database == "__default__" else cast(str, url.database),
-            query=dict(query),
+            query=query,
             encryption=encryption,
         )
 

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -336,7 +336,7 @@ class ClickHouseConnectEngineSpec(BasicParametersMixin, ClickHouseEngineSpec):
         url = make_url_safe(uri)
         query = dict(url.query)
         if "secure" in query:
-            encryption = query == "true"
+            encryption = query.get("secure") == "true"
             query.pop("secure")
         else:
             encryption = False


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`url = make_url_safe(uri)` return an object where `url.query` is an immutable dict causing the pop action to failed when `secure` is defined. This makes the Edit database modal to be empty due to empty returned `parameters`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
![image](https://github.com/user-attachments/assets/cefd98fc-0222-4848-bb3a-02045e06b22b)

AFTER: 
![image](https://github.com/user-attachments/assets/3e9b8f0b-a06a-4397-a8f7-5be439129eda)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
