### PR TITLE
fix: %s for plural (Added to %s dashboard) to avoid poedit alert

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader/useExploreMetadataBar.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/useExploreMetadataBar.tsx
@@ -36,7 +36,7 @@ export const useExploreMetadataBar = (
         title:
           metadata.dashboards.length > 0
             ? tn(
-                'Added to 1 dashboard',
+                'Added to %s dashboard',
                 'Added to %s dashboards',
                 metadata.dashboards.length,
                 metadata.dashboards.length,

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -996,7 +996,7 @@ msgid "Added"
 msgstr "مضاف"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "إضافة إلى لوحة القيادة"
 msgstr[1] ""

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -1049,7 +1049,7 @@ msgid "Added"
 msgstr "Hinzugefügt"
 
 #, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Zu Dashboard hinzugefügt"
 msgstr[1] "Zu %s Dashboards hinzugefügt"

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -913,7 +913,7 @@ msgid "Added"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] ""
 msgstr[1] ""

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -991,7 +991,7 @@ msgid "Added"
 msgstr "Añadido"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Añadir a un nuevo Dashboard"
 msgstr[1] ""

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -1014,9 +1014,9 @@ msgid "Added"
 msgstr "Ajouté"
 
 #, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
-msgstr[0] "Ajouté à 1 tableau de bord"
+msgstr[0] "Ajouté à %s tableau de bord"
 msgstr[1] "Ajoutés à %s tableaux de bords"
 
 msgid "Additional Parameters"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -959,7 +959,7 @@ msgid "Added"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Aggiungi ad una nuova dashboard"
 

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -962,7 +962,7 @@ msgid "Added"
 msgstr "追加済み"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "1 つのダッシュボードに追加"
 

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -956,7 +956,7 @@ msgid "Added"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "대시보드 추가"
 

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -918,7 +918,7 @@ msgid "Added"
 msgstr ""
 
 #, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] ""
 msgstr[1] ""

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -1007,7 +1007,7 @@ msgid "Added"
 msgstr "Toegevoegd"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Toegevoegd aan het dashboard"
 msgstr[1] ""

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -1028,7 +1028,7 @@ msgid "Added"
 msgstr "Dodano"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Dodano do 1 pulpitu"
 msgstr[1] "Dodano do %s pulpitów"

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -973,7 +973,7 @@ msgid "Added"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Adicionar ao novo dashboard"
 msgstr[1] ""

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1023,7 +1023,7 @@ msgid "Added"
 msgstr "Adicionado"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Adicionado a 1 painel"
 msgstr[1] ""

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -1008,7 +1008,7 @@ msgid "Added"
 msgstr "Добавлено"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Добавлено на один дашборд"
 msgstr[1] "Добавлено на %s дашборда"

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -917,7 +917,7 @@ msgid "Added"
 msgstr ""
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Importovať dashboard"
 msgstr[1] ""

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -1044,7 +1044,7 @@ msgid "Added"
 msgstr "Dodano"
 
 #, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Dodano na 1 nadzorno ploščo"
 msgstr[1] "Dodano na %s nadzorni plošči"

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -916,7 +916,7 @@ msgid "Added"
 msgstr "Eklendi"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "1 Dashboarda eklendi"
 

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -1011,7 +1011,7 @@ msgid "Added"
 msgstr "Доданий"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "Додано до 1 інформаційної панелі"
 msgstr[1] ""

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -979,7 +979,7 @@ msgid "Added"
 msgstr "已添加"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "添加到看板"
 

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -978,7 +978,7 @@ msgid "Added"
 msgstr "已增加"
 
 #, fuzzy, python-format
-msgid "Added to 1 dashboard"
+msgid "Added to %s dashboard"
 msgid_plural "Added to %s dashboards"
 msgstr[0] "增加到看板"
 


### PR DESCRIPTION
This PR fix #32674

### SUMMARY
Update to avoid alert in poedit, the msgid use %s for singular and plural.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before : 
![image](https://github.com/user-attachments/assets/6a4a4b35-11e8-4c7d-8259-2cbd2e12931e)

After : 
![image](https://github.com/user-attachments/assets/202293d7-4309-4cd5-bac6-ee709f21b403)


### TESTING INSTRUCTIONS
Create a graph and add it to a dashboard
The tag mention : "Added to 1 dashboard"
![image](https://github.com/user-attachments/assets/d6d7744f-ff93-4a26-917a-0ecbffe0ff8e)
