### PR TITLE
fix: os.makedirs race condition

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -88,8 +88,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         """
         wtforms_json.init()
 
-        if not os.path.exists(self.config["DATA_DIR"]):
-            os.makedirs(self.config["DATA_DIR"])
+        os.makedirs(self.config["DATA_DIR"], exist_ok=True)
 
     def post_init(self) -> None:
         """


### PR DESCRIPTION
### SUMMARY
We found an error in our logs causing the restarts of kubernetes containers. It is infrequent but does happen on occasion. The error message is `FileExistsError: [Errno 17] File exists: '/home/pod_user/.superset'`. The error can occur due to a race condition when multiple processes or threads (in this case, Kubernetes pods) attempt to create the same directory at the same time.

### TESTING INSTRUCTIONS
This is an intermittent issue. The attempted fix uses exist_ok which should be thread safe enough for this use case. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
