### PR TITLE
chore(ci): use npm/yarn lock files where possible

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Install Frontend Dependencies
         run: |
           cd superset-frontend
-          npm install
+          npm ci
 
       - name: Install Docs Dependencies
         run: |
           cd docs
-          yarn install
+          yarn install --immutable
 
       - name: pre-commit
         run: |
@@ -66,7 +66,7 @@ jobs:
             if [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ]; then
               echo "❌ Pre-commit check failed (exit code: ${EXIT_CODE})."
             else
-              echo "❌ Git working directory is dirty after running pre-commit."
+              echo "❌ Git working directory is dirty."
               echo "📌 This likely means that pre-commit made changes that were not committed."
               echo "🔍 Modified files:"
               git diff --name-only

--- a/.github/workflows/tech-debt.yml
+++ b/.github/workflows/tech-debt.yml
@@ -35,7 +35,7 @@ jobs:
           node-version-file: './superset-frontend/.nvmrc'
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./superset-frontend
 
       - name: Run Script


### PR DESCRIPTION
### SUMMARY
This is a continuation of #32517. This changes the pre-commit and tech debt workflow to use npm and yarn lock files for installation of dependencies. We also update the error message for the dirty git working directory to reflect the fact that anything might have changed the files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
