### PR TITLE
fix(chart list): Facepile shows correct users when saving chart properties

### DIFF
--- a/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/PropertiesModal.test.tsx
@@ -86,6 +86,12 @@ fetchMock.get('glob:*/api/v1/chart/318*', {
           type: 1,
         },
       ],
+      show_title: 'Show Slice',
+      certification_details: 'Test certification details',
+      certified_by: 'Test certified by',
+      description: 'Test description',
+      cache_timeout: '1000',
+      slice_name: 'Test chart new name',
     },
     show_columns: [
       'owners.id',

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -192,33 +192,15 @@ function PropertiesModal({
     }
 
     try {
-      const res = await SupersetClient.put({
+      let res = await SupersetClient.put({
         endpoint: `/api/v1/chart/${slice.slice_id}`,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      // update the redux state
-      // convert the tags to the format used in the selectOwners back to original redux format
-      const selectedOwnersArray = ensureIsArray(selectedOwners);
-      const newOwners = selectedOwnersArray.map((owner: any) => {
-        const nameParts = owner.label.split(' ');
-        const first_name = nameParts[0] || '';
-        const last_name =
-          nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
-        return {
-          id: owner.value,
-          first_name,
-          last_name,
-        };
+      res = await SupersetClient.get({
+        endpoint: `/api/v1/chart/${slice.slice_id}`,
       });
-      const updatedChart = {
-        ...payload,
-        ...res.json.result,
-        tags,
-        id: slice.slice_id,
-        owners: newOwners,
-      };
-      onSave(updatedChart);
+      onSave(res.json.result);
       addSuccessToast(t('Chart properties updated'));
       onHide();
     } catch (res) {

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -192,13 +192,14 @@ function PropertiesModal({
     }
 
     try {
+      const chartEndpoint = `/api/v1/chart/${slice.slice_id}`;
       let res = await SupersetClient.put({
-        endpoint: `/api/v1/chart/${slice.slice_id}`,
+        endpoint: chartEndpoint,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
       res = await SupersetClient.get({
-        endpoint: `/api/v1/chart/${slice.slice_id}`,
+        endpoint: chartEndpoint,
       });
       onSave(res.json.result);
       addSuccessToast(t('Chart properties updated'));

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -201,11 +201,14 @@ function PropertiesModal({
       // convert the tags to the format used in the selectOwners back to original redux format
       const selectedOwnersArray = ensureIsArray(selectedOwners);
       const newOwners = selectedOwnersArray.map((owner: any) => {
-        const [first_name, ...last_name_parts] = owner.label.split(' ');
+        const nameParts = owner.label.split(' ');
+        const first_name = nameParts[0] || '';
+        const last_name =
+          nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
         return {
           id: owner.value,
           first_name,
-          last_name: last_name_parts.join(' '),
+          last_name,
         };
       });
       const updatedChart = {

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -198,12 +198,22 @@ function PropertiesModal({
         body: JSON.stringify(payload),
       });
       // update the redux state
+      // convert the tags to the format used in the selectOwners back to original redux format
+      const selectedOwnersArray = ensureIsArray(selectedOwners);
+      const newOwners = selectedOwnersArray.map((owner: any) => {
+        const [first_name, ...last_name_parts] = owner.label.split(' ');
+        return {
+          id: owner.value,
+          first_name,
+          last_name: last_name_parts.join(' '),
+        };
+      });
       const updatedChart = {
         ...payload,
         ...res.json.result,
         tags,
         id: slice.slice_id,
-        owners: selectedOwners,
+        owners: newOwners,
       };
       onSave(updatedChart);
       addSuccessToast(t('Chart properties updated'));


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Looking to fix: https://github.com/apache/superset/issues/31592.
It's reproducible on all the test-env up environments. Add "Superset Admin" as user on a chart and then save shows the undefined undefined.

I just update the redux with the owner list back in it's original "shape".

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
first half is the broken, second half is working
![fix-chart-list](https://github.com/user-attachments/assets/84e1ee05-cd23-448b-98d8-b7f33b5366d5)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/31592
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
