### PR TITLE
refactor(jinja macro): Update current_user_roles() macro to fetch roles from existing get_user_roles() method

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -33,6 +33,7 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.expression import bindparam
 from sqlalchemy.types import String
 
+from superset import security_manager
 from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.common.utils.time_range_utils import get_since_until_from_time_range
 from superset.constants import LRU_CACHE_MAX_SIZE, NO_TIME_RANGE
@@ -46,7 +47,6 @@ from superset.utils.core import (
     FilterOperator,
     get_user_email,
     get_user_id,
-    get_user_roles,
     get_username,
     merge_extra_filters,
 )
@@ -176,17 +176,21 @@ class ExtraCache:
 
     def current_user_roles(self, add_to_cache_keys: bool = True) -> list[str] | None:
         """
-        Return the list of roles of the user who is currently logged in.
+        Return the sorted list of roles of the user who is currently logged in.
 
         :param add_to_cache_keys: Whether the value should be included in the cache key
         :returns: List of role names
         """
+        try:
+            roles = sorted([role.name for role in security_manager.get_user_roles()])
 
-        if user_roles := get_user_roles():
-            if add_to_cache_keys:
-                self.cache_key_wrapper(json.dumps(user_roles))
-            return user_roles
-        return None
+            if roles:
+                if add_to_cache_keys:
+                    self.cache_key_wrapper(json.dumps(roles))
+                return roles
+            return None
+        except Exception:  # pylint: disable=broad-except
+            return None
 
     def cache_key_wrapper(self, key: Any) -> Any:
         """

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -185,11 +185,11 @@ class ExtraCache:
             user_roles = sorted(
                 [role.name for role in security_manager.get_user_roles()]
             )
-            if user_roles:
-                if add_to_cache_keys:
-                    self.cache_key_wrapper(json.dumps(user_roles))
-                return user_roles
-            return None
+            if not user_roles:
+                return None
+            if add_to_cache_keys:
+                self.cache_key_wrapper(json.dumps(user_roles))
+            return user_roles
         except Exception:  # pylint: disable=broad-except
             return None
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -182,12 +182,13 @@ class ExtraCache:
         :returns: List of role names
         """
         try:
-            roles = sorted([role.name for role in security_manager.get_user_roles()])
-
-            if roles:
+            user_roles = sorted(
+                [role.name for role in security_manager.get_user_roles()]
+            )
+            if user_roles:
                 if add_to_cache_keys:
-                    self.cache_key_wrapper(json.dumps(roles))
-                return roles
+                    self.cache_key_wrapper(json.dumps(user_roles))
+                return user_roles
             return None
         except Exception:  # pylint: disable=broad-except
             return None

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1292,19 +1292,6 @@ def get_user_email() -> str | None:
         return None
 
 
-def get_user_roles() -> list[str] | None:
-    """
-    Get the roles (if defined) associated with the current user.
-
-    :returns: The sorted list of roles
-    """
-
-    try:
-        return sorted([role.name for role in g.user.roles])
-    except Exception:  # pylint: disable=broad-except
-        return None
-
-
 @contextmanager
 def override_user(user: User | None, force: bool = True) -> Iterator[Any]:
     """

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -27,6 +27,7 @@ import pytest
 import numpy as np
 import pandas as pd
 from flask.ctx import AppContext
+from flask_appbuilder.security.sqla.models import Role
 from pytest_mock import MockerFixture
 from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import TextClause
@@ -844,7 +845,10 @@ def test_none_operand_in_filter(login_as_admin, physical_dataset):
 @patch("superset.jinja_context.get_user_id", return_value=1)
 @patch("superset.jinja_context.get_username", return_value="abc")
 @patch("superset.jinja_context.get_user_email", return_value="abc@test.com")
-@patch("superset.jinja_context.get_user_roles", return_value=["role1", "role2"])
+@patch(
+    "superset.jinja_context.security_manager.get_user_roles",
+    return_value=[Role(name="role1"), Role(name="role2")],
+)
 def test_extra_cache_keys(
     mock_get_user_roles,
     mock_user_email,
@@ -888,7 +892,10 @@ def test_extra_cache_keys(
 @patch("superset.jinja_context.get_user_id", return_value=1)
 @patch("superset.jinja_context.get_username", return_value="abc")
 @patch("superset.jinja_context.get_user_email", return_value="abc@test.com")
-@patch("superset.jinja_context.get_user_roles", return_value=["role1", "role2"])
+@patch(
+    "superset.jinja_context.security_manager.get_user_roles",
+    return_value=[Role(name="role1"), Role(name="role2")],
+)
 def test_extra_cache_keys_in_sql_expression(
     mock_get_user_roles,
     mock_user_email,

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -364,13 +364,14 @@ def test_user_macros(mocker: MockerFixture):
         - ``current_user_roles``
     """
     mock_g = mocker.patch("superset.utils.core.g")
+    mock_get_user_roles = mocker.patch("superset.security_manager.get_user_roles")
     mock_cache_key_wrapper = mocker.patch(
         "superset.jinja_context.ExtraCache.cache_key_wrapper"
     )
     mock_g.user.id = 1
     mock_g.user.username = "my_username"
     mock_g.user.email = "my_email@test.com"
-    mock_g.user.roles = [Role(name="my_role1"), Role(name="my_role2")]
+    mock_get_user_roles.return_value = [Role(name="my_role1"), Role(name="my_role2")]
     cache = ExtraCache()
     assert cache.current_user_id() == 1
     assert cache.current_username() == "my_username"
@@ -384,13 +385,14 @@ def test_user_macros_without_cache_key_inclusion(mocker: MockerFixture):
     Test all user macros with ``add_to_cache_keys`` set to ``False``.
     """
     mock_g = mocker.patch("superset.utils.core.g")
+    mock_get_user_roles = mocker.patch("superset.security_manager.get_user_roles")
     mock_cache_key_wrapper = mocker.patch(
         "superset.jinja_context.ExtraCache.cache_key_wrapper"
     )
     mock_g.user.id = 1
     mock_g.user.username = "my_username"
     mock_g.user.email = "my_email@test.com"
-    mock_g.user.roles = [Role(name="my_role1"), Role(name="my_role2")]
+    mock_get_user_roles.return_value = [Role(name="my_role1"), Role(name="my_role2")]
     cache = ExtraCache()
     assert cache.current_user_id(False) == 1
     assert cache.current_username(False) == "my_username"

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -379,6 +379,9 @@ def test_user_macros(mocker: MockerFixture):
     assert cache.current_user_roles() == ["my_role1", "my_role2"]
     assert mock_cache_key_wrapper.call_count == 4
 
+    mock_get_user_roles.return_value = []
+    assert cache.current_user_roles() is None
+
 
 def test_user_macros_without_cache_key_inclusion(mocker: MockerFixture):
     """
@@ -402,6 +405,19 @@ def test_user_macros_without_cache_key_inclusion(mocker: MockerFixture):
 
 
 def test_user_macros_without_user_info(mocker: MockerFixture):
+    """
+    Test all user macros when no user info is available.
+    """
+    mock_g = mocker.patch("superset.utils.core.g")
+    mock_g.user = None
+    cache = ExtraCache()
+    assert cache.current_user_id() == None  # noqa: E711
+    assert cache.current_username() == None  # noqa: E711
+    assert cache.current_user_email() == None  # noqa: E711
+    assert cache.current_user_roles() == None  # noqa: E711
+
+
+def test_current_user_roles_empty(mocker: MockerFixture):
     """
     Test all user macros when no user info is available.
     """

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -417,19 +417,6 @@ def test_user_macros_without_user_info(mocker: MockerFixture):
     assert cache.current_user_roles() == None  # noqa: E711
 
 
-def test_current_user_roles_empty(mocker: MockerFixture):
-    """
-    Test all user macros when no user info is available.
-    """
-    mock_g = mocker.patch("superset.utils.core.g")
-    mock_g.user = None
-    cache = ExtraCache()
-    assert cache.current_user_id() == None  # noqa: E711
-    assert cache.current_username() == None  # noqa: E711
-    assert cache.current_user_email() == None  # noqa: E711
-    assert cache.current_user_roles() == None  # noqa: E711
-
-
 def test_where_in() -> None:
     """
     Test the ``where_in`` Jinja2 filter.


### PR DESCRIPTION
### SUMMARY
I recently added a new Jinja macro `current_user_roles()` in https://github.com/apache/superset/pull/32770
In this PR I added a new function `get_user_roles()` in `core.py` to get the roles of the logged-in user.

However I noticed today there's already a `get_user_roles()` method defined in `superset/security/manager.py` [[source](https://github.com/apache/superset/blob/master/superset/security/manager.py#L2437)].

I'm proposing a small refactor to rely on the existing method instead of the new method I introduced in https://github.com/apache/superset/pull/32770.

### TESTING INSTRUCTIONS
I've updated the unit tests accordingly, so they should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
