### PR TITLE
feat(where_in): Support returning None if filter_values return None

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -549,12 +549,10 @@ class WhereInMacro:  # pylint: disable=too-few-public-methods
         ]
         joined_values = ", ".join(string_representations)
         result = (
-            f"({joined_values})"
-            if (joined_values is not None or not default_to_none)
-            else None
+            f"({joined_values})" if (joined_values or not default_to_none) else None
         )
 
-        if mark:
+        if mark and result:
             result += (
                 "\n-- WARNING: the `mark` parameter was removed from the `where_in` "
                 "macro for security reasons\n"

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -519,7 +519,12 @@ class WhereInMacro:  # pylint: disable=too-few-public-methods
     def __init__(self, dialect: Dialect):
         self.dialect = dialect
 
-    def __call__(self, values: list[Any], mark: Optional[str] = None) -> str:
+    def __call__(
+        self,
+        values: list[Any],
+        mark: Optional[str] = None,
+        default_to_none: bool = False,
+    ) -> str | None:
         """
         Given a list of values, build a parenthesis list suitable for an IN expression.
 
@@ -528,6 +533,10 @@ class WhereInMacro:  # pylint: disable=too-few-public-methods
             >>> where_in([1, "Joe's", 3])
             (1, 'Joe''s', 3)
 
+        The `default_to_none` parameter is used to determine the return value when the
+        list of values is empty:
+            - If `default_to_none` is `False` (default), the return value is ().
+            - If `default_to_none` is `True`, the return value is `None`.
         """
         binds = [bindparam(f"value_{i}", value) for i, value in enumerate(values)]
         string_representations = [
@@ -539,7 +548,11 @@ class WhereInMacro:  # pylint: disable=too-few-public-methods
             for bind in binds
         ]
         joined_values = ", ".join(string_representations)
-        result = f"({joined_values})"
+        result = (
+            f"({joined_values})"
+            if (joined_values is not None or not default_to_none)
+            else None
+        )
 
         if mark:
             result += (

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -416,6 +416,19 @@ def test_where_in() -> None:
     assert where_in(["O'Malley's"]) == "('O''Malley''s')"
 
 
+def test_where_in_empty_list() -> None:
+    """
+    Test the ``where_in`` Jinja2 filter when it receives an
+    empty list.
+    """
+    where_in = WhereInMacro(mysql.dialect())
+
+    # By default, the filter should return empty parenthesis (as a string)
+    assert where_in([]) == "()"
+    # With the default_to_none parameter set to True, it should return None
+    assert where_in([], default_to_none=True) is None
+
+
 def test_dataset_macro(mocker: MockerFixture) -> None:
     """
     Test the ``dataset_macro`` macro.


### PR DESCRIPTION
### SUMMARY
The `|where_in` Jinja2 filter currently returns `()` (as a string) in case the `filter_values()` macro doesn't return any value. This makes it impossible to use it in combination with the `default` Jinja2 filter. For example, using:
``` sql
select * from my_table
where column in {{ filter_values('column_name')|where_in|d('(NULL) or TRUE',True) }}
```
Produces:
``` sql
select * from my_table
where column in ()
```

This PR adds the `default_to_none` parameter to the `|where_in` filter, so that using:
``` sql
select * from my_table
where column in {{ filter_values('column_name')|where_in(default_to_none=True)|d('(NULL) or TRUE',True) }}
```

Results in:
``` sql
select * from my_table
where column in (NULL) or TRUE
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/user-attachments/assets/8f19dbd2-ee04-46d4-be89-cf3a4e7d9e5d)

### TESTING INSTRUCTIONS
Tests added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
