### PR TITLE
fix: Remove 'Stream' stacked style option for Bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -339,9 +339,7 @@ const config: ControlPanelConfig = {
           {
             name: 'stack',
             config: {
-              // 'Stream' stacking is intentionally not available for Bar charts.
-              // See BarChartStackControlOptions in constants.ts for allowed options.
-              // If a user switches from a Streamed Area/Line chart to Bar, the override below resets it.
+              // 'Stream' stack is disabled for Bar charts; see formDataOverrides.
               type: 'SelectControl',
               label: t('Stacked Style'),
               renderTrigger: true,
@@ -381,7 +379,7 @@ const config: ControlPanelConfig = {
       metrics: getStandardizedControls().popAllMetrics(),
       groupby: getStandardizedControls().popAllColumns(),
     };
-    // If switching to Bar chart and stack is 'Stream', reset to null (not allowed for Bar)
+    // Reset 'Stream' stack, as it is not supported for Bar charts.
     if (newFormData.stack === StackControlsValue.Stream) {
       newFormData.stack = null;
     }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -193,7 +193,6 @@ export default function transformProps(
     yAxisTitleMargin,
     yAxisTitlePosition,
     zoomable,
-    stackDimension,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
@@ -420,23 +419,6 @@ export default function transformProps(
         );
       }
     });
-
-  if (
-    stack === StackControlsValue.Stack &&
-    stackDimension &&
-    chartProps.rawFormData.groupby
-  ) {
-    const idxSelectedDimension =
-      formData.metrics.length > 1
-        ? 1
-        : 0 + chartProps.rawFormData.groupby.indexOf(stackDimension);
-    for (const s of series) {
-      if (s.id) {
-        const columnsArr = labelMap[s.id];
-        (s as any).stack = columnsArr[idxSelectedDimension];
-      }
-    }
-  }
 
   // axis bounds need to be parsed to replace incompatible values with undefined
   const [xAxisMin, xAxisMax] = (xAxisBounds || []).map(parseAxisBound);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -74,7 +74,6 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   rowLimit: number;
   seriesType: EchartsTimeseriesSeriesType;
   stack: StackType;
-  stackDimension: string;
   timeCompare?: string[];
   tooltipTimeFormat?: string;
   showTooltipTotal?: boolean;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -90,6 +90,15 @@ export const AreaChartStackControlOptions: [
   Exclude<ReactNode, null | undefined | boolean>,
 ][] = [...StackControlOptions, [StackControlsValue.Expand, t('Expand')]];
 
+// For Bar charts, only allow 'None' and 'Stack' (no 'Stream')
+export const BarChartStackControlOptions: [
+  JsonValue,
+  Exclude<ReactNode, null | undefined | boolean>,
+][] = [
+  [null, t('None')],
+  [StackControlsValue.Stack, t('Stack')],
+];
+
 export const TIMEGRAIN_TO_TIMESTAMP = {
   [TimeGranularity.HOUR]: 3600 * 1000,
   [TimeGranularity.DAY]: 3600 * 1000 * 24,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Ensures the 'Stream' option is not available for Bar charts in the Stacked Style control.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Steps:

1. Create or edit an ECharts Area chart.
2. Set "Stacked Style" to "Stream".
3. Change the chart type to ECharts Bar.
4. Open the "Stacked Style" dropdown.

Expected: "Stream" is not present - only "None" and "Stack" are available.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: resolves #33820
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
