### PR TITLE
fix(asf): moving notifications to the top of `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,12 @@
 
 # https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
 ---
+notifications:
+  commits: commits@superset.apache.org
+  issues: notifications@superset.apache.org
+  pullrequests: notifications@superset.apache.org
+  discussions: notifications@superset.apache.org
+
 github:
   del_branch_on_merge: true
   description: "Apache Superset is a Data Visualization and Data Exploration Platform"
@@ -99,9 +105,3 @@ github:
         required_approving_review_count: 1
 
       required_signatures: false
-
-notifications:
-  commits: commits@superset.apache.org
-  issues: notifications@superset.apache.org
-  pullrequests: notifications@superset.apache.org
-  discussions: notifications@superset.apache.org


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Seems adding notifications at the bottom turned off branch protection rules somehow?! 🤯 Hoping this fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
