### PR TITLE
fix(sankey): incorrect nodeValues

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
@@ -73,13 +73,26 @@ export default function transformProps(
   }));
 
   // stores a map with the total values for each node considering the links
-  const nodeValues = new Map<string, number>();
+  const incomingFlows = new Map<string, number>();
+  const outgoingFlows = new Map<string, number>();
+
   links.forEach(link => {
     const { source, target, value } = link;
-    const sourceValue = nodeValues.get(source) || 0;
-    const targetValue = nodeValues.get(target) || 0;
-    nodeValues.set(source, sourceValue + value);
-    nodeValues.set(target, targetValue + value);
+    incomingFlows.set(target, (incomingFlows.get(target) || 0) + value);
+    outgoingFlows.set(source, (outgoingFlows.get(source) || 0) + value);
+  });
+
+  const nodeValues = new Map<string, number>();
+  const allNodeNames = new Set([
+    ...outgoingFlows.keys(),
+    ...incomingFlows.keys(),
+  ]);
+
+  allNodeNames.forEach(nodeName => {
+    const totalIncoming = incomingFlows.get(nodeName) || 0;
+    const totalOutgoing = outgoingFlows.get(nodeName) || 0;
+
+    nodeValues.set(nodeName, Math.max(totalIncoming, totalOutgoing));
   });
 
   const tooltipFormatter = (params: CallbackDataParams) => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/transformProps.ts
@@ -75,18 +75,17 @@ export default function transformProps(
   // stores a map with the total values for each node considering the links
   const incomingFlows = new Map<string, number>();
   const outgoingFlows = new Map<string, number>();
+  const allNodeNames = new Set<string>();
 
   links.forEach(link => {
     const { source, target, value } = link;
+    allNodeNames.add(source);
+    allNodeNames.add(target);
     incomingFlows.set(target, (incomingFlows.get(target) || 0) + value);
     outgoingFlows.set(source, (outgoingFlows.get(source) || 0) + value);
   });
 
   const nodeValues = new Map<string, number>();
-  const allNodeNames = new Set([
-    ...outgoingFlows.keys(),
-    ...incomingFlows.keys(),
-  ]);
 
   allNodeNames.forEach(nodeName => {
     const totalIncoming = incomingFlows.get(nodeName) || 0;


### PR DESCRIPTION
### SUMMARY
The Sankey chart incorrectly calculates the size of nodes that act as both inputs and outputs (intermediate nodes). The current method double-counts the flow through these intermediate points. This inflates their visual size and can distort any overall percentage calculations, making it seem like initial source columns contribute less to the total flow than they actually do (e.g., appearing as 50% instead of 100%).


### BEFORE/AFTER SCREENSHOTS
#### Incorrect
When adding up the values for % (15 to 29 minutes), (20.39% and 29.61%) in the two images below they make a total of 50% instead of 100%
<img width="639" alt="Screenshot 2025-05-13 at 18 20 57" src="https://github.com/user-attachments/assets/f9df9a79-290c-445f-8417-aa1a1d3eb0f9" />
<img width="634" alt="Screenshot 2025-05-13 at 18 20 51" src="https://github.com/user-attachments/assets/b9ae4b20-64f0-46c4-b350-ad7dee3610a8" />
#### Correct
The percentages make a total of 100% in the following images
<img width="630" alt="Screenshot 2025-05-13 at 18 23 01" src="https://github.com/user-attachments/assets/f8a35928-8e47-4930-8112-a123aa68b4dd" />
<img width="623" alt="Screenshot 2025-05-13 at 18 22 51" src="https://github.com/user-attachments/assets/642193a3-b0ee-493f-a53a-ec1313a54b1e" />


### TESTING INSTRUCTIONS
I'm including this [attached chart ](https://github.com/user-attachments/files/20206495/sankey_bug_chart.zip) so the issue is easily reproducible but you can also reproduce the issue following the steps below:
1.  **Configure a Sankey chart with at least three stages (e.g., Source → Intermediate Node → Target).** The attached chart demonstrates this with `is_first_dev_job` → `communite_time` → `job_pref (null)`.
2.  Ensure `communite_time` (the intermediate node) receives links from the first stage and sends links to the third stage.
3.  Observe the chart, particularly the relative sizes of the columns or the way total flow is implied.


### ADDITIONAL INFORMATION
- [X] Fixes #33426 
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
