### PR TITLE
fix(dashboard): prevent crash on invalid CSS selectors in CSS templates

### DIFF
--- a/superset-frontend/src/dashboard/components/CssEditor/index.tsx
+++ b/superset-frontend/src/dashboard/components/CssEditor/index.tsx
@@ -103,8 +103,13 @@ class CssEditor extends PureComponent<CssEditorProps, CssEditorState> {
   }
 
   changeCssTemplate(info: { key: Key }) {
-    const keyAsString = String(info.key);
-    this.changeCss(keyAsString);
+    const templateName = String(info.key);
+    const selectedTemplate = this.state.templates?.find(
+      template => template.label === templateName,
+    );
+    if (selectedTemplate) {
+      this.changeCss(selectedTemplate.css);
+    }
   }
 
   renderTemplateSelector() {
@@ -113,7 +118,7 @@ class CssEditor extends PureComponent<CssEditorProps, CssEditorState> {
         <Menu
           onClick={this.changeCssTemplate}
           items={this.state.templates.map(template => ({
-            key: template.css,
+            key: template.label,
             label: template.label,
           }))}
         />

--- a/superset-frontend/src/dashboard/components/CssEditor/index.tsx
+++ b/superset-frontend/src/dashboard/components/CssEditor/index.tsx
@@ -103,9 +103,8 @@ class CssEditor extends PureComponent<CssEditorProps, CssEditorState> {
   }
 
   changeCssTemplate(info: { key: Key }) {
-    const templateName = String(info.key);
     const selectedTemplate = this.state.templates?.find(
-      template => template.label === templateName,
+      template => template.label === info.key,
     );
     if (selectedTemplate) {
       this.changeCss(selectedTemplate.css);


### PR DESCRIPTION
### Summary
This PR fixes a crash in the CSS Template editor where invalid CSS (like malformed selectors) caused a runtime error during querySelector evaluation.

Keys should be simple, stable and unique strings or numbers used for identification.

### Related Issue
Fixes #33970

### Screenshot
[Attach any screenshot or recording if needed]

### Test Plan
- Navigate to a Dashboard → Edit CSS
- Load a CSS Template (even with potentially broken or malformed CSS)
- Expected: App no longer crashes; editor handles input gracefully

### Before/After
Before: Runtime crash  
![image](https://github.com/user-attachments/assets/5c614567-88d8-457c-9ed5-368204c8764b)

After: App gracefully handles invalid CSS; no runtime crash
![image](https://github.com/user-attachments/assets/cb995e79-d4a1-455a-9884-2a4a5f96db99)
