### PR TITLE
chore(alerts & reports): increase Playwright timeout from 30 -> 60 seconds

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -765,7 +765,7 @@ SCREENSHOT_WAIT_FOR_ERROR_MODAL_INVISIBLE = 5
 SCREENSHOT_PLAYWRIGHT_WAIT_EVENT = "load"
 # Default timeout for Playwright browser context for all operations
 SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT = int(
-    timedelta(seconds=30).total_seconds() * 1000
+    timedelta(seconds=60).total_seconds() * 1000
 )
 
 # ---------------------------------------------------


### PR DESCRIPTION
### SUMMARY
Current default value for Playwright timeout on Alerts & Reports is 30 seconds, which seems unreasonably short. No value will please everyone but this seems like a step in the right direction.

### TESTING INSTRUCTIONS
Test it out in a deployment.
