### PR TITLE
feat(explore): X-axis sort by specific metric when more than 1 metric is set

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,7 +23,8 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
-
+- [33116](https://github.com/apache/superset/pull/33116) In Echarts Series charts (e.g. Line, Area, Bar, etc.) charts, the `x_axis_sort_series` and `x_axis_sort_series_ascending` form data items have been renamed with `x_axis_sort` and `x_axis_sort_asc`.
+There's a migration added that can potentially affect a significant number of existing charts.
 - [32317](https://github.com/apache/superset/pull/32317) The horizontal filter bar feature is now out of testing/beta development and its feature flag `HORIZONTAL_FILTER_BAR` has been removed.
 - [31976](https://github.com/apache/superset/pull/31976) Removed the `DISABLE_LEGACY_DATASOURCE_EDITOR` feature flag. The previous value of the feature flag was `True` and now the feature is permanently removed.
 - [31959](https://github.com/apache/superset/pull/32000) Removes CSV_UPLOAD_MAX_SIZE config, use your web server to control file upload size.

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/echartsTimeSeriesQuery.tsx
@@ -23,8 +23,6 @@ import {
   xAxisForceCategoricalControl,
   xAxisSortAscControl,
   xAxisSortControl,
-  xAxisSortSeriesAscendingControl,
-  xAxisSortSeriesControl,
 } from '../shared-controls';
 
 const controlsWithoutXAxis: ControlSetRow[] = [
@@ -55,8 +53,6 @@ export const echartsTimeSeriesQueryWithXAxisSort: ControlPanelSectionConfig = {
     [xAxisForceCategoricalControl],
     [xAxisSortControl],
     [xAxisSortAscControl],
-    [xAxisSortSeriesControl],
-    [xAxisSortSeriesAscendingControl],
     ...controlsWithoutXAxis,
   ],
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -85,15 +85,6 @@ export const aggregationControl = {
   },
 };
 
-const xAxisMultiSortVisibility = ({
-  controls,
-}: {
-  controls: ControlStateMapping;
-}) =>
-  isSortable(controls) &&
-  (!!ensureIsArray(controls?.groupby?.value).length ||
-    ensureIsArray(controls?.metrics?.value).length > 1);
-
 export const xAxisSortControl = {
   name: 'x_axis_sort',
   config: {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -194,20 +194,3 @@ export const xAxisForceCategoricalControl = {
     shouldMapStateToProps: () => true,
   },
 };
-
-export const xAxisSortSeriesAscendingControl = {
-  name: 'x_axis_sort_series_ascending',
-  config: {
-    type: 'CheckboxControl',
-    label: (state: ControlPanelState) =>
-      state.form_data?.orientation === 'horizontal'
-        ? t('Y-Axis Sort Ascending')
-        : t('X-Axis Sort Ascending'),
-    default: DEFAULT_XAXIS_SORT_SERIES_DATA.sort_series_ascending,
-    description: t('Whether to sort ascending or descending on the base Axis.'),
-    renderTrigger: true,
-    visibility: ({ controls }: { controls: ControlStateMapping }) =>
-      controls?.x_axis_sort_series?.value !== undefined &&
-      xAxisMultiSortVisibility({ controls }),
-  },
-};

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -179,8 +179,8 @@ export default function transformProps(
     xAxisBounds,
     xAxisForceCategorical,
     xAxisLabelRotation,
-    xAxisSortSeries,
-    xAxisSortSeriesAscending,
+    xAxisSort,
+    xAxisSortAsc,
     xAxisTimeFormat,
     xAxisTitle,
     xAxisTitleMargin,
@@ -242,10 +242,8 @@ export default function transformProps(
       isHorizontal,
       sortSeriesType,
       sortSeriesAscending,
-      xAxisSortSeries: isMultiSeries ? xAxisSortSeries : undefined,
-      xAxisSortSeriesAscending: isMultiSeries
-        ? xAxisSortSeriesAscending
-        : undefined,
+      xAxisSortSeries: isMultiSeries ? xAxisSort : undefined,
+      xAxisSortSeriesAscending: isMultiSeries ? xAxisSortAsc : undefined,
     },
   );
   const showValueIndexes = extractShowValueIndexes(rawSeries, {

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -60,7 +60,7 @@ def upgrade():
     bind = op.get_bind()
     session = db.Session(bind=bind)
     for slc in paginated_update(
-        session.query(Slice).filter(Slice.viz_type in timeseries_charts)
+        session.query(Slice).filter(Slice.viz_type.in_(timeseries_charts))
     ):
         try:
             params = json.loads(slc.params)
@@ -88,7 +88,7 @@ def downgrade():
     session = db.Session(bind=bind)
 
     for slc in paginated_update(
-        session.query(Slice).filter(Slice.viz_type in timeseries_charts)
+        session.query(Slice).filter(Slice.viz_type.in_(timeseries_charts))
     ):
         try:
             params = json.loads(slc.params)

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -72,14 +72,10 @@ def upgrade():
             ):
                 continue
 
-            if "x_axis_sort_series" in params:
-                if params["x_axis_sort_series"]:
-                    params["x_axis_sort"] = params["x_axis_sort_series"]
-
-                del params["x_axis_sort_series"]
-            if "x_axis_sort_series_ascending" in params:
-                params["x_axis_sort_asc"] = params["x_axis_sort_series_ascending"]
-                del params["x_axis_sort_series_ascending"]
+            if val := params.pop("x_axis_sort_series", None):
+                params["x_axis_sort"] = val
+            if val := params.pop("x_axis_sort_series_ascending", None):
+                params["x_axis_sort_asc"] = val
 
             slc.params = json.dumps(params, sort_keys=True)
         except Exception:  # noqa: S110
@@ -105,12 +101,10 @@ def downgrade():
             ):
                 continue
 
-            if "x_axis_sort" in params:
-                params["x_axis_sort_series"] = params["x_axis_sort"]
-                del params["x_axis_sort"]
-            if "x_axis_sort_asc" in params:
-                params["x_axis_sort_series_ascending"] = params["x_axis_sort_asc"]
-                del params["x_axis_sort_asc"]
+            if val := params.pop("x_axis_sort", None):
+                params["x_axis_sort_series"] = val
+            if val := params.pop("x_axis_sort_asc", None):
+                params["x_axis_sort_series_ascending"] = val
 
             slc.params = json.dumps(params, sort_keys=True)
         except Exception:  # noqa: S110

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""merge_x_axis_sort_series_with_x_axis_sort
+
+Revision ID: 378cecfdba9f
+Revises: 32bf93dfe2a4
+Create Date: 2025-04-13 22:10:10.836273
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "378cecfdba9f"
+down_revision = "32bf93dfe2a4"
+
+from alembic import op  # noqa: E402
+from sqlalchemy import Column, Integer, String, Text  # noqa: E402
+from sqlalchemy.ext.declarative import declarative_base  # noqa: E402
+
+from superset import db  # noqa: E402
+from superset.migrations.shared.utils import paginated_update  # noqa: E402
+from superset.utils import json  # noqa: E402
+
+Base = declarative_base()
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    params = Column(Text)
+    viz_type = Column(String(250))
+
+
+timeseries_charts = [
+    "echarts_timeseries_bar",
+    "echarts_area",
+    "echarts_timeseries_line",
+    "echarts_timeseries_scatter",
+    "echarts_timeseries_smooth",
+    "echarts_timeseries_step",
+    "echarts_timeseries",
+]
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type in timeseries_charts)
+    ):
+        try:
+            params = json.loads(slc.params)
+
+            if "x_axis_sort_series" in params:
+                if params["x_axis_sort_series"]:
+                    params["x_axis_sort"] = params["x_axis_sort_series"]
+
+                del params["x_axis_sort_series"]
+            if "x_axis_sort_series_ascending" in params:
+                if params["x_axis_sort_series_ascending"]:
+                    params["x_axis_sort_asc"] = params["x_axis_sort_series_ascending"]
+                del params["x_axis_sort_series_ascending"]
+
+            slc.params = json.dumps(params, sort_keys=True)
+        except Exception:  # noqa: S110
+            pass
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(Slice.viz_type in timeseries_charts)
+    ):
+        try:
+            params = json.loads(slc.params)
+
+            # x_axis_sort_series only appears when there are multiple metrics or groupby
+            if ("metrics" in params and len(params["metrics"]) > 1) or (
+                "groupby" in params and len(params["groupby"]) > 0
+            ):
+                if "x_axis_sort" in params:
+                    params["x_axis_sort_series"] = params["x_axis_sort"]
+                    del params["x_axis_sort"]
+                if "x_axis_sort_asc" in params:
+                    params["x_axis_sort_series_ascending"] = params["x_axis_sort_asc"]
+                    del params["x_axis_sort_asc"]
+
+                slc.params = json.dumps(params, sort_keys=True)
+        except Exception:  # noqa: S110
+            pass
+
+    session.commit()
+    session.close()

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -72,10 +72,10 @@ def upgrade():
             ):
                 continue
 
-            if val := params.pop("x_axis_sort_series", None):
-                params["x_axis_sort"] = val
-            if val := params.pop("x_axis_sort_series_ascending", None):
-                params["x_axis_sort_asc"] = val
+            if "x_axis_sort_series" in params:
+                params["x_axis_sort"] = params.pop("x_axis_sort_series")
+            if "x_axis_sort_series_ascending" in params:
+                params["x_axis_sort_asc"] = params.pop("x_axis_sort_series_ascending")
 
             slc.params = json.dumps(params, sort_keys=True)
         except Exception:  # noqa: S110
@@ -101,10 +101,10 @@ def downgrade():
             ):
                 continue
 
-            if val := params.pop("x_axis_sort", None):
-                params["x_axis_sort_series"] = val
-            if val := params.pop("x_axis_sort_asc", None):
-                params["x_axis_sort_series_ascending"] = val
+            if "x_axis_sort" in params:
+                params["x_axis_sort_series"] = params.pop("x_axis_sort")
+            if "x_axis_sort_asc" in params:
+                params["x_axis_sort_series_ascending"] = params.pop("x_axis_sort_asc")
 
             slc.params = json.dumps(params, sort_keys=True)
         except Exception:  # noqa: S110

--- a/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
+++ b/superset/migrations/versions/2025-04-13_22-10_378cecfdba9f_merge_x_axis_sort_series_with_x_axis_.py
@@ -65,14 +65,20 @@ def upgrade():
         try:
             params = json.loads(slc.params)
 
+            # x_axis_sort_series only appears when there are multiple metrics or groupby
+            if not (
+                ("metrics" in params and len(params["metrics"]) > 1)
+                or ("groupby" in params and len(params["groupby"]) > 0)
+            ):
+                continue
+
             if "x_axis_sort_series" in params:
                 if params["x_axis_sort_series"]:
                     params["x_axis_sort"] = params["x_axis_sort_series"]
 
                 del params["x_axis_sort_series"]
             if "x_axis_sort_series_ascending" in params:
-                if params["x_axis_sort_series_ascending"]:
-                    params["x_axis_sort_asc"] = params["x_axis_sort_series_ascending"]
+                params["x_axis_sort_asc"] = params["x_axis_sort_series_ascending"]
                 del params["x_axis_sort_series_ascending"]
 
             slc.params = json.dumps(params, sort_keys=True)
@@ -92,19 +98,21 @@ def downgrade():
     ):
         try:
             params = json.loads(slc.params)
-
             # x_axis_sort_series only appears when there are multiple metrics or groupby
-            if ("metrics" in params and len(params["metrics"]) > 1) or (
-                "groupby" in params and len(params["groupby"]) > 0
+            if not (
+                ("metrics" in params and len(params["metrics"]) > 1)
+                or ("groupby" in params and len(params["groupby"]) > 0)
             ):
-                if "x_axis_sort" in params:
-                    params["x_axis_sort_series"] = params["x_axis_sort"]
-                    del params["x_axis_sort"]
-                if "x_axis_sort_asc" in params:
-                    params["x_axis_sort_series_ascending"] = params["x_axis_sort_asc"]
-                    del params["x_axis_sort_asc"]
+                continue
 
-                slc.params = json.dumps(params, sort_keys=True)
+            if "x_axis_sort" in params:
+                params["x_axis_sort_series"] = params["x_axis_sort"]
+                del params["x_axis_sort"]
+            if "x_axis_sort_asc" in params:
+                params["x_axis_sort_series_ascending"] = params["x_axis_sort_asc"]
+                del params["x_axis_sort_asc"]
+
+            slc.params = json.dumps(params, sort_keys=True)
         except Exception:  # noqa: S110
             pass
 


### PR DESCRIPTION
### SUMMARY
Currently in Echarts Series charts, you can only sort X Axis by a specific metric if there is only 1 metric specified and no dimensions. This PR enables sorting x axis by a specific metric when there are more than 1 metrics.
Sorting by a specific metric is still not available when there are dimensions specified.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


https://github.com/user-attachments/assets/025017f6-0f45-423e-beab-6930cd233a1d



### TESTING INSTRUCTIONS
1. Create an echarts series chart, like a bar chart
2. Set a non-temporal x-axis and some metric
3. Verify that you can sort x axis by that metric and x-axis column
4. Add more metrics
5. Verify that you can sort x axis by any of the specified metrics, x-axis column and measures such as total, max, min, average
6. Add a dimension
7. Verify that you can only sort by measures such as total, max, min, average

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided
Current: 0.19 s
10+: 0.21 s
100+: 0.12 s
1000+: 0.20 s
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
