### PR TITLE
fix(docs): Update quickstart.mdx to reflect latest version tag

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -32,7 +32,7 @@ git clone https://github.com/apache/superset
 $ cd superset
 
 # Set the repo to the state associated with the latest official version
-$ git checkout tags/4.1.1
+$ git checkout tags/4.1.2
 
 # Fire up Superset using Docker Compose
 $ docker compose -f docker-compose-image-tag.yml up


### PR DESCRIPTION
This simply updates the quickstart instructions from 4.1.1 to 4.1.2 (the latest official release) with no additional changes.