### PR TITLE
docs: clarify docker-compose-image-tag instructions

### DIFF
--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -114,6 +114,8 @@ docker compose -f docker-compose-non-dev.yml up
 ```bash
 # Set the version you want to run
 export TAG=3.1.1
+# Fetch the tag you're about to check out (assuming you shallow-cloned the repo)
+git fetch origin $TAG
 # Checkout the corresponding git ref
 git checkout $TAG
 # Fire up docker compose

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -112,7 +112,11 @@ docker compose -f docker-compose-non-dev.yml up
 ### Option #3 - boot up an official release
 
 ```bash
+# Set the version you want to run
 export TAG=3.1.1
+# Checkout the corresponding git ref
+git checkout $TAG
+# Fire up docker compose
 docker compose -f docker-compose-image-tag.yml up
 ```
 

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -115,7 +115,9 @@ docker compose -f docker-compose-non-dev.yml up
 # Set the version you want to run
 export TAG=3.1.1
 # Fetch the tag you're about to check out (assuming you shallow-cloned the repo)
-git fetch origin $TAG
+git fetch --depth=1 origin tag $TAG
+# Could also fetch all tags too if you've got bandwidth to spare
+# git fetch --tags
 # Checkout the corresponding git ref
 git checkout $TAG
 # Fire up docker compose


### PR DESCRIPTION
People get confused around running older versions of Superset with `docker-compose`, this should help a bit.

Now note that the solution here would be to NOT mount the `docker/` folder as a volume, but would required new releases/docker images with the proper ADD inststruction in the docker file. Personally can't commit the time/effort to go pull these old branches and producing new builds.

Another solution is to do this so that releases, moving forward, would be more self-contained.

NOTE: adding new runnable scripts inside images has some security implications, probably need to think through which scripts are runnable/executable by which users (`superset` and `root`) and get this right.
