### PR TITLE
fix: Allows configuration of Selenium Webdriver binary

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1525,7 +1525,7 @@ WEBDRIVER_AUTH_FUNC = None
 
 # Any config options to be passed as-is to the webdriver
 WEBDRIVER_CONFIGURATION = {
-    "options": {"capabilities": {}, "preferences": {}},
+    "options": {"capabilities": {}, "preferences": {}, "binary_location": ""},
     "service": {"log_output": "/dev/null", "service_args": [], "port": 0, "env": {}},
 }
 

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -275,6 +275,10 @@ class WebDriverSelenium(WebDriverProxy):
         # Add additional configured webdriver options
         webdriver_conf = dict(current_app.config["WEBDRIVER_CONFIGURATION"])
 
+        # Set the binary location if provided
+        # We need to pop it from the dict due to selenium_version < 4.10.0
+        options.binary_location = webdriver_conf.pop("binary_location", "")
+
         if version.parse(selenium_version) < version.parse("4.10.0"):
             kwargs |= webdriver_conf
         else:


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/25933 bumped Selenium and changed how the Webdriver is configured. Unfortunately, that change had a side-effect that prevents the configuration of the Webdriver binary location and this PR restores that capability.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
