### PR TITLE
chore(reports): add task for slack channels warm-up

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1494,6 +1494,7 @@ EMAIL_REPORTS_CTA = "Explore in Superset"
 # Slack API token for the superset reports, either string or callable
 SLACK_API_TOKEN: Callable[[], str] | str | None = None
 SLACK_PROXY = None
+SLACK_CACHE_TIMEOUT = int(timedelta(days=1).total_seconds())
 
 # The webdriver to use for generating reports. Use one of the following
 # firefox

--- a/superset/config.py
+++ b/superset/config.py
@@ -1015,6 +1015,7 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         "superset.tasks.scheduler",
         "superset.tasks.thumbnails",
         "superset.tasks.cache",
+        "superset.tasks.slack",
     )
     result_backend = "db+sqlite:///celery_results.sqlite"
     worker_prefetch_multiplier = 1
@@ -1045,6 +1046,11 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         #     "task": "prune_logs",
         #     "schedule": crontab(minute="*", hour="*"),
         #     "kwargs": {"retention_period_days": 180},
+        # },
+        # Uncomment to enable Slack channel cache warm-up
+        # "slack.cache_channels": {
+        #     "task": "slack.cache_channels",
+        #     "schedule": crontab(minute="0", hour="*"),
         # },
     }
 

--- a/superset/tasks/slack.py
+++ b/superset/tasks/slack.py
@@ -26,4 +26,10 @@ logger = logging.getLogger(__name__)
 
 @celery_app.task(name="slack.cache_channels")
 def cache_channels() -> None:
-    get_channels(force=True, cache_timeout=current_app.config["SLACK_CACHE_TIMEOUT"])
+    try:
+        get_channels(
+            force=True, cache_timeout=current_app.config["SLACK_CACHE_TIMEOUT"]
+        )
+    except Exception as ex:
+        logger.exception("An error occurred while caching Slack channels: %s", ex)
+        raise

--- a/superset/tasks/slack.py
+++ b/superset/tasks/slack.py
@@ -16,6 +16,8 @@
 # under the License.
 import logging
 
+from flask import current_app
+
 from superset.extensions import celery_app
 from superset.utils.slack import get_channels
 
@@ -24,4 +26,4 @@ logger = logging.getLogger(__name__)
 
 @celery_app.task(name="slack.cache_channels")
 def cache_channels() -> None:
-    get_channels(force=True)
+    get_channels(force=True, cache_timeout=current_app.config["SLACK_CACHE_TIMEOUT"])

--- a/superset/tasks/slack.py
+++ b/superset/tasks/slack.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+from superset.extensions import celery_app
+from superset.utils.slack import get_channels
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="slack.cache_channels")
+def cache_channels() -> None:
+    get_channels(force=True)

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -102,7 +102,7 @@ def get_channels_with_search(
     try:
         channels = get_channels(
             force=force,
-            cache_timeout=86400,
+            cache_timeout=current_app.config["SLACK_CACHE_TIMEOUT"],
         )
     except (SlackClientError, SlackApiError) as ex:
         raise SupersetException(f"Failed to list channels: {ex}") from ex

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -17,7 +17,7 @@
 
 
 import logging
-from typing import Any, Optional
+from typing import Callable, Optional
 
 from flask import current_app
 from slack_sdk import WebClient
@@ -60,7 +60,7 @@ def get_slack_client() -> WebClient:
     key="slack_conversations_list",
     cache=cache_manager.cache,
 )
-def get_channels(limit: int, extra_params: dict[str, Any]) -> list[SlackChannelSchema]:
+def get_channels() -> list[SlackChannelSchema]:
     """
     Retrieves a list of all conversations accessible by the bot
     from the Slack API, and caches results (to avoid rate limits).
@@ -71,11 +71,12 @@ def get_channels(limit: int, extra_params: dict[str, Any]) -> list[SlackChannelS
     client = get_slack_client()
     channel_schema = SlackChannelSchema()
     channels: list[SlackChannelSchema] = []
+    extra_params = {"types": ",".join(SlackChannelTypes)}
     cursor = None
 
     while True:
         response = client.conversations_list(
-            limit=limit, cursor=cursor, exclude_archived=True, **extra_params
+            limit=999, cursor=cursor, exclude_archived=True, **extra_params
         )
         channels.extend(
             channel_schema.load(channel) for channel in response.data["channels"]
@@ -89,7 +90,6 @@ def get_channels(limit: int, extra_params: dict[str, Any]) -> list[SlackChannelS
 
 def get_channels_with_search(
     search_string: str = "",
-    limit: int = 999,
     types: Optional[list[SlackChannelTypes]] = None,
     exact_match: bool = False,
     force: bool = False,
@@ -99,17 +99,24 @@ def get_channels_with_search(
     all channels and filter them ourselves
     This will search by slack name or id
     """
-    extra_params = {}
-    extra_params["types"] = ",".join(types) if types else None
     try:
         channels = get_channels(
-            limit=limit,
-            extra_params=extra_params,
             force=force,
             cache_timeout=86400,
         )
     except (SlackClientError, SlackApiError) as ex:
         raise SupersetException(f"Failed to list channels: {ex}") from ex
+
+    if types and not len(types) == len(SlackChannelTypes):
+        conditions: list[Callable[[SlackChannelSchema], bool]] = []
+        if SlackChannelTypes.PUBLIC in types:
+            conditions.append(lambda channel: not channel["is_private"])
+        if SlackChannelTypes.PRIVATE in types:
+            conditions.append(lambda channel: channel["is_private"])
+
+        channels = [
+            channel for channel in channels if any(cond(channel) for cond in conditions)
+        ]
 
     # The search string can be multiple channels separated by commas
     if search_string:

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from superset.utils.slack import get_channels_with_search
+from superset.utils.slack import get_channels_with_search, SlackChannelTypes
 
 
 class MockResponse:
@@ -150,14 +150,34 @@ class TestGetChannelsWithSearch:
 The server responded with: missing scope: channels:read"""
         )
 
-    def test_filter_channels_by_specified_types(self, mocker):
+    @pytest.mark.parametrize(
+        "types, expected_channel_ids",
+        [
+            ([SlackChannelTypes.PUBLIC], {"public_channel_id"}),
+            ([SlackChannelTypes.PRIVATE], {"private_channel_id"}),
+            (
+                [SlackChannelTypes.PUBLIC, SlackChannelTypes.PRIVATE],
+                {"public_channel_id", "private_channel_id"},
+            ),
+            ([], {"public_channel_id", "private_channel_id"}),
+        ],
+    )
+    def test_filter_channels_by_specified_types(
+        self, types: list[SlackChannelTypes], expected_channel_ids: set[str], mocker
+    ):
         mock_data = {
             "channels": [
                 {
-                    "id": "C12345",
-                    "name": "general",
+                    "id": "public_channel_id",
+                    "name": "open",
                     "is_member": False,
                     "is_private": False,
+                },
+                {
+                    "id": "private_channel_id",
+                    "name": "secret",
+                    "is_member": False,
+                    "is_private": True,
                 },
             ],
             "response_metadata": {"next_cursor": None},
@@ -168,15 +188,8 @@ The server responded with: missing scope: channels:read"""
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(types=["public"])
-        assert result == [
-            {
-                "id": "C12345",
-                "name": "general",
-                "is_member": False,
-                "is_private": False,
-            }
-        ]
+        result = get_channels_with_search(types=types)
+        assert {channel["id"] for channel in result} == expected_channel_ids
 
     def test_handle_pagination_multiple_pages(self, mocker):
         mock_data_page1 = {


### PR DESCRIPTION
### SUMMARY

Adds a celery task to warm up the Slack channel cache and allows admins to schedule the same task (with example). This is helpful for cases where retrieval of the full channel list takes minutes.

#### Changes to the `get_channels` function

The Slack conversations API is not necessarily faster when using the `types` filter: For example, when we filter for private channels, the cursor will still iterate over all public channels and the number of requests remains the same, only the data transmitted is less.

With this in mind, I believe it is more efficient for us to cache only a single value for `get_channels()` and avoid having multiple cache values for each possible value of `types`. Doing the filtering in `get_channels_with_search` on demand doesn't add much cost.

Additionally, the `limit` param is also not relevant for the cache key and is inlined.

... and, of course, this change makes the celery task more sensible :)

#### Warning

There is a minor API change in this PR: Previously, we followed Slack's [conversations.list](https://api.slack.com/methods/conversations.list) convention, where empty an `types` param means that only public channels are returned. After this PR we will return all channel types when `types` is empty or null. To me that feels more logical, but if people feel we should stick to previous approach I'm OK with changing this.

### TESTING INSTRUCTIONS

Pre:
- Set `SLACK_API_TOKEN`
- Enable `ALERT_REPORTS`

#### Test Celery Task

```
celery --app=superset.tasks.celery_app:app call slack.cache_channels
```

**Expected**: Task is launched and result is cached.

#### Test Beat Schedule Example

1. Uncomment the beat schedule entry for `slack.cache_channels`
2. [Optional]: Adapt schedule to trigger every minute (or set time)

**Expected**: Task is scheduled and result is cached.

#### Test REST API

Try for `TYPES={"public_channel", "private_channel", "", "public_channel, private_channel"}`

```
curl -X 'GET' \
  'http://localhost:8088/api/v1/report/slack_channels/?q=(types%3A!(<TYPES>))' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <TOKEN>'
```

**Expected**: Cached value is used, filtered and returned.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/32480
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @Vitor-Avila since this builds on your recent work in https://github.com/apache/superset/pull/32529
