### PR TITLE
fix(standalone): Ensure correct URL param value for standalone mode

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -135,7 +135,7 @@ class Superset(BaseSupersetView):
         endpoint_params = {"form_data": f"{form_data}"}
 
         if ReservedUrlParameters.is_standalone_mode():
-            endpoint_params[ReservedUrlParameters.STANDALONE] = "true"
+            endpoint_params[ReservedUrlParameters.STANDALONE.value] = "true"
         return redirect(url_for("ExploreView.root", **endpoint_params))
 
     def get_query_string_response(self, viz_obj: BaseViz) -> FlaskResponse:


### PR DESCRIPTION
### SUMMARY
In order to generate a chart screenshot via async mode, the celery worker accesses `https://${SUPERSET_DOMAIN}/superset/slice/${ID}/?standalone=true`. We have logic in place to add the `form_data` to the query parameters, and also persist the `standalone` parameter. The latter was done by getting the parameter name from an `Enum`.

The logic was currently not explicitly accessing the Enum's `.value`, which would not work properly for older Python versions (for example, `3.10.x`).

This PR should enforce we're using it's value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Run Superset with Python `3.10.x` and validate that downloading a chart screenshot via the API works properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
