### PR TITLE
fix: app icon should not use subdirectory

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -19,7 +19,6 @@
 import { useState, useEffect } from 'react';
 import { styled, css } from '@superset-ui/core';
 import { debounce } from 'lodash';
-import { assetUrl } from 'src/utils/assetUrl';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { Row, Col, Grid } from 'src/components';
 import { MainNav, MenuMode } from 'src/components/Menu';

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -269,11 +269,11 @@ export function Menu({
           >
             {isFrontendRoute(window.location.pathname) ? (
               <GenericLink className="navbar-brand" to={brand.path}>
-                <img src={assetUrl(brand.icon)} alt={brand.alt} />
+                <img src={brand.icon} alt={brand.alt} />
               </GenericLink>
             ) : (
               <a className="navbar-brand" href={brand.path} tabIndex={-1}>
-                <img src={assetUrl(brand.icon)} alt={brand.alt} />
+                <img src={brand.icon} alt={brand.alt} />
               </a>
             )}
           </Tooltip>

--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DEFAULT_BOOTSTRAP_DATA } from '../constants';
+
+describe('getBootstrapData and helpers', () => {
+  afterEach(() => {
+    // Clean up the DOM
+    document.body.innerHTML = '';
+  });
+
+  describe('getBootstrapData()', () => {
+    it('should return DEFAULT_BOOTSTRAP_DATA when #app element does not exist', async () => {
+      // Ensure no #app element exists.
+      document.body.innerHTML = '';
+
+      // Reset module to clear cachedBootstrapData
+      jest.resetModules();
+      const { default: getBootstrapData } = await import('./getBootstrapData');
+      const bootstrapData = getBootstrapData();
+      expect(bootstrapData).toEqual(DEFAULT_BOOTSTRAP_DATA);
+    });
+
+    it('should return parsed bootstrap data when #app element has valid data attribute', async () => {
+      // Set up the fake #app element
+      const customData = {
+        common: {
+          application_root: '/custom-app/',
+          static_assets_prefix: '/custom-static/',
+        },
+      };
+      document.body.innerHTML = `<div id="app" data-bootstrap='${JSON.stringify(customData)}'></div>`;
+
+      // Reset modules and re-import the module so that cachedBootstrapData is clear.
+      jest.resetModules();
+      const { default: getBootstrapData } = await import('./getBootstrapData');
+      const bootstrapData = getBootstrapData();
+      expect(bootstrapData).toEqual(customData);
+    });
+  });
+
+  describe('Helper functions applicationRoot and staticAssetsPrefix', () => {
+    it('should return values without trailing slashes', async () => {
+      // Setup a fake #app element with data-bootstrap attribute.
+      const customData = {
+        common: {
+          application_root: '/custom-app/',
+          static_assets_prefix: '/custom-static/',
+        },
+      };
+      document.body.innerHTML = `<div id="app" data-bootstrap='${JSON.stringify(customData)}'></div>`;
+
+      // Reset modules and re-import the module so that cachedBootstrapData is clear.
+      jest.resetModules();
+      const {
+        default: getBootstrapData,
+        applicationRoot,
+        staticAssetsPrefix,
+      } = await import('./getBootstrapData');
+
+      // Call getBootstrapData to ensure caching is done.
+      getBootstrapData();
+
+      // The helpers should remove the trailing slash.
+      expect(applicationRoot()).toEqual('/custom-app');
+      expect(staticAssetsPrefix()).toEqual('/custom-static');
+    });
+
+    it('should return defaults without trailing slashes when #app element is missing', async () => {
+      // Ensure no #app element exists.
+      document.body.innerHTML = '';
+
+      // Reset module to clear cachedBootstrapData and re-run computed values.
+      jest.resetModules();
+      const {
+        default: getBootstrapData,
+        applicationRoot,
+        staticAssetsPrefix,
+      } = await import('./getBootstrapData');
+
+      // Call getBootstrapData to ensure caching is done.
+      getBootstrapData();
+
+      // Defaults from DEFAULT_BOOTSTRAP_DATA with trailing slashes removed.
+      const expectedAppRoot =
+        DEFAULT_BOOTSTRAP_DATA.common.application_root.replace(/\/$/, '');
+      const expectedStaticPrefix =
+        DEFAULT_BOOTSTRAP_DATA.common.static_assets_prefix.replace(/\/$/, '');
+
+      expect(applicationRoot()).toEqual(expectedAppRoot);
+      expect(staticAssetsPrefix()).toEqual(expectedStaticPrefix);
+    });
+  });
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of https://github.com/apache/superset/pull/30134 we are adding the static asset url to the brand icon, but since the brand icon is already a separate config `APP_ICON` we don't want to add the static asset url to this existing url, but allow it to be separate. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
