### PR TITLE
fix(migrations): fix foreign keys to match FAB 4.6.0 tables

### DIFF
--- a/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
+++ b/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
@@ -22,9 +22,7 @@ Create Date: 2025-03-19 17:46:25.702610
 
 """
 
-from alembic import op
-
-from superset.migrations.shared.utils import drop_fks_for_table_by_names
+from superset.migrations.shared.utils import create_fks_for_table, drop_fks_for_table
 
 # revision identifiers, used by Alembic.
 revision = "32bf93dfe2a4"
@@ -32,15 +30,14 @@ down_revision = "94e7a3499973"
 
 
 def upgrade():
-    drop_fks_for_table_by_names(
+    drop_fks_for_table(
         "ab_permission_view_role",
         [
             "ab_permission_view_role_permission_view_id_fkey",
             "ab_permission_view_role_role_id_fkey",
         ],
     )
-
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_permission_view_role_role_id_fkey",
         "ab_permission_view_role",
         "ab_role",
@@ -48,7 +45,7 @@ def upgrade():
         ["id"],
         ondelete="CASCADE",
     )
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_permission_view_role_permission_view_id_fkey",
         "ab_permission_view_role",
         "ab_permission_view",
@@ -57,12 +54,11 @@ def upgrade():
         ondelete="CASCADE",
     )
 
-    drop_fks_for_table_by_names(
+    drop_fks_for_table(
         "ab_user_role",
         ["ab_user_role_user_id_fkey", "ab_user_role_role_id_fkey"],
     )
-
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_user_role_user_id_fkey",
         "ab_user_role",
         "ab_user",
@@ -70,7 +66,7 @@ def upgrade():
         ["id"],
         ondelete="CASCADE",
     )
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_user_role_role_id_fkey",
         "ab_user_role",
         "ab_role",
@@ -81,22 +77,21 @@ def upgrade():
 
 
 def downgrade():
-    drop_fks_for_table_by_names(
+    drop_fks_for_table(
         "ab_permission_view_role",
         [
             "ab_permission_view_role_permission_view_id_fkey",
             "ab_permission_view_role_role_id_fkey",
         ],
     )
-
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_permission_view_role_permission_view_id_fkey",
         "ab_permission_view_role",
         "ab_permission_view",
         ["permission_view_id"],
         ["id"],
     )
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_permission_view_role_role_id_fkey",
         "ab_permission_view_role",
         "ab_role",
@@ -104,14 +99,13 @@ def downgrade():
         ["id"],
     )
 
-    drop_fks_for_table_by_names(
+    drop_fks_for_table(
         "ab_user_role",
         ["ab_user_role_user_id_fkey", "ab_user_role_role_id_fkey"],
     )
-
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_user_role_user_id_fkey", "ab_user_role", "ab_user", ["user_id"], ["id"]
     )
-    op.create_foreign_key(
+    create_fks_for_table(
         "ab_user_role_role_id_fkey", "ab_user_role", "ab_role", ["role_id"], ["id"]
     )

--- a/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
+++ b/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
@@ -23,37 +23,22 @@ Create Date: 2025-03-19 17:46:25.702610
 """
 
 from alembic import op
-from sqlalchemy.engine.reflection import Inspector
+
+from superset.migrations.shared.utils import drop_fks_for_table_by_names
 
 # revision identifiers, used by Alembic.
 revision = "32bf93dfe2a4"
 down_revision = "94e7a3499973"
 
 
-def constraint_exists(table_name, constraint_name):
-    bind = op.get_bind()
-    inspector = Inspector.from_engine(bind)
-    constraints = [fk["name"] for fk in inspector.get_foreign_keys(table_name)]
-    return constraint_name in constraints
-
-
 def upgrade():
-    if constraint_exists(
-        "ab_permission_view_role", "ab_permission_view_role_permission_view_id_fkey"
-    ):
-        op.drop_constraint(
+    drop_fks_for_table_by_names(
+        "ab_permission_view_role",
+        [
             "ab_permission_view_role_permission_view_id_fkey",
-            "ab_permission_view_role",
-            type_="foreignkey",
-        )
-    if constraint_exists(
-        "ab_permission_view_role", "ab_permission_view_role_role_id_fkey"
-    ):
-        op.drop_constraint(
             "ab_permission_view_role_role_id_fkey",
-            "ab_permission_view_role",
-            type_="foreignkey",
-        )
+        ],
+    )
 
     op.create_foreign_key(
         "ab_permission_view_role_role_id_fkey",
@@ -72,14 +57,10 @@ def upgrade():
         ondelete="CASCADE",
     )
 
-    if constraint_exists("ab_user_role", "ab_user_role_user_id_fkey"):
-        op.drop_constraint(
-            "ab_user_role_user_id_fkey", "ab_user_role", type_="foreignkey"
-        )
-    if constraint_exists("ab_user_role", "ab_user_role_role_id_fkey"):
-        op.drop_constraint(
-            "ab_user_role_role_id_fkey", "ab_user_role", type_="foreignkey"
-        )
+    drop_fks_for_table_by_names(
+        "ab_user_role",
+        ["ab_user_role_user_id_fkey", "ab_user_role_role_id_fkey"],
+    )
 
     op.create_foreign_key(
         "ab_user_role_user_id_fkey",
@@ -100,22 +81,13 @@ def upgrade():
 
 
 def downgrade():
-    if constraint_exists(
-        "ab_permission_view_role", "ab_permission_view_role_permission_view_id_fkey"
-    ):
-        op.drop_constraint(
+    drop_fks_for_table_by_names(
+        "ab_permission_view_role",
+        [
             "ab_permission_view_role_permission_view_id_fkey",
-            "ab_permission_view_role",
-            type_="foreignkey",
-        )
-    if constraint_exists(
-        "ab_permission_view_role", "ab_permission_view_role_role_id_fkey"
-    ):
-        op.drop_constraint(
             "ab_permission_view_role_role_id_fkey",
-            "ab_permission_view_role",
-            type_="foreignkey",
-        )
+        ],
+    )
 
     op.create_foreign_key(
         "ab_permission_view_role_permission_view_id_fkey",
@@ -131,14 +103,11 @@ def downgrade():
         ["role_id"],
         ["id"],
     )
-    if constraint_exists("ab_user_role", "ab_user_role_role_id_fkey"):
-        op.drop_constraint(
-            "ab_user_role_role_id_fkey", "ab_user_role", type_="foreignkey"
-        )
-    if constraint_exists("ab_user_role", "ab_user_role_user_id_fkey"):
-        op.drop_constraint(
-            "ab_user_role_user_id_fkey", "ab_user_role", type_="foreignkey"
-        )
+
+    drop_fks_for_table_by_names(
+        "ab_user_role",
+        ["ab_user_role_user_id_fkey", "ab_user_role_role_id_fkey"],
+    )
 
     op.create_foreign_key(
         "ab_user_role_user_id_fkey", "ab_user_role", "ab_user", ["user_id"], ["id"]

--- a/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
+++ b/superset/migrations/versions/2025-03-19_17-46_32bf93dfe2a4_add_on_cascade_in_fab_tables.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from alembic import op
+
+"""Add on cascade to foreign keys in ab_permission_view_role and ab_user_role
+
+Revision ID: 32bf93dfe2a4
+Revises: 94e7a3499973
+Create Date: 2025-03-19 17:46:25.702610
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "32bf93dfe2a4"
+down_revision = "94e7a3499973"
+
+
+def upgrade():
+    op.drop_constraint(
+        "ab_permission_view_role_permission_view_id_fkey",
+        "ab_permission_view_role",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "ab_permission_view_role_role_id_fkey",
+        "ab_permission_view_role",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        None,
+        "ab_permission_view_role",
+        "ab_role",
+        ["role_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        None,
+        "ab_permission_view_role",
+        "ab_permission_view",
+        ["permission_view_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint("ab_user_role_user_id_fkey", "ab_user_role", type_="foreignkey")
+    op.drop_constraint("ab_user_role_role_id_fkey", "ab_user_role", type_="foreignkey")
+    op.create_foreign_key(
+        None, "ab_user_role", "ab_user", ["user_id"], ["id"], ondelete="CASCADE"
+    )
+    op.create_foreign_key(
+        None, "ab_user_role", "ab_role", ["role_id"], ["id"], ondelete="CASCADE"
+    )
+
+
+def downgrade():
+    op.drop_constraint("ab_user_role_role_id_fkey", "ab_user_role", type_="foreignkey")
+    op.drop_constraint("ab_user_role_user_id_fkey", "ab_user_role", type_="foreignkey")
+    op.create_foreign_key(
+        "ab_user_role_role_id_fkey", "ab_user_role", "ab_role", ["role_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "ab_user_role_user_id_fkey", "ab_user_role", "ab_user", ["user_id"], ["id"]
+    )
+
+    op.drop_constraint(
+        "ab_permission_view_role_role_id_fkey",
+        "ab_permission_view_role",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "ab_permission_view_role_permission_view_id_fkey",
+        "ab_permission_view_role",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "ab_permission_view_role_role_id_fkey",
+        "ab_permission_view_role",
+        "ab_role",
+        ["role_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "ab_permission_view_role_permission_view_id_fkey",
+        "ab_permission_view_role",
+        "ab_permission_view",
+        ["permission_view_id"],
+        ["id"],
+    )


### PR DESCRIPTION
### SUMMARY
With the introduction of FAB 4.6.0 the `ab_permission_view_role` and `ab_user_role` tables are using `ON CASCADE` for deletions, however, this change is only applied in newly created DBs as there's no migration to incorporate such changes into superset for existing DBs.

Without these changes it's not possible to delete Roles due to related data still existing (Integrity error).

This PR is adding a migration to recreate those foreign keys with the proper deletion treatment and thus fixing the role deletion behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Error:
![error](https://github.com/user-attachments/assets/d0c8330e-ad84-41d1-92d9-91a190ce9412)

Fix:
![fix](https://github.com/user-attachments/assets/7f928fa6-c393-4c5b-b354-60d428aed18b)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [X] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [X] Migration is atomic, supports rollback & is backwards-compatible
  - [X] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
