### PR TITLE
SONK-3386: Fix encoding issue (#1)

### DIFF
--- a/superset/db_engine_specs/drill.py
+++ b/superset/db_engine_specs/drill.py
@@ -87,7 +87,9 @@ class DrillEngineSpec(BaseEngineSpec):
         schema: str | None = None,
     ) -> tuple[URL, dict[str, Any]]:
         if schema:
-            uri = uri.set(database=parse.quote(schema.replace(".", "/"), safe=""))
+            if uri.get_driver_name() == 'sadrill' and uri.get_backend_name() != 'drill':
+                schema = schema.replace(".", "/")
+            uri = uri.set(database=parse.quote(schema, safe=""))
 
         return uri, connect_args
 


### PR DESCRIPTION
Don't format mongo commands with a '/' if using drill+sadrill. 
Needed in addition to https://github.com/JohnOmernik/sqlalchemy-drill/pull/98 to make MongoDB + SqlAlchemyDrill + Superset to work properly