### PR TITLE
fix: optimize catalog permission sync when importing dashboards

### DIFF
--- a/superset/commands/database/utils.py
+++ b/superset/commands/database/utils.py
@@ -57,10 +57,21 @@ def add_permissions(database: Database, ssh_tunnel: SSHTunnel | None) -> None:
     """
     # TODO: Migrate this to use the non-commiting add_pvm helper instead
     if database.db_engine_spec.supports_catalog:
-        catalogs = database.get_all_catalog_names(
-            cache=False,
-            ssh_tunnel=ssh_tunnel,
-        )
+        # Adding permissions to all catalogs (and all their schemas) can take a long
+        # time (minutes, while importing a chart, eg). If the database does not
+        # support cross-catalog queries (like Postgres), and the multi-catalog
+        # feature is not enabled, then we only need to add permissions to the
+        # default catalog.
+        if (
+            database.db_engine_spec.supports_cross_catalog_queries
+            or database.allow_multi_catalog
+        ):
+            catalogs = database.get_all_catalog_names(
+                        cache=False,
+                        ssh_tunnel=ssh_tunnel,
+                    )
+        else:
+            catalogs = {database.get_default_catalog()}
 
         for catalog in catalogs:
             security_manager.add_permission_view_menu(

--- a/superset/commands/database/utils.py
+++ b/superset/commands/database/utils.py
@@ -67,9 +67,9 @@ def add_permissions(database: Database, ssh_tunnel: SSHTunnel | None) -> None:
             or database.allow_multi_catalog
         ):
             catalogs = database.get_all_catalog_names(
-                        cache=False,
-                        ssh_tunnel=ssh_tunnel,
-                    )
+                cache=False,
+                ssh_tunnel=ssh_tunnel,
+            )
         else:
             catalogs = {database.get_default_catalog()}
 


### PR DESCRIPTION
### SUMMARY
Following up from https://github.com/apache/superset/pull/33000. The previous PR fixed catalog permission syncing for databases like Postgres, which don't support multiple catalogs in one instance. However, permissions were still being synced for all the catalogs when creating a database connection (e.g. during a dashboard import).

This PR applies the same logic as the previous fix to `CreateDatabaseCommand`.

Fixes https://github.com/apache/superset/issues/32993.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
