### PR TITLE
fix(plugin-chart-echarts): remove erroneous upper bound value

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -226,7 +226,7 @@ export function transformSeries(
     stackId = forecastSeries.name;
   } else if (stack && isObservation) {
     // the suffix of the observation series is '' (falsy), which disables
-    // stacking. Therefore we need to set something that is truthy.
+    // stacking. Therefore, we need to set something that is truthy.
     stackId = getTimeCompareStackId('obs', timeCompare, name);
   } else if (stack && isTrend) {
     stackId = getTimeCompareStackId(forecastSeries.type, timeCompare, name);
@@ -322,6 +322,15 @@ export function transformSeries(
       show: !!showValue,
       position: isHorizontal ? 'right' : 'top',
       formatter: (params: any) => {
+        // don't show confidence band value labels, as they're already visible on the tooltip
+        if (
+          [
+            ForecastSeriesEnum.ForecastUpper,
+            ForecastSeriesEnum.ForecastLower,
+          ].includes(forecastSeries.type)
+        ) {
+          return '';
+        }
         const { value, dataIndex, seriesIndex, seriesName } = params;
         const numericValue = isHorizontal ? value[0] : value[1];
         const isSelectedLegend = !legendState || legendState[seriesName];


### PR DESCRIPTION
### SUMMARY
Currently when selecting "show value" on the chart, the upper bound shows the confidence bound width (400), not the actual value (which is 1.76k). In the tooltip this is fixed by adding the lower bound to the upper bound. However, this is more difficult to implement in the label formatter, as it only receives the single value of the series, while the tooltip formatter receives all series, making it easier to do the addition.

### BEFORE
Notice the incorrect upper bound label (400), as opposed to the actual value seen on the tooltip (1.76k):
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/11391d6e-b79b-4fad-acf1-bebcd7060e68" />

### AFTER
Now the lower and upper bound labels are no longer shown when hovering:
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/77b4e1e7-a683-4811-b378-456f8440572c" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: closes #32428
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
