### PR TITLE
feat(sqllab): Add cache sqllab sidebar table schema (#32796)

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -785,6 +785,9 @@ CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "NullCache"}
 # Cache for datasource metadata and query results
 DATA_CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "NullCache"}
 
+# Schema caching configuration
+SCHEMA_CACHE_CONFIG: CacheConfig = {"CACHE_TYPE": "NullCache"}
+
 # Cache for dashboard filter state. `CACHE_TYPE` defaults to `SupersetMetastoreCache`
 # that stores the values in the key-value table in the Superset metastore, as it's
 # required for Superset to operate correctly, but can be replaced by any

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -58,6 +58,7 @@ class CacheManager:
         self._thumbnail_cache = Cache()
         self._filter_state_cache = Cache()
         self._explore_form_data_cache = ExploreFormDataCache()
+        self._schema_cache = Cache()
 
     @staticmethod
     def _init_cache(
@@ -90,6 +91,7 @@ class CacheManager:
         self._init_cache(app, self._cache, "CACHE_CONFIG")
         self._init_cache(app, self._data_cache, "DATA_CACHE_CONFIG")
         self._init_cache(app, self._thumbnail_cache, "THUMBNAIL_CACHE_CONFIG")
+        self._init_cache(app, self._schema_cache, "SCHEMA_CACHE_CONFIG")
         self._init_cache(
             app, self._filter_state_cache, "FILTER_STATE_CACHE_CONFIG", required=True
         )
@@ -119,3 +121,7 @@ class CacheManager:
     @property
     def explore_form_data_cache(self) -> Cache:
         return self._explore_form_data_cache
+        
+    @property
+    def schema_cache(self) -> Cache:
+        return self._schema_cache


### PR DESCRIPTION
### SUMMARY
Add cache for table schema in sqllab. 

Motivation: Fetching schema can be a slow operation on query engines such as Trino and Athena. We have noticed the schema takes up to 300s to appear when Trino cluster is under load. Caching the schema allows users to have better interactive experience with sqllab.

Design: Added a new schema cache to cache manager so this can be managed separately from other caches. Many users including relational DB's such as Postgres or MySQL likely won't require this feature as this feature is ideal for query engines where fetching table schema is not a trivial operation. Feature is disabled by default and requires setting SCHEMA_CACHE_CONFIG in config.py to be enable.

### TESTING INSTRUCTIONS
1. Add Trino cluster as a database
2. Test to ensure there are no breaking changes (schema cache disabled, by default): Open sqllab and select a schema and table. Opening table schema takes up to 300s.
3. Enable schema cache: Add to config.py and restart:
```
SCHEMA_CACHE_CONFIG = {
    'CACHE_TYPE': 'redis',
    'CACHE_DEFAULT_TIMEOUT': 60 * 60 * 12, # 12 hr cache
    'CACHE_KEY_PREFIX': 'superset_schema_',
    'CACHE_REDIS_URL': f"redis://{REDIS}:{REDIS_PORT}/{REDIS_DB}"
}
```
4. Test schema cache enabled: open sqllab and select a schema and table. Opening schema table takes long on cache miss but subsequent requests are fast.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
[x] Required feature flags:
SCHEMA_CACHE_CONFIG = {
    'CACHE_TYPE': 'redis',
    'CACHE_DEFAULT_TIMEOUT': 60 * 60 * 12, # 12 hr cache
    'CACHE_KEY_PREFIX': 'superset_schema_',
    'CACHE_REDIS_URL': f"redis://{REDIS}:{REDIS_PORT}/{REDIS_DB}"
} 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
