### PR TITLE
feat(Chart): Add Column-Based Coloring Feature with Optional Header & Total Row

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -110,6 +110,7 @@
         "react-ace": "^10.1.0",
         "react-checkbox-tree": "^1.8.0",
         "react-color": "^2.13.8",
+        "react-colorful": "^5.6.1",
         "react-diff-viewer-continued": "^3.4.0",
         "react-dnd": "^11.1.3",
         "react-dnd-html5-backend": "^11.1.3",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -177,6 +177,7 @@
     "react-ace": "^10.1.0",
     "react-checkbox-tree": "^1.8.0",
     "react-color": "^2.13.8",
+    "react-colorful": "^5.6.1",
     "react-diff-viewer-continued": "^3.4.0",
     "react-dnd": "^11.1.3",
     "react-dnd-html5-backend": "^11.1.3",

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -443,7 +443,7 @@ export type SectionOverrides = {
 };
 
 // Ref:
-//  - superset-frontend/src/explore/components/ConditionalFormattingControl.tsx
+//  - superset-frontend/src/explore/components/ColumnColoringControl.tsx
 export enum Comparator {
   None = 'None',
   GreaterThan = '>',
@@ -472,6 +472,11 @@ export type ConditionalFormattingConfig = {
   targetValueRight?: number;
   column?: string;
   colorScheme?: string;
+};
+
+export type ColumnColoringConfig = {
+  column: string;
+  colorScheme: string;
 };
 
 export type ColorFormatters = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -22,6 +22,7 @@ import {
   ColorFormatters,
   Comparator,
   ConditionalFormattingConfig,
+  ColumnColoringConfig,
   MultipleValueComparators,
 } from '../types';
 
@@ -211,6 +212,22 @@ export const getColorFormatters = memoizeOne(
               data.map(row => row[config.column!] as number),
               alpha,
             ),
+          });
+        }
+        return acc;
+      },
+      [],
+    ) ?? [],
+);
+
+export const getColorColumns = memoizeOne(
+  (columnConfig: ColumnColoringConfig[] | undefined) =>
+    columnConfig?.reduce(
+      (acc: ColorFormatters, config: ColumnColoringConfig) => {
+        if (config?.column !== undefined && config?.colorScheme !== undefined) {
+          acc.push({
+            column: config.column,
+            getColorFromValue: () => config.colorScheme,
           });
         }
         return acc;

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -151,10 +151,12 @@ export default function PivotTableChart(props: PivotTableProps) {
     currencyFormats,
     metricsLayout,
     metricColorFormatters,
+    columnColorFormatters,
     dateFormatters,
     onContextMenu,
     timeGrainSqla,
     allowRenderHtml,
+    colorHeadersTotals,
   } = props;
 
   const theme = useTheme();
@@ -446,6 +448,8 @@ export default function PivotTableChart(props: PivotTableProps) {
       omittedHighlightHeaderGroups: [METRIC_KEY],
       cellColorFormatters: { [METRIC_KEY]: metricColorFormatters },
       dateFormatters,
+      columnColorFormatters,
+      colorHeadersTotals,
     }),
     [
       colTotals,
@@ -453,10 +457,12 @@ export default function PivotTableChart(props: PivotTableProps) {
       dateFormatters,
       emitCrossFilters,
       metricColorFormatters,
+      columnColorFormatters,
       rowTotals,
       rowSubTotals,
       selectedFilters,
       toggleFilter,
+      colorHeadersTotals,
     ],
   );
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/controlPanel.tsx
@@ -447,6 +447,60 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'column_coloring',
+            config: {
+              type: 'ColumnColoringControl',
+              renderTrigger: true,
+              label: t('Column coloring'),
+              description: t(
+                'Apply a fixed color to a selected column without conditions',
+              ),
+              mapStateToProps(explore, _, chart) {
+                const values =
+                  (explore?.controls?.metrics?.value as QueryFormMetric[]) ??
+                  [];
+                const verboseMap = explore?.datasource?.hasOwnProperty(
+                  'verbose_map',
+                )
+                  ? (explore?.datasource as Dataset)?.verbose_map
+                  : (explore?.datasource?.columns ?? {});
+                const chartStatus = chart?.chartStatus;
+                const metricColumn = values.map(value => {
+                  if (typeof value === 'string') {
+                    return {
+                      value,
+                      label: Array.isArray(verboseMap)
+                        ? value
+                        : verboseMap[value],
+                    };
+                  }
+                  return { value: value.label, label: value.label };
+                });
+                return {
+                  removeIrrelevantConditions: chartStatus === 'success',
+                  columnOptions: metricColumn,
+                  verboseMap,
+                };
+              },
+            },
+          },
+        ],
+        [
+          {
+            name: 'color_headers_totals',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Apply color to headers & total rows'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'If enabled, the selected color in "Column Coloring" will also be applied to the headers and total row.',
+              ),
+            },
+          },
+        ],
       ],
     },
   ],

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -27,7 +27,10 @@ import {
   SMART_DATE_ID,
   TimeFormats,
 } from '@superset-ui/core';
-import { getColorFormatters } from '@superset-ui/chart-controls';
+import {
+  getColorFormatters,
+  getColorColumns,
+} from '@superset-ui/chart-controls';
 import { DateFormatter } from '../types';
 
 const { DATABASE_DATETIME } = TimeFormats;
@@ -103,10 +106,13 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     dateFormat,
     metricsLayout,
     conditionalFormatting,
+    columnColoring,
     timeGrainSqla,
     currencyFormat,
     allowRenderHtml,
+    colorHeadersTotals,
   } = formData;
+
   const { selectedFilters } = filterState;
   const granularity = extractTimegrain(rawFormData);
 
@@ -142,6 +148,7 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
       {},
     );
   const metricColorFormatters = getColorFormatters(conditionalFormatting, data);
+  const columnColorFormatters = getColorColumns(columnColoring);
 
   return {
     width,
@@ -172,9 +179,11 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     currencyFormats,
     metricsLayout,
     metricColorFormatters,
+    columnColorFormatters,
     dateFormatters,
     onContextMenu,
     timeGrainSqla,
     allowRenderHtml,
+    colorHeadersTotals,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -65,6 +65,16 @@ function displayHeaderCell(
   );
 }
 
+const isColorDark = hexColor => {
+  if (!hexColor || typeof hexColor !== 'string') return false;
+  const color = hexColor.replace('#', '');
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+
+  return brightness < 160;
+};
 export class TableRenderer extends Component {
   constructor(props) {
     super(props);
@@ -343,8 +353,6 @@ export class TableRenderer extends Component {
   }
 
   renderColHeaderRow(attrName, attrIdx, pivotSettings) {
-    // Render a single row in the column header at the top of the pivot table.
-
     const {
       rowAttrs,
       colAttrs,
@@ -365,6 +373,8 @@ export class TableRenderer extends Component {
       omittedHighlightHeaderGroups = [],
       highlightedHeaderCells,
       dateFormatters,
+      columnColorFormatters,
+      colorHeadersTotals,
     } = this.props.tableOptions;
 
     const spaceCell =
@@ -400,16 +410,15 @@ export class TableRenderer extends Component {
         )}
       </th>
     );
-
     const attrValueCells = [];
     const rowIncrSpan = rowAttrs.length !== 0 ? 1 : 0;
-    // Iterate through columns. Jump over duplicate values.
     let i = 0;
     while (i < visibleColKeys.length) {
       let handleContextMenu;
       const colKey = visibleColKeys[i];
       const colSpan = attrIdx < colKey.length ? colAttrSpans[i][attrIdx] : 1;
       let colLabelClass = 'pvtColLabel';
+
       if (attrIdx < colKey.length) {
         if (!omittedHighlightHeaderGroups.includes(colAttrs[attrIdx])) {
           if (highlightHeaderCellsOnHover) {
@@ -432,12 +441,28 @@ export class TableRenderer extends Component {
         const flatColKey = flatKey(colKey.slice(0, attrIdx + 1));
         const onArrowClick = needToggle ? this.toggleColKey(flatColKey) : null;
 
+        let headerBackgroundColor;
+        let headerTextColor;
+        const columnName = colKey.join(' ');
+
+        if (colorHeadersTotals) {
+          columnColorFormatters.forEach(formatter => {
+            if (formatter.column === columnName) {
+              headerBackgroundColor = formatter.getColorFromValue();
+              headerTextColor = isColorDark(headerBackgroundColor)
+                ? '#FFFFFF'
+                : undefined;
+            }
+          });
+        }
+
         const headerCellFormattedValue =
           dateFormatters &&
           dateFormatters[attrName] &&
           typeof dateFormatters[attrName] === 'function'
             ? dateFormatters[attrName](colKey[attrIdx])
             : colKey[attrIdx];
+
         attrValueCells.push(
           <th
             className={colLabelClass}
@@ -453,6 +478,12 @@ export class TableRenderer extends Component {
               this.props.tableOptions.clickColumnHeaderCallback,
             )}
             onContextMenu={handleContextMenu}
+            style={{
+              backgroundColor: headerBackgroundColor
+                ? headerBackgroundColor
+                : undefined,
+              color: headerTextColor ? headerTextColor : undefined,
+            }}
           >
             {displayHeaderCell(
               needToggle,
@@ -488,7 +519,6 @@ export class TableRenderer extends Component {
           </th>,
         );
       }
-      // The next colSpan columns will have the same value anyway...
       i += colSpan;
     }
 
@@ -610,6 +640,7 @@ export class TableRenderer extends Component {
       omittedHighlightHeaderGroups = [],
       highlightedHeaderCells,
       cellColorFormatters,
+      columnColorFormatters,
       dateFormatters,
     } = this.props.tableOptions;
     const flatRowKey = flatKey(rowKey);
@@ -729,9 +760,20 @@ export class TableRenderer extends Component {
         });
       }
 
-      const style = agg.isSubtotal
-        ? { fontWeight: 'bold' }
-        : { backgroundColor };
+      if (!backgroundColor && columnColorFormatters) {
+        const columnName = colKey.join(' ');
+        columnColorFormatters.forEach(formatter => {
+          if (formatter.column === columnName) {
+            backgroundColor = formatter.getColorFromValue();
+          }
+        });
+      }
+
+      const style = {
+        backgroundColor,
+        color: isColorDark(backgroundColor) ? '#FFFFFF' : undefined,
+        fontWeight: agg.isSubtotal ? 'bold' : 'normal',
+      };
 
       return (
         <td
@@ -776,7 +818,6 @@ export class TableRenderer extends Component {
 
   renderTotalsRow(pivotSettings) {
     // Render the final totals rows that has the totals for all the columns.
-
     const {
       rowAttrs,
       colAttrs,
@@ -786,6 +827,9 @@ export class TableRenderer extends Component {
       colTotalCallbacks,
       grandTotalCallback,
     } = pivotSettings;
+
+    const { columnColorFormatters, colorHeadersTotals } =
+      this.props.tableOptions;
 
     const totalLabelCell = (
       <th
@@ -813,6 +857,21 @@ export class TableRenderer extends Component {
       const flatColKey = flatKey(colKey);
       const agg = pivotData.getAggregator([], colKey);
       const aggValue = agg.value();
+      const columnName = colKey.join(' ');
+
+      let totalBackgroundColor;
+      let totalTextColor;
+
+      if (colorHeadersTotals) {
+        columnColorFormatters.forEach(formatter => {
+          if (formatter.column === columnName) {
+            totalBackgroundColor = formatter.getColorFromValue();
+            totalTextColor = isColorDark(totalBackgroundColor)
+              ? '#FFFFFF'
+              : undefined;
+          }
+        });
+      }
 
       return (
         <td
@@ -821,7 +880,11 @@ export class TableRenderer extends Component {
           key={`total-${flatColKey}`}
           onClick={colTotalCallbacks[flatColKey]}
           onContextMenu={e => this.props.onContextMenu(e, colKey, undefined)}
-          style={{ padding: '5px' }}
+          style={{
+            padding: '5px',
+            backgroundColor: totalBackgroundColor,
+            color: totalTextColor,
+          }}
         >
           {agg.format(aggValue)}
         </td>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
@@ -76,6 +76,7 @@ interface PivotTableCustomizeProps {
   currencyFormats: Record<string, Currency>;
   metricsLayout?: MetricsLayoutEnum;
   metricColorFormatters: ColorFormatters;
+  columnColorFormatters: ColorFormatters;
   dateFormatters: Record<string, DateFormatter | undefined>;
   legacy_order_by: QueryFormMetric[] | QueryFormMetric | null;
   order_desc: boolean;
@@ -88,6 +89,7 @@ interface PivotTableCustomizeProps {
   time_grain_sqla?: TimeGranularity;
   granularity_sqla?: string;
   allowRenderHtml?: boolean;
+  colorHeadersTotals?: boolean;
 }
 
 export type PivotTableQueryFormData = QueryFormData &

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -46,6 +46,7 @@ const formData: PivotTableQueryFormData = {
   columnFormats: {},
   currencyFormats: {},
   metricColorFormatters: [],
+  columnColorFormatters: [],
   dateFormatters: {},
   setDataMask: () => {},
   legacy_order_by: 'count',

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -702,7 +702,7 @@ const config: ControlPanelConfig = {
           {
             name: 'conditional_formatting',
             config: {
-              type: 'ConditionalFormattingControl',
+              type: 'ColumnColoringControl',
               renderTrigger: true,
               label: t('Custom Conditional Formatting'),
               extraColorChoices: [

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopover.tsx
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useState } from 'react';
+import Popover from 'src/components/Popover';
+import { ColoringPopoverContent } from './ColoringPopoverContent';
+import { ColumnColoringConfig, ColoringPopoverProps } from './types';
+
+export const ColoringPopover = ({
+  title,
+  columns,
+  onChange,
+  config,
+  children,
+  extraColorChoices,
+  ...props
+}: ColoringPopoverProps) => {
+  const [visible, setVisible] = useState(false);
+
+  const handleSave = useCallback(
+    (newConfig: ColumnColoringConfig) => {
+      setVisible(false);
+      onChange(newConfig);
+    },
+    [onChange],
+  );
+
+  return (
+    <Popover
+      title={title}
+      content={
+        <ColoringPopoverContent
+          onChange={handleSave}
+          config={config}
+          columns={columns}
+        />
+      }
+      open={visible}
+      onOpenChange={setVisible}
+      trigger={['click']}
+      overlayStyle={{ width: '450px' }}
+      {...props}
+    >
+      {children}
+    </Popover>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopoverContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopoverContent.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import { Comparator } from '@superset-ui/chart-controls';
+import { ColorSchemeEnum } from '@superset-ui/plugin-chart-table';
+import { ColoringPopoverContent } from './ColoringPopoverContent';
+
+const mockOnChange = jest.fn();
+
+const columns = [
+  { label: 'Column 1', value: 'column1' },
+  { label: 'Column 2', value: 'column2' },
+];
+
+test('renders ColoringPopoverContent component', () => {
+  render(<ColoringPopoverContent onChange={mockOnChange} columns={columns} />);
+
+  // Assert that the component renders correctly
+  expect(screen.getByLabelText('Column')).toBeInTheDocument();
+  expect(screen.getAllByLabelText('Color scheme')).toHaveLength(2);
+  expect(screen.getAllByLabelText('Operator')).toHaveLength(2);
+  expect(screen.queryByLabelText('Left value')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Right value')).not.toBeInTheDocument();
+  expect(screen.getByText('Apply')).toBeInTheDocument();
+});
+
+test('calls onChange when Apply button is clicked', async () => {
+  render(<ColoringPopoverContent onChange={mockOnChange} columns={columns} />);
+
+  // Simulate user interaction by clicking the Apply button
+  fireEvent.click(screen.getByText('Apply'));
+
+  // Assert that the onChange function is called with the correct config
+  await waitFor(() => {
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+});
+
+test('renders the correct input fields based on the selected operator', async () => {
+  render(<ColoringPopoverContent onChange={mockOnChange} columns={columns} />);
+
+  // Select the 'Between' operator
+  fireEvent.change(screen.getAllByLabelText('Operator')[0], {
+    target: { value: Comparator.Between },
+  });
+  fireEvent.click(await screen.findByTitle('< x <'));
+
+  // Assert that the left and right value inputs are rendered
+  expect(await screen.findByLabelText('Left value')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Right value')).toBeInTheDocument();
+});
+
+test('renders None for operator when Green for increase is selected', async () => {
+  render(<ColoringPopoverContent onChange={mockOnChange} columns={columns} />);
+
+  // Select the 'Green for increase' color scheme
+  fireEvent.change(screen.getAllByLabelText(/color scheme/i)[0], {
+    target: { value: ColorSchemeEnum.Green },
+  });
+
+  fireEvent.click(await screen.findByTitle(/green for increase/i));
+
+  // Assert that the operator is set to 'None'
+  expect(screen.getByText(/none/i)).toBeInTheDocument();
+});

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColoringPopoverContent.tsx
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState } from 'react';
+import { styled, t } from '@superset-ui/core';
+import { Form, FormItem } from 'src/components/Form';
+import { Input } from 'src/components/Input';
+import Select from 'src/components/Select/Select';
+import { Col, Row } from 'src/components';
+import Button from 'src/components/Button';
+import { HexColorPicker } from 'react-colorful';
+import { ColumnColoringConfig } from './types';
+
+const JustifyEnd = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const rulesRequired = [{ required: true, message: t('Required') }];
+
+export const ColoringPopoverContent = ({
+  config,
+  onChange,
+  columns = [],
+}: {
+  config?: ColumnColoringConfig;
+  onChange: (config: ColumnColoringConfig) => void;
+  columns: { label: string; value: string }[];
+}) => {
+  const [selectedColumn, setSelectedColumn] = useState(
+    config?.column || columns[0]?.value || '',
+  );
+  const [selectedColor, setSelectedColor] = useState(
+    config?.colorScheme ?? '#FFFFFF',
+  );
+
+  const handleValidate = () => {
+    onChange({ column: selectedColumn, colorScheme: selectedColor });
+  };
+
+  return (
+    <Form requiredMark="optional" layout="vertical">
+      <Row gutter={12}>
+        <Col span={12}>
+          <FormItem
+            name="column"
+            label={t('Column')}
+            rules={rulesRequired}
+            initialValue={config?.column || columns[0]?.value}
+          >
+            <Select
+              ariaLabel={t('Select column')}
+              options={columns}
+              value={selectedColumn}
+              onChange={(value: string | number) =>
+                setSelectedColumn(value.toString())
+              }
+            />
+          </FormItem>
+          <FormItem name="color" label={t('Color')}>
+            <div className="color-picker-wrapper">
+              <Input
+                type="text"
+                value={selectedColor}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setSelectedColor(e.target.value)
+                }
+                placeholder="#FFFFFF"
+                allowClear
+              />
+            </div>
+          </FormItem>
+        </Col>
+        <Col span={12}>
+          <HexColorPicker
+            color={selectedColor}
+            onChange={setSelectedColor}
+            style={{ height: '133px' }}
+          />
+        </Col>
+      </Row>
+      <FormItem>
+        <JustifyEnd>
+          <Button buttonStyle="primary" onClick={handleValidate}>
+            {t('Apply')}
+          </Button>
+        </JustifyEnd>
+      </FormItem>
+    </Form>
+  );
+};

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColumnColoringControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColumnColoringControl.tsx
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect, useState } from 'react';
+import { styled, css, t, useTheme } from '@superset-ui/core';
+import Icons from 'src/components/Icons';
+import ControlHeader from 'src/explore/components/ControlHeader';
+import { ColoringPopover } from './ColoringPopover';
+import { ColumnColoringConfig, ColumnColoringControlProps } from './types';
+import {
+  AddControlLabel,
+  CaretContainer,
+  Label,
+  OptionControlContainer,
+} from '../OptionControls';
+import { ConditionalFormattingConfig } from '../ConditionalFormattingControl';
+
+const FormattersContainer = styled.div`
+  ${({ theme }) => css`
+    padding: ${theme.gridUnit}px;
+    border: solid 1px ${theme.colors.grayscale.light2};
+    border-radius: ${theme.gridUnit}px;
+  `}
+`;
+
+export const FormatterContainer = styled(OptionControlContainer)`
+  &,
+  & > div {
+    margin-bottom: ${({ theme }) => theme.gridUnit}px;
+    :last-child {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+export const CloseButton = styled.button`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.light1};
+    height: 100%;
+    width: ${theme.gridUnit * 6}px;
+    border: none;
+    border-right: solid 1px ${theme.colors.grayscale.dark2}0C;
+    padding: 0;
+    outline: none;
+    border-bottom-left-radius: 3px;
+    border-top-left-radius: 3px;
+  `}
+`;
+
+const ColumnColoringControl = ({
+  value,
+  onChange,
+  columnOptions,
+  verboseMap,
+  removeIrrelevantConditions,
+  extraColorChoices,
+  ...props
+}: ColumnColoringControlProps) => {
+  const theme = useTheme();
+  const [columnColoringConfigs, setColumnColoringConfigs] = useState<
+    ColumnColoringConfig[]
+  >(value ?? []);
+
+  useEffect(() => {
+    if (onChange) {
+      onChange(columnColoringConfigs);
+    }
+  }, [columnColoringConfigs, onChange]);
+
+  useEffect(() => {
+    if (removeIrrelevantConditions) {
+      // remove formatter when corresponding column is removed from controls
+      const newColoringConfigs = columnColoringConfigs.filter(config =>
+        columnOptions.some((option: any) => option?.value === config?.column),
+      );
+      if (
+        newColoringConfigs.length !== columnColoringConfigs.length &&
+        removeIrrelevantConditions
+      ) {
+        setColumnColoringConfigs(newColoringConfigs);
+      }
+    }
+  }, [columnColoringConfigs, columnOptions, removeIrrelevantConditions]);
+
+  const onDelete = (index: number) => {
+    setColumnColoringConfigs(prevConfigs =>
+      prevConfigs.filter((_, i) => i !== index),
+    );
+  };
+
+  const onSave = (config: ConditionalFormattingConfig) => {
+    setColumnColoringConfigs(prevConfigs => [...prevConfigs, config]);
+  };
+
+  const onEdit = (newConfig: ConditionalFormattingConfig, index: number) => {
+    const newConfigs = [...columnColoringConfigs];
+    newConfigs.splice(index, 1, newConfig);
+    setColumnColoringConfigs(newConfigs);
+  };
+
+  const createLabel = ({ column }: ColumnColoringConfig) => {
+    const columnName = (column && verboseMap?.[column]) ?? column;
+    return `${columnName}`;
+  };
+
+  return (
+    <div>
+      <ControlHeader {...props} />
+      <FormattersContainer>
+        {columnColoringConfigs.map((config, index) => (
+          <FormatterContainer key={index}>
+            <CloseButton onClick={() => onDelete(index)}>
+              <Icons.XSmall iconColor={theme.colors.grayscale.light1} />
+            </CloseButton>
+            <ColoringPopover
+              title={t('Edit color')}
+              config={config}
+              columns={columnOptions}
+              onChange={(newConfig: ColumnColoringConfig) =>
+                onEdit(newConfig, index)
+              }
+              destroyTooltipOnHide
+              extraColorChoices={extraColorChoices}
+            >
+              <OptionControlContainer withCaret>
+                <Label>{createLabel(config)}</Label>
+                <CaretContainer>
+                  <Icons.CaretRight iconColor={theme.colors.grayscale.light1} />
+                </CaretContainer>
+              </OptionControlContainer>
+            </ColoringPopover>
+          </FormatterContainer>
+        ))}
+        <ColoringPopover
+          title={t('Add new color')}
+          columns={columnOptions}
+          onChange={onSave}
+          destroyTooltipOnHide
+          extraColorChoices={extraColorChoices}
+        >
+          <AddControlLabel>
+            <Icons.PlusSmall iconColor={theme.colors.grayscale.light1} />
+            {t('Add new column color')}
+          </AddControlLabel>
+        </ColoringPopover>
+      </FormattersContainer>
+    </div>
+  );
+};
+
+export default ColumnColoringControl;

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColumnColoringControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/ColumnColoringControl.tsx
@@ -18,7 +18,7 @@
  */
 import { useEffect, useState } from 'react';
 import { styled, css, t, useTheme } from '@superset-ui/core';
-import Icons from 'src/components/Icons';
+import { Icons } from 'src/components/Icons';
 import ControlHeader from 'src/explore/components/ControlHeader';
 import { ColoringPopover } from './ColoringPopover';
 import { ColumnColoringConfig, ColumnColoringControlProps } from './types';

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/index.ts
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import ColumnColoringControl from './ColumnColoringControl';
+
+export * from './types';
+export default ColumnColoringControl;

--- a/superset-frontend/src/explore/components/controls/ColumnColoringControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ColumnColoringControl/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ReactNode } from 'react';
+import { PopoverProps } from 'src/components/Popover';
+import { ControlComponentProps } from '@superset-ui/chart-controls';
+
+export type ColumnColoringConfig = {
+  column?: string;
+  colorScheme?: string;
+};
+
+export type ColumnColoringControlProps = ControlComponentProps<
+  ColumnColoringConfig[]
+> & {
+  columnOptions: { label: string; value: string }[];
+  removeIrrelevantConditions: boolean;
+  verboseMap: Record<string, string>;
+  label: string;
+  description: string;
+  extraColorChoices?: { label: string; value: string }[];
+};
+
+export type ColoringPopoverProps = PopoverProps & {
+  columns: { label: string; value: string }[];
+  onChange: (value: ColumnColoringConfig) => void;
+  config?: ColumnColoringConfig;
+  title: string;
+  children: ReactNode;
+  extraColorChoices?: { label: string; value: string }[];
+};

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -40,6 +40,7 @@ import VizTypeControl from './VizTypeControl';
 import MetricsControl from './MetricControl/MetricsControl';
 import AdhocFilterControl from './FilterControl/AdhocFilterControl';
 import ConditionalFormattingControl from './ConditionalFormattingControl';
+import ColumnColoringControl from './ColumnColoringControl';
 import ContourControl from './ContourControl';
 import DndColumnSelectControl, {
   DndColumnSelect,
@@ -86,6 +87,7 @@ const controlMap = {
   MetricsControl,
   AdhocFilterControl,
   ConditionalFormattingControl,
+  ColumnColoringControl,
   XAxisSortControl,
   ContourControl,
   ComparisonRangeLabel,


### PR DESCRIPTION
### SUMMARY
Implemented a new Column Coloring feature that allows users to apply fixed background colors to selected metric columns in the Pivot Table.
Integrated a color picker for enhanced usability.
Added an optional "Apply color to headers & total rows" checkbox to extend the column coloring to headers and total cells.
Ensured seamless integration with existing Conditional Formatting, preserving its functionality.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Capture d’écran 2025-02-28 à 15 21 42](https://github.com/user-attachments/assets/6dc5ff4f-50c0-4524-8872-ea1f4a722105)

![Capture d’écran 2025-02-28 à 15 21 54](https://github.com/user-attachments/assets/f77f2aff-4e32-4a7f-9c1e-5340fcca6531)

![Capture d’écran 2025-02-28 à 15 22 14](https://github.com/user-attachments/assets/cd0f1b62-7119-4195-8a4b-cf65010d2a59)

![Capture d’écran 2025-02-28 à 15 22 23](https://github.com/user-attachments/assets/0487d5fa-a323-40cb-9556-d98a8ebd56b1)



### TESTING INSTRUCTIONS
In the Customization tab, locate the Column Coloring section.
Click "Add new color formatter".
Select a Metric column from the dropdown.
Pick a color using the color picker or manually enter a HEX color code.
Click Apply.
Expected Result: The selected metric column should be highlighted with the chosen background color.

Enable the "Apply color to headers & total rows" checkbox.
Expected Result: The column headers and total row for the selected metric should match the column’s background color.
Disable the checkbox.
Expected Result: The header and total row should return to the default styling.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
