### PR TITLE
fix: Consider default catalog when getting tables and view lists

### DIFF
--- a/superset/commands/database/tables.py
+++ b/superset/commands/database/tables.py
@@ -54,6 +54,7 @@ class TablesDatabaseCommand(BaseCommand):
 
     def run(self) -> dict[str, Any]:
         self.validate()
+        self._catalog_name = self._catalog_name or self._model.get_default_catalog()
         try:
             tables = security_manager.get_datasources_accessible_by_user(
                 database=self._model,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -801,6 +801,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :param force: whether to force refresh the cache
         :return: The table/schema pairs
         """
+        catalog = catalog or self.get_default_catalog()
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
@@ -835,6 +836,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :param force: whether to force refresh the cache
         :return: set of views
         """
+        catalog = catalog or self.get_default_catalog()
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -801,7 +801,6 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :param force: whether to force refresh the cache
         :return: The table/schema pairs
         """
-        catalog = catalog or self.get_default_catalog()
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {
@@ -836,7 +835,6 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         :param force: whether to force refresh the cache
         :return: set of views
         """
-        catalog = catalog or self.get_default_catalog()
         try:
             with self.get_inspector(catalog=catalog, schema=schema) as inspector:
                 return {

--- a/tests/integration_tests/databases/commands_tests.py
+++ b/tests/integration_tests/databases/commands_tests.py
@@ -1202,3 +1202,44 @@ class TestTablesDatabaseCommand(SupersetTestCase):
         assert result["count"] > 0
         assert len(result["result"]) > 0
         assert len(result["result"]) == result["count"]
+
+    @patch("superset.daos.database.DatabaseDAO.find_by_id")
+    @patch("superset.security.manager.SupersetSecurityManager.can_access_database")
+    @patch("superset.utils.core.g")
+    def test_database_tables_list_tables_default_catalog(
+        self, mock_g, mock_can_access_database, mock_find_by_id
+    ):
+        database = get_example_database()
+        mock_find_by_id.return_value = database
+        mock_can_access_database.return_value = True
+        mock_g.user = security_manager.find_user("admin")
+
+        with (
+            patch.object(
+                database, "get_default_catalog", return_value="default_catalog"
+            ),
+            patch.object(
+                database, "get_all_table_names_in_schema", return_value=[]
+            ) as mock_get_all_table_names,
+            patch.object(
+                database, "get_all_view_names_in_schema", return_value=[]
+            ) as mock_get_all_view_names,
+        ):
+            command = TablesDatabaseCommand(database.id, None, "schema_name", False)
+            command.run()
+
+            # Assert that the default catalog is used instead of None
+            mock_get_all_table_names.assert_called_once_with(
+                catalog="default_catalog",
+                schema="schema_name",
+                force=False,
+                cache=database.table_cache_enabled,
+                cache_timeout=database.table_cache_timeout,
+            )
+            mock_get_all_view_names.assert_called_once_with(
+                catalog="default_catalog",
+                schema="schema_name",
+                force=False,
+                cache=database.table_cache_enabled,
+                cache_timeout=database.table_cache_timeout,
+            )

--- a/tests/unit_tests/commands/databases/tables_test.py
+++ b/tests/unit_tests/commands/databases/tables_test.py
@@ -34,6 +34,7 @@ def database_with_catalog(mocker: MockerFixture) -> MagicMock:
 
     database = mocker.MagicMock()
     database.database_name = "test_database"
+    database.get_default_catalog.return_value = "catalog1"
     database.get_all_table_names_in_schema.return_value = {
         ("table1", "schema1", "catalog1"),
         ("table2", "schema1", "catalog1"),
@@ -57,6 +58,7 @@ def database_without_catalog(mocker: MockerFixture) -> MagicMock:
 
     database = mocker.MagicMock()
     database.database_name = "test_database"
+    database.get_default_catalog.return_value = None
     database.get_all_table_names_in_schema.return_value = {
         ("table1", "schema1", None),
         ("table2", "schema1", None),

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -17,7 +17,6 @@
 
 # pylint: disable=import-outside-toplevel
 from datetime import datetime
-from unittest.mock import ANY
 
 import pytest
 from pytest_mock import MockerFixture
@@ -883,33 +882,6 @@ def test_get_all_table_names_in_schema(mocker: MockerFixture) -> None:
     )
 
 
-def test_get_all_table_names_in_schema_default_catalog(mocker: MockerFixture) -> None:
-    """
-    Test the `get_all_table_names_in_schema` method with a DB that supports
-    multiple catalogs.
-    """
-    database = Database(
-        database_name="db",
-        sqlalchemy_uri="postgresql://user:password@host:5432/examples",
-    )
-
-    mocker.patch.object(database, "get_inspector")
-    mocker.patch.object(database, "get_default_catalog", return_value="examples")
-    mock_get_table_names = mocker.patch(
-        "superset.db_engine_specs.postgres.PostgresEngineSpec.get_table_names"
-    )
-
-    database.get_all_table_names_in_schema(
-        catalog=None,
-        schema="public",
-    )
-    mock_get_table_names.assert_called_once_with(
-        database=database,
-        inspector=ANY,
-        schema="public",
-    )
-
-
 def test_get_all_view_names_in_schema(mocker: MockerFixture) -> None:
     """
     Test the `get_all_view_names_in_schema` method.
@@ -935,33 +907,6 @@ def test_get_all_view_names_in_schema(mocker: MockerFixture) -> None:
             ("second_view", "public", "examples"),
             ("third_view", "public", "examples"),
         }
-    )
-
-
-def test_get_all_view_names_in_schema_default_catalog(mocker: MockerFixture) -> None:
-    """
-    Test the `get_all_view_names_in_schema` method with a DB that supports
-    multiple catalogs.
-    """
-    database = Database(
-        database_name="db",
-        sqlalchemy_uri="postgresql://user:password@host:5432/examples",
-    )
-
-    mocker.patch.object(database, "get_inspector")
-    mocker.patch.object(database, "get_default_catalog", return_value="examples")
-    mock_get_view_names = mocker.patch(
-        "superset.db_engine_specs.base.BaseEngineSpec.get_view_names"
-    )
-
-    database.get_all_view_names_in_schema(
-        catalog=None,
-        schema="public",
-    )
-    mock_get_view_names.assert_called_once_with(
-        database=database,
-        inspector=ANY,
-        schema="public",
     )
 
 

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -16,9 +16,8 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel
-
-
 from datetime import datetime
+from unittest.mock import ANY
 
 import pytest
 from pytest_mock import MockerFixture
@@ -884,6 +883,33 @@ def test_get_all_table_names_in_schema(mocker: MockerFixture) -> None:
     )
 
 
+def test_get_all_table_names_in_schema_default_catalog(mocker: MockerFixture) -> None:
+    """
+    Test the `get_all_table_names_in_schema` method with a DB that supports
+    multiple catalogs.
+    """
+    database = Database(
+        database_name="db",
+        sqlalchemy_uri="postgresql://user:password@host:5432/examples",
+    )
+
+    mocker.patch.object(database, "get_inspector")
+    mocker.patch.object(database, "get_default_catalog", return_value="examples")
+    mock_get_table_names = mocker.patch(
+        "superset.db_engine_specs.postgres.PostgresEngineSpec.get_table_names"
+    )
+
+    database.get_all_table_names_in_schema(
+        catalog=None,
+        schema="public",
+    )
+    mock_get_table_names.assert_called_once_with(
+        database=database,
+        inspector=ANY,
+        schema="public",
+    )
+
+
 def test_get_all_view_names_in_schema(mocker: MockerFixture) -> None:
     """
     Test the `get_all_view_names_in_schema` method.
@@ -909,6 +935,33 @@ def test_get_all_view_names_in_schema(mocker: MockerFixture) -> None:
             ("second_view", "public", "examples"),
             ("third_view", "public", "examples"),
         }
+    )
+
+
+def test_get_all_view_names_in_schema_default_catalog(mocker: MockerFixture) -> None:
+    """
+    Test the `get_all_view_names_in_schema` method with a DB that supports
+    multiple catalogs.
+    """
+    database = Database(
+        database_name="db",
+        sqlalchemy_uri="postgresql://user:password@host:5432/examples",
+    )
+
+    mocker.patch.object(database, "get_inspector")
+    mocker.patch.object(database, "get_default_catalog", return_value="examples")
+    mock_get_view_names = mocker.patch(
+        "superset.db_engine_specs.base.BaseEngineSpec.get_view_names"
+    )
+
+    database.get_all_view_names_in_schema(
+        catalog=None,
+        schema="public",
+    )
+    mock_get_view_names.assert_called_once_with(
+        database=database,
+        inspector=ANY,
+        schema="public",
     )
 
 


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue that was preventing limited roles (for example, `Alpha`) to get a list of tables and views from a DB. This would happen for DBs that support `multi_catalog` but had **Allow changing catalogs** disabled. The issue:
1. The DB metadata dropdowns would not include a **Catalog** option.
2. The API call fired by the client to `/api/v1/database/${DB_CONNECTION_ID}/tables` would not specify the catalog to use.
3. Backend logic would use `None` as opposed to the connection's default catalog.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Added test coverage. For manual testing:
1. Connect a DB that supports multi_catalog. Make sure that **Allow changing catalogs** is disabled. 
2. Create one dataset from this connection.
3. Create a test user and grant this account the `Alpha` and `sql_lab` roles.
4. Grant this user access to the dataset created in step 3.
5. While logged in with the test account, navigate to **SQL > SQL Lab**.
6. Select the DB and schema in the dropdowns.
7. Confirm the table list is displayed as well.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
