### PR TITLE
SONK-3386: Custom thales adaptation

### DIFF
--- a/.github/workflows/ecs-task-definition.json
+++ b/.github/workflows/ecs-task-definition.json
@@ -7,8 +7,8 @@
             "links": [],
             "portMappings": [
                 {
-                    "containerPort": 8080,
-                    "hostPort": 8080,
+                    "containerPort": 8082,
+                    "hostPort": 8082,
                     "protocol": "tcp"
                 }
             ],
@@ -22,7 +22,7 @@
                 },
                 {
                     "name": "SUPERSET_PORT",
-                    "value": "8080"
+                    "value": "8082"
                 },
                 {
                     "name": "SUPERSET_SECRET_KEY",

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -316,7 +316,7 @@ jobs:
               issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `@${{ github.actor }} Ephemeral environment spinning up at http://${{ steps.get-ip.outputs.ip }}:8080. Credentials are 'admin'/'admin'. Please allow several minutes for bootstrapping and startup.`
+              body: `@${{ github.actor }} Ephemeral environment spinning up at http://${{ steps.get-ip.outputs.ip }}:8082. Credentials are 'admin'/'admin'. Please allow several minutes for bootstrapping and startup.`
             });
       - name: Comment (failure)
         if: ${{ failure() }}

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -41,7 +41,7 @@ jobs:
         ports:
           # Use custom ports for services to avoid accidentally connecting to
           # GitHub action runner's default installations
-          - 15433:8080
+          - 15433:8082
       redis:
         image: redis:7-alpine
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ x-superset-volumes: &superset-volumes
   - ./superset-frontend:/app/superset-frontend
   - superset_home:/app/superset_home
   - ./tests:/app/tests
+  - ../thales-sqlalchemy-drill:/app/sqlalchemy-drill
 x-common-build: &common-build
   context: .
   target: ${SUPERSET_BUILD_TARGET:-dev} # can use `dev` (default) or `lean`
@@ -109,7 +110,7 @@ services:
     container_name: superset_websocket
     build: ./superset-websocket
     ports:
-      - 8080:8080
+      - 8082:8082
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -133,7 +134,7 @@ services:
       # do not use this docker compose in production
       - ./docker/superset-websocket/config.json:/home/superset-websocket/config.json
     environment:
-      - PORT=8080
+      - PORT=8082
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_SSL=false

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -59,6 +59,11 @@ else
   echo "Skipping local overrides"
 fi
 
+if [ -d /app/sqlalchemy-drill ]; then
+  echo "Installing local sqlalchemy-drill in editable mode"
+  pip install -e /app/sqlalchemy-drill
+fi
+
 case "${1}" in
   worker)
     echo "Starting Celery worker..."

--- a/docker/nginx/templates/superset.conf.template
+++ b/docker/nginx/templates/superset.conf.template
@@ -21,7 +21,7 @@ upstream superset_app {
 }
 
 upstream superset_websocket {
-    server host.docker.internal:8080;
+    server host.docker.internal:8082;
     keepalive 100;
 }
 

--- a/docker/pythonpath_dev/superset_config.py
+++ b/docker/pythonpath_dev/superset_config.py
@@ -27,6 +27,8 @@ import sys
 from celery.schedules import crontab
 from flask_caching.backends.filesystemcache import FileSystemCache
 
+LOG_LEVEL = logging.DEBUG
+
 logger = logging.getLogger()
 
 DATABASE_DIALECT = os.getenv("DATABASE_DIALECT")

--- a/docker/superset-websocket/config.json
+++ b/docker/superset-websocket/config.json
@@ -1,5 +1,5 @@
 {
-  "port": 8080,
+  "port": 8082,
   "logLevel": "info",
   "logToFile": false,
   "logFilename": "app.log",

--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -197,7 +197,7 @@ Please refer to `ExecutorType` in the codebase for other executor types.
 - It is recommended to run separate workers for the `sql_lab` and `email_reports` tasks. This can be
   done using the `queue` field in `task_annotations`.
 - Adjust `WEBDRIVER_BASEURL` in your configuration file if celery workers can’t access Superset via
-  its default value of `http://0.0.0.0:8080/`.
+  its default value of `http://0.0.0.0:8082/`.
 
 It's also possible to specify a minimum interval between each report's execution through the config file:
 

--- a/docs/docs/configuration/databases.mdx
+++ b/docs/docs/configuration/databases.mdx
@@ -1140,7 +1140,7 @@ presto://{username}:{password}@{hostname}:{port}/{database}
 Here is an example connection string with values:
 
 ```
-presto://datascientist:securepassword@presto.example.com:8080/hive
+presto://datascientist:securepassword@presto.example.com:8082/hive
 ```
 
 By default Superset assumes the most recent version of Presto is being used when querying the
@@ -1431,7 +1431,7 @@ trino://{username}:{password}@{hostname}:{port}/{catalog}
 If you are running Trino with docker on local machine, please use the following connection URL
 
 ```
-trino://trino@host.docker.internal:8080
+trino://trino@host.docker.internal:8082
 ```
 
 ##### Authentications

--- a/docs/docs/configuration/timezones.mdx
+++ b/docs/docs/configuration/timezones.mdx
@@ -35,7 +35,7 @@ pd.read_sql_query(
 
 pd.read_sql_query(
     sql="SELECT TIMESTAMP '2022-01-01 00:00:00' AS ts",
-    con=create_engine("presto://localhost:8080"),
+    con=create_engine("presto://localhost:8082"),
 ).to_json()
 ```
 

--- a/helm/superset/README.md
+++ b/helm/superset/README.md
@@ -290,7 +290,7 @@ On helm this can be set on `extraSecretEnv.SUPERSET_SECRET_KEY` or `configOverri
 | supersetWebsockets.service.annotations | object | `{}` |  |
 | supersetWebsockets.service.loadBalancerIP | string | `nil` |  |
 | supersetWebsockets.service.nodePort.http | int | `"nil"` |  |
-| supersetWebsockets.service.port | int | `8080` |  |
+| supersetWebsockets.service.port | int | `8082` |  |
 | supersetWebsockets.service.type | string | `"ClusterIP"` |  |
 | supersetWebsockets.startupProbe.failureThreshold | int | `60` |  |
 | supersetWebsockets.startupProbe.httpGet.path | string | `"/health"` |  |

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -634,7 +634,7 @@ supersetWebsockets:
   # @default -- see `values.yaml`
   config:
     {
-      "port": 8080,
+      "port": 8082,
       "logLevel": "debug",
       "logToFile": false,
       "logFilename": "app.log",
@@ -655,7 +655,7 @@ supersetWebsockets:
     type: ClusterIP
     annotations: {}
     loadBalancerIP: ~
-    port: 8080
+    port: 8082
     nodePort:
       # -- (int)
       http: nil

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -168,7 +168,7 @@ describe('asyncEvent middleware', () => {
     const config = {
       GLOBAL_ASYNC_QUERIES_TRANSPORT: 'ws',
       GLOBAL_ASYNC_QUERIES_POLLING_DELAY: 50,
-      GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL: 'ws://127.0.0.1:8080/',
+      GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL: 'ws://127.0.0.1:8082/',
     };
 
     beforeEach(async () => {

--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -1,5 +1,5 @@
 {
-  "port": 8080,
+  "port": 8082,
   "logLevel": "info",
   "logToFile": false,
   "logFilename": "app.log",

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -54,7 +54,7 @@ type ConfigType = {
 
 function defaultConfig(): ConfigType {
   return {
-    port: 8080,
+    port: 8082,
     logLevel: 'info',
     logToFile: false,
     logFilename: 'app.log',

--- a/superset-websocket/utils/client-ws-app/public/javascripts/app.js
+++ b/superset-websocket/utils/client-ws-app/public/javascripts/app.js
@@ -36,7 +36,7 @@ function connect() {
   Cookies.set(cookieName, tokens[socketCount], { path: '' });
 
   // Create WebSocket connection.
-  let url = `ws://127.0.0.1:8080?last_id=${ts()}`;
+  let url = `ws://127.0.0.1:8082?last_id=${ts()}`;
   const socket = new WebSocket(url);
 
   // Connection opened

--- a/superset/config.py
+++ b/superset/config.py
@@ -326,7 +326,7 @@ LOGO_TOOLTIP = ""
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
 
 # Enables SWAGGER UI for superset openapi spec
-# ex: http://localhost:8080/swagger/v1
+# ex: http://localhost:8082/swagger/v1
 FAB_API_SWAGGER_UI = True
 
 # ----------------------------------------------------
@@ -575,7 +575,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
 #                             |
 # -------------+              |    +----------+
 #     LOCAL    |              |    |  REMOTE  | :22 SSH
-#     CLIENT   | <== SSH ========> |  SERVER  | :8080 web service
+#     CLIENT   | <== SSH ========> |  SERVER  | :8082 web service
 # -------------+              |    +----------+
 #                             |
 #                          FIREWALL (only port 22 is open)
@@ -1538,7 +1538,7 @@ WEBDRIVER_CONFIGURATION = {
 WEBDRIVER_OPTION_ARGS = ["--headless"]
 
 # The base URL to query for accessing the user interface
-WEBDRIVER_BASEURL = "http://0.0.0.0:8080/"
+WEBDRIVER_BASEURL = "http://0.0.0.0:8082/"
 # The base URL for the email report hyperlinks.
 WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 # Time selenium will wait for the page to load and render for the email report.
@@ -1777,7 +1777,7 @@ GLOBAL_ASYNC_QUERIES_TRANSPORT: Literal["polling", "ws"] = "polling"
 GLOBAL_ASYNC_QUERIES_POLLING_DELAY = int(
     timedelta(milliseconds=500).total_seconds() * 1000
 )
-GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL = "ws://127.0.0.1:8080/"
+GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL = "ws://127.0.0.1:8082/"
 
 # Global async queries cache backend configuration options:
 # - Set 'CACHE_TYPE' to 'RedisCache' for RedisCacheBackend.

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -359,7 +359,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
 
         For Presto the SQLAlchemy URI looks like this:
 
-            presto://localhost:8080/hive[/default]
+            presto://localhost:8082/hive[/default]
 
         """
         database = sqlalchemy_uri.database.strip("/")

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -451,7 +451,7 @@ class SupersetTestCase(TestCase):
         database = self.get_or_create(
             cls=models.Database,
             criteria={"database_name": database_name},
-            sqlalchemy_uri="db_for_macros_testing://user@host:8080/hive",
+            sqlalchemy_uri="db_for_macros_testing://user@host:8082/hive",
             id=db_id,
         )
 

--- a/tests/integration_tests/databases/api_tests.py
+++ b/tests/integration_tests/databases/api_tests.py
@@ -332,7 +332,7 @@ class TestDatabaseApi(SupersetTestCase):
             return
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -383,7 +383,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -436,7 +436,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -485,7 +485,7 @@ class TestDatabaseApi(SupersetTestCase):
             return
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -553,7 +553,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -617,7 +617,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -686,7 +686,7 @@ class TestDatabaseApi(SupersetTestCase):
 
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -771,13 +771,13 @@ class TestDatabaseApi(SupersetTestCase):
             return
         initial_ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
         updated_ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "Test",
             "password": "new_bar",
         }
@@ -816,7 +816,7 @@ class TestDatabaseApi(SupersetTestCase):
         assert response_update.get("result")["ssh_tunnel"]["password"] == "XXXXXXXXXX"  # noqa: S105
         assert model_ssh_tunnel.username == "Test"
         assert model_ssh_tunnel.server_address == "123.132.123.1"
-        assert model_ssh_tunnel.server_port == 8080
+        assert model_ssh_tunnel.server_port == 8082
         # Cleanup
         model = db.session.query(Database).get(response.get("id"))
         db.session.delete(model)
@@ -845,7 +845,7 @@ class TestDatabaseApi(SupersetTestCase):
             return
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -947,7 +947,7 @@ class TestDatabaseApi(SupersetTestCase):
             return
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }
@@ -958,7 +958,7 @@ class TestDatabaseApi(SupersetTestCase):
         }
         response_ssh_tunnel = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "XXXXXXXXXX",
         }
@@ -996,7 +996,7 @@ class TestDatabaseApi(SupersetTestCase):
             return
         ssh_tunnel_properties = {
             "server_address": "123.132.123.1",
-            "server_port": 8080,
+            "server_port": 8082,
             "username": "foo",
             "password": "bar",
         }

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -58,7 +58,7 @@ class TestDatabaseModel(SupersetTestCase):
         SupersetTestCase.is_module_installed("pyhive"), "pyhive not installed"
     )
     def test_database_schema_presto(self):
-        sqlalchemy_uri = "presto://presto.airbnb.io:8080/hive/default"
+        sqlalchemy_uri = "presto://presto.airbnb.io:8082/hive/default"
         model = Database(database_name="test_database", sqlalchemy_uri=sqlalchemy_uri)
 
         with model.get_sqla_engine() as engine:
@@ -69,7 +69,7 @@ class TestDatabaseModel(SupersetTestCase):
             db = make_url(engine.url).database
             assert "hive/core_db" == db
 
-        sqlalchemy_uri = "presto://presto.airbnb.io:8080/hive"
+        sqlalchemy_uri = "presto://presto.airbnb.io:8082/hive"
         model = Database(database_name="test_database", sqlalchemy_uri=sqlalchemy_uri)
 
         with model.get_sqla_engine() as engine:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -692,7 +692,7 @@ def test_email_chart_report_schedule_with_cc_bcc(
 
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_report_email_chart_with_cc_and_bcc.chart.id}"
             '%7D&force=false">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -749,7 +749,7 @@ def test_email_chart_report_schedule(
         )
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_report_email_chart.chart.id}"
             '%7D&force=false">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -806,7 +806,7 @@ def test_email_chart_report_schedule_alpha_owner(
 
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_report_email_chart_alpha_owner.chart.id}"
             '%7D&force=false">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -853,7 +853,7 @@ def test_email_chart_report_schedule_force_screenshot(
         )
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_report_email_chart_force_screenshot.chart.id}"
             '%7D&force=true">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -890,7 +890,7 @@ def test_email_chart_alert_schedule(
         notification_targets = get_target_from_report_schedule(create_alert_email_chart)
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_alert_email_chart.chart.id}"
             '%7D&force=true">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -963,7 +963,7 @@ def test_email_chart_report_schedule_with_csv(
         )
         # assert that the link sent is correct
         assert (
-            '<a href="http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+'
+            '<a href="http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+'
             f"{create_report_email_chart_with_csv.chart.id}%7D&"
             'force=false">Explore in Superset</a>' in email_mock.call_args[0][2]
         )
@@ -1673,7 +1673,7 @@ def test_slack_chart_report_schedule_with_text(
             ]
         )
         assert (
-            f"<http://0.0.0.0:8080/explore/?form_data=%7B%22slice_id%22:+{create_report_slack_chart_with_text.chart.id}%7D&force=false|Explore in Superset>"  # noqa: E501
+            f"<http://0.0.0.0:8082/explore/?form_data=%7B%22slice_id%22:+{create_report_slack_chart_with_text.chart.id}%7D&force=false|Explore in Superset>"  # noqa: E501
             in slack_client_mock_class.return_value.chat_postMessage.call_args[1][
                 "text"
             ]
@@ -1877,7 +1877,7 @@ def test_email_dashboard_report_fails_uncaught_exception(
 
     assert_log(ReportState.ERROR, error_message="Uncaught exception")
     assert (
-        '<a href="http://0.0.0.0:8080/superset/dashboard/'
+        '<a href="http://0.0.0.0:8082/superset/dashboard/'
         f"{create_report_email_dashboard.dashboard.uuid}/"
         '?force=false">Call to action</a>' in email_mock.call_args[0][2]
     )

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -243,15 +243,15 @@ def test_log_data_with_missing_values(mocker: MockerFixture) -> None:
             ["mock_tab_anchor_1", "mock_tab_anchor_2"],
             ["url1", "url2"],
             [
-                "http://0.0.0.0:8080/superset/dashboard/p/url1/",
-                "http://0.0.0.0:8080/superset/dashboard/p/url2/",
+                "http://0.0.0.0:8082/superset/dashboard/p/url1/",
+                "http://0.0.0.0:8082/superset/dashboard/p/url2/",
             ],
         ),
         # Test user select one tab to export in a dashboard report
         (
             "mock_tab_anchor_1",
             ["url1"],
-            ["http://0.0.0.0:8080/superset/dashboard/p/url1/"],
+            ["http://0.0.0.0:8082/superset/dashboard/p/url1/"],
         ),
     ],
 )
@@ -323,7 +323,7 @@ def test_get_dashboard_urls_with_exporting_dashboard_only(
 
     result: list[str] = class_instance.get_dashboard_urls()
 
-    assert "http://0.0.0.0:8080/superset/dashboard/p/url1/" == result[0]
+    assert "http://0.0.0.0:8082/superset/dashboard/p/url1/" == result[0]
 
 
 @patch(
@@ -344,8 +344,8 @@ def test_get_tab_urls(
     tab_anchors = ["1", "2"]
     result: list[str] = class_instance._get_tabs_urls(tab_anchors)
     assert result == [
-        "http://0.0.0.0:8080/superset/dashboard/p/uri1/",
-        "http://0.0.0.0:8080/superset/dashboard/p/uri2/",
+        "http://0.0.0.0:8082/superset/dashboard/p/uri1/",
+        "http://0.0.0.0:8082/superset/dashboard/p/uri2/",
     ]
 
 
@@ -371,7 +371,7 @@ def test_get_tab_url(
         urlParams=None,
     )
     result: str = class_instance._get_tab_url(dashboard_state)
-    assert result == "http://0.0.0.0:8080/superset/dashboard/p/uri/"
+    assert result == "http://0.0.0.0:8082/superset/dashboard/p/uri/"
 
 
 def create_report_schedule(

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -98,7 +98,7 @@ def test_get_schema_from_engine_params() -> None:
 
     assert (
         PrestoEngineSpec.get_schema_from_engine_params(
-            make_url("presto://localhost:8080/hive/default"),
+            make_url("presto://localhost:8082/hive/default"),
             {},
         )
         == "default"
@@ -106,7 +106,7 @@ def test_get_schema_from_engine_params() -> None:
 
     assert (
         PrestoEngineSpec.get_schema_from_engine_params(
-            make_url("presto://localhost:8080/hive"),
+            make_url("presto://localhost:8082/hive"),
             {},
         )
         is None
@@ -162,24 +162,24 @@ def test_adjust_engine_params_fully_qualified() -> None:
     """
     from superset.db_engine_specs.presto import PrestoEngineSpec
 
-    url = make_url("presto://localhost:8080/hive/default")
+    url = make_url("presto://localhost:8082/hive/default")
 
     uri = PrestoEngineSpec.adjust_engine_params(url, {})[0]
-    assert str(uri) == "presto://localhost:8080/hive/default"
+    assert str(uri) == "presto://localhost:8082/hive/default"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
         {},
         schema="new_schema",
     )[0]
-    assert str(uri) == "presto://localhost:8080/hive/new_schema"
+    assert str(uri) == "presto://localhost:8082/hive/new_schema"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
         {},
         catalog="new_catalog",
     )[0]
-    assert str(uri) == "presto://localhost:8080/new_catalog/default"
+    assert str(uri) == "presto://localhost:8082/new_catalog/default"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
@@ -187,7 +187,7 @@ def test_adjust_engine_params_fully_qualified() -> None:
         catalog="new_catalog",
         schema="new_schema",
     )[0]
-    assert str(uri) == "presto://localhost:8080/new_catalog/new_schema"
+    assert str(uri) == "presto://localhost:8082/new_catalog/new_schema"
 
 
 def test_adjust_engine_params_catalog_only() -> None:
@@ -196,24 +196,24 @@ def test_adjust_engine_params_catalog_only() -> None:
     """
     from superset.db_engine_specs.presto import PrestoEngineSpec
 
-    url = make_url("presto://localhost:8080/hive")
+    url = make_url("presto://localhost:8082/hive")
 
     uri = PrestoEngineSpec.adjust_engine_params(url, {})[0]
-    assert str(uri) == "presto://localhost:8080/hive"
+    assert str(uri) == "presto://localhost:8082/hive"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
         {},
         schema="new_schema",
     )[0]
-    assert str(uri) == "presto://localhost:8080/hive/new_schema"
+    assert str(uri) == "presto://localhost:8082/hive/new_schema"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
         {},
         catalog="new_catalog",
     )[0]
-    assert str(uri) == "presto://localhost:8080/new_catalog"
+    assert str(uri) == "presto://localhost:8082/new_catalog"
 
     uri = PrestoEngineSpec.adjust_engine_params(
         url,
@@ -221,7 +221,7 @@ def test_adjust_engine_params_catalog_only() -> None:
         catalog="new_catalog",
         schema="new_schema",
     )[0]
-    assert str(uri) == "presto://localhost:8080/new_catalog/new_schema"
+    assert str(uri) == "presto://localhost:8082/new_catalog/new_schema"
 
 
 def test_get_default_catalog() -> None:
@@ -233,13 +233,13 @@ def test_get_default_catalog() -> None:
 
     database = Database(
         database_name="my_db",
-        sqlalchemy_uri="presto://localhost:8080/hive",
+        sqlalchemy_uri="presto://localhost:8082/hive",
     )
     assert PrestoEngineSpec.get_default_catalog(database) == "hive"
 
     database = Database(
         database_name="my_db",
-        sqlalchemy_uri="presto://localhost:8080/hive/default",
+        sqlalchemy_uri="presto://localhost:8082/hive/default",
     )
     assert PrestoEngineSpec.get_default_catalog(database) == "hive"
 

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -669,24 +669,24 @@ def test_adjust_engine_params_fully_qualified() -> None:
     """
     from superset.db_engine_specs.trino import TrinoEngineSpec
 
-    url = make_url("trino://user:pass@localhost:8080/system/default")
+    url = make_url("trino://user:pass@localhost:8082/system/default")
 
     uri = TrinoEngineSpec.adjust_engine_params(url, {})[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/system/default"
+    assert str(uri) == "trino://user:pass@localhost:8082/system/default"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
         {},
         schema="new_schema",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/system/new_schema"
+    assert str(uri) == "trino://user:pass@localhost:8082/system/new_schema"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
         {},
         catalog="new_catalog",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/new_catalog/default"
+    assert str(uri) == "trino://user:pass@localhost:8082/new_catalog/default"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
@@ -694,7 +694,7 @@ def test_adjust_engine_params_fully_qualified() -> None:
         catalog="new_catalog",
         schema="new_schema",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/new_catalog/new_schema"
+    assert str(uri) == "trino://user:pass@localhost:8082/new_catalog/new_schema"
 
 
 def test_adjust_engine_params_catalog_only() -> None:
@@ -703,24 +703,24 @@ def test_adjust_engine_params_catalog_only() -> None:
     """
     from superset.db_engine_specs.trino import TrinoEngineSpec
 
-    url = make_url("trino://user:pass@localhost:8080/system")
+    url = make_url("trino://user:pass@localhost:8082/system")
 
     uri = TrinoEngineSpec.adjust_engine_params(url, {})[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/system"
+    assert str(uri) == "trino://user:pass@localhost:8082/system"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
         {},
         schema="new_schema",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/system/new_schema"
+    assert str(uri) == "trino://user:pass@localhost:8082/system/new_schema"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
         {},
         catalog="new_catalog",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/new_catalog"
+    assert str(uri) == "trino://user:pass@localhost:8082/new_catalog"
 
     uri = TrinoEngineSpec.adjust_engine_params(
         url,
@@ -728,14 +728,14 @@ def test_adjust_engine_params_catalog_only() -> None:
         catalog="new_catalog",
         schema="new_schema",
     )[0]
-    assert str(uri) == "trino://user:pass@localhost:8080/new_catalog/new_schema"
+    assert str(uri) == "trino://user:pass@localhost:8082/new_catalog/new_schema"
 
 
 @pytest.mark.parametrize(
     "sqlalchemy_uri,result",
     [
-        ("trino://user:pass@localhost:8080/system", "system"),
-        ("trino://user:pass@localhost:8080/system/default", "system"),
+        ("trino://user:pass@localhost:8082/system", "system"),
+        ("trino://user:pass@localhost:8082/system/default", "system"),
         ("trino://trino@localhost:8081", None),
     ],
 )


### PR DESCRIPTION
- Change the default port 8080 to 8082 to avoid conflicting with SonarW.

- Install a modified copy of sqlalchemy-drill connector. Needs to be in a sibling directory to thales-superset called thales-sqlalchemy-drill
