### PR TITLE
fix(export): Full CSV/Excel exports respecting SQL_MAX_ROW config

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -150,6 +150,9 @@ const Chart = props => {
   const emitCrossFilters = useSelector(
     state => !!state.dashboardInfo.crossFiltersEnabled,
   );
+  const maxRows = useSelector(
+    state => state.dashboardInfo.common.conf.SQL_MAX_ROW,
+  );
   const datasource = useSelector(
     state =>
       (chart &&
@@ -360,9 +363,7 @@ const Chart = props => {
         is_cached: props.isCached,
       });
       exportChart({
-        formData: isFullCSV
-          ? { ...formData, row_limit: props.maxRows }
-          : formData,
+        formData: isFullCSV ? { ...formData, row_limit: maxRows } : formData,
         resultType: isPivot ? 'post_processed' : 'full',
         resultFormat: format,
         force: true,

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
@@ -34,7 +34,7 @@ const props = {
   height: 100,
   updateSliceName() {},
   // from redux
-  maxRows: 666,
+  maxRows: 500, // will be overwritten with SQL_MAX_ROW from conf
   formData: chartQueries[queryId].form_data,
   datasource: mockDatasource[sliceEntities.slices[queryId].datasource],
   sliceName: sliceEntities.slices[queryId].slice_name,
@@ -78,7 +78,7 @@ const defaultState = {
     superset_can_explore: false,
     superset_can_share: false,
     superset_can_csv: false,
-    common: { conf: { SUPERSET_WEBSERVER_TIMEOUT: 0 } },
+    common: { conf: { SUPERSET_WEBSERVER_TIMEOUT: 0, SQL_MAX_ROW: 666 } },
   },
 };
 


### PR DESCRIPTION
### SUMMARY
Superset provides two CSV/Excel export options:
* **Export to .CSV/Excel**: Downloads the chart data (respecting the chart's row limit).
* **Export to full .CSV/Excel**: This option is behind the `ALLOW_FULL_CSV_EXPORT` FF (disabled by default) and only available to Table charts. It would download all data from the chart query (up to the `SQL_MAX_ROW` config).

The full download was not working properly and instead of getting the `SQL_MAX_ROW` limit, it was getting a default limit of `5000`.

This is a follow up to https://github.com/apache/superset/pull/31241 and https://github.com/apache/superset/pull/31720, to fix this flow so that the full download respects the `SQL_MAX_ROW` coinfig.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

Before this change, **Export to full .CSV/Excel** results in a file with <= 5k rows. Now, it results in a file with <= `SQL_MAX_ROW` rows.

### TESTING INSTRUCTIONS
Updated one frontend test. For manual testing:
1. Enable the `ALLOW_FULL_CSV_EXPORT` FF.
2. Set `SQL_MAX_ROW` to `100000`.
3. Create a table chart using the `flights` dataset with the row limit set to `15000` and add it to a dashboard.
4. Access the dashboard.
5. Click on the chart menu, then **Download > Export to .CSV**. Validate the file includes 15k rows of data.
6. Click on the chart menu, then **Download > Export to full .CSV**. Validate the file includes ~55k rows of data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
