### PR TITLE
fix(config): correct slack image url in talisman

### DIFF
--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -280,6 +280,50 @@ TALISMAN_CONFIG = {
     "content_security_policy": { ...
 ```
 
+#### Configuring Talisman in Superset
+
+Talisman settings in Superset can be modified using superset_config.py. If you need to adjust security policies, you can override the default configuration.
+
+Example: Overriding Talisman Configuration in superset_config.py for loading images form s3 or other external sources.
+
+```python
+TALISMAN_CONFIG = {
+    "content_security_policy": {
+        "base-uri": ["'self'"],
+        "default-src": ["'self'"],
+        "img-src": [
+            "'self'",
+            "blob:",
+            "data:",
+            "https://apachesuperset.gateway.scarf.sh",
+            "https://static.scarf.sh/",
+            # "https://cdn.brandfolder.io", # Uncomment when SLACK_ENABLE_AVATARS is True  # noqa: E501
+            "ows.terrestris.de",
+            "aws.s3.com", # Add Your Bucket or external data source
+        ],
+        "worker-src": ["'self'", "blob:"],
+        "connect-src": [
+            "'self'",
+            "https://api.mapbox.com",
+            "https://events.mapbox.com",
+        ],
+        "object-src": "'none'",
+        "style-src": [
+            "'self'",
+            "'unsafe-inline'",
+        ],
+        "script-src": ["'self'", "'strict-dynamic'"],
+    },
+    "content_security_policy_nonce_in": ["script-src"],
+    "force_https": False,
+    "session_cookie_secure": False,
+}
+```
+
+Configuring External Data Sources in CSP
+
+If you need to load external data from sources like Amazon S3 or Blob, you must modify the CSP to allow these connections allowing images, scripts, and connections from external sources.
+
 ### Reporting Security Vulnerabilities
 
 Apache Software Foundation takes a rigorous standpoint in annihilating the security issues in its

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -320,9 +320,8 @@ TALISMAN_CONFIG = {
 }
 ```
 
-Configuring External Data Sources in CSP
-
-If you need to load external data from sources like Amazon S3 or Blob, you must modify the CSP to allow these connections allowing images, scripts, and connections from external sources.
+# For more information on setting up Talisman, please refer to
+https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp
 
 ### Reporting Security Vulnerabilities
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1615,7 +1615,7 @@ TALISMAN_ENABLED = utils.cast_to_boolean(os.environ.get("TALISMAN_ENABLED", True
 
 # If you want Talisman, how do you want it configured??
 # For more information on setting up Talisman, please refer to
-#https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp
+# https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp
 
 TALISMAN_CONFIG = {
     "content_security_policy": {

--- a/superset/config.py
+++ b/superset/config.py
@@ -1624,7 +1624,7 @@ TALISMAN_CONFIG = {
             "data:",
             "https://apachesuperset.gateway.scarf.sh",
             "https://static.scarf.sh/",
-            # "https://avatars.slack-edge.com", # Uncomment when SLACK_ENABLE_AVATARS is True  # noqa: E501
+            # "https://cdn.brandfolder.io", # Uncomment when SLACK_ENABLE_AVATARS is True  # noqa: E501
             "ows.terrestris.de",
         ],
         "worker-src": ["'self'", "blob:"],
@@ -1655,7 +1655,7 @@ TALISMAN_DEV_CONFIG = {
             "data:",
             "https://apachesuperset.gateway.scarf.sh",
             "https://static.scarf.sh/",
-            "https://avatars.slack-edge.com",
+            "https://cdn.brandfolder.io",
             "ows.terrestris.de",
         ],
         "worker-src": ["'self'", "blob:"],

--- a/superset/config.py
+++ b/superset/config.py
@@ -1614,6 +1614,9 @@ CONTENT_SECURITY_POLICY_WARNING = True
 TALISMAN_ENABLED = utils.cast_to_boolean(os.environ.get("TALISMAN_ENABLED", True))
 
 # If you want Talisman, how do you want it configured??
+# For more information on setting up Talisman, please refer to
+#https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp
+
 TALISMAN_CONFIG = {
     "content_security_policy": {
         "base-uri": ["'self'"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixed the configuration file by replacing the incorrect Slack image URL. The previous URL was causing images to not load, even in development mode. This update ensures Slack images now load correctly.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (Only config and documentation changes)
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Verify that Slack images now load correctly in the UI.
Review docs/security/security.mdx to confirm the new guide is correctly formatted and informative.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] No UI changes
- [ ] No DB migration required
- [ ]  Improves documentation

