### PR TITLE
chore: bump marshmallow-sqlalchemy>=1.4.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,8 +28,4 @@ async_timeout>=4.0.0,<5.0.0
 # a bit of attention to bump.
 apispec>=6.0.0,<6.7.0
 
-# 1.4.1 appears to use much more memory, where the python test suite runs out of memory
-# causing CI to fail. 1.4.0 is the last version that works.
-# https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html#id3
-# Opened this issue https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/665
-marshmallow-sqlalchemy>=1.3.0,<1.4.1
+marshmallow-sqlalchemy>=1.4.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,9 +11,7 @@ apispec==6.6.1
 apsw==3.49.1.0
     # via shillelagh
 async-timeout==4.0.3
-    # via
-    #   -r requirements/base.in
-    #   redis
+    # via -r requirements/base.in
 attrs==25.3.0
     # via
     #   cattrs
@@ -99,11 +97,6 @@ email-validator==2.2.0
     # via flask-appbuilder
 et-xmlfile==2.0.0
     # via openpyxl
-exceptiongroup==1.2.2
-    # via
-    #   cattrs
-    #   trio
-    #   trio-websocket
 flask==2.3.3
     # via
     #   apache-superset (pyproject.toml)
@@ -215,7 +208,7 @@ marshmallow==3.26.1
     # via
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.0
+marshmallow-sqlalchemy==1.4.2
     # via
     #   -r requirements/base.in
     #   flask-appbuilder
@@ -391,11 +384,9 @@ typing-extensions==4.12.2
     # via
     #   apache-superset (pyproject.toml)
     #   alembic
-    #   cattrs
     #   limits
     #   pyopenssl
     #   referencing
-    #   rich
     #   selenium
     #   shillelagh
 tzdata==2025.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -18,10 +18,6 @@ apsw==3.49.1.0
     # via
     #   -c requirements/base.txt
     #   shillelagh
-async-timeout==4.0.3
-    # via
-    #   -c requirements/base.txt
-    #   redis
 attrs==25.3.0
     # via
     #   -c requirements/base.txt
@@ -176,13 +172,6 @@ et-xmlfile==2.0.0
     # via
     #   -c requirements/base.txt
     #   openpyxl
-exceptiongroup==1.2.2
-    # via
-    #   -c requirements/base.txt
-    #   cattrs
-    #   pytest
-    #   trio
-    #   trio-websocket
 filelock==3.12.2
     # via virtualenv
 flask==2.3.3
@@ -434,7 +423,7 @@ marshmallow==3.26.1
     #   -c requirements/base.txt
     #   flask-appbuilder
     #   marshmallow-sqlalchemy
-marshmallow-sqlalchemy==1.4.0
+marshmallow-sqlalchemy==1.4.2
     # via
     #   -c requirements/base.txt
     #   flask-appbuilder
@@ -819,10 +808,6 @@ tabulate==0.8.10
     # via
     #   -c requirements/base.txt
     #   apache-superset
-tomli==2.2.1
-    # via
-    #   coverage
-    #   pytest
 tqdm==4.67.1
     # via
     #   cmdstanpy
@@ -843,11 +828,9 @@ typing-extensions==4.12.2
     #   -c requirements/base.txt
     #   alembic
     #   apache-superset
-    #   cattrs
     #   limits
     #   pyopenssl
     #   referencing
-    #   rich
     #   selenium
     #   shillelagh
 tzdata==2025.1


### PR DESCRIPTION
Last time I was bumping python lib I ran into an issue with marshmallow-sqlalchemy==1.4.1 that would fail our CI, so I did some work in their repo to fix some memory misuse stuff.

Hoping we're on the other side of this issue with 1.4.2 🤞
