### PR TITLE
fix(BaseIcon): Ensure iconSize is parsed correctly when passed as string

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Icons/BaseIcon.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Icons/BaseIcon.tsx
@@ -50,7 +50,9 @@ export const BaseIconComponent: React.FC<
   const ariaLabel = genAriaLabel(rest.fileName || '');
   const style = {
     color: iconColor,
-    fontSize: iconSize ? themeObject.getFontSize(iconSize) : theme.fontSize,
+    fontSize: iconSize
+      ? `${themeObject.getFontSize(iconSize)}px`
+      : `${theme.fontSize}px`,
     cursor: rest?.onClick ? 'pointer' : undefined,
   };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->This PR fixes an issue in the BaseIcon component where the `iconSize` prop (e.g. `'xxl'`) was being passed as a string, resulting in the computed `fontSize` not being applied correctly.

Now, the value returned by `themeObject.getFontSize(iconSize)` is explicitly suffixed with `'px'`, ensuring that `fontSize` is correctly interpreted regardless of the input format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
