### PR TITLE
fix: send pagination args for download full csv

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -359,6 +359,19 @@ const Chart = props => {
         slice_id: slice.slice_id,
         is_cached: props.isCached,
       });
+      
+      // Need to handle server pagination for full exports
+      let ownStateToUse = props.ownState;
+      
+      // For full CSV exports with server-side pagination, remove pagination parameters
+      if (isFullCSV && formData.server_pagination) {
+        // Create a new object without the pagination parameters
+        ownStateToUse = props.ownState ? { ...props.ownState } : {};
+        // Remove pagination related properties to get a full export
+        delete ownStateToUse.pageSize;
+        delete ownStateToUse.currentPage;
+      }
+      
       exportChart({
         formData: isFullCSV
           ? { ...formData, row_limit: props.maxRows }
@@ -366,7 +379,7 @@ const Chart = props => {
         resultType: isPivot ? 'post_processed' : 'full',
         resultFormat: format,
         force: true,
-        ownState: props.ownState,
+        ownState: ownStateToUse,
       });
     },
     [


### PR DESCRIPTION
This will respect the full csv download feature flag when used alongside the server side pagination of a table chart

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
