### PR TITLE
fix(docs): scrollable table of content right bar in Superset docs

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -58,7 +58,6 @@ ul.dropdown__menu svg {
   --ifm-code-font-size: 95%;
   --ifm-menu-link-padding-vertical: 12px;
   --doc-sidebar-width: 350px !important;
-  --ifm-navbar-height: none;
   --ifm-font-family-base: Roboto;
   --ifm-footer-background-color: #173036;
   --ifm-footer-color: #87939a;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(docs): scrollable table of content right bar in Superset docs

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the unscrollable ToC right bar in Superset docs. Very minor one but helps a bit with DX

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before
https://github.com/user-attachments/assets/073230db-c796-4e45-9181-17e72b3599f1

After
https://github.com/user-attachments/assets/d3da1aa0-36d4-43dc-86c4-281fb2568976

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
