### PR TITLE
feat(charts): Adds "info" and "info dark" (blue colors) values to edit formatter color scheme

### DIFF
--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -43,9 +43,11 @@ const colorSchemeOptions = (theme: SupersetTheme) => [
   { value: theme.colors.success.light1, label: t('success') },
   { value: theme.colors.warning.light1, label: t('alert') },
   { value: theme.colors.error.light1, label: t('error') },
+  { value: theme.colors.info.light1, label: t('info') },
   { value: theme.colors.success.dark1, label: t('success dark') },
   { value: theme.colors.warning.dark1, label: t('alert dark') },
   { value: theme.colors.error.dark1, label: t('error dark') },
+  { value: theme.colors.info.dark1, label: t('info dark') },
 ];
 
 const operatorOptions = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds "info" and "info dark" values to edit formatter color scheme drop down.
It allows users to use blue color for conditions


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/user-attachments/assets/8173f3ab-74b4-4398-b079-a56559fde685)

After:
![image](https://github.com/user-attachments/assets/3da82403-d125-47ef-aa23-f46c74290f88)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
