### PR TITLE
chore: enable dependabot using uv for auto-bumping python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
 
   - package-ecosystem: "github-actions"
@@ -21,9 +22,14 @@ updates:
     versioning-strategy: increase
 
 
-  # - package-ecosystem: "pip"
-  # NOTE: as dependabot isn't compatible with our usage of `uv pip compile` we're using
-  # `supersetbot` instead
+  # NOTE: `uv` support is in beta, more details here:
+  # https://github.com/dependabot/dependabot-core/pull/10040#issuecomment-2696978430
+  - package-ecosystem: "uv"
+    directory: "requirements/"
+    open-pull-requests-limit: 10
+    labels:
+      - uv
+      - dependabot
 
   - package-ecosystem: "npm"
     directory: ".github/actions"


### PR DESCRIPTION
It appears `dependabot` support for `uv` is in beta, so switching it on here to see how it behaves. Depending on results, we may have to tune it or outright turn it off if it doesn't behave as expected.

While reading through docs and issues, it appears that dependabot uses a bit of magic (over configuration), while making assumptions based on file names and comments in their respective headers (the requirements/*.txt files contain a comment referencing how they were generated).

Some success criteria:
- respecting ranges specified in `pyproject.toml` and overrides in `requierments/*.in` files
- bump one lib at a time
- more difficultly: alter both `requirements/*.txt` files atomically, meaning if for example `flask` is bumped in `base.txt`, it should also be updated in `development.txt`, with matching version numbers

Depending on results, we'll tune configurations and report issues in the dependabot repo, give this approach a fair shot. If efforts shows signs to be a dead end, we'll likely revert to fixing up `supersetbot` with a tailored process. The bot has features (now broken since we moved from `pip-compile-multi` to `uv`) that could be desirable, like bumping all libs in a dependency branch in a single PR (bundling upgrades), and is more configurable overall, allowing for custom runs with specific parameters.

More about it here: https://github.com/dependabot/dependabot-core/pull/10040#issuecomment-2696978430
