### PR TITLE
feat: optimize catalog permission sync

### DIFF
--- a/superset/commands/database/sync_permissions.py
+++ b/superset/commands/database/sync_permissions.py
@@ -199,9 +199,9 @@ class SyncPermissionsCommand(BaseCommand):
         try:
             # Adding permissions to all catalogs (and all their schemas) can take a long
             # time (minutes, while importing a chart, eg). If the database does not
-            # support cross-catalog queries (like RDS or Postgres), and the
-            # multi-catalog feature is not enabled, then we only need to add permissions
-            # to the default catalog.
+            # support cross-catalog queries (like Postgres), and the multi-catalog
+            # feature is not enabled, then we only need to add permissions to the default
+            # catalog.
             if (
                 self.db_connection.db_engine_spec.supports_cross_catalog_queries
                 or self.db_connection.allow_multi_catalog

--- a/superset/commands/database/sync_permissions.py
+++ b/superset/commands/database/sync_permissions.py
@@ -140,13 +140,7 @@ class SyncPermissionsCommand(BaseCommand):
         """
         Syncs the permissions for a DB connection.
         """
-        catalogs = (
-            self._get_catalog_names()
-            if self.db_connection.db_engine_spec.supports_catalog
-            else [None]
-        )
-
-        for catalog in catalogs:
+        for catalog in self._get_catalog_names():
             try:
                 schemas = self._get_schema_names(catalog)
 
@@ -196,12 +190,15 @@ class SyncPermissionsCommand(BaseCommand):
         """
         Helper method to load catalogs.
         """
+        if not self.db_connection.db_engine_spec.supports_catalog:
+            return {None}
+
         try:
             # Adding permissions to all catalogs (and all their schemas) can take a long
             # time (minutes, while importing a chart, eg). If the database does not
             # support cross-catalog queries (like Postgres), and the multi-catalog
-            # feature is not enabled, then we only need to add permissions to the default
-            # catalog.
+            # feature is not enabled, then we only need to add permissions to the
+            # default catalog.
             if (
                 self.db_connection.db_engine_spec.supports_cross_catalog_queries
                 or self.db_connection.allow_multi_catalog

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -428,6 +428,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # Can the catalog be changed on a per-query basis?
     supports_dynamic_catalog = False
 
+    # Does the DB engine spec support cross-catalog queries?
+    supports_cross_catalog_queries = False
+
     # Does the engine supports OAuth 2.0? This requires logic to be added to one of the
     # the user impersonation methods to handle personal tokens.
     supports_oauth2 = False

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -136,7 +136,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
     allows_hidden_cc_in_orderby = True
 
-    supports_catalog = supports_dynamic_catalog = True
+    supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
 
     # when editing the database, mask this field in `encrypted_extra`
     # pylint: disable=invalid-name
@@ -539,7 +539,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
             ]
 
     @classmethod
-    def get_default_catalog(cls, database: Database) -> str | None:
+    def get_default_catalog(cls, database: Database) -> str:
         """
         Get the default catalog.
         """

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -373,7 +373,10 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         "extra",
     }
 
-    supports_dynamic_schema = supports_catalog = supports_dynamic_catalog = True
+    supports_dynamic_schema = True
+    supports_catalog = True
+    supports_dynamic_catalog = True
+    supports_cross_catalog_queries = True
 
     @classmethod
     def build_sqlalchemy_uri(  # type: ignore
@@ -433,10 +436,7 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         return spec.to_dict()["components"]["schemas"][cls.__name__]
 
     @classmethod
-    def get_default_catalog(
-        cls,
-        database: Database,
-    ) -> str | None:
+    def get_default_catalog(cls, database: Database) -> str:
         """
         Return the default catalog.
 

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -113,7 +113,7 @@ class DorisEngineSpec(MySQLEngineSpec):
     )
     encryption_parameters = {"ssl": "0"}
     supports_dynamic_schema = True
-    supports_catalog = supports_dynamic_catalog = True
+    supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
 
     column_type_mappings = (  # type: ignore
         (

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -319,7 +319,7 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         return uri, connect_args
 
     @classmethod
-    def get_default_catalog(cls, database: Database) -> str | None:
+    def get_default_catalog(cls, database: Database) -> str:
         """
         Return the default catalog for a given database.
         """

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -162,7 +162,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     """
 
     supports_dynamic_schema = True
-    supports_catalog = supports_dynamic_catalog = True
+    supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
 
     column_type_mappings = (
         (

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -88,7 +88,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     sqlalchemy_uri_placeholder = "snowflake://"
 
     supports_dynamic_schema = True
-    supports_catalog = supports_dynamic_catalog = True
+    supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
 
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {
@@ -189,7 +189,7 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         return parse.unquote(database.split("/")[1])
 
     @classmethod
-    def get_default_catalog(cls, database: "Database") -> Optional[str]:
+    def get_default_catalog(cls, database: "Database") -> str:
         """
         Return the default catalog.
         """

--- a/tests/unit_tests/commands/databases/sync_permissions_test.py
+++ b/tests/unit_tests/commands/databases/sync_permissions_test.py
@@ -243,8 +243,8 @@ def test_sync_permissions_command_get_default_catalog(database_with_catalog: Mag
     """
     Test ``_get_catalog_names`` when only the default one should be returned.
 
-    When the database doesn't not support cross-catalog queries (like RDS), we should
-    only return all catalogs if multi-catalog is enabled.
+    When the database doesn't not support cross-catalog queries (like Postgres), we
+    should only return all catalogs if multi-catalog is enabled.
     """
     database_with_catalog.db_engine_spec.supports_cross_catalog_queries = False
     database_with_catalog.allow_multi_catalog = False

--- a/tests/unit_tests/commands/databases/sync_permissions_test.py
+++ b/tests/unit_tests/commands/databases/sync_permissions_test.py
@@ -231,10 +231,27 @@ def test_sync_permissions_command_async_mode_new_db_name(
     async_task_mock.delay.assert_called_once_with(1, "admin", "Old Name")
 
 
-def test_resync_permissions_command_get_catalogs(database_with_catalog: MagicMock):
+def test_sync_permissions_command_get_catalogs(database_with_catalog: MagicMock):
     """
     Test the ``_get_catalog_names`` method.
     """
+    cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
+    assert cmmd._get_catalog_names() == ["catalog1", "catalog2"]
+
+
+def test_sync_permissions_command_get_default_catalog(database_with_catalog: MagicMock):
+    """
+    Test ``_get_catalog_names`` when only the default one should be returned.
+
+    When the database doesn't not support cross-catalog queries (like RDS), we should
+    only return all catalogs if multi-catalog is enabled.
+    """
+    database_with_catalog.db_engine_spec.supports_cross_catalog_queries = False
+    database_with_catalog.allow_multi_catalog = False
+    cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
+    assert cmmd._get_catalog_names() == {"catalog2"}
+
+    database_with_catalog.allow_multi_catalog = True
     cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
     assert cmmd._get_catalog_names() == ["catalog1", "catalog2"]
 
@@ -249,7 +266,7 @@ def test_resync_permissions_command_get_catalogs(database_with_catalog: MagicMoc
         (GenericDBException, DatabaseConnectionFailedError),
     ],
 )
-def test_resync_permissions_command_raise_on_getting_catalogs(
+def test_sync_permissions_command_raise_on_getting_catalogs(
     inner_exception: Exception,
     outer_exception: Exception,
     database_with_catalog: MagicMock,
@@ -263,7 +280,7 @@ def test_resync_permissions_command_raise_on_getting_catalogs(
         cmmd._get_catalog_names()
 
 
-def test_resync_permissions_command_get_schemas(database_with_catalog: MagicMock):
+def test_sync_permissions_command_get_schemas(database_with_catalog: MagicMock):
     """
     Test the ``_get_schema_names`` method.
     """
@@ -282,7 +299,7 @@ def test_resync_permissions_command_get_schemas(database_with_catalog: MagicMock
         (GenericDBException, DatabaseConnectionFailedError),
     ],
 )
-def test_resync_permissions_command_raise_on_getting_schemas(
+def test_sync_permissions_command_raise_on_getting_schemas(
     inner_exception: Exception,
     outer_exception: Exception,
     database_with_catalog: MagicMock,
@@ -296,7 +313,7 @@ def test_resync_permissions_command_raise_on_getting_schemas(
         cmmd._get_schema_names("blah")
 
 
-def test_resync_permissions_command_refresh_schemas(
+def test_sync_permissions_command_refresh_schemas(
     mocker: MockerFixture, database_with_catalog: MagicMock
 ):
     """
@@ -319,7 +336,7 @@ def test_resync_permissions_command_refresh_schemas(
     )
 
 
-def test_resync_permissions_command_rename_db_in_perms(
+def test_sync_permissions_command_rename_db_in_perms(
     mocker: MockerFixture, database_with_catalog: MagicMock
 ):
     """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

For performance reasons, change the `SyncPermissionsCommand` to only sync permissions for non-default catalogs when at least one of these conditions is true:

1. Cross-catalog queries are supported (for example, in BigQuery, but not RDS). When cross-catalog queries it's good to create t/he permissions for non-default catalogs so that the admin can manage access to them.
2. Multi-catalog is enabled in the database. When multi-catalog is enabled the admin needs to have the permissions for the same reason.

This means that for a database like RDS or Postgres, when we sync the permissions we will use only the default catalog, unless multi-catalog is enabled.

Fixes https://github.com/apache/superset/issues/32993.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
