### PR TITLE
feat(User Registrations): Migrate user registrations fab view

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Result/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Result/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { Result } from 'antd';
+export type { ResultProps } from 'antd';

--- a/superset-frontend/packages/superset-ui-core/src/components/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/index.ts
@@ -164,3 +164,4 @@ export * from './Table';
 export * from './TableView';
 export * from './Tag';
 export * from './constants';
+export * from './Result';

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -18,7 +18,14 @@
  */
 
 import { SupersetClient, styled, t, css } from '@superset-ui/core';
-import { Button, Card, Flex, Form, Input } from '@superset-ui/core/components';
+import {
+  Button,
+  Card,
+  Flex,
+  Form,
+  Input,
+  Result,
+} from '@superset-ui/core/components';
 import { useState } from 'react';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import ReactCAPTCHA from 'react-google-recaptcha';
@@ -68,17 +75,24 @@ export default function Login() {
 
   if (activationHash) {
     return (
-      <Result
-        status="success"
-        title="Successfully Purchased Cloud Server ECS!"
-        subTitle="Order number: 2017182818828182881 Cloud server configuration takes 1-5 minutes, please wait."
-        extra={[
-          <Button type="primary" key="console">
-            Go Console
-          </Button>,
-          <Button key="buy">Buy Again</Button>,
-        ]}
-      />
+      <Flex
+        justify="center"
+        css={css`
+          width: 100%;
+        `}
+        data-test="register-form"
+      >
+        <Result
+          status="success"
+          title="Registration successful"
+          subTitle="Your account is activated. You can log in with your credentials."
+          extra={[
+            <Button type="default" href="/login/" data-test="login-button">
+              {t('Login')}
+            </Button>,
+          ]}
+        />
+      </Flex>
     );
   }
 

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -22,6 +22,7 @@ import { Button, Card, Flex, Form, Input } from '@superset-ui/core/components';
 import { useState } from 'react';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import ReactCAPTCHA from 'react-google-recaptcha';
+import { useParams } from 'react-router-dom';
 
 interface RegisterForm {
   username: string;
@@ -58,11 +59,28 @@ export default function Login() {
   const [form] = Form.useForm<RegisterForm>();
   const [loading, setLoading] = useState(false);
   const [captchaResponse, setCaptchaResponse] = useState<string | null>(null);
+  const { activationHash } = useParams<{ activationHash?: string }>();
 
   const bootstrapData = getBootstrapData();
 
   const authRecaptchaPublicKey: string =
     bootstrapData.common.conf.RECAPTCHA_PUBLIC_KEY || '';
+
+  if (activationHash) {
+    return (
+      <Result
+        status="success"
+        title="Successfully Purchased Cloud Server ECS!"
+        subTitle="Order number: 2017182818828182881 Cloud server configuration takes 1-5 minutes, please wait."
+        extra={[
+          <Button type="primary" key="console">
+            Go Console
+          </Button>,
+          <Button key="buy">Buy Again</Button>,
+        ]}
+      />
+    );
+  }
 
   const onFinish = (values: RegisterForm) => {
     setLoading(true);

--- a/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import fetchMock from 'fetch-mock';
+import { render, screen } from 'spec/helpers/testing-library';
+import UserRegistrations from '.';
+
+const userRegistrationsEndpoint = 'glob:*/security/user_registrations/?*';
+
+const mockUserRegistrations = [...new Array(5)].map((_, i) => ({
+  id: i,
+  username: `user${i}`,
+  first_name: `User${i}`,
+  last_name: `Test${i}`,
+  email: `user${i}@test.com`,
+  registration_date: new Date(2025, 2, 25, 11, 4, 32 + i).toISOString(),
+  registration_hash: `hash${i}`,
+}));
+
+fetchMock.get(userRegistrationsEndpoint, {
+  ids: [0, 1, 2, 3, 4],
+  count: 5,
+  result: mockUserRegistrations,
+});
+
+describe('UserRegistrations', () => {
+  beforeEach(() => {
+    render(<UserRegistrations />, {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+    });
+  });
+  it('fetches and renders user registrations', async () => {
+    expect(await screen.findByText('User registrations')).toBeVisible();
+    const calls = fetchMock.calls(userRegistrationsEndpoint);
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});

--- a/superset-frontend/src/pages/UserRegistrations/index.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/index.tsx
@@ -17,15 +17,20 @@
  * under the License.
  */
 
-import { useMemo } from 'react';
-import { t } from '@superset-ui/core';
+import { useMemo, useState } from 'react';
+import { SupersetClient, t } from '@superset-ui/core';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import {
   ListViewFilters,
   ListViewFilterOperator,
   ListView,
+  DeleteModal,
 } from 'src/components';
+import { ActionProps, ActionsBar } from 'src/components/ListView/ActionsBar';
+import SubMenu from 'src/features/home/SubMenu';
+
+const PAGE_SIZE = 25;
 
 export type UserRegistration = {
   id: number;
@@ -39,6 +44,10 @@ export type UserRegistration = {
 
 export default function UserRegistrations() {
   const { addSuccessToast, addDangerToast } = useToasts();
+  const [
+    userRegistrationCurrentlyDeleting,
+    setUserRegistrationCurrentlyDeleting,
+  ] = useState<UserRegistration | null>(null);
 
   const {
     state: {
@@ -53,6 +62,24 @@ export default function UserRegistrations() {
     t('User Registrations'),
     addDangerToast,
   );
+
+  const handleUserRegistrationDelete = async ({
+    id,
+    username,
+  }: UserRegistration) => {
+    try {
+      await SupersetClient.delete({
+        endpoint: `/api/v1/user_registrations/${id}`,
+      });
+      refreshData();
+      setUserRegistrationCurrentlyDeleting(null);
+      addSuccessToast(t('Deleted user registration for user: %s', username));
+    } catch (error) {
+      addDangerToast(
+        t('There was an issue deleting registration for user: %s', username),
+      );
+    }
+  };
 
   const initialSort = [{ id: 'registration_date', desc: true }];
 
@@ -85,15 +112,35 @@ export default function UserRegistrations() {
       {
         accessor: 'registration_hash',
         id: 'registration_hash',
-        Header: t('Registration Hash'),
+        Header: t('Registration hash'),
         Cell: ({ row: { original } }: any) => original.registration_hash,
       },
       {
         accessor: 'registration_date',
         id: 'registration_date',
-        Header: t('Registration Date'),
-        Cell: ({ row: { original } }: any) =>
-          new Date(original.registration_date).toLocaleDateString(),
+        Header: t('Registration date'),
+        Cell: ({ row: { original } }: any) => original.registration_date,
+      },
+      {
+        id: 'actions',
+        Header: t('Actions'),
+        Cell: ({ row: { original } }: any) => {
+          const actions = [
+            {
+              label: 'registrations-list-delete-action',
+              tooltip: t('Delete user registration'),
+              placement: 'bottom',
+              icon: 'DeleteOutlined',
+              onClick: () => {
+                setUserRegistrationCurrentlyDeleting(original);
+              },
+            },
+          ];
+          return <ActionsBar actions={actions as ActionProps[]} />;
+        },
+        hidden: false,
+        disableSortBy: true,
+        size: 'xl',
       },
     ],
     [],
@@ -130,14 +177,14 @@ export default function UserRegistrations() {
         operator: ListViewFilterOperator.Contains,
       },
       {
-        Header: t('Registration Hash'),
+        Header: t('Registration hash'),
         key: 'registration_hash',
         id: 'registration_hash',
         input: 'search',
         operator: ListViewFilterOperator.Contains,
       },
       {
-        Header: t('Registration Date'),
+        Header: t('Registration date'),
         key: 'registration_date',
         id: 'registration_date',
         input: 'datetime_range',
@@ -154,20 +201,38 @@ export default function UserRegistrations() {
   };
 
   return (
-    <ListView<UserRegistration>
-      className="user-registrations-list-view"
-      columns={columns}
-      count={registrationsCount}
-      data={registrations}
-      fetchData={fetchData}
-      refreshData={refreshData}
-      addDangerToast={addDangerToast}
-      addSuccessToast={addSuccessToast}
-      filters={filters}
-      initialSort={initialSort}
-      loading={loading}
-      pageSize={25}
-      emptyState={emptyState}
-    />
+    <>
+      <SubMenu name={t('User registrations')} />
+      {userRegistrationCurrentlyDeleting && (
+        <DeleteModal
+          description={t(
+            'This action will permanently delete the user registration.',
+          )}
+          onConfirm={() => {
+            if (userRegistrationCurrentlyDeleting) {
+              handleUserRegistrationDelete(userRegistrationCurrentlyDeleting);
+            }
+          }}
+          onHide={() => setUserRegistrationCurrentlyDeleting(null)}
+          open
+          title={t('Delete user registration?')}
+        />
+      )}
+      <ListView<UserRegistration>
+        className="user-registrations-list-view"
+        columns={columns}
+        count={registrationsCount}
+        data={registrations}
+        fetchData={fetchData}
+        refreshData={refreshData}
+        addDangerToast={addDangerToast}
+        addSuccessToast={addSuccessToast}
+        filters={filters}
+        initialSort={initialSort}
+        loading={loading}
+        pageSize={PAGE_SIZE}
+        emptyState={emptyState}
+      />
+    </>
   );
 }

--- a/superset-frontend/src/pages/UserRegistrations/index.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/index.tsx
@@ -25,8 +25,8 @@ import {
   ListViewFilters,
   ListViewFilterOperator,
   ListView,
-  DeleteModal,
 } from 'src/components';
+import { DeleteModal } from '@superset-ui/core/components';
 import { ActionProps, ActionsBar } from 'src/components/ListView/ActionsBar';
 import SubMenu from 'src/features/home/SubMenu';
 

--- a/superset-frontend/src/pages/UserRegistrations/index.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/index.tsx
@@ -58,7 +58,7 @@ export default function UserRegistrations() {
     refreshData,
     fetchData,
   } = useListViewResource<UserRegistration>(
-    'user_registrations',
+    'security/user_registrations',
     t('User Registrations'),
     addDangerToast,
   );
@@ -69,7 +69,7 @@ export default function UserRegistrations() {
   }: UserRegistration) => {
     try {
       await SupersetClient.delete({
-        endpoint: `/api/v1/user_registrations/${id}`,
+        endpoint: `/api/v1/security/user_registrations/${id}`,
       });
       refreshData();
       setUserRegistrationCurrentlyDeleting(null);

--- a/superset-frontend/src/pages/UserRegistrations/index.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/index.tsx
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo } from 'react';
+import { t } from '@superset-ui/core';
+import { useListViewResource } from 'src/views/CRUD/hooks';
+import { useToasts } from 'src/components/MessageToasts/withToasts';
+import {
+  ListViewFilters,
+  ListViewFilterOperator,
+  ListView,
+} from 'src/components';
+
+export type UserRegistration = {
+  id: number;
+  username: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  registration_date: string;
+  registration_hash: string;
+};
+
+export default function UserRegistrations() {
+  const { addSuccessToast, addDangerToast } = useToasts();
+
+  const {
+    state: {
+      loading,
+      resourceCount: registrationsCount,
+      resourceCollection: registrations,
+    },
+    refreshData,
+    fetchData,
+  } = useListViewResource<UserRegistration>(
+    'user_registrations',
+    t('User Registrations'),
+    addDangerToast,
+  );
+
+  const initialSort = [{ id: 'registration_date', desc: true }];
+
+  const columns = useMemo(
+    () => [
+      {
+        accessor: 'username',
+        id: 'username',
+        Header: t('Username'),
+        Cell: ({ row: { original } }: any) => original.username,
+      },
+      {
+        accessor: 'first_name',
+        id: 'first_name',
+        Header: t('First name'),
+        Cell: ({ row: { original } }: any) => original.first_name,
+      },
+      {
+        accessor: 'last_name',
+        id: 'last_name',
+        Header: t('Last name'),
+        Cell: ({ row: { original } }: any) => original.last_name,
+      },
+      {
+        accessor: 'email',
+        id: 'email',
+        Header: t('Email'),
+        Cell: ({ row: { original } }: any) => original.email,
+      },
+      {
+        accessor: 'registration_hash',
+        id: 'registration_hash',
+        Header: t('Registration Hash'),
+        Cell: ({ row: { original } }: any) => original.registration_hash,
+      },
+      {
+        accessor: 'registration_date',
+        id: 'registration_date',
+        Header: t('Registration Date'),
+        Cell: ({ row: { original } }: any) =>
+          new Date(original.registration_date).toLocaleDateString(),
+      },
+    ],
+    [],
+  );
+
+  const filters: ListViewFilters = useMemo(
+    () => [
+      {
+        Header: t('Username'),
+        key: 'username',
+        id: 'username',
+        input: 'search',
+        operator: ListViewFilterOperator.Contains,
+      },
+      {
+        Header: t('First name'),
+        key: 'first_name',
+        id: 'first_name',
+        input: 'search',
+        operator: ListViewFilterOperator.Contains,
+      },
+      {
+        Header: t('Last name'),
+        key: 'last_name',
+        id: 'last_name',
+        input: 'search',
+        operator: ListViewFilterOperator.Contains,
+      },
+      {
+        Header: t('Email'),
+        key: 'email',
+        id: 'email',
+        input: 'search',
+        operator: ListViewFilterOperator.Contains,
+      },
+      {
+        Header: t('Registration Hash'),
+        key: 'registration_hash',
+        id: 'registration_hash',
+        input: 'search',
+        operator: ListViewFilterOperator.Contains,
+      },
+      {
+        Header: t('Registration Date'),
+        key: 'registration_date',
+        id: 'registration_date',
+        input: 'datetime_range',
+        operator: ListViewFilterOperator.Between,
+        dateFilterValueType: 'iso',
+      },
+    ],
+    [],
+  );
+
+  const emptyState = {
+    title: t('No user registrations yet'),
+    image: 'filter-results.svg',
+  };
+
+  return (
+    <ListView<UserRegistration>
+      className="user-registrations-list-view"
+      columns={columns}
+      count={registrationsCount}
+      data={registrations}
+      fetchData={fetchData}
+      refreshData={refreshData}
+      addDangerToast={addDangerToast}
+      addSuccessToast={addSuccessToast}
+      filters={filters}
+      initialSort={initialSort}
+      loading={loading}
+      pageSize={25}
+      emptyState={emptyState}
+    />
+  );
+}

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -176,11 +176,11 @@ export const routes: Routes = [
     Component: Login,
   },
   {
-    path: '/register/',
+    path: '/register/activation/:activationHash',
     Component: Register,
   },
   {
-    path: '/register/activation/:activationHash',
+    path: '/register/',
     Component: Register,
   },
   {
@@ -306,7 +306,6 @@ if (isFeatureEnabled(FeatureFlag.TaggingSystem)) {
 const user = getBootstrapData()?.user;
 const authRegistrationEnabled =
   getBootstrapData()?.common.conf.AUTH_USER_REGISTRATION;
-console.log({ authRegistrationEnabled });
 const isAdmin = isUserAdmin(user);
 
 if (isAdmin) {

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -156,6 +156,13 @@ const Register = lazy(
 const GroupsList: LazyExoticComponent<any> = lazy(
   () => import(/* webpackChunkName: "GroupsList" */ 'src/pages/GroupsList'),
 );
+const UserRegistrations = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "UserRegistrations" */ 'src/pages/UserRegistrations'
+    ),
+);
+
 type Routes = {
   path: string;
   Component: ComponentType;
@@ -274,6 +281,10 @@ export const routes: Routes = [
   {
     path: '/actionlog/list',
     Component: ActionLogList,
+  },
+  {
+    path: '/registrations/',
+    Component: UserRegistrations,
   },
 ];
 

--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -180,6 +180,10 @@ export const routes: Routes = [
     Component: Register,
   },
   {
+    path: '/register/activation/:activationHash',
+    Component: Register,
+  },
+  {
     path: '/logout/',
     Component: Login,
   },
@@ -300,6 +304,9 @@ if (isFeatureEnabled(FeatureFlag.TaggingSystem)) {
 }
 
 const user = getBootstrapData()?.user;
+const authRegistrationEnabled =
+  getBootstrapData()?.common.conf.AUTH_USER_REGISTRATION;
+console.log({ authRegistrationEnabled });
 const isAdmin = isUserAdmin(user);
 
 if (isAdmin) {
@@ -317,6 +324,13 @@ if (isAdmin) {
       Component: GroupsList,
     },
   );
+}
+
+if (authRegistrationEnabled) {
+  routes.push({
+    path: '/registrations/',
+    Component: UserRegistrations,
+  });
 }
 
 const frontEndRoutes: Record<string, boolean> = routes

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -406,7 +406,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(LogRestApi)
         appbuilder.add_api(UserRegistrationsRestAPI)
         appbuilder.add_view(
-            LogModelView,
+            ActionLogView,
             "Action Log",
             label=__("Action Log"),
             category="Security",

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -150,7 +150,11 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.reports.api import ReportScheduleRestApi
         from superset.reports.logs.api import ReportExecutionLogRestApi
         from superset.row_level_security.api import RLSRestApi
-        from superset.security.api import RoleRestAPI, SecurityRestApi
+        from superset.security.api import (
+            RoleRestAPI,
+            SecurityRestApi,
+            UserRegistrationsRestAPI,
+        )
         from superset.sqllab.api import SqlLabRestApi
         from superset.sqllab.permalink.api import SqlLabPermalinkRestApi
         from superset.tags.api import TagRestApi
@@ -186,6 +190,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.sqllab import SqllabView
         from superset.views.tags import TagModelView, TagView
         from superset.views.user_info import UserInfoView
+        from superset.views.user_registrations import UserRegistrationsView
         from superset.views.users.api import CurrentUserRestApi, UserRestApi
         from superset.views.users_list import UsersListView
 
@@ -282,6 +287,15 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=__("Security"),
             icon="fa-lock",
+        )
+
+        appbuilder.add_view(
+            UserRegistrationsView,
+            "User Registrations",
+            label=__("User Registrations"),
+            category="Security",
+            category_label=__("Security"),
+            icon="fa-user-plus",
         )
 
         appbuilder.add_view(
@@ -388,6 +402,20 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category_icon="",
             category="Manage",
             menu_cond=lambda: feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"),
+        )
+        appbuilder.add_api(LogRestApi)
+        appbuilder.add_api(UserRegistrationsRestAPI)
+        appbuilder.add_view(
+            LogModelView,
+            "Action Log",
+            label=__("Action Log"),
+            category="Security",
+            category_label=__("Security"),
+            icon="fa-list-ol",
+            menu_cond=lambda: (
+                self.config["FAB_ADD_SECURITY_VIEWS"]
+                and self.config["SUPERSET_LOG_VIEW"]
+            ),
         )
         appbuilder.add_api(SecurityRestApi)
         #

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -307,14 +307,6 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         )
 
         appbuilder.add_view(
-            ActionLogView,
-            "Action Logs",
-            label=__("Action Logs"),
-            category="Security",
-            category_label=__("Security"),
-        )
-
-        appbuilder.add_view(
             GroupsListView,
             "List Groups",
             label=__("List Groups"),

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -295,7 +295,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             label=__("User Registrations"),
             category="Security",
             category_label=__("Security"),
-            icon="fa-user-plus",
+            menu_cond=lambda: bool(appbuilder.app.config["AUTH_USER_REGISTRATION"]),
         )
 
         appbuilder.add_view(

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -18,11 +18,11 @@ import logging
 from typing import Any
 
 from flask import current_app, request, Response
-from flask_appbuilder import expose
-from flask_appbuilder.api import rison, safe
+from flask_appbuilder import expose, ModelRestApi
+from flask_appbuilder.api import rison, safe, SQLAInterface
 from flask_appbuilder.api.schemas import get_list_schema
 from flask_appbuilder.security.decorators import permission_name, protect
-from flask_appbuilder.security.sqla.models import Role
+from flask_appbuilder.security.sqla.models import RegisterUser, Role
 from flask_wtf.csrf import generate_csrf
 from marshmallow import EXCLUDE, fields, post_load, Schema, ValidationError
 from sqlalchemy import asc, desc
@@ -337,3 +337,21 @@ class RoleRestAPI(BaseSupersetApi):
             return self.response_403(message=str(e))
         except Exception as e:
             return self.response_500(message=str(e))
+
+
+class UserRegistrationsRestAPI(ModelRestApi):
+    """
+    APIs for listing user registrations (Admin only)
+    """
+
+    resource_name = "user_registrations"
+    datamodel = SQLAInterface(RegisterUser)
+    allow_browser_login = True
+    list_columns = [
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "registration_date",
+        "registration_hash",
+    ]

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any
 
 from flask import current_app, request, Response
-from flask_appbuilder import expose, ModelRestApi
+from flask_appbuilder import expose
 from flask_appbuilder.api import rison, safe, SQLAInterface
 from flask_appbuilder.api.schemas import get_list_schema
 from flask_appbuilder.security.decorators import permission_name, protect
@@ -35,7 +35,11 @@ from superset.commands.exceptions import ForbiddenError
 from superset.exceptions import SupersetGenericErrorException
 from superset.extensions import db, event_logger
 from superset.security.guest_token import GuestTokenResourceType
-from superset.views.base_api import BaseSupersetApi, statsd_metrics
+from superset.views.base_api import (
+    BaseSupersetApi,
+    BaseSupersetModelRestApi,
+    statsd_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -339,7 +343,7 @@ class RoleRestAPI(BaseSupersetApi):
             return self.response_500(message=str(e))
 
 
-class UserRegistrationsRestAPI(ModelRestApi):
+class UserRegistrationsRestAPI(BaseSupersetModelRestApi):
     """
     APIs for listing user registrations (Admin only)
     """
@@ -348,6 +352,7 @@ class UserRegistrationsRestAPI(ModelRestApi):
     datamodel = SQLAInterface(RegisterUser)
     allow_browser_login = True
     list_columns = [
+        "id",
         "username",
         "email",
         "first_name",

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -348,7 +348,7 @@ class UserRegistrationsRestAPI(BaseSupersetModelRestApi):
     APIs for listing user registrations (Admin only)
     """
 
-    resource_name = "user_registrations"
+    resource_name = "security/user_registrations"
     datamodel = SQLAInterface(RegisterUser)
     allow_browser_login = True
     list_columns = [

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2798,7 +2798,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         for view in list(self.appbuilder.baseviews):
             if isinstance(view, self.rolemodelview.__class__) and getattr(
                 view, "route_base", None
-            ) in ["/roles", "/users", "/groups"]:
+            ) in ["/roles", "/users", "/groups", "registrations"]:
                 self.appbuilder.baseviews.remove(view)
 
         security_menu = next(
@@ -2806,5 +2806,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         )
         if security_menu:
             for item in list(security_menu.childs):
-                if item.name in ["List Roles", "List Users", "List Groups"]:
+                if item.name in [
+                    "List Roles",
+                    "List Users",
+                    "List Groups",
+                    "User Registrations",
+                ]:
                     security_menu.childs.remove(item)

--- a/superset/views/auth.py
+++ b/superset/views/auth.py
@@ -57,7 +57,7 @@ class SupersetRegisterUserView(BaseSupersetView):
         return super().render_app_template()
 
     @expose("/activation/<string:activation_hash>")
-    def activation(self, activation_hash):
+    def activation(self, activation_hash: str) -> WerkzeugResponse:
         """
         Endpoint to expose an activation url, this url
         is sent to the user by email, when accessed the user is inserted

--- a/superset/views/auth.py
+++ b/superset/views/auth.py
@@ -15,14 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 from typing import Optional
 
-from flask import g, redirect
+from flask import flash, g, redirect
 from flask_appbuilder import expose
+from flask_appbuilder._compat import as_unicode
+from flask_appbuilder.const import LOGMSG_ERR_SEC_NO_REGISTER_HASH
 from flask_appbuilder.security.decorators import no_cache
 from flask_appbuilder.security.views import AuthView, WerkzeugResponse
+from flask_babel import lazy_gettext
 
 from superset.views.base import BaseSupersetView
+
+logger = logging.getLogger(__name__)
 
 
 class SupersetAuthView(BaseSupersetView, AuthView):
@@ -39,8 +45,47 @@ class SupersetAuthView(BaseSupersetView, AuthView):
 
 class SupersetRegisterUserView(BaseSupersetView):
     route_base = "/register"
+    activation_template = ""
+    error_message = lazy_gettext(
+        "Not possible to register you at the moment, try again later"
+    )
+    false_error_message = lazy_gettext("Registration not found")
 
     @expose("/")
     @no_cache
     def register(self) -> WerkzeugResponse:
         return super().render_app_template()
+
+    @expose("/activation/<string:activation_hash>")
+    def activation(self, activation_hash):
+        """
+        Endpoint to expose an activation url, this url
+        is sent to the user by email, when accessed the user is inserted
+        and activated
+        """
+        reg = self.appbuilder.sm.find_register_user(activation_hash)
+        if not reg:
+            logger.error(LOGMSG_ERR_SEC_NO_REGISTER_HASH, activation_hash)
+            flash(as_unicode(self.false_error_message), "danger")
+            return redirect(self.appbuilder.get_url_for_index)
+        if not self.appbuilder.sm.add_user(
+            username=reg.username,
+            email=reg.email,
+            first_name=reg.first_name,
+            last_name=reg.last_name,
+            role=self.appbuilder.sm.find_role(
+                self.appbuilder.sm.auth_user_registration_role
+            ),
+            hashed_password=reg.password,
+        ):
+            flash(as_unicode(self.error_message), "danger")
+            return redirect(self.appbuilder.get_url_for_index)
+        else:
+            self.appbuilder.sm.del_register_user(reg)
+            return super().render_app_template(
+                {
+                    "username": reg.username,
+                    "first_name": reg.first_name,
+                    "last_name": reg.last_name,
+                },
+            )

--- a/superset/views/user_registrations.py
+++ b/superset/views/user_registrations.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask_appbuilder import permission_name
+from flask_appbuilder.api import expose
+from flask_appbuilder.security.decorators import has_access
+
+from superset.superset_typing import FlaskResponse
+
+from .base import BaseSupersetView
+
+
+class UserRegistrationsView(BaseSupersetView):
+    route_base = "/"
+    class_permission_name = "security"
+
+    @expose("/registrations/")
+    @has_access
+    @permission_name("read")
+    def list(self) -> FlaskResponse:
+        return super().render_app_template()

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1556,6 +1556,7 @@ class TestRolePermission(SupersetTestCase):
             ["SupersetAuthView", "login"],
             ["SupersetAuthView", "logout"],
             ["SupersetRegisterUserView", "register"],
+            ["SupersetRegisterUserView", "activation"],
         ]
         unsecured_views = []
         for view_class in appbuilder.baseviews:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move user registrations fab view to frontend for themeability. Also includes the activation page that is accessed from activation email.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/user-attachments/assets/36b69116-a7a5-4a67-8e71-7fe043e67dbe)
After:
![image](https://github.com/user-attachments/assets/798bff3d-02b1-4ec3-9acc-46aaef5c2eed)

Before (mail activation route: `/register/activation/:hash`)
![image](https://github.com/user-attachments/assets/cfabc24f-a6fc-457a-ba09-7605cf0ef2f5)

After
![image](https://github.com/user-attachments/assets/b05d13e1-fa29-4d77-9658-d87c046f2c78)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Here's a sample config to access the page:
```py
AUTH_USER_REGISTRATION = True
# The default user self registration role
AUTH_USER_REGISTRATION_ROLE = "Admin"
RECAPTCHA_PUBLIC_KEY = ""
RECAPTCHA_PRIVATE_KEY = ""
CSRF_ENABLED = True

MAIL_SERVER = "localhost"
MAIL_PORT = 1025
MAIL_USE_TLS = False
MAIL_USERNAME = "yourappemail@gmail.com"
MAIL_PASSWORD = "passwordformail"
MAIL_DEFAULT_SENDER = "fabtest10@gmail.com"
```
1. Register as another user
2. Don't confirm the registration email
3. Log in as admin
4. Go to User Registrations from the right menu.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API