### PR TITLE
fix(thumbnails): ensure consistent cache_key

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1306,6 +1306,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 current_user=current_user,
                 dashboard_id=dashboard.id,
                 force=False,
+                cache_key=cache_key,
             )
             return self.response(
                 202,

--- a/superset/tasks/thumbnails.py
+++ b/superset/tasks/thumbnails.py
@@ -78,6 +78,7 @@ def cache_dashboard_thumbnail(
     force: bool,
     thumb_size: Optional[WindowSize] = None,
     window_size: Optional[WindowSize] = None,
+    cache_key: str | None = None,
 ) -> None:
     # pylint: disable=import-outside-toplevel
     from superset.models.dashboard import Dashboard
@@ -103,6 +104,7 @@ def cache_dashboard_thumbnail(
             window_size=window_size,
             thumb_size=thumb_size,
             force=force,
+            cache_key=cache_key,
         )
 
 


### PR DESCRIPTION
### SUMMARY
similar to #32193 this fixes cache_key mismatch between frontend and task

### TESTING INSTRUCTIONS
configure thumbnails+Playwright+FixedExecutor(), try to generate thumbnail without login, observe frontend claiming it's PENDING while task says it's set to UPDATED

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
