### PR TITLE
feat(theming): support user OS-level dark/light mode configuration

### DIFF
--- a/superset-frontend/src/setup/setupApp.ts
+++ b/superset-frontend/src/setup/setupApp.ts
@@ -62,20 +62,14 @@ function toggleCheckbox(apiUrlPrefix: string, selector: string) {
 
 function syncBrowserThemePreferenceWithCookie() {
   try {
-    const getCurrentPreference = () =>
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-
-    const setThemeCookie = theme => {
-      document.cookie = `superset_theme=${theme}; path=/; SameSite=Lax; secure`;
-    };
-
-    const currentPreference = getCurrentPreference();
+    const currentPreference = window.matchMedia('(prefers-color-scheme: dark)')
+      .matches
+      ? 'dark'
+      : 'light';
     const cookies = parseCookie();
 
     if (cookies.superset_theme !== currentPreference) {
-      setThemeCookie(currentPreference);
+      document.cookie = `superset_theme=${currentPreference}; path=/; SameSite=Lax; secure`;
     }
   } catch (err) {
     console.warn('Failed to sync theme preference', err);

--- a/superset-frontend/src/setup/setupApp.ts
+++ b/superset-frontend/src/setup/setupApp.ts
@@ -24,6 +24,7 @@ import {
   ClientErrorObject,
 } from '@superset-ui/core';
 import setupErrorMessages from 'src/setup/setupErrorMessages';
+import parseCookie from 'src/utils/parseCookie';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare global {
@@ -57,6 +58,28 @@ function toggleCheckbox(apiUrlPrefix: string, selector: string) {
         }
       }),
     );
+}
+
+function syncBrowserThemePreferenceWithCookie() {
+  try {
+    const getCurrentPreference = () =>
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+    const setThemeCookie = theme => {
+      document.cookie = `superset_theme=${theme}; path=/; SameSite=Lax; secure`;
+    };
+
+    const currentPreference = getCurrentPreference();
+    const cookies = parseCookie();
+
+    if (cookies.superset_theme !== currentPreference) {
+      setThemeCookie(currentPreference);
+    }
+  } catch (err) {
+    console.warn('Failed to sync theme preference', err);
+  }
 }
 
 export default function setupApp() {
@@ -93,6 +116,9 @@ export default function setupApp() {
   // this allows for the server side generated menus to function
   window.$ = $;
   window.jQuery = $;
+
+  // set up the OS-level preference around light/dark mode
+  syncBrowserThemePreferenceWithCookie();
 
   // set up app wide custom error messages
   setupErrorMessages();

--- a/superset-frontend/src/theme/ThemeController.tsx
+++ b/superset-frontend/src/theme/ThemeController.tsx
@@ -66,7 +66,7 @@ export class ThemeController {
 
   private mediaQuery: MediaQueryList;
 
-  constructor(options: ThemeControllerOptions = {}) {
+  constructor(options: ThemeControllerOptions = { themeObject }) {
     this.storage = options.storage || new LocalStorageAdapter();
     this.storageKey = options.storageKey || 'superset-theme';
     this.modeStorageKey = options.modeStorageKey || `${this.storageKey}-mode`;
@@ -152,6 +152,10 @@ export class ThemeController {
     return this.currentMode;
   }
 
+  /**
+   * Sets new theme customizations (e.g., from a JSON editor).
+   * This method updates the theme's appearance but preserves the current mode.
+   */
   public setTheme(newCustomizations: AnyThemeConfig): void {
     if (!this.canUpdateTheme()) {
       throw new Error('User does not have permission to update the theme');
@@ -170,6 +174,10 @@ export class ThemeController {
     this.notifyListeners();
   }
 
+  /**
+   * Changes the theme mode (light, dark, or system).
+   * This is for the mode switch.
+   */
   public changeThemeMode(newMode: ThemeMode): void {
     if (!this.canUpdateMode()) {
       throw new Error('User does not have permission to update the theme mode');
@@ -208,6 +216,9 @@ export class ThemeController {
     }
   };
 
+  /**
+   * Centralized method to apply the current customizations and mode.
+   */
   private applyTheme(): void {
     const newConfig = { ...this.customizations };
 

--- a/superset-frontend/src/theme/ThemeController.tsx
+++ b/superset-frontend/src/theme/ThemeController.tsx
@@ -76,7 +76,7 @@ export class ThemeController {
     if (options.themeObject) {
       this.themeObject = options.themeObject;
     } else {
-      this.themeObject = ThemeController.loadThemeFromBootstrap();
+      this.themeObject = ThemeController.getThemeFromBootstrapData();
     }
 
     // Load customizations from storage
@@ -119,7 +119,7 @@ export class ThemeController {
    * once the backend knows about the user preferences, it will return only `bootstrapData.theme`
    * which takes precedence over `bootstrapData.themes` (not available in this case)
    */
-  private static loadThemeFromBootstrap(): Theme {
+  private static getThemeFromBootstrapData(): Theme {
     const bootstrapData = getBootstrapData().common;
 
     let themeConfig: AnyThemeConfig = {};
@@ -132,11 +132,8 @@ export class ThemeController {
       if (bootstrapData.themes[preferred]) {
         themeConfig = bootstrapData.themes[preferred];
       }
-    } else {
-      console.warn('No theme data found in bootstrapData');
     }
-
-    return themeObject.setConfig(themeConfig);
+    return Theme.fromConfig(themeConfig);
   }
 
   public destroy(): void {

--- a/superset-frontend/src/theme/ThemeController.tsx
+++ b/superset-frontend/src/theme/ThemeController.tsx
@@ -111,6 +111,13 @@ export class ThemeController {
 
   /**
    * Load theme object directly from bootstrapData if not provided explicitly
+   * Note that there is special logic/handling to support getting the first request
+   * where the backend doesn't know about user preferences yet.
+   * In that case, since the backend doesn't know about the user preferences,
+   * it will return both themes to the back as part of the bootstrap data, leaving
+   * the decision to the frontend to pick the right one under `bootstrapData.themes`
+   * once the backend knows about the user preferences, it will return only `bootstrapData.theme`
+   * which takes precedence over `bootstrapData.themes` (not available in this case)
    */
   private static loadThemeFromBootstrap(): Theme {
     const bootstrapData = getBootstrapData().common;

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -11,6 +11,7 @@ import { TimeLocaleDefinition } from 'd3-time-format';
 import { isPlainObject } from 'lodash';
 import { Languages } from 'src/features/home/LanguagePicker';
 import type { FlashMessage } from 'src/components';
+import type { SerializableThemeConfig } from '@superset-ui/core/theme/types';
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -153,7 +154,12 @@ export interface CommonBootstrapData {
   language_pack: LanguagePack;
   extra_categorical_color_schemes: ColorSchemeConfig[];
   extra_sequential_color_schemes: SequentialSchemeConfig[];
-  theme: JsonObject;
+  // Depending on if the cookie is set, either theme or themes will be defined.
+  theme?: SerializableThemeConfig;
+  themes?: {
+    light: SerializableThemeConfig;
+    dark: SerializableThemeConfig;
+  };
   menu_data: MenuData;
   d3_format: Partial<FormatLocaleDefinition>;
   d3_time_format: Partial<TimeLocaleDefinition>;

--- a/superset-frontend/src/views/RootContextProviders.tsx
+++ b/superset-frontend/src/views/RootContextProviders.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Route } from 'react-router-dom';
-import { getExtensionsRegistry, themeObject } from '@superset-ui/core';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import { Provider as ReduxProvider } from 'react-redux';
 import { QueryParamProvider } from 'use-query-params';
 import { DndProvider } from 'react-dnd';

--- a/superset-frontend/src/views/RootContextProviders.tsx
+++ b/superset-frontend/src/views/RootContextProviders.tsx
@@ -33,10 +33,7 @@ import '../preamble';
 
 const { common } = getBootstrapData();
 
-if (Object.keys(common?.theme || {}).length > 0) {
-  themeObject.setConfig(common.theme);
-}
-const themeController = new ThemeController({ themeObject });
+const themeController = new ThemeController();
 
 const extensionsRegistry = getExtensionsRegistry();
 export const RootContextProviders: React.FC = ({ children }) => {

--- a/superset/config.py
+++ b/superset/config.py
@@ -669,17 +669,17 @@ COMMON_BOOTSTRAP_OVERRIDES_FUNC: Callable[  # noqa: E731
 # This is merely a default
 EXTRA_CATEGORICAL_COLOR_SCHEMES: list[dict[str, Any]] = []
 
-# THEME is used for setting a custom theme to Superset, it follows the ant design
-# theme structure
+# THEME and THEME_DARK are used for setting a custom theme to Superset,
+# it follows the ant design theme structure.
 # You can use the AntDesign theme editor to generate a theme structure
 # https://ant.design/theme-editor
-# To expose a JSON theme editor modal that can be triggered from the navbar
-# set the `ENABLE_THEME_EDITOR` feature flag to True.
-#
-# To set up the dark theme:
-# THEME = {"algorithm": "dark"}
+# The config are set as a callable returning an antd-compatible theme object
+# so that themes can be hot-swapped by fetching a theme object definition remotely
 
-THEME: dict[str, Any] = {}
+# Whether to respect the user's OS dark mode setting. If True, THEME_DARK must be set
+THEME_RESPECT_USER_OS_DARK_SETTING = False
+THEME: dict[str, Any] = lambda: {}  # NOQA
+THEME_DARK: dict[str, Any] = lambda: {"algorithm": "dark"}  # NOQA
 
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES is used for adding custom sequential color schemes
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES =  [

--- a/superset/config.py
+++ b/superset/config.py
@@ -563,12 +563,12 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Adds a switch to the navbar to easily switch between light and dark themes.
     # This is intended to use for development, visual review, and theming-debugging
     # purposes.
-    "THEME_ENABLE_DARK_THEME_SWITCH": False,
+    "THEME_ENABLE_DARK_THEME_SWITCH": True,
     # Adds a theme editor as a modal dialog in the navbar. Allows people to type in JSON
     # and see the changes applied to the current theme.
     # This is intended to use for theme creation, visual review and theming-debugging
     # purposes.
-    "THEME_ALLOW_THEME_EDITOR_BETA": False,
+    "THEME_ALLOW_THEME_EDITOR_BETA": True,
     # Allow users to optionally specify date formats in email subjects, which will
     # be parsed if enabled
     "DATE_FORMAT_IN_EMAIL_SUBJECT": False,


### PR DESCRIPTION
This PR introduce new `superset_config` settings:

```
# THEME and THEME_DARK are used for setting a custom theme to Superset,
# it follows the ant design theme structure.
# You can use the AntDesign theme editor to generate a theme structure
# https://ant.design/theme-editor
# The config are set as a callable returning an antd-compatible theme object
# so that themes can be hot-swapped by fetching a theme object definition remotely

# Whether to respect the user's OS dark mode setting. If True, THEME_DARK must be set
THEME_RESPECT_USER_OS_DARK_SETTING = False
THEME: dict[str, Any] = lambda: {}  # NOQA
THEME_DARK: dict[str, Any] = lambda: {"algorithm": "dark"}  # NOQA
```

Some of the logic:
- the frontend will set a cookie with the os-level preference for dark theme
- on first request, before cookie is set, the backend returns both theme (light and dark) configuration under `boostrapData.themes`, letting the frontend to pick the right one
- on subsequent request, once the cookie is available, the backend return the right theme under `boostrapData.themes`
