### PR TITLE
chore: bump marshmallow-sqlalchemy to 1.4.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,9 +28,8 @@ async_timeout>=4.0.0,<5.0.0
 # a bit of attention to bump.
 apispec>=6.0.0,<6.7.0
 
-# 1.4.0 appears to use much more memory, where the python test suite runs out of memory
-# causing CI to fail. 1.3.0 is the last version that works.
-# This is probably related to the changes around PickleType
+# 1.4.1 appears to use much more memory, where the python test suite runs out of memory
+# causing CI to fail. 1.4.0 is the last version that works.
 # https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html#id3
 # Opened this issue https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665
-marshmallow-sqlalchemy>=1.3.0,<1.4.0
+marshmallow-sqlalchemy>=1.3.0,<1.4.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,7 +158,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.14.0
@@ -216,7 +215,7 @@ marshmallow==3.26.1
     # via
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.3.0
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -r requirements/base.in
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -318,7 +318,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -435,7 +434,7 @@ marshmallow==3.26.1
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.3.0
+marshmallow-sqlalchemy==1.4.0
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder


### PR DESCRIPTION
title
