### PR TITLE
fix: boolean filters in Explore

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -225,8 +225,8 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter2.translateToSql()).toBe('SUM(value) <> 5');
   });
-  it('sets comparator to null when operator is IS_NULL', () => {
-    const adhocFilter2 = new AdhocFilter({
+  it('sets comparator to undefined when operator is IS_NULL', () => {
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'SUM(value)',
       operator: 'IS NULL',
@@ -234,10 +234,10 @@ describe('AdhocFilter', () => {
       comparator: '5',
       clause: Clauses.Having,
     });
-    expect(adhocFilter2.comparator).toBe(null);
+    expect(adhocFilter.comparator).toBe(undefined);
   });
-  it('sets comparator to null when operator is IS_NOT_NULL', () => {
-    const adhocFilter2 = new AdhocFilter({
+  it('sets comparator to undefined when operator is IS_NOT_NULL', () => {
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'SUM(value)',
       operator: 'IS NOT NULL',
@@ -245,38 +245,60 @@ describe('AdhocFilter', () => {
       comparator: '5',
       clause: Clauses.Having,
     });
-    expect(adhocFilter2.comparator).toBe(null);
+    expect(adhocFilter.comparator).toBe(undefined);
+  });
+  it('sets comparator to undefined when operator is IS_TRUE', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: 'IS TRUE',
+      operatorId: Operators.IsTrue,
+      comparator: '5',
+      clause: Clauses.Having,
+    });
+    expect(adhocFilter.comparator).toBe(undefined);
+  });
+  it('sets comparator to undefined when operator is IS_FALSE', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: 'IS FALSE',
+      operatorId: Operators.IsFalse,
+      comparator: '5',
+      clause: Clauses.Having,
+    });
+    expect(adhocFilter.comparator).toBe(undefined);
   });
   it('sets the label properly if subject is a string', () => {
-    const adhocFilter2 = new AdhocFilter({
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'order_date',
     });
-    expect(adhocFilter2.getDefaultLabel()).toBe('order_date');
+    expect(adhocFilter.getDefaultLabel()).toBe('order_date');
   });
   it('sets the label properly if subject is an object with the column_date property', () => {
-    const adhocFilter2 = new AdhocFilter({
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: {
         column_name: 'year',
       },
     });
-    expect(adhocFilter2.getDefaultLabel()).toBe('year');
+    expect(adhocFilter.getDefaultLabel()).toBe('year');
   });
   it('sets the label to empty is there is no column_name in the object', () => {
-    const adhocFilter2 = new AdhocFilter({
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: {
         unknown: 'year',
       },
     });
-    expect(adhocFilter2.getDefaultLabel()).toBe('');
+    expect(adhocFilter.getDefaultLabel()).toBe('');
   });
   it('sets the label to empty is there is no subject', () => {
-    const adhocFilter2 = new AdhocFilter({
+    const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: undefined,
     });
-    expect(adhocFilter2.getDefaultLabel()).toBe('');
+    expect(adhocFilter.getDefaultLabel()).toBe('');
   });
 });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -330,25 +330,25 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       expect(isOperatorRelevant(operator, 'value')).toBe(true);
     });
   });
-  it('sets comparator to true when operator is IS_TRUE', () => {
+  it('sets comparator to undefined when operator is IS_TRUE', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     onOperatorChange(Operators.IsTrue);
     expect(props.onChange.calledOnce).toBe(true);
     expect(props.onChange.lastCall.args[0].operatorId).toBe(Operators.IsTrue);
-    expect(props.onChange.lastCall.args[0].operator).toBe('==');
-    expect(props.onChange.lastCall.args[0].comparator).toBe(true);
+    expect(props.onChange.lastCall.args[0].operator).toBe('IS TRUE');
+    expect(props.onChange.lastCall.args[0].comparator).toBe(undefined);
   });
-  it('sets comparator to false when operator is IS_FALSE', () => {
+  it('sets comparator to undefined when operator is IS_FALSE', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     onOperatorChange(Operators.IsFalse);
     expect(props.onChange.calledOnce).toBe(true);
     expect(props.onChange.lastCall.args[0].operatorId).toBe(Operators.IsFalse);
-    expect(props.onChange.lastCall.args[0].operator).toBe('==');
-    expect(props.onChange.lastCall.args[0].comparator).toBe(false);
+    expect(props.onChange.lastCall.args[0].operator).toBe('IS FALSE');
+    expect(props.onChange.lastCall.args[0].comparator).toBe(undefined);
   });
-  it('sets comparator to null when operator is IS_NULL or IS_NOT_NULL', () => {
+  it('sets comparator to undefined when operator is IS_NULL or IS_NOT_NULL', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     [Operators.IsNull, Operators.IsNotNull].forEach(op => {
@@ -358,7 +358,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       expect(props.onChange.lastCall.args[0].operator).toBe(
         OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation,
       );
-      expect(props.onChange.lastCall.args[0].comparator).toBe(null);
+      expect(props.onChange.lastCall.args[0].comparator).toBe(undefined);
     });
   });
 });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -209,9 +209,6 @@ export const useSimpleTabFilterProps = (props: Props) => {
         ? currentComparator[0]
         : currentComparator;
     }
-    if (operatorId === Operators.IsTrue || operatorId === Operators.IsFalse) {
-      newComparator = Operators.IsTrue === operatorId;
-    }
     if (operatorId && CUSTOM_OPERATORS.has(operatorId)) {
       props.onChange(
         props.adhocFilter.duplicateWith({

--- a/superset-frontend/src/explore/constants.ts
+++ b/superset-frontend/src/explore/constants.ts
@@ -83,8 +83,8 @@ export const OPERATOR_ENUM_TO_OPERATOR_TYPE: {
     display: t('use latest_partition template'),
     operation: 'LATEST PARTITION',
   },
-  [Operators.IsTrue]: { display: t('Is true'), operation: '==' },
-  [Operators.IsFalse]: { display: t('Is false'), operation: '==' },
+  [Operators.IsTrue]: { display: t('Is true'), operation: 'IS TRUE' },
+  [Operators.IsFalse]: { display: t('Is false'), operation: 'IS FALSE' },
   [Operators.TemporalRange]: {
     display: t('TEMPORAL_RANGE'),
     operation: 'TEMPORAL_RANGE',

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -32,6 +32,7 @@ import { safeStringify } from 'src/utils/safeStringify';
 import { optionLabel } from 'src/utils/common';
 import { URL_PARAMS } from 'src/constants';
 import {
+  DISABLE_INPUT_OPERATORS,
   MULTI_OPERATORS,
   OPERATOR_ENUM_TO_OPERATOR_TYPE,
   UNSAVED_CHART_ID,
@@ -300,6 +301,10 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
     [...MULTI_OPERATORS]
       .map(op => OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation)
       .indexOf(operator) >= 0;
+  const showComparator =
+    DISABLE_INPUT_OPERATORS.map(
+      op => OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation,
+    ).indexOf(operator) === -1;
   // If returned value is an object after changing dataset
   let expression =
     typeof subject === 'object'
@@ -314,13 +319,13 @@ export const getSimpleSQLExpression = (subject, operator, comparator) => {
       firstValue !== undefined && Number.isNaN(Number(firstValue));
     const quote = isString ? "'" : '';
     const [prefix, suffix] = isMulti ? ['(', ')'] : ['', ''];
-    const formattedComparators = comparatorArray
-      .map(val => optionLabel(val))
-      .map(
-        val =>
-          `${quote}${isString ? String(val).replace(/'/g, "''") : val}${quote}`,
-      );
-    if (comparatorArray.length > 0) {
+    if (comparatorArray.length > 0 && showComparator) {
+      const formattedComparators = comparatorArray
+        .map(val => optionLabel(val))
+        .map(
+          val =>
+            `${quote}${isString ? String(val).replace(/'/g, "''") : val}${quote}`,
+        );
       expression += ` ${prefix}${formattedComparators.join(', ')}${suffix}`;
     }
   }

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -722,6 +722,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     }
     fetch_values_predicate = None
 
+    normalize_columns = False
+
     @property
     def type(self) -> str:
         raise NotImplementedError()
@@ -1976,7 +1978,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         self.make_orderby_compatible(select_exprs, orderby_exprs)
 
-        for col, (orig_col, ascending) in zip(orderby_exprs, orderby, strict=False):  # noqa: B007
+        for col, (_orig_col, ascending) in zip(orderby_exprs, orderby, strict=False):  # noqa: B007
             if not db_engine_spec.allows_alias_in_orderby and isinstance(col, Label):
                 # if engine does not allow using SELECT alias in ORDER BY
                 # revert to the underlying column


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When filtering boolean columns in the chart builder we're using the operator `==` for `IS TRUE` and `IS FALSE`, instead of the native operators:

```typescript
  [Operators.IsTrue]: { display: t('Is true'), operation: '==' },
  [Operators.IsFalse]: { display: t('Is false'), operation: '==' },
```

There are two problems with this approach. First, the rendered filtered looks ugly, showing `value = TRUE` instead of `value IS TRUE`:

<img width="386" alt="Screenshot 2025-03-17 at 10 44 33 AM" src="https://github.com/user-attachments/assets/ea704e1e-abee-4694-90da-2591061e72ef" />

<img width="322" alt="Screenshot 2025-03-17 at 10 44 43 AM" src="https://github.com/user-attachments/assets/32b12173-3aae-480e-9cf9-3301688b9672" />

Second, the filter in the request payload looks like this:

```json
{"col": "value", "op": "==", "val": true}
```

When the SQLAlchemy query is generated, the filter will be built like this:

```python
where_clause_and.append(sqla_col == eq)
```

Which is iffy and error prone, specially because many databases don't support native boolean types, using integers for them. This could potentially result in broken comparisons between a boolean and an integer, for example.

It's much better to map the `IS TRUE` and `IS FALSE` to the `IS TRUE` and `IS FALSE` operators, since then the SQLAlchemy filter is generated like this:

```python
where_clause_and.append(sqla_col.is_(True))
```

This PR fixes the problem by mapping `IS TRUE` and `IS FALSE` to the correct operators (and cleaning up some code). With these changes, the UI looks correct:

<img width="319" alt="Screenshot 2025-03-17 at 11 11 26 AM" src="https://github.com/user-attachments/assets/a78e86ae-3f3b-44ca-996a-24848e2a9565" />

And the request payload:

```json
{"col": "value", "op": "IS TRUE"}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

See discussion above.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
