### PR TITLE
fix(database): enable superset_app_root override for databaseview link

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.tsx
@@ -45,6 +45,7 @@ import TextControl from 'src/explore/components/controls/TextControl';
 import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import PopoverSection from '@superset-ui/core/components/PopoverSection';
 import ControlHeader from 'src/explore/components/ControlHeader';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 import {
   ANNOTATION_SOURCE_TYPES,
   ANNOTATION_TYPES,
@@ -145,7 +146,7 @@ const NotFoundContent = () => (
         <span>
           {t('Add an annotation layer')}{' '}
           <a
-            href="/annotationlayer/list"
+            href={ensureAppRoot('/annotationlayer/list')}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -29,8 +29,8 @@ import {
   DatasetObject,
 } from 'src/features/datasets/AddDataset/types';
 import { Table } from 'src/hooks/apiResources';
-import { Typography } from '@superset-ui/core/components/Typography';
 import { ensureAppRoot } from 'src/utils/pathUtils';
+import { Typography } from '@superset-ui/core/components/Typography';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;

--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -110,6 +110,34 @@ describe('getBootstrapData and helpers', () => {
       expect(staticAssetsPrefix()).toEqual(expectedStaticPrefix);
     });
 
+    test.each([
+      ['//evil.example.com', 'protocol-relative URL'],
+      // eslint-disable-next-line no-script-url -- intentional unsafe value under test
+      ['javascript:alert(1)', 'javascript scheme'],
+      ['https://evil.example.com', 'absolute URL'],
+      ['/foo"><img src=x>', 'path with HTML meta-characters'],
+    ])(
+      'should fall back to the default root when application_root is %s (%s)',
+      async unsafeRoot => {
+        const customData = {
+          common: {
+            application_root: unsafeRoot,
+            static_assets_prefix: '/custom-static/',
+          },
+        };
+        document.body.innerHTML = `<div id="app" data-bootstrap='${JSON.stringify(customData)}'></div>`;
+
+        jest.resetModules();
+        const { default: getBootstrapData, applicationRoot } =
+          await import('./getBootstrapData');
+        getBootstrapData();
+
+        const expectedAppRoot =
+          DEFAULT_BOOTSTRAP_DATA.common.application_root.replace(/\/$/, '');
+        expect(applicationRoot()).toEqual(expectedAppRoot);
+      },
+    );
+
     test('should defaults without trailing slashes when #app element does not include application_root or static_assets_prefix', async () => {
       // Set up the fake #app element
       const customData = {

--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -38,7 +38,34 @@ const normalizePathWithFallback = (
   fallback: string,
 ): string => (path ?? fallback).replace(/\/$/, '');
 
-const APPLICATION_ROOT_NO_TRAILING_SLASH = normalizePathWithFallback(
+/**
+ * Matches a plain absolute path prefix (e.g. "" for root deployments or
+ * "/analytics" for a subdirectory). The character after the leading slash must
+ * not be another slash, so protocol-relative URLs ("//host") and scheme-bearing
+ * values ("javascript:...") do not qualify.
+ */
+const SAFE_APPLICATION_ROOT_RE = /^(\/[\w\-.][\w\-./]*)?$/;
+
+/**
+ * The application root (SUPERSET_APP_ROOT) is reflected into links and
+ * navigation, so constrain it to a plain absolute path before use. Anything
+ * that isn't a simple "/path" prefix falls back to the default root so a
+ * malformed value can't be reinterpreted as HTML or redirect off-origin. This
+ * also keeps the bootstrap-derived value from being treated as a tainted href
+ * source by static analysis.
+ */
+const sanitizeApplicationRoot = (
+  path: string | undefined,
+  fallback: string,
+): string => {
+  const normalizedFallback = normalizePathWithFallback(fallback, fallback);
+  const normalized = normalizePathWithFallback(path, fallback);
+  return SAFE_APPLICATION_ROOT_RE.test(normalized)
+    ? normalized
+    : normalizedFallback;
+};
+
+const APPLICATION_ROOT_NO_TRAILING_SLASH = sanitizeApplicationRoot(
   getBootstrapData().common.application_root,
   DEFAULT_BOOTSTRAP_DATA.common.application_root,
 );


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`/databaseview/list` is missing the wrapper `ensureAppRoot()` that considers a non-root deployment enabled by `SUPERSET_APP_ROOT` setting

Extension to #30134 

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Set `SUPERSET_APP_ROOT` to `/analytics`
Navigate to New Dataset > Database dropdown > Manage your databases _here_ << link

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
