### PR TITLE
fix(spreadsheet uploads): make file extension comparisons case-insensitive

### DIFF
--- a/superset-frontend/src/features/databases/UploadDataModel/index.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/index.tsx
@@ -183,8 +183,9 @@ export const validateUploadFileExtension = (
     return false;
   }
 
-  const fileType = extensionMatch[1];
-  return allowedExtensions.includes(fileType);
+  const fileType = extensionMatch[1].toLowerCase();
+  const lowerCaseAllowedExtensions = allowedExtensions.map(ext => ext.toLowerCase());
+  return lowerCaseAllowedExtensions.includes(fileType);
 };
 
 interface StyledSwitchContainerProps extends SwitchProps {

--- a/superset-frontend/src/features/databases/UploadDataModel/index.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/index.tsx
@@ -184,7 +184,9 @@ export const validateUploadFileExtension = (
   }
 
   const fileType = extensionMatch[1].toLowerCase();
-  const lowerCaseAllowedExtensions = allowedExtensions.map(ext => ext.toLowerCase());
+  const lowerCaseAllowedExtensions = allowedExtensions.map(ext =>
+    ext.toLowerCase(),
+  );
   return lowerCaseAllowedExtensions.includes(fileType);
 };
 

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -1086,7 +1086,10 @@ class BaseUploadFilePostSchemaMixin(Schema):
     def validate_file_extension(self, file: FileStorage) -> None:
         allowed_extensions = current_app.config["ALLOWED_EXTENSIONS"]
         file_suffix = Path(file.filename).suffix
-        if not file_suffix or file_suffix[1:] not in allowed_extensions:
+        if not file_suffix:
+            raise ValidationError([_("File extension is not allowed.")])
+        # Make case-insensitive comparison
+        if file_suffix[1:].lower() not in [ext.lower() for ext in allowed_extensions]:
             raise ValidationError([_("File extension is not allowed.")])
 
 


### PR DESCRIPTION
### SUMMARY
If `.xlsx` is an allowed upload type, files ending in `.XLSX` should be allowed as well.

### TESTING INSTRUCTIONS
Tried it out locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: fixes #32654 
