### PR TITLE
fix(table-chart): time shift is not working

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -59,8 +59,9 @@ export default async function parseResponse<T extends ParseMethod = 'json'>(
       response,
       json: cloneDeepWith(json, (value: any) => {
         if (
-          value?.isGreaterThan?.(Number.MAX_SAFE_INTEGER) ||
-          value?.isLessThan?.(Number.MIN_SAFE_INTEGER)
+          value?.isInteger?.() === true &&
+          (value?.isGreaterThan?.(Number.MAX_SAFE_INTEGER) ||
+            value?.isLessThan?.(Number.MIN_SAFE_INTEGER))
         ) {
           return BigInt(value);
         }

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/parseResponse.ts
@@ -58,16 +58,16 @@ export default async function parseResponse<T extends ParseMethod = 'json'>(
     const result: JsonResponse = {
       response,
       json: cloneDeepWith(json, (value: any) => {
-        // `json-bigint` could not handle floats well, see sidorares/json-bigint#62
-        // TODO: clean up after json-bigint>1.0.1 is released
-        if (value?.isInteger?.() === false) {
-          return Number(value);
-        }
         if (
           value?.isGreaterThan?.(Number.MAX_SAFE_INTEGER) ||
           value?.isLessThan?.(Number.MIN_SAFE_INTEGER)
         ) {
           return BigInt(value);
+        }
+        // // `json-bigint` could not handle floats well, see sidorares/json-bigint#62
+        // // TODO: clean up after json-bigint>1.0.1 is released
+        if (value?.isNaN?.() === false) {
+          return value?.toNumber?.();
         }
         return undefined;
       }),

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
@@ -143,7 +143,7 @@ describe('parseResponse()', () => {
     const mockBigIntUrl = '/mock/get/bigInt';
     const mockGetBigIntPayload = `{
       "value": 9223372036854775807, "minus": { "value": -483729382918228373892, "str": "something" },
-      "number": 1234, "floatValue": { "plus": 0.3452211361231223, "minus": -0.3452211361231223 },
+      "number": 1234, "floatValue": { "plus": 0.3452211361231223, "minus": -0.3452211361231223, "even": 1234567890123456.0000000 },
       "string.constructor": "data.constructor",
       "constructor": "constructor"
     }`;
@@ -161,6 +161,7 @@ describe('parseResponse()', () => {
     expect(responseBigNumber.json.floatValue.minus).toEqual(
       -0.3452211361231223,
     );
+    expect(responseBigNumber.json.floatValue.even).toEqual(1234567890123456);
     expect(
       responseBigNumber.json.floatValue.plus +
         responseBigNumber.json.floatValue.minus,


### PR DESCRIPTION
### SUMMARY
In situations where a floating number is even and the decimal number is large, there is an issue with JSONbig parse converting it to BigNumber instead of a number. This leads to a problem in the process of checking [isMetric](https://github.com/apache/superset/blob/7f14e434c87d3c3ffe403ecf84d10f1ca7686446/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts#L234), as it recognizes that the data contains items that are not of type number, resulting in incorrect output of the time shift values.

The code addresses this issue by converting the parse section to a number.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![Screenshot 2025-05-13 at 1 40 13 PM](https://github.com/user-attachments/assets/9d0ddfa3-ed40-4341-b575-bb66ebde086b)

After:
![Screenshot 2025-05-13 at 1 36 44 PM](https://github.com/user-attachments/assets/1a74f3d5-bf4d-46d4-9a19-c34f516bda52)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
