### PR TITLE
fix: add query identifier to legend items in mixed time series charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -382,7 +382,10 @@ export default function transformProps(
     );
 
     const transformedSeries = transformSeries(
-      entry,
+      {
+        ...entry,
+        id: `${entry.name || ''} (Query A)`,
+      },
       colorScale,
       colorScaleKey,
       {
@@ -430,7 +433,11 @@ export default function transformProps(
     );
 
     const transformedSeries = transformSeries(
-      entry,
+      {
+        ...entry,
+        id: `${entry.name || ''} (Query B)`,
+      },
+
       colorScale,
       colorScaleKey,
       {
@@ -444,9 +451,7 @@ export default function transformProps(
         stackIdSuffix: '\nb',
         yAxisIndex: yAxisIndexB,
         filterState,
-        seriesKey: primarySeries.has(entry.name as string)
-          ? `${entry.name} (1)`
-          : entry.name,
+        seriesKey: entry.name,
         sliceId,
         queryIndex: 1,
         formatter:

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -97,6 +97,7 @@ import {
   getXAxisFormatter,
   getYAxisFormatter,
 } from '../utils/formatters';
+import { getMetricDisplayName } from '../utils/metricDisplayName';
 
 const getFormatter = (
   customFormatters: Record<string, ValueFormatter>,
@@ -222,6 +223,10 @@ export default function transformProps(
   }
 
   const rebasedDataA = rebaseForecastDatum(data1, verboseMap);
+
+  const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
+  const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
+
   const [rawSeriesA] = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
     xAxis: xAxisLabel,
@@ -373,6 +378,12 @@ export default function transformProps(
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
 
+    let displayName = `${entryName} (Query A)`;
+
+    if (groupby.length > 0) {
+      displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
+    }
+
     const seriesFormatter = getFormatter(
       customFormatters,
       formatter,
@@ -384,7 +395,7 @@ export default function transformProps(
     const transformedSeries = transformSeries(
       {
         ...entry,
-        id: `${entry.name || ''} (Query A)`,
+        id: `${displayName || ''}`,
       },
       colorScale,
       colorScaleKey,
@@ -424,6 +435,12 @@ export default function transformProps(
     const seriesName = `${seriesEntry} (1)`;
     const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
+    let displayName = `${entryName} (Query B)`;
+
+    if (groupbyB.length > 0) {
+      displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
+    }
+
     const seriesFormatter = getFormatter(
       customFormattersSecondary,
       formatterSecondary,
@@ -435,7 +452,7 @@ export default function transformProps(
     const transformedSeries = transformSeries(
       {
         ...entry,
-        id: `${entry.name || ''} (Query B)`,
+        id: `${displayName || ''}`,
       },
 
       colorScale,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/metricDisplayName.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/metricDisplayName.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { QueryFormMetric } from '@superset-ui/core';
+
+export const getMetricDisplayName = (
+  metric: QueryFormMetric,
+  verboseMap: Record<string, string> = {},
+): string => {
+  // Case 1: Simple string metric - use verboseMap or the string itself
+  if (typeof metric === 'string') {
+    return verboseMap[metric] || metric;
+  }
+
+  // Case 2: Metric with explicit label - always prefer this if available
+  if (metric.label) {
+    return metric.label;
+  }
+
+  // Case 3: SIMPLE expression type (column with aggregate)
+  if (metric.expressionType === 'SIMPLE') {
+    const column = metric.column || {};
+    const columnName = column.column_name || '';
+    // Use verbose name from column if available
+    const displayName = column.verbose_name || columnName;
+    const aggregate = metric.aggregate || '';
+
+    // If the verbose map has this column, use that
+    if (verboseMap[columnName]) {
+      return `${aggregate}(${verboseMap[columnName]})`;
+    }
+
+    return `${aggregate}(${displayName})`;
+  }
+
+  // Case 4: SQL expression
+  if (metric.expressionType === 'SQL') {
+    return metric.sqlExpression || 'Custom SQL Metric';
+  }
+
+  // Fallback
+  return 'Unknown Metric';
+};

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -129,7 +129,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 1],
               [599916000000, 3],
             ],
-            id: 'boy (Query A)',
+            id: 'sum__num (Query A), boy',
             stack: 'obs\na',
           }),
           expect.objectContaining({
@@ -137,7 +137,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 2],
               [599916000000, 4],
             ],
-            id: 'girl (Query A)',
+            id: 'sum__num (Query A), girl',
             stack: 'obs\na',
           }),
           // Query B — Bar series
@@ -146,7 +146,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 1],
               [599916000000, 3],
             ],
-            id: 'boy (Query B)',
+            id: 'sum__num (Query B), boy',
             stack: 'obs\nb',
           }),
           expect.objectContaining({
@@ -154,7 +154,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 2],
               [599916000000, 4],
             ],
-            id: 'girl (Query B)',
+            id: 'sum__num (Query B), girl',
             stack: 'obs\nb',
           }),
         ]),

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -118,7 +118,9 @@ const chartPropsConfig = {
 
 it('should transform chart props for viz', () => {
   const chartProps = new ChartProps(chartPropsConfig);
-  expect(transformProps(chartProps as EchartsMixedTimeseriesProps)).toEqual(
+  const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
+
+  expect(transformed).toEqual(
     expect.objectContaining({
       echartOptions: expect.objectContaining({
         series: expect.arrayContaining([
@@ -127,7 +129,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 1],
               [599916000000, 3],
             ],
-            id: 'boy',
+            id: 'boy (Query A)',
             stack: 'obs\na',
           }),
           expect.objectContaining({
@@ -135,15 +137,16 @@ it('should transform chart props for viz', () => {
               [599616000000, 2],
               [599916000000, 4],
             ],
-            id: 'girl',
+            id: 'girl (Query A)',
             stack: 'obs\na',
           }),
+          // Query B — Bar series
           expect.objectContaining({
             data: [
               [599616000000, 1],
               [599916000000, 3],
             ],
-            id: 'boy (1)',
+            id: 'boy (Query B)',
             stack: 'obs\nb',
           }),
           expect.objectContaining({
@@ -151,7 +154,7 @@ it('should transform chart props for viz', () => {
               [599616000000, 2],
               [599916000000, 4],
             ],
-            id: 'girl (1)',
+            id: 'girl (Query B)',
             stack: 'obs\nb',
           }),
         ]),


### PR DESCRIPTION
fix(chart): improve legend clarity for mixed time series charts

Fixes: #33552  

## SUMMARY  
This PR improves the legend display in Mixed Time Series Charts when multiple queries with overlapping dimensions are used. Previously, the legend did not clearly distinguish which metric belonged to which query, leading to ambiguity in interpretation.

## BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF  
<!--- Skip this if not applicable -->

## Changes  
- Updated legend format to display metrics as `Metric Name (Query)`, followed by the dimension value.  
- Example format:  
  - `P75ResponseTime (Query A), EXP UI: 25.66`  
  - `QueryCount (Query B), EXP UI: 49`  
- This ensures each legend entry is clearly associated with its respective query, improving readability in cases of overlapping dimension values.

## BEFORE/AFTER SCREENSHOTS  
### Before  
a) Legend entries listed without clarity on their metric name and query source, causing confusion in mixed charts.

![image](https://github.com/user-attachments/assets/5546abb0-d053-4e97-96cb-43c6d95a8fc6)

b) It’s not clear which metric name belongs to which query.

![Screenshot 2025-05-19 at 9 04 50 PM](https://github.com/user-attachments/assets/1eceb052-d47c-4f67-ab2d-8c3e26906de1)

### After  
a) Legend entries now follow this pattern:  
**Metric Name (Query), Dimension Value: OKR Value**, clearly differentiating series per query.

![Screenshot 2025-05-22 at 3 28 35 AM](https://github.com/user-attachments/assets/d46566e6-6f40-42ce-9cd9-92b657a0dc16)

b) The query name is added alongside the metric name to improve clarity and indicate which query it belongs to.

[
![Screenshot 2025-05-19 at 9 03 53 PM](https://github.com/user-attachments/assets/3d30055f-65b4-4ce4-bee4-3a05406f0d07)
](url)

