### PR TITLE
fix: Correct state handling in CSS Template modal

### DIFF
--- a/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
+++ b/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
@@ -105,8 +105,8 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
 
   // Functions
   const hide = () => {
-    setIsHidden(true);
     onHide();
+    setCurrentCssTemplate(null);
   };
 
   const onSave = () => {
@@ -202,7 +202,7 @@ const CssTemplateModal: FunctionComponent<CssTemplateModalProps> = ({
         css: '',
       });
     }
-  }, [cssTemplate]);
+  }, [cssTemplate, show]);
 
   useEffect(() => {
     if (resource) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This resolves both issues by:
- Adding the `show` prop to the dependency array of the initialization `useEffect`, forcing it to reset the state every time the modal is opened.
- Clearing the `currentCssTemplate` state within the `hide` function, ensuring the modal is clean every time it is closed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: resolves #31269 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
