### PR TITLE
docs: add information about ephemeral environments

### DIFF
--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -126,7 +126,11 @@ jobs:
               throw new Error("Issue number is not available.");
             }
 
-            const body = `@${user} Processing your ephemeral environment request [here](${workflowUrl}). Action: **${action}**.`;
+            const body = `@${user} Processing your ephemeral environment request [here](${workflowUrl}).` +
+              ` Action: **${action}**.` +
+              ` More information on [how to use or configure ephemeral environments]` +
+              `(https://superset.apache.org/docs/contributing/howtos/#gitHub-ephermeral-environments)`;
+
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -612,9 +612,9 @@ If using the eslint extension with vscode, put the following in your workspace `
 ## GitHub Ephermeral Environments
 
 On any given pull request on GitHub, it's possible to create a temporary environment/deployment
-by simply adding the label `testenv-up` to the PR. This will trigger a GitHub Action that will.
+by simply adding the label `testenv-up` to the PR.  Once you add the `testenv-up` label, a
+GitHub Action will be triggered that will:
 
-Once you add the `testenv-up` label, a GitHub Action will be triggered that will:
 - build a docker image
 - deploy it in EC2 (sponsored by the folks at [Preset](https://preset.io))
 - write a comment on the PR with a link to the ephemeral environment

--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -608,3 +608,27 @@ If using the eslint extension with vscode, put the following in your workspace `
   "superset-frontend"
 ]
 ```
+
+## GitHub Ephermeral Environments
+
+On any given pull request on GitHub, it's possible to create a temporary environment/deployment
+by simply adding the label `testenv-up` to the PR. This will trigger a GitHub Action that will.
+
+Once you add the `testenv-up` label, a GitHub Action will be triggered that will:
+- build a docker image
+- deploy it in EC2 (sponsored by the folks at [Preset](https://preset.io))
+- write a comment on the PR with a link to the ephemeral environment
+
+For more advanced use cases, it's possible to set a feature flag on the PR body, which will
+take effect on the ephemeral environment. For example, if you want to set the `TAGGING_SYSTEM`
+feature flag to `true`, you can add the following line to the PR body/description:
+
+```
+FEATURE_TAGGING_SYSTEM=true
+```
+
+Simarly, it's possible to disable feature flags with:
+
+```
+FEATURE_TAGGING_SYSTEM=false
+```


### PR DESCRIPTION
Adding an entry in the docs about how to use/configure ephemeral environments.

