### PR TITLE
fix: loading examples in CI returns http error "too many requests"

### DIFF
--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -16,7 +16,6 @@
 # under the License.
 import logging
 
-import pandas as pd
 import polyline
 from sqlalchemy import inspect, String, Text
 
@@ -25,7 +24,7 @@ from superset.sql_parse import Table
 from superset.utils import json
 
 from ..utils.database import get_example_database
-from .helpers import get_example_url, get_table_connector_registry
+from .helpers import get_table_connector_registry, read_example_csv
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +37,9 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("bart-lines.json.gz")
-            df = pd.read_json(url, encoding="latin-1", compression="gzip")
+            df = read_example_csv(
+                "bart_lines.csv", encoding="latin-1", compression="gzip"
+            )
             df["path_json"] = df.path.map(json.dumps)
             df["polyline"] = df.path.map(polyline.encode)
             del df["path"]

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -38,7 +38,7 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
 
         if not only_metadata and (not table_exists or force):
             df = read_example_csv(
-                "bart_lines.csv", encoding="latin-1", compression="gzip"
+                "bart-lines.json.gz", encoding="latin-1", compression="gzip"
             )
             df["path_json"] = df.path.map(json.dumps)
             df["polyline"] = df.path.map(polyline.encode)

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -24,7 +24,7 @@ from superset.sql_parse import Table
 from superset.utils import json
 
 from ..utils.database import get_example_database
-from .helpers import get_table_connector_registry, read_example_csv
+from .helpers import get_table_connector_registry, read_example_data
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            df = read_example_csv(
+            df = read_example_data(
                 "bart-lines.json.gz", encoding="latin-1", compression="gzip"
             )
             df["path_json"] = df.path.map(json.dumps)

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -33,11 +33,11 @@ from superset.utils.core import DatasourceType
 
 from ..utils.database import get_example_database
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
     update_slice_ids,
 )
 
@@ -57,8 +57,8 @@ def gen_filter(
 
 
 def load_data(tbl_name: str, database: Database, sample: bool = False) -> None:
-    url = get_example_url("birth_names2.json.gz")
-    pdf = pd.read_json(url, compression="gzip")
+    pdf = read_example_csv("birth_names2.json.gz", compression="gzip")
+
     # TODO(bkyryliuk): move load examples data into the pytest fixture
     if database.backend == "presto":
         pdf.ds = pd.to_datetime(pdf.ds, unit="ms")

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -37,7 +37,7 @@ from .helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
     update_slice_ids,
 )
 
@@ -57,7 +57,7 @@ def gen_filter(
 
 
 def load_data(tbl_name: str, database: Database, sample: bool = False) -> None:
-    pdf = read_example_csv("birth_names2.json.gz", compression="gzip")
+    pdf = read_example_data("birth_names2.json.gz", compression="gzip")
 
     # TODO(bkyryliuk): move load examples data into the pytest fixture
     if database.backend == "presto":

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -17,7 +17,6 @@
 import datetime
 import logging
 
-import pandas as pd
 from sqlalchemy import BigInteger, Date, inspect, String
 from sqlalchemy.sql import column
 
@@ -29,11 +28,11 @@ from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,8 +48,9 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("birth_france_data_for_country_map.csv")
-            data = pd.read_csv(url, encoding="utf-8")
+            data = read_example_csv(
+                "birth_france_data_for_country_map.csv", encoding="utf-8"
+            )
             data["dttm"] = datetime.datetime.now().date()
             data.to_sql(
                 tbl_name,

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -32,7 +32,7 @@ from .helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            data = read_example_csv(
+            data = read_example_data(
                 "birth_france_data_for_country_map.csv", encoding="utf-8"
             )
             data["dttm"] = datetime.datetime.now().date()

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -32,7 +32,7 @@ from .helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ def load_energy(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv("energy.json.gz", compression="gzip")
+            pdf = read_example_data("energy.json.gz", compression="gzip")
             pdf = pdf.head(100) if sample else pdf
             pdf.to_sql(
                 tbl_name,

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -17,7 +17,6 @@
 import logging
 import textwrap
 
-import pandas as pd
 from sqlalchemy import Float, inspect, String
 from sqlalchemy.sql import column
 
@@ -29,11 +28,11 @@ from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,8 +50,7 @@ def load_energy(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("energy.json.gz")
-            pdf = pd.read_json(url, compression="gzip")
+            pdf = read_example_csv("energy.json.gz", compression="gzip")
             pdf = pdf.head(100) if sample else pdf
             pdf.to_sql(
                 tbl_name,

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -43,7 +43,7 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
 
             # Loading airports info to join and get lat/long
             airports = read_example_csv(
-                "flight_data.csv.gz", encoding="latin-1", compression="gzip"
+                "airports.csv.gz", encoding="latin-1", compression="gzip"
             )
             airports = airports.set_index("IATA_CODE")
 

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -23,7 +23,7 @@ import superset.utils.database as database_utils
 from superset import db
 from superset.sql_parse import Table
 
-from .helpers import get_table_connector_registry, read_example_csv
+from .helpers import get_table_connector_registry, read_example_data
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,12 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv(
+            pdf = read_example_data(
                 "flight_data.csv.gz", encoding="latin-1", compression="gzip"
             )
 
             # Loading airports info to join and get lat/long
-            airports = read_example_csv(
+            airports = read_example_data(
                 "airports.csv.gz", encoding="latin-1", compression="gzip"
             )
             airports = airports.set_index("IATA_CODE")

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -23,7 +23,7 @@ import superset.utils.database as database_utils
 from superset import db
 from superset.sql_parse import Table
 
-from .helpers import get_example_url, get_table_connector_registry
+from .helpers import get_table_connector_registry, read_example_csv
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,14 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            flight_data_url = get_example_url("flight_data.csv.gz")
-            pdf = pd.read_csv(flight_data_url, encoding="latin-1", compression="gzip")
+            pdf = read_example_csv(
+                "flight_data.csv.gz", encoding="latin-1", compression="gzip"
+            )
 
             # Loading airports info to join and get lat/long
-            airports_url = get_example_url("airports.csv.gz")
-            airports = pd.read_csv(airports_url, encoding="latin-1", compression="gzip")
+            airports = read_example_csv(
+                "flight_data.csv.gz", encoding="latin-1", compression="gzip"
+            )
             airports = airports.set_index("IATA_CODE")
 
             pdf[  # pylint: disable=unsupported-assignment-operation,useless-suppression

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -19,7 +19,6 @@ import logging
 import random
 
 import geohash
-import pandas as pd
 from sqlalchemy import DateTime, Float, inspect, String
 
 import superset.utils.database as database_utils
@@ -29,11 +28,11 @@ from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,8 +47,9 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("san_francisco.csv.gz")
-            pdf = pd.read_csv(url, encoding="utf-8", compression="gzip")
+            pdf = read_example_csv(
+                "san_francisco.csv.gz", encoding="utf-8", compression="gzip"
+            )
             start = datetime.datetime.now().replace(
                 hour=0, minute=0, second=0, microsecond=0
             )

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -32,7 +32,7 @@ from .helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv(
+            pdf = read_example_data(
                 "san_francisco.csv.gz", encoding="utf-8", compression="gzip"
             )
             start = datetime.datetime.now().replace(

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -27,11 +27,11 @@ from superset.utils.core import DatasourceType
 
 from ..utils.database import get_example_database
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,8 +48,10 @@ def load_multiformat_time_series(  # pylint: disable=too-many-locals
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("multiformat_time_series.json.gz")
-            pdf = pd.read_json(url, compression="gzip")
+            pdf = read_example_csv(
+                "multiformat_time_series.json.gz", compression="gzip"
+            )
+
             # TODO(bkyryliuk): move load examples data into the pytest fixture
             if database.backend == "presto":
                 pdf.ds = pd.to_datetime(pdf.ds, unit="s")

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -31,7 +31,7 @@ from .helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ def load_multiformat_time_series(  # pylint: disable=too-many-locals
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv(
+            pdf = read_example_data(
                 "multiformat_time_series.json.gz", compression="gzip"
             )
 

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -17,7 +17,6 @@
 
 import logging
 
-import pandas as pd
 from sqlalchemy import inspect, String, Text
 
 import superset.utils.database as database_utils
@@ -25,7 +24,7 @@ from superset import db
 from superset.sql_parse import Table
 from superset.utils import json
 
-from .helpers import get_example_url, get_table_connector_registry
+from .helpers import get_table_connector_registry, read_example_csv
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +37,7 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("paris_iris.json.gz")
-            df = pd.read_json(url, compression="gzip")
+            df = read_example_csv("paris_iris.json.gz", compression="gzip")
             df["features"] = df.features.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -24,7 +24,7 @@ from superset import db
 from superset.sql_parse import Table
 from superset.utils import json
 
-from .helpers import get_table_connector_registry, read_example_csv
+from .helpers import get_table_connector_registry, read_example_data
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            df = read_example_csv("paris_iris.json.gz", compression="gzip")
+            df = read_example_data("paris_iris.json.gz", compression="gzip")
             df["features"] = df.features.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -26,10 +26,10 @@ from superset.sql_parse import Table
 from superset.utils.core import DatasourceType
 
 from .helpers import (
-    get_example_url,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
+    read_example_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,8 +46,7 @@ def load_random_time_series_data(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("random_time_series.json.gz")
-            pdf = pd.read_json(url, compression="gzip")
+            pdf = read_example_csv("random_time_series.json.gz", compression="gzip")
             if database.backend == "presto":
                 pdf.ds = pd.to_datetime(pdf.ds, unit="s")
                 pdf.ds = pdf.ds.dt.strftime("%Y-%m-%d %H:%M%:%S")

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -29,7 +29,7 @@ from .helpers import (
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
-    read_example_csv,
+    read_example_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def load_random_time_series_data(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv("random_time_series.json.gz", compression="gzip")
+            pdf = read_example_data("random_time_series.json.gz", compression="gzip")
             if database.backend == "presto":
                 pdf.ds = pd.to_datetime(pdf.ds, unit="s")
                 pdf.ds = pdf.ds.dt.strftime("%Y-%m-%d %H:%M%:%S")

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -17,7 +17,6 @@
 
 import logging
 
-import pandas as pd
 from sqlalchemy import BigInteger, Float, inspect, Text
 
 import superset.utils.database as database_utils
@@ -25,7 +24,7 @@ from superset import db
 from superset.sql_parse import Table
 from superset.utils import json
 
-from .helpers import get_example_url, get_table_connector_registry
+from .helpers import get_table_connector_registry, read_example_csv
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +39,7 @@ def load_sf_population_polygons(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("sf_population.json.gz")
-            df = pd.read_json(url, compression="gzip")
+            df = read_example_csv("sf_population.json.gz", compression="gzip")
             df["contour"] = df.contour.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -24,7 +24,7 @@ from superset import db
 from superset.sql_parse import Table
 from superset.utils import json
 
-from .helpers import get_table_connector_registry, read_example_csv
+from .helpers import get_table_connector_registry, read_example_data
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ def load_sf_population_polygons(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            df = read_example_csv("sf_population.json.gz", compression="gzip")
+            df = read_example_data("sf_population.json.gz", compression="gzip")
             df["contour"] = df.contour.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -25,12 +25,12 @@ import superset.utils.database
 from superset import app, db
 from superset.connectors.sqla.models import BaseDatasource, SqlMetric
 from superset.examples.helpers import (
-    get_example_url,
     get_examples_folder,
     get_slice_json,
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
+    read_example_csv,
     update_slice_ids,
 )
 from superset.models.dashboard import Dashboard
@@ -55,8 +55,7 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            url = get_example_url("countries.json.gz")
-            pdf = pd.read_json(url, compression="gzip")
+            pdf = read_example_csv("countries.json.gz", compression="gzip")
             pdf.columns = [col.replace(".", "_") for col in pdf.columns]
             if database.backend == "presto":
                 pdf.year = pd.to_datetime(pdf.year)

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -30,7 +30,7 @@ from superset.examples.helpers import (
     get_table_connector_registry,
     merge_slice,
     misc_dash_slices,
-    read_example_csv,
+    read_example_data,
     update_slice_ids,
 )
 from superset.models.dashboard import Dashboard
@@ -55,7 +55,7 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_csv("countries.json.gz", compression="gzip")
+            pdf = read_example_data("countries.json.gz", compression="gzip")
             pdf.columns = [col.replace(".", "_") for col in pdf.columns]
             if database.backend == "presto":
                 pdf.year = pd.to_datetime(pdf.year)


### PR DESCRIPTION
Recently in https://github.com/apache/superset/pull/33354 I tried to address http 429 "too many attempts that we started getting in CI. This PR adds a bit of custom logic with retries and expodential backoffs to work around the issue. Ideally we'd have another approach using a proper CDN that supports our needs or use a github repo to clone locally, but this should help relieve the issue.

Regardless of the approach, having a central function `examples.helpers.read_example_csv` is a step in the right direction as it centralizes the logic used to load the csv into a single DRY place.