### PR TITLE
fix: always extract query source from request

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -36,7 +36,7 @@ import numpy
 import pandas as pd
 import sqlalchemy as sqla
 import sshtunnel
-from flask import g, request
+from flask import g
 from flask_appbuilder import Model
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import (
@@ -84,7 +84,7 @@ from superset.superset_typing import (
 )
 from superset.utils import cache as cache_util, core as utils, json
 from superset.utils.backports import StrEnum
-from superset.utils.core import get_username
+from superset.utils.core import get_query_source_from_request, get_username
 from superset.utils.oauth2 import (
     check_for_oauth2,
     get_oauth2_access_token,
@@ -537,13 +537,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         self.update_params_from_encrypted_extra(params)
 
         if DB_CONNECTION_MUTATOR:
-            if not source and request and request.referrer:
-                if "/superset/dashboard/" in request.referrer:
-                    source = utils.QuerySource.DASHBOARD
-                elif "/explore/" in request.referrer:
-                    source = utils.QuerySource.CHART
-                elif "/sqllab/" in request.referrer:
-                    source = utils.QuerySource.SQL_LAB
+            source = source or get_query_source_from_request()
 
             sqlalchemy_url, params = DB_CONNECTION_MUTATOR(
                 sqlalchemy_url,

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1799,7 +1799,20 @@ def to_int(v: Any, value_if_invalid: int = 0) -> int:
         return value_if_invalid
 
 
+def get_query_source_from_request() -> QuerySource | None:
+    if not request or not request.referrer:
+        return None
+    if "/superset/dashboard/" in request.referrer:
+        return QuerySource.DASHBOARD
+    if "/explore/" in request.referrer:
+        return QuerySource.CHART
+    if "/sqllab/" in request.referrer:
+        return QuerySource.SQL_LAB
+    return None
+
+
 def get_user_agent(database: Database, source: QuerySource | None) -> str:
+    source = source or get_query_source_from_request()
     if user_agent_func := current_app.config["USER_AGENT_FUNC"]:
         return user_agent_func(database, source)
 

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -31,6 +31,7 @@ from superset.utils.core import (
     generic_find_constraint_name,
     generic_find_fk_constraint_name,
     get_datasource_full_name,
+    get_query_source_from_request,
     get_user_agent,
     is_test,
     normalize_dttm_col,
@@ -399,6 +400,28 @@ def test_get_datasource_full_name():
         get_datasource_full_name("db", "table", "catalog", None)
         == "[db].[catalog].[table]"
     )
+
+
+@pytest.mark.parametrize(
+    "referrer,expected",
+    [
+        (None, None),
+        ("https://mysuperset.com/abc", None),
+        ("https://mysuperset.com/superset/dashboard/", QuerySource.DASHBOARD),
+        ("https://mysuperset.com/explore/", QuerySource.CHART),
+        ("https://mysuperset.com/sqllab/", QuerySource.SQL_LAB),
+    ],
+)
+def test_get_query_source_from_request(
+    referrer: str | None,
+    expected: QuerySource | None,
+    mocker: MockerFixture,
+) -> None:
+    if referrer:
+        request_mock = mocker.patch("superset.utils.core.request")
+        request_mock.referrer = referrer
+
+    assert get_query_source_from_request() == expected
 
 
 def test_get_user_agent(mocker: MockerFixture) -> None:


### PR DESCRIPTION
### SUMMARY
This is a continuation of #32506. While testing the previous PR, I noticed that the query source was missing in many cases outside the db connection mutator context. It turns out there are many code paths that bypass the query source extraction part, causing the agent to be missing for most other cases than async SQL Lab queries.

This centralizes the request extraction logic in a single place, and falls back to checking the request referrer whenever the source is needed but isn't provided explicitly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
