### PR TITLE
feat: don't pivot when we don't need to

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/pivotOperator.ts
@@ -37,7 +37,8 @@ export const pivotOperator: PostProcessingFactory<PostProcessingPivot> = (
   const xAxisLabel = getXAxisLabel(formData);
   const columns = queryObject.series_columns || queryObject.columns;
 
-  if (xAxisLabel && metricLabels.length) {
+  // Only pivot if we have an x-axis and at least one metric and column
+  if (xAxisLabel && metricLabels.length && columns?.length) {
     return {
       operation: 'pivot',
       options: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Pivoting without dimensions is an unnecessary operation, and worse, it breaks sorting.

(This is a simpler solution than https://github.com/apache/superset/pull/27616.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="1728" alt="Screenshot 2025-03-28 at 4 01 38 PM" src="https://github.com/user-attachments/assets/c244282e-0e77-443c-978d-ae40a816b4dd" />

After:

<img width="1728" alt="Screenshot 2025-03-28 at 4 04 12 PM" src="https://github.com/user-attachments/assets/949e6d30-f5e9-4964-ac07-a376a142970a" />

Note that when we have dimensions sorting the query doesn't make much sense. Instead, we can sort by the x-axis:

<img width="1728" alt="Screenshot 2025-03-28 at 4 10 57 PM" src="https://github.com/user-attachments/assets/06be3c1b-f3ac-4d5e-b536-3409aa044320" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
