### PR TITLE
fix(import): Missing catalog field in saved query schema

### DIFF
--- a/superset/queries/saved_queries/schemas.py
+++ b/superset/queries/saved_queries/schemas.py
@@ -39,6 +39,7 @@ get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
 
 
 class ImportV1SavedQuerySchema(Schema):
+    catalog = fields.String(allow_none=True, validate=Length(0, 128))
     schema = fields.String(allow_none=True, validate=Length(0, 128))
     label = fields.String(allow_none=True, validate=Length(0, 256))
     description = fields.String(allow_none=True)

--- a/tests/integration_tests/fixtures/importexport.py
+++ b/tests/integration_tests/fixtures/importexport.py
@@ -689,4 +689,5 @@ saved_queries_config = {
     "uuid": "05b679b5-8eaf-452c-b874-a7a774cfa4e9",
     "version": "1.0.0",
     "database_uuid": "b8a1ccd3-779d-4ab7-8ad8-9ab119d7fe89",
+    "catalog": "default",
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR fixes error "An error occurred while importing queries: Error importing saved_queries. Please re-export your file and try importing again".

Fixes #32706

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Go to SQL Lab
2. Create any query, save it as Saved Query
3. Go to Saved Query list page
4. Export query
5. Import query

Query should be imported without errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #32706
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
