### PR TITLE
Potential fix for code scanning alert no. 2006: DOM text reinterpreted as HTML

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -214,7 +214,8 @@
     "use-event-callback": "^0.1.0",
     "use-immer": "^0.9.0",
     "use-query-params": "^1.1.9",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "dompurify": "^3.2.5"
   },
   "devDependencies": {
     "@applitools/eyes-storybook": "^3.50.9",

--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { BootstrapData } from 'src/types/bootstrapTypes';
+import DOMPurify from 'dompurify';
 import { DEFAULT_BOOTSTRAP_DATA } from 'src/constants';
 
 let cachedBootstrapData: BootstrapData | null = null;
@@ -25,8 +26,11 @@ export default function getBootstrapData(): BootstrapData {
   if (cachedBootstrapData === null) {
     const appContainer = document.getElementById('app');
     const dataBootstrap = appContainer?.getAttribute('data-bootstrap');
-    cachedBootstrapData = dataBootstrap
-      ? JSON.parse(dataBootstrap)
+    const sanitizedDataBootstrap = dataBootstrap
+      ? DOMPurify.sanitize(dataBootstrap)
+      : null;
+    cachedBootstrapData = sanitizedDataBootstrap
+      ? JSON.parse(sanitizedDataBootstrap)
       : DEFAULT_BOOTSTRAP_DATA;
   }
   // Add a fallback to ensure the returned value is always of type BootstrapData

--- a/superset-frontend/src/utils/pathUtils.ts
+++ b/superset-frontend/src/utils/pathUtils.ts
@@ -24,5 +24,6 @@ import { applicationRoot } from 'src/utils/getBootstrapData';
  * @param path A string path to a resource
  */
 export function ensureAppRoot(path: string): string {
-  return `${applicationRoot()}${path.startsWith('/') ? path : `/${path}`}`;
+  const fullPath = `${applicationRoot()}${path.startsWith('/') ? path : `/${path}`}`;
+  return encodeURI(fullPath);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/apache/superset/security/code-scanning/2006](https://github.com/apache/superset/security/code-scanning/2006)

To fix the issue, we need to sanitize the `data-bootstrap` attribute before using it. This can be achieved by escaping special characters or validating the input to ensure it conforms to expected patterns. Additionally, we should ensure that any URLs constructed using `ensureAppRoot` are properly encoded to prevent XSS.

1. Modify the `getBootstrapData` function to sanitize the `data-bootstrap` attribute when it is read from the DOM.
2. Update the `ensureAppRoot` function to encode the constructed URL to ensure it is safe for use in navigation functions.
3. Use a utility function like `encodeURIComponent` or a library like `DOMPurify` to sanitize and encode the data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
