### PR TITLE
fix: Show response message as default error

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -240,15 +240,7 @@ class Chart extends PureComponent<ChartProps, {}> {
       height,
       datasetsStatus,
     } = this.props;
-    let error = queryResponse?.errors?.[0];
-    if (error === undefined) {
-      error = {
-        error_type: ErrorTypeEnum.FRONTEND_NETWORK_ERROR,
-        level: 'error',
-        message: t('Check your network connection'),
-        extra: null,
-      };
-    }
+    const error = queryResponse?.errors?.[0];
     const message = chartAlert || queryResponse?.message;
 
     // if datasource is still loading, don't render JS errors

--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -24,7 +24,6 @@ import {
   logging,
   QueryFormData,
   styled,
-  ErrorTypeEnum,
   t,
   SqlaFormData,
   ClientErrorObject,

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from 'spec/helpers/testing-library';
+import '@testing-library/jest-dom';
+import { ChartSource } from 'src/types/ChartSource';
+import { useChartOwnerNames } from 'src/hooks/apiResources';
+import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
+import { ErrorType } from '@superset-ui/core';
+import { ChartErrorMessage } from './ChartErrorMessage';
+import { ErrorMessageComponentProps } from '../ErrorMessage/types';
+import getErrorMessageComponentRegistry from '../ErrorMessage/getErrorMessageComponentRegistry';
+
+// Mock the useChartOwnerNames hook
+jest.mock('src/hooks/apiResources', () => ({
+  useChartOwnerNames: jest.fn(),
+}));
+
+const mockUseChartOwnerNames = useChartOwnerNames as jest.MockedFunction<
+  typeof useChartOwnerNames
+>;
+
+const ERROR_MESSAGE_COMPONENT = (props: ErrorMessageComponentProps) => (
+  <>
+    <div>Test error</div>
+    <div>{props.subtitle}</div>
+  </>
+);
+
+describe('ChartErrorMessage', () => {
+  const defaultProps = {
+    chartId: '1',
+    subtitle: 'Test subtitle',
+    source: 'test_source' as ChartSource,
+  };
+
+  it('renders the default error message when error is null', () => {
+    mockUseChartOwnerNames.mockReturnValue({
+      result: null,
+      status: ResourceStatus.Loading,
+      error: null,
+    });
+    render(<ChartErrorMessage {...defaultProps} />);
+
+    expect(screen.getByText('Data error')).toBeInTheDocument();
+    expect(screen.getByText('Test subtitle')).toBeInTheDocument();
+  });
+
+  it('renders the error message that is passed in from the error', () => {
+    getErrorMessageComponentRegistry().registerValue(
+      'VALID_KEY',
+      ERROR_MESSAGE_COMPONENT,
+    );
+    render(
+      <ChartErrorMessage
+        {...defaultProps}
+        error={{
+          error_type: 'VALID_KEY' as unknown as ErrorType,
+          message: 'Subtitle',
+          level: 'error',
+          extra: {},
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Test error')).toBeInTheDocument();
+    expect(screen.getByText('Test subtitle')).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.tsx
@@ -32,6 +32,8 @@ export type Props = {
   stackTrace?: string;
 } & Omit<ClientErrorObject, 'error'>;
 
+const DEFAULT_CHART_ERROR = 'Data error';
+
 export const ChartErrorMessage: FC<Props> = ({ chartId, error, ...props }) => {
   // fetches the chart owners and adds them to the extra data of the error message
   const { result: owners } = useChartOwnerNames(chartId);
@@ -42,5 +44,11 @@ export const ChartErrorMessage: FC<Props> = ({ chartId, error, ...props }) => {
     extra: { ...error.extra, owners },
   };
 
-  return <ErrorMessageWithStackTrace {...props} error={ownedError} />;
+  return (
+    <ErrorMessageWithStackTrace
+      {...props}
+      error={ownedError}
+      title={DEFAULT_CHART_ERROR}
+    />
+  );
 };

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -42,7 +42,6 @@ export default function ErrorMessageWithStackTrace({
   title = DEFAULT_TITLE,
   error,
   subtitle,
-  copyText,
   link,
   stackTrace,
   source,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We were showing a network error as a default message. Removing a bit of code to allow the response message to show up. Also changed the default error for Charts to be different than other default errors.  

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="2068" alt="Screenshot 2025-03-04 at 5 01 33 PM" src="https://github.com/user-attachments/assets/b6add612-28cd-42e6-951d-226a50f0b796" />

After:
Error from response still shows error message
<img width="693" alt="Screenshot 2025-03-04 at 5 26 49 PM" src="https://github.com/user-attachments/assets/797f0ec8-33c9-4e5f-b6ea-37b79d6f9d97" />
Default error for charts says "Data error" with message from response
<img width="823" alt="Screenshot 2025-03-04 at 5 27 00 PM" src="https://github.com/user-attachments/assets/047d5b08-ae90-4aa3-8672-858bc4232be5" />
Other parts of the codebase (SqlLab for example) still show the correct error
<img width="1217" alt="Screenshot 2025-03-04 at 5 27 20 PM" src="https://github.com/user-attachments/assets/9590cb4c-f961-40ec-8a8e-0f5969e56d73" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
