### PR TITLE
fix: Edge case with metric not getting quoted in sort by when normalize_columns is enabled

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1585,10 +1585,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     # use the existing instance.
                     col = metrics_exprs_by_expr.get(str(col), col)
                     need_groupby = True
-            elif col in columns_by_name:
-                col = self.convert_tbl_column_to_sqla_col(
-                    columns_by_name[col], template_processor=template_processor
-                )
             elif col in metrics_exprs_by_label:
                 col = metrics_exprs_by_label[col]
                 need_groupby = True
@@ -1597,6 +1593,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     template_processor=template_processor
                 )
                 need_groupby = True
+            elif col in columns_by_name:
+                col = self.convert_tbl_column_to_sqla_col(
+                    columns_by_name[col], template_processor=template_processor
+                )
 
             if isinstance(col, ColumnElement):
                 orderby_exprs.append(col)


### PR DESCRIPTION
### SUMMARY
When using Snowflake, it's possible to enable the `normalize_columns` setting at the dataset level to have all columns as lowercase. With this setting enabled, in case you use a metric in the chart that has the same key as a column that exists in the dataset (but it's not used in the chart), you would get a SQL error as the metric is used on sorting by default, and the metric name won't be quoted. Superset would generate:

``` sql
SELECT DATE_TRUNC('DAY', time) AS "time", COUNT(*) AS "count_lower" 
FROM public.new GROUP BY DATE_TRUNC('DAY', time) ORDER BY count_lower DESC
LIMIT 1000;
```

As opposed to:
``` sql
SELECT DATE_TRUNC('DAY', time) AS "time", COUNT(*) AS "count_lower" 
FROM public.new GROUP BY DATE_TRUNC('DAY', time) ORDER BY "count_lower" DESC
LIMIT 1000;
```

This only happens with this setting enabled. If you disable it and have the columns in uppercase, the exact same chart configuration works.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Create a table in Snowflake.
2. Create a dataset for it.
3. Enable `normalize_columns` on the dataset.
4. Sync columns so they revert to lowercase.
5. Create a metric in the dataset with a key named after a column from the table.
6. Create a chart using this metric, and another column.
7. Validate the metric name is properly quoted in the `ORDER BY` statement.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
