### PR TITLE
fix(explore): Change dataset icon on explore to match datasets view

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -73,6 +73,16 @@ const defaultProps = {
   isEditable: true,
 };
 
+const getDatasetType = datasource => {
+  if (datasource.type === 'query') {
+    return 'query';
+  }
+  if (datasource.type === 'table' && datasource.sql) {
+    return 'virtual_dataset';
+  }
+  return 'physical_dataset';
+};
+
 const Styles = styled.div`
   .data-container {
     display: flex;
@@ -134,10 +144,9 @@ const VISIBLE_TITLE_LENGTH = 25;
 
 // Assign icon for each DatasourceType.  If no icon assignment is found in the lookup, no icon will render
 export const datasourceIconLookup = {
-  [DatasourceType.Query]: (
-    <Icons.ConsoleSqlOutlined className="datasource-svg" />
-  ),
-  [DatasourceType.Table]: <Icons.TableOutlined className="datasource-svg" />,
+  query: <Icons.ConsoleSqlOutlined className="datasource-svg" />,
+  physical_dataset: <Icons.TableOutlined className="datasource-svg" />,
+  virtual_dataset: <Icons.ConsoleSqlOutlined className="datasource-svg" />,
 };
 
 // Render title for datasource with tooltip only if text is longer than VISIBLE_TITLE_LENGTH
@@ -397,7 +406,7 @@ class DatasourceControl extends PureComponent {
     return (
       <Styles data-test="datasource-control" className="DatasourceControl">
         <div className="data-container">
-          {datasourceIconLookup[datasource?.type]}
+          {datasourceIconLookup[getDatasetType(datasource)]}
           {renderDatasourceTitle(titleText, tooltip)}
           {healthCheckMessage && (
             <Tooltip title={healthCheckMessage}>


### PR DESCRIPTION
### SUMMARY
To fix https://github.com/apache/superset/discussions/33366

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before, for a virtual dataset, the icon was different between dataset list and explore :
![image](https://github.com/user-attachments/assets/343aea67-bca6-436b-800a-42e46faa15b4)
![image](https://github.com/user-attachments/assets/736ddbdd-1526-4ef3-a916-17c459d0735c)

After, for a virtual dataset, the icon is the same between dataset list and explore :
![image](https://github.com/user-attachments/assets/343aea67-bca6-436b-800a-42e46faa15b4)
![image](https://github.com/user-attachments/assets/a4d343d5-1f30-417e-96e8-f6cff21aea54)

### TESTING INSTRUCTIONS
Initiate the chart creation from virtual dataset
FEATURE_TAGGING_SYSTEM=true
TAGGING_SYSTEM=true