### PR TITLE
chore(ci): show more failed pre-commit context

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,8 +59,9 @@ jobs:
           # Skip auto-fixing in CI to ensure changes are committed locally
           export SKIP_FIX=1
           pre-commit run --all-files
-          if [ $? -ne 0 ] || ! git diff --quiet --exit-code; then
-            echo "❌ Pre-commit check failed."
+          EXIT_CODE=$?
+          if [ ${EXIT_CODE} -ne 0 ] || ! git diff --quiet --exit-code; then
+            echo "❌ Pre-commit check failed (exit code: ${EXIT_CODE})."
             echo "🚒 To prevent/address this CI issue, please install/use pre-commit locally."
             echo "📖 More details here: https://superset.apache.org/docs/contributing/development#git-hooks"
             exit 1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,9 +59,19 @@ jobs:
           # Skip auto-fixing in CI to ensure changes are committed locally
           export SKIP_FIX=1
           pre-commit run --all-files
-          EXIT_CODE=$?
-          if [ ${EXIT_CODE} -ne 0 ] || ! git diff --quiet --exit-code; then
-            echo "❌ Pre-commit check failed (exit code: ${EXIT_CODE})."
+          PRE_COMMIT_EXIT_CODE=$?
+          git diff --quiet --exit-code
+          GIT_DIFF_EXIT_CODE=$?
+          if [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ] || [ "${GIT_DIFF_EXIT_CODE}" -ne 0 ]; then
+            if [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ]; then
+              echo "❌ Pre-commit check failed (exit code: ${EXIT_CODE})."
+            else
+              echo "❌ Git working directory is dirty after running pre-commit."
+              echo "📌 This likely means that pre-commit made changes that were not committed."
+              echo "🔍 Modified files:"
+              git diff --name-only
+            fi
+
             echo "🚒 To prevent/address this CI issue, please install/use pre-commit locally."
             echo "📖 More details here: https://superset.apache.org/docs/contributing/development#git-hooks"
             exit 1

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -50792,20 +50792,6 @@
         "react-dom": "^17.0.2"
       }
     },
-    "plugins/plugin-chart-pivot-table/node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "plugins/plugin-chart-table": {
       "name": "@superset-ui/plugin-chart-table",
       "version": "0.20.3",


### PR DESCRIPTION
### SUMMARY
Show exit code on failed `pre-commit` CI check. Also break out `git diff --quiet --exit-code` and display modified files. Also fix the broken lock file to unblock master.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
