### PR TITLE
refactor(theming): Remove direct imports of supersetTheme

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
@@ -18,11 +18,7 @@
  */
 import '@testing-library/jest-dom';
 import { render } from '@superset-ui/core/spec';
-import {
-  ThemeProvider,
-  supersetTheme,
-  GenericDataType,
-} from '@superset-ui/core';
+import { GenericDataType } from '@superset-ui/core';
 
 import { ColumnOption, ColumnOptionProps } from '../../src';
 
@@ -53,11 +49,7 @@ const defaultProps: ColumnOptionProps = {
 };
 
 const setup = (props: Partial<ColumnOptionProps> = {}) =>
-  render(
-    <ThemeProvider theme={supersetTheme}>
-      <ColumnOption {...defaultProps} {...props} />
-    </ThemeProvider>,
-  );
+  render(<ColumnOption {...defaultProps} {...props} />);
 test('shows a label with verbose_name', () => {
   const { container } = setup();
   const lbl = container.getElementsByClassName('option-label');

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/InfoTooltipWithTrigger.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/InfoTooltipWithTrigger.test.tsx
@@ -18,7 +18,6 @@
  */
 import '@testing-library/jest-dom';
 import { fireEvent, render } from '@superset-ui/core/spec';
-import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import { InfoTooltip, InfoTooltipProps } from '@superset-ui/core/components';
 
 jest.mock('@superset-ui/core/components/Tooltip', () => ({
@@ -30,11 +29,7 @@ jest.mock('@superset-ui/core/components/Tooltip', () => ({
 const defaultProps = {};
 
 const setup = (props: Partial<InfoTooltipProps> = {}) =>
-  render(
-    <ThemeProvider theme={supersetTheme}>
-      <InfoTooltip {...defaultProps} {...props} />
-    </ThemeProvider>,
-  );
+  render(<InfoTooltip {...defaultProps} {...props} />);
 
 test('renders a tooltip', () => {
   const { getAllByTestId } = setup({

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -18,7 +18,6 @@
  */
 import '@testing-library/jest-dom';
 import { render } from '@superset-ui/core/spec';
-import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import {
   MetricOption,
   MetricOptionProps,
@@ -61,11 +60,7 @@ const defaultProps = {
 };
 
 const setup = (props: Partial<MetricOptionProps> = {}) =>
-  render(
-    <ThemeProvider theme={supersetTheme}>
-      <MetricOption {...defaultProps} {...props} />
-    </ThemeProvider>,
-  );
+  render(<MetricOption {...defaultProps} {...props} />);
 test('shows a label with verbose_name', () => {
   const { container } = setup();
   const lbl = container.getElementsByClassName('option-label');

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/labelUtils.test.tsx
@@ -16,19 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactElement } from 'react';
 import { render, screen } from '@superset-ui/core/spec';
 import '@testing-library/jest-dom';
-import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import {
   getColumnLabelText,
   getColumnTooltipNode,
   getMetricTooltipNode,
   getColumnTypeTooltipNode,
 } from '../../src/components/labelUtils';
-
-const renderWithTheme = (ui: ReactElement) =>
-  render(<ThemeProvider theme={supersetTheme}>{ui}</ThemeProvider>);
 
 test("should get column name when column doesn't have verbose_name", () => {
   expect(
@@ -78,7 +73,7 @@ test('should get null for column datatype tooltip when type is blank', () => {
 });
 
 test('should get column datatype rendered as tooltip when column has a type', () => {
-  renderWithTheme(
+  render(
     <>
       {getColumnTypeTooltipNode({
         id: 123,
@@ -96,7 +91,7 @@ test('should get column datatype rendered as tooltip when column has a type', ()
 
 test('should get column name, verbose name and description when it has a verbose name', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getColumnTooltipNode(
         {
@@ -120,7 +115,7 @@ test('should get column name, verbose name and description when it has a verbose
 
 test('should get column name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getColumnTooltipNode(
         {
@@ -141,7 +136,7 @@ test('should get column name as tooltip if it overflowed', () => {
 
 test('should get column name, verbose name and description as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getColumnTooltipNode(
         {
@@ -180,7 +175,7 @@ test('should get null as tooltip in metric', () => {
 
 test('should get metric name, verbose name and description as tooltip in metric', () => {
   const ref = { current: { scrollWidth: 100, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getMetricTooltipNode(
         {
@@ -203,7 +198,7 @@ test('should get metric name, verbose name and description as tooltip in metric'
 
 test('should get metric name as tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getMetricTooltipNode(
         {
@@ -224,7 +219,7 @@ test('should get metric name as tooltip if it overflowed', () => {
 
 test('should get metric name, verbose name and description in tooltip if it overflowed', () => {
   const ref = { current: { scrollWidth: 200, clientWidth: 100 } };
-  renderWithTheme(
+  render(
     <>
       {getMetricTooltipNode(
         {

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/ModalTrigger.test.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { render, screen, userEvent } from '@superset-ui/core/spec';
-import { supersetTheme } from '@superset-ui/core';
 import { ModalTrigger } from '.';
 
 const mockedProps = {
@@ -74,16 +73,4 @@ test('should render a modal after click', async () => {
   render(<ModalTrigger {...mockedProps} />);
   await userEvent.click(screen.getByRole('button'));
   expect(screen.getByRole('dialog')).toBeInTheDocument();
-});
-
-test('renders with theme', () => {
-  const btnProps = {
-    ...mockedProps,
-    isButton: true,
-  };
-  render(<ModalTrigger {...btnProps} />);
-  const button = screen.getByRole('button');
-  expect(button.firstChild).toHaveStyle(`
-    fontSize: ${supersetTheme.fontSizeSM};
-  `);
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/Popover/Popover.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Popover/Popover.test.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { render, screen, userEvent, waitFor } from '@superset-ui/core/spec';
-import { supersetTheme } from '../..';
 import { Icons, Popover } from '..';
 import { Button } from '../Button';
 
@@ -71,12 +70,4 @@ test('fires an event when visibility is changed', async () => {
   );
   await userEvent.hover(screen.getByRole('button'));
   await waitFor(() => expect(onOpenChange).toHaveBeenCalledTimes(1));
-});
-
-test('renders with theme', () => {
-  render(<Popover content="Content sample" title="Popover title" open />);
-  const title = screen.getByText('Popover title');
-  expect(title).toHaveStyle({
-    fontSize: supersetTheme.sizeUnit * 3.5,
-  });
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/Table/cell-renderers/NullCell/NullCell.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/cell-renderers/NullCell/NullCell.test.tsx
@@ -17,18 +17,10 @@
  * under the License.
  */
 import { render, screen } from '@superset-ui/core/spec';
-import { supersetTheme } from '../../../..';
 import { Constants } from '../../..';
 import NullCell from '.';
 
 test('renders null value', async () => {
   render(<NullCell />);
   expect(screen.getByText(Constants.NULL_DISPLAY)).toBeInTheDocument();
-});
-
-test('renders with gray font', async () => {
-  render(<NullCell />);
-  expect(screen.getByText(Constants.NULL_DISPLAY)).toHaveStyle(
-    `color: ${supersetTheme.colors.grayscale.light1}`,
-  );
 });

--- a/superset-frontend/packages/superset-ui-core/src/spec/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/spec/index.tsx
@@ -42,5 +42,6 @@ export {
   waitFor,
   cleanup,
   within,
+  act,
 } from '@testing-library/react';
 export { customRender as render, userEvent };

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/FallbackComponent.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/FallbackComponent.test.tsx
@@ -17,30 +17,23 @@
  * under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render } from '@superset-ui/core/spec';
 import '@testing-library/jest-dom';
 import { FallbackProps } from 'react-error-boundary';
-import { ThemeProvider, supersetTheme } from '../../../src/theme';
 
 import FallbackComponent from '../../../src/chart/components/FallbackComponent';
 
-const renderWithTheme = (
-  props: Partial<FallbackProps> & FallbackProps['error'],
-) =>
-  render(
-    <ThemeProvider theme={supersetTheme}>
-      <FallbackComponent {...props} />
-    </ThemeProvider>,
-  );
+const setup = (props: Partial<FallbackProps> & FallbackProps['error']) =>
+  render(<FallbackComponent {...props} />);
 
 const ERROR = new Error('CaffeineOverLoadException');
 
 test('renders error only', () => {
-  const { getByText } = renderWithTheme({ error: ERROR });
+  const { getByText } = setup({ error: ERROR });
   expect(getByText('Error: CaffeineOverLoadException')).toBeInTheDocument();
 });
 
 test('renders when nothing is given', () => {
-  const { getByText } = renderWithTheme({});
+  const { getByText } = setup({});
   expect(getByText('Unknown Error')).toBeInTheDocument();
 });

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/NoResultsComponent.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/NoResultsComponent.test.tsx
@@ -17,17 +17,12 @@
  * under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@superset-ui/core/spec';
 import '@testing-library/jest-dom';
-import { ThemeProvider, supersetTheme } from '../../../src/theme';
 import NoResultsComponent from '../../../src/chart/components/NoResultsComponent';
 
 const renderNoResultsComponent = () =>
-  render(
-    <ThemeProvider theme={supersetTheme}>
-      <NoResultsComponent height="400" width="300" />
-    </ThemeProvider>,
-  );
+  render(<NoResultsComponent height="400" width="300" />);
 
 test('renders the no results error', () => {
   renderNoResultsComponent();

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
@@ -18,18 +18,12 @@
  */
 
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
-import { ReactElement } from 'react';
+import { render, screen } from '@superset-ui/core/spec';
 import mockConsole, { RestoreConsole } from 'jest-mock-console';
 import { triggerResizeObserver } from 'resize-observer-polyfill';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import {
-  promiseTimeout,
-  SuperChart,
-  supersetTheme,
-  ThemeProvider,
-} from '@superset-ui/core';
+import { promiseTimeout, SuperChart } from '@superset-ui/core';
 import { WrapperProps } from '../../../src/chart/components/SuperChart';
 
 import {
@@ -50,13 +44,6 @@ function getDimensionText(container: HTMLElement) {
   const dimensionEl = container.querySelector('.dimension');
   return dimensionEl?.textContent || '';
 }
-
-const renderWithTheme = (component: ReactElement) =>
-  render(component, {
-    wrapper: ({ children }) => (
-      <ThemeProvider theme={supersetTheme}>{children}</ThemeProvider>
-    ),
-  });
 
 describe('SuperChart', () => {
   jest.setTimeout(5000);
@@ -108,7 +95,7 @@ describe('SuperChart', () => {
 
     it('renders default FallbackComponent', async () => {
       expectedErrors = 1;
-      renderWithTheme(
+      render(
         <SuperChart
           chartType={ChartKeys.BUGGY}
           queriesData={[DEFAULT_QUERY_DATA]}
@@ -128,7 +115,7 @@ describe('SuperChart', () => {
         <div>Custom Fallback!</div>
       ));
 
-      renderWithTheme(
+      render(
         <SuperChart
           chartType={ChartKeys.BUGGY}
           queriesData={[DEFAULT_QUERY_DATA]}
@@ -144,7 +131,7 @@ describe('SuperChart', () => {
     it('call onErrorBoundary', async () => {
       expectedErrors = 1;
       const handleError = jest.fn();
-      renderWithTheme(
+      render(
         <SuperChart
           chartType={ChartKeys.BUGGY}
           queriesData={[DEFAULT_QUERY_DATA]}
@@ -163,7 +150,7 @@ describe('SuperChart', () => {
       expectedErrors = 1;
       const inactiveErrorHandler = jest.fn();
       const activeErrorHandler = jest.fn();
-      renderWithTheme(
+      render(
         <ErrorBoundary
           fallbackRender={() => <div>Error!</div>}
           onError={activeErrorHandler}
@@ -195,7 +182,7 @@ describe('SuperChart', () => {
 
   // Update the props test to wait for component to render
   it('passes the props to renderer correctly', async () => {
-    const { container } = renderWithTheme(
+    const { container } = render(
       <SuperChart
         chartType={ChartKeys.DILIGENT}
         queriesData={[DEFAULT_QUERY_DATA]}
@@ -273,7 +260,7 @@ describe('SuperChart', () => {
 
   // Update the resize observer trigger to ensure it's called after component mount
   it.skip('works when width and height are percent', async () => {
-    const { container } = renderWithTheme(
+    const { container } = render(
       <SuperChart
         chartType={ChartKeys.DILIGENT}
         queriesData={[DEFAULT_QUERY_DATA]}
@@ -321,7 +308,7 @@ describe('SuperChart', () => {
   });
 
   it('passes the props with multiple queries to renderer correctly', async () => {
-    const { container } = renderWithTheme(
+    const { container } = render(
       <SuperChart
         chartType={ChartKeys.DILIGENT}
         queriesData={DEFAULT_QUERIES_DATA}
@@ -341,7 +328,7 @@ describe('SuperChart', () => {
 
   describe('supports NoResultsComponent', () => {
     it('renders NoResultsComponent when queriesData is missing', () => {
-      renderWithTheme(
+      render(
         <SuperChart chartType={ChartKeys.DILIGENT} width="200" height="200" />,
       );
 
@@ -349,7 +336,7 @@ describe('SuperChart', () => {
     });
 
     it('renders NoResultsComponent when queriesData data is null', () => {
-      renderWithTheme(
+      render(
         <SuperChart
           chartType={ChartKeys.DILIGENT}
           queriesData={[{ data: null }]}
@@ -376,7 +363,7 @@ describe('SuperChart', () => {
     }
 
     it('works with width and height that are numbers', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChart
           chartType={ChartKeys.DILIGENT}
           queriesData={[DEFAULT_QUERY_DATA]}
@@ -397,7 +384,7 @@ describe('SuperChart', () => {
       const wrapper = createSizedWrapper();
       document.body.appendChild(wrapper);
 
-      const { container } = renderWithTheme(
+      const { container } = render(
         <div style={{ width: '100%', height: '100%', position: 'absolute' }}>
           <SuperChart
             chartType={ChartKeys.DILIGENT}

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChartCore.test.tsx
@@ -18,10 +18,9 @@
  */
 
 import '@testing-library/jest-dom';
-import { ReactElement } from 'react';
 import mockConsole, { RestoreConsole } from 'jest-mock-console';
-import { ChartProps, supersetTheme, ThemeProvider } from '@superset-ui/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { ChartProps, supersetTheme } from '@superset-ui/core';
+import { render, screen, waitFor } from '@superset-ui/core/spec';
 import SuperChartCore from '../../../src/chart/components/SuperChartCore';
 import {
   ChartKeys,
@@ -29,9 +28,6 @@ import {
   LazyChartPlugin,
   SlowChartPlugin,
 } from './MockChartPlugins';
-
-const renderWithTheme = (component: ReactElement) =>
-  render(<ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>);
 
 describe('SuperChartCore', () => {
   const chartProps = new ChartProps();
@@ -66,7 +62,7 @@ describe('SuperChartCore', () => {
 
   describe('registered charts', () => {
     it('renders registered chart', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           chartProps={chartProps}
@@ -79,7 +75,7 @@ describe('SuperChartCore', () => {
     });
 
     it('renders registered chart with lazy loading', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.LAZY} />,
       );
 
@@ -90,7 +86,7 @@ describe('SuperChartCore', () => {
 
     it('does not render if chartType is not set', async () => {
       // @ts-ignore chartType is required
-      const { container } = renderWithTheme(<SuperChartCore />);
+      const { container } = render(<SuperChartCore />);
 
       await waitFor(() => {
         const testComponent = container.querySelector('.test-component');
@@ -99,7 +95,7 @@ describe('SuperChartCore', () => {
     });
 
     it('adds id to container if specified', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.DILIGENT} id="the-chart" />,
       );
 
@@ -111,7 +107,7 @@ describe('SuperChartCore', () => {
     });
 
     it('adds class to container if specified', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.DILIGENT} className="the-chart" />,
       );
 
@@ -123,7 +119,7 @@ describe('SuperChartCore', () => {
     });
 
     it('uses overrideTransformProps when specified', async () => {
-      renderWithTheme(
+      render(
         <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           overrideTransformProps={() => ({ message: 'hulk' })}
@@ -141,7 +137,7 @@ describe('SuperChartCore', () => {
         theme: supersetTheme,
       });
 
-      renderWithTheme(
+      render(
         <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           preTransformProps={() => chartPropsWithPayload}
@@ -155,7 +151,7 @@ describe('SuperChartCore', () => {
     });
 
     it('uses postTransformProps when specified', async () => {
-      renderWithTheme(
+      render(
         <SuperChartCore
           chartType={ChartKeys.DILIGENT}
           postTransformProps={() => ({ message: 'hulk' })}
@@ -168,7 +164,7 @@ describe('SuperChartCore', () => {
     });
 
     it('renders if chartProps is not specified', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.DILIGENT} />,
       );
 
@@ -178,7 +174,7 @@ describe('SuperChartCore', () => {
     });
 
     it('does not render anything while waiting for Chart code to load', () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.SLOW} />,
       );
 
@@ -187,7 +183,7 @@ describe('SuperChartCore', () => {
     });
 
     it('eventually renders after Chart is loaded', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.SLOW} />,
       );
 
@@ -202,7 +198,7 @@ describe('SuperChartCore', () => {
     });
 
     it('does not render if chartProps is null', async () => {
-      const { container } = renderWithTheme(
+      const { container } = render(
         <SuperChartCore chartType={ChartKeys.DILIGENT} chartProps={null} />,
       );
 
@@ -214,7 +210,7 @@ describe('SuperChartCore', () => {
 
   describe('unregistered charts', () => {
     it('renders error message', async () => {
-      renderWithTheme(
+      render(
         <SuperChartCore chartType="4d-pie-chart" chartProps={chartProps} />,
       );
 

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/OptionDescription.test.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/OptionDescription.test.jsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 import '@testing-library/jest-dom';
-import { screen, render, fireEvent, act } from '@testing-library/react';
-import { ThemeProvider, supersetTheme } from '@superset-ui/core';
+import { screen, render, fireEvent, act } from '@superset-ui/core/spec';
 import OptionDescription from '../src/OptionDescription';
 
 const defaultProps = {
@@ -39,11 +38,7 @@ afterEach(() => {
 describe('OptionDescription', () => {
   beforeEach(() => {
     const props = { option: { ...defaultProps.option } };
-    render(
-      <ThemeProvider theme={supersetTheme}>
-        <OptionDescription {...props} />
-      </ThemeProvider>,
-    );
+    render(<OptionDescription {...props} />);
   });
 
   it('renders an InfoTooltip', () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -18,7 +18,6 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@superset-ui/core/spec';
-import { ThemeProvider, supersetTheme } from '@superset-ui/core';
 import TableChart from '../src/TableChart';
 import transformProps from '../src/transformProps';
 import DateWithFormatter from '../src/utils/DateWithFormatter';
@@ -268,9 +267,7 @@ describe('plugin-chart-table', () => {
     describe('TableChart', () => {
       it('render basic data', () => {
         render(
-          <ThemeProvider theme={supersetTheme}>
-            <TableChart {...transformProps(testData.basic)} sticky={false} />,
-          </ThemeProvider>,
+          <TableChart {...transformProps(testData.basic)} sticky={false} />,
         );
 
         const firstDataRow = screen.getAllByRole('rowgroup')[1];
@@ -289,10 +286,10 @@ describe('plugin-chart-table', () => {
 
       it('render advanced data', () => {
         render(
-          <ThemeProvider theme={supersetTheme}>
+          <>
             <TableChart {...transformProps(testData.advanced)} sticky={false} />
             ,
-          </ThemeProvider>,
+          </>,
         );
         const secondColumnHeader = screen.getByText('Sum of Num');
         expect(secondColumnHeader).toBeInTheDocument();
@@ -413,9 +410,7 @@ describe('plugin-chart-table', () => {
 
       it('render empty data', () => {
         render(
-          <ThemeProvider theme={supersetTheme}>
-            <TableChart {...transformProps(testData.empty)} sticky={false} />,
-          </ThemeProvider>,
+          <TableChart {...transformProps(testData.empty)} sticky={false} />,
         );
         expect(screen.getByText('No records found')).toBeInTheDocument();
       });
@@ -498,11 +493,7 @@ describe('plugin-chart-table', () => {
       it('should display original label in grouped headers', () => {
         const props = transformProps(testData.comparison);
 
-        render(
-          <ThemeProvider theme={supersetTheme}>
-            <TableChart {...props} sticky={false} />
-          </ThemeProvider>,
-        );
+        render(<TableChart {...props} sticky={false} />);
         const groupHeaders = screen.getAllByRole('columnheader');
         expect(groupHeaders.length).toBeGreaterThan(0);
         const hasMetricHeaders = groupHeaders.some(

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -16,16 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC } from 'react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import fetchMock from 'fetch-mock';
-import { Provider } from 'react-redux';
-import {
-  supersetTheme,
-  ThemeProvider,
-  isFeatureEnabled,
-} from '@superset-ui/core';
+import { isFeatureEnabled } from '@superset-ui/core';
 import {
   render,
   screen,
@@ -71,12 +65,6 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
-const standardProvider: FC = ({ children }) => (
-  <ThemeProvider theme={supersetTheme}>
-    <Provider store={store}>{children}</Provider>
-  </ThemeProvider>
-);
-
 const unsavedQueryEditor = {
   id: defaultProps.queryEditorId,
   dbId: 9888,
@@ -86,22 +74,6 @@ const unsavedQueryEditor = {
   autorun: true,
   templateParams: '{ "my_value": "foo" }',
 };
-
-const standardProviderWithUnsaved: FC = ({ children }) => (
-  <ThemeProvider theme={supersetTheme}>
-    <Provider
-      store={mockStore({
-        ...initialState,
-        sqlLab: {
-          ...initialState.sqlLab,
-          unsavedQueryEditor,
-        },
-      })}
-    >
-      {children}
-    </Provider>
-  </ThemeProvider>
-);
 
 describe('ShareSqlLabQuery', () => {
   const storeQueryUrl = 'glob:*/api/v1/sqllab/permalink';
@@ -133,7 +105,8 @@ describe('ShareSqlLabQuery', () => {
     it('calls storeQuery() with the query when getCopyUrl() is called', async () => {
       await act(async () => {
         render(<ShareSqlLabQuery {...defaultProps} />, {
-          wrapper: standardProvider,
+          useRedux: true,
+          store,
         });
       });
       const button = screen.getByRole('button');
@@ -150,7 +123,14 @@ describe('ShareSqlLabQuery', () => {
     it('calls storeQuery() with unsaved changes', async () => {
       await act(async () => {
         render(<ShareSqlLabQuery {...defaultProps} />, {
-          wrapper: standardProviderWithUnsaved,
+          useRedux: true,
+          store: mockStore({
+            ...initialState,
+            sqlLab: {
+              ...initialState.sqlLab,
+              unsavedQueryEditor,
+            },
+          }),
         });
       });
       const button = screen.getByRole('button');

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -172,6 +172,7 @@ const SliceHeaderControls = (
   const [modalFilters, setFilters] = useState<BinaryQueryObjectFilterClause[]>(
     [],
   );
+  const theme = useTheme();
 
   const canEditCrossFilters =
     useSelector<RootState, boolean>(
@@ -250,7 +251,7 @@ const SliceHeaderControls = (
           getScreenshotNodeSelector(props.slice.slice_id),
           props.slice.slice_name,
           true,
-          // @ts-ignore
+          theme,
         )(domEvent).then(() => {
           if (menu) {
             menu.style.visibility = 'visible';
@@ -503,7 +504,6 @@ const SliceHeaderControls = (
       )}
     </Menu>
   );
-  const theme = useTheme();
   return (
     <>
       {isFullSize && (

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.stories.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.stories.tsx
@@ -18,7 +18,6 @@
  */
 
 import { StoryFn, Meta } from '@storybook/react';
-import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 import DatasetPanel from './DatasetPanel';
 import { exampleColumns } from './fixtures';
 
@@ -28,11 +27,9 @@ export default {
 } as Meta<typeof DatasetPanel>;
 
 export const Basic: StoryFn<typeof DatasetPanel> = args => (
-  <ThemeProvider theme={supersetTheme}>
-    <div style={{ height: '350px' }}>
-      <DatasetPanel {...args} />
-    </div>
-  </ThemeProvider>
+  <div style={{ height: '350px' }}>
+    <DatasetPanel {...args} />
+  </div>
 );
 
 Basic.args = {

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -20,7 +20,7 @@ import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
 import { kebabCase } from 'lodash';
 // eslint-disable-next-line no-restricted-imports
-import { t, supersetTheme } from '@superset-ui/core';
+import { SupersetTheme, t } from '@superset-ui/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
 
 /**
@@ -45,6 +45,7 @@ export default function downloadAsImage(
   selector: string,
   description: string,
   isExactSelector = false,
+  theme?: SupersetTheme,
 ) {
   return (event: SyntheticEvent) => {
     const elementToPrint = isExactSelector
@@ -71,7 +72,7 @@ export default function downloadAsImage(
 
     return domToImage
       .toJpeg(elementToPrint, {
-        bgcolor: supersetTheme.colors.grayscale.light4,
+        bgcolor: theme?.colors.grayscale.light4,
         filter,
       })
       .then((dataUrl: string) => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of the theming effort, wherever possible using the useTheme hook instead of directly importing supersetTheme is the preferred way for accesing theme object. This pr aims to clean up leftover uses.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the testing suite.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
