### PR TITLE
fix(sqllab): Allow clear on schema and catalog

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -406,6 +406,7 @@ export default function DatabaseSelector({
         options={catalogOptions}
         showSearch
         value={currentCatalog || undefined}
+        allowClear
       />,
       refreshIcon,
     );
@@ -432,6 +433,7 @@ export default function DatabaseSelector({
         options={schemaOptions}
         showSearch
         value={currentSchema}
+        allowClear
       />,
       refreshIcon,
     );


### PR DESCRIPTION
### SUMMARY
When I open SQL Lab, the schema field is set to the default value from the previous tab's schema, and there doesn't seem to be a way to clear that field. This commit changes the schema and catalog options to allow for clearing the field to fix the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/7b651d96-09a3-470a-a1f2-e2fd3a169785


### TESTING INSTRUCTIONS
Go to SQL Lab and then choose a schema/catalog

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
