### PR TITLE
chore(explore): Add format sql and view in SQL Lab option in View Query

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  screen,
+  render,
+  fireEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import fetchMock from 'fetch-mock';
+import copyTextToClipboard from 'src/utils/copy';
+import ViewQuery, { ViewQueryProps } from './ViewQuery';
+
+const mockHistoryPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+jest.mock('src/utils/copy', () =>
+  jest.fn().mockImplementation(fn => Promise.resolve(fn())),
+);
+
+function setup(props: ViewQueryProps) {
+  return render(<ViewQuery {...props} />, { useRouter: true, useRedux: true });
+}
+
+const mockProps = {
+  sql: 'select * from table',
+  datasource: '1__table',
+};
+
+const datasetApiEndpoint = 'glob:*/api/v1/dataset/1?**';
+const formatSqlEndpoint = 'glob:*/api/v1/sqllab/format_sql/';
+const formattedSQL = 'SELECT * FROM table;';
+beforeEach(() => {
+  fetchMock.get(datasetApiEndpoint, {
+    result: {
+      database: {
+        backend: 'sqlite',
+      },
+    },
+  });
+  fetchMock.post(formatSqlEndpoint, {
+    result: formattedSQL,
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  fetchMock.restore();
+});
+
+it('renders the component with SQL and buttons', () => {
+  const { container } = setup(mockProps);
+  expect(screen.getByText('Copy')).toBeInTheDocument();
+  expect(screen.getByText('Format SQL')).toBeInTheDocument();
+  expect(screen.getByText('View in SQL Lab')).toBeInTheDocument();
+  expect(container).toHaveTextContent(mockProps.sql);
+});
+
+// it('copies the SQL to the clipboard when Copy button is clicked', async () => {
+//   setup(mockProps);
+//   const copyButton = screen.getByText('Copy');
+//   fireEvent.click(copyButton);
+// });
+
+it('formats the SQL when Format SQL button is clicked', async () => {
+  const { container } = setup(mockProps);
+  const formatButton = screen.getByText('Format SQL');
+
+  fireEvent.click(formatButton);
+
+  await waitFor(() =>
+    expect(fetchMock.calls(formatSqlEndpoint)).toHaveLength(1),
+  );
+  expect(container).toHaveTextContent(formattedSQL);
+});
+
+it('toggles back to original SQL when Show Original button is clicked', async () => {
+  const { container } = setup(mockProps);
+  const formatButton = screen.getByText('Format SQL');
+
+  // Click to format SQL
+  fireEvent.click(formatButton);
+
+  await waitFor(() =>
+    expect(fetchMock.calls(formatSqlEndpoint)).toHaveLength(1),
+  );
+
+  // Click to show original SQL
+  const showOriginalButton = screen.getByText('Show Original');
+  fireEvent.click(showOriginalButton);
+
+  await waitFor(() => expect(container).toHaveTextContent(mockProps.sql));
+});
+
+it('navigates to SQL Lab when View in SQL Lab button is clicked', () => {
+  setup(mockProps);
+
+  const viewInSQLLabButton = screen.getByText('View in SQL Lab');
+  fireEvent.click(viewInSQLLabButton);
+
+  expect(mockHistoryPush).toHaveBeenCalledWith('/sqllab', {
+    state: {
+      requestedQuery: {
+        datasourceKey: mockProps.datasource,
+        sql: mockProps.sql,
+      },
+    },
+  });
+});
+
+it('opens SQL Lab in a new tab when View in SQL Lab button is clicked with meta key', () => {
+  window.open = jest.fn();
+
+  setup(mockProps);
+  const viewInSQLLabButton = screen.getByText('View in SQL Lab');
+
+  fireEvent.click(viewInSQLLabButton, { metaKey: true });
+
+  const { datasource, sql } = mockProps;
+  expect(window.open).toHaveBeenCalledWith(
+    `/sqllab?datasourceKey=${datasource}&sql=${sql}`,
+    '_blank',
+  );
+});

--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -35,9 +35,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('src/utils/copy', () =>
-  jest.fn().mockImplementation(fn => Promise.resolve(fn())),
-);
+jest.mock('src/utils/copy');
 
 function setup(props: ViewQueryProps) {
   return render(<ViewQuery {...props} />, { useRouter: true, useRedux: true });
@@ -77,11 +75,15 @@ it('renders the component with SQL and buttons', () => {
   expect(container).toHaveTextContent(mockProps.sql);
 });
 
-// it('copies the SQL to the clipboard when Copy button is clicked', async () => {
-//   setup(mockProps);
-//   const copyButton = screen.getByText('Copy');
-//   fireEvent.click(copyButton);
-// });
+it('copies the SQL to the clipboard when Copy button is clicked', async () => {
+  setup(mockProps);
+
+  (copyTextToClipboard as jest.Mock).mockResolvedValue('');
+  const copyButton = screen.getByText('Copy');
+  expect(copyTextToClipboard as jest.Mock).not.toHaveBeenCalled();
+  fireEvent.click(copyButton);
+  expect(copyTextToClipboard as jest.Mock).toHaveBeenCalled();
+});
 
 it('formats the SQL when Format SQL button is clicked', async () => {
   const { container } = setup(mockProps);

--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -69,7 +69,7 @@ afterEach(() => {
 });
 
 const getFormatSwitch = () =>
-  screen.getByRole('switch', { name: 'Show formatted SQL' });
+  screen.getByRole('switch', { name: 'Show original SQL' });
 
 it('renders the component with Formatted SQL and buttons', async () => {
   const { container } = setup(mockProps);

--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -71,7 +71,7 @@ afterEach(() => {
 const getFormatSwitch = () =>
   screen.getByRole('switch', { name: 'Show original SQL' });
 
-it('renders the component with Formatted SQL and buttons', async () => {
+test('renders the component with Formatted SQL and buttons', async () => {
   const { container } = setup(mockProps);
   expect(screen.getByText('Copy')).toBeInTheDocument();
   expect(getFormatSwitch()).toBeInTheDocument();
@@ -84,7 +84,7 @@ it('renders the component with Formatted SQL and buttons', async () => {
   expect(container).toHaveTextContent(formattedSQL);
 });
 
-it('copies the SQL to the clipboard when Copy button is clicked', async () => {
+test('copies the SQL to the clipboard when Copy button is clicked', async () => {
   setup(mockProps);
 
   (copyTextToClipboard as jest.Mock).mockResolvedValue('');
@@ -94,7 +94,7 @@ it('copies the SQL to the clipboard when Copy button is clicked', async () => {
   expect(copyTextToClipboard as jest.Mock).toHaveBeenCalled();
 });
 
-it('shows the original SQL when Format switch is unchecked', async () => {
+test('shows the original SQL when Format switch is unchecked', async () => {
   const { container } = setup(mockProps);
   const formatButton = getFormatSwitch();
 
@@ -107,7 +107,7 @@ it('shows the original SQL when Format switch is unchecked', async () => {
   expect(container).toHaveTextContent(mockProps.sql);
 });
 
-it('toggles back to formatted SQL when Format switch is clicked', async () => {
+test('toggles back to formatted SQL when Format switch is clicked', async () => {
   const { container } = setup(mockProps);
   const formatButton = getFormatSwitch();
 
@@ -126,7 +126,7 @@ it('toggles back to formatted SQL when Format switch is clicked', async () => {
   await waitFor(() => expect(container).toHaveTextContent(formattedSQL));
 });
 
-it('navigates to SQL Lab when View in SQL Lab button is clicked', () => {
+test('navigates to SQL Lab when View in SQL Lab button is clicked', () => {
   setup(mockProps);
 
   const viewInSQLLabButton = screen.getByText('View in SQL Lab');
@@ -142,7 +142,7 @@ it('navigates to SQL Lab when View in SQL Lab button is clicked', () => {
   });
 });
 
-it('opens SQL Lab in a new tab when View in SQL Lab button is clicked with meta key', () => {
+test('opens SQL Lab in a new tab when View in SQL Lab button is clicked with meta key', () => {
   window.open = jest.fn();
 
   setup(mockProps);

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -104,16 +104,16 @@ const ViewQuery: FC<ViewQueryProps> = props => {
       SupersetClient.get({
         endpoint: `/api/v1/dataset/${datasetId}?q=${queryParams}`,
       })
-        .then(({ json }) => {
-          return SupersetClient.post({
+        .then(({ json }) =>
+          SupersetClient.post({
             endpoint: `/api/v1/sqllab/format_sql/`,
             body: JSON.stringify({
               sql,
               engine: json.result.database.backend,
             }),
             headers: { 'Content-Type': 'application/json' },
-          });
-        })
+          }),
+        )
         .then(({ json }) => {
           setFormattedSQL(json.result);
           setShowFormatSQL(true);

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -165,11 +165,11 @@ const ViewQuery: FC<ViewQueryProps> = props => {
         <StyledHeaderActionContainer>
           <Switch
             id="formatSwitch"
-            checked={showFormatSQL}
+            checked={!showFormatSQL}
             onChange={formatCurrentQuery}
           />
           <StyledLabel htmlFor="formatSwitch">
-            {t('Show formatted SQL')}
+            {t('Show original SQL')}
           </StyledLabel>
         </StyledHeaderActionContainer>
       </StyledHeaderMenuContainer>

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -23,13 +23,14 @@ import {
   ensureIsArray,
   t,
   getClientErrorObject,
+  QueryFormData,
 } from '@superset-ui/core';
 import Loading from 'src/components/Loading';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
 
 interface Props {
-  latestQueryFormData: object;
+  latestQueryFormData: QueryFormData;
 }
 
 type Result = {
@@ -43,7 +44,7 @@ const ViewQueryModalContainer = styled.div`
   flex-direction: column;
 `;
 
-const ViewQueryModal: FC<Props> = props => {
+const ViewQueryModal: FC<Props> = ({ latestQueryFormData }) => {
   const [result, setResult] = useState<Result[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,7 +52,7 @@ const ViewQueryModal: FC<Props> = props => {
   const loadChartData = (resultType: string) => {
     setIsLoading(true);
     getChartDataRequest({
-      formData: props.latestQueryFormData,
+      formData: latestQueryFormData,
       resultFormat: 'json',
       resultType,
     })
@@ -74,7 +75,7 @@ const ViewQueryModal: FC<Props> = props => {
   };
   useEffect(() => {
     loadChartData('query');
-  }, [JSON.stringify(props.latestQueryFormData)]);
+  }, [JSON.stringify(latestQueryFormData)]);
 
   if (isLoading) {
     return <Loading />;
@@ -87,7 +88,11 @@ const ViewQueryModal: FC<Props> = props => {
     <ViewQueryModalContainer>
       {result.map(item =>
         item.query ? (
-          <ViewQuery sql={item.query} language={item.language || undefined} />
+          <ViewQuery
+            datasource={latestQueryFormData.datasource}
+            sql={item.query}
+            language={item.language || undefined}
+          />
         ) : null,
       )}
     </ViewQueryModalContainer>


### PR DESCRIPTION
### SUMMARY
The "View Query" feature was previously used to display SQL in a formatted manner. However, the prettier formatting was reverted in [this pull request](https://github.com/apache/superset/pull/30350) due to unintended changes in the original SQL. To minimize the impact while retaining the formatting option, this commit introduces a "Format SQL" feature in View Query modal and an option to show the original SQL for comparison. Additionally, this commit adds a "View in SQL Lab" button, allowing users to conveniently connect to SQL Lab directly from the dashboard, which is particularly useful for users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
![Screenshot 2025-05-01 at 5 20 53 PM](https://github.com/user-attachments/assets/6b9ce861-831b-40ca-a215-62c659e1f60c)

After:

https://github.com/user-attachments/assets/504b1e61-0dad-4c1a-8c57-d6c9b3c47842

### TESTING INSTRUCTIONS

Click "View Query" in the chart or explore and then check the toolbars above.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
