### PR TITLE
fix(deckgl): fix deckgl multiple layers chart filter and viewport

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -78,8 +78,8 @@ const DeckMulti = (props: DeckMultiProps) => {
       ...getPointsHeatmap(props.payload.data.features.deck_heatmap || []),
       ...getPointsHex(props.payload.data.features.deck_hex || []),
       ...getPointsArc(props.payload.data.features.deck_arc || []),
-      ...getPointsGeojson(props.payload.data.features.deck_geojaon || []),
-      ...getPointsScreengrid(props.payload.data.features.deck_geojaon || []),
+      ...getPointsGeojson(props.payload.data.features.deck_geojson || []),
+      ...getPointsScreengrid(props.payload.data.features.deck_screengrid || []),
     ];
 
     if (props.formData) {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/Multi/Multi.tsx
@@ -38,8 +38,19 @@ import {
 } from '../DeckGLContainer';
 import { getExploreLongUrl } from '../utils/explore';
 import layerGenerators from '../layers';
-import { Viewport } from '../utils/fitViewport';
+import fitViewport, { Viewport } from '../utils/fitViewport';
 import { TooltipProps } from '../components/Tooltip';
+
+import { getPoints as getPointsArc } from '../layers/Arc/Arc';
+import { getPoints as getPointsPath } from '../layers/Path/Path';
+import { getPoints as getPointsPolygon } from '../layers/Polygon/Polygon';
+import { getPoints as getPointsGrid } from '../layers/Grid/Grid';
+import { getPoints as getPointsScatter } from '../layers/Scatter/Scatter';
+import { getPoints as getPointsContour } from '../layers/Contour/Contour';
+import { getPoints as getPointsHeatmap } from '../layers/Heatmap/Heatmap';
+import { getPoints as getPointsHex } from '../layers/Hex/Hex';
+import { getPoints as getPointsGeojson } from '../layers/Geojson/Geojson';
+import { getPoints as getPointsScreengrid } from '../layers/Screengrid/Screengrid';
 
 export type DeckMultiProps = {
   formData: QueryFormData;
@@ -56,7 +67,35 @@ export type DeckMultiProps = {
 const DeckMulti = (props: DeckMultiProps) => {
   const containerRef = useRef<DeckGLContainerHandle>();
 
-  const [viewport, setViewport] = useState<Viewport>();
+  const getAdjustedViewport = useCallback(() => {
+    let viewport = { ...props.viewport };
+    const points = [
+      ...getPointsPolygon(props.payload.data.features.deck_polygon || []),
+      ...getPointsPath(props.payload.data.features.deck_path || []),
+      ...getPointsGrid(props.payload.data.features.deck_grid || []),
+      ...getPointsScatter(props.payload.data.features.deck_scatter || []),
+      ...getPointsContour(props.payload.data.features.deck_contour || []),
+      ...getPointsHeatmap(props.payload.data.features.deck_heatmap || []),
+      ...getPointsHex(props.payload.data.features.deck_hex || []),
+      ...getPointsArc(props.payload.data.features.deck_arc || []),
+      ...getPointsGeojson(props.payload.data.features.deck_geojaon || []),
+      ...getPointsScreengrid(props.payload.data.features.deck_geojaon || []),
+    ];
+
+    if (props.formData) {
+      viewport = fitViewport(viewport, {
+        width: props.width,
+        height: props.height,
+        points,
+      });
+    }
+    if (viewport.zoom < 0) {
+      viewport.zoom = 0;
+    }
+    return viewport;
+  }, [props]);
+
+  const [viewport, setViewport] = useState<Viewport>(getAdjustedViewport());
   const [subSlicesLayers, setSubSlicesLayers] = useState<Record<number, Layer>>(
     {},
   );
@@ -70,23 +109,31 @@ const DeckMulti = (props: DeckMultiProps) => {
 
   const loadLayers = useCallback(
     (formData: QueryFormData, payload: JsonObject, viewport?: Viewport) => {
-      setViewport(viewport);
+      setViewport(getAdjustedViewport());
       setSubSlicesLayers({});
       payload.data.slices.forEach(
         (subslice: { slice_id: number } & JsonObject) => {
           // Filters applied to multi_deck are passed down to underlying charts
           // note that dashboard contextual information (filter_immune_slices and such) aren't
           // taken into consideration here
-          const filters = [
-            ...(subslice.form_data.filters || []),
-            ...(formData.filters || []),
+          const extra_filters = [
+            ...(subslice.form_data.extra_filters || []),
             ...(formData.extra_filters || []),
+            ...(formData.extra_form_data?.filters || []),
           ];
+
+          const adhoc_filters = [
+            ...(formData.adhoc_filters || []),
+            ...(subslice.formData?.adhoc_filters || []),
+            ...(formData.extra_form_data?.adhoc_filters || []),
+          ];
+
           const subsliceCopy = {
             ...subslice,
             form_data: {
               ...subslice.form_data,
-              filters,
+              extra_filters,
+              adhoc_filters,
             },
           };
 
@@ -117,7 +164,13 @@ const DeckMulti = (props: DeckMultiProps) => {
         },
       );
     },
-    [props.datasource, props.onAddFilter, props.onSelect, setTooltip],
+    [
+      props.datasource,
+      props.onAddFilter,
+      props.onSelect,
+      setTooltip,
+      getAdjustedViewport,
+    ],
   );
 
   const prevDeckSlices = usePrevious(props.formData.deck_slices);
@@ -136,7 +189,7 @@ const DeckMulti = (props: DeckMultiProps) => {
     <DeckGLContainerStyledWrapper
       ref={containerRef}
       mapboxApiAccessToken={payload.data.mapboxApiKey}
-      viewport={viewport || props.viewport}
+      viewport={viewport}
       layers={layers}
       mapStyle={formData.mapbox_style}
       setControlValue={setControlValue}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Arc/Arc.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Arc/Arc.tsx
@@ -29,7 +29,7 @@ import TooltipRow from '../../TooltipRow';
 import { TooltipProps } from '../../components/Tooltip';
 import { Point } from '../../types';
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   const points: Point[] = [];
   data.forEach(d => {
     points.push(d.sourcePosition);

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
@@ -97,7 +97,7 @@ export const getLayer: getLayerType<unknown> = function (
   });
 };
 
-function getPoints(data: any[]) {
+export function getPoints(data: any[]) {
   return data.map(d => d.position);
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/Grid.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Grid/Grid.tsx
@@ -86,7 +86,7 @@ export function getLayer(
   });
 }
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   return data.map(d => d.position);
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Heatmap/Heatmap.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Heatmap/Heatmap.tsx
@@ -79,7 +79,7 @@ export const getLayer: getLayerType<unknown> = (
   });
 };
 
-function getPoints(data: any[]) {
+export function getPoints(data: any[]) {
   return data.map(d => d.position);
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/Hex.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/Hex.tsx
@@ -84,7 +84,7 @@ export function getLayer(
   });
 }
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   return data.map(d => d.position);
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.tsx
@@ -76,7 +76,7 @@ export function getLayer(
   });
 }
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   let points: Point[] = [];
   data.forEach(d => {
     points = points.concat(d.path);

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
@@ -173,6 +173,10 @@ export type DeckGLPolygonProps = {
   height: number;
 };
 
+export function getPoints(data: JsonObject[]) {
+  return data.flatMap(getPointsFromPolygon);
+}
+
 const DeckGLPolygon = (props: DeckGLPolygonProps) => {
   const containerRef = useRef<DeckGLContainerHandle>();
 
@@ -183,7 +187,7 @@ const DeckGLPolygon = (props: DeckGLPolygonProps) => {
       viewport = fitViewport(viewport, {
         width: props.width,
         height: props.height,
-        points: features.flatMap(getPointsFromPolygon),
+        points: getPoints(features),
       });
     }
     if (viewport.zoom < 0) {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -30,7 +30,7 @@ import TooltipRow from '../../TooltipRow';
 import { unitToRadius } from '../../utils/geo';
 import { TooltipProps } from '../../components/Tooltip';
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   return data.map(d => d.position);
 }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Screengrid/Screengrid.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Screengrid/Screengrid.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../DeckGLContainer';
 import { TooltipProps } from '../../components/Tooltip';
 
-function getPoints(data: JsonObject[]) {
+export function getPoints(data: JsonObject[]) {
   return data.map(d => d.position);
 }
 


### PR DESCRIPTION
### SUMMARY
Filters werent applying to multiple layers deck.gl chart because they werent being passed down to the sublayers properly. Fixes #13731 

### Before
[430684705-7217504e-9ae2-43f4-821d-a03e9fd77a0b.webm](https://github.com/user-attachments/assets/aebbc52a-11e7-46a7-8cbf-72f38cadb235)

### After
[Screencast_20250501_203725.webm](https://github.com/user-attachments/assets/063f681d-661a-40b8-a139-155a261e473e)
