### PR TITLE
fix(heatmap): correctly render int and boolean falsy values on axes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -150,7 +150,7 @@ export default function transformProps(
       data: data.map(row =>
         colnames.map(col => {
           const value = row[col];
-          if (!value) {
+          if (value === null || value === undefined) {
             return NULL_STRING;
           }
           if (typeof value === 'boolean' || typeof value === 'bigint') {


### PR DESCRIPTION
### SUMMARY
Currently values of 0 and false on a heatmap axis render as `<NULL>`. This fixes that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE**
![Screenshot from 2025-04-24 20-52-14](https://github.com/user-attachments/assets/1b4f4817-acdf-4dde-bc22-b2935ff8db56)
![Screenshot from 2025-04-24 21-16-39](https://github.com/user-attachments/assets/6b1a08e0-97f2-48ec-9989-8e55ba6ab8f2)

**AFTER**
![Screenshot from 2025-04-24 20-44-08](https://github.com/user-attachments/assets/a30b4476-81f8-4ee9-aa90-732648f604ba)
![Screenshot from 2025-04-24 21-08-55](https://github.com/user-attachments/assets/d7f67de5-db0e-432a-8ca7-e4b29932b0bb)



### TESTING INSTRUCTIONS
Create a new dataset in SQL Lab like this and make a heatmap.
```
SELECT column1 as foo, column2 as bar, column3::boolean as is_active
FROM (VALUES 
    (0, 0, 't'),
    (1, 1, 'f'),
    (2, 2, 't'),
    (1, 0, 'f'),
    (0, 2, 't'),
    (2, 2, 'f')
) as t(column1, column2, column3);
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #33105 - that is a two-part issue, this fixes one problem