### PR TITLE
fix: Migrate charts with empty query_context

### DIFF
--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -160,6 +160,7 @@ class MigrateViz:
             backup = {FORM_DATA_BAK_FIELD_NAME: form_data_bak}
 
             query_context = try_load_json(slc.query_context)
+            queries_bak = None
 
             if query_context:
                 if "form_data" in query_context:
@@ -169,10 +170,11 @@ class MigrateViz:
 
                 queries = clz._build_query()["queries"]
                 query_context["queries"] = queries
-
-                slc.query_context = json.dumps(query_context)
-                backup[QUERIES_BAK_FIELD_NAME] = queries_bak
-
+            else:
+                query_context = clz._build_query()
+                
+            slc.query_context = json.dumps(query_context)
+            backup[QUERIES_BAK_FIELD_NAME] = queries_bak
             slc.params = json.dumps({**clz.data, **backup})
 
         except Exception as e:
@@ -189,11 +191,14 @@ class MigrateViz:
                 slc.viz_type = form_data_bak.get("viz_type")
                 query_context = try_load_json(slc.query_context)
                 queries_bak = form_data.get(QUERIES_BAK_FIELD_NAME, {})
-                query_context["queries"] = queries_bak
-                if "form_data" in query_context:
-                    query_context["form_data"] = form_data_bak
+                if queries_bak:
+                    query_context["queries"] = queries_bak
+                    if "form_data" in query_context:
+                        query_context["form_data"] = form_data_bak
+                        slc.query_context = json.dumps(query_context)
+                else:
+                    slc.query_context = None
 
-                slc.query_context = json.dumps(query_context)
         except Exception as e:
             logger.warning(f"Failed to downgrade slice {slc.id}: {e}")
 

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -4,7 +4,7 @@
 # regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# with the License. You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -157,7 +157,7 @@ class MigrateViz:
             # because a source viz can be mapped to different target viz types
             slc.viz_type = clz.target_viz_type
 
-            backup = {FORM_DATA_BAK_FIELD_NAME: form_data_bak}
+            backup: Any | dict[str, Any] = {FORM_DATA_BAK_FIELD_NAME: form_data_bak}
 
             query_context = try_load_json(slc.query_context)
             queries_bak = None
@@ -172,7 +172,7 @@ class MigrateViz:
                 query_context["queries"] = queries
             else:
                 query_context = clz._build_query()
-                
+
             slc.query_context = json.dumps(query_context)
             backup[QUERIES_BAK_FIELD_NAME] = queries_bak
             slc.params = json.dumps({**clz.data, **backup})


### PR DESCRIPTION
### SUMMARY
This PR implements a fix for the legacy charts migration. When a chart has a `null` `query_context` , a new `query_context` will be generated using the migrated `form_data` . Additionally, the query backup will be saved as `null` in the backup field `queries_bak` , ensuring that if the chart is downgraded, the `query_context` will revert to `null` .

This change was necessary because executing `warm_up_cache` for a migrated chart with a `null` `query_context` results in the error: `Chart's query context does not exist`. As a consequence, the chart fails to be cached.


### TESTING INSTRUCTIONS
Run superset db upgrade and superset db downgrade CLI commands.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
