### PR TITLE
build(deps): remove legacy browser polyfills

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
       '<rootDir>/node_modules/@superset-ui/$1/src/$2',
     '^@superset-ui/([^/]+)$': '<rootDir>/node_modules/@superset-ui/$1/src',
   },
-  testEnvironment: 'jsdom',
+  testEnvironment: '<rootDir>/spec/helpers/jsDomWithFetchAPI.ts',
   modulePathIgnorePatterns: ['<rootDir>/packages/generator-superset'],
   setupFilesAfterEnv: ['<rootDir>/spec/helpers/setup.ts'],
   snapshotSerializers: ['@emotion/jest/serializer'],

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -52769,12 +52769,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
-    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -54111,7 +54105,6 @@
         "reselect": "^4.0.0",
         "rison": "^0.1.1",
         "seedrandom": "^3.0.5",
-        "whatwg-fetch": "^3.6.20",
         "xss": "^1.0.14"
       },
       "devDependencies": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -52,7 +52,6 @@
         "@visx/scale": "^3.5.0",
         "@visx/tooltip": "^3.0.0",
         "@visx/xychart": "^3.5.1",
-        "abortcontroller-polyfill": "^1.7.8",
         "ag-grid-community": "33.1.1",
         "ag-grid-react": "33.1.1",
         "antd": "^5.24.6",
@@ -15957,12 +15956,6 @@
       "engines": {
         "node": ">=6.5"
       }
-    },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
-      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
-      "license": "MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -120,7 +120,6 @@
     "@visx/scale": "^3.5.0",
     "@visx/tooltip": "^3.0.0",
     "@visx/xychart": "^3.5.1",
-    "abortcontroller-polyfill": "^1.7.8",
     "ag-grid-community": "33.1.1",
     "ag-grid-react": "33.1.1",
     "antd": "^5.24.6",

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -62,7 +62,6 @@
     "rison": "^0.1.1",
     "seedrandom": "^3.0.5",
     "@visx/responsive": "^3.12.0",
-    "whatwg-fetch": "^3.6.20",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/superset-frontend/packages/superset-ui-core/src/connection/README.md
+++ b/superset-frontend/packages/superset-ui-core/src/connection/README.md
@@ -93,7 +93,6 @@ Per-request aborting is implemented through the `AbortController` API:
 
 ```javascript
 import { SupersetClient } from '@superset-ui/core';
-import AbortController from 'abortcontroller-polyfill';
 
 const controller = new AbortController();
 const { signal } = controller;

--- a/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/callApi/callApi.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import 'whatwg-fetch';
 import fetchRetry from 'fetch-retry';
 import { CallApi, Payload, JsonValue, JsonObject } from '../types';
 import {

--- a/superset-frontend/packages/superset-ui-core/test/query/api/v1/handleError.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/v1/handleError.test.ts
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import 'whatwg-fetch'; // for adding Response polyfill
 import {
   JsonObject,
   SupersetApiError,

--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -1,0 +1,16 @@
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+// https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    // FIXME https://github.com/jsdom/jsdom/issues/1724
+    this.global.fetch = fetch;
+    this.global.Headers = Headers;
+    this.global.Request = Request;
+    this.global.Response = Response;
+    this.global.AbortSignal = AbortSignal;
+    this.global.AbortController = AbortController;
+  }
+}

--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import JSDOMEnvironment from 'jest-environment-jsdom';
 
 // https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string

--- a/superset-frontend/spec/helpers/shim.tsx
+++ b/superset-frontend/spec/helpers/shim.tsx
@@ -19,7 +19,6 @@
 import { AriaAttributes } from 'react';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import jQuery from 'jquery';
 // https://jestjs.io/docs/jest-object#jestmockmodulename-factory-options
 // in order to mock modules in test case, so avoid absolute import module

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { setConfig as setHotLoaderConfig } from 'react-hot-loader';
-import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import dayjs from 'dayjs';
 // eslint-disable-next-line no-restricted-imports
 import {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -258,7 +258,6 @@ const config = {
           name: 'vendors',
           test: new RegExp(
             `/node_modules/(${[
-              'abortcontroller-polyfill',
               'react',
               'react-dom',
               'prop-types',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
build(deps): remove legacy browser polyfills

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove polyfills for `fetch` and `abortcontroller` that are no longer relevant thanks to built-in support modern browsers.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/0a7e33e8-7be5-4805-b3ca-09dcd89c711b" />

<img width="804" alt="image" src="https://github.com/user-attachments/assets/c5ebad85-5f7a-4795-b87d-624fa6e4d523" />


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
