### PR TITLE
fix(open-api): Add missing FormatQueryPayloadSchema and DashboardScreenshotPostSchema to open-api component schemas

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -99,6 +99,7 @@ from superset.dashboards.schemas import (
     screenshot_query_schema,
     TabsPayloadSchema,
     thumbnail_query_schema,
+    DashboardScreenshotPostSchema,
 )
 from superset.extensions import event_logger
 from superset.models.dashboard import Dashboard
@@ -310,6 +311,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         TabsPayloadSchema,
         GetFavStarIdsSchema,
         EmbeddedDashboardResponseSchema,
+        DashboardScreenshotPostSchema,
     )
     apispec_parameter_schemas = {
         "get_delete_ids_schema": get_delete_ids_schema,

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -89,6 +89,7 @@ from superset.dashboards.schemas import (
     DashboardNativeFiltersConfigUpdateSchema,
     DashboardPostSchema,
     DashboardPutSchema,
+    DashboardScreenshotPostSchema,
     EmbeddedDashboardConfigSchema,
     EmbeddedDashboardResponseSchema,
     get_delete_ids_schema,
@@ -99,7 +100,6 @@ from superset.dashboards.schemas import (
     screenshot_query_schema,
     TabsPayloadSchema,
     thumbnail_query_schema,
-    DashboardScreenshotPostSchema,
 )
 from superset.extensions import event_logger
 from superset.models.dashboard import Dashboard

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -89,6 +89,7 @@ class SqlLabRestApi(BaseSupersetApi):
     openapi_spec_component_schemas = (
         EstimateQueryCostSchema,
         ExecutePayloadSchema,
+        FormatQueryPayloadSchema,
         QueryExecutionResponseSchema,
         SQLLabBootstrapSchema,
     )


### PR DESCRIPTION
### SUMMARY
FormatQueryPayloadSchema and DashboardScreenshotPostSchema were missing from the open-api spec component schemas which made the open-api invalid.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://github.com/user-attachments/assets/4b5c2d1f-aa0d-41eb-b9af-85f5ea98af7d)
![image](https://github.com/user-attachments/assets/0587f027-13aa-4966-abde-a3953afbaaf3)


After:
![image](https://github.com/user-attachments/assets/1aab5b85-f6ca-4305-b08a-8f31ed524865)
![image](https://github.com/user-attachments/assets/7feab8bd-683b-4ad0-bb69-493ab4f02842)


### TESTING INSTRUCTIONS
Check that FormatQueryPayloadSchema and DashboardScreenshotPostSchema now exists in open0api spec.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
