### PR TITLE
fix: key error in frontend on disallowed GSheets

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -319,7 +319,7 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
 
     # verify client has google sheets installed
     available_specs = get_available_engine_specs()
-    frontend_config["HAS_GSHEETS_INSTALLED"] = bool(available_specs[GSheetsEngineSpec])
+    frontend_config["HAS_GSHEETS_INSTALLED"] = GSheetsEngineSpec in available_specs and bool(available_specs[GSheetsEngineSpec])
 
     language = locale.language if locale else "en"
 

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -319,7 +319,10 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
 
     # verify client has google sheets installed
     available_specs = get_available_engine_specs()
-    frontend_config["HAS_GSHEETS_INSTALLED"] = GSheetsEngineSpec in available_specs and bool(available_specs[GSheetsEngineSpec])
+    frontend_config["HAS_GSHEETS_INSTALLED"] = (
+        GSheetsEngineSpec in available_specs
+        and bool(available_specs[GSheetsEngineSpec])
+    )
 
     language = locale.language if locale else "en"
 


### PR DESCRIPTION

### SUMMARY
Adding Google sheets to the DBS_AVAILABLE_DENYLIST in a config py will no longer result in a key error when views/base.py tries to verify the installation of Google sheets.

### TESTING INSTRUCTIONS
Add to your config py:
DBS_AVAILABLE_DENYLIST = {
    "gsheets": {"apsw"},
}

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #32791
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
