### PR TITLE
chore: implement eslint typescript-eslint/consistent-type-imports

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageConfig = require('./package');
 
 const importCoreModules = [];
@@ -83,6 +85,7 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:react-prefer-function-component/recommended',
     'plugin:storybook/recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   parser: '@babel/eslint-parser',
   parserOptions: {
@@ -117,6 +120,7 @@ module.exports = {
     'i18n-strings',
     'react-prefer-function-component',
     'prettier',
+    '@typescript-eslint/eslint-plugin',
   ],
   overrides: [
     {
@@ -134,6 +138,10 @@ module.exports = {
         '@typescript-eslint/ban-ts-ignore': 0,
         '@typescript-eslint/ban-ts-comment': 0, // disabled temporarily
         '@typescript-eslint/ban-types': 0, // disabled temporarily
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          { prefer: 'type-imports' },
+        ],
         '@typescript-eslint/naming-convention': [
           'error',
           {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -237,7 +237,7 @@
         "css-minimizer-webpack-plugin": "^7.0.2",
         "enzyme": "^3.11.0",
         "enzyme-matchers": "^7.1.2",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^7.2.0",
         "eslint-import-resolver-typescript": "^3.7.0",
@@ -50727,7 +50727,7 @@
       "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/react-redux": "^7.1.10",
+        "@types/react-redux": "^7.1.34",
         "d3-array": "^1.2.0",
         "dayjs": "^1.11.13",
         "lodash": "^4.17.21"

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -304,7 +304,7 @@
     "css-minimizer-webpack-plugin": "^7.0.2",
     "enzyme": "^3.11.0",
     "enzyme-matchers": "^7.1.2",
-    "eslint": "^8.56.0",
+    "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^7.2.0",
     "eslint-import-resolver-typescript": "^3.7.0",


### PR DESCRIPTION
Recently looked into typescript's import `type` keyword and its implications. Turns out using it should have noticeable impacts on bundle size and memory usage (yeh!), and there's a nice lint rule for it.

This PR is DRAFT and will be on hold until we merge the Theming branch to avoid a lot of conflicts.

Note that:
- there are north of 2k lint instance
- `--fix` seems to cover most cases, short by 100-200
- unclear how much we'll save on bundle size, but clearly is good hygiene

Let's pick this up after the great merge of https://github.com/apache/superset/pull/31590

```
✖ 2606 problems (2606 errors, 0 warnings)
  2443 errors and 0 warnings potentially fixable with the `--fix` option.
```

Some context:
<img width="877" alt="Screenshot 2025-04-09 at 2 43 11 PM" src="https://github.com/user-attachments/assets/5988dab2-c476-4b51-8749-9e175277501c" />
