### PR TITLE
fix(dashboard): Fix subitem selection on dashboard download menu

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadAsImage.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadAsImage.tsx
@@ -27,6 +27,7 @@ export default function DownloadAsImage({
   text,
   logEvent,
   dashboardTitle,
+  ...props
 }: {
   text: string;
   dashboardTitle: string;
@@ -50,6 +51,7 @@ export default function DownloadAsImage({
       onClick={e => {
         onDownloadImage(e.domEvent);
       }}
+      {...props}
     >
       {text}
     </Menu.Item>

--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadAsPdf.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadAsPdf.tsx
@@ -27,6 +27,7 @@ export default function DownloadAsPdf({
   text,
   logEvent,
   dashboardTitle,
+  ...props
 }: {
   text: string;
   dashboardTitle: string;
@@ -50,6 +51,7 @@ export default function DownloadAsPdf({
       onClick={e => {
         onDownloadPdf(e.domEvent);
       }}
+      {...props}
     >
       {text}
     </Menu.Item>


### PR DESCRIPTION
### SUMMARY

Dashboard download menu show both item selected on hover (as id is undefined for both). This is not probably correct way to fix as it is not still the key used but at least it works.



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
