### PR TITLE
fix(echarts): rename time series shifted colnames

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -26,6 +26,7 @@ import {
 } from '@superset-ui/core';
 import { PostProcessingFactory } from './types';
 import { getMetricOffsetsMap, isTimeComparison } from './utils';
+import { TIME_COMPARISON_SEPARATOR } from './utils/constants';
 
 export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
   formData,
@@ -37,50 +38,60 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
   );
   const { truncate_metric } = formData;
   const xAxisLabel = getXAxisLabel(formData);
+  const isTimeComparisonValue = isTimeComparison(formData, queryObject);
+
   // remove or rename top level of column name(metric name) in the MultiIndex when
-  // 1) only 1 metric
+  // 1) at least 1 metric
   // 2) dimension exist
   // 3) xAxis exist
-  // 4) time comparison exist, and comparison type is "actual values"
-  // 5) truncate_metric in form_data and truncate_metric is true
+  // 4) truncate_metric in form_data and truncate_metric is true
   if (
-    metrics.length === 1 &&
+    metrics.length > 0 &&
     columns.length > 0 &&
     xAxisLabel &&
-    !(
-      // todo: we should provide an approach to handle derived metrics
-      (
-        isTimeComparison(formData, queryObject) &&
-        [
-          ComparisonType.Difference,
-          ComparisonType.Ratio,
-          ComparisonType.Percentage,
-        ].includes(formData.comparison_type)
-      )
-    ) &&
     truncate_metric !== undefined &&
     !!truncate_metric
   ) {
     const renamePairs: [string, string | null][] = [];
-
     if (
       // "actual values" will add derived metric.
       // we will rename the "metric" from the metricWithOffset label
       // for example: "count__1 year ago" =>	"1 year ago"
-      isTimeComparison(formData, queryObject) &&
-      formData.comparison_type === ComparisonType.Values
+      isTimeComparisonValue
     ) {
       const metricOffsetMap = getMetricOffsetsMap(formData, queryObject);
       const timeOffsets = ensureIsArray(formData.time_compare);
-      [...metricOffsetMap.keys()].forEach(metricWithOffset => {
-        const offsetLabel = timeOffsets.find(offset =>
-          metricWithOffset.includes(offset),
-        );
-        renamePairs.push([metricWithOffset, offsetLabel]);
-      });
+      [...metricOffsetMap.entries()].forEach(
+        ([metricWithOffset, metricOnly]) => {
+          const offsetLabel = timeOffsets.find(offset =>
+            metricWithOffset.includes(offset),
+          );
+          renamePairs.push([
+            formData.comparison_type === ComparisonType.Values
+              ? metricWithOffset
+              : [formData.comparison_type, metricOnly, metricWithOffset].join(
+                  TIME_COMPARISON_SEPARATOR,
+                ),
+            metrics.length > 1 ? `${metricOnly}, ${offsetLabel}` : offsetLabel,
+          ]);
+        },
+      );
     }
 
-    renamePairs.push([getMetricLabel(metrics[0]), null]);
+    if (
+      ![
+        ComparisonType.Difference,
+        ComparisonType.Percentage,
+        ComparisonType.Ratio,
+      ].includes(formData.comparison_type) &&
+      metrics.length === 1
+    ) {
+      renamePairs.push([getMetricLabel(metrics[0]), null]);
+    }
+
+    if (renamePairs.length === 0) {
+      return undefined;
+    }
 
     return {
       operation: 'rename',

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -186,7 +186,7 @@ test('should add renameOperator if exist "actual value" time comparison', () => 
   });
 });
 
-test('should add renameOperator if exist derived time comparison', () => {
+test('should add renameOperator if derived time comparison exists', () => {
   expect(
     renameOperator(
       {
@@ -211,7 +211,7 @@ test('should add renameOperator if exist derived time comparison', () => {
   });
 });
 
-test('should add renameOperator if exists multiple metrics', () => {
+test('should add renameOperator if multiple metrics exist', () => {
   expect(
     renameOperator(
       {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -109,7 +109,7 @@ test('should add renameOperator if exists derived metrics', () => {
     ).toEqual({
       operation: 'rename',
       options: {
-        columns: { 'difference__count(*)__count(*)__1 year ago': '1 year ago' },
+        columns: { [`${type}__count(*)__count(*)__1 year ago`]: '1 year ago' },
         inplace: true,
         level: 0,
       },

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -43,12 +43,12 @@ const queryObject: QueryObject = {
   post_processing: [],
 };
 
-test('should skip renameOperator if exists multiple metrics', () => {
+test('should skip renameOperator for empty metrics', () => {
   expect(
     renameOperator(formData, {
       ...queryObject,
       ...{
-        metrics: ['count(*)', 'sum(sales)'],
+        metrics: [],
       },
     }),
   ).toEqual(undefined);
@@ -77,7 +77,14 @@ test('should skip renameOperator if does not exist x_axis and is_timeseries', ()
   ).toEqual(undefined);
 });
 
-test('should skip renameOperator if exists derived metrics', () => {
+test('should add renameOperator', () => {
+  expect(renameOperator(formData, queryObject)).toEqual({
+    operation: 'rename',
+    options: { columns: { 'count(*)': null }, inplace: true, level: 0 },
+  });
+});
+
+test('should add renameOperator if exists derived metrics', () => {
   [
     ComparisonType.Difference,
     ComparisonType.Ratio,
@@ -99,14 +106,14 @@ test('should skip renameOperator if exists derived metrics', () => {
           },
         },
       ),
-    ).toEqual(undefined);
-  });
-});
-
-test('should add renameOperator', () => {
-  expect(renameOperator(formData, queryObject)).toEqual({
-    operation: 'rename',
-    options: { columns: { 'count(*)': null }, inplace: true, level: 0 },
+    ).toEqual({
+      operation: 'rename',
+      options: {
+        columns: { 'difference__count(*)__count(*)__1 year ago': '1 year ago' },
+        inplace: true,
+        level: 0,
+      },
+    });
   });
 });
 
@@ -163,6 +170,61 @@ test('should add renameOperator if exist "actual value" time comparison', () => 
         'count(*)': null,
         'count(*)__1 year ago': '1 year ago',
         'count(*)__1 year later': '1 year later',
+      },
+      inplace: true,
+      level: 0,
+    },
+  });
+});
+
+test('should add renameOperator if exist derived time comparison', () => {
+  expect(
+    renameOperator(
+      {
+        ...formData,
+        ...{
+          comparison_type: ComparisonType.Ratio,
+          time_compare: ['1 year ago', '1 year later'],
+        },
+      },
+      queryObject,
+    ),
+  ).toEqual({
+    operation: 'rename',
+    options: {
+      columns: {
+        'ratio__count(*)__count(*)__1 year ago': '1 year ago',
+        'ratio__count(*)__count(*)__1 year later': '1 year later',
+      },
+      inplace: true,
+      level: 0,
+    },
+  });
+});
+
+test('should add renameOperator if exists multiple metrics', () => {
+  expect(
+    renameOperator(
+      {
+        ...formData,
+        ...{
+          comparison_type: ComparisonType.Values,
+          time_compare: ['1 year ago'],
+        },
+      },
+      {
+        ...queryObject,
+        ...{
+          metrics: ['count(*)', 'sum(sales)'],
+        },
+      },
+    ),
+  ).toEqual({
+    operation: 'rename',
+    options: {
+      columns: {
+        'count(*)__1 year ago': 'count(*), 1 year ago',
+        'sum(sales)__1 year ago': 'sum(sales), 1 year ago',
       },
       inplace: true,
       level: 0,

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -77,6 +77,15 @@ test('should skip renameOperator if does not exist x_axis and is_timeseries', ()
   ).toEqual(undefined);
 });
 
+test('should skip renameOperator if not is_timeseries and multi metrics', () => {
+  expect(
+    renameOperator(formData, {
+      ...queryObject,
+      ...{ is_timeseries: false, metrics: ['count(*)', 'sum(val)'] },
+    }),
+  ).toEqual(undefined);
+});
+
 test('should add renameOperator', () => {
   expect(renameOperator(formData, queryObject)).toEqual({
     operation: 'rename',


### PR DESCRIPTION
### SUMMARY
With the migration to eChart, the logic for colnames in the legacy time-series has changed. When applying a time shift, the metric name is displayed along with the formula, making it difficult to review the column items.

|legacy chart|echart|
|--|--|
|![Screenshot_2025-04-28_at_4_21_16 PM](https://github.com/user-attachments/assets/db6efdda-8dce-4c92-b381-1a078ec2a1ff)|![Screenshot 2025-04-28 at 4 25 22 PM](https://github.com/user-attachments/assets/49fc5ffe-5824-4357-9148-32f678071584)|

This commit expands the existing rename post-processing logic applied to actual values, enabling it to be similarly applied when multiple metrics are selected and when the comparison type is not actual values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

||Before|After|legacy chart|
|--|--|--|--|
|1 metric|![Screenshot 2025-04-28 at 4 25 22 PM](https://github.com/user-attachments/assets/49fc5ffe-5824-4357-9148-32f678071584)|![Screenshot 2025-04-28 at 4 23 11 PM](https://github.com/user-attachments/assets/5e2967bf-2d8b-4d2a-a21d-81a5311ceff6)|![Screenshot_2025-04-28_at_4_54_12 PM](https://github.com/user-attachments/assets/f316311c-1735-409d-901c-92b4a2feb9cc)|
|multi metrics|![Screenshot 2025-04-28 at 4 25 02 PM](https://github.com/user-attachments/assets/c22e2e39-0c36-46ff-bcf4-a58858fab2ab)|![Screenshot 2025-04-28 at 4 23 31 PM](https://github.com/user-attachments/assets/11891406-3892-401e-a37a-45929a721eaa)|![Screenshot_2025-04-28_at_4_21_51 PM](https://github.com/user-attachments/assets/936841f9-cb8d-4cb5-ae71-44634b1dfdca)|


### TESTING INSTRUCTIONS
Create a bar chart and apply time shift
Select any value other than "actual values" in calculation type

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
