### PR TITLE
fix: SQL Lab warning message sizes

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -476,9 +476,8 @@ const ResultSet = ({
             <div ref={calculateAlertRefHeight}>
               <Alert
                 type="warning"
-                message={t('%(rows)d rows returned', { rows })}
                 onClose={() => setAlertIsOpen(false)}
-                description={t(
+                message={t(
                   'The number of rows displayed is limited to %(rows)d by the dropdown.',
                   { rows },
                 )}
@@ -490,8 +489,7 @@ const ResultSet = ({
               <Alert
                 type="warning"
                 onClose={() => setAlertIsOpen(false)}
-                message={t('%(rows)d rows returned', { rows: rowsCount })}
-                description={
+                message={
                   isAdmin
                     ? displayMaxRowsReachedMessage.withAdmin
                     : displayMaxRowsReachedMessage.withoutAdmin


### PR DESCRIPTION
### SUMMARY
Warning messages were really big in SQL Lab, completely overshadowing the results. This PR adjusts the messages to look more similar to previous versions of Superset.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1911" alt="Screenshot 2025-06-18 at 11 35 53" src="https://github.com/user-attachments/assets/5fd71f96-0e17-46fc-9138-4967e401e457" />
<img width="1912" alt="Screenshot 2025-06-18 at 11 45 35" src="https://github.com/user-attachments/assets/07f6c343-a49f-4819-a0c4-f0e2ee36ff83" />
<img width="1915" alt="Screenshot 2025-06-18 at 11 36 18" src="https://github.com/user-attachments/assets/6a972440-2a1d-471b-9e49-84297059fa6f" />
<img width="1909" alt="Screenshot 2025-06-18 at 11 46 39" src="https://github.com/user-attachments/assets/1960a277-8e78-4fbc-aca0-599b1f86fe8d" />

### TESTING INSTRUCTIONS
Check the new size of warning messages.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
