### PR TITLE
feat(rls-frontend): Add new buttons to select/deselect all datasets/roles in RLS

### DIFF
--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
@@ -348,4 +348,58 @@ describe('Rule modal', () => {
       screen.queryByText('birth_names', { selector: '.tag-content' }),
     ).not.toBeInTheDocument();
   });
+
+  it('Select all button selects all available roles', async () => {
+    await renderAndWait(addNewRuleDefaultProps);
+
+    const rolesSelect = screen.getByRole('combobox', { name: /roles/i });
+    userEvent.click(rolesSelect);
+
+    const selectAllButton = screen.getByRole('button', {
+      name: 'Select all',
+      exact: true,
+    });
+    userEvent.click(selectAllButton);
+
+    await waitFor(() => {
+      const calls = fetchMock.calls(getRelatedRolesEndpoint);
+      // Verify that one of the API calls has the expected query parameters for getting all tables
+      const hasExpectedCall = calls.some(call =>
+        call[0].includes('q=(page:0,page_size:-1)'),
+      );
+      expect(hasExpectedCall).toBe(true);
+    });
+
+    expect(
+      screen.queryByText('Admin', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Public', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Alpha', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Deselect all button clears all selected roles', async () => {
+    await renderAndWait(addNewRuleDefaultProps);
+
+    const rolesSelect = screen.getByRole('combobox', { name: /roles/i });
+    userEvent.click(rolesSelect);
+
+    await selectOption('Admin', 'Roles');
+    expect(
+      screen.getByText('Admin', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+
+    const deselectAllButton = screen.getByRole('button', {
+      name: 'Deselect all',
+      exact: true,
+    });
+    userEvent.click(deselectAllButton);
+
+    expect(
+      screen.queryByText('Admin', { selector: '.tag-content' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
@@ -294,4 +294,58 @@ describe('Rule modal', () => {
       { timeout: 10000 },
     );
   });
+
+  it('Select all button selects all available tables', async () => {
+    await renderAndWait(addNewRuleDefaultProps);
+
+    const tablesSelect = screen.getByRole('combobox', { name: /tables/i });
+    userEvent.click(tablesSelect);
+
+    const selectAllButton = screen.getByRole('button', {
+      name: 'Select all',
+      exact: true,
+    });
+    userEvent.click(selectAllButton);
+
+    await waitFor(() => {
+      const calls = fetchMock.calls(getRelatedTablesEndpoint);
+      // Verify that one of the API calls has the expected query parameters for getting all tables
+      const hasExpectedCall = calls.some(call =>
+        call[0].includes('q=(page:0,page_size:-1)'),
+      );
+      expect(hasExpectedCall).toBe(true);
+    });
+
+    expect(
+      screen.queryByText('wb_health_population', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('birth_names', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('long_lat', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Deselect all button clears all selected tables', async () => {
+    await renderAndWait(addNewRuleDefaultProps);
+
+    const tablesSelect = screen.getByRole('combobox', { name: /tables/i });
+    userEvent.click(tablesSelect);
+
+    await selectOption('birth_names', 'Tables');
+    expect(
+      screen.getByText('birth_names', { selector: '.tag-content' }),
+    ).toBeInTheDocument();
+
+    const deselectAllButton = screen.getByRole('button', {
+      name: 'Deselect all',
+      exact: true,
+    });
+    userEvent.click(deselectAllButton);
+
+    expect(
+      screen.queryByText('birth_names', { selector: '.tag-content' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -343,8 +343,8 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
     [],
   );
 
-  const tableDropdownRender = useCallback(
-    menu => (
+  const createDropdownRender = useCallback(
+    (entityType: 'tables' | 'roles') => (menu: React.ReactNode) => (
       <>
         <StyledDropdownContainer>
           <StyledDropdownButton
@@ -355,16 +355,16 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 page_size: -1,
               });
               SupersetClient.get({
-                endpoint: `/api/v1/rowlevelsecurity/related/tables?q=${query}`,
+                endpoint: `/api/v1/rowlevelsecurity/related/${entityType}?q=${query}`,
               }).then(response => {
-                const allTables = response.json.result.map(
+                const allEntities = response.json.result.map(
                   (item: { value: number; text: string }) => ({
                     key: item.value,
                     label: item.text,
                     value: item.value,
                   }),
                 );
-                updateRuleState('tables', allTables || []);
+                updateRuleState(entityType, allEntities || []);
               });
             }}
           >
@@ -372,7 +372,7 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
           </StyledDropdownButton>
           <StyledDropdownButton
             type="button"
-            onClick={() => updateRuleState('tables', [])}
+            onClick={() => updateRuleState(entityType, [])}
           >
             {t('Deselect all')}
           </StyledDropdownButton>
@@ -380,7 +380,16 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
         {menu}
       </>
     ),
-    [],
+    [updateRuleState],
+  );
+
+  const tableDropdownRender = useMemo(
+    () => createDropdownRender('tables'),
+    [createDropdownRender],
+  );
+  const roleDropdownRender = useMemo(
+    () => createDropdownRender('roles'),
+    [createDropdownRender],
   );
 
   return (
@@ -472,7 +481,6 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 value={(currentRule?.tables as SelectValue[]) || []}
                 options={loadTableOptions}
                 dropdownRender={tableDropdownRender}
-                showSearch
               />
             </div>
           </StyledInputContainer>
@@ -495,6 +503,7 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 onChange={onRolesChange}
                 value={(currentRule?.roles as SelectValue[]) || []}
                 options={loadRoleOptions}
+                dropdownRender={roleDropdownRender}
               />
             </div>
           </StyledInputContainer>

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -102,6 +102,28 @@ const StyledTextArea = styled(TextArea)`
   margin-top: ${({ theme }) => theme.gridUnit}px;
 `;
 
+const StyledDropdownContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    gap: ${theme.gridUnit}px;
+    padding: ${theme.gridUnit}px;
+    border-bottom: 1px solid ${theme.colors.grayscale.light2};
+  `}
+`;
+
+const StyledDropdownButton = styled.button`
+  ${({ theme }) => css`
+    padding: ${theme.gridUnit}px ${theme.gridUnit * 2}px;
+    border: 1px solid ${theme.colors.grayscale.light2};
+    border-radius: ${theme.gridUnit}px;
+    background: ${theme.colors.grayscale.light5};
+    cursor: pointer;
+    &:hover {
+      background: ${theme.colors.grayscale.light4};
+    }
+  `}
+`;
+
 export interface RowLevelSecurityModalProps {
   rule: RLSObject | null;
   addSuccessToast: (msg: string) => void;
@@ -321,6 +343,46 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
     [],
   );
 
+  const tableDropdownRender = useCallback(
+    menu => (
+      <>
+        <StyledDropdownContainer>
+          <StyledDropdownButton
+            type="button"
+            onClick={() => {
+              const query = rison.encode({
+                page: 0,
+                page_size: -1,
+              });
+              SupersetClient.get({
+                endpoint: `/api/v1/rowlevelsecurity/related/tables?q=${query}`,
+              }).then(response => {
+                const allTables = response.json.result.map(
+                  (item: { value: number; text: string }) => ({
+                    key: item.value,
+                    label: item.text,
+                    value: item.value,
+                  }),
+                );
+                updateRuleState('tables', allTables || []);
+              });
+            }}
+          >
+            {t('Select all')}
+          </StyledDropdownButton>
+          <StyledDropdownButton
+            type="button"
+            onClick={() => updateRuleState('tables', [])}
+          >
+            {t('Deselect all')}
+          </StyledDropdownButton>
+        </StyledDropdownContainer>
+        {menu}
+      </>
+    ),
+    [],
+  );
+
   return (
     <StyledModal
       className="no-content-padding"
@@ -409,6 +471,8 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
                 onChange={onTablesChange}
                 value={(currentRule?.tables as SelectValue[]) || []}
                 options={loadTableOptions}
+                dropdownRender={tableDropdownRender}
+                showSearch
               />
             </div>
           </StyledInputContainer>


### PR DESCRIPTION
### SUMMARY
This PR introduces "Select All" and "Deselect All" buttons to the Table & Roles elements of the Row Level Security (RLS) configuration interface. This enhancement aims to improve user experience, particularly when managing a large number of tables or roles, by allowing bulk selection and deselection instead of requiring individual clicks for each item. The implementation adds two distinct buttons to trigger these actions, updating the selection state accordingly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### BEFORE
<img width="430" alt="Screenshot 2025-04-03 at 12 59 20" src="https://github.com/user-attachments/assets/bb87f34d-646e-4f8f-9ea3-e9c637067490" />

#### AFTER
<img width="427" alt="Screenshot 2025-04-03 at 13 02 44" src="https://github.com/user-attachments/assets/d761da32-03c9-425a-8d2c-707a7bda9e69" />

### TESTING INSTRUCTIONS
1. Navigate to the Row Level Security configuration section.
2. Click on Datasets or Roles boxes
3. Observe the presence of the new "Select All" and "Deselect All" buttons.
4. If starting with no items selected, click "Select All". Verify that all relevant items (e.g., tables, roles) are now selected.
5. Click "Deselect All". Verify that all items are now deselected.
6. Manually select a subset of items.
7. Click "Deselect All". Verify all are deselected.
8. Manually select a subset of items.
9. Click "Select All". Verify all are selected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: *(Fill in if applicable, e.g., `Fixes #123`)*
- [ ] Required feature flags: *(Fill in if applicable)*
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API *(Implicitly, via UI interaction)*
- [ ] Removes existing feature or API