### PR TITLE
fix(pivot-table): apply safeHtmlSpan for cells in the pivot table chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -65,6 +65,13 @@ function displayHeaderCell(
   );
 }
 
+function renderFormattedValue(formattedValue, allowRenderHtml) {
+  if (allowRenderHtml && typeof formattedValue === 'string') {
+    return safeHtmlSpan(formattedValue);
+  }
+  return formattedValue;
+}
+
 export class TableRenderer extends Component {
   constructor(props) {
     super(props);
@@ -742,7 +749,7 @@ export class TableRenderer extends Component {
           onContextMenu={e => this.props.onContextMenu(e, colKey, rowKey)}
           style={style}
         >
-          {agg.format(aggValue)}
+          {renderFormattedValue(agg.format(aggValue), allowRenderHtml)}
         </td>
       );
     });
@@ -759,7 +766,7 @@ export class TableRenderer extends Component {
           onClick={rowTotalCallbacks[flatRowKey]}
           onContextMenu={e => this.props.onContextMenu(e, undefined, rowKey)}
         >
-          {agg.format(aggValue)}
+          {renderFormattedValue(agg.format(aggValue), allowRenderHtml)}
         </td>
       );
     }
@@ -785,6 +792,7 @@ export class TableRenderer extends Component {
       pivotData,
       colTotalCallbacks,
       grandTotalCallback,
+      allowRenderHtml,
     } = pivotSettings;
 
     const totalLabelCell = (
@@ -823,7 +831,7 @@ export class TableRenderer extends Component {
           onContextMenu={e => this.props.onContextMenu(e, colKey, undefined)}
           style={{ padding: '5px' }}
         >
-          {agg.format(aggValue)}
+          {renderFormattedValue(agg.format(aggValue), allowRenderHtml)}
         </td>
       );
     });
@@ -840,7 +848,7 @@ export class TableRenderer extends Component {
           onClick={grandTotalCallback}
           onContextMenu={e => this.props.onContextMenu(e, undefined, undefined)}
         >
-          {agg.format(aggValue)}
+          {renderFormattedValue(agg.format(aggValue), allowRenderHtml)}
         </td>
       );
     }


### PR DESCRIPTION
### SUMMARY
The Pivot Table chart was not rendering HTML content within its cells. Instead of displaying formatted HTML (e.g., hyperlinks), it showed the raw HTML tags as plain text. This occurred even when the underlying data contained valid HTML strings and the allowRenderHtml prop was set to true.

### BEFORE SCREENSHOT
<img width="1480" alt="Screenshot 2025-05-15 at 11 58 30" src="https://github.com/user-attachments/assets/8de45ea4-0cfd-4268-8282-a2ce53f342e5" />

### AFTER SCREENSHOT
<img width="675" alt="Screenshot 2025-05-15 at 12 19 33" src="https://github.com/user-attachments/assets/56f811ba-3d96-4706-abf6-7d25c6556469" />

### TESTING INSTRUCTIONS
- This [chart export](https://github.com/user-attachments/files/20231051/chart_export_20250515T153644.zip) can be imported into Superset to directly observe the issue. But also possible to be reproduced following the steps below:
1. Create or import a Pivot Table chart where the dataset provides HTML content for one or more cells.
2. Configure the chart to use these HTML-containing fields.
3. Observe the rendering of the data cells in the pivot table. The attached chart export can be imported into Superset to directly observe the issue.


### ADDITIONAL INFORMATION
- [X] Has associated issue: #33449 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
