### PR TITLE
fix(asf): Revert "fix(asf): moving notifications to the top of `.asf.yaml`"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,12 +17,6 @@
 
 # https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
 ---
-notifications:
-  commits: commits@superset.apache.org
-  issues: notifications@superset.apache.org
-  pullrequests: notifications@superset.apache.org
-  discussions: notifications@superset.apache.org
-
 github:
   del_branch_on_merge: true
   description: "Apache Superset is a Data Visualization and Data Exploration Platform"
@@ -105,3 +99,9 @@ github:
         required_approving_review_count: 1
 
       required_signatures: false
+
+notifications:
+  commits: commits@superset.apache.org
+  issues: notifications@superset.apache.org
+  pullrequests: notifications@superset.apache.org
+  discussions: notifications@superset.apache.org


### PR DESCRIPTION
Reverts apache/superset#32726

There was an ASF bug that broke the branch protection rules. ANY change to asf.yaml will supposedly fix it now.

This actually seems arbitrary change I made, so I'll just revert it to kick things.