### PR TITLE
chore: simplify query cleanup using dict.pop instead of suppressing exception

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -397,8 +397,7 @@ class ChartDataRestApi(ChartRestApi):
             queries = result["queries"]
             if security_manager.is_guest_user():
                 for query in queries:
-                    with contextlib.suppress(KeyError):
-                        del query["query"]
+                    query.pop("query", None)
             with event_logger.log_context(f"{self.__class__.__name__}.json_dumps"):
                 response_data = json.dumps(
                     {"result": queries},


### PR DESCRIPTION
### SUMMARY
This PR simplifies the removal of "query" keys from each dictionary in the queries list by replacing the use of contextlib.suppress(KeyError) with the more concise and idiomatic dict.pop() method. This improves readability without changing the behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
