### PR TITLE
fix(OAuth2): Update connection should not fail if connection is missing OAuth2 token

### DIFF
--- a/superset/commands/database/exceptions.py
+++ b/superset/commands/database/exceptions.py
@@ -138,6 +138,15 @@ class DatabaseConnectionFailedError(  # pylint: disable=too-many-ancestors
     message = _("Connection failed, please check your connection settings")
 
 
+class MissingOAuth2TokenError(DatabaseUpdateFailedError):
+    """
+    Exception for when the connection is missing an OAuth2 token
+    and it's not possible to initiate an OAuth2 dance.
+    """
+
+    message = _("Missing OAuth2 token")
+
+
 class DatabaseDeleteDatasetsExistFailedError(DeleteFailedError):
     message = _("Cannot delete a database that has datasets attached")
 

--- a/superset/commands/database/sync_permissions.py
+++ b/superset/commands/database/sync_permissions.py
@@ -28,6 +28,7 @@ from superset.commands.database.exceptions import (
     DatabaseConnectionFailedError,
     DatabaseConnectionSyncPermissionsError,
     DatabaseNotFoundError,
+    MissingOAuth2TokenError,
     UserNotFoundInSessionError,
 )
 from superset.commands.database.utils import (
@@ -115,6 +116,11 @@ class SyncPermissionsCommand(BaseCommand):
             try:
                 alive = ping(engine)
             except Exception as err:
+                if (
+                    self.db_connection.is_oauth2_enabled()
+                    and self.db_connection.db_engine_spec.needs_oauth2(err)
+                ):
+                    raise MissingOAuth2TokenError() from err
                 raise DatabaseConnectionFailedError() from err
 
         if not alive:

--- a/superset/commands/database/update.py
+++ b/superset/commands/database/update.py
@@ -30,6 +30,7 @@ from superset.commands.database.exceptions import (
     DatabaseInvalidError,
     DatabaseNotFoundError,
     DatabaseUpdateFailedError,
+    MissingOAuth2TokenError,
 )
 from superset.commands.database.ssh_tunnel.create import CreateSSHTunnelCommand
 from superset.commands.database.ssh_tunnel.delete import DeleteSSHTunnelCommand
@@ -108,7 +109,7 @@ class UpdateDatabaseCommand(BaseCommand):
                 db_connection=database,
                 ssh_tunnel=ssh_tunnel,
             ).run()
-        except OAuth2RedirectError:
+        except (OAuth2RedirectError, MissingOAuth2TokenError):
             pass
 
         return database

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -35,6 +35,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.sql import func
 
 from superset import db, security_manager
+from superset.commands.database.exceptions import MissingOAuth2TokenError
 from superset.connectors.sqla.models import SqlaTable
 from superset.databases.ssh_tunnel.models import SSHTunnel
 from superset.databases.utils import make_url_safe  # noqa: F401
@@ -1388,6 +1389,32 @@ class TestDatabaseApi(SupersetTestCase):
         }
         assert rv.status_code == 422
         assert response == expected_response
+        # Cleanup
+        model = db.session.query(Database).get(test_database.id)
+        db.session.delete(model)
+        db.session.commit()
+
+    @mock.patch(
+        "superset.commands.database.sync_permissions.SyncPermissionsCommand.run",
+    )
+    def test_update_database_missing_oauth2_token(self, mock_sync_perms):
+        """
+        Database API: Test update DB connection that does not have
+        an OAuth2 token yet does not raise.
+        """
+        example_db = get_example_database()
+        test_database = self.insert_database(
+            "test-oauth-database", example_db.sqlalchemy_uri_decrypted
+        )
+        mock_sync_perms.side_effect = MissingOAuth2TokenError()
+        self.login(ADMIN_USERNAME)
+        database_data = {
+            "database_name": "test-database-updated",
+            "configuration_method": ConfigurationMethod.SQLALCHEMY_FORM,
+        }
+        uri = f"api/v1/database/{test_database.id}"
+        rv = self.client.put(uri, json=database_data)
+        assert rv.status_code == 200
         # Cleanup
         model = db.session.query(Database).get(test_database.id)
         db.session.delete(model)

--- a/tests/unit_tests/commands/databases/conftest.py
+++ b/tests/unit_tests/commands/databases/conftest.py
@@ -64,6 +64,8 @@ def database_without_catalog(mocker: MockerFixture) -> MagicMock:
     database.db_engine_spec.__name__ = "test_engine"
     database.db_engine_spec.supports_catalog = False
     database.get_all_schema_names.return_value = ["schema1", "schema2"]
+    database.is_oauth2_enabled.return_value = False
+    database.db_engine_spec.needs_oauth2.return_value = False
 
     return database
 


### PR DESCRIPTION
### SUMMARY
The `UpdateDatabaseCommand` command calls the `SyncPermissionsCommand` to reflect new datasources into Roles (for data access). The update itself might purge all OAuth2 tokens, or the user performing the change might not have a valid token yet, so the update should not fail in case the token is missing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Test coverage added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
