### PR TITLE
fix(Charts.exportTable): download the whole chart when Export to full .CSV is clicked

### DIFF
--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -98,8 +98,7 @@ class CeleryConfig:
 
 
 CELERY_CONFIG = CeleryConfig
-
-FEATURE_FLAGS = {"ALERT_REPORTS": True}
+FEATURE_FLAGS = {"ALERT_REPORTS": True, "ALLOW_FULL_CSV_EXPORT": True}
 ALERT_REPORTS_NOTIFICATION_DRY_RUN = True
 WEBDRIVER_BASEURL = f"http://superset_app{os.environ.get('SUPERSET_APP_ROOT', '/')}/"  # When using docker compose baseurl should be http://superset_nginx{ENV{BASEPATH}}/  # noqa: E501
 # The base URL for the email report hyperlinks.

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -359,6 +359,19 @@ const Chart = props => {
         slice_id: slice.slice_id,
         is_cached: props.isCached,
       });
+      
+      // Need to handle server pagination for full exports
+      let ownStateToUse = props.ownState;
+      
+      // For full CSV exports with server-side pagination, remove pagination parameters
+      if (isFullCSV && formData.server_pagination) {
+        // Create a new object without the pagination parameters
+        ownStateToUse = props.ownState ? { ...props.ownState } : {};
+        // Remove pagination related properties to get a full export
+        delete ownStateToUse.pageSize;
+        delete ownStateToUse.currentPage;
+      }
+      
       exportChart({
         formData: isFullCSV
           ? { ...formData, row_limit: props.maxRows }
@@ -366,7 +379,7 @@ const Chart = props => {
         resultType: isPivot ? 'post_processed' : 'full',
         resultFormat: format,
         force: true,
-        ownState: props.ownState,
+        ownState: ownStateToUse,
       });
     },
     [


### PR DESCRIPTION
### SUMMARY

Previously, when Server-side pagination was enabled, the “Export to full .CSV” button behaved the same as “Export to .CSV”, exporting only the currently visible page (e.g., 50 rows), instead of the entire dataset.

This PR updates Chart.jsx to ensure that the pageSize and currentPage parameters are omitted from the full export request, allowing the “Export to full .CSV” action to retrieve and export the complete dataset as expected.

**We intend to add tests assuming that maintainers are happy with the concept**

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- Before: Clicking “Export to full .CSV” with server pagination enabled only exported the current page (e.g., 50 rows). 
![superset_no_pagination_fix](https://github.com/user-attachments/assets/9d9b5016-8980-4ac2-8587-ff9b8042326c)

- After: Clicking “Export to full .CSV” exports the entire dataset, regardless of the current page size. 
![superset_with_pagination_fix](https://github.com/user-attachments/assets/34352aa4-79a8-4642-89f9-1c1e82c7dcc9)


### TESTING INSTRUCTIONS

1. Go to `Games` chart whose have more than one page of rows (e.g., >100 rows).
2. Enable Server-side pagination and set Server Page Length to 50.
3. Save it as `Games Server pagination`.
4. Add it to the `Video Games Salse` dashboard as `Games Server pagination`
3. Click “Export to full .CSV”.
   - Before this change: Only 50 rows are exported.
   - After this change: All rows in the dataset are exported.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
