### PR TITLE
fix(list roles): dont send invalid querystrings

### DIFF
--- a/superset-frontend/src/pages/RolesList/index.tsx
+++ b/superset-frontend/src/pages/RolesList/index.tsx
@@ -114,7 +114,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
 
       const fetchPage = async (pageIndex: number) => {
         const response = await SupersetClient.get({
-          endpoint: `api/v1/security/permissions-resources/?q={"page_size":${pageSize}, "page":${pageIndex}}`,
+          endpoint: `api/v1/security/permissions-resources/?q=(page_size:${pageSize},page:${pageIndex})`,
         });
 
         return {
@@ -163,7 +163,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
 
       const fetchPage = async (pageIndex: number) => {
         const response = await SupersetClient.get({
-          endpoint: `api/v1/security/users/?q={"page_size":${pageSize},"page":${pageIndex}}`,
+          endpoint: `api/v1/security/users/?q=(page_size:${pageSize},page:${pageIndex})`,
         });
         return response.json;
       };


### PR DESCRIPTION
appeases java apps proxying superset

modeled after the query listing roles done by the same page, eg: 
`/api/v1/security/roles/search/?q=(order_column:name,order_direction:desc,page:0,page_size:25)`

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
with #32432, two queries sent by the react page are invalid urls and confuse a java-based proxy.

cf https://github.com/apache/superset/pull/32432#issuecomment-2789646953 and georchestra/superset#13

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
