### PR TITLE
feat: implement CTEs logic in sqlglot

### DIFF
--- a/tests/unit_tests/db_engine_specs/test_mssql.py
+++ b/tests/unit_tests/db_engine_specs/test_mssql.py
@@ -217,17 +217,21 @@ select 'EUR' as cur
 select * from currency union all select * from currency_2
 """
             ),
-            dedent(
-                """WITH currency as (
-select 'INR' as cur
-),
-currency_2 as (
-select 'EUR' as cur
-),
-__cte AS (
-select * from currency union all select * from currency_2
-)"""
-            ),
+            """WITH currency AS (
+  SELECT
+    'INR' AS cur
+), currency_2 AS (
+  SELECT
+    'EUR' AS cur
+), __cte AS (
+  SELECT
+    *
+  FROM currency
+  UNION ALL
+  SELECT
+    *
+  FROM currency_2
+)""",
         ),
         (
             "SELECT 1 as cnt",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Part of https://github.com/apache/superset/issues/26786, stacked on:
- https://github.com/apache/superset/pull/33457
- https://github.com/apache/superset/pull/33456
- https://github.com/apache/superset/pull/33473
- https://github.com/apache/superset/pull/33515
- https://github.com/apache/superset/pull/33474.

Reimplements the `allows_cte_in_subquery` logic in `sqlglot` for SIP-117. This is used by MS SQL and Ocient when wrapping a query in the chart builder: if the original query has CTEs they need to be moved from the subquery to the top level of the query.

That is, this virtual dataset based off of MS SQL:

```sql
WITH foo AS (SELECT * FROM bar)
SELECT * FROM foo;
```

When used in a chart becomes:

```sql
WITH foo AS (SELECT * FROM bar),
     __cte AS (SELECT * FROM foo)
SELECT
  metric1(), metric2(), ...
  dim1, dim2, ...
  FROM __cte
GROUP BY dim1, dim2, ...
```

Note that in theory we could extract just the CTEs to the top-level, building this query:

```sql
WITH foo AS (SELECT * FROM bar)
SELECT
  metric1(), metric2(), ...
  dim1, dim2, ...
  FROM (SELECT * FROM foo)
GROUP BY dim1, dim2, ...
```

But since I don't have access to an MS SQL database I opted to preserve the existing behavior. If we ever decide to do that we could add a method `split_ctes` to `SQLStatement` which returns CTEs and the main query.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
