### PR TITLE
fix(dashboard): Support bigint value in native filters

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -23,7 +23,6 @@ import { ParseMethod, TextResponse, JsonResponse } from '../types';
 
 const JSONbig = _JSONbig({
   constructorAction: 'preserve',
-  useNativeBigInt: true,
 });
 
 export default async function parseResponse<T extends ParseMethod = 'json'>(
@@ -58,11 +57,20 @@ export default async function parseResponse<T extends ParseMethod = 'json'>(
     const json = JSONbig.parse(rawData);
     const result: JsonResponse = {
       response,
-      // `json-bigint` could not handle floats well, see sidorares/json-bigint#62
-      // TODO: clean up after json-bigint>1.0.1 is released
-      json: cloneDeepWith(json, (value: any) =>
-        value?.isInteger?.() === false ? Number(value) : undefined,
-      ),
+      json: cloneDeepWith(json, (value: any) => {
+        // `json-bigint` could not handle floats well, see sidorares/json-bigint#62
+        // TODO: clean up after json-bigint>1.0.1 is released
+        if (value?.isInteger?.() === false) {
+          return Number(value);
+        }
+        if (
+          value?.isGreaterThan?.(Number.MAX_SAFE_INTEGER) ||
+          value?.isLessThan?.(Number.MIN_SAFE_INTEGER)
+        ) {
+          return BigInt(value);
+        }
+        return undefined;
+      }),
     };
     return result as ReturnType;
   }

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -23,6 +23,7 @@ import { ParseMethod, TextResponse, JsonResponse } from '../types';
 
 const JSONbig = _JSONbig({
   constructorAction: 'preserve',
+  useNativeBigInt: true,
 });
 
 export default async function parseResponse<T extends ParseMethod = 'json'>(

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -31,7 +31,7 @@ import { Maybe } from '../../types';
 import { PostProcessingRule } from './PostProcessing';
 import { JsonObject } from '../../connection';
 import { TimeGranularity } from '../../time-format';
-import { GenericDataType } from './QueryResponse';
+import { GenericDataType, DataRecordValue } from './QueryResponse';
 
 export type BaseQueryObjectFilterClause = {
   col: QueryFormColumn;
@@ -41,13 +41,13 @@ export type BaseQueryObjectFilterClause = {
 
 export type BinaryQueryObjectFilterClause = BaseQueryObjectFilterClause & {
   op: BinaryOperator;
-  val: string | number | boolean;
+  val: DataRecordValue;
   formattedVal?: string;
 };
 
 export type SetQueryObjectFilterClause = BaseQueryObjectFilterClause & {
   op: SetOperator;
-  val: (string | number | boolean)[];
+  val: DataRecordValue[];
   formattedVal?: string[];
 };
 

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -33,7 +33,7 @@ export enum GenericDataType {
 /**
  * Primitive types for data field values.
  */
-export type DataRecordValue = number | string | boolean | Date | null;
+export type DataRecordValue = number | string | boolean | Date | null | bigint;
 
 export interface DataRecord {
   [key: string]: DataRecordValue;

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.test.ts
@@ -60,4 +60,12 @@ test('finestTemporalGrain', () => {
   expect(localTimeFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
     '2002-12-31 19:00',
   );
+
+  const bigIntFormatter = finestTemporalGrain([
+    BigInt(1234567890123456789n),
+    BigInt(1234567890123456789n),
+  ]);
+  expect(bigIntFormatter(new Date('2003-01-01 00:00:00Z').getTime())).toBe(
+    '2003',
+  );
 });

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
@@ -48,30 +48,30 @@ export default function finestTemporalGrain(
   } = useLocalTime ? localTimeUtils : utcUtils;
 
   let formatFunc = formatYear;
-  try {
-    values.forEach((value: any) => {
-      if (formatFunc === formatYear && isNotFirstMonth(value)) {
-        formatFunc = formatMonth;
-      }
-      if (formatFunc === formatMonth && isNotFirstDayOfMonth(value)) {
-        formatFunc = formatDay;
-      }
-      if (formatFunc === formatDay && hasHour(value)) {
-        formatFunc = formatHour;
-      }
-      if (formatFunc === formatHour && hasMinute(value)) {
-        formatFunc = formatMinute;
-      }
-      if (formatFunc === formatMinute && hasSecond(value)) {
-        formatFunc = formatSecond;
-      }
-      if (formatFunc === formatSecond && hasMillisecond(value)) {
-        formatFunc = formatMillisecond;
-      }
-    });
-  } catch (e) {
-    // ignore
-  }
+
+  values.forEach((value: any) => {
+    if (typeof value === 'bigint') {
+      return;
+    }
+    if (formatFunc === formatYear && isNotFirstMonth(value)) {
+      formatFunc = formatMonth;
+    }
+    if (formatFunc === formatMonth && isNotFirstDayOfMonth(value)) {
+      formatFunc = formatDay;
+    }
+    if (formatFunc === formatDay && hasHour(value)) {
+      formatFunc = formatHour;
+    }
+    if (formatFunc === formatHour && hasMinute(value)) {
+      formatFunc = formatMinute;
+    }
+    if (formatFunc === formatMinute && hasSecond(value)) {
+      formatFunc = formatSecond;
+    }
+    if (formatFunc === formatSecond && hasMillisecond(value)) {
+      formatFunc = formatMillisecond;
+    }
+  });
 
   return new TimeFormatter({
     description:

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/finestTemporalGrain.ts
@@ -48,26 +48,30 @@ export default function finestTemporalGrain(
   } = useLocalTime ? localTimeUtils : utcUtils;
 
   let formatFunc = formatYear;
-  values.forEach((value: any) => {
-    if (formatFunc === formatYear && isNotFirstMonth(value)) {
-      formatFunc = formatMonth;
-    }
-    if (formatFunc === formatMonth && isNotFirstDayOfMonth(value)) {
-      formatFunc = formatDay;
-    }
-    if (formatFunc === formatDay && hasHour(value)) {
-      formatFunc = formatHour;
-    }
-    if (formatFunc === formatHour && hasMinute(value)) {
-      formatFunc = formatMinute;
-    }
-    if (formatFunc === formatMinute && hasSecond(value)) {
-      formatFunc = formatSecond;
-    }
-    if (formatFunc === formatSecond && hasMillisecond(value)) {
-      formatFunc = formatMillisecond;
-    }
-  });
+  try {
+    values.forEach((value: any) => {
+      if (formatFunc === formatYear && isNotFirstMonth(value)) {
+        formatFunc = formatMonth;
+      }
+      if (formatFunc === formatMonth && isNotFirstDayOfMonth(value)) {
+        formatFunc = formatDay;
+      }
+      if (formatFunc === formatDay && hasHour(value)) {
+        formatFunc = formatHour;
+      }
+      if (formatFunc === formatHour && hasMinute(value)) {
+        formatFunc = formatMinute;
+      }
+      if (formatFunc === formatMinute && hasSecond(value)) {
+        formatFunc = formatSecond;
+      }
+      if (formatFunc === formatSecond && hasMillisecond(value)) {
+        formatFunc = formatMillisecond;
+      }
+    });
+  } catch (e) {
+    // ignore
+  }
 
   return new TimeFormatter({
     description:

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -98,6 +98,7 @@ class BigNumberVis extends PureComponent<BigNumberVizProps> {
       !formatTime ||
       !showTimestamp ||
       typeof timestamp === 'string' ||
+      typeof timestamp === 'bigint' ||
       typeof timestamp === 'boolean'
     )
       return null;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -153,7 +153,7 @@ export default function transformProps(
           if (!value) {
             return NULL_STRING;
           }
-          if (typeof value === 'boolean') {
+          if (typeof value === 'boolean' || typeof value === 'bigint') {
             return String(value);
           }
           return value;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -183,7 +183,7 @@ export class EchartsChartPlugin<
     super({
       ...restProps,
       metadata: new ChartMetadata({
-        parseMethod: 'json',
+        parseMethod: 'json-bigint',
         ...metadata,
       }),
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -363,7 +363,7 @@ export function formatSeriesName(
   if (name === undefined || name === null) {
     return NULL_STRING;
   }
-  if (typeof name === 'boolean') {
+  if (typeof name === 'boolean' || typeof name === 'bigint') {
     return name.toString();
   }
   if (name instanceof Date || coltype === GenericDataType.Temporal) {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/index.test.ts
@@ -125,6 +125,6 @@ test('@superset-ui/plugin-chart-echarts-parsemethod-validation', () => {
   ];
 
   plugins.forEach(plugin => {
-    expect(plugin.metadata.parseMethod).toEqual('json');
+    expect(plugin.metadata.parseMethod).toEqual('json-bigint');
   });
 });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -238,4 +238,25 @@ describe('SelectFilterPlugin', () => {
     // One call for the search term and other for the empty search
     expect(setDataMask).toHaveBeenCalledTimes(2);
   });
+
+  test('Select big int value', async () => {
+    const bigValue = 1100924931345932234n;
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps({
+          ...selectMultipleProps,
+          formData: { ...selectMultipleProps.formData, groupby: 'bval' },
+        })}
+        coltypeMap={{ bval: 1 }}
+        data={[{ bval: bigValue }]}
+        setDataMask={jest.fn()}
+      />,
+    );
+    userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
+    await userEvent.type(screen.getByRole('combobox'), '1');
+    expect(screen.queryByLabelText(String(bigValue))).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/filters/utils.ts
+++ b/superset-frontend/src/filters/utils.ts
@@ -117,6 +117,9 @@ export function getDataRecordFormatter({
     if (typeof value === 'string') {
       return value;
     }
+    if (typeof value === 'bigint') {
+      return String(value);
+    }
     if (timeFormatter && dtype === GenericDataType.Temporal) {
       return timeFormatter(value);
     }


### PR DESCRIPTION
### SUMMARY

When the dataset values of the native filter include bigint values, an error occurs in the filter selection rendering.
This happens because the value is converted to a BigNumber class implemented by json-bigint and passed as a React child. To resolve this issue, this commit enables an option to convert the values to native int(`useNativeBigInt`), which allows them to be passed as compatible bigint to the children, thus solving the problem.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

![Screenshot 2025-03-07 at 2 20 49 PM](https://github.com/user-attachments/assets/71a09d6e-618b-4d40-b45a-a57ce70474d6)

After:

![Screenshot 2025-03-07 at 4 58 54 PM](https://github.com/user-attachments/assets/efbd6941-eb4b-4e11-9bed-8d690bbe5a3d)

### TESTING INSTRUCTIONS

Create a dataset from the following SQL
```
select 1234567890123456789 as bigIntVal
```
Choose the dataset in the filter, and then select the input box to check if the option is rendered correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
