### PR TITLE
chore: fix precommit for eslint

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -56,8 +56,7 @@ jobs:
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
-          # Skip auto-fixing in CI to ensure changes are committed locally
-          export SKIP_FIX=1
+          export SKIP=eslint-frontend,type-checking-frontend
           pre-commit run --all-files
           PRE_COMMIT_EXIT_CODE=$?
           git diff --quiet --exit-code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       files: ^superset-frontend/.*\.(js|jsx|ts|tsx)$
     - id: eslint-docs
       name: eslint (docs)
-      entry: bash -c 'cd docs && FILES=$(echo "$@" | sed "s|docs/||g") && yarn eslint --ext .js,.jsx,.ts,.tsx --quiet $([ -z "$SKIP_FIX" ] && echo "--fix") $FILES'
+      entry: bash -c 'cd docs && FILES=$(echo "$@" | sed "s|docs/||g") && yarn eslint --fix --ext .js,.jsx,.ts,.tsx --quiet $FILES'
       language: system
       pass_filenames: true
       files: ^docs/.*\.(js|jsx|ts|tsx)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,40 +52,35 @@ repos:
       - id: trailing-whitespace
         exclude: ^.*\.(snap)
         args: ["--markdown-linebreak-ext=md"]
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
-        name: prettier
-        entry: bash -c 'cd superset-frontend && if [ -z "$SKIP_FIX" ]; then npm run format -- --log-level error; else npm run prettier-check; fi'
-        language: system
-        files: '^superset-frontend/(src|spec|cypress-base|plugins|packages|.storybook)/.+\.(js|jsx|ts|tsx|css|less|scss|sass)$|^superset-frontend/package\.json$'
-        pass_filenames: true
-      - id: eslint-frontend
-        name: eslint (frontend)
-        entry: bash -c 'cd superset-frontend && if [ -z "$SKIP_FIX" ]; then npm run lint-fix; else npm run eslint; fi'
-        language: system
-        pass_filenames: true
-        files: ^superset-frontend/.*\.(js|jsx|ts|tsx)$
-# TODO - re-assess using this script-based linting rather than the npm command. Both approaches have their merits
-#       - id: eslint
-#         name: eslint
-#         entry: ./scripts/eslint.sh
-#         language: script
-#         pass_filenames: true
-#         files: ^superset-frontend\/.*\.(js|jsx|ts|tsx)$
-      - id: eslint-docs
-        name: eslint (docs)
-        entry: bash -c 'cd docs && FILES=$(echo "$@" | sed "s|docs/||g") && yarn eslint --ext .js,.jsx,.ts,.tsx --quiet $([ -z "$SKIP_FIX" ] && echo "--fix") $FILES'
-        language: system
-        pass_filenames: true
-        files: ^docs/.*\.(js|jsx|ts|tsx)$
-      - id: type-checking-frontend
-        name: Type-Checking (Frontend)
-        entry: bash -c './scripts/check-type.js package=superset-frontend excludeDeclarationDir=cypress-base'
-        language: system
-        files: ^superset-frontend\/.*\.(js|jsx|ts|tsx)$
-        exclude: ^superset-frontend/cypress-base\/
-        require_serial: true
+        additional_dependencies:
+          - prettier@3.3.3
+        args: ["--ignore-path=./superset-frontend/.prettierignore"]
+        files: "superset-frontend"
+  - repo: local
+    hooks:
+    - id: eslint-frontend
+      name: eslint (frontend)
+      entry: ./scripts/eslint.sh
+      language: system
+      pass_filenames: true
+      files: ^superset-frontend/.*\.(js|jsx|ts|tsx)$
+    - id: eslint-docs
+      name: eslint (docs)
+      entry: bash -c 'cd docs && FILES=$(echo "$@" | sed "s|docs/||g") && yarn eslint --ext .js,.jsx,.ts,.tsx --quiet $([ -z "$SKIP_FIX" ] && echo "--fix") $FILES'
+      language: system
+      pass_filenames: true
+      files: ^docs/.*\.(js|jsx|ts|tsx)$
+    - id: type-checking-frontend
+      name: Type-Checking (Frontend)
+      entry: bash -c './scripts/check-type.js package=superset-frontend excludeDeclarationDir=cypress-base'
+      language: system
+      files: ^superset-frontend\/.*\.(js|jsx|ts|tsx)$
+      exclude: ^superset-frontend/cypress-base\/
+      require_serial: true
   # blacklist unsafe functions like make_url (see #19526)
   - repo: https://github.com/skorokithakis/blacklist-pre-commit-hook
     rev: e2f070289d8eddcaec0b580d3bde29437e7c8221

--- a/scripts/eslint.sh
+++ b/scripts/eslint.sh
@@ -27,4 +27,4 @@ if [[ ! -d "$root_dir/$frontend_dir" ]]; then
 fi
 
 cd "$root_dir/$frontend_dir"
-npm run eslint -- "${@//$frontend_dir\//}"
+npm run eslint -- "${@//$frontend_dir\//}" --fix


### PR DESCRIPTION
Trying to fix prettier and eslint in pre-commit so it only runs on altered files.

@rusackas this works for me, but is largely a rollback of https://github.com/apache/superset/pull/32352 in some key areas. Wondering what's wrong here.

Changes:
- skipping dups in CI (eslint and tsc checks run in another GHA)
- using the prettier action repo as opposed to a custom script
- eslint back on using `scripts/eslint.sh`

If this doesn't work in some cases I can try and address the core issues.