### PR TITLE
fix: Applying query filters to deck.gl Multiple Layers visualization Update to Multi.tsx

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -80,13 +80,19 @@ const DeckMulti = (props: DeckMultiProps) => {
           const filters = [
             ...(subslice.form_data.filters || []),
             ...(formData.filters || []),
+          ];
+
+          const extra_filters = [
+            ...(subslice.form_data.extra_filters || []),
             ...(formData.extra_filters || []),
           ];
+
           const subsliceCopy = {
             ...subslice,
             form_data: {
               ...subslice.form_data,
               filters,
+              extra_filters,
             },
           };
 


### PR DESCRIPTION
### SUMMARY
Fixes #13731 - Applying query filters to deck.gl Multiple Layers visualization

This PR addresses the issue where filters added in the Query section aren't being executed for deck.gl Multiple Layers visualizations. The fix ensures that both regular filters and extra_filters are properly merged and passed down to the sublayers.

### ISSUE TYPE
- [x] Bug Fix

### TEST PLAN
1. Create a Multiple Layers visualization with 2+ subcharts
2. Add a filter in the Query section
3. Verify that the filter is properly applied to the visualization

### REVIEWERS
@apache/superset-committers