### PR TITLE
fix: Update dataset changed_on timestamp for all attribute changes

### DIFF
--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -197,7 +197,7 @@ class DatasetDAO(BaseDAO[SqlaTable]):
                 cls.update_metrics(item, attributes.pop("metrics"))
                 force_update = True
 
-            if force_update:
+            if attributes or force_update:
                 attributes["changed_on"] = datetime.now()
 
         return super().update(item, attributes)

--- a/tests/unit_tests/dao/dataset_test.py
+++ b/tests/unit_tests/dao/dataset_test.py
@@ -146,7 +146,7 @@ def test_validate_update_uniqueness(session: Session) -> None:
         ),
         (
             {"description": "test description"},
-            {"description": "test description"},
+            {"description": "test description", "changed_on": datetime(2025, 1, 1, 0, 0, 0)},
         ),
     ],
 )
@@ -158,7 +158,7 @@ def test_update_dataset_related_metadata_updates_changed_on(
     expected_attributes: dict[str, Any],
 ) -> None:
     """
-    Test that the changed_on property is updated when a metric or column is updated.
+    Test that the changed_on property is updated when any attributes are updated.
     """
     item = MagicMock()
     DatasetDAO.update(item, copy.deepcopy(attributes))


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes bug where "Last modified" field only updated for SOURCE/SETTINGS screen changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: resolves #31871
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
