### PR TITLE
fix: add suffix to Drill labels to avoid collision

### DIFF
--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -27,6 +27,7 @@ from sqlalchemy.engine.url import URL
 from superset.constants import TimeGrain
 from superset.db_engine_specs.base import BaseEngineSpec
 from superset.db_engine_specs.exceptions import SupersetDBAPIProgrammingError
+from superset.utils.hashing import md5_sha_from_str
 
 if TYPE_CHECKING:
     from superset.models.core import Database
@@ -143,3 +144,14 @@ class DrillEngineSpec(BaseEngineSpec):
             if str(ex) == "generator raised StopIteration":
                 return []
             raise
+
+    @staticmethod
+    def _mutate_label(label: str) -> str:
+        """
+        Suffix with the first six characters from the md5 of the label to avoid
+        collisions with original column names
+
+        :param label: Expected expression label
+        :return: Conditionally mutated label
+        """
+        return f"{label}_{md5_sha_from_str(label)[:6]}"

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -158,6 +158,7 @@ def test_get_schema_from_engine_params() -> None:
         == "dfs.test"
     )
 
+
 @pytest.mark.parametrize(
     "column_name,expected_result",
     [
@@ -167,7 +168,7 @@ def test_get_schema_from_engine_params() -> None:
 )
 def test_connect_make_label_compatible(column_name: str, expected_result: str) -> None:
     from superset.db_engine_specs.drill import (
-        DrillEngineSpec as spec, # noqa: N813
+        DrillEngineSpec as spec,  # noqa: N813
     )
 
     label = spec.make_label_compatible(column_name)

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -157,3 +157,18 @@ def test_get_schema_from_engine_params() -> None:
         )
         == "dfs.test"
     )
+
+@pytest.mark.parametrize(
+    "column_name,expected_result",
+    [
+        ("time", "time_07cc69"),
+        ("count", "count_e2942a"),
+    ],
+)
+def test_connect_make_label_compatible(column_name: str, expected_result: str) -> None:
+    from superset.db_engine_specs.drill import (
+        DrillEngineSpec as spec, # noqa: N813
+    )
+
+    label = spec.make_label_compatible(column_name)
+    assert label == expected_result


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Drill aliases with the same name as the source column makes queries ambiguous and cannot group the column properly.
A suffix is added on Drill labels to avoid this collision, as per discussion in a previous PR #29455.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
![Screenshot from 2025-03-26 09-46-40](https://github.com/user-attachments/assets/70ee3926-e7d9-4744-93ad-fa60b338f756)
![Screenshot from 2025-03-26 09-47-01](https://github.com/user-attachments/assets/f9af11d5-1c4a-48b7-b05e-0f7facce10a7)

After:
![Screenshot from 2025-03-26 09-49-08](https://github.com/user-attachments/assets/98518c29-cdd5-4d6e-ad4b-4735260e329d)
![Screenshot from 2025-03-26 09-48-53](https://github.com/user-attachments/assets/fd891fe5-a5a3-464f-8342-37a35a0e9d9e)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Start Superset
* Navigate to the Superset web application and login
* Connect to a Drill database
* Create a dataset of the Drill database
* Create a chart from that dataset
* Select visualization type Table with query mode Aggregate
* Add a column in the dimensions
* Aggregate the data of the columns (e.g. length(column_a))
* Press "view query"
* The query should now contain a GROUP BY statement of an aggregation, and the alias of that aggregation should have a MD5-based suffix at the end of the name.
Example:
```
SELECT length(n_name) AS n_name_ebba65
...
GROUP BY length(n_name)
```
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x ] Has associated issue:  Fixes #28443 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
