### PR TITLE
feat(Native Filters): Configure creatable filter behavior

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/shared_dashboard_functions.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/shared_dashboard_functions.ts
@@ -55,6 +55,7 @@ export function prepareDashboardFilters(
         controlValues: {
           enableEmptyFilter: false,
           defaultToFirstItem: false,
+          creatable: true,
           multiSelect: true,
           searchAllOptions: false,
           inverseSelection: false,

--- a/superset-frontend/spec/fixtures/mockNativeFilters.ts
+++ b/superset-frontend/spec/fixtures/mockNativeFilters.ts
@@ -48,6 +48,7 @@ export const nativeFilters: NativeFiltersState = {
         excluded: [],
       },
       controlValues: {
+        creatable: false,
         multiSelect: false,
         enableEmptyFilter: false,
         inverseSelection: false,
@@ -79,6 +80,7 @@ export const nativeFilters: NativeFiltersState = {
         excluded: [],
       },
       controlValues: {
+        creatable: false,
         multiSelect: false,
         enableEmptyFilter: false,
         inverseSelection: false,
@@ -463,6 +465,7 @@ export const buildNativeFilter = (
 ) => ({
   id,
   controlValues: {
+    creatable: true,
     multiSelect: true,
     enableEmptyFilter: false,
     defaultToFirstItem: false,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -136,6 +136,7 @@ type ControlKey = keyof PluginFilterSelectCustomizeProps;
 const controlsOrder: ControlKey[] = [
   'enableEmptyFilter',
   'defaultToFirstItem',
+  'creatable',
   'multiSelect',
   'searchAllOptions',
   'inverseSelection',

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.stories.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.stories.tsx
@@ -29,17 +29,20 @@ getChartTransformPropsRegistry().registerValue('filter_select', transformProps);
 export default {
   title: 'Filter Plugins',
   argTypes: {
+    creatable: { control: 'boolean', defaultValue: true },
     multiSelect: { control: 'boolean', defaultValue: true },
     inverseSelection: { control: 'boolean', defaultValue: false },
   },
 };
 
 export const Select = ({
+  creatable,
   multiSeelct,
   inverseSelection,
   width,
   height,
 }: {
+  creatable: boolean;
   multiSeelct: boolean;
   inverseSelection: boolean;
   width: number;
@@ -53,6 +56,7 @@ export const Select = ({
     formData={{
       adhoc_filters: [],
       extra_filters: [],
+      creatable,
       multiSelect: { multiSeelct },
       inverseSelection: { inverseSelection },
       row_limit: 1000,

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -27,6 +27,7 @@ jest.useFakeTimers();
 const selectMultipleProps = {
   formData: {
     sortAscending: true,
+    creatable: false,
     multiSelect: true,
     enableEmptyFilter: true,
     defaultToFirstItem: false,
@@ -258,5 +259,17 @@ describe('SelectFilterPlugin', () => {
     expect(await screen.findByRole('combobox')).toBeInTheDocument();
     await userEvent.type(screen.getByRole('combobox'), '1');
     expect(screen.queryByLabelText(String(bigValue))).toBeInTheDocument();
+  });
+
+  test('Should not allow for new values when creatable is false', () => {
+    getWrapper({ creatable: false });
+    userEvent.type(screen.getByRole('combobox'), 'new value');
+    expect(screen.queryByTitle('new value')).not.toBeInTheDocument();
+  });
+
+  test('Should allow for new values when creatable is false', async () => {
+    getWrapper({ creatable: true });
+    userEvent.type(screen.getByRole('combobox'), 'new value');
+    expect(await screen.findByTitle('new value')).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -100,6 +100,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   } = props;
   const {
     enableEmptyFilter,
+    creatable,
     multiSelect,
     showSearch,
     inverseSelection,
@@ -296,7 +297,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         <Select
           name={formData.nativeFilterId}
           allowClear
-          allowNewOptions={!searchAllOptions}
+          allowNewOptions={!searchAllOptions && creatable !== false}
           allowSelectAll={!searchAllOptions}
           // @ts-ignore
           value={filterState.value || []}

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -30,6 +30,7 @@ describe('Select buildQuery', () => {
     filters: undefined,
     enableEmptyFilter: false,
     inverseSelection: false,
+    creatable: false,
     multiSelect: false,
     defaultToFirstItem: false,
     searchAllOptions: false,

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -27,6 +27,7 @@ const {
   enableEmptyFilter,
   inverseSelection,
   multiSelect,
+  creatable,
   defaultToFirstItem,
   searchAllOptions,
   sortAscending,
@@ -63,6 +64,19 @@ const config: ControlPanelConfig = {
               label: t('Sort ascending'),
               default: sortAscending,
               description: t('Check for sorting ascending'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'creatable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Allow creation of new values'),
+              default: creatable,
+              resetConfig: true,
+              affectsDataMask: true,
+              renderTrigger: true,
             },
           },
         ],

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -36,6 +36,7 @@ export interface PluginFilterSelectCustomizeProps {
   defaultValue?: SelectValue;
   enableEmptyFilter: boolean;
   inverseSelection: boolean;
+  creatable: boolean;
   multiSelect: boolean;
   defaultToFirstItem: boolean;
   searchAllOptions: boolean;
@@ -71,6 +72,7 @@ export const DEFAULT_FORM_DATA: PluginFilterSelectCustomizeProps = {
   enableEmptyFilter: false,
   inverseSelection: false,
   defaultToFirstItem: false,
+  creatable: true,
   multiSelect: true,
   searchAllOptions: false,
   sortAscending: true,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR introduces a new option for Native Filters to enable / disable the creatable behavior of values filters.

### AFTER

https://github.com/user-attachments/assets/3d05a8c7-5595-48aa-9a0a-7e8cc0cb93fb


### TESTING INSTRUCTIONS
- Open a Dashboard and set a value filter
- The creatable option should be true by default and it should be possible to create new values
- Disabling the option should disallow the creation of new values

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
