### PR TITLE
build(be/deps): replace `importlib_metadata` usage with native  Python 3.10+ `importlib.metadata` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
     # known issue with holidays 0.26.0 and above related to prophet lib #25017
     "holidays>=0.25, <0.26",
     "humanize",
-    "importlib_metadata",
     "isodate",
     "jsonpath-ng>=1.6.1, <2",
     "Mako>=1.2.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,9 +11,7 @@ apispec==6.6.1
 apsw==3.50.1.0
     # via shillelagh
 async-timeout==4.0.3
-    # via
-    #   -r requirements/base.in
-    #   redis
+    # via -r requirements/base.in
 attrs==25.3.0
     # via
     #   cattrs
@@ -99,11 +97,6 @@ email-validator==2.2.0
     # via flask-appbuilder
 et-xmlfile==2.0.0
     # via openpyxl
-exceptiongroup==1.3.0
-    # via
-    #   cattrs
-    #   trio
-    #   trio-websocket
 flask==2.3.3
     # via
     #   apache-superset (pyproject.toml)
@@ -158,7 +151,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0
@@ -175,8 +167,6 @@ idna==3.10
     #   requests
     #   trio
     #   url-normalize
-importlib-metadata==8.7.0
-    # via apache-superset (pyproject.toml)
 isodate==0.7.2
     # via apache-superset (pyproject.toml)
 itsdangerous==2.2.0
@@ -401,11 +391,7 @@ typing-extensions==4.14.0
     #   apache-superset (pyproject.toml)
     #   alembic
     #   cattrs
-    #   exceptiongroup
     #   limits
-    #   pyopenssl
-    #   referencing
-    #   rich
     #   selenium
     #   shillelagh
 tzdata==2025.2
@@ -454,7 +440,5 @@ xlsxwriter==3.0.9
     # via
     #   apache-superset (pyproject.toml)
     #   pandas
-zipp==3.21.0
-    # via importlib-metadata
 zstandard==0.23.0
     # via flask-compress

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -20,10 +20,6 @@ apsw==3.50.1.0
     #   shillelagh
 astroid==3.3.10
     # via pylint
-async-timeout==4.0.3
-    # via
-    #   -c requirements/base.txt
-    #   redis
 attrs==25.3.0
     # via
     #   -c requirements/base.txt
@@ -180,13 +176,6 @@ et-xmlfile==2.0.0
     # via
     #   -c requirements/base.txt
     #   openpyxl
-exceptiongroup==1.3.0
-    # via
-    #   -c requirements/base.txt
-    #   cattrs
-    #   pytest
-    #   trio
-    #   trio-websocket
 filelock==3.12.2
     # via virtualenv
 flask==2.3.3
@@ -322,7 +311,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -360,10 +348,6 @@ idna==3.10
     #   requests
     #   trio
     #   url-normalize
-importlib-metadata==8.7.0
-    # via
-    #   -c requirements/base.txt
-    #   apache-superset
 importlib-resources==6.5.2
     # via prophet
 iniconfig==2.0.0
@@ -831,11 +815,6 @@ tabulate==0.9.0
     # via
     #   -c requirements/base.txt
     #   apache-superset
-tomli==2.2.1
-    # via
-    #   coverage
-    #   pylint
-    #   pytest
 tomlkit==0.13.3
     # via pylint
 tqdm==4.67.1
@@ -858,13 +837,8 @@ typing-extensions==4.14.0
     #   -c requirements/base.txt
     #   alembic
     #   apache-superset
-    #   astroid
     #   cattrs
-    #   exceptiongroup
     #   limits
-    #   pyopenssl
-    #   referencing
-    #   rich
     #   selenium
     #   shillelagh
 tzdata==2025.2
@@ -936,10 +910,6 @@ xlsxwriter==3.0.9
     #   -c requirements/base.txt
     #   apache-superset
     #   pandas
-zipp==3.21.0
-    # via
-    #   -c requirements/base.txt
-    #   importlib-metadata
 zope-event==5.0
     # via gevent
 zope-interface==5.4.0

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -33,11 +33,11 @@ import logging
 import pkgutil
 from collections import defaultdict
 from importlib import import_module
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any, Optional
 
 import sqlalchemy.dialects
-from importlib_metadata import entry_points
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.exc import NoSuchModuleError
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Closes https://github.com/apache/superset/pull/33801

Migrate `importlib-metadata` usage to built-in `importlib.metadata` module in Python 3.10+ since the project no longer support Python 3.9, required as [workaround](https://github.com/apache/superset/pull/24514) in the past.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
