### PR TITLE
fix: Missing processor context when rendering Jinja

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -641,6 +641,12 @@ class BaseTemplateProcessor:
         self._context.update(kwargs)
         self._context.update(context_addons())
 
+    def get_context(self) -> dict[str, Any]:
+        """
+        Returns the current template context.
+        """
+        return self._context
+
     def process_template(self, sql: str, **kwargs: Any) -> str:
         """Processes a sql template
 

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -645,7 +645,7 @@ class BaseTemplateProcessor:
         """
         Returns the current template context.
         """
-        return self._context
+        return self._context.copy()
 
     def process_template(self, sql: str, **kwargs: Any) -> str:
         """Processes a sql template

--- a/superset/sql_parse.py
+++ b/superset/sql_parse.py
@@ -972,12 +972,12 @@ def extract_tables_from_jinja_sql(sql: str, database: Database) -> set[Table]:
             node.data = "NULL"
 
     # re-render template back into a string
-    rendered_template = Template(template).render()
+    rendered_sql = Template(template).render(processor.get_context())
 
     return (
         tables
         | ParsedQuery(
-            sql_statement=processor.process_template(rendered_template),
+            sql_statement=processor.process_template(rendered_sql),
             engine=database.db_engine_spec.engine,
         ).tables
     )


### PR DESCRIPTION
### SUMMARY
The processor context was missing when rendering the modified Jinja template in `extract_tables_from_jinja_sql`. This PR passes the context when rendering the template to avoid the following error:

```
UndefinedError("'filter_values' is undefined")
```

@betodealmeida I tried the suggested approach [here](https://github.com/apache/superset/issues/33579#issuecomment-2912938587) but it didn't work.

Fixes https://github.com/apache/superset/issues/33579

### TESTING INSTRUCTIONS
Check the original issue for instructions.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
