### PR TITLE
chore: update migrations to use utils

### DIFF
--- a/superset/migrations/versions/2024-09-25_17-59_7b17aa722e30_uuidmixin.py
+++ b/superset/migrations/versions/2024-09-25_17-59_7b17aa722e30_uuidmixin.py
@@ -24,7 +24,8 @@ Create Date: 2024-09-25 17:59:21.028426
 
 import sqlalchemy as sa
 import sqlalchemy_utils
-from alembic import op
+
+from superset.migrations.shared.utils import add_columns, drop_columns
 
 # revision identifiers, used by Alembic.
 revision = "7b17aa722e30"
@@ -32,16 +33,16 @@ down_revision = "48cbb571fa3a"
 
 
 def upgrade():
-    op.add_column(
+    add_columns(
         "css_templates",
         sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
     )
-    op.add_column(
+    add_columns(
         "favstar",
         sa.Column("uuid", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True),
     )
 
 
 def downgrade():
-    op.drop_column("css_templates", "uuid")
-    op.drop_column("favstar", "uuid")
+    drop_columns("css_templates", "uuid")
+    drop_columns("favstar", "uuid")

--- a/superset/migrations/versions/2025-03-03_20-52_94e7a3499973_add_folders_column_to_dataset.py
+++ b/superset/migrations/versions/2025-03-03_20-52_94e7a3499973_add_folders_column_to_dataset.py
@@ -25,7 +25,7 @@ Create Date: 2025-03-03 20:52:24.585143
 import sqlalchemy as sa
 from sqlalchemy.types import JSON
 
-from superset.migrations.shared.utils import add_column, drop_column
+from superset.migrations.shared.utils import add_columns, drop_columns
 
 # revision identifiers, used by Alembic.
 revision = "94e7a3499973"
@@ -33,11 +33,11 @@ down_revision = "74ad1125881c"
 
 
 def upgrade():
-    add_column(
+    add_columns(
         "tables",
         sa.Column("folders", JSON, nullable=True),
     )
 
 
 def downgrade():
-    drop_column("tables", "folders")
+    drop_columns("tables", "folders")

--- a/superset/migrations/versions/2025-03-03_20-52_94e7a3499973_add_folders_column_to_dataset.py
+++ b/superset/migrations/versions/2025-03-03_20-52_94e7a3499973_add_folders_column_to_dataset.py
@@ -23,8 +23,9 @@ Create Date: 2025-03-03 20:52:24.585143
 """
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.types import JSON
+
+from superset.migrations.shared.utils import add_column, drop_column
 
 # revision identifiers, used by Alembic.
 revision = "94e7a3499973"
@@ -32,11 +33,11 @@ down_revision = "74ad1125881c"
 
 
 def upgrade():
-    op.add_column(
+    add_column(
         "tables",
         sa.Column("folders", JSON, nullable=True),
     )
 
 
 def downgrade():
-    op.drop_column("tables", "folders")
+    drop_column("tables", "folders")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Noticed some of our newer migrations are not using the util functions. Updating this so we use the utils to add and drop columns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
