### PR TITLE
fix(echart): Thrown errors shown after resized

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -190,6 +190,10 @@ function Echart(
     }
   }, [didMount, echartOptions, eventHandlers, zrEventHandlers]);
 
+  useEffect(() => {
+    return () => chartRef.current?.dispose();
+  }, []);
+
   // highlighting
   useEffect(() => {
     if (!chartRef.current) return;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -108,12 +108,13 @@ use([
 ]);
 
 const loadLocale = async (locale: string) => {
+  let lang;
   try {
-    const lang = await import(`echarts/lib/i18n/lang${locale}`);
-    return lang?.default;
+    lang = await import(`echarts/lib/i18n/lang${locale}`);
   } catch (e) {
     console.error(`Locale ${locale} not supported in ECharts`, e);
   }
+  return lang?.default;
 };
 
 function Echart(
@@ -184,15 +185,16 @@ function Echart(
       });
 
       chartRef.current?.setOption(echartOptions, true);
-
-      // did mount
-      handleSizeChange({ width, height });
     }
   }, [didMount, echartOptions, eventHandlers, zrEventHandlers]);
 
+  // did mount
   useEffect(() => {
+    if (didMount) {
+      handleSizeChange({ width, height });
+    }
     return () => chartRef.current?.dispose();
-  }, []);
+  }, [didMount]);
 
   // highlighting
   useEffect(() => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -185,16 +185,13 @@ function Echart(
       });
 
       chartRef.current?.setOption(echartOptions, true);
+
+      // did mount
+      handleSizeChange({ width, height });
     }
   }, [didMount, echartOptions, eventHandlers, zrEventHandlers]);
 
-  // did mount
-  useEffect(() => {
-    if (didMount) {
-      handleSizeChange({ width, height });
-    }
-    return () => chartRef.current?.dispose();
-  }, [didMount]);
+  useEffect(() => () => chartRef.current?.dispose(), []);
 
   // highlighting
   useEffect(() => {


### PR DESCRIPTION
### SUMMARY
With the introduction of the hotfix related to the #31751 ECharts locale, the `init` and `setOption` blocks of ECharts were moved into an `async` block. This caused an issue where errors occurring during the `setOption` process were not passed to the `react-error-boundary`.
To address this issue, this commit separated the locale's async loading process into a separate async block and added a `didMount` state to ensure that the chart options are properly applied.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/b77529a4-54fd-4fd8-a45e-eaf3c592ede8

After:

https://github.com/user-attachments/assets/9720901d-0c8a-48c7-9ead-ef39be1b63fd


### TESTING INSTRUCTIONS
Create a sankey chart including a cycle data
The error should be shown after rendering

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
