### PR TITLE
fix(plugin-chart-table): Don't render redundant items in column config when time comparison is enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -37,15 +37,17 @@ import {
 import {
   ensureIsArray,
   GenericDataType,
+  getMetricLabel,
   isAdhocColumn,
   isPhysicalColumn,
   QueryFormColumn,
+  QueryFormMetric,
   QueryMode,
   SMART_DATE_ID,
   t,
 } from '@superset-ui/core';
 
-import { isEmpty } from 'lodash';
+import { isEmpty, last } from 'lodash';
 import { PAGE_SIZE_OPTIONS } from './consts';
 import { ColorSchemeEnum } from './types';
 
@@ -486,51 +488,69 @@ const config: ControlPanelConfig = {
                 return true;
               },
               mapStateToProps(explore, _, chart) {
-                const timeComparisonStatus = !isEmpty(
-                  explore?.controls?.time_compare?.value,
-                );
-
+                const timeComparisonValue =
+                  explore?.controls?.time_compare?.value;
                 const { colnames: _colnames, coltypes: _coltypes } =
                   chart?.queriesResponse?.[0] ?? {};
                 let colnames: string[] = _colnames || [];
                 let coltypes: GenericDataType[] = _coltypes || [];
                 const childColumnMap: Record<string, boolean> = {};
+                const timeComparisonColumnMap: Record<string, boolean> = {};
 
-                if (timeComparisonStatus) {
+                if (!isEmpty(timeComparisonValue)) {
                   /**
                    * Replace numeric columns with sets of comparison columns.
                    */
                   const updatedColnames: string[] = [];
                   const updatedColtypes: GenericDataType[] = [];
 
-                  colnames.forEach((colname, index) => {
-                    if (coltypes[index] === GenericDataType.Numeric) {
-                      const comparisonColumns =
-                        generateComparisonColumns(colname);
-                      comparisonColumns.forEach((name, idx) => {
-                        updatedColnames.push(name);
-                        updatedColtypes.push(
-                          ...generateComparisonColumnTypes(4),
-                        );
-
-                        if (idx === 0 && name.startsWith('Main ')) {
-                          childColumnMap[name] = false;
-                        } else {
-                          childColumnMap[name] = true;
-                        }
-                      });
-                    } else {
-                      updatedColnames.push(colname);
-                      updatedColtypes.push(coltypes[index]);
-                      childColumnMap[colname] = false;
-                    }
-                  });
+                  colnames
+                    .filter(
+                      colname =>
+                        last(colname.split('__')) !== timeComparisonValue,
+                    )
+                    .forEach((colname, index) => {
+                      if (
+                        explore.form_data.metrics?.some(
+                          metric => getMetricLabel(metric) === colname,
+                        ) ||
+                        explore.form_data.percent_metrics?.some(
+                          (metric: QueryFormMetric) =>
+                            getMetricLabel(metric) === colname,
+                        )
+                      ) {
+                        const comparisonColumns =
+                          generateComparisonColumns(colname);
+                        comparisonColumns.forEach((name, idx) => {
+                          updatedColnames.push(name);
+                          updatedColtypes.push(
+                            ...generateComparisonColumnTypes(4),
+                          );
+                          timeComparisonColumnMap[name] = true;
+                          if (idx === 0 && name.startsWith('Main ')) {
+                            childColumnMap[name] = false;
+                          } else {
+                            childColumnMap[name] = true;
+                          }
+                        });
+                      } else {
+                        updatedColnames.push(colname);
+                        updatedColtypes.push(coltypes[index]);
+                        childColumnMap[colname] = false;
+                        timeComparisonColumnMap[colname] = false;
+                      }
+                    });
 
                   colnames = updatedColnames;
                   coltypes = updatedColtypes;
                 }
                 return {
-                  columnsPropsObject: { colnames, coltypes, childColumnMap },
+                  columnsPropsObject: {
+                    colnames,
+                    coltypes,
+                    childColumnMap,
+                    timeComparisonColumnMap,
+                  },
                 };
               },
             },

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
@@ -38,6 +38,7 @@ export type ColumnConfigControlProps<T extends ColumnConfig> =
       colnames: string[];
       coltypes: GenericDataType[];
       childColumnMap?: Record<string, boolean>;
+      timeComparisonColumnMap?: Record<string, boolean>;
     };
     configFormLayout?: ColumnConfigFormLayout;
     appliedColumnNames?: string[];
@@ -87,6 +88,8 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
         type: coltypes?.[idx],
         config: value?.[col] || {},
         isChildColumn: columnsPropsObject?.childColumnMap?.[col] ?? false,
+        isTimeComparisonColumn:
+          columnsPropsObject?.timeComparisonColumnMap?.[col] ?? false,
       };
     });
     return configs;
@@ -136,7 +139,7 @@ export default function ColumnConfigControl<T extends ColumnConfig>({
             column={col}
             onChange={config => setColumnConfig(col.name, config as T)}
             configFormLayout={
-              col.isChildColumn
+              col.isTimeComparisonColumn
                 ? ({
                     [col.type ?? GenericDataType.String]: [
                       {

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
@@ -41,6 +41,7 @@ export type ColumnConfig = {
  */
 export interface ColumnConfigInfo {
   isChildColumn: boolean;
+  isTimeComparisonColumn: boolean;
   name: string;
   type?: GenericDataType;
   config: JsonObject;


### PR DESCRIPTION
### SUMMARY
In table chart, when time comparison is enabled, we generated some broken column configs.
1. Due to faulty logic, we generated time comparison variants for every numeric column instead of only for metrics
2. We didn't render the "General" tab for the "Main" time comparison column
This PR fixes both issues
Related to PR https://github.com/apache/superset/pull/32975

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/02d856f1-a9b6-4461-b1cc-58c746946db1


After:

https://github.com/user-attachments/assets/1286e128-19d9-4829-95ba-d8baf29cb098



### TESTING INSTRUCTIONS
1. Create a table chart with time comparison
2. Add some numeric columns and metrics
3. Verify that you can customize all 4 time comparison column names for each metric and that there are no redundant, not working column config items

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
