### PR TITLE
fix: python 3.9 annotations from the future

### DIFF
--- a/superset/db_engine_specs/starrocks.py
+++ b/superset/db_engine_specs/starrocks.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import logging
 import re

--- a/superset/utils/ssh_tunnel.py
+++ b/superset/utils/ssh_tunnel.py
@@ -14,6 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+from __future__ import annotations
 
 from typing import Any
 


### PR DESCRIPTION
### SUMMARY
Fix to support python 3.9 using future annotations, we had a couple missing  

Can fail builds with:
```
    File "/home/runner/work/superset-private/superset-private/superset/utils/ssh_tunnel.py", line 53, in <module>
      def get_default_port(backend: str) -> int | None:
  TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
