### PR TITLE
fix(chart): big number with trendline subheader handling

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -65,7 +65,7 @@ const config: ControlPanelConfig = {
               label: t('Subheader'),
               renderTrigger: true,
               description: t(
-                'Description text that shows up below your Big Number. Act as a prefix if Comparaison period lag is enabled',
+                'Description text that shows up below your Big Number. Act as a prefix if Comparison period lag is enabled',
               ),
             },
           },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/controlPanel.tsx
@@ -59,6 +59,19 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'subheader',
+            config: {
+              type: 'TextControl',
+              label: t('Subheader'),
+              renderTrigger: true,
+              description: t(
+                'Description text that shows up below your Big Number. Act as a prefix if Comparaison period lag is enabled',
+              ),
+            },
+          },
+        ],
+        [
+          {
             name: 'compare_suffix',
             config: {
               type: 'TextControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -125,7 +125,7 @@ export default function transformProps(
           percentChange = compareValue
             ? (bigNumber - compareValue) / Math.abs(compareValue)
             : 0;
-          formattedSubheader = `${formatPercentChange(
+          formattedSubheader = `${subheader} ${formatPercentChange(
             percentChange,
           )} ${compareSuffix}`;
         }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #32776

Added a subheader field type. 
Currently the subheader variable inherited from the big number viz props was unused so i added a field to handle it.
Following this, the subheader and the compare lag (Comparaison Period Lag) couldn't be both handled in the front.
So i took the liberty to let them co exist but the subheader might be used as a prefix, since there was already a suffix variable for the comparaison period lag.
Both can be modified by subheader size

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before   : 
![image](https://github.com/user-attachments/assets/67fe9e01-1dc2-494f-b2ff-c02f81067846)

After : 
![image](https://github.com/user-attachments/assets/737993ba-3e0e-4faf-8ee9-6016e5fe0d6e)
![image](https://github.com/user-attachments/assets/ff59f70b-91ef-4a0a-8d17-4ed13c4a313e)
![image](https://github.com/user-attachments/assets/d7f3e0fb-f052-4e37-8f1e-c33882351f69)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1 - Get a dataset
2 - Create a Big number with trendline
3 - Add a subheader
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
https://github.com/apache/superset/issues/32776
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
