### PR TITLE
feat(Pie Chart): threshold for Other

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/constants.ts
@@ -16,30 +16,4 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  buildQueryContext,
-  getMetricLabel,
-  QueryFormData,
-} from '@superset-ui/core';
-import { getContributionLabel } from './utils';
-
-export default function buildQuery(formData: QueryFormData) {
-  const { metric, sort_by_metric } = formData;
-  const metricLabel = getMetricLabel(metric);
-
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      ...(sort_by_metric && { orderby: [[metric, false]] }),
-      post_processing: [
-        {
-          operation: 'contribution',
-          options: {
-            columns: [metricLabel],
-            rename_columns: [getContributionLabel(metricLabel)],
-          },
-        },
-      ],
-    },
-  ]);
-}
+export const CONTRIBUTION_SUFFIX = '__contribution' as const;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -86,6 +86,23 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'threshold_for_other',
+            config: {
+              type: 'NumberControl',
+              label: t('Threshold for Other'),
+              min: 0,
+              step: 0.5,
+              max: 100,
+              default: 0,
+              renderTrigger: true,
+              description: t(
+                'Values less than this percentage will be grouped into the Other category.',
+              ),
+            },
+          },
+        ],
+        [
+          {
             name: 'roseType',
             config: {
               type: 'SelectControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -215,29 +215,23 @@ export default function transformProps(
       numberFormatter(otherSum),
       percentFormatter(contributionSum),
     ]);
-    otherDatum = {
-      name: otherName,
-      value: otherSum,
-      itemStyle: {
-        color: theme.colors.grayscale.dark1,
-        opacity:
-          filterState.selectedValues &&
-          !filterState.selectedValues.includes(otherName)
-            ? OpacityEnum.SemiTransparent
-            : OpacityEnum.NonTransparent,
-      },
-      isOther: true,
-    };
+    if (otherSum) {
+      otherDatum = {
+        name: otherName,
+        value: otherSum,
+        itemStyle: {
+          color: theme.colors.grayscale.dark1,
+          opacity:
+            filterState.selectedValues &&
+            !filterState.selectedValues.includes(otherName)
+              ? OpacityEnum.SemiTransparent
+              : OpacityEnum.NonTransparent,
+        },
+        isOther: true,
+      };
+    }
   }
 
-  const keys = data.map(datum =>
-    extractGroupbyLabel({
-      datum,
-      groupby: groupbyLabels,
-      coltypeMapping,
-      timeFormatter: getTimeFormatter(dateFormat),
-    }),
-  );
   const labelMap = data.reduce((acc: Record<string, string[]>, datum) => {
     const label = extractGroupbyLabel({
       datum,
@@ -283,6 +277,10 @@ export default function transformProps(
       },
     };
   });
+  if (otherDatum) {
+    transformedData.push(otherDatum);
+    totalValue += otherSum;
+  }
 
   const selectedValues = (filterState.selectedValues || []).reduce(
     (acc: Record<string, number>, selectedValue: string) => {
@@ -412,11 +410,6 @@ export default function transformProps(
     },
   ];
 
-  if (otherDatum) {
-    transformedData.push(otherDatum);
-    totalValue += otherSum;
-  }
-
   const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
@@ -442,7 +435,7 @@ export default function transformProps(
     },
     legend: {
       ...getLegendProps(legendType, legendOrientation, showLegend, theme),
-      data: keys,
+      data: transformedData.map(datum => datum.name),
     },
     graphic: showTotal
       ? {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -27,6 +27,7 @@ import {
   ValueFormatter,
   getValueFormatter,
   tooltipHtml,
+  DataRecord,
 } from '@superset-ui/core';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
 import type { EChartsCoreOption } from 'echarts/core';
@@ -36,6 +37,7 @@ import {
   EchartsPieChartProps,
   EchartsPieFormData,
   EchartsPieLabelType,
+  PieChartDataItem,
   PieChartTransformedProps,
 } from './types';
 import { DEFAULT_LEGEND_FORM_DATA, OpacityEnum } from '../constants';
@@ -50,6 +52,7 @@ import { defaultGrid } from '../defaults';
 import { convertInteger } from '../utils/convertInteger';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
+import { getContributionLabel } from './utils';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 
@@ -133,7 +136,7 @@ export default function transformProps(
     datasource,
   } = chartProps;
   const { columnFormats = {}, currencyFormats = {} } = datasource;
-  const { data = [] } = queriesData[0];
+  const { data: rawData = [] } = queriesData[0];
   const coltypeMapping = getColtypesMapping(queriesData[0]);
 
   const {
@@ -159,6 +162,7 @@ export default function transformProps(
     sliceId,
     showTotal,
     roseType,
+    thresholdForOther,
   }: EchartsPieFormData = {
     ...DEFAULT_LEGEND_FORM_DATA,
     ...DEFAULT_PIE_FORM_DATA,
@@ -166,8 +170,65 @@ export default function transformProps(
   };
   const refs: Refs = {};
   const metricLabel = getMetricLabel(metric);
+  const contributionLabel = getContributionLabel(metricLabel);
   const groupbyLabels = groupby.map(getColumnLabel);
   const minShowLabelAngle = (showLabelsThreshold || 0) * 3.6;
+
+  const numberFormatter = getValueFormatter(
+    metric,
+    currencyFormats,
+    columnFormats,
+    numberFormat,
+    currencyFormat,
+  );
+
+  let data = rawData;
+  const otherRows: DataRecord[] = [];
+  const otherTooltipData: string[][] = [];
+  let otherDatum: PieChartDataItem | null = null;
+  let otherSum = 0;
+  if (thresholdForOther) {
+    let contributionSum = 0;
+    data = data.filter(datum => {
+      const contribution = datum[contributionLabel] as number;
+      if (!contribution || contribution * 100 >= thresholdForOther) {
+        return true;
+      }
+      otherSum += datum[metricLabel] as number;
+      contributionSum += contribution;
+      otherRows.push(datum);
+      otherTooltipData.push([
+        extractGroupbyLabel({
+          datum,
+          groupby: groupbyLabels,
+          coltypeMapping,
+          timeFormatter: getTimeFormatter(dateFormat),
+        }),
+        numberFormatter(datum[metricLabel] as number),
+        percentFormatter(contribution),
+      ]);
+      return false;
+    });
+    const otherName = t('Other');
+    otherTooltipData.push([
+      t('Total'),
+      numberFormatter(otherSum),
+      percentFormatter(contributionSum),
+    ]);
+    otherDatum = {
+      name: otherName,
+      value: otherSum,
+      itemStyle: {
+        color: theme.colors.grayscale.dark1,
+        opacity:
+          filterState.selectedValues &&
+          !filterState.selectedValues.includes(otherName)
+            ? OpacityEnum.SemiTransparent
+            : OpacityEnum.NonTransparent,
+      },
+      isOther: true,
+    };
+  }
 
   const keys = data.map(datum =>
     extractGroupbyLabel({
@@ -192,13 +253,6 @@ export default function transformProps(
 
   const { setDataMask = () => {}, onContextMenu } = hooks;
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
-  const numberFormatter = getValueFormatter(
-    metric,
-    currencyFormats,
-    columnFormats,
-    numberFormat,
-    currencyFormat,
-  );
 
   let totalValue = 0;
 
@@ -358,6 +412,11 @@ export default function transformProps(
     },
   ];
 
+  if (otherDatum) {
+    transformedData.push(otherDatum);
+    totalValue += otherSum;
+  }
+
   const echartOptions: EChartsCoreOption = {
     grid: {
       ...defaultGrid,
@@ -372,6 +431,9 @@ export default function transformProps(
           numberFormatter,
           sanitizeName: true,
         });
+        if (params?.data?.isOther) {
+          return tooltipHtml(otherTooltipData, name);
+        }
         return tooltipHtml(
           [[metricLabel, formattedValue, formattedPercent]],
           name,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -98,5 +98,5 @@ export interface PieChartDataItem {
     color: string;
     opacity: number;
   };
-  [key: string]: unknown;
+  isOther?: boolean;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -47,6 +47,7 @@ export type EchartsPieFormData = QueryFormData &
     dateFormat: string;
     showLabelsThreshold: number;
     roseType: 'radius' | 'area' | null;
+    thresholdForOther: number;
   };
 
 export enum EchartsPieLabelType {
@@ -82,9 +83,20 @@ export const DEFAULT_FORM_DATA: EchartsPieFormData = {
   showLabelsThreshold: 5,
   dateFormat: 'smart_date',
   roseType: null,
+  thresholdForOther: 0,
 };
 
 export type PieChartTransformedProps =
   BaseTransformedProps<EchartsPieFormData> &
     ContextMenuTransformedProps &
     CrossFilterTransformedProps;
+
+export interface PieChartDataItem {
+  name: string;
+  value: number;
+  itemStyle: {
+    color: string;
+    opacity: number;
+  };
+  [key: string]: unknown;
+}

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/utils.ts
@@ -16,30 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  buildQueryContext,
-  getMetricLabel,
-  QueryFormData,
-} from '@superset-ui/core';
-import { getContributionLabel } from './utils';
+import { CONTRIBUTION_SUFFIX } from './constants';
 
-export default function buildQuery(formData: QueryFormData) {
-  const { metric, sort_by_metric } = formData;
-  const metricLabel = getMetricLabel(metric);
-
-  return buildQueryContext(formData, baseQueryObject => [
-    {
-      ...baseQueryObject,
-      ...(sort_by_metric && { orderby: [[metric, false]] }),
-      post_processing: [
-        {
-          operation: 'contribution',
-          options: {
-            columns: [metricLabel],
-            rename_columns: [getContributionLabel(metricLabel)],
-          },
-        },
-      ],
-    },
-  ]);
-}
+export const getContributionLabel = (metricLabel: string) =>
+  `${metricLabel}${CONTRIBUTION_SUFFIX}`;

--- a/superset-frontend/src/explore/components/controls/NumberControl/NumberControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/NumberControl.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import NumberControl from '.';
+
+const mockedProps = {
+  min: -5,
+  max: 10,
+  step: 1,
+  default: 0,
+};
+
+test('render', () => {
+  const { container } = render(<NumberControl {...mockedProps} />);
+  expect(container).toBeInTheDocument();
+});
+
+test('type number', async () => {
+  const props = {
+    ...mockedProps,
+    onChange: jest.fn(),
+  };
+  render(<NumberControl {...props} />);
+  const input = screen.getByRole('spinbutton');
+  await userEvent.type(input, '9');
+  expect(props.onChange).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenLastCalledWith(9);
+});
+
+test('type >max', async () => {
+  const props = {
+    ...mockedProps,
+    onChange: jest.fn(),
+  };
+  render(<NumberControl {...props} />);
+  const input = screen.getByRole('spinbutton');
+  await userEvent.type(input, '20');
+  expect(props.onChange).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenLastCalledWith(2);
+});
+
+test('type NaN', async () => {
+  const props = {
+    ...mockedProps,
+    onChange: jest.fn(),
+  };
+  render(<NumberControl {...props} />);
+  const input = screen.getByRole('spinbutton');
+  await userEvent.type(input, 'not a number');
+  expect(props.onChange).toHaveBeenCalledTimes(0);
+});

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { styled } from '@superset-ui/core';
+import { InputNumber } from 'src/components/Input';
+import ControlHeader, { ControlHeaderProps } from '../../ControlHeader';
+
+type NumberValueType = number | undefined;
+
+export interface NumberControlProps extends ControlHeaderProps {
+  onChange?: (value: NumberValueType) => void;
+  value?: NumberValueType;
+  label?: string;
+  description?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const FullWidthDiv = styled.div`
+  width: 100%;
+`;
+
+const FullWidthInputNumber = styled(InputNumber)`
+  width: 100%;
+`;
+
+function parseValue(value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  return Number(value);
+}
+
+export default function NumberControl({
+  min,
+  max,
+  step,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  ...rest
+}: NumberControlProps) {
+  return (
+    <FullWidthDiv>
+      <ControlHeader {...rest} />
+      <FullWidthInputNumber
+        min={min}
+        max={max}
+        step={step}
+        placeholder={placeholder}
+        value={value}
+        onChange={value => onChange?.(parseValue(value))}
+        disabled={disabled}
+        aria-label={rest.label}
+      />
+    </FullWidthDiv>
+  );
+}

--- a/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/NumberControl/index.tsx
@@ -46,7 +46,8 @@ function parseValue(value: string | number | null | undefined) {
   if (value === null || value === undefined || value === '') {
     return undefined;
   }
-  return Number(value);
+  const num = Number(value);
+  return Number.isNaN(num) ? undefined : num;
 }
 
 export default function NumberControl({

--- a/superset-frontend/src/explore/components/controls/index.js
+++ b/superset-frontend/src/explore/components/controls/index.js
@@ -53,6 +53,7 @@ import { ComparisonRangeLabel } from './ComparisonRangeLabel';
 import LayerConfigsControl from './LayerConfigsControl/LayerConfigsControl';
 import MapViewControl from './MapViewControl/MapViewControl';
 import ZoomConfigControl from './ZoomConfigControl/ZoomConfigControl';
+import NumberControl from './NumberControl';
 
 const controlMap = {
   AnnotationLayerControl,
@@ -90,6 +91,7 @@ const controlMap = {
   ComparisonRangeLabel,
   TimeOffsetControl,
   ZoomConfigControl,
+  NumberControl,
   ...sharedControlComponents,
 };
 export default controlMap;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR introduces a new control for the Pie chart that allows you to set a threshold value. If a metric value is smaller than this threshold, it will be grouped in the "Other" category.

Additionally, I've added a new control type called `NumberControl` that is used for setting the threshold.

https://github.com/apache/superset/discussions/32868

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Снимок экрана 03 05 2025](https://github.com/user-attachments/assets/a425e7eb-8ec7-48c5-8704-0947bc0c3ed1)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create Pie chart.
2. Go to customize tab, setup "Threshold for Other" control.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
