### PR TITLE
fix: #33862 – Security menu missing on MySQL due to case mismatch

### DIFF
--- a/superset/views/roles.py
+++ b/superset/views/roles.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class RolesListView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/roles/")
     @has_access

--- a/superset/views/users_list.py
+++ b/superset/views/users_list.py
@@ -25,7 +25,7 @@ from .base import BaseSupersetView
 
 class UsersListView(BaseSupersetView):
     route_base = "/"
-    class_permission_name = "security"
+    class_permission_name = "Security"
 
     @expose("/users/")
     @has_access


### PR DESCRIPTION
### Summary
Align view permission names with their menu label so Superset creates the correct “Security” row on MySQL.

### Fix
* superset/views/roles.py – `class_permission_name = "Security"`
* superset/views/users_list.py – `class_permission_name = "Security"`

### Impact
Restores the Security menu on fresh MySQL installs without affecting
PostgreSQL or existing deployments.

Resolves #33862  
