### PR TITLE
docs(api): correct attribute `name` instead of `table` for GET table_metadata in openapi.json

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -18736,7 +18736,7 @@
           {
             "description": "Table name",
             "in": "query",
-            "name": "table",
+            "name": "name",
             "required": true,
             "schema": {
               "type": "string"

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -1016,7 +1016,7 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
           - in: query
             schema:
               type: string
-            name: table
+            name: name
             required: true
             description: Table name
           - in: query


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
docs(api): correct attribute `name` instead of `table` for GET table_metadata in openapi.json

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #32685 using Korbit's suggestion, which is true.

After
<img width="773" alt="image" src="https://github.com/user-attachments/assets/0a83ce93-a370-48a8-9a8b-1de76c1e578d" />


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
