### PR TITLE
fix: Bar Chart (legacy) migration to keep labels layout

### DIFF
--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -236,6 +236,7 @@ class MigrateDistBarChart(TimeseriesChart):
         self.remove_keys.add("bar_stacked")
 
         self.data["stack"] = "Stack" if self.data.get("bar_stacked") else None
+        self.data["x_ticks_layout"] = 45
 
 
 class MigrateBubbleChart(MigrateViz):


### PR DESCRIPTION
### SUMMARY
This PR fixes the Bar Chart (legacy) migration to keep the 45° labels layout that was the default in the legacy chart. It's also important to note that the legacy chart didn't offer a control to change the layout and that's why this fix assumes that all charts of that type will have a 45° labels layout.

### TESTING INSTRUCTIONS
Run the migration and check that migrated bar charts have a 45° labels layout by default.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
