### PR TITLE
fix(sqllab): pass DB id instead of name

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -353,7 +353,7 @@ test('Sends the correct db when changing the database', async () => {
   await waitFor(() =>
     expect(props.onDbChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: 2,
+        value: 2,
         database_name: 'test-mysql',
         backend: 'mysql',
       }),

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -353,7 +353,7 @@ test('Sends the correct db when changing the database', async () => {
   await waitFor(() =>
     expect(props.onDbChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: `mysql-test-mysql-2`,
+        id: 2,
         database_name: 'test-mysql',
         backend: 'mysql',
       }),

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -196,7 +196,6 @@ export function DatabaseSelector({
               />
             ),
             value: row.id,
-            id: row.id,
             database_name: row.database_name,
             backend: row.backend,
             allow_multi_catalog: row.allow_multi_catalog,

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -196,7 +196,7 @@ export function DatabaseSelector({
               />
             ),
             value: row.id,
-            id: `${row.backend}-${row.database_name}-${row.id}`,
+            id: row.id,
             database_name: row.database_name,
             backend: row.backend,
             allow_multi_catalog: row.allow_multi_catalog,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/31590 broke SQL Lab by replacing the dbID with a name:

https://github.com/apache/superset/pull/31590/files#diff-ea7a7f3b0884ed0d868929c970403455028773ec29a90c6ef8b507d6b4e9ab34R199

This PR fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes https://github.com/apache/superset/issues/33935
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
