### PR TITLE
fix(sqllab permalink): Commit SQL Lab permalinks

### DIFF
--- a/superset/commands/sql_lab/permalink/create.py
+++ b/superset/commands/sql_lab/permalink/create.py
@@ -15,14 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
+from functools import partial
 from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
 
 from superset import db
 from superset.commands.sql_lab.permalink.base import BaseSqlLabPermalinkCommand
 from superset.daos.key_value import KeyValueDAO
-from superset.key_value.exceptions import KeyValueCodecEncodeException
+from superset.key_value.exceptions import (
+    KeyValueCodecEncodeException,
+    KeyValueCreateFailedError,
+)
 from superset.key_value.utils import encode_permalink_key
 from superset.sqllab.permalink.exceptions import SqlLabPermalinkCreateFailedError
+from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -31,19 +38,25 @@ class CreateSqlLabPermalinkCommand(BaseSqlLabPermalinkCommand):
     def __init__(self, state: dict[str, Any]):
         self._properties = state.copy()
 
+    @transaction(
+        on_error=partial(
+            on_error,
+            catches=(
+                KeyValueCodecEncodeException,
+                KeyValueCreateFailedError,
+                SQLAlchemyError,
+            ),
+            reraise=SqlLabPermalinkCreateFailedError,
+        ),
+    )
     def run(self) -> str:
         self.validate()
-        try:
-            entry = KeyValueDAO.create_entry(
-                self.resource, self._properties, self.codec
-            )
-            db.session.flush()
-            key = entry.id
-            if key is None:
-                raise SqlLabPermalinkCreateFailedError("Unexpected missing key id")
-            return encode_permalink_key(key=key, salt=self.salt)
-        except KeyValueCodecEncodeException as ex:
-            raise SqlLabPermalinkCreateFailedError(str(ex)) from ex
+        entry = KeyValueDAO.create_entry(self.resource, self._properties, self.codec)
+        db.session.flush()
+        key = entry.id
+        if key is None:
+            raise SqlLabPermalinkCreateFailedError("Unexpected missing key id")
+        return encode_permalink_key(key=key, salt=self.salt)
 
     def validate(self) -> None:
         pass


### PR DESCRIPTION
### SUMMARY
The SQL Lab permalink creation process was not being committed. This PR adds the `@transaction` decorator to the `CreateSqlLabPermalinkCommand` command to persist it properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
N/A.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
