### PR TITLE
chore(Databricks): Display older Databricks driver as legacy

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -353,7 +353,7 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
 
 class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
     engine = "databricks"
-    engine_name = "Databricks"
+    engine_name = "Databricks (legacy)"
     drivers = {"connector": "Native all-purpose driver"}
     default_driver = "connector"
 
@@ -485,7 +485,7 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
 
 class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
     engine = "databricks"
-    engine_name = "Databricks Python Connector"
+    engine_name = "Databricks"
     default_driver = "databricks-sql-python"
     drivers = {"databricks-sql-python": "Databricks SQL Python"}
 

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -187,7 +187,7 @@ def test_extract_errors() -> None:
             error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
             level=ErrorLevel.ERROR,
             extra={
-                "engine_name": "Databricks",
+                "engine_name": "Databricks (legacy)",
                 "issue_codes": [
                     {
                         "code": 1002,
@@ -214,7 +214,7 @@ def test_extract_errors_with_context() -> None:
             error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
             level=ErrorLevel.ERROR,
             extra={
-                "engine_name": "Databricks",
+                "engine_name": "Databricks (legacy)",
                 "issue_codes": [
                     {
                         "code": 1002,


### PR DESCRIPTION
### SUMMARY
The Databricks native connector (`sqlalchemy-databricks` package) is archived/no longer maintained ([reference](https://github.com/crflynn/sqlalchemy-databricks)) in favor of 
 Databricks Python Connector (`databricks-sql-python` package). 

This PR renames this connection option from `Databricks` to `Databricks (legacy)`, and `Databricks Python Connector` to `Databricks`. This should help increase adoption for the current supported driver.

A potential V2 would be to auto-migrate existing connections to the new driver and fully remove this duplicated engine spec.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**
![image](https://github.com/user-attachments/assets/1ac84739-0e46-43aa-b315-f7f333798f6b)

**After**
![image](https://github.com/user-attachments/assets/68e309f3-7192-4411-9ceb-a5e2ccac0db7)


### TESTING INSTRUCTIONS
No actual code changes -- all existing connections should continue working.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
