### PR TITLE
fix(plugin-chart-echarts): last month doesn't appear on X axis for time series line chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -505,6 +505,7 @@ export default function transformProps(
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
+      showMaxLabel: true,
     },
     minorTick: { show: minorTicks },
     minInterval:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The last month label wasnt visible for the time series line chart so I turned the showMaxLabel config to true.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![Screenshot_20250629_100030](https://github.com/user-attachments/assets/32d65672-80f3-4bbc-8629-fd3fd0653036)

Fixes: https://github.com/apache/superset/issues/25099, https://github.com/apache/superset/issues/33905

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33905
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
