### PR TITLE
docs(security): add Q&A related to CVE scans to FAQ

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -278,7 +278,7 @@ Alternatively, you can programmatically take regular exports of the assets as a 
 
 ## I ran a security scan of Superset and it showed dozens of "high" and "critical" vulnerabilities! Can you release a version of Superset without these?
 
-You are talking about dependency CVEs: identified vulnerabilities in software that Superset uses. Many of these are deep in the dependency tree and/or aren't relevant to Superset. For instance, if there's a bug in the Linux kernel related to Bluetooth, that doesn't effect Superset. And most of these CVEs are in the Linux kernel or Python, both of which have many other people working on their security.
+You are talking about dependency CVEs: identified vulnerabilities in software that Superset uses. Many of these are deep in the dependency tree and/or aren't relevant to Superset. For instance, if there's a bug in the Linux kernel related to Bluetooth, that doesn't affect Superset. And most of these CVEs are in the Linux kernel or Python, both of which have many other people working on their security.
 
 We address these dependency CVEs as best we can by regularly updating our dependencies to newer versions. We use bots to assist with that and cheerfully welcome pull requests from humans that fix dependency CVEs.
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -275,3 +275,11 @@ No. Currently, there is no way to recover a deleted Superset dashboard/chart/dat
 Hence, it is recommended to take periodic backups of the metadata database. For recovery, you can launch a recovery instance of a Superset server with the backed-up copy of the DB attached and use the Export Dashboard button in the Superset UI (or the `superset export-dashboards` CLI command). Then, take the .zip file and import it into the current Superset instance.
 
 Alternatively, you can programmatically take regular exports of the assets as a backup.
+
+## I ran a security scan of Superset and it showed dozens of "high" and "critical" vulnerabilities! Can you release a version of Superset without these?
+
+You are talking about dependency CVEs: identified vulnerabilities in software that Superset uses. Many of these are deep in the dependency tree and/or aren't relevant to Superset. For instance, if there's a bug in the Linux kernel related to Bluetooth, that doesn't effect Superset. And most of these CVEs are in the Linux kernel or Python, both of which have many other people working on their security.
+
+We address these dependency CVEs as best we can by regularly updating our dependencies to newer versions. We use bots to assist with that and cheerfully welcome pull requests from humans that fix dependency CVEs.
+
+The Superset [security team](https://superset.apache.org/docs/security/#reporting-security-vulnerabilities) focuses primarily on vulnerabilities _in Superset itself_. See our [CVEs page](https://superset.apache.org/docs/security/cves) for a list of past Superset CVEs.

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -276,9 +276,9 @@ Hence, it is recommended to take periodic backups of the metadata database. For 
 
 Alternatively, you can programmatically take regular exports of the assets as a backup.
 
-## I ran a security scan of Superset and it showed dozens of "high" and "critical" vulnerabilities! Can you release a version of Superset without these?
+## I ran a security scan of the Superset container image and it showed dozens of "high" and "critical" vulnerabilities! Can you release a version of Superset without these?
 
-You are talking about dependency CVEs: identified vulnerabilities in software that Superset uses. Many of these are deep in the dependency tree and/or aren't relevant to Superset. For instance, if there's a bug in the Linux kernel related to Bluetooth, that doesn't affect Superset. And most of these CVEs are in the Linux kernel or Python, both of which have many other people working on their security.
+You are talking about dependency CVEs: identified vulnerabilities in software that Superset uses. Most of these CVEs are in the Linux kernel or Python, both of which have many other people working on their security.
 
 We address these dependency CVEs as best we can by regularly updating our dependencies to newer versions. We use bots to assist with that and cheerfully welcome pull requests from humans that fix dependency CVEs.
 

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -340,8 +340,8 @@ TALISMAN_CONFIG = {
 }
 ```
 
-# For more information on setting up Talisman, please refer to
-https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp
+For more information on setting up Talisman, please refer to
+https://superset.apache.org/docs/configuration/networking-settings/#changing-flask-talisman-csp.
 
 ### Reporting Security Vulnerabilities
 


### PR DESCRIPTION
### SUMMARY
We get enough posts in Slack and GitHub of CVE lists that look alarming (e.g., https://github.com/apache/superset/issues/24490) that I thought I'd add something to the FAQ. That way we can just point people to that answer.

(I also fixed a formatting bug in a different docs file)