### PR TITLE
fix: Do not convert dataset changed_on to UTC

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import dateutil.parser
@@ -198,7 +198,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):
                 force_update = True
 
             if force_update:
-                attributes["changed_on"] = datetime.now(tz=timezone.utc)
+                attributes["changed_on"] = datetime.now()
 
         return super().update(item, attributes)
 

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import copy
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -99,7 +99,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
                 "columns": [{"id": 1, "name": "col1"}],
                 "metrics": [{"id": 1, "name": "metric1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
         ),
         (
             {
@@ -109,14 +109,14 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
             },
         ),
         (
             {
                 "columns": [{"id": 1, "name": "col1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
         ),
         (
             {
@@ -125,14 +125,14 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
             },
         ),
         (
             {
                 "metrics": [{"id": 1, "name": "metric1"}],
             },
-            {"changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)},
+            {"changed_on": datetime(2025, 1, 1, 0, 0, 0)},
         ),
         (
             {
@@ -141,7 +141,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
             },
             {
                 "description": "test description",
-                "changed_on": datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                "changed_on": datetime(2025, 1, 1, 0, 0, 0),
             },
         ),
         (


### PR DESCRIPTION
### SUMMARY
In https://github.com/apache/superset/pull/33626, we decided to store the dataset's `changed_on` attribute in UTC, to ensure consistency. This introduced an issue to calculate the `changed_on_humanized` property (`now - item.changed_on`). In order to fix this calculation for new edits, we would have to update it to `now.utc() - item.changed_on` which then would break the calculation for items that were modified before this modification.

Ideally, a long-term solution would be to implement timezone support at the DB level, and then migrate existing columns to use the timezone from the server. This however is not aligned with https://github.com/apache/superset/pull/33626 original's scope, so this PR just reverts that to store the `changed_on` using `now()`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
N/A.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
