### PR TITLE
feat(Select): Select all and Deselect all that works on visible items while searching

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -328,12 +328,18 @@ test('Should schema select display options', async () => {
   });
   expect(select).toBeInTheDocument();
   userEvent.click(select);
-  expect(
-    await screen.findByRole('option', { name: 'public' }),
-  ).toBeInTheDocument();
-  expect(
-    await screen.findByRole('option', { name: 'information_schema' }),
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
+  const publicOption = await screen.findByText('public', {
+    selector: '.ant-select-item-option-content',
+  });
+  expect(publicOption).toBeInTheDocument();
+
+  const infoSchemaOption = await screen.findByText('information_schema', {
+    selector: '.ant-select-item-option-content',
+  });
+  expect(infoSchemaOption).toBeInTheDocument();
 });
 
 test('Sends the correct db when changing the database', async () => {

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -331,13 +331,11 @@ test('Should schema select display options', async () => {
   await waitFor(() => {
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
   });
-  const publicOption = await screen.findByText('public', {
-    selector: '.ant-select-item-option-content',
-  });
+  const publicOption = await screen.findByRole('option', { name: 'public' });
   expect(publicOption).toBeInTheDocument();
 
-  const infoSchemaOption = await screen.findByText('information_schema', {
-    selector: '.ant-select-item-option-content',
+  const infoSchemaOption = await screen.findByRole('option', {
+    name: 'information_schema',
   });
   expect(infoSchemaOption).toBeInTheDocument();
 });

--- a/superset-frontend/src/components/Select/CustomTag.tsx
+++ b/superset-frontend/src/components/Select/CustomTag.tsx
@@ -23,8 +23,6 @@ import { styled, useCSSTextTruncation } from '@superset-ui/core';
 import { Tooltip } from '../Tooltip';
 import { CustomCloseIcon } from '../Tags/Tag';
 import { CustomTagProps } from './types';
-import { SELECT_ALL_VALUE } from './utils';
-import { NoElement } from './styles';
 
 const StyledTag = styled(AntdTag)`
   & .ant-tag-close-icon {
@@ -61,7 +59,7 @@ const Tag = (props: any) => {
  * Custom tag renderer
  */
 export const customTagRender = (props: CustomTagProps) => {
-  const { label, value } = props;
+  const { label } = props;
 
   const onPreventMouseDown = (event: MouseEvent<HTMLElement>) => {
     // if close icon is clicked, stop propagation to avoid opening the dropdown
@@ -76,12 +74,9 @@ export const customTagRender = (props: CustomTagProps) => {
     }
   };
 
-  if (value !== SELECT_ALL_VALUE) {
-    return (
-      <Tag onMouseDown={onPreventMouseDown} {...(props as object)}>
-        {label}
-      </Tag>
-    );
-  }
-  return <NoElement />;
+  return (
+    <Tag onMouseDown={onPreventMouseDown} {...(props as object)}>
+      {label}
+    </Tag>
+  );
 };

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -26,7 +26,6 @@ import {
   within,
 } from 'spec/helpers/testing-library';
 import Select from 'src/components/Select/Select';
-import { SELECT_ALL_VALUE } from './utils';
 
 type Option = {
   label: string;
@@ -77,9 +76,6 @@ const defaultProps = {
   showSearch: true,
 };
 
-const selectAllOptionLabel = (numOptions: number) =>
-  `${String(SELECT_ALL_VALUE)} (${numOptions})`;
-
 const getElementByClassName = (className: string) =>
   document.querySelector(className)! as HTMLElement;
 
@@ -87,6 +83,9 @@ const getElementsByClassName = (className: string) =>
   document.querySelectorAll(className)! as NodeListOf<HTMLElement>;
 
 const getSelect = () => screen.getByRole('combobox', { name: ARIA_LABEL });
+
+const selectAllButtonText = (length: number) => `Select all (${length})`;
+const deselectAllButtonText = (length: number) => `Deselect all (${length})`;
 
 const findSelectOption = (text: string) =>
   waitFor(() =>
@@ -109,11 +108,6 @@ const findSelectValue = () =>
 
 const findAllSelectValues = () =>
   waitFor(() => [...getElementsByClassName('.ant-select-selection-item')]);
-
-const findAllCheckedValues = () =>
-  waitFor(() => [
-    ...getElementsByClassName('.ant-select-item-option-selected'),
-  ]);
 
 const clearAll = () => userEvent.click(screen.getByLabelText('close-circle'));
 
@@ -255,33 +249,22 @@ test('should sort selected to the top when in multi mode', async () => {
 
   await open();
   userEvent.click(await findSelectOption(labels[2]));
-  expect(
-    await matchOrder([selectAllOptionLabel(originalLabels.length), ...labels]),
-  ).toBe(true);
+  expect(await matchOrder(labels)).toBe(true);
 
   await reopen();
   labels = labels.splice(2, 1).concat(labels);
-  expect(
-    await matchOrder([selectAllOptionLabel(originalLabels.length), ...labels]),
-  ).toBe(true);
+  expect(await matchOrder(labels)).toBe(true);
 
   await open();
   userEvent.click(await findSelectOption(labels[5]));
   await reopen();
   labels = [labels.splice(0, 1)[0], labels.splice(4, 1)[0]].concat(labels);
-  expect(
-    await matchOrder([selectAllOptionLabel(originalLabels.length), ...labels]),
-  ).toBe(true);
+  expect(await matchOrder(labels)).toBe(true);
 
   // should revert to original order
   clearAll();
   await reopen();
-  expect(
-    await matchOrder([
-      selectAllOptionLabel(originalLabels.length),
-      ...originalLabels,
-    ]),
-  ).toBe(true);
+  expect(await matchOrder(originalLabels)).toBe(true);
 });
 
 test('searches for label or value', async () => {
@@ -634,15 +617,19 @@ test('finds an element with a numeric value and does not duplicate the options',
 test('render "Select all" for multi select', async () => {
   render(<Select {...defaultProps} mode="multiple" options={OPTIONS} />);
   await open();
-  const options = await findAllSelectOptions();
-  expect(options[0]).toHaveTextContent(selectAllOptionLabel(OPTIONS.length));
+  expect(
+    await screen.findByText(selectAllButtonText(OPTIONS.length)),
+  ).toBeInTheDocument();
 });
 
 test('does not render "Select all" for single select', async () => {
   render(<Select {...defaultProps} options={OPTIONS} mode="single" />);
   await open();
   expect(
-    screen.queryByText(selectAllOptionLabel(OPTIONS.length)),
+    screen.queryByText(selectAllButtonText(OPTIONS.length)),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(selectAllButtonText(OPTIONS.length)),
   ).not.toBeInTheDocument();
 });
 
@@ -650,43 +637,19 @@ test('does not render "Select all" for an empty multiple select', async () => {
   render(<Select {...defaultProps} options={[]} mode="multiple" />);
   await open();
   expect(
-    screen.queryByText(selectAllOptionLabel(OPTIONS.length)),
+    screen.queryByText(selectAllButtonText(OPTIONS.length)),
   ).not.toBeInTheDocument();
 });
 
-test('does not render "Select all" when searching', async () => {
+test('Renders "Select all" when searching', async () => {
   render(<Select {...defaultProps} options={OPTIONS} mode="multiple" />);
   await open();
   await type('Select');
   await waitFor(() =>
     expect(
-      screen.queryByText(selectAllOptionLabel(OPTIONS.length)),
+      screen.queryByText(selectAllButtonText(OPTIONS.length)),
     ).not.toBeInTheDocument(),
   );
-});
-
-test('does not render "Select all" as one of the tags after selection', async () => {
-  render(<Select {...defaultProps} options={OPTIONS} mode="multiple" />);
-  await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(OPTIONS.length)));
-  const values = await findAllSelectValues();
-  expect(values[0]).not.toHaveTextContent(selectAllOptionLabel(OPTIONS.length));
-});
-
-test('keeps "Select all" at the top after a selection', async () => {
-  const selected = OPTIONS[2];
-  render(
-    <Select
-      {...defaultProps}
-      options={OPTIONS.slice(0, 10)}
-      mode="multiple"
-      value={[selected]}
-    />,
-  );
-  await open();
-  const options = await findAllSelectOptions();
-  expect(options[0]).toHaveTextContent(selectAllOptionLabel(10));
-  expect(options[1]).toHaveTextContent(selected.label);
 });
 
 test('selects all values', async () => {
@@ -699,7 +662,7 @@ test('selects all values', async () => {
     />,
   );
   await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(OPTIONS.length)));
+  userEvent.click(await screen.findByText(selectAllButtonText(OPTIONS.length)));
   const values = await findAllSelectValues();
   expect(values.length).toBe(1);
   expect(values[0]).toHaveTextContent(`+ ${OPTIONS.length} ...`);
@@ -715,31 +678,15 @@ test('unselects all values', async () => {
     />,
   );
   await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(OPTIONS.length)));
+  userEvent.click(await screen.findByText(selectAllButtonText(OPTIONS.length)));
   let values = await findAllSelectValues();
   expect(values.length).toBe(1);
   expect(values[0]).toHaveTextContent(`+ ${OPTIONS.length} ...`);
-  userEvent.click(await findSelectOption(selectAllOptionLabel(OPTIONS.length)));
+  userEvent.click(
+    await screen.findByText(deselectAllButtonText(OPTIONS.length)),
+  );
   values = await findAllSelectValues();
   expect(values.length).toBe(0);
-});
-
-test('deselecting a value also deselects "Select all"', async () => {
-  render(
-    <Select
-      {...defaultProps}
-      options={OPTIONS.slice(0, 10)}
-      mode="multiple"
-      maxTagCount={0}
-    />,
-  );
-  await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(10)));
-  let values = await findAllCheckedValues();
-  expect(values[0]).toHaveTextContent(selectAllOptionLabel(10));
-  userEvent.click(await findSelectOption(OPTIONS[0].label));
-  values = await findAllCheckedValues();
-  expect(values[0]).not.toHaveTextContent(selectAllOptionLabel(10));
 });
 
 test('deselecting a new value also removes it from the options', async () => {
@@ -758,27 +705,6 @@ test('deselecting a new value also removes it from the options', async () => {
   clearTypedText();
   userEvent.click(await findSelectOption(NEW_OPTION));
   expect(await querySelectOption(NEW_OPTION)).not.toBeInTheDocument();
-});
-
-test('selecting all values also selects "Select all"', async () => {
-  render(
-    <Select
-      {...defaultProps}
-      options={OPTIONS.slice(0, 10)}
-      mode="multiple"
-      maxTagCount={0}
-    />,
-  );
-  await open();
-  const options = await findAllSelectOptions();
-  options.forEach((option, index) => {
-    // skip select all
-    if (index > 0) {
-      userEvent.click(option);
-    }
-  });
-  const values = await findAllSelectValues();
-  expect(values[0]).toHaveTextContent(`+ 10 ...`);
 });
 
 test('Renders only 1 tag and an overflow tag in oneLine mode', () => {
@@ -829,56 +755,12 @@ test('Renders only an overflow tag if dropdown is open in oneLine mode', async (
   expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
 });
 
-test('+N tag does not count the "Select All" option', async () => {
-  render(
-    <Select
-      {...defaultProps}
-      options={OPTIONS.slice(0, 10)}
-      mode="multiple"
-      maxTagCount={0}
-    />,
-  );
-  await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(10)));
-  const values = await findAllSelectValues();
-  // maxTagCount is 0 so the +N tag should be + 10 ...
-  expect(values[0]).toHaveTextContent('+ 10 ...');
-});
-
-test('"Select All" is checked when unchecking a newly added option and all the other options are still selected', async () => {
-  render(
-    <Select
-      {...defaultProps}
-      options={OPTIONS.slice(0, 10)}
-      mode="multiple"
-      allowNewOptions
-    />,
-  );
-  await open();
-  userEvent.click(await findSelectOption(selectAllOptionLabel(10)));
-  expect(await findSelectOption(selectAllOptionLabel(10))).toBeInTheDocument();
-  // add a new option
-  await type(NEW_OPTION);
-  expect(await findSelectOption(NEW_OPTION)).toBeInTheDocument();
-  clearTypedText();
-  expect(await findSelectOption(selectAllOptionLabel(11))).toBeInTheDocument();
-  // select all should be selected
-  let values = await findAllCheckedValues();
-  expect(values[0]).toHaveTextContent(selectAllOptionLabel(11));
-  // remove new option
-  userEvent.click(await findSelectOption(NEW_OPTION));
-  // select all should still be selected
-  values = await findAllCheckedValues();
-  expect(values[0]).toHaveTextContent(selectAllOptionLabel(10));
-  expect(await findSelectOption(selectAllOptionLabel(10))).toBeInTheDocument();
-});
-
 test('does not render "Select All" when there are 0 or 1 options', async () => {
   const { rerender } = render(
     <Select {...defaultProps} options={[]} mode="multiple" allowNewOptions />,
   );
   await open();
-  expect(screen.queryByText(selectAllOptionLabel(0))).not.toBeInTheDocument();
+  expect(screen.queryByText(selectAllButtonText(0))).not.toBeInTheDocument();
   rerender(
     <Select
       {...defaultProps}
@@ -888,7 +770,7 @@ test('does not render "Select All" when there are 0 or 1 options', async () => {
     />,
   );
   await open();
-  expect(screen.queryByText(selectAllOptionLabel(1))).not.toBeInTheDocument();
+  expect(screen.queryByText(selectAllButtonText(1))).not.toBeInTheDocument();
   rerender(
     <Select
       {...defaultProps}
@@ -898,7 +780,7 @@ test('does not render "Select All" when there are 0 or 1 options', async () => {
     />,
   );
   await open();
-  expect(screen.getByText(selectAllOptionLabel(2))).toBeInTheDocument();
+  expect(screen.getByText(selectAllButtonText(2))).toBeInTheDocument();
 });
 
 test('do not count unselected disabled options in "Select All"', async () => {
@@ -917,7 +799,7 @@ test('do not count unselected disabled options in "Select All"', async () => {
   // We have 2 options disabled but one is selected initially
   // Select All should count one and ignore the other
   expect(
-    screen.getByText(selectAllOptionLabel(OPTIONS.length - 1)),
+    screen.getByText(selectAllButtonText(OPTIONS.length - 1)),
   ).toBeInTheDocument();
 });
 
@@ -940,13 +822,13 @@ test('"Select All" does not affect disabled options', async () => {
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 
   // Checking Select All shouldn't affect the disabled options
-  const selectAll = selectAllOptionLabel(OPTIONS.length - 1);
-  userEvent.click(await findSelectOption(selectAll));
+  const selectAll = selectAllButtonText(OPTIONS.length - 1);
+  userEvent.click(await screen.findByText(selectAll));
   expect(await findSelectValue()).toHaveTextContent(options[0].label);
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 
   // Unchecking Select All shouldn't affect the disabled options
-  userEvent.click(await findSelectOption(selectAll));
+  userEvent.click(await screen.findByText(selectAll));
   expect(await findSelectValue()).toHaveTextContent(options[0].label);
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 });

--- a/superset-frontend/src/components/Select/Select.test.tsx
+++ b/superset-frontend/src/components/Select/Select.test.tsx
@@ -755,7 +755,7 @@ test('Renders only an overflow tag if dropdown is open in oneLine mode', async (
   expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
 });
 
-test('does not render "Select All" when there are 0 or 1 options', async () => {
+test('does not render "Select all" when there are 0 or 1 options', async () => {
   const { rerender } = render(
     <Select {...defaultProps} options={[]} mode="multiple" allowNewOptions />,
   );
@@ -783,7 +783,7 @@ test('does not render "Select All" when there are 0 or 1 options', async () => {
   expect(screen.getByText(selectAllButtonText(2))).toBeInTheDocument();
 });
 
-test('do not count unselected disabled options in "Select All"', async () => {
+test('do not count unselected disabled options in "Select all"', async () => {
   const options = [...OPTIONS];
   options[0].disabled = true;
   options[1].disabled = true;
@@ -797,13 +797,39 @@ test('do not count unselected disabled options in "Select All"', async () => {
   );
   await open();
   // We have 2 options disabled but one is selected initially
-  // Select All should count one and ignore the other
+  // Select all should count one and ignore the other
   expect(
     screen.getByText(selectAllButtonText(OPTIONS.length - 1)),
   ).toBeInTheDocument();
 });
 
-test('"Select All" does not affect disabled options', async () => {
+test('"Deselect all" counts all selected options', async () => {
+  render(<Select {...defaultProps} allowNewOptions mode="multiple" />);
+  await open();
+  userEvent.click(await findSelectOption('Ava'));
+  expect(await screen.findByText(deselectAllButtonText(1))).toBeInTheDocument();
+});
+
+test('"Deselect all" counts new selected options', async () => {
+  render(<Select {...defaultProps} allowNewOptions mode="multiple" />);
+  await open();
+  await type(NEW_OPTION);
+  userEvent.click(await findSelectOption(NEW_OPTION));
+  clearTypedText();
+  await open();
+  userEvent.click(await findSelectOption('Ava'));
+  expect(await screen.findByText(deselectAllButtonText(2))).toBeInTheDocument();
+});
+
+test('"Select all" does not count unselected new options', async () => {
+  render(<Select {...defaultProps} allowNewOptions mode="multiple" />);
+  await open();
+  await type('er');
+  // We have 5 options matching the search
+  expect(await screen.findByText(selectAllButtonText(5))).toBeInTheDocument();
+});
+
+test('"Select all" does not affect disabled options', async () => {
   const options = [...OPTIONS];
   options[0].disabled = true;
   options[1].disabled = true;
@@ -821,13 +847,13 @@ test('"Select All" does not affect disabled options', async () => {
   expect(await findSelectValue()).toHaveTextContent(options[0].label);
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 
-  // Checking Select All shouldn't affect the disabled options
+  // Checking Select all shouldn't affect the disabled options
   const selectAll = selectAllButtonText(OPTIONS.length - 1);
   userEvent.click(await screen.findByText(selectAll));
   expect(await findSelectValue()).toHaveTextContent(options[0].label);
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);
 
-  // Unchecking Select All shouldn't affect the disabled options
+  // Unchecking Select all shouldn't affect the disabled options
   userEvent.click(await screen.findByText(selectAll));
   expect(await findSelectValue()).toHaveTextContent(options[0].label);
   expect(await findSelectValue()).not.toHaveTextContent(options[1].label);

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -132,6 +132,28 @@ const Select = forwardRef(
     );
     const [onChangeCount, setOnChangeCount] = useState(0);
     const previousChangeCount = usePrevious(onChangeCount, 0);
+    const [bulkSelectCounts, setBulkSelectCounts] = useState({
+      selectable: 0,
+      deselectable: 0,
+    });
+
+    useEffect(() => {
+      const selectedValues = ensureIsArray(selectValue);
+      const selectable = visibleOptions.filter(
+        option =>
+          !option.disabled &&
+          !hasOption(option.value, selectedValues) &&
+          !option.isNewOption,
+      ).length;
+
+      const deselectable = visibleOptions.filter(
+        option =>
+          !option.disabled &&
+          hasOption(option.value, ensureIsArray(selectValue)),
+      ).length;
+
+      setBulkSelectCounts({ selectable, deselectable });
+    }, [visibleOptions, selectValue]);
 
     const fireOnChange = useCallback(
       () => setOnChangeCount(onChangeCount + 1),
@@ -423,59 +445,40 @@ const Select = forwardRef(
       fireOnChange,
     ]);
 
-    const selectableOptionsCount = useMemo(() => {
-      const selectedValues = ensureIsArray(selectValue);
-      return visibleOptions.filter(
-        option =>
-          !option.disabled &&
-          !hasOption(option.value, selectedValues) &&
-          !option.isNewOption,
-      ).length;
-    }, [visibleOptions, selectValue]);
-    const deselectableOptionsCount = useMemo(
-      () =>
-        visibleOptions.filter(
-          option =>
-            !option.disabled &&
-            hasOption(option.value, ensureIsArray(selectValue)),
-        ).length,
-      [visibleOptions, selectValue],
-    );
-
     const bulkSelectComponent = useMemo(
       () => (
         <StyledBulkActionsContainer size={0}>
           <Button
             type="link"
             buttonSize="xsmall"
-            disabled={selectableOptionsCount === 0}
-            onClick={e => {
+            disabled={bulkSelectCounts.selectable === 0}
+            onMouseDown={e => {
               e.preventDefault();
               e.stopPropagation();
               handleSelectAll();
             }}
           >
-            {`${t('Select all')} (${selectableOptionsCount})`}
+            {`${t('Select all')} (${bulkSelectCounts.selectable})`}
           </Button>
           <Button
             type="link"
             buttonSize="xsmall"
-            disabled={deselectableOptionsCount === 0}
-            onClick={e => {
+            disabled={bulkSelectCounts.deselectable === 0}
+            onMouseDown={e => {
               e.preventDefault();
               e.stopPropagation();
               handleDeselectAll();
             }}
           >
-            {`${t('Deselect all')} (${deselectableOptionsCount})`}
+            {`${t('Deselect all')} (${bulkSelectCounts.deselectable})`}
           </Button>
         </StyledBulkActionsContainer>
       ),
       [
         handleSelectAll,
         handleDeselectAll,
-        selectableOptionsCount,
-        deselectableOptionsCount,
+        bulkSelectCounts.selectable,
+        bulkSelectCounts.deselectable,
       ],
     );
 

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -132,11 +132,6 @@ const Select = forwardRef(
     );
     const [onChangeCount, setOnChangeCount] = useState(0);
     const previousChangeCount = usePrevious(onChangeCount, 0);
-    const [bulkSelectCounts, setBulkSelectCounts] = useState({
-      selectable: 0,
-      deselectable: 0,
-    });
-
     const fireOnChange = useCallback(
       () => setOnChangeCount(onChangeCount + 1),
       [onChangeCount],
@@ -237,10 +232,11 @@ const Select = forwardRef(
       [selectValue, selectAllEligible],
     );
 
-    useEffect(() => {
-      const selectedValues = ensureIsArray(selectValue);
-      const selectedValuesSet = new Set(selectedValues.map(getValue));
-      const counts = visibleOptions.reduce(
+    const bulkSelectCounts = useMemo(() => {
+      const selectedValuesSet = new Set(
+        ensureIsArray(selectValue).map(getValue),
+      );
+      return visibleOptions.reduce(
         (acc, option) => {
           const isSelected = selectedValuesSet.has(option.value);
           const isDisabled = option.disabled;
@@ -249,17 +245,13 @@ const Select = forwardRef(
           if ((!isDisabled || isSelected) && !isNew) {
             acc.selectable += 1;
           }
-
           if (isSelected && !isDisabled) {
             acc.deselectable += 1;
           }
-
           return acc;
         },
         { selectable: 0, deselectable: 0 },
       );
-
-      setBulkSelectCounts(counts);
     }, [visibleOptions, selectValue]);
 
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -28,7 +28,7 @@ import {
   ClipboardEvent,
 } from 'react';
 
-import { css, ensureIsArray, t, usePrevious } from '@superset-ui/core';
+import { ensureIsArray, t, usePrevious } from '@superset-ui/core';
 // eslint-disable-next-line no-restricted-imports
 import { LabeledValue as AntdLabeledValue } from 'antd/lib/select'; // TODO: Remove antd
 import { debounce, isEqual, uniq } from 'lodash';
@@ -52,6 +52,7 @@ import {
 } from './utils';
 import { RawValue, SelectOptionsType, SelectProps } from './types';
 import {
+  StyledBulkActionsContainer,
   StyledCheckOutlined,
   StyledContainer,
   StyledHeader,
@@ -66,7 +67,6 @@ import {
 } from './constants';
 import { customTagRender } from './CustomTag';
 import Button from '../Button';
-import { Space } from '../Space';
 
 /**
  * This component is a customized version of the Antdesign 4.X Select component
@@ -348,13 +348,13 @@ const Select = forwardRef(
     const handleOnDropdownVisibleChange = (isDropdownVisible: boolean) => {
       setIsDropdownVisible(isDropdownVisible);
 
+      setVisibleOptions(initialOptionsSorted);
       // if no search input value, force sort options because it won't be sorted by
       // `filterSort`.
       if (isDropdownVisible && !inputValue && selectOptions.length > 1) {
         if (!isEqual(initialOptionsSorted, selectOptions)) {
           setSelectOptions(initialOptionsSorted);
         }
-        setVisibleOptions(fullSelectOptions);
       }
       if (onDropdownVisibleChange) {
         onDropdownVisibleChange(isDropdownVisible);
@@ -430,16 +430,10 @@ const Select = forwardRef(
 
     const bulkSelectComponent = useMemo(
       () => (
-        <Space
-          css={css`
-            display: flex;
-            justify-content: space-around;
-            margin-bottom: 4px;
-            width: 90%;
-          `}
-        >
+        <StyledBulkActionsContainer size={0}>
           <Button
             type="link"
+            buttonSize="xsmall"
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
@@ -450,6 +444,7 @@ const Select = forwardRef(
           </Button>
           <Button
             type="link"
+            buttonSize="xsmall"
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
@@ -458,7 +453,7 @@ const Select = forwardRef(
           >
             {`${t('Deselect all')} (${visibleOptionsCount})`}
           </Button>
-        </Space>
+        </StyledBulkActionsContainer>
       ),
       [handleSelectAll, handleDeselectAll, visibleOptionsCount],
     );

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -423,9 +423,23 @@ const Select = forwardRef(
       fireOnChange,
     ]);
 
-    const visibleOptionsCount = useMemo(
-      () => visibleOptions.filter(option => !option.isNewOption).length,
-      [visibleOptions],
+    const selectableOptionsCount = useMemo(() => {
+      const selectedValues = ensureIsArray(selectValue);
+      return visibleOptions.filter(
+        option =>
+          !option.disabled &&
+          !hasOption(option.value, selectedValues) &&
+          !option.isNewOption,
+      ).length;
+    }, [visibleOptions, selectValue]);
+    const deselectableOptionsCount = useMemo(
+      () =>
+        visibleOptions.filter(
+          option =>
+            !option.disabled &&
+            hasOption(option.value, ensureIsArray(selectValue)),
+        ).length,
+      [visibleOptions, selectValue],
     );
 
     const bulkSelectComponent = useMemo(
@@ -434,29 +448,40 @@ const Select = forwardRef(
           <Button
             type="link"
             buttonSize="xsmall"
+            disabled={selectableOptionsCount === 0}
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
               handleSelectAll();
             }}
           >
-            {`${t('Select all')} (${visibleOptionsCount})`}
+            {`${t('Select all')} (${selectableOptionsCount})`}
           </Button>
           <Button
             type="link"
             buttonSize="xsmall"
+            disabled={deselectableOptionsCount === 0}
             onClick={e => {
               e.preventDefault();
               e.stopPropagation();
               handleDeselectAll();
             }}
           >
-            {`${t('Deselect all')} (${visibleOptionsCount})`}
+            {`${t('Deselect all')} (${deselectableOptionsCount})`}
           </Button>
         </StyledBulkActionsContainer>
       ),
-      [handleSelectAll, handleDeselectAll, visibleOptionsCount],
+      [
+        handleSelectAll,
+        handleDeselectAll,
+        selectableOptionsCount,
+        deselectableOptionsCount,
+      ],
     );
+
+    useEffect(() => {
+      console.log({ visibleOptions, selectValue });
+    }, [visibleOptions, selectValue]);
 
     const dropdownRender = (
       originNode: ReactElement & { ref?: RefObject<HTMLElement> },

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -256,7 +256,7 @@ const Select = forwardRef(
 
           return acc;
         },
-        { selectable: 0, deselectable: 0 }, // Initial accumulator
+        { selectable: 0, deselectable: 0 },
       );
 
       setBulkSelectCounts(counts);

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -195,8 +195,8 @@ const Select = forwardRef(
         missingValues.length > 0
           ? missingValues.concat(selectOptions)
           : selectOptions;
-      return result;
-    }, [selectOptions, selectValue]);
+      return result.slice().sort(sortSelectedFirst);
+    }, [selectOptions, selectValue, sortSelectedFirst]);
 
     const enabledOptions = useMemo(
       () => visibleOptions.filter(option => !option.disabled),

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -239,19 +239,27 @@ const Select = forwardRef(
 
     useEffect(() => {
       const selectedValues = ensureIsArray(selectValue);
-      const selectable = visibleOptions.filter(
-        option =>
-          (!option.disabled || hasOption(option.value, selectedValues)) &&
-          !option.isNewOption,
-      ).length;
-      const deselectable = visibleOptions.filter(
-        option => !option.disabled && hasOption(option.value, selectedValues),
-      ).length;
+      const selectedValuesSet = new Set(selectedValues.map(getValue));
+      const counts = visibleOptions.reduce(
+        (acc, option) => {
+          const isSelected = selectedValuesSet.has(option.value);
+          const isDisabled = option.disabled;
+          const isNew = option.isNewOption;
 
-      setBulkSelectCounts({
-        selectable,
-        deselectable,
-      });
+          if ((!isDisabled || isSelected) && !isNew) {
+            acc.selectable += 1;
+          }
+
+          if (isSelected && !isDisabled) {
+            acc.deselectable += 1;
+          }
+
+          return acc;
+        },
+        { selectable: 0, deselectable: 0 }, // Initial accumulator
+      );
+
+      setBulkSelectCounts(counts);
     }, [visibleOptions, selectValue]);
 
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -241,8 +241,7 @@ const Select = forwardRef(
       const selectedValues = ensureIsArray(selectValue);
       const selectable = visibleOptions.filter(
         option =>
-          !option.disabled &&
-          !hasOption(option.value, selectedValues) &&
+          (!option.disabled || hasOption(option.value, selectedValues)) &&
           !option.isNewOption,
       ).length;
       const deselectable = visibleOptions.filter(
@@ -373,6 +372,7 @@ const Select = forwardRef(
       if (isDropdownVisible && !inputValue && selectOptions.length > 1) {
         if (!isEqual(initialOptionsSorted, selectOptions)) {
           setSelectOptions(initialOptionsSorted);
+          setVisibleOptions(initialOptionsSorted);
         }
       }
       if (onDropdownVisibleChange) {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -310,8 +310,9 @@ const Select = forwardRef(
 
     const handleOnDeselect: SelectProps['onDeselect'] = (value, option) => {
       if (Array.isArray(selectValue)) {
-        let array = selectValue as AntdLabeledValue[];
-        array = array.filter(element => getValue(element) !== getValue(value));
+        const array = (selectValue as AntdLabeledValue[]).filter(
+          element => getValue(element) !== getValue(value),
+        );
         setSelectValue(array);
 
         // removes new option

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -326,6 +326,9 @@ const Select = forwardRef(
       onDeselect?.(value, option);
     };
 
+    const handleFilterOption = (search: string, option: AntdLabeledValue) =>
+      handleFilterOptionHelper(search, option, optionFilterProps, filterOption);
+
     const handleOnSearch = debounce((search: string) => {
       const searchValue = search.trim();
       setIsSearching(!!searchValue);
@@ -348,13 +351,8 @@ const Select = forwardRef(
         setSelectOptions(updatedOptions);
       }
 
-      const filteredOptions = updatedOptions.filter(option =>
-        handleFilterOptionHelper(
-          search,
-          option as AntdLabeledValue,
-          ['label', 'value'],
-          true,
-        ),
+      const filteredOptions = updatedOptions.filter(
+        (option: AntdLabeledValue) => handleFilterOption(search, option),
       );
 
       setVisibleOptions(filteredOptions);
@@ -363,9 +361,6 @@ const Select = forwardRef(
     }, FAST_DEBOUNCE);
 
     useEffect(() => () => handleOnSearch.cancel(), [handleOnSearch]);
-
-    const handleFilterOption = (search: string, option: AntdLabeledValue) =>
-      handleFilterOptionHelper(search, option, optionFilterProps, filterOption);
 
     const handleOnDropdownVisibleChange = (isDropdownVisible: boolean) => {
       setIsDropdownVisible(isDropdownVisible);

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -238,17 +238,22 @@ const Select = forwardRef(
     );
 
     useEffect(() => {
-      const deselectable = visibleOptions.filter(
+      const selectedValues = ensureIsArray(selectValue);
+      const selectable = visibleOptions.filter(
         option =>
           !option.disabled &&
-          hasOption(option.value, ensureIsArray(selectValue)),
+          !hasOption(option.value, selectedValues) &&
+          !option.isNewOption,
+      ).length;
+      const deselectable = visibleOptions.filter(
+        option => !option.disabled && hasOption(option.value, selectedValues),
       ).length;
 
       setBulkSelectCounts({
-        selectable: selectAllEligible.length,
+        selectable,
         deselectable,
       });
-    }, [visibleOptions, selectValue, selectAllEligible.length]);
+    }, [visibleOptions, selectValue]);
 
     const handleOnSelect: SelectProps['onSelect'] = (selectedItem, option) => {
       if (isSingleMode) {

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -631,9 +631,29 @@ const Select = forwardRef(
       } else {
         const token = tokenSeparators.find(token => pastedText.includes(token));
         const array = token ? uniq(pastedText.split(token)) : [pastedText];
+
+        const newOptions: SelectOptionsType = [];
+
         const values = array
-          .map(item => getPastedTextValue(item))
+          .map(item => {
+            const option = getOption(item, fullSelectOptions, true);
+            if (!option && allowNewOptions) {
+              const newOption = {
+                label: item,
+                value: item,
+                isNewOption: true,
+              };
+              newOptions.push(newOption);
+            }
+            return getPastedTextValue(item);
+          })
           .filter(item => item !== undefined);
+
+        if (newOptions.length > 0) {
+          const updatedOptions = [...fullSelectOptions, ...newOptions];
+          setSelectOptions(updatedOptions);
+          setVisibleOptions(updatedOptions);
+        }
         if (labelInValue) {
           setSelectValue(previous => [
             ...((previous || []) as AntdLabeledValue[]),

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -479,10 +479,6 @@ const Select = forwardRef(
       ],
     );
 
-    useEffect(() => {
-      console.log({ visibleOptions, selectValue });
-    }, [visibleOptions, selectValue]);
-
     const dropdownRender = (
       originNode: ReactElement & { ref?: RefObject<HTMLElement> },
     ) =>

--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -242,7 +242,10 @@ const Select = forwardRef(
           const isDisabled = option.disabled;
           const isNew = option.isNewOption;
 
-          if ((!isDisabled || isSelected) && !isNew) {
+          if (
+            (!isDisabled || isSelected) &&
+            ((isNew && isSelected) || !isNew)
+          ) {
             acc.selectable += 1;
           }
           if (isSelected && !isDisabled) {
@@ -373,8 +376,10 @@ const Select = forwardRef(
       if (isDropdownVisible && !inputValue && selectOptions.length > 1) {
         if (!isEqual(initialOptionsSorted, selectOptions)) {
           setSelectOptions(initialOptionsSorted);
-          setVisibleOptions(initialOptionsSorted);
         }
+      }
+      if (!isDropdownVisible) {
+        setSelectOptions(initialOptionsSorted);
       }
       if (onDropdownVisibleChange) {
         onDropdownVisibleChange(isDropdownVisible);
@@ -420,12 +425,7 @@ const Select = forwardRef(
     const handleDeselectAll = useCallback(() => {
       if (isSingleMode) return;
 
-      const optionsToDeselect = isSearching
-        ? visibleOptions.filter(option => !option.isNewOption)
-        : enabledOptions;
-      const deselectionValues = new Set(
-        optionsToDeselect.map(opt => opt.value),
-      );
+      const deselectionValues = new Set(enabledOptions.map(opt => opt.value));
 
       const newValues = ensureIsArray(selectValue).filter(item => {
         const itemValue = getValue(item);
@@ -434,14 +434,7 @@ const Select = forwardRef(
 
       setSelectValue(newValues);
       fireOnChange();
-    }, [
-      isSingleMode,
-      isSearching,
-      visibleOptions,
-      enabledOptions,
-      selectValue,
-      fireOnChange,
-    ]);
+    }, [isSingleMode, enabledOptions, selectValue, fireOnChange]);
 
     const bulkSelectComponent = useMemo(
       () => (

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -139,7 +139,7 @@ export const StyledErrorMessage = styled.div`
 
 export const StyledBulkActionsContainer = styled(Space)`
   ${({ theme }) => `
-    padding: ${theme.gridUnit * 2}px;
+    padding: ${theme.gridUnit}px;
     display: flex;
     justify-content: center;
     border-top: 1px solid ${theme.colors.grayscale.light3};

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -142,7 +142,13 @@ export const StyledBulkActionsContainer = styled(Space)`
     padding: ${theme.gridUnit * 2}px;
     display: flex;
     justify-content: center;
-    border-bottom: 1px solid ${theme.colors.grayscale.light3};
-    font-size: ${theme.typography.sizes.xxs}px;
+    border-top: 1px solid ${theme.colors.grayscale.light3};
+    .superset-button {
+      color: ${theme.colors.primary.dark1};
+      font-weight: ${theme.typography.weights.normal};
+    }
+    .superset-button:disabled {
+      background-color: transparent;
+    }
   `}
 `;

--- a/superset-frontend/src/components/Select/styles.tsx
+++ b/superset-frontend/src/components/Select/styles.tsx
@@ -22,6 +22,7 @@ import { Icons } from 'src/components/Icons';
 import { Spin, Tag } from 'antd'; // TODO: Remove antd
 // eslint-disable-next-line no-restricted-imports
 import AntdSelect from 'antd/lib/select'; // TODO: Remove antd
+import { Space } from '../Space';
 
 export const StyledHeader = styled.span<{ headerPosition: string }>`
   ${({ theme, headerPosition }) => `
@@ -53,9 +54,6 @@ export const StyledSelect = styled(AntdSelect, {
     // This is fixed in version 4.16
     .ant-select-arrow .anticon:not(.ant-select-suffix) {
       pointer-events: none;
-    }
-    .select-all {
-      border-bottom: 1px solid ${theme.colors.grayscale.light3};
     }
     ${
       oneLine &&
@@ -137,4 +135,14 @@ export const StyledError = styled.div`
 export const StyledErrorMessage = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
+`;
+
+export const StyledBulkActionsContainer = styled(Space)`
+  ${({ theme }) => `
+    padding: ${theme.gridUnit * 2}px;
+    display: flex;
+    justify-content: center;
+    border-bottom: 1px solid ${theme.colors.grayscale.light3};
+    font-size: ${theme.typography.sizes.xxs}px;
+  `}
 `;

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -158,6 +158,7 @@ export const dropDownRenderHelper = (
   optionsLength: number,
   helperText: string | undefined,
   errorComponent?: JSX.Element,
+  bulkSelectComponents?: JSX.Element,
 ) => {
   if (!isDropdownVisible) {
     originNode.ref?.current?.scrollTo({ top: 0 });
@@ -170,6 +171,7 @@ export const dropDownRenderHelper = (
   }
   return (
     <>
+      {bulkSelectComponents}
       {helperText && (
         <StyledHelperText role="note">{helperText}</StyledHelperText>
       )}

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -171,11 +171,11 @@ export const dropDownRenderHelper = (
   }
   return (
     <>
-      {bulkSelectComponents}
       {helperText && (
         <StyledHelperText role="note">{helperText}</StyledHelperText>
       )}
       {originNode}
+      {bulkSelectComponents}
     </>
   );
 };

--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -26,12 +26,6 @@ import { LabeledValue, RawValue, SelectOptionsType, V } from './types';
 
 const { Option } = AntdSelect;
 
-export const SELECT_ALL_VALUE: RawValue = 'Select All';
-export const selectAllOption = {
-  value: SELECT_ALL_VALUE,
-  label: String(SELECT_ALL_VALUE),
-};
-
 export function isObject(value: unknown): value is Record<string, unknown> {
   return (
     value !== null &&

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
@@ -97,7 +97,7 @@ describe('SelectControl', () => {
       expect(selectorWrapper).toBeInTheDocument();
       expect(selectorInput).toBeInTheDocument();
       userEvent.click(selectorInput);
-      expect(screen.getByText('Select All (3)')).toBeInTheDocument();
+      expect(screen.getByText('Select all (3)')).toBeInTheDocument();
     });
 
     it('renders with allowNewOptions when freeForm', () => {
@@ -167,8 +167,8 @@ describe('SelectControl', () => {
       expect(yearOption).toBeInTheDocument();
       expect(yearOption).toHaveAttribute('aria-selected', 'true');
       const weekOption = screen.getByText(/1 week ago/, {
-        selector: 'div',
-      }).parentNode;
+        selector: 'div [role="option"]',
+      });
       expect(weekOption?.getAttribute('aria-selected')).toEqual('true');
     });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pr aims to change our sync Select component to have `Select all` and `Deselect all` buttons that works on visible options. With this change users can filter what they want to select by searching for common patterns without clicking each item individually.

fixes: #33362

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Some current screenshots from storybook:

![image](https://github.com/user-attachments/assets/ff75de73-bcf2-4d78-ac10-742f8275f689)
![image](https://github.com/user-attachments/assets/e816040e-fa30-4b79-8489-e4c0c1295073)
![image](https://github.com/user-attachments/assets/791e8a6d-74c6-4475-89d6-fe9c513a1297)

Demo that showcases the functionality:

[select_demo.webm](https://github.com/user-attachments/assets/aab33a57-80d1-409b-b3ea-82ccd391080c)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the testing suite

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
