### PR TITLE
fix(Select): Add buttonStyle prop for backward compatibility

### DIFF
--- a/superset-frontend/src/components/Select/Select.tsx
+++ b/superset-frontend/src/components/Select/Select.tsx
@@ -443,6 +443,7 @@ const Select = forwardRef(
         <StyledBulkActionsContainer className="select-bulk-actions" size={0}>
           <Button
             type="link"
+            buttonStyle="link"
             buttonSize="xsmall"
             disabled={bulkSelectCounts.selectable === 0}
             onMouseDown={e => {
@@ -455,6 +456,7 @@ const Select = forwardRef(
           </Button>
           <Button
             type="link"
+            buttonStyle="link"
             buttonSize="xsmall"
             disabled={bulkSelectCounts.deselectable === 0}
             onMouseDown={e => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We have noticed an issue without the buttonStyle prop for backward compatibility of the button styles. This fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot 2025-05-20 at 17 10 15](https://github.com/user-attachments/assets/946fca23-6447-4949-9176-63bd077d808b)

![Screenshot 2025-05-20 at 17 09 14](https://github.com/user-attachments/assets/a6462720-a060-44c2-8e27-b5337bb90af6)


### TESTING INSTRUCTIONS
1. Open a Select filter with multi options
2. Select All / Deselect All should appear as links

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
