### PR TITLE
feat(sqllab): use sqlglot instead of sqlparse

### DIFF
--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -95,6 +95,7 @@ class HiveEngineSpec(PrestoEngineSpec):
     allows_hidden_orderby_agg = False
 
     supports_dynamic_schema = True
+    supports_cross_catalog_queries = False
 
     # When running `SHOW FUNCTIONS`, what is the name of the column with the
     # function names?

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -432,3 +432,54 @@ class TableNotFoundException(SupersetErrorException):
                 level=ErrorLevel.ERROR,
             )
         )
+
+
+class SupersetDMLNotAllowedException(SupersetErrorException):
+    def __init__(self) -> None:
+        error = SupersetError(
+            message=_(
+                "This database does not allow for DDL/DML, but the query mutates "
+                "data. Please contact your administrator for more assistance."
+            ),
+            error_type=SupersetErrorType.DML_NOT_ALLOWED_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+        super().__init__(error)
+
+
+class SupersetInvalidCTASException(SupersetErrorException):
+    def __init__(self) -> None:
+        error = SupersetError(
+            message=_(
+                "CTAS (create table as select) can only be run with a query where "
+                "the last statement is a SELECT. Please make sure your query has "
+                "a SELECT as its last statement. Then, try running your query again."
+            ),
+            error_type=SupersetErrorType.INVALID_CTAS_QUERY_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+        super().__init__(error)
+
+
+class SupersetInvalidCVASException(SupersetErrorException):
+    def __init__(self) -> None:
+        error = SupersetError(
+            message=_(
+                "CVAS (create view as select) can only be run with a query with "
+                "a single SELECT statement. Please make sure your query has only "
+                "a SELECT statement. Then, try running your query again."
+            ),
+            error_type=SupersetErrorType.INVALID_CVAS_QUERY_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+        super().__init__(error)
+
+
+class SupersetResultsBackendNotConfigureException(SupersetErrorException):
+    def __init__(self) -> None:
+        error = SupersetError(
+            message=_("Results backend is not configured."),
+            error_type=SupersetErrorType.RESULTS_BACKEND_NOT_CONFIGURED_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+        super().__init__(error)

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -56,7 +56,8 @@ from superset.models.helpers import (
     ExtraJSONMixin,
     ImportExportMixin,
 )
-from superset.sql_parse import CtasMethod, extract_tables_from_jinja_sql, Table
+from superset.sql.parse import CTASMethod
+from superset.sql_parse import extract_tables_from_jinja_sql, Table
 from superset.sqllab.limiting_factor import LimitingFactor
 from superset.utils import json
 from superset.utils.core import (
@@ -128,7 +129,7 @@ class Query(
     )
     select_as_cta = Column(Boolean)
     select_as_cta_used = Column(Boolean, default=False)
-    ctas_method = Column(String(16), default=CtasMethod.TABLE)
+    ctas_method = Column(String(16), default=CTASMethod.TABLE.name)
 
     progress = Column(Integer, default=0)  # 1..100
     # # of rows in the result set or rows modified.

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -439,22 +439,26 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
-    def as_cte(self, alias: str = "__cte") -> SQLStatement:
+    def as_cte(self, alias: str = "__cte") -> BaseSQLStatement[InternalRepresentation]:
         """
         Rewrite the statement as a CTE.
 
         :param alias: The alias to use for the CTE.
-        :return: A new SQLStatement with the CTE.
+        :return: A new BaseSQLStatement[InternalRepresentation] with the CTE.
         """
         raise NotImplementedError()
 
-    def as_create_table(self, table: Table, method: CTASMethod) -> SQLStatement:
+    def as_create_table(
+        self,
+        table: Table,
+        method: CTASMethod,
+    ) -> BaseSQLStatement[InternalRepresentation]:
         """
         Rewrite the statement as a `CREATE TABLE AS` statement.
 
         :param table: The table to create.
         :param method: The method to use for creating the table.
-        :return: A new SQLStatement with the CTE.
+        :return: A new BaseSQLStatement[InternalRepresentation] with the CTE.
         """
         raise NotImplementedError()
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -458,6 +458,15 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def parse_predicate(self, predicate: str) -> InternalRepresentation:
+        """
+        Parse a predicate string into an AST.
+
+        :param predicate: The predicate to parse.
+        :return: The parsed predicate.
+        """
+        raise NotImplementedError()
+
     def apply_rls(
         self,
         catalog: str | None,
@@ -790,6 +799,15 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         return SQLStatement(ast=create_table, engine=self.engine)
 
+    def parse_predicate(self, predicate: str) -> exp.Expression:
+        """
+        Parse a predicate string into an AST.
+
+        :param predicate: The predicate to parse.
+        :return: The parsed predicate.
+        """
+        return sqlglot.parse_one(predicate, dialect=self._dialect)
+
     def apply_rls(
         self,
         catalog: str | None,
@@ -804,6 +822,9 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         :param schema: The default schema for non-qualified table names
         :param method: The method to use for applying the rules.
         """
+        if not predicates:
+            return
+
         transformers = {
             RLSMethod.AS_PREDICATE: RLSAsPredicateTransformer,
             RLSMethod.AS_SUBQUERY: RLSAsSubqueryTransformer,
@@ -1127,6 +1148,15 @@ class KustoKQLStatement(BaseSQLStatement[str]):
             )
 
         self._parsed = "".join(val for _, val in tokens)
+
+    def parse_predicate(self, predicate: str) -> str:
+        """
+        Parse a predicate string into an AST.
+
+        :param predicate: The predicate to parse.
+        :return: The parsed predicate.
+        """
+        return predicate
 
 
 class SQLScript:

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -36,7 +36,7 @@ from sqlalchemy.dialects.mysql import dialect
 
 from tests.integration_tests.constants import ADMIN_USERNAME
 from tests.integration_tests.test_app import app, login
-from superset.sql_parse import CtasMethod
+from superset.sql.parse import CTASMethod
 from superset import db, security_manager
 from superset.connectors.sqla.models import BaseDatasource, SqlaTable
 from superset.models import core as models
@@ -387,7 +387,7 @@ class SupersetTestCase(TestCase):
         select_as_cta=False,
         tmp_table_name=None,
         schema=None,
-        ctas_method=CtasMethod.TABLE,
+        ctas_method=CTASMethod.TABLE,
         template_params="{}",
     ):
         if username:
@@ -400,7 +400,7 @@ class SupersetTestCase(TestCase):
             "client_id": client_id,
             "queryLimit": query_limit,
             "sql_editor_id": sql_editor_id,
-            "ctas_method": ctas_method,
+            "ctas_method": ctas_method.name,
             "templateParams": template_params,
         }
         if tmp_table_name:

--- a/tests/integration_tests/celery_tests.py
+++ b/tests/integration_tests/celery_tests.py
@@ -39,7 +39,7 @@ from superset.db_engine_specs.base import BaseEngineSpec
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.extensions import celery_app
 from superset.models.sql_lab import Query
-from superset.sql_parse import ParsedQuery, CtasMethod
+from superset.sql.parse import CTASMethod
 from superset.utils.core import backend
 from superset.utils.database import get_example_database
 from tests.integration_tests.conftest import CTAS_SCHEMA_NAME
@@ -76,13 +76,19 @@ def setup_sqllab():
         db.session.query(Query).delete()
         db.session.commit()
         for tbl in TMP_TABLES:
-            drop_table_if_exists(f"{tbl}_{CtasMethod.TABLE.lower()}", CtasMethod.TABLE)
-            drop_table_if_exists(f"{tbl}_{CtasMethod.VIEW.lower()}", CtasMethod.VIEW)
             drop_table_if_exists(
-                f"{CTAS_SCHEMA_NAME}.{tbl}_{CtasMethod.TABLE.lower()}", CtasMethod.TABLE
+                f"{tbl}_{CTASMethod.TABLE.name.lower()}", CTASMethod.TABLE
             )
             drop_table_if_exists(
-                f"{CTAS_SCHEMA_NAME}.{tbl}_{CtasMethod.VIEW.lower()}", CtasMethod.VIEW
+                f"{tbl}_{CTASMethod.VIEW.name.lower()}", CTASMethod.VIEW
+            )
+            drop_table_if_exists(
+                f"{CTAS_SCHEMA_NAME}.{tbl}_{CTASMethod.TABLE.name.lower()}",
+                CTASMethod.TABLE,
+            )
+            drop_table_if_exists(
+                f"{CTAS_SCHEMA_NAME}.{tbl}_{CTASMethod.VIEW.name.lower()}",
+                CTASMethod.VIEW,
             )
 
 
@@ -90,7 +96,7 @@ def run_sql(
     test_client,
     sql,
     cta=False,
-    ctas_method=CtasMethod.TABLE,
+    ctas_method=CTASMethod.TABLE,
     tmp_table="tmp",
     async_=False,
 ):
@@ -104,14 +110,14 @@ def run_sql(
             select_as_cta=cta,
             tmp_table_name=tmp_table,
             client_id="".join(random.choice(string.ascii_lowercase) for i in range(5)),  # noqa: S311
-            ctas_method=ctas_method,
+            ctas_method=ctas_method.name,
         ),
     ).json
 
 
-def drop_table_if_exists(table_name: str, table_type: CtasMethod) -> None:
+def drop_table_if_exists(table_name: str, table_type: CTASMethod) -> None:
     """Drop table if it exists, works on any DB"""
-    sql = f"DROP {table_type} IF EXISTS {table_name}"
+    sql = f"DROP {table_type.name} IF EXISTS {table_name}"
     database = get_example_database()
     with database.get_sqla_engine() as engine:
         engine.execute(sql)
@@ -124,10 +130,10 @@ def quote_f(value: Optional[str]):
         return inspector.engine.dialect.identifier_preparer.quote_identifier(value)
 
 
-def cta_result(ctas_method: CtasMethod):
+def cta_result(ctas_method: CTASMethod):
     if backend() != "presto":
         return [], []
-    if ctas_method == CtasMethod.TABLE:
+    if ctas_method == CTASMethod.TABLE:
         return [{"rows": 1}], [{"name": "rows", "type": "BIGINT", "is_dttm": False}]
     return [{"result": True}], [{"name": "result", "type": "BOOLEAN", "is_dttm": False}]
 
@@ -143,13 +149,13 @@ def get_select_star(table: str, limit: int, schema: Optional[str] = None):
 
 
 @pytest.mark.usefixtures("login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
+@pytest.mark.parametrize("ctas_method", [CTASMethod.TABLE, CTASMethod.VIEW])
 def test_run_sync_query_dont_exist(test_client, ctas_method):
     examples_db = get_example_database()
     engine_name = examples_db.db_engine_spec.engine_name
     sql_dont_exist = "SELECT name FROM table_dont_exist"
     result = run_sql(test_client, sql_dont_exist, cta=True, ctas_method=ctas_method)
-    if backend() == "sqlite" and ctas_method == CtasMethod.VIEW:
+    if backend() == "sqlite" and ctas_method == CTASMethod.VIEW:
         assert QueryStatus.SUCCESS == result["status"], result
     elif backend() == "presto":
         assert (
@@ -188,9 +194,9 @@ def test_run_sync_query_dont_exist(test_client, ctas_method):
 
 
 @pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
-def test_run_sync_query_cta(test_client, ctas_method):
-    tmp_table_name = f"{TEST_SYNC}_{ctas_method.lower()}"
+@pytest.mark.parametrize("ctas_method", [CTASMethod.TABLE, CTASMethod.VIEW])
+def test_run_sync_query_cta(test_client, ctas_method: CTASMethod) -> None:
+    tmp_table_name = f"{TEST_SYNC}_{ctas_method.name.lower()}"
     result = run_sql(
         test_client, QUERY, tmp_table=tmp_table_name, cta=True, ctas_method=ctas_method
     )
@@ -218,16 +224,44 @@ def test_run_sync_query_cta_no_data(test_client):
 
 
 @pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
+@pytest.mark.parametrize(
+    "ctas_method, expected",
+    [
+        (
+            CTASMethod.TABLE,
+            """
+CREATE TABLE sqllab_test_db.test_sync_cta_table AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+        (
+            CTASMethod.VIEW,
+            """
+CREATE VIEW sqllab_test_db.test_sync_cta_view AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+    ],
+)
 @mock.patch(  # noqa: PT008
     "superset.sqllab.sqllab_execution_context.get_cta_schema_name",
     lambda d, u, s, sql: CTAS_SCHEMA_NAME,
 )
-def test_run_sync_query_cta_config(test_client, ctas_method):
+def test_run_sync_query_cta_config(
+    test_client,
+    ctas_method: CTASMethod,
+    expected: str,
+) -> None:
     if backend() == "sqlite":
         # sqlite doesn't support schemas
         return
-    tmp_table_name = f"{TEST_SYNC_CTA}_{ctas_method.lower()}"
+    tmp_table_name = f"{TEST_SYNC_CTA}_{ctas_method.name.lower()}"
     result = run_sql(
         test_client, QUERY, cta=True, ctas_method=ctas_method, tmp_table=tmp_table_name
     )
@@ -235,10 +269,7 @@ def test_run_sync_query_cta_config(test_client, ctas_method):
     assert cta_result(ctas_method) == (result["data"], result["columns"])
 
     query = get_query_by_id(result["query"]["serverId"])
-    assert (
-        f"CREATE {ctas_method} {CTAS_SCHEMA_NAME}.{tmp_table_name} AS \n{QUERY}"
-        == query.executed_sql
-    )
+    assert query.executed_sql == expected
     assert query.select_sql == get_select_star(
         tmp_table_name, limit=query.limit, schema=CTAS_SCHEMA_NAME
     )
@@ -249,16 +280,44 @@ def test_run_sync_query_cta_config(test_client, ctas_method):
 
 
 @pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
+@pytest.mark.parametrize(
+    "ctas_method, expected",
+    [
+        (
+            CTASMethod.TABLE,
+            """
+CREATE TABLE sqllab_test_db.test_async_cta_config_table AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+        (
+            CTASMethod.VIEW,
+            """
+CREATE VIEW sqllab_test_db.test_async_cta_config_view AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+    ],
+)
 @mock.patch(  # noqa: PT008
     "superset.sqllab.sqllab_execution_context.get_cta_schema_name",
     lambda d, u, s, sql: CTAS_SCHEMA_NAME,
 )
-def test_run_async_query_cta_config(test_client, ctas_method):
+def test_run_async_query_cta_config(
+    test_client,
+    ctas_method: CTASMethod,
+    expected: str,
+) -> None:
     if backend() == "sqlite":
         # sqlite doesn't support schemas
         return
-    tmp_table_name = f"{TEST_ASYNC_CTA_CONFIG}_{ctas_method.lower()}"
+    tmp_table_name = f"{TEST_ASYNC_CTA_CONFIG}_{ctas_method.name.lower()}"
     result = run_sql(
         test_client,
         QUERY,
@@ -275,18 +334,43 @@ def test_run_async_query_cta_config(test_client, ctas_method):
         get_select_star(tmp_table_name, limit=query.limit, schema=CTAS_SCHEMA_NAME)
         == query.select_sql
     )
-    assert (
-        f"CREATE {ctas_method} {CTAS_SCHEMA_NAME}.{tmp_table_name} AS \n{QUERY}"
-        == query.executed_sql
-    )
+    assert query.executed_sql == expected
 
     delete_tmp_view_or_table(f"{CTAS_SCHEMA_NAME}.{tmp_table_name}", ctas_method)
 
 
 @pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
-def test_run_async_cta_query(test_client, ctas_method):
-    table_name = f"{TEST_ASYNC_CTA}_{ctas_method.lower()}"
+@pytest.mark.parametrize(
+    "ctas_method, expected",
+    [
+        (
+            CTASMethod.TABLE,
+            """
+CREATE TABLE test_async_cta_table AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+        (
+            CTASMethod.VIEW,
+            """
+CREATE VIEW test_async_cta_view AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+    ],
+)
+def test_run_async_cta_query(
+    test_client,
+    ctas_method: CTASMethod,
+    expected: str,
+) -> None:
+    table_name = f"{TEST_ASYNC_CTA}_{ctas_method.name.lower()}"
     result = run_sql(
         test_client,
         QUERY,
@@ -301,7 +385,7 @@ def test_run_async_cta_query(test_client, ctas_method):
     assert QueryStatus.SUCCESS == query.status
     assert get_select_star(table_name, query.limit) in query.select_sql
 
-    assert f"CREATE {ctas_method} {table_name} AS \n{QUERY}" == query.executed_sql
+    assert query.executed_sql == expected
     assert QUERY == query.sql
     assert query.rows == (1 if backend() == "presto" else 0)
     assert query.select_as_cta
@@ -311,9 +395,37 @@ def test_run_async_cta_query(test_client, ctas_method):
 
 
 @pytest.mark.usefixtures("load_birth_names_data", "login_as_admin")
-@pytest.mark.parametrize("ctas_method", [CtasMethod.TABLE, CtasMethod.VIEW])
-def test_run_async_cta_query_with_lower_limit(test_client, ctas_method):
-    tmp_table = f"{TEST_ASYNC_LOWER_LIMIT}_{ctas_method.lower()}"
+@pytest.mark.parametrize(
+    "ctas_method, expected",
+    [
+        (
+            CTASMethod.TABLE,
+            """
+CREATE TABLE test_async_lower_limit_table AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+        (
+            CTASMethod.VIEW,
+            """
+CREATE VIEW test_async_lower_limit_view AS
+SELECT
+  name
+FROM birth_names
+LIMIT 1
+            """.strip(),
+        ),
+    ],
+)
+def test_run_async_cta_query_with_lower_limit(
+    test_client,
+    ctas_method: CTASMethod,
+    expected: str,
+) -> None:
+    tmp_table = f"{TEST_ASYNC_LOWER_LIMIT}_{ctas_method.name.lower()}"
     result = run_sql(
         test_client,
         QUERY,
@@ -332,7 +444,7 @@ def test_run_async_cta_query_with_lower_limit(test_client, ctas_method):
         else get_select_star(tmp_table, query.limit)
     )
 
-    assert f"CREATE {ctas_method} {tmp_table} AS \n{QUERY}" == query.executed_sql
+    assert query.executed_sql == expected
     assert QUERY == query.sql
 
     assert query.rows == (1 if backend() == "presto" else 0)
@@ -442,28 +554,6 @@ def test_msgpack_payload_serialization():
     assert isinstance(serialized, bytes)
 
 
-def test_create_table_as():
-    q = ParsedQuery("SELECT * FROM outer_space;")
-
-    assert "CREATE TABLE tmp AS \nSELECT * FROM outer_space" == q.as_create_table("tmp")
-    assert (
-        "DROP TABLE IF EXISTS tmp;\nCREATE TABLE tmp AS \nSELECT * FROM outer_space"
-        == q.as_create_table("tmp", overwrite=True)
-    )
-
-    # now without a semicolon
-    q = ParsedQuery("SELECT * FROM outer_space")
-    assert "CREATE TABLE tmp AS \nSELECT * FROM outer_space" == q.as_create_table("tmp")
-
-    # now a multi-line query
-    multi_line_query = "SELECT * FROM planets WHERE\nLuke_Father = 'Darth Vader'"
-    q = ParsedQuery(multi_line_query)
-    assert (
-        "CREATE TABLE tmp AS \nSELECT * FROM planets WHERE\nLuke_Father = 'Darth Vader'"
-        == q.as_create_table("tmp")
-    )
-
-
 def test_in_app_context():
     @celery_app.task(bind=True)
     def my_task(self):
@@ -484,8 +574,8 @@ def test_in_app_context():
     )
 
 
-def delete_tmp_view_or_table(name: str, db_object_type: str):
-    db.get_engine().execute(f"DROP {db_object_type} IF EXISTS {name}")
+def delete_tmp_view_or_table(name: str, ctas_method: CTASMethod):
+    db.get_engine().execute(f"DROP {ctas_method.name} IF EXISTS {name}")
 
 
 def wait_for_success(result):

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -21,105 +21,38 @@ from unittest import mock
 from uuid import UUID
 
 import pytest
-import sqlparse
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
-from sqlalchemy.orm.session import Session
 
-from superset import db
 from superset.common.db_query_status import QueryStatus
 from superset.errors import ErrorLevel, SupersetErrorType
 from superset.exceptions import OAuth2Error, SupersetErrorException
 from superset.models.core import Database
-from superset.sql_lab import execute_sql_statements, get_sql_results
-from superset.utils.core import override_user
+from superset.sql_lab import execute_query, execute_sql_statements, get_sql_results
 from tests.unit_tests.models.core_test import oauth2_client_info
 
 
-def test_execute_sql_statement(mocker: MockerFixture, app: None) -> None:
+def test_execute_query(mocker: MockerFixture, app: None) -> None:
     """
     Simple test for `execute_sql_statement`.
     """
-    from superset.sql_lab import execute_sql_statement
-
-    sql_statement = "SELECT 42 AS answer"
-
     query = mocker.MagicMock()
+    query.executed_sql = "SELECT 42 AS answer"
+
     query.limit = 1
-    query.select_as_cta_used = False
     database = query.database
     database.allow_dml = False
-    database.apply_limit_to_sql.return_value = "SELECT 42 AS answer LIMIT 2"
-    database.mutate_sql_based_on_config.return_value = "SELECT 42 AS answer LIMIT 2"
     db_engine_spec = database.db_engine_spec
     db_engine_spec.fetch_data.return_value = [(42,)]
 
     cursor = mocker.MagicMock()
     SupersetResultSet = mocker.patch("superset.sql_lab.SupersetResultSet")  # noqa: N806
 
-    execute_sql_statement(
-        sql_statement,
-        query,
-        cursor=cursor,
-        log_params={},
-        apply_ctas=False,
-    )
+    execute_query(query, cursor=cursor, log_params={})
 
-    database.apply_limit_to_sql.assert_called_with("SELECT 42 AS answer", 2, force=True)
     db_engine_spec.execute_with_cursor.assert_called_with(
         cursor,
-        "SELECT 42 AS answer LIMIT 2",
-        query,
-    )
-    SupersetResultSet.assert_called_with([(42,)], cursor.description, db_engine_spec)
-
-
-def test_execute_sql_statement_with_rls(
-    mocker: MockerFixture,
-) -> None:
-    """
-    Test for `execute_sql_statement` when an RLS rule is in place.
-    """
-    from superset.sql_lab import execute_sql_statement
-
-    sql_statement = "SELECT * FROM sales"
-    sql_statement_with_rls = f"{sql_statement} WHERE organization_id=42"
-    sql_statement_with_rls_and_limit = f"{sql_statement_with_rls} LIMIT 101"
-
-    query = mocker.MagicMock()
-    query.limit = 100
-    query.select_as_cta_used = False
-    database = query.database
-    database.allow_dml = False
-    database.apply_limit_to_sql.return_value = sql_statement_with_rls_and_limit
-    database.mutate_sql_based_on_config.return_value = sql_statement_with_rls_and_limit
-    db_engine_spec = database.db_engine_spec
-    db_engine_spec.fetch_data.return_value = [(42,)]
-
-    cursor = mocker.MagicMock()
-    SupersetResultSet = mocker.patch("superset.sql_lab.SupersetResultSet")  # noqa: N806
-    mocker.patch(
-        "superset.sql_lab.insert_rls_as_subquery",
-        return_value=sqlparse.parse("SELECT * FROM sales WHERE organization_id=42")[0],
-    )
-    mocker.patch("superset.sql_lab.is_feature_enabled", return_value=True)
-
-    execute_sql_statement(
-        sql_statement,
-        query,
-        cursor=cursor,
-        log_params={},
-        apply_ctas=False,
-    )
-
-    database.apply_limit_to_sql.assert_called_with(
-        "SELECT * FROM sales WHERE organization_id=42",
-        101,
-        force=True,
-    )
-    db_engine_spec.execute_with_cursor.assert_called_with(
-        cursor,
-        "SELECT * FROM sales WHERE organization_id=42 LIMIT 101",
+        "SELECT 42 AS answer",
         query,
     )
     SupersetResultSet.assert_called_with([(42,)], cursor.description, db_engine_spec)
@@ -232,122 +165,6 @@ def test_execute_sql_statement_within_payload_limit(mocker: MockerFixture) -> No
         )
 
 
-def test_sql_lab_insert_rls_as_subquery(
-    mocker: MockerFixture,
-    session: Session,
-) -> None:
-    """
-    Integration test for `insert_rls_as_subquery`.
-    """
-    from flask_appbuilder.security.sqla.models import Role, User
-
-    from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
-    from superset.models.core import Database
-    from superset.models.sql_lab import Query
-    from superset.security.manager import SupersetSecurityManager
-    from superset.sql_lab import execute_sql_statement
-    from superset.utils.core import RowLevelSecurityFilterType
-
-    engine = db.session.connection().engine
-    Query.metadata.create_all(engine)  # pylint: disable=no-member
-
-    connection = engine.raw_connection()
-    connection.execute("CREATE TABLE t (c INTEGER)")
-    for i in range(10):
-        connection.execute("INSERT INTO t VALUES (?)", (i,))
-
-    cursor = connection.cursor()
-
-    query = Query(
-        sql="SELECT c FROM t",
-        client_id="abcde",
-        database=Database(database_name="test_db", sqlalchemy_uri="sqlite://"),
-        schema=None,
-        limit=5,
-        select_as_cta_used=False,
-    )
-    db.session.add(query)
-    db.session.commit()
-
-    admin = User(
-        first_name="Alice",
-        last_name="Doe",
-        email="adoe@example.org",
-        username="admin",
-        roles=[Role(name="Admin")],
-    )
-
-    # first without RLS
-    with override_user(admin):
-        superset_result_set = execute_sql_statement(
-            sql_statement=query.sql,
-            query=query,
-            cursor=cursor,
-            log_params=None,
-            apply_ctas=False,
-        )
-    assert (
-        superset_result_set.to_pandas_df().to_markdown()
-        == """
-|    |   c |
-|---:|----:|
-|  0 |   0 |
-|  1 |   1 |
-|  2 |   2 |
-|  3 |   3 |
-|  4 |   4 |""".strip()
-    )
-    assert query.executed_sql == "SELECT\n  c\nFROM t\nLIMIT 6"
-
-    # now with RLS
-    rls = RowLevelSecurityFilter(
-        name="sqllab_rls1",
-        filter_type=RowLevelSecurityFilterType.REGULAR,
-        tables=[SqlaTable(database_id=1, schema=None, table_name="t")],
-        roles=[admin.roles[0]],
-        group_key=None,
-        clause="c > 5",
-    )
-    db.session.add(rls)
-    db.session.flush()
-    mocker.patch.object(SupersetSecurityManager, "find_user", return_value=admin)
-    mocker.patch("superset.sql_lab.is_feature_enabled", return_value=True)
-
-    with override_user(admin):
-        superset_result_set = execute_sql_statement(
-            sql_statement=query.sql,
-            query=query,
-            cursor=cursor,
-            log_params=None,
-            apply_ctas=False,
-        )
-    assert (
-        superset_result_set.to_pandas_df().to_markdown()
-        == """
-|    |   c |
-|---:|----:|
-|  0 |   6 |
-|  1 |   7 |
-|  2 |   8 |
-|  3 |   9 |""".strip()
-    )
-    assert (
-        query.executed_sql
-        == """SELECT
-  c
-FROM (
-  SELECT
-    *
-  FROM t
-  WHERE
-    (
-      t.c > 5
-    )
-) AS t
-LIMIT 6"""
-    )
-
-
 @freeze_time("2021-04-01T00:00:00Z")
 def test_get_sql_results_oauth2(mocker: MockerFixture, app) -> None:
     """
@@ -377,8 +194,7 @@ def test_get_sql_results_oauth2(mocker: MockerFixture, app) -> None:
         "OAuth2 required"
     )
 
-    query = mocker.MagicMock()
-    query.database = database
+    query = mocker.MagicMock(select_as_cta=False, database=database)
     mocker.patch("superset.sql_lab.get_query", return_value=query)
 
     payload = get_sql_results(query_id=1, rendered_query="SELECT 1")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Part of https://github.com/apache/superset/issues/26786, stacked on:

- https://github.com/apache/superset/pull/33456
- https://github.com/apache/superset/pull/33457
- https://github.com/apache/superset/pull/33473
- https://github.com/apache/superset/pull/33515
- https://github.com/apache/superset/pull/33474
- https://github.com/apache/superset/pull/33518
- https://github.com/apache/superset/pull/33524
- https://github.com/apache/superset/pull/33525

Hooks SQL Lab to use the new `SQLScript`, instead of `ParsedQuery`. I also cleaned up the `execute_sql_statement` function, which did **way more** than executing a SQL statement — it included RLs modifications, adding limits, CTAS/CVAS, etc.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
