### PR TITLE
fix(sql_parse): correctly handle undefined Jinja macros during table extraction

### DIFF
--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -972,7 +972,7 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
             node.data = "NULL"
 
     # re-render template back into a string
-    rendered_template = Template(template).render()
+    rendered_template = Template(template).render(processor._context)
 
     return (
         tables


### PR DESCRIPTION
### SUMMARY
This patch addresses Issue #33579, where Jinja-templated queries that invoke Superset macros
(like `filter_values()`) would fail the permission-check phase with an
`UndefinedError` (and thus `QueryIsForbiddenToAccessException`). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/7853e7c0-0bb6-4cfe-b088-2931490aba22" />
After:
![image](https://github.com/user-attachments/assets/523080ea-dc7a-410e-9931-0e06b2566845)


### TESTING INSTRUCTIONS
1. Enable Jinja templating: set `ENABLE_TEMPLATE_PROCESSING = True` in
   your `superset_config.py`.  
2. Ensure a user has only datasource access (no raw SQL access) to table like `video_game_sales`.  
3. As that user, run:
   ```sql
   WITH calculation AS (
     SELECT count(*), genre
     FROM video_game_sales
     WHERE genre IN ({{ "'" + "','".join(filter_values('genre')) + "'" }})
     GROUP BY genre
   )
   SELECT * FROM calculation;
