### PR TITLE
build(dev-deps): bump prettier to v3.5.3 and follow-up refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier@3.3.3
+          - prettier@3.5.3
         args: ["--ignore-path=./superset-frontend/.prettierignore"]
         files: "superset-frontend"
   - repo: local

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -272,7 +272,7 @@
         "mini-css-extract-plugin": "^2.9.0",
         "open-cli": "^8.0.0",
         "po2json": "^0.4.5",
-        "prettier": "3.3.3",
+        "prettier": "3.5.3",
         "prettier-plugin-packagejson": "^2.5.3",
         "process": "^0.11.10",
         "react-resizable": "^3.0.5",
@@ -37462,9 +37462,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "devOptional": true,
       "license": "MIT",
       "bin": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -17353,9 +17353,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvg": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -339,7 +339,7 @@
     "mini-css-extract-plugin": "^2.9.0",
     "open-cli": "^8.0.0",
     "po2json": "^0.4.5",
-    "prettier": "3.3.3",
+    "prettier": "3.5.3",
     "prettier-plugin-packagejson": "^2.5.3",
     "process": "^0.11.10",
     "react-resizable": "^3.0.5",

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -146,7 +146,8 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
           </Menu>
         }
       />
-      <TabTitle>{qe.name}</TabTitle> <TabStatusIcon tabState={queryState} />{' '}
+      <TabTitle>{qe.name}</TabTitle>{' '}
+      <TabStatusIcon tabState={queryState} />{' '}
     </TabTitleWrapper>
   );
 };

--- a/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
+++ b/superset-frontend/src/dashboard/components/menu/BackgroundStyleDropdown.tsx
@@ -57,12 +57,13 @@ const BackgroundStyleOption = styled.div`
 
     /* Create the transparent rect icon */
     &.background--transparent:before {
-      background-image: linear-gradient(
-          45deg,
+      background-image:
+        linear-gradient(45deg, ${theme.colors.text.label} 25%, transparent 25%),
+        linear-gradient(
+          -45deg,
           ${theme.colors.text.label} 25%,
           transparent 25%
         ),
-        linear-gradient(-45deg, ${theme.colors.text.label} 25%, transparent 25%),
         linear-gradient(45deg, transparent 75%, ${theme.colors.text.label} 75%),
         linear-gradient(-45deg, transparent 75%, ${theme.colors.text.label} 75%);
       background-size: ${theme.gridUnit * 2}px ${theme.gridUnit * 2}px;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
build(dev-deps): bump prettier to v3.5.3 and follow-up refactor

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bump `prettier` across the codebase and execute `npm run prettier` to do necessary refactor. Also fix CVE-2025-25977 by bumping `canvg` to patched v3.0.11

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
