### PR TITLE
fix(log): store navigation path to get correct logging path

### DIFF
--- a/superset-frontend/src/middleware/loggerMiddleware.js
+++ b/superset-frontend/src/middleware/loggerMiddleware.js
@@ -23,7 +23,10 @@ import { SupersetClient } from '@superset-ui/core';
 
 import { safeStringify } from '../utils/safeStringify';
 import { LOG_EVENT } from '../logger/actions';
-import { LOG_EVENT_TYPE_TIMING } from '../logger/LogUtils';
+import {
+  LOG_EVENT_TYPE_TIMING,
+  LOG_ACTIONS_SPA_NAVIGATION,
+} from '../logger/LogUtils';
 import DebouncedMessageQueue from '../utils/DebouncedMessageQueue';
 
 const LOG_ENDPOINT = '/superset/log/?explode=events';
@@ -67,78 +70,87 @@ const logMessageQueue = new DebouncedMessageQueue({
   delayThreshold: 1000,
 });
 let lastEventId = 0;
-const loggerMiddleware = store => next => action => {
-  if (action.type !== LOG_EVENT) {
-    return next(action);
-  }
+const loggerMiddleware = store => next => {
+  let navPath;
+  return action => {
+    if (action.type !== LOG_EVENT) {
+      return next(action);
+    }
 
-  const { dashboardInfo, explore, impressionId, dashboardLayout, sqlLab } =
-    store.getState();
-  let logMetadata = {
-    impression_id: impressionId,
-    version: 'v2',
-  };
-  const { eventName } = action.payload;
-  let { eventData = {} } = action.payload;
-
-  const path = eventData.path || window?.location?.href;
-
-  if (dashboardInfo?.id && path?.includes('/dashboard/')) {
-    logMetadata = {
-      source: 'dashboard',
-      source_id: dashboardInfo.id,
-      dashboard_id: dashboardInfo.id,
-      ...logMetadata,
+    const { dashboardInfo, explore, impressionId, dashboardLayout, sqlLab } =
+      store.getState();
+    let logMetadata = {
+      impression_id: impressionId,
+      version: 'v2',
     };
-  } else if (explore?.slice) {
-    logMetadata = {
-      source: 'explore',
-      source_id: explore.slice ? explore.slice.slice_id : 0,
-      ...(explore.slice.slice_id && { slice_id: explore.slice.slice_id }),
-      ...logMetadata,
-    };
-  } else if (path?.includes('/sqllab/')) {
-    const editor = sqlLab.queryEditors.find(
-      ({ id }) => id === sqlLab.tabHistory.slice(-1)[0],
-    );
-    logMetadata = {
-      source: 'sqlLab',
-      source_id: editor?.id,
-      db_id: editor?.dbId,
-      schema: editor?.schema,
-    };
-  }
+    const { eventName } = action.payload;
+    let { eventData = {} } = action.payload;
 
-  eventData = {
-    ...logMetadata,
-    ts: new Date().getTime(),
-    event_name: eventName,
-    ...eventData,
-  };
-  if (LOG_EVENT_TYPE_TIMING.has(eventName)) {
+    if (eventName === LOG_ACTIONS_SPA_NAVIGATION) {
+      navPath = eventData.path;
+    }
+    const path = navPath || window?.location?.href;
+
+    if (dashboardInfo?.id && path?.includes('/dashboard/')) {
+      logMetadata = {
+        source: 'dashboard',
+        source_id: dashboardInfo.id,
+        dashboard_id: dashboardInfo.id,
+        ...logMetadata,
+      };
+    } else if (explore?.slice) {
+      logMetadata = {
+        source: 'explore',
+        source_id: explore.slice ? explore.slice.slice_id : 0,
+        ...(explore.slice.slice_id && { slice_id: explore.slice.slice_id }),
+        ...logMetadata,
+      };
+    } else if (path?.includes('/sqllab/')) {
+      const editor = sqlLab.queryEditors.find(
+        ({ id }) => id === sqlLab.tabHistory.slice(-1)[0],
+      );
+      logMetadata = {
+        source: 'sqlLab',
+        source_id: editor?.id,
+        db_id: editor?.dbId,
+        schema: editor?.schema,
+      };
+    }
+
     eventData = {
+      ...logMetadata,
+      ts: new Date().getTime(),
+      event_name: eventName,
       ...eventData,
-      event_type: 'timing',
-      trigger_event: lastEventId,
     };
-  } else {
-    lastEventId = nanoid();
-    eventData = {
-      ...eventData,
-      event_type: 'user',
-      event_id: lastEventId,
-      visibility: document.visibilityState,
-    };
-  }
+    if (LOG_EVENT_TYPE_TIMING.has(eventName)) {
+      eventData = {
+        ...eventData,
+        event_type: 'timing',
+        trigger_event: lastEventId,
+      };
+    } else {
+      lastEventId = nanoid();
+      eventData = {
+        ...eventData,
+        event_type: 'user',
+        event_id: lastEventId,
+        visibility: document.visibilityState,
+      };
+    }
 
-  if (eventData.target_id && dashboardLayout?.present?.[eventData.target_id]) {
-    const { meta } = dashboardLayout.present[eventData.target_id];
-    // chart name or tab/header text
-    eventData.target_name = meta.chartId ? meta.sliceName : meta.text;
-  }
+    if (
+      eventData.target_id &&
+      dashboardLayout?.present?.[eventData.target_id]
+    ) {
+      const { meta } = dashboardLayout.present[eventData.target_id];
+      // chart name or tab/header text
+      eventData.target_name = meta.chartId ? meta.sliceName : meta.text;
+    }
 
-  logMessageQueue.append(eventData);
-  return eventData;
+    logMessageQueue.append(eventData);
+    return eventData;
+  };
 };
 
 export default loggerMiddleware;


### PR DESCRIPTION
### SUMMARY
To determine the event source of logging, the [previous patch](https://github.com/apache/superset/pull/32708) referenced the current path using `window.location`. However, when navigating quickly between pages, the logging from the previous page was being processed, resulting in the event source of the previous page's logging being recorded with the current page's URL.
To resolve this issue, this commit modified the process to log the path at the time the `spa_navigation` event occurs, ensuring that the records during navigation are correctly attributed to the appropriate source.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![425589643-3ef58446-2e75-417e-9d00-5fa113e6c332](https://github.com/user-attachments/assets/5d857778-bd0d-4158-b1d0-f7df47811ce7)

After:
![Cursor_and_USA_Births_Names](https://github.com/user-attachments/assets/854649bf-7116-42d1-aa76-49f28ba0f861)

### TESTING INSTRUCTIONS
specs and screenshots

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
