### PR TITLE
fix: Time Comparison Feature Reverts Metric Labels to Metric Keys in Table Charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -608,9 +608,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       // Retrieve the originalLabel from the first column in this group
       const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
 
-      if (!columnsMeta[columnIndex]?.originalLabel) {
+      if (!columnsMeta[value[0]]?.originalLabel) {
+        // Use a proper logging function if available
         console.debug(
-          `originalLabel not found for column at index ${columnIndex}, using key as fallback`,
+          `originalLabel not found for column at index ${value[0]}, using key as fallback`,
         );
       }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -977,7 +977,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         ),
         Footer: totals ? (
           i === 0 ? (
-            <th>
+            <th key={`footer-summary-${i}`}>
               <div
                 css={css`
                   display: flex;
@@ -999,7 +999,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               </div>
             </th>
           ) : (
-            <td style={sharedStyle}>
+            <td key={`footer-total-${i}`} style={sharedStyle}>
               <strong>{formatColumnValue(column, totals[key])[1]}</strong>
             </td>
           )

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -608,13 +608,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       // Retrieve the originalLabel from the first column in this group
       const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
 
-      if (!columnsMeta[value[0]]?.originalLabel) {
-        // Use a proper logging function if available
-        console.debug(
-          `originalLabel not found for column at index ${value[0]}, using key as fallback`,
-        );
-      }
-
       // Add placeholder <th> for columns before this header
       for (let i = currentColumnIndex; i < startPosition; i += 1) {
         headers.push(

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -605,7 +605,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       // Calculate the number of placeholder columns needed before the current header
       const startPosition = value[0];
       const colSpan = value.length;
-
+    // Retrieve the originalLabel from the first column in this group
+    const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
+    
       // Add placeholder <th> for columns before this header
       for (let i = currentColumnIndex; i < startPosition; i += 1) {
         headers.push(
@@ -620,7 +622,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       // Add the current header <th>
       headers.push(
         <th key={`header-${key}`} colSpan={colSpan} style={{ borderBottom: 0 }}>
-          {key}
+          {originalLabel}
           <span
             css={css`
               float: right;

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -605,9 +605,15 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       // Calculate the number of placeholder columns needed before the current header
       const startPosition = value[0];
       const colSpan = value.length;
-    // Retrieve the originalLabel from the first column in this group
-    const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
-    
+      // Retrieve the originalLabel from the first column in this group
+      const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
+
+      if (!columnsMeta[columnIndex]?.originalLabel) {
+        console.debug(
+          `originalLabel not found for column at index ${columnIndex}, using key as fallback`,
+        );
+      }
+
       // Add placeholder <th> for columns before this header
       for (let i = currentColumnIndex; i < startPosition; i += 1) {
         headers.push(

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -347,6 +347,7 @@ const processComparisonColumns = (
       } = props;
       const savedFormat = columnFormats?.[col.key];
       const savedCurrency = currencyFormats?.[col.key];
+      const originalLabel = col.label;
       if (
         (col.isMetric || col.isPercentMetric) &&
         !col.key.includes(comparisonSuffix) &&
@@ -355,6 +356,7 @@ const processComparisonColumns = (
         return [
           {
             ...col,
+            originalLabel,
             label: t('Main'),
             key: `${t('Main')} ${col.key}`,
             config: getComparisonColConfig(t('Main'), col.key, columnConfig),
@@ -368,6 +370,7 @@ const processComparisonColumns = (
           },
           {
             ...col,
+            originalLabel,
             label: `#`,
             key: `# ${col.key}`,
             config: getComparisonColConfig(`#`, col.key, columnConfig),
@@ -381,6 +384,7 @@ const processComparisonColumns = (
           },
           {
             ...col,
+            originalLabel,
             label: `△`,
             key: `△ ${col.key}`,
             config: getComparisonColConfig(`△`, col.key, columnConfig),
@@ -394,6 +398,7 @@ const processComparisonColumns = (
           },
           {
             ...col,
+            originalLabel,
             label: `%`,
             key: `% ${col.key}`,
             config: getComparisonColConfig(`%`, col.key, columnConfig),

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -56,6 +56,7 @@ export interface DataColumnMeta {
   key: string;
   // `label` is verbose column name used for rendering
   label: string;
+  originalLabel?: string;
   dataType: GenericDataType;
   formatter?:
     | TimeFormatter

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -56,6 +56,7 @@ export interface DataColumnMeta {
   key: string;
   // `label` is verbose column name used for rendering
   label: string;
+  // `originalLabel` preserves the original label when time comparison transforms the labels
   originalLabel?: string;
   dataType: GenericDataType;
   formatter?:

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -175,6 +175,75 @@ describe('plugin-chart-table', () => {
         ?.formatter?.(0.123456);
       expect(formattedPercentMetric).toBe('0.123');
     });
+
+    it('should set originalLabel for comparison columns when time_compare and comparison_type are set', () => {
+      const transformedProps = transformProps(testData.comparison);
+
+      // Check if comparison columns are processed
+      const comparisonColumns = transformedProps.columns.filter(
+        col =>
+          col.label === 'Main' ||
+          col.label === '#' ||
+          col.label === '△' ||
+          col.label === '%',
+      );
+
+      expect(comparisonColumns.length).toBeGreaterThan(0);
+      expect(comparisonColumns.some(col => col.label === 'Main')).toBe(true);
+      expect(comparisonColumns.some(col => col.label === '#')).toBe(true);
+      expect(comparisonColumns.some(col => col.label === '△')).toBe(true);
+      expect(comparisonColumns.some(col => col.label === '%')).toBe(true);
+
+      // Verify originalLabel for metric_1 comparison columns
+      const mainMetric1 = transformedProps.columns.find(
+        col => col.key === 'Main metric_1',
+      );
+      expect(mainMetric1).toBeDefined();
+      expect(mainMetric1?.originalLabel).toBe('metric_1');
+
+      const hashMetric1 = transformedProps.columns.find(
+        col => col.key === '# metric_1',
+      );
+      expect(hashMetric1).toBeDefined();
+      expect(hashMetric1?.originalLabel).toBe('metric_1');
+
+      const deltaMetric1 = transformedProps.columns.find(
+        col => col.key === '△ metric_1',
+      );
+      expect(deltaMetric1).toBeDefined();
+      expect(deltaMetric1?.originalLabel).toBe('metric_1');
+
+      const percentMetric1 = transformedProps.columns.find(
+        col => col.key === '% metric_1',
+      );
+      expect(percentMetric1).toBeDefined();
+      expect(percentMetric1?.originalLabel).toBe('metric_1');
+
+      // Verify originalLabel for metric_2 comparison columns
+      const mainMetric2 = transformedProps.columns.find(
+        col => col.key === 'Main metric_2',
+      );
+      expect(mainMetric2).toBeDefined();
+      expect(mainMetric2?.originalLabel).toBe('metric_2');
+
+      const hashMetric2 = transformedProps.columns.find(
+        col => col.key === '# metric_2',
+      );
+      expect(hashMetric2).toBeDefined();
+      expect(hashMetric2?.originalLabel).toBe('metric_2');
+
+      const deltaMetric2 = transformedProps.columns.find(
+        col => col.key === '△ metric_2',
+      );
+      expect(deltaMetric2).toBeDefined();
+      expect(deltaMetric2?.originalLabel).toBe('metric_2');
+
+      const percentMetric2 = transformedProps.columns.find(
+        col => col.key === '% metric_2',
+      );
+      expect(percentMetric2).toBeDefined();
+      expect(percentMetric2?.originalLabel).toBe('metric_2');
+    });
   });
 
   describe('TableChart', () => {
@@ -399,6 +468,17 @@ describe('plugin-chart-table', () => {
         '',
       );
       expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
+    });
+    it('should display originalLabel in grouped headers', () => {
+      render(
+        <ThemeProvider theme={supersetTheme}>
+          <TableChart {...transformProps(testData.comparison)} sticky={false} />
+        </ThemeProvider>,
+      );
+
+      const groupHeaders = screen.getAllByRole('columnheader');
+      expect(groupHeaders[0]).toHaveTextContent('metric_1');
+      expect(groupHeaders[1]).toHaveTextContent('metric_2');
     });
   });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Fixes: #32621
FEATURE_CHART_PLUGINS_EXPERIMENTAL=true

### SUMMARY
This PR addresses an issue where, with Time Comparison enabled in the Table Chart, the metric name ignores the defined label and instead uses the metric key. This results in an unfriendly display name in the UI.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

###Changes
- Introduced originalLabel in the DataColumnMeta interface to retain the correct label.
- Updated processComparisonColumns to store originalLabel before modifying the metric label.
- Ensured renderGroupingHeaders retrieves and displays the originalLabel correctly in grouped headers.

### BEFORE/AFTER SCREENSHOTS
#### Before
![Screenshot 2025-03-14 at 11 33 05 AM](https://github.com/user-attachments/assets/90d54d69-b31a-42a0-b9b5-fc06ce41ae93)

#### After
![Screenshot 2025-03-14 at 12 29 16 PM](https://github.com/user-attachments/assets/4d40269d-232e-4739-b7ed-6b229c420640)
