### PR TITLE
fix(chart): set tab name as chart name

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -71,8 +71,6 @@ const DashboardBuilder = lazy(
     ),
 );
 
-const originalDocumentTitle = document.title;
-
 type PageProps = {
   idOrSlug: string;
 };
@@ -204,7 +202,7 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       document.title = dashboard_title;
     }
     return () => {
-      document.title = originalDocumentTitle;
+      document.title = 'Superset';
     };
   }, [dashboard_title]);
 

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -269,15 +269,14 @@ function ExploreViewContainer(props) {
 
   const theme = useTheme();
 
-  const originalDocumentTitle = document.title;
   useEffect(() => {
     if (props.sliceName) {
       document.title = props.sliceName;
     }
     return () => {
-      document.title = originalDocumentTitle;
+      document.title = 'Superset';
     };
-  }, [props.sliceName])
+  }, [props.sliceName]);
 
   const addHistory = useCallback(
     async ({ isReplace = false, title } = {}) => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -269,6 +269,16 @@ function ExploreViewContainer(props) {
 
   const theme = useTheme();
 
+  const originalDocumentTitle = document.title;
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName])
+
   const addHistory = useCallback(
     async ({ isReplace = false, title } = {}) => {
       const formData = props.dashboardId


### PR DESCRIPTION
### SUMMARY
This PR changes tab name as chart name when we open the chart 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before
![image](https://github.com/user-attachments/assets/cdef2f88-ea10-445c-b77e-465ced9cb82a)

#### After
![image](https://github.com/user-attachments/assets/477a03a2-f868-4e11-bf83-2d95ed001b34)


### TESTING INSTRUCTIONS
1. Open a random chart
2. See tab name gets changed to chart name

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
