### PR TITLE
fix(sync perms): Avoid UnboundLocalError during perm sync for DBs that don't support catalogs

### DIFF
--- a/superset/commands/database/sync_permissions.py
+++ b/superset/commands/database/sync_permissions.py
@@ -249,11 +249,11 @@ class SyncPermissionsCommand(BaseCommand):
         self, catalog: str | None, schemas: Iterable[str]
     ) -> None:
         # rename existing catalog permission
+        new_catalog_perm_name = security_manager.get_catalog_perm(
+            self.db_connection.name,
+            catalog,
+        )
         if catalog:
-            new_catalog_perm_name = security_manager.get_catalog_perm(
-                self.db_connection.name,
-                catalog,
-            )
             new_catalog_vm = add_vm(db.session, security_manager, new_catalog_perm_name)
             perm = security_manager.get_catalog_perm(
                 self.old_db_connection_name,


### PR DESCRIPTION
### SUMMARY
The `SyncPermissionsCommand` could result in an `UnboundLocalError` in case the DB connection doesn't support catalogs (and therefore the `catalog` value is `None`). This would happen in case the connection display name has been updated + the connection has at least one dataset associated with it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Create a connection to a DB engine that don't support catalogs.
2. Create a dataset from it.
3. Create a chart from this dataset as well, just for good measure.
4. Edit the connection, updating its display name.

Test coverage added too.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
