### PR TITLE
fix: Update file naming to skip ID in chart and dashboard exports

### DIFF
--- a/superset/commands/chart/export.py
+++ b/superset/commands/chart/export.py
@@ -47,7 +47,7 @@ class ExportChartsCommand(ExportModelsCommand):
 
     @staticmethod
     def _file_name(model: Slice) -> str:
-        file_name = get_filename(model.slice_name, model.id)
+        file_name = get_filename(model.slice_name, model.id, skip_id=True)
         return f"charts/{file_name}.yaml"
 
     @staticmethod

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -111,7 +111,7 @@ class ExportDashboardsCommand(ExportModelsCommand):
 
     @staticmethod
     def _file_name(model: Dashboard) -> str:
-        file_name = get_filename(model.dashboard_title, model.id)
+        file_name = get_filename(model.dashboard_title, model.id, skip_id=True)
         return f"dashboards/{file_name}.yaml"
 
     @staticmethod


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Added `skip_id=True` to `get_filename()` calls in dashboard/chart exports to remove ID suffixes from filenames.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: resolves #33784 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
