### PR TITLE
fix(import): Import a DB connection with expanded rows enabled

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -831,6 +831,7 @@ class ImportV1DatabaseExtraSchema(Schema):
     disable_drill_to_detail = fields.Boolean(required=False)
     allow_multi_catalog = fields.Boolean(required=False)
     version = fields.String(required=False, allow_none=True)
+    schema_options = fields.Dict(keys=fields.Str(), values=fields.Raw())
 
 
 class ImportV1DatabaseSchema(Schema):

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3168,6 +3168,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         database_config_row_expansion = database_config.copy()
         database_config_row_expansion["extra"]["schema_options"] = {"expand_rows": True}
+        database_config_row_expansion["uuid"] = "b8a1ccd3-779d-4ab7-8ad8-9ab119d7ff90"
 
         buf = BytesIO()
         with ZipFile(buf, "w") as bundle:

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -3168,6 +3168,12 @@ class TestDatabaseApi(SupersetTestCase):
 
         db_config = {
             "database_name": "DB with expand rows enabled",
+            "allow_csv_upload": True,
+            "allow_ctas": True,
+            "allow_cvas": True,
+            "allow_dml": True,
+            "allow_run_async": False,
+            "cache_timeout": None,
             "expose_in_sqllab": True,
             "extra": {
                 "schema_options": {"expand_rows": True},


### PR DESCRIPTION
### SUMMARY
Trying to import a DB connection that has **Enable row expansion in schemas** enabled does not work. This PR fixes this issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes -- before you would get this error:

![image](https://github.com/user-attachments/assets/02aeedbb-43c0-4486-9990-0272fc945795)


### TESTING INSTRUCTIONS
Testing added. For manual testing:
1. Create a DB connection.
2. Edit it, access the **Advanced** tab, expand the **SQL Lab** and enable the **Enable row expansion in schemas** option.
3. Save changes.
4. Export the DB connection.
5. Try importing it, and validate it works properly (and the setting reflects as enabled via the UI).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
