### PR TITLE
fix: ensure datasource permission in explore

### DIFF
--- a/superset/commands/explore/get.py
+++ b/superset/commands/explore/get.py
@@ -120,7 +120,7 @@ class GetExploreCommand(BaseCommand, ABC):
 
         if datasource:
             datasource_name = datasource.name
-            security_manager.can_access_datasource(datasource)
+            security_manager.raise_for_access(datasource=datasource)
 
         viz_type = form_data.get("viz_type")
         if not viz_type and datasource and datasource.default_endpoint:

--- a/tests/integration_tests/explore/api_tests.py
+++ b/tests/integration_tests/explore/api_tests.py
@@ -214,12 +214,12 @@ def test_get_dataset_access_denied_with_form_data_key(
     assert data["message"] == message
 
 
-@patch("superset.security.SupersetSecurityManager.can_access_datasource")
+@patch("superset.security.SupersetSecurityManager.raise_for_access")
 def test_get_dataset_access_denied(
-    mock_can_access_datasource, test_client, login_as_admin, dataset
+    mock_raise_for_access, test_client, login_as_admin, dataset
 ):
     message = "Dataset access denied"
-    mock_can_access_datasource.side_effect = DatasetAccessDeniedError(
+    mock_raise_for_access.side_effect = DatasetAccessDeniedError(
         message=message, datasource_id=dataset.id, datasource_type=dataset.type
     )
     resp = test_client.get(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Problem: The `/explore` command does not validate if datasource access is permitted.

Source: https://github.com/apache/superset/blob/15cf06699aa05719697f34a16e4e9989dfdc8af1/superset/commands/explore/get.py#L123

The intention seems to be to `raise_for_access` but instead the boolean result is simply discarded.

Result: Metadata about inaccessible datasources is disclosed, including names, can be enumerated through
`/explore/?datasource_type=table&datasource_id=COUNTER`

### TESTING INSTRUCTIONS
open `/explore/?datasource_type=table&datasource_id=X` with(out) permissions and observe datasource name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
