### PR TITLE
fix(dashboard): invalid active tab state

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -665,18 +665,21 @@ export function setActiveTab(tabId, prevTabId) {
     const { present: currentLayout } = dashboardLayout;
     const restoredTabs = [];
     const queue = [tabId];
+    const visited = new Set();
     while (queue.length > 0) {
       const seek = queue.shift();
-      const found =
-        prevInactiveTabs?.filter(inactiveTabId =>
-          currentLayout[inactiveTabId]?.parents
-            .filter(id => id.startsWith('TAB-'))
-            .slice(-1)
-            .includes(seek),
-        ) ?? [];
-
-      restoredTabs.push(...found);
-      queue.push(...found);
+      if (!visited.has(seek)) {
+        visited.add(seek);
+        const found =
+          prevInactiveTabs?.filter(inactiveTabId =>
+            currentLayout[inactiveTabId]?.parents
+              .filter(id => id.startsWith('TAB-'))
+              .slice(-1)
+              .includes(seek),
+          ) ?? [];
+        restoredTabs.push(...found);
+        queue.push(...found);
+      }
     }
     const tabIds = restoredTabs ? [tabId].concat(restoredTabs) : [tabId];
     const inactiveTabs =

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -658,41 +658,57 @@ export function setDirectPathToChild(path) {
 }
 
 export const SET_ACTIVE_TAB = 'SET_ACTIVE_TAB';
+
+function findTabsToRestore(tabId, prevTabId, dashboardState, dashboardLayout) {
+  const { activeTabs: prevActiveTabs, inactiveTabs: prevInactiveTabs } =
+    dashboardState;
+  const { present: currentLayout } = dashboardLayout;
+  const restoredTabs = [];
+  const queue = [tabId];
+  const visited = new Set();
+  while (queue.length > 0) {
+    const seek = queue.shift();
+    if (!visited.has(seek)) {
+      visited.add(seek);
+      const found =
+        prevInactiveTabs?.filter(inactiveTabId =>
+          currentLayout[inactiveTabId]?.parents
+            .filter(id => id.startsWith('TAB-'))
+            .slice(-1)
+            .includes(seek),
+        ) ?? [];
+      restoredTabs.push(...found);
+      queue.push(...found);
+    }
+  }
+  const activeTabs = restoredTabs ? [tabId].concat(restoredTabs) : [tabId];
+  const tabChanged = Boolean(prevTabId) && tabId !== prevTabId;
+  const inactiveTabs = tabChanged
+    ? prevActiveTabs.filter(
+        activeTabId =>
+          activeTabId !== prevTabId &&
+          currentLayout[activeTabId]?.parents.includes(prevTabId),
+      )
+    : [];
+  return {
+    activeTabs,
+    inactiveTabs,
+  };
+}
+
 export function setActiveTab(tabId, prevTabId) {
   return (dispatch, getState) => {
     const { dashboardLayout, dashboardState } = getState();
-    const { activeTabs, inactiveTabs: prevInactiveTabs } = dashboardState;
-    const { present: currentLayout } = dashboardLayout;
-    const restoredTabs = [];
-    const queue = [tabId];
-    const visited = new Set();
-    while (queue.length > 0) {
-      const seek = queue.shift();
-      if (!visited.has(seek)) {
-        visited.add(seek);
-        const found =
-          prevInactiveTabs?.filter(inactiveTabId =>
-            currentLayout[inactiveTabId]?.parents
-              .filter(id => id.startsWith('TAB-'))
-              .slice(-1)
-              .includes(seek),
-          ) ?? [];
-        restoredTabs.push(...found);
-        queue.push(...found);
-      }
-    }
-    const tabIds = restoredTabs ? [tabId].concat(restoredTabs) : [tabId];
-    const inactiveTabs =
-      Boolean(prevTabId) && tabId !== prevTabId
-        ? activeTabs.filter(
-            activeTabId =>
-              activeTabId !== prevTabId &&
-              currentLayout[activeTabId]?.parents.includes(prevTabId),
-          )
-        : [];
+    const { activeTabs, inactiveTabs } = findTabsToRestore(
+      tabId,
+      prevTabId,
+      dashboardState,
+      dashboardLayout,
+    );
+
     return dispatch({
       type: SET_ACTIVE_TAB,
-      tabIds,
+      activeTabs,
       prevTabId,
       inactiveTabs,
     });

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -669,7 +669,10 @@ export function setActiveTab(tabId, prevTabId) {
       const seek = queue.shift();
       const found =
         prevInactiveTabs?.filter(inactiveTabId =>
-          currentLayout[inactiveTabId]?.parents.slice(-1).includes(seek),
+          currentLayout[inactiveTabId]?.parents
+            .filter(id => id.startsWith('TAB-'))
+            .slice(-1)
+            .includes(seek),
         ) ?? [];
 
       restoredTabs.push(...found);

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -209,12 +209,17 @@ export default function dashboardStateReducer(state = {}, action) {
       };
     },
     [SET_ACTIVE_TAB]() {
-      const newActiveTabs = new Set(state.activeTabs);
-      newActiveTabs.delete(action.prevTabId);
-      newActiveTabs.add(action.tabId);
+      const newActiveTabs = new Set(state.activeTabs).difference(
+        new Set(action.inactiveTabs.concat(action.prevTabId)),
+      );
+      const newInactiveTabs = new Set(state.inactiveTabs)
+        .difference(new Set(action.tabIds))
+        .union(new Set(action.inactiveTabs));
+
       return {
         ...state,
-        activeTabs: Array.from(newActiveTabs),
+        inactiveTabs: Array.from(newInactiveTabs),
+        activeTabs: Array.from(newActiveTabs.union(new Set(action.tabIds))),
       };
     },
     [SET_ACTIVE_TABS]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -213,13 +213,13 @@ export default function dashboardStateReducer(state = {}, action) {
         new Set(action.inactiveTabs.concat(action.prevTabId)),
       );
       const newInactiveTabs = new Set(state.inactiveTabs)
-        .difference(new Set(action.tabIds))
+        .difference(new Set(action.activeTabs))
         .union(new Set(action.inactiveTabs));
 
       return {
         ...state,
         inactiveTabs: Array.from(newInactiveTabs),
-        activeTabs: Array.from(newActiveTabs.union(new Set(action.tabIds))),
+        activeTabs: Array.from(newActiveTabs.union(new Set(action.activeTabs))),
       };
     },
     [SET_ACTIVE_TABS]() {

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -47,78 +47,78 @@ describe('DashboardState reducer', () => {
     });
 
     it('switches a multi-depth tab', () => {
-      const initState = { activeTabs: ['tab1', 'tabA', 'tab__a'] };
+      const initState = { activeTabs: ['TAB-1', 'TAB-A', 'TAB-__a'] };
       const store = mockStore({
         dashboardState: initState,
         dashboardLayout: {
           present: {
-            tab1: { parents: [] },
-            tab2: { parents: [] },
-            tabA: { parents: ['tab1'] },
-            tabB: { parents: ['tab1'] },
-            tab__a: { parents: ['tab1', 'tabA'] },
-            tab__b: { parents: ['tab1', 'tabB'] },
+            'TAB-1': { parents: [] },
+            'TAB-2': { parents: [] },
+            'TAB-A': { parents: ['TAB-1', 'TABS-1'] },
+            'TAB-B': { parents: ['TAB-1', 'TABS-1'] },
+            'TAB-__a': { parents: ['TAB-1', 'TABS-1', 'TAB-A', 'TABS-A'] },
+            'TAB-__b': { parents: ['TAB-1', 'TABS-1', 'TAB-B', 'TABS-B'] },
           },
         },
       });
-      let request = setActiveTab('tabB', 'tabA');
+      let request = setActiveTab('TAB-B', 'TAB-A');
       let thunkAction = request(store.dispatch, store.getState);
       let result = dashboardStateReducer(
-        { activeTabs: ['tab1', 'tabA', 'tab__a'] },
+        { activeTabs: ['TAB-1', 'TAB-A', 'TAB-__a'] },
         thunkAction,
       );
       expect(result).toEqual({
-        activeTabs: expect.arrayContaining(['tab1', 'tabB']),
-        inactiveTabs: ['tab__a'],
+        activeTabs: expect.arrayContaining(['TAB-1', 'TAB-B']),
+        inactiveTabs: ['TAB-__a'],
       });
-      request = setActiveTab('tab2', 'tab1');
+      request = setActiveTab('TAB-2', 'TAB-1');
       thunkAction = request(store.dispatch, () => ({
         ...(store.getState() ?? {}),
         dashboardState: result,
       }));
       result = dashboardStateReducer(result, thunkAction);
       expect(result).toEqual({
-        activeTabs: ['tab2'],
-        inactiveTabs: expect.arrayContaining(['tabB', 'tab__a']),
+        activeTabs: ['TAB-2'],
+        inactiveTabs: expect.arrayContaining(['TAB-B', 'TAB-__a']),
       });
-      request = setActiveTab('tab1', 'tab2');
+      request = setActiveTab('TAB-1', 'TAB-2');
       thunkAction = request(store.dispatch, () => ({
         ...(store.getState() ?? {}),
         dashboardState: result,
       }));
       result = dashboardStateReducer(result, thunkAction);
       expect(result).toEqual({
-        activeTabs: expect.arrayContaining(['tab1', 'tabB']),
-        inactiveTabs: ['tab__a'],
+        activeTabs: expect.arrayContaining(['TAB-1', 'TAB-B']),
+        inactiveTabs: ['TAB-__a'],
       });
-      request = setActiveTab('tabA', 'tabB');
+      request = setActiveTab('TAB-A', 'TAB-B');
       thunkAction = request(store.dispatch, () => ({
         ...(store.getState() ?? {}),
         dashboardState: result,
       }));
       result = dashboardStateReducer(result, thunkAction);
       expect(result).toEqual({
-        activeTabs: expect.arrayContaining(['tab1', 'tabA', 'tab__a']),
+        activeTabs: expect.arrayContaining(['TAB-1', 'TAB-A', 'TAB-__a']),
         inactiveTabs: [],
       });
-      request = setActiveTab('tab2', 'tab1');
+      request = setActiveTab('TAB-2', 'TAB-1');
       thunkAction = request(store.dispatch, () => ({
         ...(store.getState() ?? {}),
         dashboardState: result,
       }));
       result = dashboardStateReducer(result, thunkAction);
       expect(result).toEqual({
-        activeTabs: expect.arrayContaining(['tab2']),
-        inactiveTabs: ['tabA', 'tab__a'],
+        activeTabs: expect.arrayContaining(['TAB-2']),
+        inactiveTabs: ['TAB-A', 'TAB-__a'],
       });
-      request = setActiveTab('tab1', 'tab2');
+      request = setActiveTab('TAB-1', 'TAB-2');
       thunkAction = request(store.dispatch, () => ({
         ...(store.getState() ?? {}),
         dashboardState: result,
       }));
       result = dashboardStateReducer(result, thunkAction);
       expect(result).toEqual({
-        activeTabs: expect.arrayContaining(['tab1', 'tabA', 'tab__a']),
+        activeTabs: expect.arrayContaining(['TAB-1', 'TAB-A', 'TAB-__a']),
         inactiveTabs: [],
       });
     });

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -16,24 +16,112 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import dashboardStateReducer from './dashboardState';
 import { setActiveTab, setActiveTabs } from '../actions/dashboardState';
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
 describe('DashboardState reducer', () => {
-  it('SET_ACTIVE_TAB', () => {
-    expect(
-      dashboardStateReducer({ activeTabs: [] }, setActiveTab('tab1')),
-    ).toEqual({ activeTabs: ['tab1'] });
-    expect(
-      dashboardStateReducer({ activeTabs: ['tab1'] }, setActiveTab('tab1')),
-    ).toEqual({ activeTabs: ['tab1'] });
-    expect(
-      dashboardStateReducer(
-        { activeTabs: ['tab1'] },
-        setActiveTab('tab2', 'tab1'),
-      ),
-    ).toEqual({ activeTabs: ['tab2'] });
+  describe('SET_ACTIVE_TAB', () => {
+    it('switches a single tab', () => {
+      const store = mockStore({
+        dashboardState: { activeTabs: [] },
+        dashboardLayout: { present: { tab1: { parents: [] } } },
+      });
+      const request = setActiveTab('tab1');
+      const thunkAction = request(store.dispatch, store.getState);
+
+      expect(dashboardStateReducer({ activeTabs: [] }, thunkAction)).toEqual({
+        activeTabs: ['tab1'],
+        inactiveTabs: [],
+      });
+
+      const request2 = setActiveTab('tab2', 'tab1');
+      const thunkAction2 = request2(store.dispatch, store.getState);
+      expect(
+        dashboardStateReducer({ activeTabs: ['tab1'] }, thunkAction2),
+      ).toEqual({ activeTabs: ['tab2'], inactiveTabs: [] });
+    });
+
+    it('switches a multi-depth tab', () => {
+      const initState = { activeTabs: ['tab1', 'tabA', 'tab__a'] };
+      const store = mockStore({
+        dashboardState: initState,
+        dashboardLayout: {
+          present: {
+            tab1: { parents: [] },
+            tab2: { parents: [] },
+            tabA: { parents: ['tab1'] },
+            tabB: { parents: ['tab1'] },
+            tab__a: { parents: ['tab1', 'tabA'] },
+            tab__b: { parents: ['tab1', 'tabB'] },
+          },
+        },
+      });
+      let request = setActiveTab('tabB', 'tabA');
+      let thunkAction = request(store.dispatch, store.getState);
+      let result = dashboardStateReducer(
+        { activeTabs: ['tab1', 'tabA', 'tab__a'] },
+        thunkAction,
+      );
+      expect(result).toEqual({
+        activeTabs: expect.arrayContaining(['tab1', 'tabB']),
+        inactiveTabs: ['tab__a'],
+      });
+      request = setActiveTab('tab2', 'tab1');
+      thunkAction = request(store.dispatch, () => ({
+        ...(store.getState() ?? {}),
+        dashboardState: result,
+      }));
+      result = dashboardStateReducer(result, thunkAction);
+      expect(result).toEqual({
+        activeTabs: ['tab2'],
+        inactiveTabs: expect.arrayContaining(['tabB', 'tab__a']),
+      });
+      request = setActiveTab('tab1', 'tab2');
+      thunkAction = request(store.dispatch, () => ({
+        ...(store.getState() ?? {}),
+        dashboardState: result,
+      }));
+      result = dashboardStateReducer(result, thunkAction);
+      expect(result).toEqual({
+        activeTabs: expect.arrayContaining(['tab1', 'tabB']),
+        inactiveTabs: ['tab__a'],
+      });
+      request = setActiveTab('tabA', 'tabB');
+      thunkAction = request(store.dispatch, () => ({
+        ...(store.getState() ?? {}),
+        dashboardState: result,
+      }));
+      result = dashboardStateReducer(result, thunkAction);
+      expect(result).toEqual({
+        activeTabs: expect.arrayContaining(['tab1', 'tabA', 'tab__a']),
+        inactiveTabs: [],
+      });
+      request = setActiveTab('tab2', 'tab1');
+      thunkAction = request(store.dispatch, () => ({
+        ...(store.getState() ?? {}),
+        dashboardState: result,
+      }));
+      result = dashboardStateReducer(result, thunkAction);
+      expect(result).toEqual({
+        activeTabs: expect.arrayContaining(['tab2']),
+        inactiveTabs: ['tabA', 'tab__a'],
+      });
+      request = setActiveTab('tab1', 'tab2');
+      thunkAction = request(store.dispatch, () => ({
+        ...(store.getState() ?? {}),
+        dashboardState: result,
+      }));
+      result = dashboardStateReducer(result, thunkAction);
+      expect(result).toEqual({
+        activeTabs: expect.arrayContaining(['tab1', 'tabA', 'tab__a']),
+        inactiveTabs: [],
+      });
+    });
   });
   it('SET_ACTIVE_TABS', () => {
     expect(


### PR DESCRIPTION
### SUMMARY
The bug where filters outside the current scope are displayed was newly introduced during the process of identifying filters applied to active tabs in [#32115](https://github.com/apache/superset/pull/32115/files#diff-1bbe96474254d89b21e3b373e1c9e8a222ee892518595a69a809c5f035e5bd4eR126). The root cause occurs from the issue that when tabs are structured with multiple levels and the scope is applied to a lower tab, changing the top-level tab leads to an issue where tabs that are no longer visible are not removed from the active tabs state.
For example, in the following tab structure, when the top-level tab is changed, the previous active tabs retain the sub-tabs of the previous tab.

```
        ROOT
    |         |
   TAB-A     TAB-B
    |         |
   TAB-SUB-A     TAB-SUB-B

active_tabs: ['ROOT', 'TAB-A', 'TAB-SUB-A']
// setActiveTab from TAB-A to TAB-B
active_tabs: ['ROOT', 'TAB-B', 'TAB-SUB-A', 'TAB-SUB-B']
```

To address this issue, this commit added a logic to remove the inactive tabs from the active tabs when the top-level tab is switched. Furthermore, to restore the state of previously selected sub-tabs when the tabs return to their original state, this commit modified the logic to store them in the inactive tabs state and recover the sub-tabs associated with the changed top-level tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/6348574e-3177-4fae-b7ad-39780dd8ae72

After:

https://github.com/user-attachments/assets/a19bc36e-6381-4c01-8152-26b859f47b83


### TESTING INSTRUCTIONS
Follow the above screencapture steps

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
