### PR TITLE
fix(excel export): big number truncation handling

### DIFF
--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -56,10 +56,24 @@ def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
 def apply_column_types(
     df: pd.DataFrame, column_types: list[GenericDataType]
 ) -> pd.DataFrame:
+    """
+    Applies the column types to the dataframe to prepare for an excel export
+
+    :param df: The dataframe to apply the column types to
+    :param column_types: The types of the columns
+    :return: The dataframe with the column types applied
+    """
     for column, column_type in zip(df.columns, column_types, strict=False):
         if column_type == GenericDataType.NUMERIC:
             try:
                 df[column] = pd.to_numeric(df[column])
+                # if the number is too large, convert it to a string
+                # Excel does not support numbers larger than 10^15
+                df[column] = df[column].apply(
+                    lambda x: str(x)
+                    if isinstance(x, (int, float)) and abs(x) > 10**15
+                    else x
+                )
             except ValueError:
                 df[column] = df[column].astype(str)
         elif pd.api.types.is_datetime64tz_dtype(df[column]):

--- a/tests/unit_tests/utils/excel_tests.py
+++ b/tests/unit_tests/utils/excel_tests.py
@@ -105,3 +105,27 @@ def test_column_data_types_with_failing_conversion():
     assert not is_numeric_dtype(df["col1"])
     assert not is_numeric_dtype(df["col2"])
     assert not is_numeric_dtype(df["col3"])
+
+
+def test_column_data_types_with_large_numeric_values():
+    df = pd.DataFrame(
+        {
+            "big_number": [
+                10**14,
+                999999999999999,
+                10**15 + 1,
+                10**16,
+                1100108628127863,
+                2**54,
+            ],
+        }
+    )
+    apply_column_types(df, [GenericDataType.NUMERIC])
+    assert df["big_number"].tolist() == [
+        100000000000000,
+        999999999999999,
+        "1000000000000001",
+        "10000000000000000",
+        "1100108628127863",
+        "18014398509481984",
+    ]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #28551 
Better handling of excel export, convert 10**15 numbers to a string to prevent truncation from xlsx format.
Added test too

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![image](https://github.com/user-attachments/assets/012e57a4-0c07-4841-9a8f-eb3a375535dd)

Excel export : 
BEFORE : 
Big number 1 is truncated 
![image](https://github.com/user-attachments/assets/d6d85ff6-54f3-4dde-b2ef-cab118af8bf0)

AFTER : 
Big number 1 is a string but not truncated
![image](https://github.com/user-attachments/assets/74f71864-6153-4674-ac59-8b7211d2f569)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create a dataset with some big numbers, such as : 
```
SELECT NUMERIC '1100108628127863' AS big_number, NUMERIC '999999999999999' as big_number2
FROM video_game_sales
```
Try an excel export

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
https://github.com/apache/superset/issues/28551
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
