### PR TITLE
feat: Add confirmation modal for unsaved changes

### DIFF
--- a/superset-frontend/src/components/Modal/Modal.tsx
+++ b/superset-frontend/src/components/Modal/Modal.tsx
@@ -282,13 +282,16 @@ const CustomModal = ({
   const [bounds, setBounds] = useState<DraggableBounds>();
   const [dragDisabled, setDragDisabled] = useState<boolean>(true);
   let FooterComponent;
-  if (isValidElement(footer)) {
+
+  // This safely avoids injecting "closeModal" into native elements like <div> or <span>
+  if (isValidElement(footer) && typeof footer.type === 'function')
     // If a footer component is provided inject a closeModal function
     // so the footer can provide a "close" button if desired
     FooterComponent = cloneElement(footer, {
       closeModal: onHide,
     } as Partial<unknown>);
-  }
+  else FooterComponent = footer;
+
   const modalFooter = isNil(FooterComponent)
     ? [
         <Button key="back" onClick={onHide} cta data-test="modal-cancel-button">
@@ -357,7 +360,7 @@ const CustomModal = ({
       open={show}
       title={<ModalTitle />}
       closeIcon={
-        <span className="close" aria-hidden="true">
+        <span data-test="close-modal-btn" className="close" aria-hidden="true">
           ×
         </span>
       }

--- a/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.stories.tsx
+++ b/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.stories.tsx
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ReactElement } from 'react';
+import UnsavedChangesModal, { type UnsavedChangesModalProps } from '.';
+
+export default {
+  title: 'UnsavedChangesModal',
+  component: UnsavedChangesModal,
+};
+
+export const InteractiveUnsavedChangesModal = (
+  props: UnsavedChangesModalProps,
+): ReactElement => (
+  <UnsavedChangesModal {...props}>
+    If you don't save, changes will be lost.
+  </UnsavedChangesModal>
+);
+
+InteractiveUnsavedChangesModal.args = {
+  showModal: true,
+  onHide: () => {},
+  handleSave: () => {},
+  onConfirmNavigation: () => {},
+  title: 'Unsaved Changes',
+};
+
+InteractiveUnsavedChangesModal.argTypes = {
+  onHandledPrimaryAction: { action: 'onHandledPrimaryAction' },
+  onHide: { action: 'onHide' },
+};

--- a/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.test.tsx
+++ b/superset-frontend/src/components/UnsavedChangesModal/UnsavedChangesModal.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { fireEvent, render, waitFor } from 'spec/helpers/testing-library';
+import UnsavedChangesModal from '.';
+
+test('should render nothing if showModal is false', () => {
+  const { queryByTestId } = render(
+    <UnsavedChangesModal
+      showModal={false}
+      onHide={() => {}}
+      handleSave={() => {}}
+      onConfirmNavigation={() => {}}
+    />,
+  );
+
+  expect(queryByTestId('unsaved-changes-modal')).not.toBeInTheDocument();
+});
+
+test('should render the UnsavedChangesModal component if showModal is true', async () => {
+  const { findByTestId } = render(
+    <UnsavedChangesModal
+      showModal
+      onHide={() => {}}
+      handleSave={() => {}}
+      onConfirmNavigation={() => {}}
+    />,
+  );
+
+  expect(await findByTestId('unsaved-changes-modal')).toBeInTheDocument();
+});
+
+test('should only call onConfirmNavigation when click on the modal Discard button', async () => {
+  const mockOnHide = jest.fn();
+  const mockHandleSave = jest.fn();
+  const mockOnConfirmNavigation = jest.fn();
+
+  const { findByTestId } = render(
+    <UnsavedChangesModal
+      showModal
+      onHide={mockOnHide}
+      handleSave={mockHandleSave}
+      onConfirmNavigation={mockOnConfirmNavigation}
+    />,
+  );
+
+  await waitFor(async () => {
+    expect(mockOnHide).toHaveBeenCalledTimes(0);
+    expect(mockHandleSave).toHaveBeenCalledTimes(0);
+    expect(mockOnConfirmNavigation).toHaveBeenCalledTimes(0);
+
+    const cancelButton: HTMLElement = await findByTestId(
+      'unsaved-modal-discard-button',
+    );
+    fireEvent.click(cancelButton);
+
+    expect(mockOnHide).toHaveBeenCalledTimes(0);
+    expect(mockHandleSave).toHaveBeenCalledTimes(0);
+    expect(mockOnConfirmNavigation).toHaveBeenCalled();
+  });
+});
+
+test('should only call handleSave when click on the modal Save button', async () => {
+  const mockOnHide = jest.fn();
+  const mockHandleSave = jest.fn();
+  const mockOnConfirmNavigation = jest.fn();
+
+  const { findByTestId } = render(
+    <UnsavedChangesModal
+      showModal
+      onHide={mockOnHide}
+      handleSave={mockHandleSave}
+      onConfirmNavigation={mockOnConfirmNavigation}
+    />,
+  );
+
+  await waitFor(async () => {
+    expect(mockOnHide).toHaveBeenCalledTimes(0);
+    expect(mockHandleSave).toHaveBeenCalledTimes(0);
+    expect(mockOnConfirmNavigation).toHaveBeenCalledTimes(0);
+
+    const confirmationButton: HTMLElement = await findByTestId(
+      'unsaved-confirm-save-button',
+    );
+    fireEvent.click(confirmationButton);
+
+    expect(mockHandleSave).toHaveBeenCalled();
+    expect(mockOnHide).toHaveBeenCalledTimes(0);
+    expect(mockOnConfirmNavigation).toHaveBeenCalledTimes(0);
+  });
+});

--- a/superset-frontend/src/components/UnsavedChangesModal/index.tsx
+++ b/superset-frontend/src/components/UnsavedChangesModal/index.tsx
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import Modal from 'src/components/Modal';
+import Button from 'src/components/Button';
+import { t, styled, css } from '@superset-ui/core';
+import type { FC, ReactElement } from 'react';
+import { Icons } from 'src/components/Icons';
+
+const StyledModalTitle = styled.h1`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.dark1};
+    font-size: ${theme.typography.sizes.l}px;
+    font-weight: ${theme.typography.weights.bold};
+    margin: 0;
+  `}
+`;
+
+const StyledModalBody = styled.p`
+  ${({ theme }) => css`
+    color: ${theme.colors.grayscale.dark1};
+    font-size: ${theme.typography.sizes.m}px;
+    margin: 0;
+    padding: 0 ${theme.gridUnit * 2}px;
+  `}
+`;
+
+const StyledDiscardBtn = styled(Button)`
+  ${({ theme }) => css`
+    min-width: ${theme.gridUnit * 22}px;
+    height: ${theme.gridUnit * 8}px;
+  `}
+`;
+
+const StyledSaveBtn = styled(Button)`
+  ${({ theme }) => css`
+    min-width: ${theme.gridUnit * 17}px;
+    height: ${theme.gridUnit * 8}px;
+    span > :first-of-type {
+      margin-right: 0;
+    }
+  `}
+`;
+
+const StyledWarningIcon = styled(Icons.WarningOutlined)`
+  ${({ theme }) => css`
+    color: ${theme.colors.warning.base};
+    margin-right: ${theme.gridUnit * 2}px;
+  `}
+`;
+
+export type UnsavedChangesModalProps = {
+  showModal: boolean;
+  onHide: () => void;
+  handleSave: () => void;
+  onConfirmNavigation: () => void;
+  title?: string;
+  body?: string;
+};
+
+const UnsavedChangesModal: FC<UnsavedChangesModalProps> = ({
+  showModal,
+  onHide,
+  handleSave,
+  onConfirmNavigation,
+  title = 'Unsaved Changes',
+  body = "If you don't save, changes will be lost.",
+}: UnsavedChangesModalProps): ReactElement => (
+  <Modal
+    centered
+    responsive
+    onHide={onHide}
+    show={showModal}
+    width="444px"
+    wrapProps={{ 'data-test': 'unsaved-changes-modal' }}
+    title={
+      <div
+        css={css`
+          align-items: center;
+          display: flex;
+        `}
+      >
+        <StyledWarningIcon />
+        <StyledModalTitle>{t(title)}</StyledModalTitle>
+      </div>
+    }
+    footer={
+      <div
+        css={css`
+          display: flex;
+          justify-content: flex-end;
+          width: 100%;
+        `}
+      >
+        <StyledDiscardBtn
+          htmlType="button"
+          buttonSize="small"
+          onClick={onConfirmNavigation}
+          data-test="unsaved-modal-discard-button"
+        >
+          {t('Discard')}
+        </StyledDiscardBtn>
+        <StyledSaveBtn
+          data-test="unsaved-confirm-save-button"
+          htmlType="button"
+          buttonSize="small"
+          buttonStyle="primary"
+          onClick={handleSave}
+        >
+          {t('Save')}
+        </StyledSaveBtn>
+      </div>
+    }
+  >
+    <StyledModalBody>{t(body)}</StyledModalBody>
+  </Modal>
+);
+
+export default UnsavedChangesModal;

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -55,8 +55,10 @@ import setPeriodicRunner, {
 } from 'src/dashboard/util/setPeriodicRunner';
 import ReportModal from 'src/features/reports/ReportModal';
 import DeleteModal from 'src/components/DeleteModal';
+import UnsavedChangesModal from 'src/components/UnsavedChangesModal';
 import { deleteActiveReport } from 'src/features/reports/ReportModal/actions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
+import { useUnsavedChangesPrompt } from 'src/hooks/useUnsavedChangesPrompt';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
 import {
@@ -464,6 +466,16 @@ const Header = () => {
     slug,
   ]);
 
+  const {
+    showModal: showUnsavedChangesModal,
+    setShowModal: setShowUnsavedChangesModal,
+    handleConfirmNavigation,
+    handleSaveAndCloseModal,
+  } = useUnsavedChangesPrompt({
+    hasUnsavedChanges,
+    onSave: overwriteDashboard,
+  });
+
   const showPropertiesModal = useCallback(() => {
     setShowingPropertiesModal(true);
   }, []);
@@ -822,6 +834,15 @@ const Header = () => {
             border-right: none;
           }
         `}
+      />
+
+      <UnsavedChangesModal
+        title="Save changes to your dashboard?"
+        body="If you don't save, changes will be lost."
+        showModal={showUnsavedChangesModal}
+        onHide={() => setShowUnsavedChangesModal(false)}
+        onConfirmNavigation={handleConfirmNavigation}
+        handleSave={handleSaveAndCloseModal}
       />
     </div>
   );

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -30,6 +30,7 @@ import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import * as downloadAsImage from 'src/utils/downloadAsImage';
 import * as exploreUtils from 'src/explore/exploreUtils';
 import { FeatureFlag, VizType } from '@superset-ui/core';
+import { useUnsavedChangesPrompt } from 'src/hooks/useUnsavedChangesPrompt';
 import ExploreHeader from '.';
 
 const chartEndpoint = 'glob:*api/v1/chart/*';
@@ -39,6 +40,10 @@ fetchMock.get(chartEndpoint, { json: 'foo' });
 window.featureFlags = {
   [FeatureFlag.EmbeddableCharts]: true,
 };
+
+jest.mock('src/hooks/useUnsavedChangesPrompt', () => ({
+  useUnsavedChangesPrompt: jest.fn(),
+}));
 
 const createProps = (additionalProps = {}) => ({
   chart: {
@@ -134,6 +139,18 @@ fetchMock.post(
 describe('ExploreChartHeader', () => {
   jest.setTimeout(15000); // ✅ Applies to all tests in this suite
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: false,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave: jest.fn(),
+    });
+  });
+
   test('Cancelling changes to the properties should reset previous properties', async () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, { useRedux: true });
@@ -201,34 +218,175 @@ describe('ExploreChartHeader', () => {
   });
 
   test('Save chart', async () => {
-    const setSaveChartModalVisibility = jest.spyOn(
+    const setSaveChartModalVisibilitySpy = jest.spyOn(
       saveModalActions,
       'setSaveChartModalVisibility',
     );
+
+    const setSaveChartModalVisibilityMock =
+      setSaveChartModalVisibilitySpy as jest.Mock;
+
+    const triggerManualSave = jest.fn(() => {
+      setSaveChartModalVisibilityMock(true);
+    });
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: false,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave,
+    });
+
     const props = createProps();
     render(<ExploreHeader {...props} />, { useRedux: true });
-    expect(await screen.findByText('Save')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Save'));
-    expect(setSaveChartModalVisibility).toHaveBeenCalledWith(true);
-    setSaveChartModalVisibility.mockClear();
+
+    const saveButton: HTMLElement =
+      await screen.findByTestId('query-save-button');
+
+    expect(saveButton).toBeInTheDocument();
+
+    userEvent.click(saveButton);
+
+    expect(triggerManualSave).toHaveBeenCalled();
+    expect(setSaveChartModalVisibilityMock).toHaveBeenCalledWith(true);
+
+    setSaveChartModalVisibilityMock.mockClear();
   });
 
   test('Save disabled', async () => {
-    const setSaveChartModalVisibility = jest.spyOn(
-      saveModalActions,
-      'setSaveChartModalVisibility',
-    );
+    const triggerManualSave = jest.fn();
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: false,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave,
+    });
+
     const props = createProps();
     render(<ExploreHeader {...props} saveDisabled />, { useRedux: true });
-    expect(await screen.findByText('Save')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Save'));
-    expect(setSaveChartModalVisibility).not.toHaveBeenCalled();
-    setSaveChartModalVisibility.mockClear();
+
+    const saveButton: HTMLElement =
+      await screen.findByTestId('query-save-button');
+
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    userEvent.click(saveButton);
+
+    expect(triggerManualSave).not.toHaveBeenCalled();
+  });
+
+  test('should render UnsavedChangesModal when showModal is true', async () => {
+    const props = createProps();
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: true,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave: jest.fn(),
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Save changes to your chart?'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('If you don’t save, changes will be lost.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('should call handleSaveAndCloseModal when clicking Save in UnsavedChangesModal', async () => {
+    const handleSaveAndCloseModal = jest.fn();
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: true,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal,
+      triggerManualSave: jest.fn(),
+    });
+
+    const props = createProps();
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('unsaved-confirm-save-button'),
+      ).toBeInTheDocument(),
+    );
+
+    userEvent.click(screen.getByTestId('unsaved-confirm-save-button'));
+
+    expect(handleSaveAndCloseModal).toHaveBeenCalled();
+  });
+
+  test('should call handleConfirmNavigation when clicking Discard in UnsavedChangesModal', async () => {
+    const handleConfirmNavigation = jest.fn();
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: true,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation,
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave: jest.fn(),
+    });
+
+    const props = createProps();
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('unsaved-modal-discard-button'),
+      ).toBeInTheDocument(),
+    );
+
+    userEvent.click(screen.getByTestId('unsaved-modal-discard-button'));
+
+    expect(handleConfirmNavigation).toHaveBeenCalled();
+  });
+
+  test('should call setShowModal(false) when clicking close button in UnsavedChangesModal', async () => {
+    const setShowModal = jest.fn();
+
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: true,
+      setShowModal,
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave: jest.fn(),
+    });
+
+    const props = createProps();
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('close-modal-btn')).toBeInTheDocument(),
+    );
+
+    userEvent.click(screen.getByTestId('close-modal-btn'));
+
+    expect(setShowModal).toHaveBeenCalledWith(false);
   });
 });
 
 describe('Additional actions tests', () => {
   jest.setTimeout(15000); // ✅ Applies to all tests in this suite
+
+  beforeEach(() => {
+    (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+      showModal: false,
+      setShowModal: jest.fn(),
+      handleConfirmNavigation: jest.fn(),
+      handleSaveAndCloseModal: jest.fn(),
+      triggerManualSave: jest.fn(),
+    });
+  });
 
   test('Should render a button', async () => {
     const props = createProps();
@@ -356,6 +514,14 @@ describe('Additional actions tests', () => {
     beforeEach(() => {
       spyDownloadAsImage = sinon.spy(downloadAsImage, 'default');
       spyExportChart = sinon.spy(exploreUtils, 'exportChart');
+
+      (useUnsavedChangesPrompt as jest.Mock).mockReturnValue({
+        showModal: false,
+        setShowModal: jest.fn(),
+        handleConfirmNavigation: jest.fn(),
+        handleSaveAndCloseModal: jest.fn(),
+        triggerManualSave: jest.fn(),
+      });
     });
 
     afterEach(async () => {

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -586,6 +586,7 @@ function ExploreViewContainer(props) {
         reports={props.reports}
         saveDisabled={errorMessage || props.chart.chartStatus === 'loading'}
         metadata={props.metadata}
+        isSaveModalVisible={props.isSaveModalVisible}
       />
       <ExplorePanelContainer id="explore-container">
         <Global

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getClientErrorObject, t } from '@superset-ui/core';
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+type UseUnsavedChangesPromptProps = {
+  hasUnsavedChanges: boolean;
+  onSave: () => Promise<void> | void;
+  isSaveModalVisible?: boolean;
+  manualSaveOnUnsavedChanges?: boolean;
+};
+
+export const useUnsavedChangesPrompt = ({
+  hasUnsavedChanges,
+  onSave,
+  isSaveModalVisible = false,
+  manualSaveOnUnsavedChanges = false,
+}: UseUnsavedChangesPromptProps) => {
+  const history = useHistory();
+  const [showModal, setShowModal] = useState(false);
+
+  const confirmNavigationRef = useRef<(() => void) | null>(null);
+  const unblockRef = useRef<() => void>(() => {});
+  const manualSaveRef = useRef(false); // Track if save was user-initiated (not via navigation)
+
+  const handleConfirmNavigation = useCallback(() => {
+    confirmNavigationRef.current?.();
+  }, []);
+
+  const handleSaveAndCloseModal = useCallback(async () => {
+    try {
+      if (manualSaveOnUnsavedChanges) manualSaveRef.current = true;
+
+      await onSave();
+      setShowModal(false);
+    } catch (err) {
+      const clientError = await getClientErrorObject(err);
+      throw new Error(
+        clientError.message ||
+          clientError.error ||
+          t('Sorry, an error occurred'),
+        { cause: err },
+      );
+    }
+  }, [manualSaveOnUnsavedChanges, onSave]);
+
+  const triggerManualSave = useCallback(() => {
+    manualSaveRef.current = true;
+    onSave();
+  }, [onSave]);
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return undefined;
+
+    const unblock = history.block(({ pathname }: { pathname: string }) => {
+      if (manualSaveRef.current) {
+        manualSaveRef.current = false;
+        return undefined;
+      }
+
+      confirmNavigationRef.current = () => {
+        unblockRef.current?.();
+        history.push(pathname);
+      };
+
+      setShowModal(true);
+      return false;
+    });
+
+    unblockRef.current = unblock;
+    return () => unblock();
+  }, [hasUnsavedChanges, history]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedChanges) return;
+      event.preventDefault();
+
+      // Most browsers require a "returnValue" set to empty string
+      const evt = event as any;
+      evt.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  useEffect(() => {
+    if (!isSaveModalVisible && manualSaveRef.current) {
+      setShowModal(false);
+      manualSaveRef.current = false;
+    }
+  }, [isSaveModalVisible]);
+
+  return {
+    showModal,
+    setShowModal,
+    handleConfirmNavigation,
+    handleSaveAndCloseModal,
+    triggerManualSave,
+  };
+};

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useUnsavedChangesPrompt } from 'src/hooks/useUnsavedChangesPrompt';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { act } from 'spec/helpers/testing-library';
+
+const history = createMemoryHistory({
+  initialEntries: ['/dashboard'],
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Router history={history}>{children}</Router>
+);
+
+describe('useUnsavedChangesPrompt', () => {
+  it('should not show modal initially', () => {
+    const { result } = renderHook(
+      () =>
+        useUnsavedChangesPrompt({
+          hasUnsavedChanges: true,
+          onSave: jest.fn(),
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('should block navigation and show modal if there are unsaved changes', () => {
+    const { result } = renderHook(
+      () =>
+        useUnsavedChangesPrompt({
+          hasUnsavedChanges: true,
+          onSave: jest.fn(),
+        }),
+      { wrapper },
+    );
+
+    // Simulate blocked navigation
+    act(() => {
+      const unblock = history.block((tx: any) => tx);
+      unblock();
+      history.push('/another-page');
+    });
+
+    expect(result.current.showModal).toBe(true);
+  });
+
+  it('should trigger onSave and hide modal on handleSaveAndCloseModal', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(
+      () =>
+        useUnsavedChangesPrompt({
+          hasUnsavedChanges: true,
+          onSave,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleSaveAndCloseModal();
+    });
+
+    expect(onSave).toHaveBeenCalled();
+    expect(result.current.showModal).toBe(false);
+  });
+
+  it('should trigger manual save and not show modal again', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(
+      () =>
+        useUnsavedChangesPrompt({
+          hasUnsavedChanges: true,
+          onSave,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.triggerManualSave();
+    });
+
+    expect(onSave).toHaveBeenCalled();
+    expect(result.current.showModal).toBe(false);
+  });
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a confirmation modal to alert users about unsaved changes in both the Dashboard Editing and Explore section.

### AFTER
<!--- Skip this if not applicable -->
#### Unsaved Changes on Dashboard Editing
[unsaved_dashboard.webm](https://github.com/user-attachments/assets/03cad343-fa93-44da-9d53-d5ed1ce0ddf1)

#### Unsaved Changes on Explore Section
[unsaved_explore_section.webm](https://github.com/user-attachments/assets/bd7332f9-4b94-4f6c-bfee-dc52585bfc99)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Dashboard Creation/Editing:
- Navigate to an existing Dashboard or create a new one
- Make any change without saving (e.g., add a chart)
- Attempt to navigate away to a different section (e.g., Datasets)

✅ Expected behavior: A confirmation modal should appear prompting you to either Save or Discard your unsaved changes.

2. Explore Section:
- Go to the Explore section
- Without needing to make any change, try navigating away to another section (e.g., Datasets)

✅ Expected Behavior: A confirmation modal should appear asking you to `Save` or `Discard` your changes
- If `Save` is selected, the standard save flow should execute

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
