### PR TITLE
fix: improve error type on parse error

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -272,7 +272,7 @@ class ParsedQuery:
             logger.warning("Unable to parse SQL (%s): %s", self._dialect, self.sql)
             raise SupersetSecurityException(
                 SupersetError(
-                    error_type=SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR,
+                    error_type=SupersetErrorType.INVALID_SQL_ERROR,
                     message=__(
                         "You may have an error in your SQL statement. {message}"
                     ).format(message=ex.error.message),


### PR DESCRIPTION
### SUMMARY
When _sql_parse_ encounters a **SupersetParseError**, the logged _error_type_ is recorded as `QUERY_SECURITY_ACCESS_ERROR`, which is ambiguous. This commit updates the _error_type_ to `INVALID_SQL_ERROR` for clarity.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![Screenshot 2025-04-08 at 4 41 12 PM](https://github.com/user-attachments/assets/e6b4ae46-838b-4ed0-a34f-2bd01bb630fa)

After:
![Screenshot 2025-04-08 at 4 42 38 PM](https://github.com/user-attachments/assets/3e62a55a-cc8d-4d62-87ca-c9c17043bbf3)

### TESTING INSTRUCTIONS
Run a invalid sql that causes the sql_parse error like `SELECT * FROM table LIMIT 100'`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
