### PR TITLE
fix(docker): fallback to pip if uv is not available

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -50,7 +50,11 @@ fi
 #
 if [ -f "${REQUIREMENTS_LOCAL}" ]; then
   echo "Installing local overrides at ${REQUIREMENTS_LOCAL}"
-  uv pip install --no-cache-dir -r "${REQUIREMENTS_LOCAL}"
+  if command -v uv > /dev/null 2>&1; then
+    uv pip install --no-cache-dir -r "${REQUIREMENTS_LOCAL}"
+  else
+    pip install --no-cache-dir -r "${REQUIREMENTS_LOCAL}"
+  fi
 else
   echo "Skipping local overrides"
 fi


### PR DESCRIPTION
### SUMMARY
This change improves robustness in the Docker bootstrap script. Previously, the script failed if `uv` was not installed, even though `pip` was available. Now it falls back to using `pip` when `uv` is not present, ensuring local overrides can still be installed.

This is useful in environments where `uv` may not be installed or supported by default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Tested locally by running the `docker-bootstrap.sh` script:
- With `uv` installed → installs as expected using `uv`
- Without `uv` installed → falls back to `pip` and continues without error

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI (only via Docker experience)
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API