### PR TITLE
fix(sqllab): Invalid SQL Error breaks SQL Lab

### DIFF
--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
@@ -36,6 +36,21 @@ const defaultProps = {
   subtitle: 'Test subtitle',
 };
 
+const missingExtraProps = {
+  ...defaultProps,
+  error: {
+    error_type: ErrorTypeEnum.INVALID_SQL_ERROR,
+    message: 'SQLStatement should have exactly one statement',
+    level: 'error' as ErrorLevel,
+    extra: {
+      sql: null,
+      line: null,
+      column: null,
+      engine: null,
+    },
+  },
+};
+
 const renderComponent = (overrides = {}) =>
   render(<InvalidSQLErrorMessage {...defaultProps} {...overrides} />);
 
@@ -58,6 +73,12 @@ describe('InvalidSQLErrorMessage', () => {
     expect(getByText('SELECT * FFROM table')).toBeInTheDocument();
 
     unmount();
+  });
+
+  it('renders the error message with the empty extra properties', () => {
+    const { getByText } = renderComponent(missingExtraProps);
+    expect(getByText('Unable to parse SQL')).toBeInTheDocument();
+    expect(getByText(missingExtraProps.error.message)).toBeInTheDocument();
   });
 
   it('displays the SQL error line and column indicator', async () => {

--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.tsx
@@ -36,20 +36,22 @@ function InvalidSQLErrorMessage({
   source,
   subtitle,
 }: ErrorMessageComponentProps<SupersetParseErrorExtra>) {
-  const { extra, level } = error;
+  const { extra, level, message } = error;
 
   const { sql, line, column } = extra;
-  const lines = sql.split('\n');
+  const lines = sql?.split('\n');
   let errorLine;
-  if (line !== null) errorLine = lines[line - 1];
-  else if (lines.length > 0) {
+  if (line !== null && Number.isInteger(line)) errorLine = lines[line - 1];
+  else if (lines?.length > 0) {
     errorLine = lines[0];
   }
-  const body = errorLine && (
+  const body = errorLine ? (
     <>
       <pre>{errorLine}</pre>
       {column !== null && <pre>{' '.repeat(column - 1)}^</pre>}
     </>
+  ) : (
+    message
   );
   return (
     <ErrorAlert

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -277,7 +277,7 @@ class ParsedQuery:
                         "You may have an error in your SQL statement. {message}"
                     ).format(message=ex.error.message),
                     level=ErrorLevel.ERROR,
-                    extra=ex.error.extra
+                    extra=ex.error.extra,
                 )
             ) from ex
 

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -277,6 +277,7 @@ class ParsedQuery:
                         "You may have an error in your SQL statement. {message}"
                     ).format(message=ex.error.message),
                     level=ErrorLevel.ERROR,
+                    extra=ex.error.extra
                 )
             ) from ex
 


### PR DESCRIPTION
### SUMMARY
The InvalidSQLError message introduced in #30501 had an issue where, in certain [cases](https://github.com/apache/superset/blob/master/superset/sql/parse.py#L342), if the extra payload was not included, it would cause a page error instead of displaying the error message.
This commit fixes the issue by ensuring the error message is displayed without errors in such cases.
Additionally, this commit fixed the existing INVALID_SQL_ERROR block where the extra payload was missing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/02731178-fca7-4785-989c-c3560e55c768

After:

https://github.com/user-attachments/assets/81ee6e51-31d0-4662-aebf-ebb4e056b7a4


### TESTING INSTRUCTIONS
specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
