### PR TITLE
fix: Set time filter's isExtra to false when saving as new chart

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -689,4 +689,40 @@ describe('getSlicePayload', () => {
 
     expect(hasTemporalRange).toBe(true);
   });
+
+  test('should reset isExtra flag to false for temporal filter when saving as a new chart', () => {
+    const formDataWithTemporalFilterWithExtra: QueryFormData = {
+      ...formDataWithNativeFilters,
+      adhoc_filters: [
+        {
+          clause: 'WHERE',
+          subject: 'year',
+          operator: 'TEMPORAL_RANGE',
+          comparator: '2004 : ',
+          expressionType: 'SIMPLE',
+          isExtra: true,
+        },
+      ],
+    };
+
+    const result = getSlicePayload(
+      sliceName,
+      formDataWithTemporalFilterWithExtra,
+      dashboards,
+      owners as [],
+      {} as QueryFormData,
+    );
+
+    const savedFilters = JSON.parse(result.params as string).adhoc_filters;
+
+    expect(savedFilters).toHaveLength(1);
+    expect(savedFilters[0]).toMatchObject({
+      clause: 'WHERE',
+      subject: 'year',
+      operator: 'TEMPORAL_RANGE',
+      comparator: 'No filter',
+      expressionType: 'SIMPLE',
+      isExtra: false,
+    });
+  });
 });

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -132,6 +132,7 @@ export const getSlicePayload = (
             adhocFilters[filtersKey].push({
               ...filter,
               comparator: 'No filter',
+              isExtra: false,
             });
           }
         },


### PR DESCRIPTION
### SUMMARY
When accessing a chart from a dashboard, filters are carried over. If a temporal filter was carried over, saving the chart as a new item would correctly reset the filter to `No filter`, however it would preserve `isExtra=true`, so it can't be overwritten.

This PR fixes this flow.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

https://github.com/user-attachments/assets/3883a69e-6118-4d3b-b1a4-1adf593fd9ca

**After**

https://github.com/user-attachments/assets/738c3b0a-08e7-45b3-ba76-2ba26ebbec10


### TESTING INSTRUCTIONS
Frontend test added. For manual testing:

1. Create a chart.
2. Save it to a dashboard that has a time range filter.
3. Apply a time range filter value to the dashboard, and access the chart.
4. Use the Save as option to duplicate the chart.
5. Validate the new chart does not have any extra filters.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
