### PR TITLE
fix: clarify GUEST_TOKEN_JWT_AUDIENCE usage in the SDK

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -117,7 +117,7 @@ Example `POST /security/guest_token` payload:
 ```
 
 Alternatively, a guest token can be created directly in your app without interacting with the Superset API.
-To do this, you should update the  `GUEST_TOKEN_JWT_SECRET` 
+To do this, you should update the `GUEST_TOKEN_JWT_SECRET`
 in the Superset [config.py](https://github.com/apache/superset/blob/master/superset/config.py). Also set the
 `GUEST_TOKEN_JWT_AUDIENCE` variable that matches what is set for the `aud` in the JSON payload:
 

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -116,8 +116,11 @@ Example `POST /security/guest_token` payload:
 }
 ```
 
-Alternatively, a guest token can be created directly in your app with a json like the following, and then signed
-with the secret set in configuration variable `GUEST_TOKEN_JWT_SECRET` (see configuration file config.py)
+Alternatively, a guest token can be created directly in your app without interacting with the Superset API.
+To do this, you should update the  `GUEST_TOKEN_JWT_SECRET` 
+in the Superset [config.py](https://github.com/apache/superset/blob/master/superset/config.py). Also set the
+`GUEST_TOKEN_JWT_AUDIENCE` variable that matches what is set for the `aud` in the JSON payload:
+
 ```
 {
   "user": {
@@ -145,7 +148,6 @@ In this example, the configuration file includes the following setting:
 GUEST_TOKEN_JWT_AUDIENCE="superset"
 ```
 
-If you're using a different audience value, be sure to update the GUEST_TOKEN_JWT_AUDIENCE variable accordingly.
 
 ### Sandbox iframe
 

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -139,6 +139,14 @@ with the secret set in configuration variable `GUEST_TOKEN_JWT_SECRET` (see conf
 }
 ```
 
+In this example, the configuration file includes the following setting:
+
+```python
+GUEST_TOKEN_JWT_AUDIENCE="superset"
+```
+
+If you're using a different audience value, be sure to update the GUEST_TOKEN_JWT_AUDIENCE variable accordingly.
+
 ### Sandbox iframe
 
 The Embedded SDK creates an iframe with [sandbox](https://developer.mozilla.org/es/docs/Web/HTML/Element/iframe#sandbox) mode by default

--- a/superset/config.py
+++ b/superset/config.py
@@ -1808,7 +1808,8 @@ GUEST_TOKEN_HEADER_NAME = "X-GuestToken"  # noqa: S105
 GUEST_TOKEN_JWT_EXP_SECONDS = 300  # 5 minutes
 # Audience for the Superset guest token used in embedded mode.
 # Can be a string or a callable. Defaults to WEBDRIVER_BASEURL.
-# When generating the guest token, ensure the payload's `aud` matches GUEST_TOKEN_JWT_AUDIENCE.
+# When generating the guest token, ensure the 
+# payload's `aud` matches GUEST_TOKEN_JWT_AUDIENCE.
 GUEST_TOKEN_JWT_AUDIENCE: Callable[[], str] | str | None = None
 
 # A callable that can be supplied to do extra validation of guest token configuration

--- a/superset/config.py
+++ b/superset/config.py
@@ -1808,7 +1808,7 @@ GUEST_TOKEN_HEADER_NAME = "X-GuestToken"  # noqa: S105
 GUEST_TOKEN_JWT_EXP_SECONDS = 300  # 5 minutes
 # Audience for the Superset guest token used in embedded mode.
 # Can be a string or a callable. Defaults to WEBDRIVER_BASEURL.
-# When generating the guest token, ensure the 
+# When generating the guest token, ensure the
 # payload's `aud` matches GUEST_TOKEN_JWT_AUDIENCE.
 GUEST_TOKEN_JWT_AUDIENCE: Callable[[], str] | str | None = None
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1806,7 +1806,9 @@ GUEST_TOKEN_JWT_SECRET = "test-guest-secret-change-me"  # noqa: S105
 GUEST_TOKEN_JWT_ALGO = "HS256"  # noqa: S105
 GUEST_TOKEN_HEADER_NAME = "X-GuestToken"  # noqa: S105
 GUEST_TOKEN_JWT_EXP_SECONDS = 300  # 5 minutes
-# Guest token audience for the embedded superset, either string or callable
+# Audience for the Superset guest token used in embedded mode.
+# Can be a string or a callable. Defaults to WEBDRIVER_BASEURL.
+# When generating the guest token, ensure the payload's `aud` matches GUEST_TOKEN_JWT_AUDIENCE.
 GUEST_TOKEN_JWT_AUDIENCE: Callable[[], str] | str | None = None
 
 # A callable that can be supplied to do extra validation of guest token configuration


### PR DESCRIPTION
### SUMMARY

Change to the wording of the SDK. There is little documentation around `GUEST_TOKEN_JWT_AUDIENCE` and having it set is crucial to having the SDK work. 



### ADDITIONAL INFORMATION

- [x] Has associated issue: https://github.com/apache/superset/issues/25740

