### PR TITLE
fix: optimize Explore popovers rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,12 @@ disallow_untyped_calls = false
 disallow_untyped_defs = false
 disable_error_code = "annotation-unchecked"
 
+# TODO: remove this once cryptography is fixed, introduced in cryptography 44.0.3
+[[tool.mypy.overrides]]
+module = "cryptography.*"
+ignore_errors = true
+follow_imports = "skip"
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -271,7 +277,6 @@ exclude = [
     "site-packages",
     "venv",
 ]
-
 
 # Same as Black.
 line-length = 88

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -83,6 +83,7 @@
         "geostyler-style": "^7.5.0",
         "geostyler-wfs-parser": "^2.0.3",
         "googleapis": "^130.0.0",
+        "handlebars": "^4.7.8",
         "immer": "^10.1.1",
         "interweave": "^13.1.0",
         "jquery": "^3.7.1",
@@ -49924,7 +49925,7 @@
         "@storybook/react-webpack5": "8.2.9",
         "babel-loader": "^9.1.3",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
-        "ts-loader": "^9.5.1",
+        "ts-loader": "^9.5.2",
         "typescript": "^5.7.2"
       },
       "peerDependencies": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -84,7 +84,6 @@
         "geostyler-style": "^7.5.0",
         "geostyler-wfs-parser": "^2.0.3",
         "googleapis": "^130.0.0",
-        "handlebars": "^4.7.8",
         "immer": "^10.1.1",
         "interweave": "^13.1.0",
         "jquery": "^3.7.1",
@@ -50827,6 +50826,7 @@
         "d3": "^3.5.17",
         "d3-tip": "^0.9.1",
         "dayjs": "^1.11.13",
+        "dompurify": "^3.2.4",
         "fast-safe-stringify": "^2.1.1",
         "lodash": "^4.17.21",
         "nvd3-fork": "^2.0.5",
@@ -50836,7 +50836,6 @@
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
-        "dompurify": "^3.2.4",
         "react": "^17.0.2"
       }
     },
@@ -50845,7 +50844,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
       "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -70,6 +70,7 @@
         "dayjs": "^1.11.13",
         "dom-to-image-more": "^3.2.0",
         "dom-to-pdf": "^0.3.2",
+        "dompurify": "^3.2.4",
         "echarts": "^5.6.0",
         "emotion-rgba": "0.0.12",
         "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
@@ -20812,7 +20813,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
       "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -50827,7 +50827,6 @@
         "d3": "^3.5.17",
         "d3-tip": "^0.9.1",
         "dayjs": "^1.11.13",
-        "dompurify": "^3.2.4",
         "fast-safe-stringify": "^2.1.1",
         "lodash": "^4.17.21",
         "nvd3-fork": "^2.0.5",
@@ -50837,6 +50836,7 @@
       "peerDependencies": {
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
+        "dompurify": "^3.2.4",
         "react": "^17.0.2"
       }
     },
@@ -50845,6 +50845,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
       "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -150,6 +150,7 @@
     "geostyler-style": "^7.5.0",
     "geostyler-wfs-parser": "^2.0.3",
     "googleapis": "^130.0.0",
+    "handlebars": "^4.7.8",
     "immer": "^10.1.1",
     "interweave": "^13.1.0",
     "jquery": "^3.7.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -151,7 +151,6 @@
     "geostyler-style": "^7.5.0",
     "geostyler-wfs-parser": "^2.0.3",
     "googleapis": "^130.0.0",
-    "handlebars": "^4.7.8",
     "immer": "^10.1.1",
     "interweave": "^13.1.0",
     "jquery": "^3.7.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -137,6 +137,7 @@
     "dayjs": "^1.11.13",
     "dom-to-image-more": "^3.2.0",
     "dom-to-pdf": "^0.3.2",
+    "dompurify": "^3.2.4",
     "echarts": "^5.6.0",
     "emotion-rgba": "0.0.12",
     "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
@@ -35,12 +35,12 @@
     "lodash": "^4.17.21",
     "dayjs": "^1.11.13",
     "nvd3-fork": "^2.0.5",
+    "dompurify": "^3.2.4",
     "prop-types": "^15.8.1",
     "urijs": "^1.19.11"
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
-    "dompurify": "^3.2.4",
     "@superset-ui/core": "*",
     "react": "^17.0.2"
   }

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
-    "dompurify": "^3.2.4",
     "fast-safe-stringify": "^2.1.1",
     "lodash": "^4.17.21",
     "dayjs": "^1.11.13",
@@ -41,6 +40,7 @@
   },
   "peerDependencies": {
     "@superset-ui/chart-controls": "*",
+    "dompurify": "^3.2.4",
     "@superset-ui/core": "*",
     "react": "^17.0.2"
   }

--- a/superset-frontend/src/components/AsyncAceEditor/Tooltip.test.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/Tooltip.test.tsx
@@ -17,40 +17,17 @@
  * under the License.
  */
 
-import { render, screen } from 'spec/helpers/testing-library';
-import Tooltip, { getTooltipHTML } from './Tooltip';
-
-test('should render a tooltip (React)', () => {
-  const props = {
-    title: 'tooltip title',
-    icon: <div>icon</div>,
-    body: 'body text',
-    meta: 'meta info',
-    footer: 'footer note',
-  };
-
-  render(<Tooltip {...props} />);
-
-  expect(screen.getByText('tooltip title')).toBeInTheDocument();
-  expect(screen.getByText('meta info')).toBeInTheDocument();
-  expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(screen.getByText('body text')).toBeInTheDocument();
-  expect(screen.getByText('footer note')).toBeInTheDocument();
-});
+import { getTooltipHTML } from './Tooltip';
 
 test('getTooltipHTML returns the expected HTML (string inputs)', () => {
   const html = getTooltipHTML({
     title: 'tooltip title',
-    icon: '🔥',
     body: 'body text',
-    meta: 'meta info',
     footer: 'footer note',
   });
 
   expect(html).toContain('tooltip-detail');
   expect(html).toContain('tooltip title');
-  expect(html).toContain('🔥');
   expect(html).toContain('body text');
-  expect(html).toContain('meta info');
   expect(html).toContain('footer note');
 });

--- a/superset-frontend/src/components/AsyncAceEditor/Tooltip.test.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/Tooltip.test.tsx
@@ -11,37 +11,46 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied.  See the License for
+ * the specific language governing permissions and limitations
  * under the License.
  */
 
 import { render, screen } from 'spec/helpers/testing-library';
 import Tooltip, { getTooltipHTML } from './Tooltip';
 
-test('should render a tooltip', () => {
-  const expected = {
+test('should render a tooltip (React)', () => {
+  const props = {
     title: 'tooltip title',
     icon: <div>icon</div>,
-    body: <div>body</div>,
-    meta: 'meta',
-    footer: <div>footer</div>,
+    body: 'body text',
+    meta: 'meta info',
+    footer: 'footer note',
   };
-  render(<Tooltip {...expected} />);
-  expect(screen.getByText(expected.title)).toBeInTheDocument();
-  expect(screen.getByText(expected.meta)).toBeInTheDocument();
+
+  render(<Tooltip {...props} />);
+
+  expect(screen.getByText('tooltip title')).toBeInTheDocument();
+  expect(screen.getByText('meta info')).toBeInTheDocument();
   expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(screen.getByText('body')).toBeInTheDocument();
+  expect(screen.getByText('body text')).toBeInTheDocument();
+  expect(screen.getByText('footer note')).toBeInTheDocument();
 });
 
-test('returns the tooltip HTML', () => {
+test('getTooltipHTML returns the expected HTML (string inputs)', () => {
   const html = getTooltipHTML({
     title: 'tooltip title',
-    icon: <div>icon</div>,
-    body: <div>body</div>,
-    meta: 'meta',
-    footer: <div>footer</div>,
+    icon: '🔥',
+    body: 'body text',
+    meta: 'meta info',
+    footer: 'footer note',
   });
+
+  expect(html).toContain('tooltip-detail');
   expect(html).toContain('tooltip title');
+  expect(html).toContain('🔥');
+  expect(html).toContain('body text');
+  expect(html).toContain('meta info');
+  expect(html).toContain('footer note');
 });

--- a/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
@@ -19,6 +19,7 @@
 
 import Handlebars from 'handlebars';
 import { Tag } from 'src/components';
+import DOMPurify from 'dompurify';
 
 type Props = {
   title: string;
@@ -52,25 +53,27 @@ export const Tooltip: React.FC<Props> = ({
   </div>
 );
 
-const tooltipTemplate = Handlebars.compile(`
-  <div class="tooltip-detail">
-    <div class="tooltip-detail-head">
-      <div class="tooltip-detail-title">
-        {{#if icon}}<span class="tooltip-icon">{{icon}}</span>{{/if}}{{title}}
+export function getTooltipHTML({
+  title,
+  icon,
+  body,
+  meta,
+  footer,
+}: Props): string {
+  const html = `
+    <div class="tooltip-detail">
+      <div class="tooltip-detail-head">
+        <div class="tooltip-detail-title">
+          ${icon ? `<span class="tooltip-icon">${icon}</span>` : ''}${title}
+        </div>
+        ${meta ? `<span class="tooltip-detail-meta"><span class="ant-tag">${meta}</span></span>` : ''}
       </div>
-      {{#if meta}}
-        <span class="tooltip-detail-meta"><span class="ant-tag">{{meta}}</span></span>
-      {{/if}}
+      ${body ? `<div class="tooltip-detail-body">${body}</div>` : ''}
+      ${footer ? `<div class="tooltip-detail-footer">${footer}</div>` : ''}
     </div>
-    {{#if body}}
-      <div class="tooltip-detail-body">{{body}}</div>
-    {{/if}}
-    {{#if footer}}
-      <div class="tooltip-detail-footer">{{footer}}</div>
-    {{/if}}
-  </div>
-`);
+  `;
 
-export const getTooltipHTML = (props: Props): string => tooltipTemplate(props);
+  return DOMPurify.sanitize(html);
+}
 
 export default Tooltip;

--- a/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
@@ -16,15 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { renderToStaticMarkup } from 'react-dom/server';
+
+import Handlebars from 'handlebars';
 import { Tag } from 'src/components';
 
 type Props = {
   title: string;
-  icon?: React.ReactNode;
-  body?: React.ReactNode;
+  icon?: string; // Pass in string if needed, or drop icon entirely
+  body?: string;
   meta?: string;
-  footer?: React.ReactNode;
+  footer?: string;
 };
 
 export const Tooltip: React.FC<Props> = ({
@@ -51,7 +52,25 @@ export const Tooltip: React.FC<Props> = ({
   </div>
 );
 
-export const getTooltipHTML = (props: Props) =>
-  `${renderToStaticMarkup(<Tooltip {...props} />)}`;
+const tooltipTemplate = Handlebars.compile(`
+  <div class="tooltip-detail">
+    <div class="tooltip-detail-head">
+      <div class="tooltip-detail-title">
+        {{#if icon}}<span class="tooltip-icon">{{icon}}</span>{{/if}}{{title}}
+      </div>
+      {{#if meta}}
+        <span class="tooltip-detail-meta"><span class="ant-tag">{{meta}}</span></span>
+      {{/if}}
+    </div>
+    {{#if body}}
+      <div class="tooltip-detail-body">{{body}}</div>
+    {{/if}}
+    {{#if footer}}
+      <div class="tooltip-detail-footer">{{footer}}</div>
+    {{/if}}
+  </div>
+`);
+
+export const getTooltipHTML = (props: Props): string => tooltipTemplate(props);
 
 export default Tooltip;

--- a/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/Tooltip.tsx
@@ -17,63 +17,21 @@
  * under the License.
  */
 
-import Handlebars from 'handlebars';
-import { Tag } from 'src/components';
 import DOMPurify from 'dompurify';
 
 type Props = {
-  title: string;
-  icon?: string; // Pass in string if needed, or drop icon entirely
+  title?: string;
   body?: string;
-  meta?: string;
   footer?: string;
 };
 
-export const Tooltip: React.FC<Props> = ({
-  title,
-  icon,
-  body,
-  meta,
-  footer,
-}) => (
-  <div className="tooltip-detail">
-    <div className="tooltip-detail-head">
-      <div className="tooltip-detail-title">
-        {icon}
-        {title}
-      </div>
-      {meta && (
-        <span className="tooltip-detail-meta">
-          <Tag color="default">{meta}</Tag>
-        </span>
-      )}
-    </div>
-    {body && <div className="tooltip-detail-body">{body ?? title}</div>}
-    {footer && <div className="tooltip-detail-footer">{footer}</div>}
-  </div>
-);
-
-export function getTooltipHTML({
-  title,
-  icon,
-  body,
-  meta,
-  footer,
-}: Props): string {
+export function getTooltipHTML({ title, body, footer }: Props): string {
   const html = `
     <div class="tooltip-detail">
-      <div class="tooltip-detail-head">
-        <div class="tooltip-detail-title">
-          ${icon ? `<span class="tooltip-icon">${icon}</span>` : ''}${title}
-        </div>
-        ${meta ? `<span class="tooltip-detail-meta"><span class="ant-tag">${meta}</span></span>` : ''}
-      </div>
+      ${title ? `<div class="tooltip-detail-title">${title}</div>` : ''}
       ${body ? `<div class="tooltip-detail-body">${body}</div>` : ''}
       ${footer ? `<div class="tooltip-detail-footer">${footer}</div>` : ''}
     </div>
   `;
-
   return DOMPurify.sanitize(html);
 }
-
-export default Tooltip;

--- a/superset-frontend/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/src/components/AsyncAceEditor/index.tsx
@@ -190,50 +190,37 @@ export default function AsyncAceEditor(
         return (
           <>
             <Global
+              key="ace-tooltip-global"
               styles={css`
                 .ace_tooltip {
-                  margin-left: ${supersetTheme.gridUnit * 2}px;
-                  padding: 0px;
+                  all: unset;
+                  position: fixed;
+                  z-index: 9999;
+                  background: ${supersetTheme.colors.grayscale.light5};
                   border: 1px solid ${supersetTheme.colors.grayscale.light1};
+                  padding: ${supersetTheme.gridUnit}px
+                    ${supersetTheme.gridUnit * 2}px;
+                  line-height: 1.4;
+                  max-width: 400px;
+                  min-width: 200px;
+                  pointer-events: auto;
+                  font-size: ${supersetTheme.typography.sizes.m}px;
                 }
 
                 & .tooltip-detail {
-                  background-color: ${supersetTheme.colors.grayscale.light5};
-                  white-space: pre-wrap;
-                  word-break: break-all;
-                  min-width: ${supersetTheme.gridUnit * 50}px;
-                  max-width: ${supersetTheme.gridUnit * 100}px;
-                  & .tooltip-detail-head {
-                    background-color: ${supersetTheme.colors.grayscale.light4};
-                    color: ${supersetTheme.colors.grayscale.dark1};
-                    display: flex;
-                    column-gap: ${supersetTheme.gridUnit}px;
-                    align-items: baseline;
-                    justify-content: space-between;
-                  }
                   & .tooltip-detail-title {
-                    display: flex;
-                    column-gap: ${supersetTheme.gridUnit}px;
+                    font-weight: bold;
+                    font-size: ${supersetTheme.typography.sizes.m}px;
                   }
                   & .tooltip-detail-body {
-                    word-break: break-word;
+                    font-size: ${supersetTheme.typography.sizes.s}px;
+                    padding: ${supersetTheme.gridUnit}px;
                   }
                   & .tooltip-detail-head,
                   & .tooltip-detail-body {
-                    padding: ${supersetTheme.gridUnit}px
-                      ${supersetTheme.gridUnit * 2}px;
                   }
                   & .tooltip-detail-footer {
-                    border-top: 1px ${supersetTheme.colors.grayscale.light2}
-                      solid;
-                    padding: 0 ${supersetTheme.gridUnit * 2}px;
-                    color: ${supersetTheme.colors.grayscale.dark1};
-                    font-size: ${supersetTheme.typography.sizes.xs}px;
-                  }
-                  & .tooltip-detail-meta {
-                    & > .ant-tag {
-                      margin-right: 0px;
-                    }
+                    font-size: ${supersetTheme.typography.sizes.s}px;
                   }
                 }
               `}

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -19,10 +19,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TextArea } from 'src/components/Input';
-import {
-  Tooltip,
-  TooltipProps as TooltipOptions,
-} from 'src/components/Tooltip';
+import { Tooltip, TooltipProps } from 'src/components/Tooltip';
 import { t, withTheme } from '@superset-ui/core';
 
 import Button from 'src/components/Button';
@@ -59,7 +56,7 @@ const propTypes = {
     'vertical',
   ]),
   textAreaStyles: PropTypes.object,
-  tooltipOptions: PropTypes.oneOf([null, TooltipOptions]),
+  tooltipOptions: PropTypes.oneOf([null, TooltipProps]),
 };
 
 const defaultProps = {

--- a/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
+++ b/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
@@ -36,8 +36,7 @@ export function getColumnKeywords(columns: ColumnMeta[]) {
       value: column_name,
       docHTML: getTooltipHTML({
         title: column_name,
-        meta: type ? `column: ${type}` : 'column',
-        body: `${description ?? ''}`,
+        body: `type: ${type || 'unknown'}<br />${description ? `description: ${description}` : ''}`,
         footer: is_certified ? t('Certified by %s', certified_by) : undefined,
       }),
       score: COLUMN_AUTOCOMPLETE_SCORE,

--- a/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
+++ b/superset-frontend/src/explore/controlUtils/getColumnKeywords.tsx
@@ -38,9 +38,7 @@ export function getColumnKeywords(columns: ColumnMeta[]) {
         title: column_name,
         meta: type ? `column: ${type}` : 'column',
         body: `${description ?? ''}`,
-        footer: is_certified ? (
-          <>{t('Certified by %s', certified_by)}</>
-        ) : undefined,
+        footer: is_certified ? t('Certified by %s', certified_by) : undefined,
       }),
       score: COLUMN_AUTOCOMPLETE_SCORE,
       meta: 'column',


### PR DESCRIPTION
Recently noticed that in Explore, loading popovers for metrics, columns, and filters take forever to load. 10+ seconds depending on the number of columns in your dataset. Upon inspection it had to do with a call to `react-dom/server`'s `renderToStaticMarkup` which isn't meant to be used on the client, more of a server thing. The goal was to align tooltips in AceEditor (which use native html) with AntD's. For that we would pass an antd Tooltip to a server-side like component to generate html, which is super slow and inefficient, also it won't work once we land the theming branch as it leverages antdv4's .less definitions.

My solution is to generate the html directly. Not great or fancy but it works and is fast. Plan is probably to move off Ace and onto Monaco...

10 seconds to load a tooltip is not ok ...
<img width="1728" alt="Screenshot 2025-05-16 at 5 37 41 PM" src="https://github.com/user-attachments/assets/4bc4ac69-8f21-4cea-afc8-36cf1936ef5e" />

Also throwing in dompurify in here as we html-render potentially unsafe, user-provided field into html. I think this addresses a XSS vulnerability.


#### before
<img width="532" alt="Screenshot 2025-05-17 at 10 48 26 AM" src="https://github.com/user-attachments/assets/d7db63b0-8a58-4289-95b4-e709f2043ec7" />

#### after
<img width="572" alt="Screenshot 2025-05-17 at 10 40 49 AM" src="https://github.com/user-attachments/assets/2ede2d2f-cd1b-4c95-9367-c95b26e9d83b" />

Tagging @justinpark since he introduced `react-dom/server` here ->  https://github.com/apache/superset/pull/29672
