### PR TITLE
feat(ci): flag chart metadata changes via labeler

### DIFF
--- a/.github/workflows/metadata-backward-compatibility.yml
+++ b/.github/workflows/metadata-backward-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
             CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
             echo "Changed files: $CHANGED_FILES"
 
-            if echo "$CHANGED_FILES" | grep -qE '^superset-frontend/plugins/.*/transformProps'; then
+            if echo "$CHANGED_FILES" | grep -qE '^superset-frontend/plugins/.*/(transformProps|controlPanel)'; then
                 echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=true" >> $GITHUB_ENV
             else
                 echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=false" >> $GITHUB_ENV
@@ -50,9 +50,9 @@ jobs:
                 if (!validationLabelPresent) {
                     core.setFailed(
                         [
-                            "🚨 We have identified potential changes to the chart metadata in `transformProps`.",
-                            "⚠️ This could affect backward compatibility.",
-                            "✅ To proceed, please review your changes and add the label:",
+                            "🚨 Identified potential changes to the chart metadata in `transformProps` or `controlPanel`.",
+                            "⚠️ Such changes may affect backward compatibility and cause charts dependent on previous metadata to break.",
+                            "✅ To proceed, please review your changes to confirm backward-compatibility and add the label:",
                             "`validation:backward-compatible`",
                         ].join("\n")
                     );

--- a/.github/workflows/metadata-backward-compatibility.yml
+++ b/.github/workflows/metadata-backward-compatibility.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "[0-9].[0-9]*"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -39,13 +39,19 @@ jobs:
             else
                 echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=false" >> $GITHUB_ENV
             fi
-      - name: "Enforce backward compatibility label"
+
+      - name: "Check for 'validation:backward-compatible' label"
         if: env.BACKWARD_COMPATIBILITY_CHECK_FAILED == 'true'
-        run: |
-          echo "🚨 Please add the label 'validation:backward-compatible' to confirm chart metadata backward compatibility."
-          exit 1
+        uses: actions/github-script@v7
+        with:
+            script: |
+                const payload = context.payload.pull_request;
+                const validationLabelPresent = !!payload.labels.find(label => label.name.includes('validation:backward-compatible'));
+                if (!validationLabelPresent) {
+                    core.setFailed("🚨 Please add the label 'validation:backward-compatible' to confirm chart metadata backward compatibility.");
+                }
 
       - name: "Continue with other checks"
         if: env.BACKWARD_COMPATIBILITY_CHECK_FAILED == 'false'
         run: |
-          echo "✅ No chart metadata backward compatibility issues detected. Proceeding with further checks."
+            echo "✅ No chart metadata backward compatibility issues detected. Proceeding with further checks."

--- a/.github/workflows/metadata-backward-compatibility.yml
+++ b/.github/workflows/metadata-backward-compatibility.yml
@@ -32,7 +32,7 @@ jobs:
         id: check_changes
         run: |
             CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
-            echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+            echo "Changed files: $CHANGED_FILES"
 
             if echo "$CHANGED_FILES" | grep -qE '^superset-frontend/plugins/.*/transformProps'; then
                 echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=true" >> $GITHUB_ENV

--- a/.github/workflows/metadata-backward-compatibility.yml
+++ b/.github/workflows/metadata-backward-compatibility.yml
@@ -48,7 +48,14 @@ jobs:
                 const payload = context.payload.pull_request;
                 const validationLabelPresent = !!payload.labels.find(label => label.name.includes('validation:backward-compatible'));
                 if (!validationLabelPresent) {
-                    core.setFailed("🚨 Please add the label 'validation:backward-compatible' to confirm chart metadata backward compatibility.");
+                    core.setFailed(
+                        [
+                            "🚨 We have identified potential changes to the chart metadata in `transformProps`.",
+                            "⚠️ This could affect backward compatibility.",
+                            "✅ To proceed, please review your changes and add the label:",
+                            "`validation:backward-compatible`",
+                        ].join("\n")
+                    );
                 }
 
       - name: "Continue with other checks"

--- a/.github/workflows/metadata-backward-compatibility.yml
+++ b/.github/workflows/metadata-backward-compatibility.yml
@@ -1,0 +1,51 @@
+name: "Chart Metadata Backward Compatibility Check"
+
+on:
+  push:
+    branches:
+      - "master"
+      - "[0-9].[0-9]*"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  backward-compatibility-check:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+            persist-credentials: false
+            submodules: recursive
+
+      - name: "Set up Git"
+        run: |
+          git fetch origin master
+
+      - name: "Check for changes in critical files"
+        id: check_changes
+        run: |
+            CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
+            echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+
+            if echo "$CHANGED_FILES" | grep -qE '^superset-frontend/plugins/.*/transformProps'; then
+                echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=true" >> $GITHUB_ENV
+            else
+                echo "BACKWARD_COMPATIBILITY_CHECK_FAILED=false" >> $GITHUB_ENV
+            fi
+      - name: "Enforce backward compatibility label"
+        if: env.BACKWARD_COMPATIBILITY_CHECK_FAILED == 'true'
+        run: |
+          echo "🚨 Please add the label 'validation:backward-compatible' to confirm chart metadata backward compatibility."
+          exit 1
+
+      - name: "Continue with other checks"
+        if: env.BACKWARD_COMPATIBILITY_CHECK_FAILED == 'false'
+        run: |
+          echo "✅ No chart metadata backward compatibility issues detected. Proceeding with further checks."

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -185,8 +185,6 @@ export default function transformProps(chartProps: ChartProps) {
     valueDifference,
     percentDifferenceFormattedString: percentDifference,
     boldText,
-    subtitle,
-    subtitleFontSize,
     headerFontSize: getHeaderFontSize(headerFontSize),
     subheaderFontSize: getComparisonFontSize(subheaderFontSize),
     headerText,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/transformProps.ts
@@ -185,6 +185,8 @@ export default function transformProps(chartProps: ChartProps) {
     valueDifference,
     percentDifferenceFormattedString: percentDifference,
     boldText,
+    subtitle,
+    subtitleFontSize,
     headerFontSize: getHeaderFontSize(headerFontSize),
     subheaderFontSize: getComparisonFontSize(subheaderFontSize),
     headerText,


### PR DESCRIPTION
### SUMMARY

A chart's `controlPanel` declares the `form_data` keys that get persisted on every slice using it, and its `transformProps` reads those keys back at render time. Changing either can silently break charts and dashboards that were saved against the previous shape, and nothing surfaces that risk during review.

This adds a `risk:chart-metadata` entry to `.github/labeler.yml`, so the `actions/labeler` run we already have flags any PR touching chart metadata — alongside the `risk:db-migration` and `risk:ci-script` warnings already in that file.

Coverage spans chart plugins, native filters, chart customizations and TimeTable, which all register through the same plugin API, plus the shared control panel sections. Native filter config is persisted into dashboard `json_metadata`, so it carries the same risk.

| Glob | Matches |
| --- | --- |
| `superset-frontend/**/{controlPanel,transformProps}.{ts,tsx}` | 125 files — chart plugins at any nesting depth, native filters, chart customizations |
| `superset-frontend/**/config/{controlPanel,transformProps}/index.ts` | TimeTable's config barrels |
| `superset-frontend/src/explore/controlPanels/**` | shared control panel sections |

131 files in total. The globs match metadata files by exact name, so unit tests like `test/transformProps.test.ts` don't trigger the label — the one exception is `explore/controlPanels/Separator.test.ts`, which sits in a directory that is otherwise entirely metadata.

`risk:chart-metadata` doesn't exist on the repo yet. `actions/labeler` will auto-create it, but as an undescribed grey label, so it's worth creating properly first:

```
gh label create "risk:chart-metadata" --repo apache/superset --color e67e22 \
  --description "PR changes a chart's controlPanel/transformProps; needs backward-compatibility review"
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI config only, no UI change.

### TESTING INSTRUCTIONS

`actions/labeler` runs on `pull_request_target`, so the new entry only takes effect once this is on `master` — it can't label this PR itself. To verify the globs without merging, run them through `minimatch`, which is what the pinned action uses internally:

```bash
npm i minimatch js-yaml
node -e "
const {Minimatch}=require('minimatch'), yaml=require('js-yaml'), fs=require('fs');
const globs=yaml.load(fs.readFileSync('.github/labeler.yml','utf8'))['risk:chart-metadata'][0]['changed-files'][0]['any-glob-to-any-file'];
const ms=globs.map(g=>new Minimatch(g,{dot:true}));
require('child_process').execSync('git ls-files').toString().trim().split('\n')
  .filter(f=>ms.some(m=>m.match(f))).forEach(f=>console.log(f));
"
```

Expect 131 files, no `.test.` files other than `Separator.test.ts`. Spot checks:

- `superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx` → labeled
- `superset-frontend/src/filters/components/Select/controlPanel.ts` → labeled
- `superset-frontend/plugins/plugin-chart-country-map/test/transformProps.test.ts` → not labeled
- `superset-frontend/src/explore/components/ControlPanelsContainer.tsx` → not labeled

After merge, open any PR touching a plugin's `controlPanel` and confirm the label lands.

### ADDITIONAL INFORMATION

<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
