### PR TITLE
feat: Enable passing a permalink to cache_dashboard_screenshot endpoint

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1087,16 +1087,19 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             "urlParams": payload.get("urlParams", []),
         }
 
-        permalink_key = CreateDashboardPermalinkCommand(
-            dashboard_id=str(dashboard.id),
-            state=dashboard_state,
-        ).run()
+        # if the permalink key is provided, dashboard_state will be ignored
+        # else, create a permalink key from the dashboard_state
+        permalink_key = (
+            payload.get("permalinkKey", None)
+            or CreateDashboardPermalinkCommand(
+                dashboard_id=str(dashboard.id),
+                state=dashboard_state,
+            ).run()
+        )
 
         dashboard_url = get_url_path("Superset.dashboard_permalink", key=permalink_key)
         screenshot_obj = DashboardScreenshot(dashboard_url, dashboard.digest)
-        cache_key = screenshot_obj.get_cache_key(
-            window_size, thumb_size, dashboard_state
-        )
+        cache_key = screenshot_obj.get_cache_key(window_size, thumb_size, permalink_key)
         image_url = get_url_path(
             "DashboardRestApi.screenshot", pk=dashboard.id, digest=cache_key
         )

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -521,3 +521,4 @@ class CacheScreenshotSchema(Schema):
     urlParams = fields.List(  # noqa: N815
         fields.List(fields.Str(), validate=lambda x: len(x) == 2), required=False
     )
+    permalinkKey = fields.Str(required=False)  # noqa: N815

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -26,7 +26,6 @@ from typing import cast, TYPE_CHECKING, TypedDict
 from flask import current_app
 
 from superset import app, feature_flag_manager, thumbnail_cache
-from superset.dashboards.permalink.types import DashboardPermalinkState
 from superset.extensions import event_logger
 from superset.utils.hashing import md5_sha_from_dict
 from superset.utils.urls import modify_url_query
@@ -349,7 +348,7 @@ class DashboardScreenshot(BaseScreenshot):
         self,
         window_size: bool | WindowSize | None = None,
         thumb_size: bool | WindowSize | None = None,
-        dashboard_state: DashboardPermalinkState | None = None,
+        permalink_key: str | None = None,
     ) -> str:
         window_size = window_size or self.window_size
         thumb_size = thumb_size or self.thumb_size
@@ -359,6 +358,6 @@ class DashboardScreenshot(BaseScreenshot):
             "type": "thumb",
             "window_size": window_size,
             "thumb_size": thumb_size,
-            "dashboard_state": dashboard_state,
+            "permalink_key": permalink_key,
         }
         return md5_sha_from_dict(args)

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3040,6 +3040,18 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
 
     @with_feature_flags(THUMBNAILS=True, ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS=True)
     @pytest.mark.usefixtures("create_dashboard_with_tag")
+    def test_cache_dashboard_screenshot_success_permalink_payload(self):
+        self.login(ADMIN_USERNAME)
+        dashboard = (
+            db.session.query(Dashboard)
+            .filter(Dashboard.dashboard_title == "dash with tag")
+            .first()
+        )
+        response = self._cache_screenshot(dashboard.id, {"permalink": "1234"})
+        assert response.status_code == 202
+
+    @with_feature_flags(THUMBNAILS=True, ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS=True)
+    @pytest.mark.usefixtures("create_dashboard_with_tag")
     def test_cache_dashboard_screenshot_dashboard_validation(self):
         self.login(ADMIN_USERNAME)
         dashboard = (

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3047,7 +3047,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             .filter(Dashboard.dashboard_title == "dash with tag")
             .first()
         )
-        response = self._cache_screenshot(dashboard.id, {"permalink": "1234"})
+        response = self._cache_screenshot(dashboard.id, {"permalinkKey": "1234"})
         assert response.status_code == 202
 
     @with_feature_flags(THUMBNAILS=True, ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS=True)


### PR DESCRIPTION
### SUMMARY
In `/v1/dashboard/<pk>/cache_dashboard_screenshot/` endpoint, user could pass dashboard state as a payload, which was later used to generate a permalink to be used by Selenium. This PR allows the users to pass a permalink key in the payload instead of the dashboard state.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Enable `THUMBNAILS` and `ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS` feature flags
2. Generate a permalink key
3. Send a POST request to `/v1/dashboard/<pk>/cache_dashboard_screenshot/` endpoint with payload `{ permalinkKey: <your permalink key> }`
4. Verify that the screenshot is generated correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
