### PR TITLE
[WIP] feat: add feature flag for CSS Templates

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -58,6 +58,7 @@ export enum FeatureFlag {
   SlackEnableAvatars = 'SLACK_ENABLE_AVATARS',
   EnableDashboardScreenshotEndpoints = 'ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS',
   EnableDashboardDownloadWebDriverScreenshot = 'ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT',
+  EnableCssTemplates = 'ENABLE_CSS_TEMPLATES',
 }
 
 export type ScheduleQueriesProps = {

--- a/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
+++ b/superset-frontend/src/dashboard/components/Header/useHeaderActionsDropdownMenu.tsx
@@ -19,7 +19,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Menu } from 'src/components/Menu';
-import { t } from '@superset-ui/core';
+import { t, isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { isEmpty } from 'lodash';
 import { URL_PARAMS } from 'src/constants';
 import ShareMenuItems from 'src/dashboard/components/menu/ShareMenuItems';
@@ -192,7 +192,7 @@ export const useHeaderActionsMenu = ({
             {t('Edit properties')}
           </Menu.Item>
         )}
-        {editMode && (
+        {editMode && isFeatureEnabled(FeatureFlag.EnableCssTemplates) && (
           <Menu.Item key={MenuKeys.EditCss}>
             <CssEditor
               triggerNode={<div>{t('Edit CSS')}</div>}

--- a/superset/config.py
+++ b/superset/config.py
@@ -564,6 +564,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Allow metrics and columns to be grouped into (potentially nested) folders in the
     # chart builder
     "DATASET_FOLDERS": False,
+    # Allow users to create and use custom CSS templates by default
+    "ENABLE_CSS_TEMPLATES": True,
 }
 
 # ------------------------------
@@ -1155,8 +1157,8 @@ SQLLAB_CTAS_NO_LIMIT = False
 #         else:
 #             return f'tmp_{schema}'
 # Function accepts database object, user object, schema name and sql that will be run.
-SQLLAB_CTAS_SCHEMA_NAME_FUNC: (
-    None | (Callable[[Database, models.User, str, str], str])
+SQLLAB_CTAS_SCHEMA_NAME_FUNC: None | (
+    Callable[[Database, models.User, str, str], str]
 ) = None
 
 # If enabled, it can be used to store the results of long-running queries

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -326,6 +326,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Manage",
             category_label=__("Manage"),
             category_icon="",
+            menu_cond=lambda: feature_flag_manager.is_feature_enabled(
+                "ENABLE_CSS_TEMPLATES"
+            ),
         )
 
         #


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

At Yahoo, one of our security personnel flagged this feature as a potential security issue:

> The application allows user's to create custom CSS templates for their Dashboards. In doing so, the attacker was able to specify CSS that performed GET requests to the superset application. External interactions were blocked by CSP and therefore reduce the severity of the attack. 
Additional CSS Injections can allow arbitrary dynamic CSS to be injected into the browser under the ` <style> ` element.
Due to availability issues this feature could not be tested further. There is likely a DOM Breakout method for this as it gets inserted plaintext into the Body of the page.
CSP Bypasses can also occur which would allow for data exfiltration in the event an open redirect can be utilized.

Additionally, there was a discussion around this feature: https://github.com/apache/superset/discussions/296

I added a feature flag (`ENABLE_CSS_TEMPLATES`) that will allow users to disable CSS templates. The feature remains enabled by default.

There is a flag check in the Menu builder, a `@before_request()` hook in front of the CssTemplates API endpoints, and flag checks in `useHeaderActionsDropdownMenu`. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
(In Progress)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
(In Progress)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/discussions/29685
- [x] Required feature flags: `ENABLE_CSS_TEMPLATES` 
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
