### PR TITLE
fix(compose): environment entries in compose*.yml override values in docker/.env

### DIFF
--- a/docker-compose-image-tag.yml
+++ b/docker-compose-image-tag.yml
@@ -65,8 +65,6 @@ services:
       superset-init:
         condition: service_completed_successfully
     volumes: *superset-volumes
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-init:
     image: *superset-image
@@ -86,9 +84,6 @@ services:
     volumes: *superset-volumes
     healthcheck:
       disable: true
-    environment:
-      SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-worker:
     image: *superset-image
@@ -111,8 +106,6 @@ services:
           "CMD-SHELL",
           "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME",
         ]
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-worker-beat:
     image: *superset-image
@@ -131,8 +124,6 @@ services:
     volumes: *superset-volumes
     healthcheck:
       disable: true
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
 volumes:
   superset_home:

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -71,8 +71,6 @@ services:
       superset-init:
         condition: service_completed_successfully
     volumes: *superset-volumes
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-init:
     container_name: superset_init
@@ -93,9 +91,6 @@ services:
     volumes: *superset-volumes
     healthcheck:
       disable: true
-    environment:
-      SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-worker:
     build:
@@ -119,8 +114,6 @@ services:
           "CMD-SHELL",
           "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME",
         ]
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-worker-beat:
     build:
@@ -140,8 +133,6 @@ services:
     volumes: *superset-volumes
     healthcheck:
       disable: true
-    environment:
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
 volumes:
   superset_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,9 +104,6 @@ services:
       superset-init:
         condition: service_completed_successfully
     volumes: *superset-volumes
-    environment:
-      CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-websocket:
     container_name: superset_websocket
@@ -158,10 +155,6 @@ services:
         condition: service_started
     user: *superset-user
     volumes: *superset-volumes
-    environment:
-      CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
-      SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
     healthcheck:
       disable: true
 
@@ -206,8 +199,6 @@ services:
         required: false
     environment:
       CELERYD_CONCURRENCY: 2
-      CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
     restart: unless-stopped
     depends_on:
       superset-init:
@@ -239,9 +230,6 @@ services:
     volumes: *superset-volumes
     healthcheck:
       disable: true
-    environment:
-      CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
 
   superset-tests-worker:
     build:
@@ -262,7 +250,6 @@ services:
       REDIS_RESULTS_DB: 3
       REDIS_HOST: localhost
       CELERYD_CONCURRENCY: 8
-      SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
     network_mode: host
     depends_on:
       superset-init:


### PR DESCRIPTION
### SUMMARY

Docker compose files (`docker-compose.yml`, `docker-compose-non-dev.yml`, `docker-compose-image-tag.yml`) contain `environment` entries for several containers, establishing values for env variables that are also included in `docker/.env`.

But due to [the way environment variable precedence works in Docker](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/), any env variable merely listed in the `.yml` files –even if no value is specified– will overwrite any values coming from the `env-file` entries (`docker/.env` and `docker/.env-local`).

This means that if users set, for instance, `SUPERSET_LOAD_EXAMPLES=no` in `docker/.env` or `docker/.env-local` (as explained in the documentation), this value **will be ignored** and examples will be loaded anyway, because the `docker-compose-*.yml` contain this:
v
### TESTING INSTRUCTIONS

  - Set `SUPERSET_LOAD_EXAMPLES=no` in `docker/.env-local`.
  - Start with `docker compose ... up -d`
  - Examples will be loaded (and container `superset_init` will take a long time to start, which is inconvenient).


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #31747 (`environment` entries were added here).
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


### ADDITIONAL COMMENTS

Please note the above would not happen if `docker/.env` was in fact `.env`, and this may cause some confusion.

The reason is, the `.env` file present in the docker-compose root folder will be used for replacing any environment variables **used in the `.yml` file itself**. So for instance, if we had a `.env` file with:

```
SUPERSET_LOAD_EXAMPLES=no
```
Then this line in `docker-compose.yml` would work as expected, setting the value of the variable to `no`:
```yml
environment:
  SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
```
But there is a difference between `.env` and Docker compose's `env-file`'s specified for each of the containers. The former applies on the `.yml` file, while the latter applies exclusively _inside the container_, but taking less precedence than the former.

So the fact that those files in the `docker/` folder are called `.env` **is misleading**. Those are not `.env` files, but instead `env-file`s (yes, subtle 😄).

So, **proposal**: Would you consider renaming those files inside the `docker/` folder to something like (just a suggestion):
  * `docker/.env` -> `docker/environment`
  * `docker/.env-local` -> `docker/environment-local`

(Please note renaming these would mean also changes in the public documentation, and in the `.gitignore` file.)

If it makes sense for you, we could provide an additional PR for that.



