### PR TITLE
chore: add unique option to index migration utils

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -351,7 +351,9 @@ def drop_columns(table_name: str, *columns: str) -> None:
             batch_op.drop_column(col)
 
 
-def create_index(table_name: str, index_name: str, *columns: str) -> None:
+def create_index(
+    table_name: str, index_name: str, columns: list[str], *, unique: bool = False
+) -> None:
     """
     Creates an index on specified columns of an existing database table.
 
@@ -360,7 +362,8 @@ def create_index(table_name: str, index_name: str, *columns: str) -> None:
 
     :param table_name: The name of the table on which the index will be created.
     :param index_name: The name of the index to be created.
-    :param columns: A list column names where the index will be created
+    :param columns: A list of column names for which the index will be created
+    :param unique: If True, create a unique index.
     """  # noqa: E501
 
     if table_has_index(table=table_name, index=index_name):
@@ -373,7 +376,12 @@ def create_index(table_name: str, index_name: str, *columns: str) -> None:
         f"Creating index {GREEN}{index_name}{RESET} on table {GREEN}{table_name}{RESET}"
     )
 
-    op.create_index(table_name=table_name, index_name=index_name, columns=columns)
+    op.create_index(
+        table_name=table_name,
+        index_name=index_name,
+        unique=unique,
+        columns=columns,
+    )
 
 
 def drop_index(table_name: str, index_name: str) -> None:


### PR DESCRIPTION
### SUMMARY
The signature on the `create_index` migration util doesn't align with that of the signature of the corresponding classmethod in [alembic](https://github.com/sqlalchemy/alembic/blob/f4b269a370264eae531277fe795e1f9bee2a0446/alembic/operations/ops.py#L929-L941):
- no `unique` option
- the columns need to be an explicit list, as otherwise we can't have an optional `unique` in it.

By adding an optional `unique` flag (that has to be passed as a keyword argument) and making `columns` an explicit list rather than variable arguments makes it possible to create unique indexes, and more closely aligns with the original class method in alembic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
