### PR TITLE
fix(cosmetics): allow toast message to be toggled off when modal is opened

### DIFF
--- a/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
+++ b/superset-frontend/src/components/MessageToasts/ToastPresenter.tsx
@@ -31,7 +31,7 @@ const StyledToastPresenter = styled.div<VisualProps>`
   right: 0px;
   margin-right: 50px;
   margin-bottom: 50px;
-  z-index: ${({ theme }) => theme.zIndex.max};
+  z-index: ${({ theme }) => theme.zIndex.max + 1};
   word-break: break-word;
 
   .toast {


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(cosmetics): allow toast message to be toggled off when modal is opened

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #32536

Allow toast message to be interactive when a modal is opened. This is done by always have the toast at least 1 `z-index` higher than the max value.

Maybe I'm simple-minded but I just couldn't find a way to configure AntD to insert Toasts outside of DOM like Evan has suggested in the linked issue.

Normal toast functionality seems to be OK when there's no modal involved.

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/9638ca87-81d4-4953-bd2a-007dcc98a17a" />


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/d2fc55d8-51bb-4e07-8135-fff31a0646ec" />

After
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/1d6ff4de-8199-4435-9389-31ff54419e6f" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
