### PR TITLE
fix: set sideEffect:false in package.json

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -36,6 +36,7 @@
     "plugins/*",
     "src/setup/*"
   ],
+  "sideEffects": false,
   "scripts": {
     "_prettier": "prettier './({src,spec,cypress-base,plugins,packages,.storybook}/**/*{.js,.jsx,.ts,.tsx,.css,.less,.scss,.sass}|package.json)'",
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 NODE_ENV=production BABEL_ENV=\"${BABEL_ENV:=production}\" webpack --color --mode production",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -246,7 +246,6 @@ const config = {
     },
   },
   optimization: {
-    sideEffects: true,
     splitChunks: {
       chunks: 'all',
       // increase minSize for devMode to 1000kb because of sourcemap


### PR DESCRIPTION
Was reading recently about how modern tree-shaking 💨🌳🍂 works in modern web apps, and the `sideEffect` property in `package.json` was mentionned so I checked to see our settings.

Apparently we don't have it set right - unless I'm missing something - so I decided to open a DRAFT PR to test things and have the conversation.

Apparently the `sideEffect` we have in `webpack.config.js` is probably an artifact/legacy from a previous era. Nowadays npm packages should define weather/which sideEffect they contain as a hint for the bundler to tree-shake the right things.

Anyhow, let's see if this builds and passes CI.

Doing some git archeology, it looks like this was added back in 2020 ->
https://github.com/apache/superset/commit/9bdfa055ac0#diff-3834c36280e1af5685801f3357578aaec5a110699a2b8eb97844c56b4400c091R197
