### PR TITLE
fix(pivot-table): Revert "fix(Pivot Table): Fix column width to respect currency config (#31414)"

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -51,7 +51,6 @@ const Styles = styled.div<PivotTableStylesProps>`
       width: ${
         typeof width === 'string' ? parseInt(width, 10) : width - margin * 2
       }px;
-      white-space: nowrap;
  `}
 `;
 


### PR DESCRIPTION
### SUMMARY

#31414 has an issue where both the header and the long text cells are causing the chart area to inefficiently expand due to the nowrap setting. Therefore, this commit reverts the changes first and then finding a new approach that only applies to the currency text.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2025-04-01 at 1 42 31 PM](https://github.com/user-attachments/assets/f87e4807-6f22-4c49-abf5-890a099bb343)

After:
![Screenshot 2025-04-01 at 1 41 52 PM](https://github.com/user-attachments/assets/4edb4c59-0b49-48a7-97ad-f5978c4a7906)


### TESTING INSTRUCTIONS
Create a Pivot table
Select a column with a long text value

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
