### PR TITLE
chore(build): prevent Dependabot opening PR to bump `prettier`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
 
   - package-ecosystem: "npm"
     ignore:
-      # not until React >= 18.0.0
+      # TODO: remove once project's React >= 18.0.0
       - dependency-name: "storybook"
       - dependency-name: "@storybook*"
+      # has to coordinate with the version in pre-commit as well
+      # and prettify whole codebase to avoid breaking CI
+      # TODO: agentic AI can do this?
+      - dependency-name: "prettier"
     directory: "/superset-frontend/"
     schedule:
       interval: "monthly"
@@ -329,7 +333,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-core/"
     ignore:
-      # not until React >= 18.0.0
+      # TODO: remove once project's React >= 18.0.0
       - dependency-name: "react-markdown"
       - dependency-name: "remark-gfm"
     schedule:
@@ -342,6 +346,10 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/superset-frontend/packages/superset-ui-demo/"
+    ignore:
+      # TODO: remove once project's React >= 18.0.0
+      - dependency-name: "storybook"
+      - dependency-name: "@storybook*"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(build): prevent Dependabot opening PR to bump `prettier`

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bumping versions for `prettier` in superset-frontend is a bit manually atm. Mere change in lockfile is not enough; we have to bump the version in pre-commit config and to actually run `npm run lint-fix` to get the codebase up to date with newer `prettier` baseline. This PR is to reduce a bit of maintenance hassle.

In addition, I pinned `storybook` at v8.1.11 for `superset-ui-demo` to avoid Dependabot PRs as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
