### PR TITLE
fix(rls): removing unnecessary wrapper

### DIFF
--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.tsx
@@ -456,25 +456,23 @@ function RowLevelSecurityModal(props: RowLevelSecurityModalProps) {
             />
           </StyledInputContainer>
           <StyledInputContainer>
-            <div className="control-label">
-              <LabeledErrorBoundInput
-                id="clause"
-                name="clause"
-                value={currentRule ? currentRule.clause : ''}
-                required
-                validationMethods={{
-                  onChange: ({ target }: { target: HTMLInputElement }) =>
-                    onTextChange(target),
-                }}
-                css={noMargins}
-                label={t('Clause')}
-                hasTooltip
-                tooltipText={t(
-                  'This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).',
-                )}
-                data-test="clause-test"
-              />
-            </div>
+            <LabeledErrorBoundInput
+              id="clause"
+              name="clause"
+              value={currentRule ? currentRule.clause : ''}
+              required
+              validationMethods={{
+                onChange: ({ target }: { target: HTMLInputElement }) =>
+                  onTextChange(target),
+              }}
+              css={noMargins}
+              label={t('Clause')}
+              hasTooltip
+              tooltipText={t(
+                'This is the condition that will be added to the WHERE clause. For example, to only return rows for a particular client, you might define a regular filter with the clause `client_id = 9`. To display no rows unless a user belongs to a RLS filter role, a base filter can be created with the clause `1 = 0` (always false).',
+              )}
+              data-test="clause-test"
+            />
           </StyledInputContainer>
           <StyledInputContainer>
             <div className="control-label">{t('Description')}</div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Remove unnecessary wrapper for "Clause" Field in the RLS so that it now spans the full width of the modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
![2025-06-27_12h53_03](https://github.com/user-attachments/assets/99e67196-2f02-4582-94e6-9943605a227e)

After
![2025-06-27_12h54_24](https://github.com/user-attachments/assets/2511b4ab-d8dc-4b73-a66a-15d7f5d06eb7)



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
