### PR TITLE
fix: CI file change detector to handle large PRs

### DIFF
--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -63,7 +63,10 @@ def fetch_files_github_api(url: str):  # type: ignore
 
 def fetch_changed_files_pr(repo: str, pr_number: str) -> List[str]:
     """Fetches files changed in a PR using the GitHub API."""
-    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files"
+
+    # NOTE: limited to 100 files ideally should page-through but instead resorting
+    # to assuming we should trigger when 100 files have been touched
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
     files = fetch_files_github_api(url)
     return [file_info["filename"] for file_info in files]
 
@@ -103,7 +106,7 @@ def main(event_type: str, sha: str, repo: str) -> None:
     """Main function to check for file changes based on event context."""
     print("SHA:", sha)
     print("EVENT_TYPE", event_type)
-    files = None
+    files = []
     if event_type == "pull_request":
         pr_number = os.getenv("GITHUB_REF", "").split("/")[-2]
         if is_int(pr_number):
@@ -133,7 +136,10 @@ def main(event_type: str, sha: str, repo: str) -> None:
     output_path = os.getenv("GITHUB_OUTPUT") or "/tmp/GITHUB_OUTPUT.txt"  # noqa: S108
     with open(output_path, "a") as f:
         for check, changed in changes_detected.items():
-            if changed:
+            # NOTE: as noted above, we assume that if 100 files are touched, we should
+            # trigger all checks. This is a workaround for the GitHub API limit of 100
+            # files. Using >= 99 because off-by-one errors are not uncommon
+            if changed or len(files) >= 99:
                 print(f"{check}={str(changed).lower()}", file=f)
                 print(f"Triggering group: {check}")
 


### PR DESCRIPTION
Improve our change detector. The way it works currently, we do a simple call to the github API to fetch the list of files that have changed in the PR, so that we can see if we should trigger cetain jobs. Now it appears that the particular endpoint we use returns a max of 30 results by call, unless we specify the `?per_page=100` argument.

Now I'm a bit lazy and didn't want to implement paging, so instead I'm resorting to fetching 100, and if/when we see 100, we assume that we should trigger all checks.

Why not paging?
- i'm lazy, and we should probably use a proper github client instead of re-implementing paging, and that'd require a bit more time/effort
- triggering everything if we have 100 files is fine, maybe super occasionally we'll trigger a bit more work than necessary (large frontend-only refactor, large backend-only refactor, ...) but I think that's fine
