### PR TITLE
fix: Update dataset's last modified date from column/metric update

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -49,7 +49,6 @@ from sqlalchemy import (
     String,
     Table as DBTable,
     Text,
-    update,
 )
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.ext.declarative import declared_attr
@@ -2023,21 +2022,6 @@ class SqlaTable(
         security_manager.dataset_before_update(mapper, connection, target)
 
     @staticmethod
-    def update_column(  # pylint: disable=unused-argument
-        mapper: Mapper, connection: Connection, target: SqlMetric | TableColumn
-    ) -> None:
-        """
-        :param mapper: Unused.
-        :param connection: Unused.
-        :param target: The metric or column that was updated.
-        """
-        session = inspect(target).session  # pylint: disable=disallowed-name
-
-        # Forces an update to the table's changed_on value when a metric or column on the  # noqa: E501
-        # table is updated. This busts the cache key for all charts that use the table.
-        session.execute(update(SqlaTable).where(SqlaTable.id == target.table.id))
-
-    @staticmethod
     def after_insert(
         mapper: Mapper,
         connection: Connection,
@@ -2072,8 +2056,6 @@ class SqlaTable(
 sa.event.listen(SqlaTable, "before_update", SqlaTable.before_update)
 sa.event.listen(SqlaTable, "after_insert", SqlaTable.after_insert)
 sa.event.listen(SqlaTable, "after_delete", SqlaTable.after_delete)
-sa.event.listen(SqlMetric, "after_update", SqlaTable.update_column)
-sa.event.listen(TableColumn, "after_update", SqlaTable.update_column)
 
 RLSFilterRoles = DBTable(
     "rls_filter_roles",

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from typing import Any
 
 import dateutil.parser
-from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
@@ -198,11 +197,8 @@ class DatasetDAO(BaseDAO[SqlaTable]):
                 cls.update_metrics(item, attributes.pop("metrics"))
                 force_update = True
 
-            # columns and metrics are stored in separate tables so if they change we
-            # force an update to the dataset too to ensure the last_updated_timestamp
-            # is updated (it's possible no other dataset attributes are changed).
             if force_update:
-                db.session.execute(update(SqlaTable).where(SqlaTable.id == item.id))
+                attributes["changed_on"] = datetime.now()
 
         return super().update(item, attributes)
 

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import dateutil.parser
@@ -198,7 +198,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):
                 force_update = True
 
             if force_update:
-                attributes["changed_on"] = datetime.now()
+                attributes["changed_on"] = datetime.now(tz=timezone.utc)
 
         return super().update(item, attributes)
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -1147,6 +1147,7 @@ class TestDatasetApi(SupersetTestCase):
 
         # create example dataset by Command
         dataset = self.insert_default_dataset()
+        current_changed_on = dataset.changed_on
 
         new_column_data = {
             "column_name": "new_col",
@@ -1232,6 +1233,10 @@ class TestDatasetApi(SupersetTestCase):
         assert metrics[1].verbose_name == new_metric_data["verbose_name"]
         assert metrics[1].warning_text == new_metric_data["warning_text"]
         assert str(metrics[1].uuid) == new_metric_data["uuid"]
+
+        # Validate that the changed_on is updated
+        updated_dataset = db.session.query(SqlaTable).filter_by(id=dataset.id).first()
+        assert updated_dataset.changed_on > current_changed_on
 
         self.items_to_delete = [dataset]
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 import unittest
 from io import BytesIO
 from unittest.mock import ANY, patch
@@ -1189,6 +1190,10 @@ class TestDatasetApi(SupersetTestCase):
             metric.pop("type_generic", None)
 
         data["result"]["metrics"].append(new_metric_data)
+
+        # Sleep to ensure that the changed_on is updated
+        time.sleep(3)
+
         rv = self.client.put(
             uri,
             json={

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -95,7 +95,7 @@ def test_update_dataset_forbidden(mocker: MockerFixture) -> None:
         ),
     ],
 )
-def test_update_validation_errors(
+def test_update_dataset_validation_errors(
     payload: dict[str, Any],
     exception: Exception,
     error_msg: str,

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import copy
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -99,7 +99,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
                 "columns": [{"id": 1, "name": "col1"}],
                 "metrics": [{"id": 1, "name": "metric1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
         ),
         (
             {
@@ -109,14 +109,14 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             },
         ),
         (
             {
                 "columns": [{"id": 1, "name": "col1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
         ),
         (
             {
@@ -125,14 +125,14 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             },
         ),
         (
             {
                 "metrics": [{"id": 1, "name": "metric1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
         ),
         (
             {
@@ -141,7 +141,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             },
         ),
         (

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -15,8 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import copy
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
 from sqlalchemy.orm.session import Session
 
+from superset.daos.base import BaseDAO
 from superset.daos.dataset import DatasetDAO
 from superset.sql_parse import Table
 
@@ -77,3 +85,94 @@ def test_validate_update_uniqueness(session: Session) -> None:
         )
         is True
     )
+
+
+@freeze_time("2025-01-01 00:00:00")
+@patch.object(DatasetDAO, "update_columns")
+@patch.object(DatasetDAO, "update_metrics")
+@patch.object(BaseDAO, "update")
+@pytest.mark.parametrize(
+    "attributes,expected_attributes",
+    [
+        (
+            {
+                "columns": [{"id": 1, "name": "col1"}],
+                "metrics": [{"id": 1, "name": "metric1"}],
+            },
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+        ),
+        (
+            {
+                "columns": [{"id": 1, "name": "col1"}],
+                "metrics": [{"id": 1, "name": "metric1"}],
+                "description": "test description",
+            },
+            {
+                "description": "test description",
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+            },
+        ),
+        (
+            {
+                "columns": [{"id": 1, "name": "col1"}],
+            },
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+        ),
+        (
+            {
+                "columns": [{"id": 1, "name": "col1"}],
+                "description": "test description",
+            },
+            {
+                "description": "test description",
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+            },
+        ),
+        (
+            {
+                "metrics": [{"id": 1, "name": "metric1"}],
+            },
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
+        ),
+        (
+            {
+                "metrics": [{"id": 1, "name": "metric1"}],
+                "description": "test description",
+            },
+            {
+                "description": "test description",
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
+            },
+        ),
+        (
+            {"description": "test description"},
+            {"description": "test description"},
+        ),
+    ],
+)
+def test_update_dataset_related_metadata_updates_changed_on(
+    base_update_mock: MagicMock,
+    update_metrics_mock: MagicMock,
+    update_columns_mock: MagicMock,
+    attributes: dict[str, Any],
+    expected_attributes: dict[str, Any],
+) -> None:
+    """
+    Test that the changed_on property is updated when a metric or column is updated.
+    """
+    item = MagicMock()
+    DatasetDAO.update(item, copy.deepcopy(attributes))
+
+    if "columns" in attributes:
+        update_columns_mock.assert_called_once_with(
+            item, attributes["columns"], override_columns=False
+        )
+    else:
+        update_columns_mock.assert_not_called()
+
+    if "metrics" in attributes:
+        update_metrics_mock.assert_called_once_with(item, attributes["metrics"])
+    else:
+        update_metrics_mock.assert_not_called()
+
+    base_update_mock.assert_called_once_with(item, expected_attributes)


### PR DESCRIPTION
### SUMMARY
The `last_modified` value for datasets was not getting updated in case only metric(s) and/or column(s) changed. I suspect the issue started with the introduction of the `@transaction` decorator + the way we handle these updates:
- Before [SIP-99B](https://github.com/apache/superset/issues/25108), we would `commit` after these changes -- [ref](https://github.com/apache/superset/commit/8fb8199a55257ae5121300aa3bd28d14d327bc33#diff-1fabcc7af69ff8ee94b640857ad3552402286c735a5a770b9d14f204774c8f60L269-L322).
- We're currently using `bulk_insert_mappings` for the update which does not integrate well with SQLAlchemy's state management (and therefore does not trigger an `after_update`) -- [ref](https://github.com/apache/superset/blob/master/superset/daos/dataset.py#L233-L256).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**

https://github.com/user-attachments/assets/9187b29a-bc63-4c6e-9ee7-8db8254cd4bd

**After**

https://github.com/user-attachments/assets/67a82bcc-0f57-4450-a540-1968c1526201



### TESTING INSTRUCTIONS
1. Apply a label to a column, and confirm the `last_modified` value for the dataset gets updated.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
