### PR TITLE
fix: Makes time compare migration more resilient

### DIFF
--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -294,8 +294,7 @@ class TimeseriesChart(MigrateViz):
         if (rolling_type := self.data.get("rolling_type")) and rolling_type != "None":
             self.data["rolling_type"] = rolling_type
 
-        time_compare = self.data.get("time_compare")
-        if time_compare is not None:
+        if (time_compare := self.data.get("time_compare")) is not None:
             self.data["time_compare"] = [
                 v if v.endswith(" ago") else v + " ago"
                 for value in as_list(time_compare)

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -296,7 +296,9 @@ class TimeseriesChart(MigrateViz):
 
         if time_compare := self.data.get("time_compare"):
             self.data["time_compare"] = [
-                value + " ago" for value in as_list(time_compare) if value
+                value if value.endswith(" ago") else value + " ago"
+                for value in as_list(time_compare)
+                if value
             ]
 
         comparison_type = self.data.get("comparison_type") or "values"

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -294,11 +294,12 @@ class TimeseriesChart(MigrateViz):
         if (rolling_type := self.data.get("rolling_type")) and rolling_type != "None":
             self.data["rolling_type"] = rolling_type
 
-        if time_compare := self.data.get("time_compare"):
+        time_compare = self.data.get("time_compare")
+        if time_compare is not None:
             self.data["time_compare"] = [
-                value if value.endswith(" ago") else value + " ago"
+                v if v.endswith(" ago") else v + " ago"
                 for value in as_list(time_compare)
-                if value
+                if (v := value.strip())
             ]
 
         comparison_type = self.data.get("comparison_type") or "values"


### PR DESCRIPTION
### SUMMARY
While testing 5.0, we noticed that some users manually entered time compare values like `1 year ago` that are valid for ECharts visualizations but not for legacy visualizations. We also found empty time compare values instead of an empty list. This fix makes the migration more resilient by handling these cases.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
