### PR TITLE
fix: block MySQL system variables (@@) in SQL queries

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1393,6 +1393,11 @@ DISALLOWED_SQL_FUNCTIONS: dict[str, set[str]] = {
 def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument  # noqa: N802
     sql: str, **kwargs: Any
 ) -> str:
+    import re
+
+    # Check if the query contains any @@ variables
+    if re.search(r"@@\w+", sql):
+        raise Exception("MySQL system variables (@@) are blocked for security reasons")
     return sql
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds protection against MySQL system variables (@@) in SQL queries, which can be used to extract sensitive system information.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Set up a local instance of Superset with the modified code
- In SQL Lab, attempt to execute a query containing a MySQL system variable like SELECT @@hostname
- Verify that the query is blocked and an error message appears stating that MySQL system variables are not allowed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
