### PR TITLE
feat(embedded): Force a specific referrerPolicy for the iframe request

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -60,7 +60,9 @@ embedDashboard({
       }
   },
     // optional additional iframe sandbox attributes
-  iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
+  iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
+  // optional config to enforce a particular referrerPolicy
+  referrerPolicy: "same-origin"
 });
 ```
 
@@ -146,3 +148,11 @@ To pass additional sandbox attributes you can use `iframeSandboxExtras`:
   // optional additional iframe sandbox attributes
   iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
 ```
+
+### Enforcing a ReferrerPolicy on the request triggered by the iframe
+
+By default, the Embedded SDK creates an `iframe` element without a `referrerPolicy` value enforced. This means that a policy defined for `iframe` elements at the host app level would reflect to it.
+
+This can be an issue as during the embedded enablement for a dashboard it's possible to specify which domain(s) are allowed to embed the dashboard, and this validation happens throuth the `Referrer` header. That said, in case the hosting app has a more restrictive policy that would omit this header, this validation would fail.
+
+Use the `referrerPolicy` parameter in the `embedDashboard` method to specify [a particular policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy) that works for your implementation.

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -65,7 +65,7 @@ export type EmbedDashboardParams = {
   /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
   iframeSandboxExtras?: string[]
   /** force a specific refererPolicy to be used in the iframe request **/
-  referrerPolicy?: ReferrerPolicy | null
+  referrerPolicy?: ReferrerPolicy
 }
 
 export type Size = {
@@ -91,7 +91,7 @@ export async function embedDashboard({
   debug = false,
   iframeTitle = "Embedded Dashboard",
   iframeSandboxExtras = [],
-  referrerPolicy = null
+  referrerPolicy,
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   function log(...info: unknown[]) {
     if (debug) {

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -64,6 +64,8 @@ export type EmbedDashboardParams = {
   iframeTitle?: string
   /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
   iframeSandboxExtras?: string[]
+  /** force a specific refererPolicy to be used in the iframe request **/
+  referrerPolicy?: ReferrerPolicy | null
 }
 
 export type Size = {
@@ -88,7 +90,8 @@ export async function embedDashboard({
   dashboardUiConfig,
   debug = false,
   iframeTitle = "Embedded Dashboard",
-  iframeSandboxExtras = []
+  iframeSandboxExtras = [],
+  referrerPolicy = null
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   function log(...info: unknown[]) {
     if (debug) {
@@ -142,6 +145,10 @@ export async function embedDashboard({
       iframeSandboxExtras.forEach((key: string) => {
         iframe.sandbox.add(key);
       });
+      // force a specific refererPolicy to be used in the iframe request
+      if(referrerPolicy) {
+        iframe.referrerPolicy = referrerPolicy;
+      }
 
       // add the event listener before setting src, to be 100% sure that we capture the load event
       iframe.addEventListener('load', () => {


### PR DESCRIPTION
### SUMMARY
Some hosting apps might have configurations to automatically set a `referrerPolicy` value for any `iframe` element added, which would affect the `iframe` created by the SDK as it doesn't have a value set. This becomes an issue for more restrictive policies since the validation of allowed domains is done through the `Referrer` header value, and therefore including this header in the request is important.

This PR adds a new parameter to the `embedDashboard` function that allows specifying a `referrerPolicy` value. This parameter is optional (to ensure backwards compatibility) and if not provided should respect the hosting app.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Load a dashboard in embedded mode specifying a `refererPolicy` in the `embedDashboard` method. 
2. Inspect the browser and validate the `refererPolicy` propagates to the request triggered by the `iframe`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
