### PR TITLE
fix: Dashboard native filter fixes

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -303,4 +303,50 @@ describe('FilterBar', () => {
 
     expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   });
+
+  it('should render without errors with proper state setup', () => {
+    const stateWithFilter = {
+      ...stateWithoutNativeFilters,
+      dashboardInfo: {
+        id: 1,
+      },
+      dataMask: {
+        'test-filter': {
+          id: 'test-filter',
+          filterState: { value: undefined },
+          extraFormData: {},
+        },
+      },
+      nativeFilters: {
+        filters: {
+          'test-filter': {
+            id: 'test-filter',
+            name: 'Test Filter',
+            filterType: 'filter_select',
+            targets: [{ datasetId: 1, column: { name: 'test_column' } }],
+            defaultDataMask: {
+              filterState: { value: undefined },
+              extraFormData: {},
+            },
+            controlValues: {
+              enableEmptyFilter: true,
+            },
+            cascadeParentIds: [],
+            scope: {
+              rootPath: ['ROOT_ID'],
+              excluded: [],
+            },
+            type: 'NATIVE_FILTER',
+            description: '',
+            chartsInScope: [],
+            tabsInScope: [],
+          },
+        },
+        filtersState: {},
+      },
+    };
+
+    const { container } = renderWrapper(openedBarProps, stateWithFilter);
+    expect(container).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -286,6 +286,8 @@ const FilterControl = ({
   parentRef,
   orientation = FilterBarOrientation.Vertical,
   overflow = false,
+  clearAllTrigger,
+  onClearAllComplete,
 }: FilterControlProps) => {
   const portalNode = useMemo(() => createHtmlPortalNode(), []);
   const [isFilterActive, setIsFilterActive] = useState(false);
@@ -358,6 +360,8 @@ const FilterControl = ({
           orientation={orientation}
           overflow={overflow}
           validateStatus={validateStatus}
+          clearAllTrigger={clearAllTrigger}
+          onClearAllComplete={onClearAllComplete}
         />
       </InPortal>
       <FilterControlContainer

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -65,11 +65,15 @@ import { useChartsVerboseMaps } from '../utils';
 type FilterControlsProps = {
   dataMaskSelected: DataMaskStateWithId;
   onFilterSelectionChange: (filter: Filter, dataMask: DataMask) => void;
+  clearAllTriggers?: Record<string, boolean>;
+  onClearAllComplete?: (filterId: string) => void;
 };
 
 const FilterControls: FC<FilterControlsProps> = ({
   dataMaskSelected,
   onFilterSelectionChange,
+  clearAllTriggers,
+  onClearAllComplete,
 }) => {
   const filterBarOrientation = useSelector<RootState, FilterBarOrientation>(
     ({ dashboardInfo }) => dashboardInfo.filterBarOrientation,
@@ -100,6 +104,8 @@ const FilterControls: FC<FilterControlsProps> = ({
   const { filterControlFactory, filtersWithValues } = useFilterControlFactory(
     dataMaskSelected,
     onFilterSelectionChange,
+    clearAllTriggers,
+    onClearAllComplete,
   );
   const portalNodes = useMemo(() => {
     const nodes = new Array(filtersWithValues.length);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -95,6 +95,8 @@ const FilterValue: FC<FilterControlProps> = ({
   orientation = FilterBarOrientation.Vertical,
   overflow = false,
   validateStatus,
+  clearAllTrigger,
+  onClearAllComplete,
 }) => {
   const { id, targets, filterType, adhoc_filters, time_range } = filter;
   const metadata = getChartMetadataRegistry().get(filterType);
@@ -273,6 +275,8 @@ const FilterValue: FC<FilterControlProps> = ({
       setFocusedFilter,
       unsetFocusedFilter,
       setFilterActive,
+      clearAllTrigger,
+      onClearAllComplete,
     }),
     [
       setDataMask,
@@ -281,13 +285,15 @@ const FilterValue: FC<FilterControlProps> = ({
       unsetHoveredFilter,
       setFocusedFilter,
       unsetFocusedFilter,
+      clearAllTrigger,
+      onClearAllComplete,
     ],
   );
 
   const filterState = useMemo(
     () => ({
-      validateStatus,
       ...filter.dataMask?.filterState,
+      validateStatus,
     }),
     [filter.dataMask?.filterState, validateStatus],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
@@ -44,4 +44,6 @@ export interface FilterControlProps extends BaseFilterProps {
   parentRef?: RefObject<any>;
   setFilterActive?: (isActive: boolean) => void;
   validateStatus?: string;
+  clearAllTrigger?: boolean;
+  onClearAllComplete?: () => void;
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -69,6 +69,8 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
   filterValues,
   isInitialized,
   onSelectionChange,
+  clearAllTriggers,
+  onClearAllComplete,
 }) => {
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
     state => state.dataMask,
@@ -107,6 +109,8 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
               <FilterControls
                 dataMaskSelected={dataMaskSelected}
                 onFilterSelectionChange={onSelectionChange}
+                clearAllTriggers={clearAllTriggers}
+                onClearAllComplete={onClearAllComplete}
               />
             )}
             {actions}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -125,6 +125,8 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
   onSelectionChange,
   toggleFiltersBar,
   width,
+  clearAllTriggers,
+  onClearAllComplete,
 }) => {
   const theme = useTheme();
   const [isScrolling, setIsScrolling] = useState(false);
@@ -180,6 +182,8 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
           <FilterControls
             dataMaskSelected={dataMaskSelected}
             onFilterSelectionChange={onSelectionChange}
+            clearAllTriggers={clearAllTriggers}
+            onClearAllComplete={onClearAllComplete}
           />
         </FilterControlsWrapper>
       ),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -171,6 +171,12 @@ const FilterBar: FC<FiltersBarProps> = ({
   >(state => state.user);
 
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
+  const [clearAllTriggers, setClearAllTriggers] = useState<
+    Record<string, boolean>
+  >({});
+  const [initializedFilters, setInitializedFilters] = useState<Set<string>>(
+    new Set(),
+  );
 
   const dataMaskSelectedRef = useRef(dataMaskSelected);
   dataMaskSelectedRef.current = dataMaskSelected;
@@ -180,23 +186,49 @@ const FilterBar: FC<FiltersBarProps> = ({
       dataMask: Partial<DataMask>,
     ) => {
       setDataMaskSelected(draft => {
+        const isFirstTimeInitialization =
+          !initializedFilters.has(filter.id) &&
+          dataMaskSelectedRef.current[filter.id]?.filterState?.value ===
+            undefined;
+
         // force instant updating on initialization for filters with `requiredFirst` is true or instant filters
         if (
           // filterState.value === undefined - means that value not initialized
           dataMask.filterState?.value !== undefined &&
-          dataMaskSelectedRef.current[filter.id]?.filterState?.value ===
-            undefined &&
+          isFirstTimeInitialization &&
           filter.requiredFirst
         ) {
           dispatch(updateDataMask(filter.id, dataMask));
         }
-        draft[filter.id] = {
+
+        // Mark filter as initialized after getting its first value
+        if (
+          dataMask.filterState?.value !== undefined &&
+          !initializedFilters.has(filter.id)
+        ) {
+          setInitializedFilters(prev => new Set(prev).add(filter.id));
+        }
+
+        const baseDataMask = {
           ...(getInitialDataMask(filter.id) as DataMaskWithId),
           ...dataMask,
         };
+
+        // Recalculate validation status
+        const hasRequiredValue =
+          filter.controlValues?.enableEmptyFilter &&
+          baseDataMask.filterState?.value == null;
+
+        draft[filter.id] = {
+          ...baseDataMask,
+          filterState: {
+            ...baseDataMask.filterState,
+            validateStatus: hasRequiredValue ? 'error' : undefined,
+          },
+        };
       });
     },
-    [dispatch, setDataMaskSelected],
+    [dispatch, setDataMaskSelected, initializedFilters, setInitializedFilters],
   );
 
   useEffect(() => {
@@ -256,6 +288,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   }, [dataMaskSelected, dispatch]);
 
   const handleClearAll = useCallback(() => {
+    const newClearAllTriggers = { ...clearAllTriggers };
     filtersInScope.filter(isNativeFilter).forEach(filter => {
       const { id } = filter;
       if (dataMaskSelected[id]) {
@@ -265,9 +298,19 @@ const FilterBar: FC<FiltersBarProps> = ({
           }
           draft[id].extraFormData = {};
         });
+        newClearAllTriggers[id] = true;
       }
     });
-  }, [dataMaskSelected, dispatch, filtersInScope, setDataMaskSelected]);
+    setClearAllTriggers(newClearAllTriggers);
+  }, [dataMaskSelected, filtersInScope, setDataMaskSelected, clearAllTriggers]);
+
+  const handleClearAllComplete = useCallback((filterId: string) => {
+    setClearAllTriggers(prev => {
+      const newTriggers = { ...prev };
+      delete newTriggers[filterId];
+      return newTriggers;
+    });
+  }, []);
 
   useFilterUpdates(dataMaskSelected, setDataMaskSelected);
   const isApplyDisabled = checkIsApplyDisabled(
@@ -310,6 +353,8 @@ const FilterBar: FC<FiltersBarProps> = ({
         filterValues={filterValues}
         isInitialized={isInitialized}
         onSelectionChange={handleFilterSelectionChange}
+        clearAllTriggers={clearAllTriggers}
+        onClearAllComplete={handleClearAllComplete}
       />
     ) : verticalConfig ? (
       <Vertical
@@ -324,6 +369,8 @@ const FilterBar: FC<FiltersBarProps> = ({
         onSelectionChange={handleFilterSelectionChange}
         toggleFiltersBar={verticalConfig.toggleFiltersBar}
         width={verticalConfig.width}
+        clearAllTriggers={clearAllTriggers}
+        onClearAllComplete={handleClearAllComplete}
       />
     ) : null;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
@@ -36,6 +36,8 @@ interface CommonFiltersBarProps {
     filter: Pick<Filter, 'id'> & Partial<Filter>,
     dataMask: Partial<DataMask>,
   ) => void;
+  clearAllTriggers?: Record<string, boolean>;
+  onClearAllComplete?: (filterId: string) => void;
 }
 
 interface VerticalBarConfig {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/useFilterControlFactory.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/useFilterControlFactory.tsx
@@ -33,6 +33,8 @@ import FilterDivider from './FilterControls/FilterDivider';
 export const useFilterControlFactory = (
   dataMaskSelected: DataMaskStateWithId,
   onFilterSelectionChange: (filter: Filter, dataMask: DataMask) => void,
+  clearAllTriggers?: Record<string, boolean>,
+  onClearAllComplete?: (filterId: string) => void,
 ) => {
   const filters = useFilters();
   const filterValues = useMemo(() => Object.values(filters), [filters]);
@@ -70,10 +72,18 @@ export const useFilterControlFactory = (
           inView={false}
           orientation={filterBarOrientation}
           overflow={overflow}
+          clearAllTrigger={clearAllTriggers?.[filter.id]}
+          onClearAllComplete={() => onClearAllComplete?.(filter.id)}
         />
       );
     },
-    [filtersWithValues, dataMaskSelected, onFilterSelectionChange],
+    [
+      filtersWithValues,
+      dataMaskSelected,
+      onFilterSelectionChange,
+      clearAllTriggers,
+      onClearAllComplete,
+    ],
   );
 
   return { filterControlFactory, filtersWithValues };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DataMaskStateWithId, Filter } from '@superset-ui/core';
+import {
+  checkIsApplyDisabled,
+  checkIsValidateError,
+  checkIsMissingRequiredValue,
+} from './utils';
+
+describe('FilterBar Utils - Validation and Apply Logic', () => {
+  describe('checkIsValidateError', () => {
+    test('should return true when no filters have validation errors', () => {
+      const dataMask: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {},
+        },
+        'filter-2': {
+          id: 'filter-2',
+          filterState: {
+            validateStatus: undefined,
+            value: ['NY'],
+          },
+          extraFormData: {},
+        },
+      };
+
+      expect(checkIsValidateError(dataMask)).toBe(true);
+    });
+
+    test('should return false when any filter has validation error', () => {
+      const dataMask: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: 'error',
+            value: undefined,
+          },
+          extraFormData: {},
+        },
+        'filter-2': {
+          id: 'filter-2',
+          filterState: {
+            validateStatus: undefined,
+            value: ['NY'],
+          },
+          extraFormData: {},
+        },
+      };
+
+      expect(checkIsValidateError(dataMask)).toBe(false);
+    });
+
+    test('should handle empty dataMask', () => {
+      const dataMask: DataMaskStateWithId = {};
+      expect(checkIsValidateError(dataMask)).toBe(true);
+    });
+
+    test('should handle filters without filterState', () => {
+      const dataMask: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          extraFormData: {},
+        },
+      };
+
+      expect(checkIsValidateError(dataMask)).toBe(true);
+    });
+  });
+
+  describe('checkIsMissingRequiredValue', () => {
+    test('should return true for required filter with undefined value', () => {
+      const filter = {
+        id: 'test-filter',
+        controlValues: {
+          enableEmptyFilter: true,
+        },
+      } as unknown as Filter;
+
+      const filterState = {
+        value: undefined,
+      };
+
+      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+    });
+
+    test('should return true for required filter with null value', () => {
+      const filter = {
+        id: 'test-filter',
+        controlValues: {
+          enableEmptyFilter: true,
+        },
+      } as unknown as Filter;
+
+      const filterState = {
+        value: null,
+      };
+
+      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+    });
+
+    test('should return false for required filter with valid value', () => {
+      const filter = {
+        id: 'test-filter',
+        controlValues: {
+          enableEmptyFilter: true,
+        },
+      } as unknown as Filter;
+
+      const filterState = {
+        value: ['CA'],
+      };
+
+      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
+    });
+
+    test('should return false for non-required filter with undefined value', () => {
+      const filter = {
+        id: 'test-filter',
+        controlValues: {
+          enableEmptyFilter: false,
+        },
+      } as unknown as Filter;
+
+      const filterState = {
+        value: undefined,
+      };
+
+      expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
+    });
+
+    test('should return false for filter without controlValues', () => {
+      const filter = {
+        id: 'test-filter',
+      } as Filter;
+
+      const filterState = {
+        value: undefined,
+      };
+
+      // checkIsMissingRequiredValue returns undefined when controlValues is missing
+      // undefined is falsy, so we check for truthiness instead of exact false
+      expect(checkIsMissingRequiredValue(filter, filterState)).toBeFalsy();
+    });
+  });
+
+  describe('checkIsApplyDisabled', () => {
+    test('should return true when filters have validation errors', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: 'error',
+            value: undefined,
+          },
+          extraFormData: {},
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const filters: Filter[] = [
+        {
+          id: 'filter-1',
+          controlValues: {
+            enableEmptyFilter: true,
+          },
+        } as unknown as Filter,
+      ];
+
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(true);
+    });
+
+    test('should return false when selected and applied states differ', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: ['NY'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['NY'] }],
+          },
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const filters: Filter[] = [
+        {
+          id: 'filter-1',
+          controlValues: {
+            enableEmptyFilter: false,
+          },
+        } as unknown as Filter,
+      ];
+
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(false);
+    });
+
+    test('should return true when selected and applied states are identical', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const filters: Filter[] = [
+        {
+          id: 'filter-1',
+          controlValues: {
+            enableEmptyFilter: false,
+          },
+        } as unknown as Filter,
+      ];
+
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(true);
+    });
+
+    test('should return true when required filter is missing value in selected state', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: undefined,
+          },
+          extraFormData: {},
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const filters: Filter[] = [
+        {
+          id: 'filter-1',
+          controlValues: {
+            enableEmptyFilter: true, // Required filter
+          },
+        } as unknown as Filter,
+      ];
+
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(true);
+    });
+
+    test('should handle filter count mismatch', () => {
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined,
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+        'filter-2': {
+          id: 'filter-2',
+          filterState: {
+            validateStatus: undefined,
+            value: ['Product A'],
+          },
+          extraFormData: {
+            filters: [{ col: 'product', op: 'IN', val: ['Product A'] }],
+          },
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+        // Missing filter-2
+      };
+
+      const filters: Filter[] = [
+        { id: 'filter-1', controlValues: {} } as unknown as Filter,
+        { id: 'filter-2', controlValues: {} } as unknown as Filter,
+      ];
+
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(true);
+    });
+
+    test('should handle validation status recalculation scenario', () => {
+      // Scenario: Filter was required and had error, then user selected value
+      // The validateStatus should be cleared and Apply should be enabled
+
+      const dataMaskSelected: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            validateStatus: undefined, // Error cleared after selection
+            value: ['CA'],
+          },
+          extraFormData: {
+            filters: [{ col: 'state', op: 'IN', val: ['CA'] }],
+          },
+        },
+      };
+
+      const dataMaskApplied: DataMaskStateWithId = {
+        'filter-1': {
+          id: 'filter-1',
+          filterState: {
+            value: undefined, // Previously cleared
+          },
+          extraFormData: {},
+        },
+      };
+
+      const filters: Filter[] = [
+        {
+          id: 'filter-1',
+          controlValues: {
+            enableEmptyFilter: true,
+          },
+        } as unknown as Filter,
+      ];
+
+      // Should be enabled because states differ and no validation errors
+      expect(
+        checkIsApplyDisabled(dataMaskSelected, dataMaskApplied, filters),
+      ).toBe(false);
+    });
+  });
+});

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -131,6 +131,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     parentRef,
     inputRef,
     filterBarOrientation,
+    clearAllTrigger,
+    onClearAllComplete,
   } = props;
   const {
     enableEmptyFilter,
@@ -270,7 +272,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
         updateDataMask(values);
       }
     },
-    [updateDataMask],
+    [updateDataMask, formData.nativeFilterId, clearAllTrigger],
   );
 
   const placeholderText =
@@ -369,6 +371,23 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   useEffect(() => {
     setDataMask(dataMask);
   }, [JSON.stringify(dataMask)]);
+
+  useEffect(() => {
+    if (clearAllTrigger) {
+      dispatchDataMask({
+        type: 'filterState',
+        extraFormData: {},
+        filterState: {
+          value: undefined,
+          label: undefined,
+        },
+      });
+
+      updateDataMask(null);
+      setSearch('');
+      onClearAllComplete?.(formData.nativeFilterId);
+    }
+  }, [clearAllTrigger, onClearAllComplete, updateDataMask]);
 
   useEffect(() => {
     if (prevExcludeFilterValues.current !== excludeFilterValues) {

--- a/superset-frontend/src/filters/components/Select/transformProps.ts
+++ b/superset-frontend/src/filters/components/Select/transformProps.ts
@@ -44,6 +44,8 @@ export default function transformProps(
     setFocusedFilter = noOp,
     unsetFocusedFilter = noOp,
     setFilterActive = noOp,
+    clearAllTrigger,
+    onClearAllComplete,
   } = hooks;
   const [queryData] = queriesData;
   const { colnames = [], coltypes = [], data = [] } = queryData || {};
@@ -71,5 +73,7 @@ export default function transformProps(
     inputRef,
     filterBarOrientation: displaySettings?.filterBarOrientation,
     isOverflowingFilterBar: displaySettings?.isOverflowingFilterBar,
+    clearAllTrigger,
+    onClearAllComplete,
   };
 }

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -65,6 +65,8 @@ export type PluginFilterSelectProps = PluginFilterStylesProps & {
   inputRef?: RefObject<any>;
   filterBarOrientation?: FilterBarOrientation;
   isOverflowingFilterBar?: boolean;
+  clearAllTrigger?: Record<string, boolean>;
+  onClearAllComplete?: (filterId: string) => void;
 } & PluginFilterHooks;
 
 export const DEFAULT_FORM_DATA: PluginFilterSelectCustomizeProps = {


### PR DESCRIPTION
### SUMMARY
This PR fixes a few different things around native filters:
1. Proper red highlighting for required filters.
2. Do not show the Apply button when selecting the same option, as that would remove the filter.
3. Clicking on Apply after Clear All when there's a filter configured to select the first option by default (but it's not required) throws an error. Then, selecting a value would auto-fire the filter change.

This was co-authored with Claude. Feedback always encouraged and appreciated!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Proper red highlighting for required filters**
Before: 

https://github.com/user-attachments/assets/9c9c3604-14ac-4890-a91b-988081c089b1 

After:

https://github.com/user-attachments/assets/ede9a0a9-e56b-41c4-a2b9-6a26cda24b65

**Do not show the Apply button when selecting the same option, as that would remove the filter**
Before:

https://github.com/user-attachments/assets/f47a523b-435c-40c2-88eb-2c22b5f7bc26

After:

https://github.com/user-attachments/assets/c53c8521-01f9-423f-ab03-256bdb1b84c9

**Clicking on Apply after Clear All when there's a filter configured to select the first option by default (but it's not required) throws an error. Then, selecting a value would auto-fire the filter change.**
Before:

https://github.com/user-attachments/assets/46bc27ae-7f53-4323-96ae-8732b52b55c4

After:

https://github.com/user-attachments/assets/d1770f36-d4aa-4349-8f13-5784004a1490

### TESTING INSTRUCTIONS
Some test coverage added. For manual testing, it's possible to replicate the videos and confirm the expected behavior happens.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
