### PR TITLE
chore: auto-focus modal input when deleting assets

### DIFF
--- a/superset-frontend/src/components/DeleteModal/DeleteModal.test.tsx
+++ b/superset-frontend/src/components/DeleteModal/DeleteModal.test.tsx
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import DeleteModal from '.';
 
 test('Must display title and content', () => {
@@ -29,9 +34,23 @@ test('Must display title and content', () => {
   };
   render(<DeleteModal {...props} />);
   expect(screen.getByTestId('test-title')).toBeInTheDocument();
-  expect(screen.getByTestId('test-title')).toBeInTheDocument();
   expect(screen.getByTestId('test-description')).toBeInTheDocument();
-  expect(screen.getByTestId('test-description')).toBeInTheDocument();
+});
+
+test('Input should autofocus when modal opens', async () => {
+  const props = {
+    title: <div data-test="test-title">Title</div>,
+    description: <div data-test="test-description">Description</div>,
+    onConfirm: jest.fn(),
+    onHide: jest.fn(),
+    open: true,
+  };
+  render(<DeleteModal {...props} />);
+  const input = screen.getByTestId('delete-modal-input');
+  // waitFor because focus may happen after render due to useEffect
+  await waitFor(() => {
+    expect(input).toHaveFocus();
+  });
 });
 
 test('Calling "onHide"', () => {

--- a/superset-frontend/src/components/DeleteModal/index.tsx
+++ b/superset-frontend/src/components/DeleteModal/index.tsx
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { InputRef } from 'antd-v5';
 import { t, styled } from '@superset-ui/core';
-import { useState, ReactNode, ChangeEvent } from 'react';
+import { useState, useRef, useEffect, ReactNode, ChangeEvent } from 'react';
 import { Input } from 'src/components/Input';
 import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/components/Form';
@@ -52,6 +53,13 @@ export default function DeleteModal({
 }: DeleteModalProps) {
   const [disableChange, setDisableChange] = useState(true);
   const [confirmation, setConfirmation] = useState<string>('');
+  const inputRef = useRef<InputRef>(null);
+
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [open]);
 
   const hide = () => {
     setConfirmation('');
@@ -99,6 +107,7 @@ export default function DeleteModal({
           value={confirmation}
           onChange={onChange}
           onPressEnter={onPressEnter}
+          ref={inputRef}
         />
       </StyledDiv>
     </Modal>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I have one law of design:

> If the user **has** to do something, _do it for them_.

Or, as I like to phrase it, "If it's mandatory, it's automatable.".

<img width="1728" alt="Screenshot 2025-06-13 at 9 58 59 AM" src="https://github.com/user-attachments/assets/551b2a19-a7a7-4ac7-9677-2079f5d41056" />

When a user tries to delete an asset we pop up a modal asking for confirmation. Then, every single time, the poor user has to click the input field in order to focus it, so they can type "DELETE". Fortunately, after typing delete they don't have to click the button, they can just press enter (a feature I added in https://github.com/apache/superset/pull/17345).

With this PR, the input field is auto-focused when the modal opens.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
