### PR TITLE
fix(table-chart): Do not show comparison columns config if time_compare is set to []

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -486,8 +486,9 @@ const config: ControlPanelConfig = {
                 return true;
               },
               mapStateToProps(explore, _, chart) {
+                const timeComparevalue = explore?.controls?.time_compare?.value;
                 const timeComparisonStatus =
-                  !!explore?.controls?.time_compare?.value;
+                  Array.isArray(timeComparevalue) ? timeComparevalue.length > 0 : !!timeComparevalue;
 
                 const { colnames: _colnames, coltypes: _coltypes } =
                   chart?.queriesResponse?.[0] ?? {};

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -486,9 +486,7 @@ const config: ControlPanelConfig = {
                 return true;
               },
               mapStateToProps(explore, _, chart) {
-                const timeComparevalue = explore?.controls?.time_compare?.value;
-                const timeComparisonStatus =
-                  Array.isArray(timeComparevalue) ? timeComparevalue.length > 0 : !!timeComparevalue;
+                const timeComparisonStatus = !isEmpty(explore?.controls?.time_compare?.value);
 
                 const { colnames: _colnames, coltypes: _coltypes } =
                   chart?.queriesResponse?.[0] ?? {};

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -486,7 +486,9 @@ const config: ControlPanelConfig = {
                 return true;
               },
               mapStateToProps(explore, _, chart) {
-                const timeComparisonStatus = !isEmpty(explore?.controls?.time_compare?.value);
+                const timeComparisonStatus = !isEmpty(
+                  explore?.controls?.time_compare?.value,
+                );
 
                 const { colnames: _colnames, coltypes: _coltypes } =
                   chart?.queriesResponse?.[0] ?? {};


### PR DESCRIPTION
### SUMMARY
If somehow a table chart has the `time_compare` configuration set to `[]`, the time comparison columns (`#`, `△` and `%`) are visible in the customize section, even though they are not displayed in the chart.

While we can't recreate this scenario through the UI (having `time_compare` set to `[]`) we have a handful of charts with this configuration on our environment, so handling this scenario in the code. It's possible to force this state via the API/import.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
![image](https://github.com/user-attachments/assets/203daf24-6152-4a46-9d15-9d316ec2d908)

**After**
![image](https://github.com/user-attachments/assets/c7914dc0-0ee5-4fe1-878a-77f8e8164f5e)

### TESTING INSTRUCTIONS
1. Create a table chart with a non temporal dimension and a metric.
2. Set `params.time_compare` to `[]` either via the API or export/import.
3. Access the **Customize** tab.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
