### PR TITLE
fix(translations): Periodic language strings extraction, newly Translatable label positions for Radar Chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -35,7 +35,7 @@ import {
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
-import { LabelPositionEnum } from '../types'
+import { LabelPositionEnum } from '../types';
 import { legendSection } from '../controls';
 
 const { labelType, labelPosition, numberFormat, showLabels, isCircle } =

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -35,7 +35,7 @@ import {
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
 import { DEFAULT_FORM_DATA } from './types';
-import { LABEL_POSITION } from '../constants';
+import { LabelPositionEnum } from '../types'
 import { legendSection } from '../controls';
 
 const { labelType, labelPosition, numberFormat, showLabels, isCircle } =
@@ -71,6 +71,22 @@ const radarMetricMinValue: { name: string; config: ControlFormItemSpec } = {
     validators: [validateNumber],
   },
 };
+
+const getLabelPositionOptions = (): [LabelPositionEnum, string][] => [
+  [LabelPositionEnum.Top, t('Top')],
+  [LabelPositionEnum.Left, t('Left')],
+  [LabelPositionEnum.Right, t('Right')],
+  [LabelPositionEnum.Bottom, t('Bottom')],
+  [LabelPositionEnum.Inside, t('Inside')],
+  [LabelPositionEnum.InsideLeft, t('Inside left')],
+  [LabelPositionEnum.InsideRight, t('Inside right')],
+  [LabelPositionEnum.InsideTop, t('Inside top')],
+  [LabelPositionEnum.InsideBottom, t('Inside bottom')],
+  [LabelPositionEnum.InsideTopLeft, t('Inside top left')],
+  [LabelPositionEnum.InsideBottomLeft, t('Inside bottom left')],
+  [LabelPositionEnum.InsideTopRight, t('Inside top right')],
+  [LabelPositionEnum.InsideBottomRight, t('Inside bottom right')],
+];
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -136,7 +152,7 @@ const config: ControlPanelConfig = {
               freeForm: false,
               label: t('Label position'),
               renderTrigger: true,
-              choices: LABEL_POSITION,
+              choices: getLabelPositionOptions(),
               default: labelPosition,
               description: D3_FORMAT_DOCS,
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -21,7 +21,6 @@ import { t } from '@apache-superset/core';
 import { JsonValue, TimeGranularity } from '@superset-ui/core';
 import { ReactNode } from 'react';
 import {
-  LabelPositionEnum,
   LegendFormData,
   LegendOrientation,
   LegendType,
@@ -50,21 +49,6 @@ export const TIMESERIES_CONSTANTS = {
   horizontalBarLabelRightPadding: 70,
 };
 
-export const LABEL_POSITION: [LabelPositionEnum, string][] = [
-  [LabelPositionEnum.Top, 'Top'],
-  [LabelPositionEnum.Left, 'Left'],
-  [LabelPositionEnum.Right, 'Right'],
-  [LabelPositionEnum.Bottom, 'Bottom'],
-  [LabelPositionEnum.Inside, 'Inside'],
-  [LabelPositionEnum.InsideLeft, 'Inside left'],
-  [LabelPositionEnum.InsideRight, 'Inside right'],
-  [LabelPositionEnum.InsideTop, 'Inside top'],
-  [LabelPositionEnum.InsideBottom, 'Inside bottom'],
-  [LabelPositionEnum.InsideTopLeft, 'Inside top left'],
-  [LabelPositionEnum.InsideBottomLeft, 'Inside bottom left'],
-  [LabelPositionEnum.InsideTopRight, 'Inside top right'],
-  [LabelPositionEnum.InsideBottomRight, 'Inside bottom right'],
-];
 
 export enum OpacityEnum {
   Transparent = 0,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -49,7 +49,6 @@ export const TIMESERIES_CONSTANTS = {
   horizontalBarLabelRightPadding: 70,
 };
 
-
 export enum OpacityEnum {
   Transparent = 0,
   SemiTransparent = 0.3,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Went to go make label positions for the Radar chart translatable, but then went ahead and updated the translated strings extraction files (.pot/.po) which looks like it hasn't been done in a while!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes: https://github.com/apache/superset/issues/29479
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
