### PR TITLE
fix(Native Filters): Keep default filter values when configuring creatable behavior

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -46,6 +46,7 @@ export const FilterTitle = styled.div`
         }
       }
       &.errored div, &.errored .warning {
+        align-items: center;
         color: ${theme.colors.error.base};
       }
   `}
@@ -120,7 +121,7 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
               {isRemoved ? t('(Removed)') : getFilterTitle(id)}
             </div>
             {!removedFilters[id] && isErrored && (
-              <StyledWarning className="warning" />
+              <StyledWarning className="warning" iconSize="s" />
             )}
             {isRemoved && (
               <span

--- a/superset-frontend/src/filters/components/Select/controlPanel.ts
+++ b/superset-frontend/src/filters/components/Select/controlPanel.ts
@@ -74,7 +74,6 @@ const config: ControlPanelConfig = {
               type: 'CheckboxControl',
               label: t('Allow creation of new values'),
               default: creatable,
-              resetConfig: true,
               affectsDataMask: true,
               renderTrigger: true,
             },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR https://github.com/apache/superset/pull/33096 introduced a creatable configuration for Select. However, default filters would reset when changing the option. This PR should fix the issue while also fixing the warning icon that looked off.

### BEFORE

https://github.com/user-attachments/assets/c2b4d65e-c334-4084-b439-839d44b87cdf

### AFTER

https://github.com/user-attachments/assets/7b5a0639-f1d3-4246-a7b4-5fe7223ee39c

### TESTING INSTRUCTIONS
1. Open a Dashboard and set a native filter with default values
2. Toggle the creatable behavior on and off
3. Default values should stay

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
