### PR TITLE
fix(frontend): add missing antd-5 icon to import

### DIFF
--- a/superset-frontend/src/components/Icons/AntdEnhanced.tsx
+++ b/superset-frontend/src/components/Icons/AntdEnhanced.tsx
@@ -110,6 +110,7 @@ import {
   FilterOutlined,
   UnorderedListOutlined,
   WarningOutlined,
+  KeyOutlined,
 } from '@ant-design/icons';
 import { FC } from 'react';
 import { IconType } from './types';
@@ -209,6 +210,7 @@ const AntdIcons = {
   FilterOutlined,
   UnorderedListOutlined,
   WarningOutlined,
+  KeyOutlined,
 } as const;
 
 type AntdIconNames = keyof typeof AntdIcons;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Front end crashes in development mode on master branch due to antd-5 upgrade. There are 2 distinct errors on this page. This fixes one of them. [Looks like other one should be fixed in #32959](https://github.com/apache/superset/pull/32959)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: 
![Screenshot 2025-04-02 at 12 33 32 PM](https://github.com/user-attachments/assets/94b6da8f-3def-42a2-b9b1-606cdf26fd37)


### TESTING INSTRUCTIONS
1. Open SqlLab
2. Select a database, schema and table
3. Front end would crash here. Specifically tested using Trino database that contains partition keys (hence key icon was missing)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

