### PR TITLE
fix: Consider last data point for Big Number comparison lag

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
@@ -194,4 +194,38 @@ describe('BigNumberWithTrendline transformProps', () => {
     );
     expect(result.headerFormatter.format(500)).toBe('$500');
   });
+
+  it('should use last data point for comparison when big number comes from aggregated data', () => {
+    const chartProps = {
+      width: 500,
+      height: 400,
+      queriesData: [
+        {
+          data: [
+            { __timestamp: 3, value: 150 },
+            { __timestamp: 2, value: 100 },
+            { __timestamp: 1, value: 110 },
+          ] as unknown as BigNumberDatum[],
+          colnames: ['__timestamp', 'value'],
+          coltypes: ['TEMPORAL', 'NUMERIC'],
+        },
+        {
+          data: [{ value: 360 }],
+          colnames: ['value'],
+          coltypes: ['NUMERIC'],
+        },
+      ],
+      formData: { ...baseFormData, aggregation: 'SUM' },
+      rawFormData: baseRawFormData,
+      hooks: baseHooks,
+      datasource: baseDatasource,
+      theme: { colors: { grayscale: { light5: '#eee' } } },
+    };
+
+    const result = transformProps(
+      chartProps as unknown as BigNumberWithTrendlineChartProps,
+    );
+    expect(result.bigNumber).toBe(360);
+    expect(result.subheader).toBe('50.0% WoW');
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -157,11 +157,13 @@ export default function transformProps(
   if (compareLag > 0 && sortedData.length > 0) {
     const compareIndex = compareLag;
     if (compareIndex < sortedData.length) {
-      const compareValue = sortedData[compareIndex][1];
+      const compareFromValue = sortedData[compareIndex][1];
+      const compareToValue = sortedData[0][1];
       // compare values must both be non-nulls
-      if (bigNumber !== null && compareValue !== null) {
-        percentChange = compareValue
-          ? (Number(bigNumber) - compareValue) / Math.abs(compareValue)
+      if (compareToValue !== null && compareFromValue !== null) {
+        percentChange = compareFromValue
+          ? (Number(compareToValue) - compareFromValue) /
+            Math.abs(compareFromValue)
           : 0;
         formattedSubheader = `${formatPercentChange(
           percentChange,


### PR DESCRIPTION
### SUMMARY
https://github.com/apache/superset/pull/32767 introduced the ability to select an aggregation for the big number displayed in a Big Number with Trendline chart. 

The comparison lag feature was relying on the big number, so when the chart is set to aggregate the calculation was comparing the aggregated value with the specified period lag. 

This PR fixes the logic so that the comparison always use the last data point.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

<img width="1499" alt="image" src="https://github.com/user-attachments/assets/e50edcae-e6f2-47c4-b0a8-a885fdbbc941" />

**After**

<img width="1503" alt="image" src="https://github.com/user-attachments/assets/29fffb15-b6be-4980-aa6b-56f9a6b0b374" />

### TESTING INSTRUCTIONS
Frontend test added. For manual testing.
1. Create a big number with trendline with an aggregation.
2. Implement a comparison lag and validate the number.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
