### PR TITLE
fix(database): remove database

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -47,7 +47,7 @@ from flask_appbuilder.widgets import ListWidget
 from flask_babel import lazy_gettext as _
 from flask_login import AnonymousUserMixin, LoginManager
 from jwt.api_jwt import _jwt_global_obj
-from sqlalchemy import and_, inspect, or_
+from sqlalchemy import and_, inspect, or_, select
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import eagerload
 from sqlalchemy.orm.mapper import Mapper
@@ -1957,8 +1957,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return
         # Delete Any Role to PVM association
         connection.execute(
-            assoc_permissionview_role.delete().where(
-                assoc_permissionview_role.c.permission_view_id == pvm.id
+            assoc_permissionview_role.c.permission_view_id.in_(
+                select(permission_view_menu_table.c.id).where(
+                    permission_view_menu_table.c.view_menu_id == pvm.view_menu_id
+                )
             )
         )
         # Delete the database access PVM


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Automatically delete related PVMs when removing database objects

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, deleting database objects could fail due to existing relations with PermissionViewModel (PVM) entries, which caused integrity errors and prevented cleanup.

This PR introduces automatic deletion of all related PVMs during the removal of associated database objects to ensure proper cascading behavior
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
