### PR TITLE
fix: Temporal filter conversion in viz migrations

### DIFF
--- a/tests/unit_tests/migrations/viz/time_related_fields_test.py
+++ b/tests/unit_tests/migrations/viz/time_related_fields_test.py
@@ -21,7 +21,7 @@ from tests.unit_tests.migrations.viz.utils import migrate_and_assert
 
 SOURCE_FORM_DATA: dict[str, Any] = {
     "granularity_sqla": "ds",
-    "time_range": "100 years ago : now",
+    "time_range": "100 years ago : today",
     "viz_type": "pivot_table",
 }
 
@@ -29,7 +29,7 @@ TARGET_FORM_DATA: dict[str, Any] = {
     "form_data_bak": SOURCE_FORM_DATA,
     "granularity_sqla": "ds",
     "rowOrder": "value_z_to_a",
-    "time_range": "100 years ago : now",
+    "time_range": "100 years ago : today",
     "viz_type": "pivot_table_v2",
 }
 
@@ -40,7 +40,7 @@ def test_migration() -> None:
     target["adhoc_filters"] = [
         {
             "clause": "WHERE",
-            "comparator": "100 years ago : now",
+            "comparator": "100 years ago : today",
             "expressionType": "SIMPLE",
             "operator": "TEMPORAL_RANGE",
             "subject": "ds",
@@ -65,7 +65,10 @@ def test_custom_sql_time_column() -> None:
             "comparator": None,
             "expressionType": "SQL",
             "operator": "TEMPORAL_RANGE",
-            "sqlExpression": "sum(ds)",
+            "sqlExpression": (
+                "sum(ds) >= '1925-04-24T00:00:00' AND "
+                "sum(ds) < '2025-04-24T00:00:00'"
+            ),
             "subject": "ds",
         }
     ]

--- a/tests/unit_tests/migrations/viz/time_related_fields_test.py
+++ b/tests/unit_tests/migrations/viz/time_related_fields_test.py
@@ -66,8 +66,7 @@ def test_custom_sql_time_column() -> None:
             "expressionType": "SQL",
             "operator": "TEMPORAL_RANGE",
             "sqlExpression": (
-                "sum(ds) >= '1925-04-24T00:00:00' AND "
-                "sum(ds) < '2025-04-24T00:00:00'"
+                "sum(ds) >= '1925-04-24T00:00:00' AND sum(ds) < '2025-04-24T00:00:00'"
             ),
             "subject": "ds",
         }


### PR DESCRIPTION
### SUMMARY
This PR fixes a bug with the conversion of legacy temporal columns to filters that happens during viz migrations. The problem occurred when generating the filter SQL expression from a custom SQL column. Previously, the SQL expression was missing the time ranges resulting in invalid WHERE clauses.

### TESTING INSTRUCTIONS
Create a legacy chart with a temporal column that uses custom SQL and use the CLI to migrate the viz.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
