### PR TITLE
chore: remove python3 install step from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ######################################################################
 # Node stage to deal with static asset construction
 ######################################################################
-ARG PY_VER=3.11.11-slim-bookworm
+ARG PY_VER=3.11.12-slim-bookworm
 
 # If BUILDPLATFORM is null, set it to 'amd64' (or leave as is otherwise).
 ARG BUILDPLATFORM=${BUILDPLATFORM:-amd64}
@@ -32,15 +32,17 @@ ARG BUILD_TRANSLATIONS="false"
 FROM --platform=${BUILDPLATFORM} node:20-bookworm-slim AS superset-node-ci
 ARG BUILD_TRANSLATIONS
 ENV BUILD_TRANSLATIONS=${BUILD_TRANSLATIONS}
-ARG DEV_MODE="false"           # Skip frontend build in dev mode
+# Skip frontend build in dev mode
+ARG DEV_MODE="false"
 ENV DEV_MODE=${DEV_MODE}
+ENV PYTHON=/usr/local/bin/python3
 
 COPY docker/ /app/docker/
 # Arguments for build configuration
 ARG NPM_BUILD_CMD="build"
 
 # Install system dependencies required for node-gyp
-RUN /app/docker/apt-install.sh build-essential python3 zstd
+RUN /app/docker/apt-install.sh build-essential zstd
 
 # Define environment variables for frontend build
 ENV BUILD_CMD=${NPM_BUILD_CMD} \


### PR DESCRIPTION
### SUMMARY
Currently we're doing `apt-get install python3`, which pulls in the default python 3 runtime. In the case of bookworm, it means pulling in 3.11. If you're using a 3.10 image, e.g. `3.10.17-bookworm`, you'll end up with the following:
```bash
$ python3<tab>
python3            python3-config     python3.10         python3.10-config  python3.11
$ which python3.11
/usr/bin/python3.11
$ which python3.10
/usr/local/bin/python3.10
```

Aapparently `python3` was pulled in to make `node-gyp` work.

This isn't great, as it both bloats the image size, and exposes the image to CVEs on whichever version `python3` is pulling in. As per the `node-gyp` docs (https://github.com/nodejs/node-gyp):
> If the PYTHON environment variable is set to the path of a Python executable, then that version will be used if it is a supported version.

This PR does the following:
- Bumps the base image to the latest version `3.11.12-slim-bookworm`
- removes the explicit `apt-get install python3` step
- Adds the `PYTHON` env var to appease `node-gyp`
- Moves a comment to the previous line (a linter was complaining about inlining it on the same line as the actual command)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
