### PR TITLE
docs: pypi-installation on Ubuntu 24.04 and statsd package for event-logging

### DIFF
--- a/docs/docs/configuration/event-logging.mdx
+++ b/docs/docs/configuration/event-logging.mdx
@@ -51,24 +51,12 @@ if desired. Most endpoints hit are logged as
 well as key events like query start and end in SQL Lab.
 
 To setup StatsD logging, it’s a matter of configuring the logger in your `superset_config.py`.
-If not already present, you need to ensure that the `statsd`-package is installed in superset's python environment.
+If not already present, you need to ensure that the `statsd`-package is installed in Superset's python environment.
 
 ```python
 from superset.stats_logger import StatsdStatsLogger
 STATS_LOGGER = StatsdStatsLogger(host='localhost', port=8125, prefix='superset')
 ```
-
-If you get the Error `ImportError: cannot import name 'StatsdStatsLogger' from 'superset.stats_logger' (/path/to/superset/env/superset/stats_logger.py)`, you can edit the `except Exception` block to print error details:
-```python
-try:
-    from statsd import StatsClient
-
-    class StatsdStatsLogger(BaseStatsLogger):
-    ...
-except Exception as e:  # pylint: disable=broad-except
-    print(e)
-```
-
 
 Note that it’s also possible to implement your own logger by deriving
 `superset.stats_logger.BaseStatsLogger`.

--- a/docs/docs/configuration/event-logging.mdx
+++ b/docs/docs/configuration/event-logging.mdx
@@ -51,11 +51,24 @@ if desired. Most endpoints hit are logged as
 well as key events like query start and end in SQL Lab.
 
 To setup StatsD logging, it’s a matter of configuring the logger in your `superset_config.py`.
+If not already present, you need to ensure that the `statsd`-package is installed in superset's python environment.
 
 ```python
 from superset.stats_logger import StatsdStatsLogger
 STATS_LOGGER = StatsdStatsLogger(host='localhost', port=8125, prefix='superset')
 ```
+
+If you get the Error `ImportError: cannot import name 'StatsdStatsLogger' from 'superset.stats_logger' (/path/to/superset/env/superset/stats_logger.py)`, you can edit the `except Exception` block to print error details:
+```python
+try:
+    from statsd import StatsClient
+
+    class StatsdStatsLogger(BaseStatsLogger):
+    ...
+except Exception as e:  # pylint: disable=broad-except
+    print(e)
+```
+
 
 Note that it’s also possible to implement your own logger by deriving
 `superset.stats_logger.BaseStatsLogger`.

--- a/docs/docs/installation/pypi.mdx
+++ b/docs/docs/installation/pypi.mdx
@@ -22,7 +22,7 @@ level dependencies.
 
 **Debian and Ubuntu**
 
-Ubuntu **24.04** uses python 3.12 per default, which currently is not supported by superset. You need to add a second python installation of 3.11 and install the required additional dependencies.
+Ubuntu **24.04** uses python 3.12 per default, which currently is not supported by Superset. You need to add a second python installation of 3.11 and install the required additional dependencies.
 ```bash
 sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt update

--- a/docs/docs/installation/pypi.mdx
+++ b/docs/docs/installation/pypi.mdx
@@ -22,6 +22,13 @@ level dependencies.
 
 **Debian and Ubuntu**
 
+Ubuntu **24.04** uses python 3.12 per default, which currently is not supported by superset. You need to add a second python installation of 3.11 and install the required additional dependencies.
+```bash
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.11 python3.11-dev python3.11-venv build-essential libssl-dev libffi-dev libsasl2-dev libldap2-dev default-libmysqlclient-dev
+```
+
 In Ubuntu **20.04 and 22.04** the following command will ensure that the required dependencies are installed:
 
 ```bash
@@ -94,14 +101,9 @@ These will now be available when pip installing requirements.
 
 ## Python Virtual Environment
 
-We highly recommend installing Superset inside of a virtual environment. Python ships with
-`virtualenv` out of the box. If you're using [pyenv](https://github.com/pyenv/pyenv), you can install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv). Or you can install it with `pip`:
+We highly recommend installing Superset inside of a virtual environment.
 
-```bash
-pip install virtualenv
-```
-
-You can create and activate a virtual environment using:
+You can create and activate a virtual environment using the following commands. Ensure you are using a compatible version of python. You might have to explicitly use for example `python3.11` instead of `python3`.
 
 ```bash
 # virtualenv is shipped in Python 3.6+ as venv instead of pyvenv.
@@ -132,7 +134,7 @@ pip install apache-superset
 
 Then, define mandatory configurations, SECRET_KEY and FLASK_APP:
 ```bash
-export SUPERSET_SECRET_KEY=YOUR-SECRET-KEY
+export SUPERSET_SECRET_KEY=YOUR-SECRET-KEY # For production use, make sure this is a strong key, for example generated using `openssl rand -base64 42`. See https://superset.apache.org/docs/configuration/configuring-superset#specifying-a-secret_key
 export FLASK_APP=superset
 ```
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
* Adds Ubuntu 24.04 and the need for an older python version to the pypi installation instructions.
* Adds note that the statsd-package needs to be installed for the StatsdStatsLogger and how to inspect errors
  * Suggestion: Maybe instead of suppressing the exception, superset could be adjusted to still create the `StatsdStatsLogger` class but it throws the caught exception on init so the users can see the actual problem?
```
try:
    from statsd import StatsClient
    ...
except Exception as e:  # pylint: disable=broad-except
    class StatsdStatsLogger(BaseStatsLogger):
        def __init__(  # pylint: disable=super-init-not-called
            self,
            host: str = "localhost",
            port: int = 8125,
            prefix: str = "superset",
            statsd_client: Optional[StatsClient] = None,
        ) -> None:
            raise e
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
