### PR TITLE
fix(dataset): Fix plural toast messages

### DIFF
--- a/superset-frontend/src/components/Datasource/utils.js
+++ b/superset-frontend/src/components/Datasource/utils.js
@@ -105,6 +105,7 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
         'Modified 1 column in the virtual dataset',
         'Modified %s columns in the virtual dataset',
         columnChanges.modified.length,
+        columnChanges.modified.length,
       ),
     );
   }
@@ -114,6 +115,7 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
         'Removed 1 column from the virtual dataset',
         'Removed %s columns from the virtual dataset',
         columnChanges.removed.length,
+        columnChanges.removed.length,
       ),
     );
   }
@@ -122,6 +124,7 @@ export function updateColumns(prevCols, newCols, addSuccessToast) {
       tn(
         'Added 1 new column to the virtual dataset',
         'Added %s new columns to the virtual dataset',
+        columnChanges.added.length,
         columnChanges.added.length,
       ),
     );

--- a/superset-frontend/src/components/Datasource/utils.test.tsx
+++ b/superset-frontend/src/components/Datasource/utils.test.tsx
@@ -51,6 +51,7 @@ describe('updateColumns', () => {
         'Added 1 new column to the virtual dataset',
         'Added %s new columns to the virtual dataset',
         2,
+        2,
       ),
     );
   });
@@ -88,6 +89,7 @@ describe('updateColumns', () => {
         'Modified 1 column in the virtual dataset',
         'Modified %s columns in the virtual dataset',
         1,
+        1,
       ),
     );
   });
@@ -113,6 +115,7 @@ describe('updateColumns', () => {
       tn(
         'Removed 1 column from the virtual dataset',
         'Removed %s columns from the virtual dataset',
+        1,
         1,
       ),
     );
@@ -146,6 +149,7 @@ describe('updateColumns', () => {
           'Modified 1 column in the virtual dataset',
           'Modified %s columns in the virtual dataset',
           1,
+          1,
         ),
       ],
       [
@@ -153,12 +157,14 @@ describe('updateColumns', () => {
           'Removed 1 column from the virtual dataset',
           'Removed %s columns from the virtual dataset',
           1,
+          1,
         ),
       ],
       [
         tn(
           'Added 1 new column to the virtual dataset',
           'Added %s new columns to the virtual dataset',
+          1,
           1,
         ),
       ],
@@ -194,6 +200,7 @@ describe('updateColumns', () => {
         tn(
           'Modified 1 column in the virtual dataset',
           'Modified %s columns in the virtual dataset',
+          1,
           1,
         ),
       ],


### PR DESCRIPTION
### SUMMARY
Fixes #33733 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/b3ec0808-2f86-4bfd-8235-b8fc8cf3f9fb" />


### TESTING INSTRUCTIONS
Remove some columns from a dataset and then sync the columns back from the source, see the message displayed correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #33733
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
