### PR TITLE
fix: Broken menu links to datasets and sql lab

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -226,6 +226,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # Setup regular views
         #
         app_root = appbuilder.app.config["APPLICATION_ROOT"]
+        if app_root.endswith("/"):
+            app_root = app_root.rstrip("/")
+
         appbuilder.add_link(
             "Home",
             label=__("Home"),


### PR DESCRIPTION
### SUMMARY
A change in https://github.com/apache/superset/pull/30134 caused some links in the menu to be broken when the superset_app_root was not set. This PR fixes it by ensuring that there is no trailing slash in the app_root URL

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
1. Start Superset normally
2. Ensure that the links to Datasets and SQL Lab in the menu work correctly
3. Start Superset with a prefixed URL (`FLASK_APP="superset.app:create_app(superset_app_root='/test')" flask run`)
4. Ensure that the links to Datasets and SQL Lab in the menu work correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
