### PR TITLE
fix(chart control): Change default of "Y Axis Title Margin"

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -510,29 +510,29 @@ describe('Drill by modal', () => {
 
     it('Line chart', () => {
       testEchart('echarts_timeseries_line', 'Line Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
     it('Area Chart', () => {
       testEchart('echarts_area', 'Area Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
     it('Scatter Chart', () => {
       testEchart('echarts_timeseries_scatter', 'Scatter Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
     it('Bar Chart', () => {
       testEchart('echarts_timeseries_bar', 'Bar Chart', [
-        [70, 94],
-        [362, 68],
+        [85, 94],
+        [490, 68],
       ]);
     });
 
@@ -565,22 +565,22 @@ describe('Drill by modal', () => {
 
     it('Generic Chart', () => {
       testEchart('echarts_timeseries', 'Generic Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
     it('Smooth Line Chart', () => {
       testEchart('echarts_timeseries_smooth', 'Smooth Line Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
     it('Step Line Chart', () => {
       testEchart('echarts_timeseries_step', 'Step Line Chart', [
-        [70, 93],
-        [70, 93],
+        [85, 93],
+        [85, 93],
       ]);
     });
 
@@ -616,8 +616,8 @@ describe('Drill by modal', () => {
       cy.get('[data-test-viz-type="mixed_timeseries"] canvas').then($canvas => {
         // click 'boy'
         cy.wrap($canvas).scrollIntoView();
-        cy.wrap($canvas).trigger('mouseover', 70, 93);
-        cy.wrap($canvas).rightclick(70, 93);
+        cy.wrap($canvas).trigger('mouseover', 85, 93);
+        cy.wrap($canvas).rightclick(85, 93);
 
         drillBy('name').then(intercepted => {
           const { queries } = intercepted.request.body;
@@ -650,8 +650,8 @@ describe('Drill by modal', () => {
         cy.get(`[data-test="drill-by-chart"] canvas`).then($canvas => {
           // click second query
           cy.wrap($canvas).scrollIntoView();
-          cy.wrap($canvas).trigger('mouseover', 246, 114);
-          cy.wrap($canvas).rightclick(246, 114);
+          cy.wrap($canvas).trigger('mouseover', 261, 114);
+          cy.wrap($canvas).rightclick(261, 114);
 
           drillBy('ds').then(intercepted => {
             const { queries } = intercepted.request.body;

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
@@ -95,24 +95,24 @@ function testTimeChart(vizType: string) {
 
   cy.get(`[data-test-viz-type='${vizType}'] canvas`).then($canvas => {
     cy.wrap($canvas).scrollIntoView();
-    cy.wrap($canvas).trigger('mousemove', 70, 93);
-    cy.wrap($canvas).rightclick(70, 93);
+    cy.wrap($canvas).trigger('mousemove', 85, 93);
+    cy.wrap($canvas).rightclick(85, 93);
 
     drillToDetailBy('Drill to detail by 1965');
     cy.getBySel('filter-val').should('contain', '1965');
     closeModal();
 
     cy.wrap($canvas).scrollIntoView();
-    cy.wrap($canvas).trigger('mousemove', 70, 93);
-    cy.wrap($canvas).rightclick(70, 93);
+    cy.wrap($canvas).trigger('mousemove', 85, 93);
+    cy.wrap($canvas).rightclick(85, 93);
 
     drillToDetailBy('Drill to detail by boy');
     cy.getBySel('filter-val').should('contain', 'boy');
     closeModal();
 
     cy.wrap($canvas).scrollIntoView();
-    cy.wrap($canvas).trigger('mousemove', 70, 93);
-    cy.wrap($canvas).rightclick(70, 93);
+    cy.wrap($canvas).trigger('mousemove', 85, 93);
+    cy.wrap($canvas).rightclick(85, 93);
 
     drillToDetailBy('Drill to detail by all');
     cy.getBySel('filter-val').first().should('contain', '1965');
@@ -434,7 +434,7 @@ describe('Drill to detail modal', () => {
       SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
     });
 
-    describe('Modal actions', () => {
+    describe.only('Modal actions', () => {
       it('clears filters', () => {
         interceptSamples();
 
@@ -442,7 +442,7 @@ describe('Drill to detail modal', () => {
         cy.get("[data-test-viz-type='box_plot'] canvas").then($canvas => {
           const canvasWidth = $canvas.width() || 0;
           const canvasHeight = $canvas.height() || 0;
-          const canvasCenterX = canvasWidth / 3;
+          const canvasCenterX = canvasWidth / 3 + 15;
           const canvasCenterY = (canvasHeight * 5) / 6;
 
           cy.wrap($canvas).scrollIntoView();

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/chartTitle.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/chartTitle.tsx
@@ -84,7 +84,7 @@ export const titleControls: ControlPanelSectionConfig = {
           clearable: true,
           label: t('Y Axis Title Margin'),
           renderTrigger: true,
-          default: TITLE_MARGIN_OPTIONS[0],
+          default: TITLE_MARGIN_OPTIONS[1],
           choices: formatSelectOptions(TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
         },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -122,7 +122,7 @@ function createAxisTitleControl(axis: 'x' | 'y'): ControlSetRow[] {
           clearable: true,
           label: t('AXIS TITLE MARGIN'),
           renderTrigger: true,
-          default: sections.TITLE_MARGIN_OPTIONS[0],
+          default: sections.TITLE_MARGIN_OPTIONS[1],
           choices: formatSelectOptions(sections.TITLE_MARGIN_OPTIONS),
           description: t('Changing this control takes effect instantly'),
           visibility: ({ controls }: ControlPanelsContainerProps) =>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes the default value of the "Y Axis Title Margin" from 15 to 30. It was reported that previous default often caused overlapping with axis value text.

Fixes #32528

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

| Before | After | 
|--------|-------|
| <img width="300" src="https://github.com/user-attachments/assets/dcdff19e-20e5-4dcf-8593-28c8999fd4b6"> | <img width="300" src="https://github.com/user-attachments/assets/552e6742-6695-4bd4-ae4d-8fad21f07abf"> |

### TESTING INSTRUCTIONS
1. Create Timeseries chart, e.g. Area Chart
2. Go to Customize tab
3. Check that "Y Axis Title Margin" is 30 by default

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/32528
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
