### PR TITLE
fix(sqllab): Pass query_id as kwarg so backoff can see it

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -193,7 +193,7 @@ def get_sql_results(  # pylint: disable=too-many-arguments
             except Exception as ex:  # pylint: disable=broad-except
                 logger.debug("Query %d: %s", query_id, ex)
                 stats_logger.incr("error_sqllab_unhandled")
-                query = get_query(query_id)
+                query = get_query(query_id=query_id)
                 return handle_query_error(ex, query)
 
 
@@ -423,7 +423,7 @@ def execute_sql_statements(  # noqa: C901
         # only asynchronous queries
         stats_logger.timing("sqllab.query.time_pending", now_as_float() - start_time)
 
-    query = get_query(query_id)
+    query = get_query(query_id=query_id)
     payload: dict[str, Any] = {"query_id": query_id}
     database = query.database
     db_engine_spec = database.db_engine_spec


### PR DESCRIPTION
### SUMMARY
The backoff method is accessing the `query_id` via the kwargs but the `get_query` method is always called with positional args instead so backoff library doesn't make the query_id visible for the method thus it fails with a KeyError('query_id').

This PR makes sure we call get_query(query_id=query_id) instead of get_query(query_id).

PS: We could also just try access to query_id from the args? but I have no strong preference.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
