### PR TITLE
fix(antd): Invalid dashed border in tertiary button

### DIFF
--- a/superset-frontend/src/components/Button/index.tsx
+++ b/superset-frontend/src/components/Button/index.tsx
@@ -67,7 +67,7 @@ const decideType = (buttonStyle: ButtonStyle) => {
     success: 'primary',
     secondary: 'default',
     default: 'default',
-    tertiary: 'dashed',
+    tertiary: 'default',
     dashed: 'dashed',
     link: 'link',
   };


### PR DESCRIPTION
### SUMMARY
During the migration process of Ant Design 5 (antd5) buttons [here](https://github.com/apache/superset/pull/31623), the border style of the tertiary button was incorrectly applied as dashed, which differs from the intended design.

|suggested|actual|
|--|--|
|![image](https://github.com/user-attachments/assets/659e24df-7246-478f-8476-25e36712d1ef)|![Screenshot 2025-04-29 at 3 33 25 PM](https://github.com/user-attachments/assets/8ae95512-c057-4f1e-9ad7-6394e741a787)|

Although this issue was resolved on the current master branch with PR [#31972](https://github.com/apache/superset/pull/31972/files#r1935947938), the fix was not included in the 5.0 release. To address this, this commit applies this correction.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

|Before|After|
|--|--|
|![Screenshot 2025-04-29 at 3 33 25 PM](https://github.com/user-attachments/assets/8ae95512-c057-4f1e-9ad7-6394e741a787)|![Screenshot 2025-04-29 at 3 31 47 PM](https://github.com/user-attachments/assets/bfe7e501-3373-4601-b8e6-60a9c3d4bd46)|

### TESTING INSTRUCTIONS
Go to a chart explore and then check the menu action button

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
