### PR TITLE
chore: migrate Tabs component to use antd-v5

### DIFF
--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -33,7 +33,7 @@ import type { SqlLabRootState } from 'src/SqlLab/types';
 import { Skeleton, AntdBreadcrumb as Breadcrumb, Button } from 'src/components';
 import { Dropdown } from 'src/components/Dropdown';
 import FilterableTable from 'src/components/FilterableTable';
-import Tabs from 'src/components/Tabs';
+import { Tabs } from 'antd-v5';
 import {
   tableApiUtil,
   TableMetaData,

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -38,7 +38,7 @@ import {
 import { Select, AsyncSelect, Row, Col } from 'src/components';
 import { FormLabel } from 'src/components/Form';
 import Button from 'src/components/Button';
-import Tabs from 'src/components/Tabs';
+import { Tabs } from 'antd-v5';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import DatabaseSelector from 'src/components/DatabaseSelector';

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -35,6 +35,7 @@ import {
   JsonResponse,
   NativeFilterType,
   styled,
+  useTheme,
   SupersetApiError,
   t,
   ClientErrorObject,
@@ -66,7 +67,7 @@ import Icons from 'src/components/Icons';
 import Loading from 'src/components/Loading';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { Radio } from 'src/components/Radio';
-import Tabs from 'src/components/Tabs';
+import { Tabs } from 'antd-v5';
 import { Tooltip } from 'src/components/Tooltip';
 import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import {
@@ -237,23 +238,6 @@ const StyledCollapse = styled(Collapse)`
   &.ant-collapse > .ant-collapse-item {
     border: 0;
     border-radius: 0;
-  }
-`;
-
-const StyledTabs = styled(Tabs)`
-  .ant-tabs-nav {
-    position: sticky;
-    top: 0;
-    background: ${({ theme }) => theme.colors.grayscale.light5};
-    z-index: 1;
-  }
-
-  .ant-tabs-nav-list {
-    padding: 0;
-  }
-
-  .ant-form-item-label {
-    padding-bottom: 0;
   }
 `;
 
@@ -815,12 +799,12 @@ const FiltersConfigForm = (
       />
     </StyledRowFormItem>
   );
-
+  const theme = useTheme();
   return (
-    <StyledTabs
+    <Tabs
       activeKey={activeTabKey}
       onChange={activeKey => setActiveTabKey(activeKey)}
-      centered
+      tabBarStyle={{ paddingLeft: theme.gridUnit * 4 }}
     >
       <TabPane
         tab={FilterTabs.configuration.name}
@@ -1358,7 +1342,7 @@ const FiltersConfigForm = (
           initiallyExcludedCharts={initiallyExcludedCharts}
         />
       </TabPane>
-    </StyledTabs>
+    </Tabs>
   );
 };
 

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -57,7 +57,7 @@ import { rgba } from 'emotion-rgba';
 import { kebabCase, isEqual } from 'lodash';
 
 import Collapse from 'src/components/Collapse';
-import Tabs from 'src/components/Tabs';
+import { Tabs } from 'antd-v5';
 import { PluginContext } from 'src/components/DynamicPlugins';
 import Loading from 'src/components/Loading';
 import Modal from 'src/components/Modal';
@@ -139,9 +139,6 @@ const Styles = styled.div`
     height: 100%;
     overflow: visible;
   }
-  .nav-tabs {
-    flex: 0 0 1;
-  }
   .tab-content {
     overflow: auto;
     flex: 1 1 100%;
@@ -156,40 +153,6 @@ const Styles = styled.div`
     text-align: center;
     font-weight: ${({ theme }) => theme.typography.weights.bold};
   }
-`;
-
-const ControlPanelsTabs = styled(Tabs)`
-  ${({ theme, fullWidth }) => css`
-    height: 100%;
-    overflow: visible;
-    .ant-tabs-nav {
-      margin-bottom: 0;
-    }
-    .ant-tabs-nav-list {
-      width: ${fullWidth ? '100%' : '50%'};
-    }
-    .ant-tabs-tabpane {
-      height: 100%;
-    }
-    .ant-tabs-content-holder {
-      padding-top: ${theme.gridUnit * 4}px;
-    }
-
-    .ant-collapse-ghost > .ant-collapse-item {
-      &:not(:last-child) {
-        border-bottom: 1px solid ${theme.colors.grayscale.light3};
-      }
-
-      & > .ant-collapse-header {
-        font-size: ${theme.typography.sizes.s}px;
-      }
-
-      & > .ant-collapse-content > .ant-collapse-content-box {
-        padding-bottom: 0;
-        font-size: ${theme.typography.sizes.s}px;
-      }
-    }
-  `}
 `;
 
 const isTimeSection = (section: ControlPanelSectionConfig): boolean =>
@@ -269,7 +232,7 @@ function useResetOnChangeRef(initialValue: () => any, resetOnChangeValue: any) {
 }
 
 export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
-  const { colors } = useTheme();
+  const { colors, gridUnit } = useTheme();
   const pluginContext = useContext(PluginContext);
 
   const prevState = usePrevious(props.exploreState);
@@ -791,10 +754,11 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
 
   return (
     <Styles ref={containerRef}>
-      <ControlPanelsTabs
+      <Tabs
         id="controlSections"
         data-test="control-tabs"
         fullWidth={showCustomizeTab}
+        tabBarStyle={{ paddingLeft: gridUnit * 4 }}
         allowOverflow={false}
       >
         <Tabs.TabPane key="query" tab={dataTabTitle}>
@@ -818,7 +782,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
             </Collapse>
           </Tabs.TabPane>
         )}
-      </ControlPanelsTabs>
+      </Tabs>
       <div css={actionButtonsContainerStyles}>
         <RunQueryButton
           onQuery={props.onQuery}

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -25,7 +25,7 @@ import {
   useTheme,
 } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
-import Tabs from 'src/components/Tabs';
+import { Tabs } from 'antd-v5';
 import {
   getItem,
   setItem,

--- a/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/EditDataset/index.tsx
@@ -17,18 +17,18 @@
  * under the License.
  */
 import { styled, t } from '@superset-ui/core';
+import { Tabs } from 'antd-v5'; // Changed to import from antd directly
 import useGetDatasetRelatedCounts from 'src/features/datasets/hooks/useGetDatasetRelatedCounts';
 import Badge from 'src/components/Badge';
-import Tabs from 'src/components/Tabs';
 import UsageTab from './UsageTab';
 
+// Updated styled component to use antd directly
 const StyledTabs = styled(Tabs)`
   ${({ theme }) => `
   margin-top: ${theme.gridUnit * 8.5}px;
   padding-left: ${theme.gridUnit * 4}px;
   padding-right: ${theme.gridUnit * 4}px;
-
-  .ant-tabs-top > .ant-tabs-nav::before {
+  .ant-tabs-nav::before {
     width: ${theme.gridUnit * 50}px;
   }
   `}
@@ -63,14 +63,30 @@ const EditPage = ({ id }: EditPageProps) => {
     </TabStyles>
   );
 
+  // Create items array for antd v5 Tabs
+  const items = [
+    {
+      key: '1',
+      label: TRANSLATIONS.COLUMNS_TEXT,
+      children: null,
+    },
+    {
+      key: '2',
+      label: TRANSLATIONS.METRICS_TEXT,
+      children: null,
+    },
+    {
+      key: '3',
+      label: usageTab,
+      children: <UsageTab datasetId={id} />,
+    },
+  ];
+
   return (
-    <StyledTabs moreIcon={null} fullWidth={false}>
-      <Tabs.TabPane tab={TRANSLATIONS.COLUMNS_TEXT} key="1" />
-      <Tabs.TabPane tab={TRANSLATIONS.METRICS_TEXT} key="2" />
-      <Tabs.TabPane tab={usageTab} key="3">
-        <UsageTab datasetId={id} />
-      </Tabs.TabPane>
-    </StyledTabs>
+    <StyledTabs
+      moreIcon={null}
+      items={items}
+    />
   );
 };
 


### PR DESCRIPTION
This is WiP, incomplete!

I started migrating tabs but realized there are many more than I thought originally so want to open this DRAFT PR for cooperation / handoff.

My approach, step-by-step was to start by moving components using tabs to point to vanilla `antd-v5` alias one by one, while keeping `src/components/Tabs` untouched (as opposed to altering `src/components/Tabs` to point to `antd-v5` and fix the broken ones one-by-one). Once all were going to be migrated, I was planning on switching everything to make `src/components/Tabs` a very simple wrapper to `antd-v5` and pointing all of the components to it.

Also AI can do the bulk of the work here. Both GPT and Claude know how to migrate antd-v4 to antd-v5 with the right instructions. It's pretty easy but requires a bit of copy/paste and adjustments here and there. 

Looks like I did 7 so far, and there are 14 left to migrate:

```bash
$ git grep "src/components/Tabs"
src/SqlLab/components/TabbedSqlEditors/index.tsx:import { EditableTabs } from 'src/components/Tabs';
src/components/Chart/DrillBy/useResultsTableView.tsx:import Tabs from 'src/components/Tabs';
src/dashboard/components/BuilderComponentPane/index.tsx:import Tabs from 'src/components/Tabs';
src/dashboard/components/DashboardBuilder/DashboardContainer.tsx:import Tabs from 'src/components/Tabs';
src/dashboard/components/gridComponents/Tabs.jsx:import { LineEditableTabs } from 'src/components/Tabs';
src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx:import Tabs from 'src/components/Tabs';
src/explore/components/controls/ColumnConfigControl/ColumnConfigPopover.tsx:import Tabs from 'src/components/Tabs';
src/explore/components/controls/ContourControl/ContourPopoverControl.tsx:import Tabs from 'src/components/Tabs';
src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx:import Tabs from 'src/components/Tabs';
src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.jsx:import Tabs from 'src/components/Tabs';
src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.jsx:import Tabs from 'src/components/Tabs';
src/features/databases/DatabaseModal/index.tsx:import Tabs from 'src/components/Tabs';
```

The goal is to make all Tabs as simple/vanilla as possible - removing custom styles - and got a thumbs up from design (@kasiazjc) to remove custom styles as much as possible. Currently we have some tabs-in-modal that try to make tabs full-width and shown as centered, which we don't need, vanilla is better/simpler. One exception might be to use the different style of tabs (using the property `type="card"`) for SQL Lab's main tabs. Note that `type="card"` is still technically vanilla antd, but probably try and use that only for SQL Lab.