### PR TITLE
fix: tag removal not working in dashboard properties modal

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -592,6 +592,10 @@ const PropertiesModal = ({
     setTags(parsedTags);
   };
 
+  const handleClearTags = () => {
+    setTags([]);
+  };
+
   return (
     <Modal
       show={show}
@@ -707,6 +711,7 @@ const PropertiesModal = ({
                   value={tagsAsSelectValues}
                   options={loadTags}
                   onChange={handleChangeTags}
+                  onClear={handleClearTags}
                   allowClear
                 />
               </StyledFormItem>


### PR DESCRIPTION
## Fix: Tag Removal Not Working in Dashboard Properties Modal

### Problem
- Tag removal works correctly in the **Explore Properties Modal** but fails in the **Dashboard Properties Modal**.
- Users can add tags, but cannot remove them using the clear functionality.

### Solution
- Implemented the missing `handleClearTags` function in the **Dashboard PropertiesModal**.
- Connected the `onClear` prop to the `AsyncSelect` component.
- Mirrored the working implementation pattern used in the Explore PropertiesModal for consistency and reliability.

### Testing
- All existing unit and integration tests pass.
- Manual testing confirms that tag removal now functions as expected in dashboard edit mode.

FEATURE_TAGGING_SYSTEM=true

TAGGING_SYSTEM=true

### Additional Information
- [x] Fixes #33758
- [ ] Has associated issue  
- [ ] Required feature flags  
- [ ] Changes UI  
- [ ] Includes DB Migration ([SIP-59](https://github.com/apache/superset/issues/13351))  
  - [ ] Migration is atomic, supports rollback & is backwards-compatible  
  - [ ] Confirm DB migration upgrade and downgrade tested  
  - [ ] Runtime estimates and downtime expectations provided  
- [ ] Introduces new feature or API  
- [ ] Removes existing feature or API  
