### PR TITLE
fix: Viz migration error handling

### DIFF
--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from enum import Enum
 from typing import Type
 
@@ -107,6 +108,7 @@ def migrate_viz() -> None:
 )
 def upgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Upgrade a viz to the latest version."""
+    setup_logger()
     if viz_type:
         migrate_by_viz_type(VizType(viz_type))
     elif ids:
@@ -133,6 +135,7 @@ def upgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
 )
 def downgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Downgrade a viz to the previous version."""
+    setup_logger()
     if viz_type:
         migrate_by_viz_type(VizType(viz_type), is_downgrade=True)
     elif ids:
@@ -163,7 +166,7 @@ def migrate_by_id(ids: tuple[int, ...], is_downgrade: bool = False) -> None:
     slices = db.session.query(Slice).filter(Slice.id.in_(ids))
     for slc in paginated_update(
         slices,
-        lambda current, total: print(
+        lambda current, total: click.echo(
             f"{('Downgraded' if is_downgrade else 'Upgraded')} {current}/{total} charts"
         ),
     ):
@@ -171,3 +174,12 @@ def migrate_by_id(ids: tuple[int, ...], is_downgrade: bool = False) -> None:
             PREVIOUS_VERSION[slc.viz_type].downgrade_slice(slc)
         elif slc.viz_type in MIGRATIONS:
             MIGRATIONS[slc.viz_type].upgrade_slice(slc)
+
+
+def setup_logger() -> None:
+    """
+    Configure the logger for the CLI commands.
+    """
+    console_handler = logging.StreamHandler()
+    logger = logging.getLogger("alembic")
+    logger.addHandler(console_handler)

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -109,7 +109,7 @@ def upgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Upgrade a viz to the latest version."""
     if viz_type:
         migrate_by_viz_type(VizType(viz_type))
-    else:
+    elif ids:
         migrate_by_id(ids)
 
 
@@ -135,7 +135,7 @@ def downgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Downgrade a viz to the previous version."""
     if viz_type:
         migrate_by_viz_type(VizType(viz_type), is_downgrade=True)
-    else:
+    elif ids:
         migrate_by_id(ids, is_downgrade=True)
 
 

--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -107,7 +107,7 @@ def migrate_viz() -> None:
 )
 def upgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Upgrade a viz to the latest version."""
-    if ids is None:
+    if viz_type:
         migrate_by_viz_type(VizType(viz_type))
     else:
         migrate_by_id(ids)
@@ -133,7 +133,7 @@ def upgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
 )
 def downgrade(viz_type: str, ids: tuple[int, ...] | None = None) -> None:
     """Downgrade a viz to the previous version."""
-    if ids is None:
+    if viz_type:
         migrate_by_viz_type(VizType(viz_type), is_downgrade=True)
     else:
         migrate_by_id(ids, is_downgrade=True)

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -172,11 +172,7 @@ def paginated_update(
 
 
 def try_load_json(data: Optional[str]) -> dict[str, Any]:
-    try:
-        return data and json.loads(data) or {}
-    except json.JSONDecodeError:
-        print(f"Failed to parse: {data}")
-        return {}
+    return data and json.loads(data) or {}
 
 
 def has_table(table_name: str) -> bool:


### PR DESCRIPTION
### SUMMARY
Fixes the viz migration error handling by:
- Proving a clear error message for failed migrations
- Preserving the chart's original content giving admins the opportunity to fix the charts

Example of a failed chart migration:
```
Failed to migrate slice 5: Invalid control character '\n' at: line 2 column 22 (char 23)
```

### TESTING INSTRUCTIONS
Run the a viz migration using the CLI command and check the new error handling.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
