### PR TITLE
fix: activity table delta time

### DIFF
--- a/superset-frontend/src/features/home/ActivityTable.tsx
+++ b/superset-frontend/src/features/home/ActivityTable.tsx
@@ -104,6 +104,9 @@ const getEntityLastActionOn = (entity: ActivityObject) => {
   }
 
   let time: number | string | undefined | null;
+  if (entity.changed_on_delta_humanized != null) {
+    return t('Modified %s', entity.changed_on_delta_humanized);
+  }
   if ('changed_on' in entity) time = entity.changed_on;
   if ('changed_on_utc' in entity) time = entity.changed_on_utc;
   return t(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
superset home page: fixed activity table delta time
-->

### SUMMARY
How to reproduce the bug:
1. create new SqlQuery and save it
2. go to home page, under 'Recents' -> 'created' 
3. see the new sqlQuery appears with wrong Modified time (see attached picture)
this Modified time appears wrong due to different timezones

The second picture shows the fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="366" alt="timezoneFix-before" src="https://github.com/user-attachments/assets/e8e78370-1bf6-484f-b420-939e9f57a5d2" />

<img width="362" alt="timezoneFix-after" src="https://github.com/user-attachments/assets/6657e264-8905-4b50-9464-9502a44716fb" />



### TESTING INSTRUCTIONS
1. create new SqlQuery and save it
2. go to home page, under 'Recents' -> 'created' 
3. see the new sqlQuery with Modified and a few seconds/minutes
4. change timezone in your computer/Chrome
5. refresh superset home page
6. verify the new sqlQuery with Modified and a few seconds/minutes still (and not hours due to timezone)
7. repeat steps 4-6 to verify it in some more different timezones

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
