### PR TITLE
fix(dataset): prevent metric duplication error when editing SQL and adding metric

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.test.jsx
@@ -34,8 +34,8 @@ import mockDatasource from 'spec/fixtures/mockDatasource';
 // Define your constants here
 const SAVE_ENDPOINT = 'glob:*/api/v1/dataset/7';
 const SAVE_PAYLOAD = { new: 'data' };
-const SAVE_DATASOURCE_ENDPOINT = 'glob:*/api/v1/dataset/7';
-const GET_DATASOURCE_ENDPOINT = SAVE_DATASOURCE_ENDPOINT;
+const SAVE_DATASOURCE_ENDPOINT = 'glob:*/api/v1/dataset/7?override_columns=*';
+const GET_DATASOURCE_ENDPOINT = 'glob:*/api/v1/dataset/7';
 const GET_DATABASE_ENDPOINT = 'glob:*/api/v1/database/?q=*';
 
 const mockedProps = {

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { FunctionComponent, useState, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Alert from 'src/components/Alert';
 import Button from 'src/components/Button';
 import {
@@ -36,15 +36,6 @@ import Modal from 'src/components/Modal';
 import AsyncEsmComponent from 'src/components/AsyncEsmComponent';
 import ErrorMessageWithStackTrace from 'src/components/ErrorMessage/ErrorMessageWithStackTrace';
 import withToasts from 'src/components/MessageToasts/withToasts';
-import {
-  startMetaDataLoading,
-  stopMetaDataLoading,
-  syncDatasourceMetadata,
-} from 'src/explore/actions/exploreActions';
-import {
-  fetchSyncedColumns,
-  updateColumns,
-} from 'src/components/Datasource/utils';
 import { DatasetObject } from '../../features/datasets/types';
 
 const DatasourceEditor = AsyncEsmComponent(() => import('./DatasourceEditor'));
@@ -98,14 +89,12 @@ function buildExtraJsonObject(
 
 const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   addSuccessToast,
-  addDangerToast,
   datasource,
   onDatasourceSave,
   onHide,
   show,
 }) => {
   const theme = useTheme();
-  const dispatch = useDispatch();
   const [currentDatasource, setCurrentDatasource] = useState(datasource);
   const currencies = useSelector<
     {
@@ -200,41 +189,13 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const onConfirmSave = async () => {
     // Pull out extra fields into the extra object
     setIsSaving(true);
+    const overrideColumns = datasource.sql !== currentDatasource.sql;
     try {
       await SupersetClient.put({
-        endpoint: `/api/v1/dataset/${currentDatasource.id}`,
+        endpoint: `/api/v1/dataset/${currentDatasource.id}?override_columns=${overrideColumns}`,
         jsonPayload: buildPayload(currentDatasource),
       });
-      if (datasource.sql !== currentDatasource.sql) {
-        // if sql has changed, save a second time with synced columns
-        dispatch(startMetaDataLoading());
-        try {
-          const columnJson = await fetchSyncedColumns(currentDatasource);
-          const columnChanges = updateColumns(
-            currentDatasource.columns,
-            columnJson,
-            addSuccessToast,
-          );
-          currentDatasource.columns = columnChanges.finalColumns;
-          dispatch(syncDatasourceMetadata(currentDatasource));
-          dispatch(stopMetaDataLoading());
-          addSuccessToast(t('Metadata has been synced'));
-        } catch (error) {
-          dispatch(stopMetaDataLoading());
-          addDangerToast(
-            t('An error has occurred while syncing virtual dataset columns'),
-          );
-        }
-        // Fetch refreshed dataset to get metric IDs
-        const { json: refreshed } = await SupersetClient.get({
-          endpoint: `/api/v1/dataset/${currentDatasource.id}`,
-        });
-        currentDatasource.metrics = refreshed.result.metrics;
-        await SupersetClient.put({
-          endpoint: `/api/v1/dataset/${currentDatasource.id}`,
-          jsonPayload: buildPayload(currentDatasource),
-        });
-      }
+
       const { json } = await SupersetClient.get({
         endpoint: `/api/v1/dataset/${currentDatasource?.id}`,
       });

--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -225,6 +225,11 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
             t('An error has occurred while syncing virtual dataset columns'),
           );
         }
+        // Fetch refreshed dataset to get metric IDs
+        const { json: refreshed } = await SupersetClient.get({
+          endpoint: `/api/v1/dataset/${currentDatasource.id}`,
+        });
+        currentDatasource.metrics = refreshed.result.metrics;
         await SupersetClient.put({
           endpoint: `/api/v1/dataset/${currentDatasource.id}`,
           jsonPayload: buildPayload(currentDatasource),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR is intended to solve the issue: https://github.com/apache/superset/issues/33505

When editing a dataset, if both the SQL and a new metric are changed at the same time, Superset throws a "metric already exists" validation error.

This happens because onConfirmSave():

Sends a first PUT to save the updated SQL and metrics

Then, if the SQL has changed, sends a second PUT after syncing columns — but reuses the outdated currentDatasource.metrics without refreshed IDs

As a result, the new metrics appear to lack ids, so the backend treats them as duplicates based on name.

This fix ensures that, after the first save and before the second PUT, we fetch the updated dataset and assign the correct metric IDs, preventing the duplication error.

fixes #33505 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

We would get this error when both the SQL and a new metric are changed at the same time:

![image](https://github.com/user-attachments/assets/83e950e5-74d1-4709-b03a-8e18d65a4830)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
After the fix, try editing the SQL query and adding a new metric would cause no errors:

![image](https://github.com/user-attachments/assets/7eb74d24-798d-4ac3-bcb9-dce139cc631c)

![image](https://github.com/user-attachments/assets/71a6b7d7-4598-4a16-94dc-f28bed7d6c67)


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
