### PR TITLE
fix: set template_params to null on empty string

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal.tsx
@@ -140,7 +140,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       cache_timeout:
         datasource.cache_timeout === '' ? null : datasource.cache_timeout,
       is_sqllab_view: datasource.is_sqllab_view,
-      template_params: datasource.template_params,
+      template_params: datasource.template_params === '' ? null : datasource.template_params,
       extra: datasource.extra,
       is_managed_externally: datasource.is_managed_externally,
       external_url: datasource.external_url,


### PR DESCRIPTION
### SUMMARY
When editing Template Parameters in the frontend the template_parameters key on a dataset gets set to empty string when saving empty data. This breaks export->import since the import validation expects a python dict or nothing. This PR only updates the frontend to not send empty strings to the backend.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
When attempting to upload a Dashboard with a dataset which has had its template parameters removed before exporting.
![GUI before](https://github.com/user-attachments/assets/d2347594-1922-4a7a-9a1d-dd6372c31fda)

Network tab for the PUT operation.
![before_network](https://github.com/user-attachments/assets/30f43681-b2cf-499f-8de7-813da6de0047)

Network tab for the PUT operation with the change.
![after_network](https://github.com/user-attachments/assets/0ad16981-30af-441b-b284-d1a0685c3714)

### TESTING INSTRUCTIONS

1. Edit a dataset belonging to a Dashboard
2. Add template parameters
3. Remove them
4. Export the Dashboard
5. Import the Dashboard

Before the fix this should fail, with the fix this should work.

### ADDITIONAL INFORMATION
I wanted a proper fix in the backend, but the data gets read/written directly from the database from what I can tell. This is a dirty quick fix that should help some people.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Maybe https://github.com/apache/superset/issues/27027
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
