### PR TITLE
fix(explore): Glitch in a tooltip with metric's name

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/labelUtils.tsx
@@ -23,20 +23,17 @@ import { ColumnMeta, Metric } from '@superset-ui/chart-controls';
 
 const TooltipSectionWrapper = styled.div`
   ${({ theme }) => css`
-    display: flex;
-    flex-direction: column;
+    display: -webkit-box;
+    -webkit-line-clamp: 40;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
     font-size: ${theme.typography.sizes.s}px;
     line-height: 1.2;
 
     &:not(:last-of-type) {
       margin-bottom: ${theme.gridUnit * 2}px;
-    }
-    &:last-of-type {
-      display: -webkit-box;
-      -webkit-line-clamp: 40;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
   `}
 `;


### PR DESCRIPTION
### SUMMARY
Fixes a small visual bug in a tooltip that displays metric's name and label - before, "Metric name", ":", and the name would be displayed in separate lines rather than inline.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="344" alt="image" src="https://github.com/user-attachments/assets/18cd8edb-fb08-4b6c-aeee-c66c3d05c3a9" />

After:

<img width="352" alt="image" src="https://github.com/user-attachments/assets/22174db1-bfa7-4449-abb4-c501749649ab" />


### TESTING INSTRUCTIONS
1. Go to Explore
2. Add a metric with a long name, so that it's truncated and a tooltip is displayed on hover
3. Verify that the name is displayed inline with the title "Metric name"
4. Check that it works for columns too and in the metrics/columns list on the left

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
