### PR TITLE
chore: 100% test coverage for SQL parsing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,36 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+source = superset
+# omit = bad_file.py
+
+[paths]
+source =
+    superset/
+    */site-packages/
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Ignore importlib backport
+    from importlib
+
+    if TYPE_CHECKING:
+
+#fail_under = 100
+show_missing = True

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -45,6 +45,13 @@ jobs:
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
           pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50
+      - name: Python 100% coverage unit tests
+        if: steps.check.outputs.python
+        env:
+          SUPERSET_TESTENV: true
+          SUPERSET_SECRET_KEY: not-a-secret
+        run: |
+          pytest --durations-min=0.5 --cov-report= --cov=superset/sql/ ./tests/unit_tests/sql/ --cache-clear --cov-fail-under=100
       - name: Upload code coverage
         uses: codecov/codecov-action@v5
         with:

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -334,6 +334,9 @@ class SupersetParseError(SupersetErrorException):
         )
         super().__init__(error)
 
+    def __str__(self) -> str:
+        return self.error.message
+
 
 class OAuth2RedirectError(SupersetErrorException):
     """

--- a/tests/unit_tests/sql/dialects/__init__.py
+++ b/tests/unit_tests/sql/dialects/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/sql/dialects/firebolt_tests.py
+++ b/tests/unit_tests/sql/dialects/firebolt_tests.py
@@ -1,0 +1,433 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import sqlglot
+
+from superset.sql.dialects.firebolt import Firebolt, FireboltOld
+
+
+def test_not_sql() -> None:  # pylint: disable=invalid-name
+    """
+    Test the `not_sql` method in the generator.
+    """
+    # use generic parser, since the Firebolt dialect will parenthesize
+    ast = sqlglot.parse_one("SELECT * FROM t WHERE NOT col IN (1, 2)")
+
+    # make sure generated SQL is parenthesized
+    assert (
+        Firebolt().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  *
+FROM t
+WHERE
+  NOT (col IN (1, 2))
+            """.strip()
+    )
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        (
+            "SELECT price, quantity, price * quantity AS sales_amount FROM Sales",
+            """
+SELECT
+  price,
+  quantity,
+  price * quantity AS sales_amount
+FROM Sales
+            """.strip(),
+        ),
+        (
+            "SELECT ALL * FROM Sales",
+            """
+SELECT
+  *
+FROM Sales
+            """.strip(),
+        ),
+        (
+            "SELECT DISTINCT product FROM Sales",
+            """
+SELECT DISTINCT
+  product
+FROM Sales
+            """.strip(),
+        ),
+        (
+            "SELECT * FROM Sales, Products",
+            """
+SELECT
+  *
+FROM Sales, Products
+            """.strip(),
+        ),
+    ],
+)
+def test_select_from(sql: str, expected: str) -> None:
+    """
+    Test the `SELECT` statement in the old dialect.
+    """
+    ast = sqlglot.parse_one(sql, FireboltOld)
+    assert FireboltOld().generate(expression=ast, pretty=True) == expected
+
+
+def test_unnest() -> None:
+    """
+    Test the `UNNEST` in the old dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+  id,
+  tags
+FROM visits
+  UNNEST(tags);
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  id,
+  tags
+FROM visits UNNEST(tags)
+        """.strip()
+    )
+
+
+def test_unnest_with_array() -> None:
+    """
+    Test the `UNNEST` in the old dialect with array columns.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+    id,
+    a_keys,
+    a_vals
+FROM
+    visits
+    UNNEST(agent_props_keys as a_keys,
+           agent_props_vals as a_vals)
+
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  id,
+  a_keys,
+  a_vals
+FROM visits UNNEST(agent_props_keys AS a_keys, agent_props_vals AS a_vals)
+        """.strip()
+    )
+
+
+def test_unnest_multiple() -> None:
+    """
+    Test multiple `UNNEST` in the old dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+    id,
+    a_keys,
+    a_vals
+FROM
+    visits
+UNNEST(agent_props_keys as a_keys)
+UNNEST(agent_props_vals as a_vals)
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  id,
+  a_keys,
+  a_vals
+FROM visits UNNEST(agent_props_keys AS a_keys) UNNEST(agent_props_vals AS a_vals)
+        """.strip()
+    )
+
+
+def test_unnest_translating() -> None:
+    """
+    Test translating the `UNNEST` from the old to the new dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+  id,
+  tags
+FROM visits
+  UNNEST(tags);
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        Firebolt().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  id,
+  tags
+FROM visits, UNNEST(tags)
+        """.strip()
+    )
+
+
+def test_join_on() -> None:
+    """
+    Test the `JOIN ... ON` syntax in the Firebolt dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+    *
+FROM
+    t1
+JOIN
+    t2
+ON t1.foo = t2.id;
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  *
+FROM t1
+JOIN t2
+  ON t1.foo = t2.id
+        """.strip()
+    )
+
+
+def test_join_using() -> None:
+    """
+    Test the `JOIN ... USING` syntax in the Firebolt dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+SELECT
+    *
+FROM
+    t1
+JOIN
+    t2 USING (id, age);
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+SELECT
+  *
+FROM t1
+JOIN t2
+  USING (id, age)
+        """.strip()
+    )
+
+
+def test_cte() -> None:
+    """
+    Test the `WITH` clause in the Firebolt dialect.
+    """
+    ast = sqlglot.parse_one(
+        """
+WITH nl_subscribers AS (
+    SELECT
+        *
+    FROM
+        players
+    WHERE
+        issubscribedtonewsletter=TRUE
+)
+SELECT
+    nickname,
+    email
+FROM
+    players
+ORDER BY
+    nickname
+        """,
+        FireboltOld,
+    )
+
+    assert (
+        FireboltOld().generate(expression=ast, pretty=True)
+        == """
+WITH nl_subscribers AS (
+  SELECT
+    *
+  FROM players
+  WHERE
+    issubscribedtonewsletter = TRUE
+)
+SELECT
+  nickname,
+  email
+FROM players
+ORDER BY
+  nickname
+        """.strip()
+    )
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        (
+            """
+SELECT
+    *
+FROM
+    num_test
+INNER JOIN
+    num_test2
+    USING (
+        firstname,
+        score
+	);
+            """,
+            """
+SELECT
+  *
+FROM num_test
+INNER JOIN num_test2
+  USING (firstname, score)
+            """.strip(),
+        ),
+        (
+            """
+SELECT
+    *
+FROM
+    num_test
+INNER JOIN
+    num_test2
+        ON num_test.firstname = num_test2.firstname
+        AND num_test.score = num_test2.score;
+            """,
+            """
+SELECT
+  *
+FROM num_test
+INNER JOIN num_test2
+  ON num_test.firstname = num_test2.firstname AND num_test.score = num_test2.score
+            """.strip(),
+        ),
+        (
+            """
+SELECT
+    num_test.firstname,
+    num_test2.firstname
+FROM num_test
+LEFT OUTER JOIN
+    num_test2
+    USING (firstname);
+            """,
+            """
+SELECT
+  num_test.firstname,
+  num_test2.firstname
+FROM num_test
+LEFT OUTER JOIN num_test2
+  USING (firstname)
+            """.strip(),
+        ),
+        (
+            """
+SELECT
+    num_test.firstname,
+    num_test2.firstname
+FROM
+    num_test
+RIGHT OUTER JOIN
+    num_test2
+    USING (firstname);
+            """,
+            """
+SELECT
+  num_test.firstname,
+  num_test2.firstname
+FROM num_test
+RIGHT OUTER JOIN num_test2
+  USING (firstname)
+            """.strip(),
+        ),
+        (
+            """
+SELECT
+    num_test.firstname,
+    num_test2.firstname
+FROM
+    num_test
+FULL OUTER JOIN
+    num_test2
+    USING (firstname);
+            """,
+            """
+SELECT
+  num_test.firstname,
+  num_test2.firstname
+FROM num_test
+FULL OUTER JOIN num_test2
+  USING (firstname)
+            """.strip(),
+        ),
+        (
+            """
+SELECT
+    crossjoin_test.letter,
+    crossjoin_test2.letter
+FROM
+    crossjoin_test
+CROSS JOIN
+    crossjoin_test2;
+            """,
+            """
+SELECT
+  crossjoin_test.letter,
+  crossjoin_test2.letter
+FROM crossjoin_test
+CROSS JOIN crossjoin_test2
+            """.strip(),
+        ),
+    ],
+)
+def test_join(sql: str, expected: str) -> None:
+    """
+    Test different joins in the old dialect.
+    """
+    ast = sqlglot.parse_one(sql, FireboltOld)
+    assert FireboltOld().generate(expression=ast, pretty=True) == expected


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Part of [SIP-117](https://github.com/apache/superset/issues/26786), stacked on:

- https://github.com/apache/superset/pull/33456
- https://github.com/apache/superset/pull/33457
- https://github.com/apache/superset/pull/33473
- https://github.com/apache/superset/pull/33515
- https://github.com/apache/superset/pull/33474
- https://github.com/apache/superset/pull/33518
- https://github.com/apache/superset/pull/33524
- https://github.com/apache/superset/pull/33525
- https://github.com/apache/superset/pull/33542
- https://github.com/apache/superset/pull/33560
- https://github.com/apache/superset/pull/33564

Adds 100% unit tests coverage to the `superset/sql/` directory, and a CI rule to enforce it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
