### PR TITLE
fix(dashboard): show dashboard thumbnail images when retrieved

### DIFF
--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -159,7 +159,7 @@ function DashboardCard({
         }
         url={bulkSelectEnabled ? undefined : dashboard.url}
         linkComponent={Link}
-        imgURL={dashboard.thumbnail_url}
+        imgURL={thumbnailUrl}
         imgFallbackURL={assetUrl(
           '/static/assets/images/dashboard-card-fallback.svg',
         )}


### PR DESCRIPTION
### SUMMARY
Fixes https://github.com/apache/superset/issues/30287, dashboard thumbnails not showing on dashboards list.

Change https://github.com/apache/superset/pull/28609 introduced useEffect to evaluate each dashboard thumbnailUrl separately from the list retrieval to improve performance. The result of the retrieval was never applied to the imgURL so thumbnails were no longer requested.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Enable thumbnail generation and navigate to the dashboards list to view thumbnails

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/30287
- [x] Required feature flags: THUMBNAILS, THUMBNAILS_SQLA_LISTENERS
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
