### PR TITLE
chore: sql/parse cleanup

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -242,7 +242,10 @@ def execute_sql_statement(  # pylint: disable=too-many-statements, too-many-loca
     if not database.allow_dml:
         errors = []
         try:
-            parsed_statement = SQLStatement(sql_statement, engine=db_engine_spec.engine)
+            parsed_statement = SQLStatement(
+                statement=sql_statement,
+                engine=db_engine_spec.engine,
+            )
             disallowed = parsed_statement.is_mutating()
         except SupersetParseError as ex:
             # if we fail to parse the query, disallow by default

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -533,7 +533,7 @@ def has_table_query(expression: str, engine: str) -> bool:
         expression = f"({expression})"
 
     sql = f"SELECT {expression}"
-    statement = SQLStatement(sql, engine)
+    statement = SQLStatement(statement=sql, engine=engine)
     return any(statement.tables)
 
 

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -318,9 +318,9 @@ def test_split_no_dialect() -> None:
     sql = "SELECT col FROM t WHERE col NOT IN (1, 2); SELECT * FROM t; SELECT foo"
     statements = SQLScript(sql, "dremio").statements
     assert len(statements) == 3
-    assert statements[0]._sql == "SELECT col FROM t WHERE col NOT IN (1, 2)"
-    assert statements[1]._sql == "SELECT * FROM t"
-    assert statements[2]._sql == "SELECT foo"
+    assert statements[0].format() == "SELECT\n  col\nFROM t\nWHERE\n  NOT col IN (1, 2)"
+    assert statements[1].format() == "SELECT\n  *\nFROM t"
+    assert statements[2].format() == "SELECT\n  foo"
 
 
 def test_extract_tables_show_columns_from() -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR removes the `_sql` attribute from `SQLStatement` and `KustoKQLStatement`, keeping only the AST in the class. This is important because in https://github.com/apache/superset/pull/33473 we modify the AST inplace, which would require calling `format()` to keep `_sql` in sync. Since the attribute is no longer used in any meaningful way it's better to just get rid of it.

Part of https://github.com/apache/superset/issues/26786, stacked on https://github.com/apache/superset/pull/33457, https://github.com/apache/superset/pull/33456, and https://github.com/apache/superset/pull/33473.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
