### PR TITLE
fix: show only filterable columns on filter dropdown

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -99,6 +99,7 @@ export function ColumnSelect({
             'columns.column_name',
             'columns.is_dttm',
             'columns.type_generic',
+            'columns.filterable',
           ],
         })}`,
       })

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -20,11 +20,38 @@ import { Filter, NativeFilterType } from '@superset-ui/core';
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import { FormInstance } from 'src/components';
 import getControlItemsMap, { ControlItemsProps } from './getControlItemsMap';
-import { getControlItems, setNativeFilterFieldValues } from './utils';
+import {
+  getControlItems,
+  setNativeFilterFieldValues,
+  doesColumnMatchFilterType,
+} from './utils';
 
 jest.mock('./utils', () => ({
   getControlItems: jest.fn(),
   setNativeFilterFieldValues: jest.fn(),
+  doesColumnMatchFilterType: jest.fn(),
+}));
+
+// Mock ColumnSelect to test filterValues logic
+jest.mock('./ColumnSelect', () => ({
+  ColumnSelect: ({
+    filterValues,
+  }: {
+    filterValues: (column: any) => boolean;
+  }) => {
+    const columns = [
+      { name: 'col1', filterable: true },
+      { name: 'col2', filterable: false },
+      { name: 'col3', filterable: true },
+    ];
+    return (
+      <>
+        {columns.filter(filterValues).map(column => (
+          <div key={column.name}>{column.name}</div>
+        ))}
+      </>
+    );
+  },
 }));
 
 const formMock: FormInstance = {
@@ -62,7 +89,7 @@ const filterMock: Filter = {
   description: '',
 };
 
-const createProps: () => ControlItemsProps = () => ({
+const createProps = (): ControlItemsProps => ({
   expanded: false,
   datasetId: 1,
   disabled: false,
@@ -178,4 +205,45 @@ test('Clicking on checkbox when resetConfig:false', () => {
   userEvent.click(screen.getByRole('checkbox'));
   expect(props.forceUpdate).toHaveBeenCalled();
   expect(setNativeFilterFieldValues).not.toHaveBeenCalled();
+});
+
+describe('ColumnSelect filterValues behavior', () => {
+  beforeEach(() => {
+    (getControlItems as jest.Mock).mockReturnValue([
+      {
+        name: 'groupby',
+        config: { label: 'Column', multiple: false, required: false },
+      },
+    ]);
+  });
+
+  test('only renders filterable columns when doesColumnMatchFilterType returns true', () => {
+    (doesColumnMatchFilterType as jest.Mock).mockReturnValue(true);
+    const props = {
+      ...createProps(),
+      formFilter: { filterType: 'filterType' },
+    };
+    // @ts-ignore: bypass incomplete formFilter type for test
+    const element = getControlItemsMap(props).mainControlItems.groupby
+      .element as React.ReactElement;
+    render(element);
+    expect(screen.getByText('col1')).toBeInTheDocument();
+    expect(screen.getByText('col3')).toBeInTheDocument();
+    expect(screen.queryByText('col2')).not.toBeInTheDocument();
+  });
+
+  test('renders no columns when doesColumnMatchFilterType returns false', () => {
+    (doesColumnMatchFilterType as jest.Mock).mockReturnValue(false);
+    const props = {
+      ...createProps(),
+      formFilter: { filterType: 'filterType' },
+    };
+    // @ts-ignore: bypass incomplete formFilter type for test
+    const element = getControlItemsMap(props).mainControlItems.groupby
+      .element as React.ReactElement;
+    render(element);
+    expect(screen.queryByText('col1')).not.toBeInTheDocument();
+    expect(screen.queryByText('col3')).not.toBeInTheDocument();
+    expect(screen.queryByText('col2')).not.toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.tsx
@@ -131,7 +131,10 @@ export default function getControlItemsMap({
               filterId={filterId}
               datasetId={datasetId}
               filterValues={column =>
-                doesColumnMatchFilterType(formFilter?.filterType || '', column)
+                doesColumnMatchFilterType(
+                  formFilter?.filterType || '',
+                  column,
+                ) && !!column?.filterable
               }
               onChange={() => {
                 // We need reset default value when column changed


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When we build native filters we currently show non-filterable columns in the column dropdown:

<img width="648" alt="Screenshot 2025-05-01 at 5 34 17 PM" src="https://github.com/user-attachments/assets/3cc36bde-ddb0-4f97-83e3-935673dde761" />

<img width="872" alt="Screenshot 2025-05-01 at 5 34 58 PM" src="https://github.com/user-attachments/assets/17840db7-bea3-4409-92ca-7927a919e647" />

What we want, instead, is this:

<img width="868" alt="Screenshot 2025-05-01 at 5 35 45 PM" src="https://github.com/user-attachments/assets/ef5b25a8-4356-4d5a-9a3c-b52a16939668" />

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
