### PR TITLE
fix: text => JSON migration util

### DIFF
--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -506,9 +506,21 @@ def cast_text_column_to_json(
         conn.execute(
             text(
                 f"""
-                ALTER TABLE {table}
-                ALTER COLUMN {column} TYPE jsonb
-                USING {column}::jsonb
+CREATE OR REPLACE FUNCTION safe_to_jsonb(input text)
+  RETURNS jsonb
+  LANGUAGE plpgsql
+  IMMUTABLE
+AS $$
+BEGIN
+  RETURN input::jsonb;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN NULL;
+END;
+$$;
+
+ALTER TABLE {table}
+ALTER COLUMN {column} TYPE jsonb
+USING safe_to_jsonb({column});
                 """
             )
         )
@@ -525,6 +537,13 @@ def cast_text_column_to_json(
     stmt_select = select(t.c[pk], t.c[column]).where(t.c[column].is_not(None))
 
     for row_pk, value in conn.execute(stmt_select):
+        try:
+            json.loads(value)
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Invalid JSON value in column {column} for {pk}={row_pk}: {value}"
+            )
+            continue
         stmt_update = update(t).where(t.c[pk] == row_pk).values({tmp_column: value})
         conn.execute(stmt_update)
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Running the migration that converts the `currency` column from text to JSON (from https://github.com/apache/superset/pull/33303) we hit some invalid data. Added a helper function that replaces invalid JSON with `NULL`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
