### PR TITLE
feat: add a title prop to the dashboard link in CRUD LIST view

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -329,7 +329,7 @@ function DashboardList(props: DashboardListProps) {
             },
           },
         }: any) => (
-          <Link to={url}>
+          <Link to={url} title={dashboardTitle}>
             {certifiedBy && (
               <>
                 <CertifiedBadge


### PR DESCRIPTION
When dashboard titles are long, they get trunctated with `...` ellipsis stuff. This solution simply uses the html <a title=""/> prop so the link can be hovered and the full title viewed by the user. More details in the issue

closes https://github.com/apache/superset/issues/23929#issuecomment-2786912016

<img width="1206" alt="Screenshot 2025-04-08 at 1 18 33 PM" src="https://github.com/user-attachments/assets/f5d0b457-1ead-4366-854c-bee840bb1d97" />


