### PR TITLE
feat(charts): Add row limit control to box plot chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -78,6 +78,7 @@ const config: ControlPanelConfig = {
         ['adhoc_filters'],
         ['series_limit'],
         ['series_limit_metric'],
+        ['row_limit'],
         [
           {
             name: 'whiskerOptions',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add a row limit control for Box Plot Chart to allow up to 50000 rows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1098" alt="Screenshot 2025-06-23 at 20 30 47" src="https://github.com/user-attachments/assets/359122ba-7053-48f2-97ac-237c44eabc48" />

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
