### PR TITLE
fix(NativeFilters): Apply existing values

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -335,7 +335,13 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       return;
     }
 
-    // Case 2: Handle the default to first Value case
+    if (filterState.value !== undefined) {
+      // Set the filter state value if it is defined
+      updateDataMask(filterState.value);
+      return;
+    }
+
+    // Handle the default to first Value case
     if (defaultToFirstItem) {
       // Set to first item if defaultToFirstItem is true
       const firstItem: SelectValue = data[0]
@@ -345,7 +351,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         updateDataMask(firstItem);
       }
     } else if (formData?.defaultValue) {
-      // Case 3 : Handle defalut value case
+      // Handle defalut value case
       updateDataMask(formData.defaultValue);
     }
   }, [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR https://github.com/apache/superset/pull/33271 has introduced an issue for which existing values would not be showing in select filters when using a permalink for filters with a default value, even though they were applied correctly to the end query.

### BEFORE

https://github.com/user-attachments/assets/f44210bc-ac7e-4c05-b644-a80c10ddb082

### AFTER

https://github.com/user-attachments/assets/7733112e-01f5-455e-af22-048f76b76a50



### TESTING INSTRUCTIONS
1. Open a Dashboard and set a filter with a default value
2. Apply some other filter value and copy a permalink
3. Visit the permalink
4. The filter value should be the last applied not the default

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
