### PR TITLE
fix(database-modal): cant enter commas into input(schemas allowed for file)

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -316,7 +316,11 @@ export function dbReducer(
             ...extraJson,
             schemas_allowed_for_file_upload: (action.payload.value || '')
               .split(',')
-              .filter(schema => schema !== ''),
+              .filter((schema, index, arr) => {
+                const trimmed = schema.trim();
+                if (index === arr.length - 1) return true;
+                return trimmed !== '';
+              }),
           }),
         };
       }

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -316,11 +316,11 @@ export function dbReducer(
             ...extraJson,
             schemas_allowed_for_file_upload: (action.payload.value || '')
               .split(',')
-              .filter((schema, index, arr) => {
-                const trimmed = schema.trim();
-                if (index === arr.length - 1) return true;
-                return trimmed !== '';
-              }),
+              .map(schema => schema.trim())
+              .filter(
+                (schema, index, arr) =>
+                  index === arr.length - 1 || schema !== '',
+              ),
           }),
         };
       }


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The user was not able to inter commas into the input(schemas allowed for file) because the filter function was removing them so I added some logic to check if it is the last comma then it shouldnt be removed.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![Screenshot_20250629_071112](https://github.com/user-attachments/assets/d34cab1d-41d8-4fbe-bf25-242440a72b19)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #28252
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
