### PR TITLE
fix(welcome): perf on distinct recent activities

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -67,6 +67,10 @@ class LRUCache<T> {
   public get size() {
     return this.cache.size;
   }
+
+  public entries(): T[] {
+    return [...this.cache.values()];
+  }
 }
 
 export function lruCache<T>(capacity = 100) {

--- a/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/lruCache.ts
@@ -68,7 +68,7 @@ class LRUCache<T> {
     return this.cache.size;
   }
 
-  public entries(): T[] {
+  public values(): T[] {
     return [...this.cache.values()];
   }
 }

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -35,8 +35,11 @@ test('LRU operations', () => {
   expect(cache.size).toBe(3);
   expect(cache.has('1')).toBeFalsy();
   expect(cache.get('1')).toBeUndefined();
+  expect(cache.entries()).toEqual(['b', 'c', 'd']);
   cache.get('2');
+  expect(cache.entries()).toEqual(['c', 'd', 'b']);
   cache.set('5', 'e');
+  expect(cache.entries()).toEqual(['d', 'b', 'e']);
   expect(cache.has('2')).toBeTruthy();
   expect(cache.has('3')).toBeFalsy();
   // @ts-expect-error
@@ -44,6 +47,7 @@ test('LRU operations', () => {
   // @ts-expect-error
   expect(() => cache.get(0)).toThrow(TypeError);
   expect(cache.size).toBe(3);
+  expect(cache.entries()).toEqual(['d', 'b', 'e']);
   cache.clear();
   expect(cache.size).toBe(0);
   expect(cache.capacity).toBe(3);

--- a/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/lruCache.test.ts
@@ -35,11 +35,11 @@ test('LRU operations', () => {
   expect(cache.size).toBe(3);
   expect(cache.has('1')).toBeFalsy();
   expect(cache.get('1')).toBeUndefined();
-  expect(cache.entries()).toEqual(['b', 'c', 'd']);
+  expect(cache.values()).toEqual(['b', 'c', 'd']);
   cache.get('2');
-  expect(cache.entries()).toEqual(['c', 'd', 'b']);
+  expect(cache.values()).toEqual(['c', 'd', 'b']);
   cache.set('5', 'e');
-  expect(cache.entries()).toEqual(['d', 'b', 'e']);
+  expect(cache.values()).toEqual(['d', 'b', 'e']);
   expect(cache.has('2')).toBeTruthy();
   expect(cache.has('3')).toBeFalsy();
   // @ts-expect-error
@@ -47,7 +47,7 @@ test('LRU operations', () => {
   // @ts-expect-error
   expect(() => cache.get(0)).toThrow(TypeError);
   expect(cache.size).toBe(3);
-  expect(cache.entries()).toEqual(['d', 'b', 'e']);
+  expect(cache.values()).toEqual(['d', 'b', 'e']);
   cache.clear();
   expect(cache.size).toBe(0);
   expect(cache.capacity).toBe(3);

--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -33,19 +33,7 @@ import { Chart } from 'src/types/Chart';
 import Icons from 'src/components/Icons';
 import SubMenu from './SubMenu';
 import EmptyState from './EmptyState';
-import { WelcomeTable } from './types';
-
-/**
- * Return result from /api/v1/log/recent_activity/
- */
-interface RecentActivity {
-  action: string;
-  item_type: 'slice' | 'dashboard';
-  item_url: string;
-  item_title: string;
-  time: number;
-  time_delta_humanized?: string;
-}
+import { WelcomeTable, RecentActivity } from './types';
 
 interface RecentSlice extends RecentActivity {
   item_type: 'slice';

--- a/superset-frontend/src/features/home/types.ts
+++ b/superset-frontend/src/features/home/types.ts
@@ -55,3 +55,15 @@ export enum GlobalMenuDataOptions {
   ExcelUpload = 'excelUpload',
   ColumnarUpload = 'columnarUpload',
 }
+
+/**
+ * Return result from /api/v1/log/recent_activity/
+ */
+export interface RecentActivity {
+  action: string;
+  item_type: 'slice' | 'dashboard';
+  item_url: string;
+  item_title: string;
+  time: number;
+  time_delta_humanized?: string;
+}

--- a/superset-frontend/src/pages/Home/Home.test.tsx
+++ b/superset-frontend/src/pages/Home/Home.test.tsx
@@ -65,9 +65,35 @@ fetchMock.get(savedQueryEndpoint, {
   result: [],
 });
 
+const mockRecentActivityResult = [
+  {
+    action: 'dashboard',
+    item_title: "World Bank's Data",
+    item_type: 'dashboard',
+    item_url: '/superset/dashboard/world_health/',
+    time: 1741644942130.566,
+    time_delta_humanized: 'a day ago',
+  },
+  {
+    action: 'dashboard',
+    item_title: '[ untitled dashboard ]',
+    item_type: 'dashboard',
+    item_url: '/superset/dashboard/19/',
+    time: 1741644881695.7869,
+    time_delta_humanized: 'a day ago',
+  },
+  {
+    action: 'dashboard',
+    item_title: '[ untitled dashboard ]',
+    item_type: 'dashboard',
+    item_url: '/superset/dashboard/19/',
+    time: 1741644381695.7869,
+    time_delta_humanized: 'two day ago',
+  },
+];
+
 fetchMock.get(recentActivityEndpoint, {
-  Created: [],
-  Viewed: [],
+  result: mockRecentActivityResult,
 });
 
 fetchMock.get(chartInfoEndpoint, {
@@ -147,6 +173,20 @@ test('With sql role - renders all panels on the page on page load', async () => 
     /Dashboards|Charts|Recents|Saved queries/,
   );
   expect(panels).toHaveLength(4);
+});
+
+test('With sql role - renders distinct recent activities', async () => {
+  await renderWelcome();
+  const recentPanel = screen.getByRole('button', { name: 'right Recents' });
+  userEvent.click(recentPanel);
+  await waitFor(() =>
+    expect(
+      screen.queryAllByText(mockRecentActivityResult[0].item_title),
+    ).toHaveLength(1),
+  );
+  expect(
+    screen.queryAllByText(mockRecentActivityResult[1].item_title),
+  ).toHaveLength(1);
 });
 
 test('With sql role - calls api methods in parallel on page load', async () => {

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -156,7 +156,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const canReadSavedQueries = userHasPermission(user, 'SavedQuery', 'can_read');
   const userid = user.userId;
   const id = userid!.toString(); // confident that user is not a guest user
-  const params = rison.encode({ page_size: 6 });
+  const params = rison.encode({ page_size: 24, distinct: false });
   const recent = `/api/v1/log/recent_activity/?q=${params}`;
   const [activeChild, setActiveChild] = useState('Loading');
   const userKey = dangerouslyGetItemDoNotUse(id, null);

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -231,7 +231,7 @@ export const getRecentActivityObjs = (
     return getFilteredChartsandDashboards(addDangerToast, filters).then(
       ({ other }) => {
         res.other = other;
-        res.viewed = distinctRes.entries().reverse();
+        res.viewed = distinctRes.values().reverse();
         return res;
       },
     );

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -26,6 +26,7 @@ import {
   SupersetTheme,
   getClientErrorObject,
   t,
+  lruCache,
 } from '@superset-ui/core';
 import Chart from 'src/types/Chart';
 import { intersection } from 'lodash';
@@ -34,7 +35,7 @@ import { FetchDataConfig, FilterValue } from 'src/components/ListView';
 import SupersetText from 'src/utils/textUtils';
 import { findPermission } from 'src/utils/findPermission';
 import { User } from 'src/types/bootstrapTypes';
-import { WelcomeTable } from 'src/features/home/types';
+import { RecentActivity, WelcomeTable } from 'src/features/home/types';
 import { Dashboard, Filter, TableTab } from './types';
 
 // Modifies the rison encoding slightly to match the backend's rison encoding/decoding. Applies globally.
@@ -223,10 +224,14 @@ export const getRecentActivityObjs = (
 ) =>
   SupersetClient.get({ endpoint: recent }).then(recentsRes => {
     const res: any = {};
+    const distinctRes = lruCache<RecentActivity>(6);
+    recentsRes.json.result.reverse().forEach((record: RecentActivity) => {
+      distinctRes.set(record.item_url, record);
+    });
     return getFilteredChartsandDashboards(addDangerToast, filters).then(
       ({ other }) => {
         res.other = other;
-        res.viewed = recentsRes.json.result;
+        res.viewed = distinctRes.entries().reverse();
         return res;
       },
     );


### PR DESCRIPTION
### SUMMARY
Currently, the `recent_activity` query for the log table groups by the dashboard ID and slice ID to extract a distinct list from the entire log table, which leads to performance issues.
(In the case of Airbnb, more than 1 million logs are generated each day, and grouping by dashboard and slice ID, even with indexing, significantly impacts database performance as shown in the following log) 
```
| 3793593 | superset         | 100.117.121.20:41904  | superset_production | Query       |  1726 s| Sending data                                                  | SELECT anon_1.dashboard_id AS anon_1_dashboard_id, anon_1.slice_id AS anon_1_slice_id, anon_1.action AS anon_1_action, anon_1.dttm AS anon_1_dttm, dashboards.slug AS dashboard_slug, dashboards.dashboard_title AS dashboards_dashboard_title, slices.slice_name AS slices_slice_name
FROM (SELECT logs.dashboard_id AS dashboard_id, logs.slice_id AS slice_id, logs.action AS action, max(logs.dttm) AS dttm
FROM logs
WHERE logs.action IN ('explore', 'dashboard') AND logs.user_id = 13295 AND logs.dttm > '2024-03-06 18:00:12.201653' AND (logs.dashboard_id IS NOT NULL OR logs.slice_id IS NOT NULL) GROUP BY logs.dashboard_id, logs.slice_id, logs.action) AS anon_1 LEFT OUTER JOIN dashboards ON dashboards.id = anon_1.dashboard_id LEFT OUTER JOIN slices ON slices.id = anon_1.slice_id
WHERE dashboards.dashboard_title != '' OR slices.slice_name != '' ORDER BY anon_1.dttm DESC
 LIMIT 0, 6 |
```

To resolve this issue, it would be appropriate to create a materialized activity statistics view through a daily/hourly batch job. However, functionally, the main purpose of recent activity is to display only a few of the most recently visited items. Therefore, we improved performance by changing the approach to fetch the latest (including duplicates) log entries (by `distinct: false`) and extract a distinct list using LRU cache in the frontend side.

### TESTING INSTRUCTIONS
specs (no visual changes)
![Screenshot 2025-03-11 at 4 21 02 PM](https://github.com/user-attachments/assets/a902bea9-60d8-4c09-ba67-2850fb08d461)



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
