### PR TITLE
feat(flag): Added feature_flag for superset security_views

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -87,6 +87,10 @@ EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True
 
+# this config is used to enable/disable the folowing security menu items:
+#  List Users, List Roles, List Groups
+SUPERSET_SECURITY_VIEW_MENU = True
+
 BASE_DIR = str(files("superset"))
 if "SUPERSET_HOME" in os.environ:
     DATA_DIR = os.environ["SUPERSET_HOME"]

--- a/superset/config.py
+++ b/superset/config.py
@@ -87,8 +87,8 @@ EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True
 
-# this config is used to enable/disable the folowing security menu items:
-#  List Users, List Roles, List Groups
+# This config is used to enable/disable the folowing security menu items:
+# List Users, List Roles, List Groups
 SUPERSET_SECURITY_VIEW_MENU = True
 
 BASE_DIR = str(files("superset"))

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -287,7 +287,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=__("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 
@@ -307,7 +307,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=__("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 
@@ -318,7 +318,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             category="Security",
             category_label=__("Security"),
             menu_cond=lambda: bool(
-                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+                appbuilder.app.config.get("SUPERSET_SECURITY_VIEW_MENU", True)
             ),
         )
 

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -286,7 +286,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             label=__("List Roles"),
             category="Security",
             category_label=__("Security"),
-            icon="fa-lock",
+            menu_cond=lambda: bool(
+                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+            ),
         )
 
         appbuilder.add_view(
@@ -304,6 +306,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             label=__("List Users"),
             category="Security",
             category_label=__("Security"),
+            menu_cond=lambda: bool(
+                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+            ),
         )
 
         appbuilder.add_view(
@@ -312,6 +317,9 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             label=__("List Groups"),
             category="Security",
             category_label=__("Security"),
+            menu_cond=lambda: bool(
+                appbuilder.app.config["SUPERSET_SECURITY_VIEW_MENU"]
+            ),
         )
 
         appbuilder.add_view(


### PR DESCRIPTION
### SUMMARY

Added feature_flag called `SUPERSET_SECURITY_VIEW_MENU` in order to have more control over the curent views.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="201" alt="image" src="https://github.com/user-attachments/assets/ec288120-5e15-4abf-a5fb-c351ee6b94a2" />

#### AFTER
<img width="210" alt="image" src="https://github.com/user-attachments/assets/0787d162-b8e2-406c-af5e-05782579749b" />

### TESTING INSTRUCTIONS
``` set feature `SUPERSET_SECURITY_VIEW_MENU` to `False` to not have the following views => "List Users", "List Roles", "List Groups" and set feature `SUPERSET_LOG_VIEW` to `False` to not see the "Action Log" view

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
