### PR TITLE
style(AsyncAceEditor): make Ace gutter line color theme-aware

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/index.tsx
@@ -212,7 +212,9 @@ export function AsyncAceEditor(
                   background-color: ${token.colorBgElevated} !important;
                   color: ${token.colorTextSecondary} !important;
                 }
-
+                .ace_editor.ace_editor .ace_gutter .ace_gutter-active-line {
+                  background-color: ${token.colorBorderSecondary};
+                }
                 /* Adjust selection color */
                 .ace_editor .ace_selection {
                   background-color: ${token.colorPrimaryBgHover} !important;

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -25,7 +25,7 @@ import {
   TextAreaEditor,
   ModalTrigger,
 } from '@superset-ui/core/components';
-import { t, withTheme, css } from '@superset-ui/core';
+import { t, withTheme } from '@superset-ui/core';
 
 import ControlHeader from 'src/explore/components/ControlHeader';
 
@@ -112,11 +112,6 @@ class TextAreaControl extends Component {
       const codeEditor = (
         <div>
           <TextAreaEditor
-            css={css`
-              .ace_gutter-active-line {
-                background-color: inherit;
-              }
-            `}
             mode={this.props.language}
             style={style}
             minLines={minLines}


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR updates the default styling of the Ace Editor gutter line within `AsyncAceEditor` to use design `tokens` instead of hardcoded values.

The change ensures consistency with the application's theme and improves support for light/dark mode and custom themes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

- Before
![Screenshot 2025-06-25 091742](https://github.com/user-attachments/assets/b2f30b8c-120e-49d0-8064-35db488658bf)

- After
![Screenshot 2025-06-25 153240](https://github.com/user-attachments/assets/5bea1300-d49d-4501-8c41-9e4e4fe8f042)
![Screenshot 2025-06-25 153308](https://github.com/user-attachments/assets/846743cf-1953-4630-b3e1-958e00d11c66)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
