### PR TITLE
fix(migrations): Handle comparator None in old time comparison migration

### DIFF
--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -85,7 +85,7 @@ def upgrade_comparison_params(slice_params: dict[str, Any]) -> dict[str, Any]:
     # Adjust adhoc_custom
     if "adhoc_custom" in params and params["adhoc_custom"]:
         adhoc = params["adhoc_custom"][0]  # As there's always only one element
-        if adhoc["comparator"] != "No filter":
+        if adhoc["comparator"] and adhoc["comparator"] != "No filter":
             # Set start_date_offset in params, not in adhoc
             start_date_offset, _ = get_since_until(adhoc["comparator"])
             params["start_date_offset"] = start_date_offset.strftime("%Y-%m-%d")

--- a/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
+++ b/tests/integration_tests/migrations/f84fde59123a_update_charts_with_old_time_comparison__test.py
@@ -170,6 +170,23 @@ params_v2_other_than_custom_false: dict[str, Any] = {
     "time_compare": [],
 }
 
+params_v1_with_custom_and_no_comparator: dict[str, Any] = {
+    **params_v1_with_custom,
+    "adhoc_custom": [
+        {
+            "expressionType": "SIMPLE",
+            "subject": "ds",
+            "operator": "TEMPORAL_RANGE",
+            "comparator": None,
+            "clause": "WHERE",
+            "sqlExpression": None,
+            "isExtra": False,
+            "isNew": False,
+            "datasourceWarning": False,
+        }
+    ],
+}
+
 
 def test_upgrade_chart_params_with_custom():
     """
@@ -241,3 +258,14 @@ def test_upgrade_chart_params_empty():
     assert downgrade_comparison_params(None) == {}
     assert downgrade_comparison_params({}) == {}
     assert downgrade_comparison_params("") == {}
+
+
+def test_upgrade_chart_params_with_custom_no_comparator():
+    """
+    ensure that the new time comparison params are added but no start_date_offset
+    """
+    original_params = deepcopy(params_v1_with_custom_and_no_comparator)
+    expected_after_upgrade = deepcopy(params_v2_with_custom)
+    expected_after_upgrade.pop("start_date_offset")
+    upgraded_params = upgrade_comparison_params(original_params)
+    assert upgraded_params == expected_after_upgrade


### PR DESCRIPTION
### SUMMARY
The time comparison migration doesn't handle slices that have comparator set as None, causing the migration to fail. This PR fixes that behavior

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
