### PR TITLE
fix(dashboard): Ensure `dashboardId` is included in `form_data` for embedded mode

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -157,6 +157,7 @@ const Chart = props => {
         state.datasources[chart.form_data.datasource]) ||
       PLACEHOLDER_DATASOURCE,
   );
+  const dashboardInfo = useSelector(state => state.dashboardInfo);
 
   const [descriptionHeight, setDescriptionHeight] = useState(0);
   const [height, setHeight] = useState(props.height);
@@ -303,6 +304,8 @@ const Chart = props => {
       ownColorScheme,
     ],
   );
+
+  formData.dashboardId = dashboardInfo.id;
 
   const onExploreChart = useCallback(
     async clickEvent => {

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
@@ -74,6 +74,7 @@ const defaultState = {
   datasources: mockDatasource,
   dashboardState: { editMode: false, expandedSlices: {} },
   dashboardInfo: {
+    id: props.dashboardId,
     superset_can_explore: false,
     superset_can_share: false,
     superset_can_csv: false,
@@ -165,7 +166,9 @@ test('should call exportChart when exportCSV is clicked', async () => {
   expect(stubbedExportCSV).toHaveBeenCalledTimes(1);
   expect(stubbedExportCSV).toHaveBeenCalledWith(
     expect.objectContaining({
-      formData: expect.anything(),
+      formData: expect.objectContaining({
+        dashboardId: 111,
+      }),
       resultType: 'full',
       resultFormat: 'csv',
     }),
@@ -195,6 +198,7 @@ test('should call exportChart with row_limit props.maxRows when exportFullCSV is
     expect.objectContaining({
       formData: expect.objectContaining({
         row_limit: 666,
+        dashboardId: 111,
       }),
       resultType: 'full',
       resultFormat: 'csv',
@@ -249,6 +253,7 @@ test('should call exportChart with row_limit props.maxRows when exportFullXLSX i
     expect.objectContaining({
       formData: expect.objectContaining({
         row_limit: 666,
+        dashboardId: 111,
       }),
       resultType: 'full',
       resultFormat: 'xlsx',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes an issue where charts fail to load in **Apache Superset’s embedded mode** when using the **Gamma role** for guest users. The error message displayed is:  

```
This endpoint requires the datasource *, database or all_datasource_access permission
```

Granting `all_datasource_access` does not resolve the issue.  

### Root Cause  
This issue was introduced after the `<Charts/>` component was refactored. The problem occurs because **the request is sent to the backend without the `dashboardID` in the `form_data` object**.  

- In the **previous working implementation**, `dashboardId` was properly set:  
  [Previous implementation](https://github.com/apache/superset/blob/superset-helm-chart-0.13.4/superset-frontend/src/dashboard/containers/Chart.jsx#L90)  
- In the **refactored version**, this logic was removed:  
  [Refactored `<Charts/>` component](https://github.com/apache/superset/blob/master/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx)  

### Fix  
This PR restores the missing `dashboardId` by adding the following two lines of code:  

```javascript
const dashboardInfo = useSelector(state => state.dashboardInfo);
formData.dashboardId = dashboardInfo.id;
```

Additionally, I have updated **unit tests** to cover this case and ensure proper validation.  

fixes: #32552
fixes: #32219

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before:
<img width="1512" alt="Image" src="https://github.com/user-attachments/assets/11a464e2-7668-4bb8-977d-72c68c75e7ac" />

#### After:
<img width="1506" alt="Image" src="https://github.com/user-attachments/assets/6b485e0e-7b2a-4244-8951-5ae3a5004e67" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Enable embedded mode:  
   ```python
   FEATURE_FLAGS = {"EMBEDDED_SUPERSET": True}
   GUEST_ROLE_NAME = "Gamma"
   ```
2. Run Superset with:  
   ```bash
   docker compose up --build
   ```
3. Open a dashboard and enable embedding.  
4. Use the dashboard ID in a frontend app (e.g., `@superset-ui/embedded-sdk`).  
5. Open the page in a browser.  
6. Verify that charts load correctly without a `403` error. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 
    #32552
    #32219
- [x] Required feature flags: `FEATURE_FLAGS = {"EMBEDDED_SUPERSET": True}` is needed
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
