### PR TITLE
docs: clarify how `requirements/` should be modified

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,0 +1,13 @@
+## Python dependency logic
+
+In this folder, the `.in` files, in conjunction with the `../pyproject.toml` file (in the root of the repo) are used to generate the pinned requirements as `.txt` files.
+
+To alter the pinned dependency, you can edit/alter the `.in` and `pyproject.toml` files, and then run the following command:
+
+```bash
+./scripts/uv-pip-compile.sh
+```
+
+This will generate the pinned requirements in the `.txt` files, which will be used in our CI/CD pipelines and in the Docker images.
+
+We recommend to everyone in the community to use the pinned requirements in their local development environments, to ensure consistency across different environments, though we don't force requirements as part of our python package semantics to allow flexibility for users to install different versions of the dependencies if they wish.


### PR DESCRIPTION
Clarifying how python requirements should be modified in a `requirements/README.md` file.
