### PR TITLE
docs(docker): fix compose file name and update error message path

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -35,14 +35,14 @@ $ cd superset
 $ git checkout tags/4.1.2
 
 # Fire up Superset using Docker Compose
-$ docker compose -f compose-image-tag.yml up
+$ docker compose -f docker-compose-image-tag.yml up
 ```
 
 This may take a moment as Docker Compose will fetch the underlying
 container images and will load up some examples. Once all containers
 are downloaded and the output settles, you're ready to log in.
 
-⚠️ If you get an error message like `validating superset\compose-image-tag.yml: services.superset-worker-beat.env_file.0 must be a string`, you need to update your version of `docker-compose`.
+⚠️ If you get an error message like `validating superset\docker-compose-image-tag.yml: services.superset-worker-beat.env_file.0 must be a string`, you need to update your version of `docker-compose`.
 Note that `docker-compose` is on the path to deprecation and you should now use `docker compose` instead.
 
 ### 3. Log into Superset


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

This PR updates the Superset Docker documentation to correct the filename from `compose-image-tag.yml` to `docker-compose-image-tag.yml` in the startup instructions. It also updates the related error message path for consistency.

These changes ensure users can start Superset using Docker Compose without confusion and avoid outdated filenames.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

*Not applicable*

### TESTING INSTRUCTIONS

1. Check out the `tags/4.1.2` release.
2. Run the updated command:

   ```bash
   docker compose -f docker-compose-image-tag.yml up  
   ```
3. Confirm that Superset starts correctly and the file reference matches.
4. Optionally, test with an outdated `docker-compose` to verify the updated error message.

### ADDITIONAL INFORMATION

* [ ] Has associated issue:
* [ ] Required feature flags:
* [ ] Changes UI
* [ ] Includes DB Migration (follow approval process in [[SIP-59](https://github.com/apache/superset/issues/13351)](https://github.com/apache/superset/issues/13351))

  * [ ] Migration is atomic, supports rollback & is backwards-compatible
  * [ ] Confirm DB migration upgrade and downgrade tested
  * [ ] Runtime estimates and downtime expectations provided
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API

---
