### PR TITLE
chore: bump marshmallow-sqlalchemy==1.4.1

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,4 +33,4 @@ apispec>=6.0.0,<6.7.0
 # This is probably related to the changes around PickleType
 # https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html#id3
 # Opened this issue https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665
-marshmallow-sqlalchemy>=1.3.0,<1.4.0
+marshmallow-sqlalchemy>=1.3.0,<1.4.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,4 +33,4 @@ apispec>=6.0.0,<6.7.0
 # This is probably related to the changes around PickleType
 # https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html#id3
 # Opened this issue https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665
-marshmallow-sqlalchemy>=1.3.0,<2.0.0
+marshmallow-sqlalchemy>=1.3.0,<1.4.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,4 +33,4 @@ apispec>=6.0.0,<6.7.0
 # This is probably related to the changes around PickleType
 # https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html#id3
 # Opened this issue https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665
-marshmallow-sqlalchemy>=1.3.0,<1.4.1
+marshmallow-sqlalchemy>=1.3.0,<2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,7 +158,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.14.0
@@ -216,7 +215,7 @@ marshmallow==3.26.1
     # via
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.3.0
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -r requirements/base.in
     #   flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -215,7 +215,7 @@ marshmallow==3.26.1
     # via
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.1
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -r requirements/base.in
     #   flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -215,7 +215,7 @@ marshmallow==3.26.1
     # via
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.0
+marshmallow-sqlalchemy==1.4.1
     # via
     #   -r requirements/base.in
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -434,7 +434,7 @@ marshmallow==3.26.1
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.1
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -434,7 +434,7 @@ marshmallow==3.26.1
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.0
+marshmallow-sqlalchemy==1.4.1
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -318,7 +318,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.68.0
     # via
     #   apache-superset
@@ -435,7 +434,7 @@ marshmallow==3.26.1
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.3.0
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder


### PR DESCRIPTION
Doing some research to provide https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665#issuecomment-2737894701 with more information as to which exact version is creating the problem with CI / memory
