### PR TITLE
chore: bump postgresql from 15 to 16

### DIFF
--- a/.github/workflows/superset-applitool-cypress.yml
+++ b/.github/workflows/superset-applitool-cypress.yml
@@ -39,7 +39,7 @@ jobs:
       APPLITOOLS_BATCH_NAME: Superset Cypress
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -23,7 +23,7 @@ jobs:
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -53,7 +53,7 @@ jobs:
       USE_DASHBOARD: ${{ github.event.inputs.use_dashboard == 'true'|| (github.ref == 'refs/heads/master' && 'true') || 'false' }}
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -85,7 +85,7 @@ jobs:
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@127.0.0.1:15432/superset
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -25,7 +25,7 @@ jobs:
       SUPERSET__SQLALCHEMY_EXAMPLES_URI: presto://localhost:15433/memory/default
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset
@@ -94,7 +94,7 @@ jobs:
       UPLOAD_FOLDER: /tmp/.superset/uploads/
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: superset
           POSTGRES_PASSWORD: superset

--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -41,7 +41,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
-    image: postgres:15
+    image: postgres:16
     container_name: superset_db
     restart: unless-stopped
     volumes:

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -46,7 +46,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
-    image: postgres:15
+    image: postgres:16
     container_name: superset_db
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
-    image: postgres:15
+    image: postgres:16
     container_name: superset_db
     restart: unless-stopped
     ports:

--- a/docs/docs/configuration/configuring-superset.mdx
+++ b/docs/docs/configuration/configuring-superset.mdx
@@ -141,10 +141,10 @@ database engine on a separate host or container.
 
 Superset supports the following database engines/versions:
 
-| Database Engine                           | Supported Versions                 |
-| ----------------------------------------- | ---------------------------------- |
-| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X |
-| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                           |
+| Database Engine                           | Supported Versions                       |
+| ----------------------------------------- | ---------------------------------------- |
+| [PostgreSQL](https://www.postgresql.org/) | 10.X, 11.X, 12.X, 13.X, 14.X, 15.X, 16.X |
+| [MySQL](https://www.mysql.com/)           | 5.7, 8.X                                 |
 
 Use the following database drivers and connection strings:
 

--- a/helm/superset/Chart.lock
+++ b/helm/superset/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.1.6
+  version: 13.4.4
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.9.4

--- a/helm/superset/Chart.yaml
+++ b/helm/superset/Chart.yaml
@@ -32,7 +32,7 @@ maintainers:
 version: 0.14.0
 dependencies:
   - name: postgresql
-    version: 12.1.6
+    version: 13.4.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis

--- a/helm/superset/README.md
+++ b/helm/superset/README.md
@@ -50,7 +50,7 @@ On helm this can be set on `extraSecretEnv.SUPERSET_SECRET_KEY` or `configOverri
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 12.1.6 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 13.4.4 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 17.9.4 |
 
 ## Values


### PR DESCRIPTION
### SUMMARY
This PR bumps to [postgresql:16](https://hub.docker.com/layers/library/postgres/16/images/sha256-295787823185868c4679563715b0a7a07309387f3836117f1b0984d1bfc2bd24) image version in Dockerfile and GH workflows.

Also this PR bumps [Helm Chart postgresql](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) to [v13.4.4](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/CHANGELOG.md#1344-2024-02-01) (latest v13 release) as it uses PostgreSQL 16 (declared [here](https://github.com/bitnami/charts/pull/19587) and [here](https://github.com/bitnami/charts/tree/main/bitnami/postgresql/#to-1300)).

PostgreSQL 16.0 change log: https://www.postgresql.org/docs/release/16.0/

From PostgreSQL release [news](https://www.postgresql.org/about/news/postgresql-16-released-2715/):
> PostgreSQL 16 improves the performance of existing PostgreSQL functionality through new query planner optimizations. In this latest release, the query planner can parallelize FULL and RIGHT joins, generate better optimized plans for queries that use aggregate functions with a DISTINCT or ORDER BY clause, utilize incremental sorts for SELECT DISTINCT queries, and optimize window functions so they execute more efficiently. It also improves RIGHT and OUTER "anti-joins", which enables users to identify rows not present in a joined table.

Documentation has been updated accordingly as done in #24147 and #19790 .

Inspired by discussion #27546 .
