### PR TITLE
fix(AllEntities): Display action buttons according to the user permissions

### DIFF
--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -148,5 +148,32 @@ describe('AllEntitiesTable', () => {
     expect(screen.getByText('Engagement')).toBeInTheDocument();
 
     expect(screen.queryByText('Current Tag')).not.toBeInTheDocument();
+
+    expect(screen.getByText('Edit tag')).toBeInTheDocument();
+  });
+
+  it('Do not show the edit tag button if the user does not have permission', () => {
+    render(
+      <AllEntitiesTable
+        search=""
+        setShowTagModal={mockSetShowTagModal}
+        objects={mockObjectsWithTags}
+        canEditTag
+      />,
+      { useRouter: true },
+    );
+
+    expect(screen.getByText('Sales Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+
+    expect(screen.getByText('Monthly Revenue')).toBeInTheDocument();
+    expect(screen.getByText('Revenue')).toBeInTheDocument();
+
+    expect(screen.getByText('User Engagement')).toBeInTheDocument();
+    expect(screen.getByText('Engagement')).toBeInTheDocument();
+
+    expect(screen.queryByText('Current Tag')).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Edit tag')).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -138,42 +138,41 @@ describe('AllEntitiesTable', () => {
       { useRouter: true },
     );
 
+    expect(screen.getByText('Dashboards')).toBeInTheDocument();
     expect(screen.getByText('Sales Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Sales')).toBeInTheDocument();
 
+    expect(screen.getByText('Charts')).toBeInTheDocument();
     expect(screen.getByText('Monthly Revenue')).toBeInTheDocument();
     expect(screen.getByText('Revenue')).toBeInTheDocument();
 
+    expect(screen.getByText('Queries')).toBeInTheDocument();
     expect(screen.getByText('User Engagement')).toBeInTheDocument();
     expect(screen.getByText('Engagement')).toBeInTheDocument();
 
     expect(screen.queryByText('Current Tag')).not.toBeInTheDocument();
-
-    expect(screen.getByText('Edit tag')).toBeInTheDocument();
   });
 
-  it('Do not show the edit tag button if the user does not have permission', () => {
+  it('Only list asset types that have entities', () => {
+    const mockObjects = {
+      dashboard: [],
+      chart: [mockObjectsWithTags.chart[0]],
+      query: [],
+    };
+
     render(
       <AllEntitiesTable
         search=""
         setShowTagModal={mockSetShowTagModal}
-        objects={mockObjectsWithTags}
+        objects={mockObjects}
         canEditTag
       />,
       { useRouter: true },
     );
 
-    expect(screen.getByText('Sales Dashboard')).toBeInTheDocument();
-    expect(screen.getByText('Sales')).toBeInTheDocument();
-
+    expect(screen.queryByText('Dashboards')).not.toBeInTheDocument();
+    expect(screen.getByText('Charts')).toBeInTheDocument();
     expect(screen.getByText('Monthly Revenue')).toBeInTheDocument();
-    expect(screen.getByText('Revenue')).toBeInTheDocument();
-
-    expect(screen.getByText('User Engagement')).toBeInTheDocument();
-    expect(screen.getByText('Engagement')).toBeInTheDocument();
-
-    expect(screen.queryByText('Current Tag')).not.toBeInTheDocument();
-
-    expect(screen.queryByText('Edit tag')).not.toBeInTheDocument();
+    expect(screen.queryByText('Queries')).not.toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -91,12 +91,13 @@ describe('AllEntitiesTable', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders when empty', () => {
+  it('renders when empty with button to tag if user has perm', () => {
     render(
       <AllEntitiesTable
         search=""
         setShowTagModal={mockSetShowTagModal}
         objects={mockObjects}
+        canEditTag
       />,
       { useRouter: true },
     );
@@ -108,12 +109,31 @@ describe('AllEntitiesTable', () => {
     expect(screen.getByText('Add tag to entities')).toBeInTheDocument();
   });
 
+  it('renders when empty without button to tag if user does not have perm', () => {
+    render(
+      <AllEntitiesTable
+        search=""
+        setShowTagModal={mockSetShowTagModal}
+        objects={mockObjects}
+        canEditTag={false}
+      />,
+      { useRouter: true },
+    );
+
+    expect(
+      screen.getByText('No entities have this tag currently assigned'),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText('Add tag to entities')).not.toBeInTheDocument();
+  });
+
   it('renders the correct tags for each object type, excluding the current tag', () => {
     render(
       <AllEntitiesTable
         search=""
         setShowTagModal={mockSetShowTagModal}
         objects={mockObjectsWithTags}
+        canEditTag
       />,
       { useRouter: true },
     );

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
@@ -65,10 +65,10 @@ export default function AllEntitiesTable({
   type objectType = 'dashboard' | 'chart' | 'query';
 
   const [tagId] = useQueryParam('id', NumberParam);
-  const showListViewObjs =
-    objects.dashboard.length > 0 ||
-    objects.chart.length > 0 ||
-    objects.query.length > 0;
+  const showDashboardList = objects.dashboard.length > 0;
+  const showChartList = objects.chart.length > 0;
+  const showQueryList = objects.query.length > 0;
+  const showListViewObjs = showDashboardList || showChartList || showQueryList;
 
   const renderTable = (type: objectType) => {
     const data = objects[type].map((o: TaggedObject) => ({
@@ -136,12 +136,24 @@ export default function AllEntitiesTable({
     <AllEntitiesTableContainer>
       {showListViewObjs ? (
         <>
-          <div className="entity-title">{t('Dashboards')}</div>
-          {renderTable('dashboard')}
-          <div className="entity-title">{t('Charts')}</div>
-          {renderTable('chart')}
-          <div className="entity-title">{t('Queries')}</div>
-          {renderTable('query')}
+          {showDashboardList && (
+            <>
+              <div className="entity-title">{t('Dashboards')}</div>
+              {renderTable('dashboard')}
+            </>
+          )}
+          {showChartList && (
+            <>
+              <div className="entity-title">{t('Charts')}</div>
+              {renderTable('chart')}
+            </>
+          )}
+          {showQueryList && (
+            <>
+              <div className="entity-title">{t('Queries')}</div>
+              {renderTable('query')}
+            </>
+          )}
         </>
       ) : (
         <>

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
@@ -156,17 +156,15 @@ export default function AllEntitiesTable({
           )}
         </>
       ) : (
-        <>
-          <EmptyState
-            image="dashboard.svg"
-            size="large"
-            title={t('No entities have this tag currently assigned')}
-            {...(canEditTag && {
-              buttonAction: () => setShowTagModal(true),
-              buttonText: t('Add tag to entities'),
-            })}
-          />
-        </>
+        <EmptyState
+          image="dashboard.svg"
+          size="large"
+          title={t('No entities have this tag currently assigned')}
+          {...(canEditTag && {
+            buttonAction: () => setShowTagModal(true),
+            buttonText: t('Add tag to entities'),
+          })}
+        />
       )}
     </AllEntitiesTableContainer>
   );

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.tsx
@@ -53,12 +53,14 @@ interface AllEntitiesTableProps {
   search?: string;
   setShowTagModal: (show: boolean) => void;
   objects: TaggedObjects;
+  canEditTag: boolean;
 }
 
 export default function AllEntitiesTable({
   search = '',
   setShowTagModal,
   objects,
+  canEditTag,
 }: AllEntitiesTableProps) {
   type objectType = 'dashboard' | 'chart' | 'query';
 
@@ -142,13 +144,17 @@ export default function AllEntitiesTable({
           {renderTable('query')}
         </>
       ) : (
-        <EmptyState
-          image="dashboard.svg"
-          size="large"
-          title={t('No entities have this tag currently assigned')}
-          buttonAction={() => setShowTagModal(true)}
-          buttonText={t('Add tag to entities')}
-        />
+        <>
+          <EmptyState
+            image="dashboard.svg"
+            size="large"
+            title={t('No entities have this tag currently assigned')}
+            {...(canEditTag && {
+              buttonAction: () => setShowTagModal(true),
+              buttonText: t('Add tag to entities'),
+            })}
+          />
+        </>
       )}
     </AllEntitiesTableContainer>
   );

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -35,6 +35,8 @@ import { fetchObjectsByTagIds, fetchSingleTag } from 'src/features/tags/tags';
 import Loading from 'src/components/Loading';
 import getOwnerName from 'src/utils/getOwnerName';
 import { TaggedObject, TaggedObjects } from 'src/types/TaggedObject';
+import { store } from 'src/views/store';
+import { findPermission } from 'src/utils/findPermission';
 
 const additionalItemsStyles = (theme: SupersetTheme) => css`
   display: flex;
@@ -99,6 +101,10 @@ function AllEntities() {
     chart: [],
     query: [],
   });
+
+  const state = store?.getState();
+  const user = state?.user;
+  const canEditTag = findPermission('can_write', 'Tag', user?.roles);
 
   const editableTitleProps = {
     title: tag?.name || '',
@@ -211,14 +217,16 @@ function AllEntities() {
           }
           rightPanelAdditionalItems={
             <>
-              <Button
-                data-test="bulk-select-action"
-                buttonStyle="secondary"
-                onClick={() => setShowTagModal(true)}
-                showMarginRight={false}
-              >
-                {t('Edit Tag')}{' '}
-              </Button>
+              {canEditTag && (
+                <Button
+                  data-test="bulk-select-action"
+                  buttonStyle="secondary"
+                  onClick={() => setShowTagModal(true)}
+                  showMarginRight={false}
+                >
+                  {t('Edit Tag')}{' '}
+                </Button>
+              )}
             </>
           }
           menuDropdownProps={{
@@ -232,6 +240,7 @@ function AllEntities() {
           search={tag?.name || ''}
           setShowTagModal={setShowTagModal}
           objects={objects}
+          canEditTag={canEditTag}
         />
       </div>
     </AllEntitiesContainer>

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -35,8 +35,9 @@ import { fetchObjectsByTagIds, fetchSingleTag } from 'src/features/tags/tags';
 import Loading from 'src/components/Loading';
 import getOwnerName from 'src/utils/getOwnerName';
 import { TaggedObject, TaggedObjects } from 'src/types/TaggedObject';
-import { store } from 'src/views/store';
 import { findPermission } from 'src/utils/findPermission';
+import { useSelector } from 'react-redux';
+import { RootState } from 'src/dashboard/types';
 
 const additionalItemsStyles = (theme: SupersetTheme) => css`
   display: flex;
@@ -102,9 +103,9 @@ function AllEntities() {
     query: [],
   });
 
-  const state = store?.getState();
-  const user = state?.user;
-  const canEditTag = findPermission('can_write', 'Tag', user?.roles);
+  const canEditTag = useSelector((state: RootState) =>
+    findPermission('can_write', 'Tag', state.user?.roles),
+  );
 
   const editableTitleProps = {
     title: tag?.name || '',
@@ -224,7 +225,7 @@ function AllEntities() {
                   onClick={() => setShowTagModal(true)}
                   showMarginRight={false}
                 >
-                  {t('Edit Tag')}{' '}
+                  {t('Edit tag')}{' '}
                 </Button>
               )}
             </>

--- a/superset/views/all_entities.py
+++ b/superset/views/all_entities.py
@@ -22,6 +22,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.security.decorators import has_access
 
 from superset import is_feature_enabled
+from superset.constants import RouteMethod
 from superset.superset_typing import FlaskResponse
 from superset.tags.models import Tag
 from superset.views.base import SupersetModelView
@@ -33,7 +34,7 @@ class TaggedObjectsModelView(SupersetModelView):
     route_base = "/superset/all_entities"
     datamodel = SQLAInterface(Tag)
     class_permission_name = "Tags"
-    include_route_methods = {"list"}
+    include_route_methods = {RouteMethod.LIST}
 
     @has_access
     @expose("/")


### PR DESCRIPTION
### SUMMARY
The All Entities view (`/superset/all_entities/?id=${TAG_ID}`) was always displaying action buttons (**Edit tag** and **Add tag to entities**), regardless if the user had permission to perform these actions or not. This PR makes the visibility of these buttons dynamic.

It also updates the list to only display the Dashboards / Charts / Queries list in case they have any item. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before, the list would include all asset types, even if there are no elements:

<img width="1789" alt="image" src="https://github.com/user-attachments/assets/0d008152-ad0c-449b-b396-748ed1309346" />

Now, the list only includes the asset type that has items:
<img width="1791" alt="image" src="https://github.com/user-attachments/assets/a3613d98-9bd5-4859-9de9-7bd40d3eda15" />

Also changed the button casing from **Edit Tag** to **Edit tag**.

Video demonstrating the other buttons:

https://github.com/user-attachments/assets/4ae4edf9-cc4a-4bc5-b102-bf929c827150

### TESTING INSTRUCTIONS
Added frontend tests. For manual testing:

1. Access Superset with an admin account.
2. Create a chart.
3. Create two tags.
4. Add one of these tags to the chart.
5. Access Superset with an account that does not have the `can_write` perm on `Tag`.
6. Access the Charts menu, and click on the Tag name in the list.
7. Confirm you don't see the **Edit tag** button.
8. Update the tag ID in the URL to the other tag that is not associated with any items.
9. Confirm you don't see the **Add tag to entities** button.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
