### PR TITLE
fix(cosmetics): better padding for force-refresh loaded data icon in Charts page

### DIFF
--- a/superset-frontend/src/components/CachedLabel/index.tsx
+++ b/superset-frontend/src/components/CachedLabel/index.tsx
@@ -21,6 +21,7 @@ import { useState, MouseEventHandler, FC } from 'react';
 import { t } from '@superset-ui/core';
 import Label from 'src/components/Label';
 import { Tooltip } from 'src/components/Tooltip';
+import Icons from 'src/components/Icons';
 import { TooltipContent } from './TooltipContent';
 
 export interface CacheLabelProps {
@@ -49,9 +50,8 @@ const CacheLabel: FC<CacheLabelProps> = ({
         onMouseOver={() => setHovered(true)}
         onMouseOut={() => setHovered(false)}
       >
-        {/* TODO: Remove fa-icon */}
-        {/* eslint-disable-next-line icons/no-fa-icons-usage */}
-        {t('Cached')} <i className="fa fa-refresh" />
+        {t('Cached')}
+        <Icons.RetweetOutlined iconSize="m" />
       </Label>
     </Tooltip>
   );

--- a/superset-frontend/src/components/CachedLabel/index.tsx
+++ b/superset-frontend/src/components/CachedLabel/index.tsx
@@ -49,9 +49,9 @@ const CacheLabel: FC<CacheLabelProps> = ({
         onClick={onClick}
         onMouseOver={() => setHovered(true)}
         onMouseOut={() => setHovered(false)}
+        icon={<Icons.RetweetOutlined iconSize="m" />}
       >
         {t('Cached')}
-        <Icons.RetweetOutlined iconSize="m" />
       </Label>
     </Tooltip>
   );

--- a/superset-frontend/src/components/Icons/AntdEnhanced.tsx
+++ b/superset-frontend/src/components/Icons/AntdEnhanced.tsx
@@ -110,6 +110,7 @@ import {
   FilterOutlined,
   UnorderedListOutlined,
   WarningOutlined,
+  RetweetOutlined,
 } from '@ant-design/icons';
 import { IconType } from './types';
 import { BaseIconComponent } from './BaseIcon';
@@ -205,6 +206,7 @@ const AntdIcons = {
   FilterOutlined,
   UnorderedListOutlined,
   WarningOutlined,
+  RetweetOutlined,
 };
 
 const AntdEnhancedIcons = Object.keys(AntdIcons)


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(cosmetics): better padding for force-refresh loaded data in Charts page

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the cosmetic issue of `Cached` text and the force-refresh icon being too close. This also reduces the `fa` usage in the codebase.

I tried using `ReloadOutline` Antd icon but this one seems better looking, imo. I'm open for discourse though :D 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

After
<img width="383" alt="image" src="https://github.com/user-attachments/assets/3dff1af2-1e0b-495f-952b-6ca213687ce7" />


Before
<img width="383" alt="image" src="https://github.com/user-attachments/assets/fd403267-1843-46d6-a775-2d104d4c676c" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
