### PR TITLE
chore: remove some of the deprecated theme.colors.*

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -19830,9 +19830,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "dev": true,
       "funding": [
         {

--- a/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
+++ b/superset-frontend/packages/generator-superset/generators/plugin-chart/templates/src/MyChart.erb
@@ -28,7 +28,7 @@ import { <%= packageLabel %>Props, <%= packageLabel %>StylesProps } from './type
 // https://github.com/apache-superset/superset-ui/blob/master/packages/superset-ui-core/src/theme/index.ts
 
 const Styles = styled.div<<%= packageLabel %>StylesProps>`
-  background-color: ${({ theme }) => theme.colors.primary.light2};
+  background-color: ${({ theme }) => theme.colorPrimaryBg};
   padding: ${({ theme }) => theme.sizeUnit * 4}px;
   border-radius: ${({ theme }) => theme.borderRadius}px;
   height: ${({ height }) => height}px;

--- a/superset-frontend/packages/superset-ui-core/src/components/AutoComplete/AutoComplete.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AutoComplete/AutoComplete.stories.tsx
@@ -165,7 +165,7 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
-    dropdownRender: {
+    popupRender: {
       control: false,
       description:
         'Custom render function for dropdown content. `(menus: ReactNode) => ReactNode`',

--- a/superset-frontend/packages/superset-ui-core/src/components/Collapse/Collapse.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Collapse/Collapse.tsx
@@ -38,7 +38,7 @@ const StyledCollapse = styled((props: CollapseProps) => (
 
       ${({ expandIconPosition }) =>
         expandIconPosition &&
-        expandIconPosition === 'right' &&
+        expandIconPosition === 'end' &&
         `
             .anticon.anticon-right.ant-collapse-arrow > svg {
               transform: rotate(90deg) !important;
@@ -72,7 +72,7 @@ const StyledCollapse = styled((props: CollapseProps) => (
     .ant-collapse-header {
       ${({ expandIconPosition }) =>
         expandIconPosition &&
-        expandIconPosition === 'right' &&
+        expandIconPosition === 'end' &&
         `
             .anticon.anticon-right.ant-collapse-arrow > svg {
               transform: rotate(-90deg) !important;

--- a/superset-frontend/packages/superset-ui-core/src/components/Dropdown/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Dropdown/index.tsx
@@ -89,7 +89,7 @@ export const MenuDotsDropdown = ({
   iconOrientation = IconOrientation.Vertical,
   ...rest
 }: MenuDotsDropdownProps) => (
-  <AntdDropdown dropdownRender={() => overlay} {...rest}>
+  <AntdDropdown popupRender={() => overlay} {...rest}>
     <MenuDotsWrapper data-test="dropdown-trigger">
       {RenderIcon(iconOrientation)}
     </MenuDotsWrapper>

--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
@@ -23,7 +23,7 @@ import { Tooltip } from '../Tooltip';
 import type { DropdownButtonProps } from './types';
 
 export const DropdownButton = ({
-  dropdownRender,
+  popupRender,
   tooltip,
   tooltipPlacement,
   children,
@@ -51,7 +51,7 @@ export const DropdownButton = ({
   `;
   const button = (
     <Dropdown.Button
-      dropdownRender={dropdownRender}
+      popupRender={popupRender}
       {...rest}
       css={[
         defaultBtnCss,

--- a/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/FaveStar/index.tsx
@@ -64,7 +64,7 @@ export const FaveStar = ({
         <Icons.StarFilled
           aria-label="starred"
           iconSize="l"
-          iconColor={theme.colors.warning.base}
+          iconColor={theme.colorWarning}
           name="favorite-selected"
         />
       ) : (

--- a/superset-frontend/packages/superset-ui-core/src/components/Icons/AsyncIcon.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Icons/AsyncIcon.tsx
@@ -25,7 +25,7 @@ import { BaseIconComponent } from './BaseIcon';
 const AsyncIcon = (props: IconType) => {
   const [, setLoaded] = useState(false);
   const ImportedSVG = useRef<FC<SVGProps<SVGSVGElement>>>();
-  const { fileName } = props;
+  const { fileName, ...restProps } = props;
 
   useEffect(() => {
     let cancelled = false;
@@ -46,7 +46,7 @@ const AsyncIcon = (props: IconType) => {
   return (
     <BaseIconComponent
       component={ImportedSVG.current || TransparentIcon}
-      {...props}
+      {...restProps}
     />
   );
 };

--- a/superset-frontend/packages/superset-ui-core/src/components/Icons/BaseIcon.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Icons/BaseIcon.tsx
@@ -43,11 +43,12 @@ export const BaseIconComponent: React.FC<
   iconSize,
   viewBox,
   customIcons,
+  fileName,
   ...rest
 }) => {
   const theme = useTheme();
   const whatRole = rest?.onClick ? 'button' : 'img';
-  const ariaLabel = genAriaLabel(rest.fileName || '');
+  const ariaLabel = genAriaLabel(fileName || '');
   const style = {
     color: iconColor,
     fontSize: iconSize

--- a/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
@@ -37,7 +37,7 @@ export const DatasetTypeLabel: React.FC<DatasetTypeLabelProps> = ({
     datasetType === 'physical' ? (
       <Icons.InsertRowAboveOutlined
         iconSize={SIZE}
-        iconColor={theme.colors.primary.dark1}
+        iconColor={theme.colorPrimary}
       />
     ) : (
       <Icons.ConsoleSqlOutlined iconSize={SIZE} />

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -214,7 +214,7 @@ const CustomModal = ({
   resizable = false,
   resizableConfig = defaultResizableConfig(hideFooter),
   draggableConfig,
-  destroyOnClose,
+  destroyOnHidden,
   openerRef,
   ...rest
 }: ModalProps) => {
@@ -344,7 +344,7 @@ const CustomModal = ({
       mask={shouldShowMask}
       draggable={draggable}
       resizable={resizable}
-      destroyOnClose={destroyOnClose}
+      destroyOnHidden={destroyOnHidden}
       {...rest}
     >
       {children}

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/types.ts
@@ -47,7 +47,7 @@ export interface ModalProps {
   resizableConfig?: ResizableProps;
   draggable?: boolean;
   draggableConfig?: DraggableProps;
-  destroyOnClose?: boolean;
+  destroyOnHidden?: boolean;
   maskClosable?: boolean;
   zIndex?: number;
   bodyStyle?: CSSProperties;

--- a/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ModalTrigger/index.tsx
@@ -39,7 +39,7 @@ export interface ModalTriggerProps {
   resizableConfig?: any;
   draggable?: boolean;
   draggableConfig?: any;
-  destroyOnClose?: boolean;
+  destroyOnHidden?: boolean;
 }
 
 export interface ModalTriggerRef {
@@ -63,7 +63,7 @@ export const ModalTrigger = forwardRef(
       tooltip,
       modalFooter,
       triggerNode,
-      destroyOnClose = true,
+      destroyOnHidden = true,
       modalBody,
       draggableConfig = {},
       resizableConfig = {},
@@ -120,7 +120,7 @@ export const ModalTrigger = forwardRef(
           resizableConfig={resizableConfig}
           draggable={draggable}
           draggableConfig={draggableConfig}
-          destroyOnClose={destroyOnClose}
+          destroyOnHidden={destroyOnHidden}
         >
           {modalBody}
         </Modal>

--- a/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
@@ -151,7 +151,7 @@ export const PageHeaderWithActions = ({
           {showMenuDropdown && (
             <Dropdown
               trigger={['click']}
-              dropdownRender={() => additionalActionsMenu}
+              popupRender={() => additionalActionsMenu}
               {...menuDropdownProps}
             >
               <Button

--- a/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PageHeaderWithActions/index.tsx
@@ -34,7 +34,7 @@ export const menuTriggerStyles = (theme: SupersetTheme) => css`
   width: ${theme.sizeUnit * 8}px;
   height: ${theme.sizeUnit * 8}px;
   padding: 0;
-  border: 1px solid ${theme.colors.primary.dark2};
+  border: 1px solid ${theme.colorPrimary};
 
   &.ant-btn > span.anticon {
     line-height: 0;
@@ -163,7 +163,7 @@ export const PageHeaderWithActions = ({
                 data-test="actions-trigger"
               >
                 <Icons.EllipsisOutlined
-                  iconColor={theme.colors.primary.dark2}
+                  iconColor={theme.colorPrimary}
                   iconSize="l"
                 />
               </Button>

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -446,7 +446,7 @@ const AsyncSelect = forwardRef(
       }
     };
 
-    const dropdownRender = (
+    const popupRender = (
       originNode: ReactElement & { ref?: RefObject<HTMLElement> },
     ) =>
       dropDownRenderHelper(
@@ -605,7 +605,7 @@ const AsyncSelect = forwardRef(
           }
           data-test={ariaLabel || name}
           autoClearSearchValue={autoClearSearchValue}
-          dropdownRender={dropdownRender}
+          popupRender={popupRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}
           getPopupContainer={

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -129,7 +129,7 @@ const AsyncSelect = forwardRef(
       onError,
       onChange,
       onClear,
-      onDropdownVisibleChange,
+      onOpenChange,
       onDeselect,
       onSearch,
       onSelect,
@@ -441,8 +441,8 @@ const AsyncSelect = forwardRef(
         }
       }
 
-      if (onDropdownVisibleChange) {
-        onDropdownVisibleChange(isDropdownVisible);
+      if (onOpenChange) {
+        onOpenChange(isDropdownVisible);
       }
     };
 
@@ -618,7 +618,7 @@ const AsyncSelect = forwardRef(
           notFoundContent={isLoading ? t('Loading...') : notFoundContent}
           onBlur={handleOnBlur}
           onDeselect={handleOnDeselect}
-          onDropdownVisibleChange={handleOnDropdownVisibleChange}
+          onOpenChange={handleOnDropdownVisibleChange}
           // @ts-ignore
           onPaste={onPaste}
           onPopupScroll={handlePagination}

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -492,7 +492,7 @@ const Select = forwardRef(
       ],
     );
 
-    const dropdownRender = (
+    const popupRender = (
       originNode: ReactElement & { ref?: RefObject<HTMLElement> },
     ) =>
       dropDownRenderHelper(
@@ -694,7 +694,7 @@ const Select = forwardRef(
           }
           data-test={ariaLabel || name}
           autoClearSearchValue={autoClearSearchValue}
-          dropdownRender={dropdownRender}
+          popupRender={popupRender}
           filterOption={handleFilterOption}
           filterSort={sortComparatorWithSearch}
           getPopupContainer={

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -104,7 +104,7 @@ const Select = forwardRef(
       onBlur,
       onChange,
       onClear,
-      onDropdownVisibleChange,
+      onOpenChange,
       onDeselect,
       onSearch,
       onSelect,
@@ -398,8 +398,8 @@ const Select = forwardRef(
       if (!isDropdownVisible) {
         setSelectOptions(initialOptionsSorted);
       }
-      if (onDropdownVisibleChange) {
-        onDropdownVisibleChange(isDropdownVisible);
+      if (onOpenChange) {
+        onOpenChange(isDropdownVisible);
       }
     };
 
@@ -708,7 +708,7 @@ const Select = forwardRef(
           notFoundContent={isLoading ? t('Loading...') : notFoundContent}
           onBlur={handleOnBlur}
           onDeselect={handleOnDeselect}
-          onDropdownVisibleChange={handleOnDropdownVisibleChange}
+          onOpenChange={handleOnDropdownVisibleChange}
           // @ts-ignore
           onPaste={onPaste}
           onPopupScroll={undefined}

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
@@ -45,7 +45,7 @@ export const StyledSelect = styled(Select, {
 })<{ headerPosition?: string; oneLine?: boolean }>`
   ${({ theme, headerPosition, oneLine }) => `
     .ant-select-item-option-active:not(.ant-select-item-option-disabled) {
-      outline: 2px solid ${theme.colors.primary.base};
+      outline: 2px solid ${theme.colorPrimary};
       outline-offset: -2px;
     }
     flex: ${headerPosition === 'left' ? 1 : 0};

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
@@ -95,7 +95,7 @@ export interface BaseSelectProps extends AntdExposedProps {
   /**
    * Renders the dropdown
    */
-  dropdownRender?: (
+  popupRender?: (
     menu: ReactElement<any, string | JSXElementConstructor<any>>,
   ) => ReactElement<any, string | JSXElementConstructor<any>>;
   /**

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
@@ -62,7 +62,7 @@ export type AntdExposedProps = Pick<
   | 'onBlur'
   | 'onPopupScroll'
   | 'onSearch'
-  | 'onDropdownVisibleChange'
+  | 'onOpenChange'
   | 'optionRender'
   | 'placeholder'
   | 'showArrow'

--- a/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/UnsavedChangesModal/index.tsx
@@ -57,7 +57,7 @@ const StyledSaveBtn = styled(Button)`
 
 const StyledWarningIcon = styled(Icons.WarningOutlined)`
   ${({ theme }) => css`
-    color: ${theme.colors.warning.base};
+    color: ${theme.colorWarning};
     margin-right: ${theme.sizeUnit * 4}px;
   `}
 `;

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/MockChartPlugins.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/MockChartPlugins.tsx
@@ -51,8 +51,8 @@ export const TestComponent = ({
       style={{
         width,
         height,
-        backgroundColor: theme.colors.primary.light5,
-        color: theme.colors.grayscale.light3,
+        backgroundColor: theme.colorPrimaryBg,
+        color: theme.colorTextSecondary,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
@@ -66,7 +66,7 @@ export const TestComponent = ({
         {[width, height].join('x')}
       </div>
       <div className="formData" style={{ padding: 10 }}>
-        <code style={{ color: theme.colors.primary.light2 }}>
+        <code style={{ color: theme.colorTextSecondary }}>
           {JSON.stringify(formData)}
         </code>
       </div>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/PopKPI.tsx
@@ -202,10 +202,8 @@ export default function PopKPI(props: PopKPIProps) {
           comparisonColorScheme === ColorSchemeEnum.Red);
 
       // Set background and text colors based on the conditions
-      bgColor = useSuccess
-        ? theme.colors.success.light2
-        : theme.colors.error.light2;
-      txtColor = useSuccess ? theme.colorSuccess : theme.colorError;
+      bgColor = useSuccess ? theme.colorSuccessBg : theme.colorErrorBg;
+      txtColor = useSuccess ? theme.colorSuccessText : theme.colorErrorText;
     }
 
     return {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -89,7 +89,7 @@ export const Styles = styled.div`
     }
 
     table.pvtTable tr th.active {
-      background-color: ${theme.colors.primary.light3};
+      background-color: ${theme.colorPrimaryBg};
     }
 
     table.pvtTable .pvtTotalLabel {
@@ -102,7 +102,7 @@ export const Styles = styled.div`
     }
 
     table.pvtTable tbody tr td {
-      color: ${theme.colors.primary.dark2};
+      color: ${theme.colorPrimaryText};
       padding: ${theme.sizeUnit}px;
       background-color: ${theme.colors.grayscale.light5};
       border-top: 1px solid ${theme.colors.grayscale.light2};
@@ -138,7 +138,7 @@ export const Styles = styled.div`
     }
 
     .hoverable:hover {
-      background-color: ${theme.colors.primary.light4};
+      background-color: ${theme.colorPrimaryBgHover};
       cursor: pointer;
     }
   `}

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/index.tsx
@@ -71,7 +71,7 @@ const QueryLimitSelect = ({
 
   return (
     <Dropdown
-      dropdownRender={() => renderQueryLimit(maxRow, setQueryLimit)}
+      popupRender={() => renderQueryLimit(maxRow, setQueryLimit)}
       trigger={['click']}
     >
       <Button size="small" showMarginRight={false} buttonStyle="link">

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -222,7 +222,7 @@ const QueryTable = ({
         config: {
           icon: (
             <Icons.LoadingOutlined
-              iconColor={theme.colors.primary.base}
+              iconColor={theme.colorPrimary}
               iconSize="m"
             />
           ),
@@ -272,7 +272,7 @@ const QueryTable = ({
             buttonStyle="link"
             onClick={() => openQuery(q.queryId)}
           >
-            <Icons.Full iconSize="m" iconColor={theme.colors.primary.dark1} />
+            <Icons.Full iconSize="m" iconColor={theme.colorPrimary} />
             {t('Edit')}
           </Button>
         );

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -48,7 +48,7 @@ const buildText = (
   if (shouldShowStopButton) {
     return (
       <>
-        <Icons.Square iconSize="xs" iconColor={theme.colors.primary.light5} />
+        <Icons.Square iconSize="xs" iconColor={theme.colorIcon} />
         {t('Stop')}
       </>
     );

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -38,7 +38,7 @@ const SaveDatasetActionButton = ({
   ) : (
     <DropdownButton
       onClick={() => setShowSave(true)}
-      dropdownRender={() => overlayMenu}
+      popupRender={() => overlayMenu}
       icon={
         <Icons.DownOutlined iconSize="xs" iconColor={theme.colorPrimaryText} />
       }

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -892,7 +892,7 @@ const SqlEditor: FC<Props> = ({
                 <ShareSqlLabQuery queryEditorId={queryEditor.id} />
               </span>
               <Dropdown
-                dropdownRender={() => renderDropdown()}
+                popupRender={() => renderDropdown()}
                 trigger={['click']}
               >
                 <Button

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/index.tsx
@@ -114,15 +114,15 @@ const SqlEditorTabHeader: FC<Props> = ({ queryEditor }) => {
   }
   const getStatusColor = (state: QueryState, theme: SupersetTheme): string => {
     const statusColors: Record<QueryState, string> = {
-      [QueryState.Running]: theme.colors.info.base,
-      [QueryState.Success]: theme.colors.success.base,
-      [QueryState.Failed]: theme.colors.error.base,
-      [QueryState.Started]: theme.colors.primary.base,
-      [QueryState.Stopped]: theme.colors.warning.base,
-      [QueryState.Pending]: theme.colors.grayscale.light1,
-      [QueryState.Scheduled]: theme.colors.grayscale.light2,
+      [QueryState.Running]: theme.colorInfo,
+      [QueryState.Success]: theme.colorSuccess,
+      [QueryState.Failed]: theme.colorError,
+      [QueryState.Started]: theme.colorPrimary,
+      [QueryState.Stopped]: theme.colorWarning,
+      [QueryState.Pending]: theme.colorIcon,
+      [QueryState.Scheduled]: theme.colorIcon,
       [QueryState.Fetching]: theme.colorWarning,
-      [QueryState.TimedOut]: theme.colors.error.dark1,
+      [QueryState.TimedOut]: theme.colorError,
     };
 
     return statusColors[state] || theme.colors.grayscale.light2;

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -378,7 +378,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
   return (
     <Collapse
       activeKey={props.activeKey}
-      expandIconPosition="right"
+      expandIconPosition="end"
       onChange={props.onChange}
       ghost
       items={[

--- a/superset-frontend/src/SqlLab/components/TableElement/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TableElement/index.tsx
@@ -231,7 +231,7 @@ const TableElement = ({ table, ...props }: TableElementProps) => {
             >
               <Icons.TableOutlined
                 iconSize="m"
-                iconColor={theme.colors.primary.dark2}
+                iconColor={theme.colorPrimary}
               />
             </IconTooltip>
           }

--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -317,7 +317,7 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
         <Icons.InsertRowAboveOutlined iconSize="l" />
         {tableName}
         <Dropdown
-          dropdownRender={() => (
+          popupRender={() => (
             <Menu
               onClick={({ key }) => {
                 if (key === 'refresh-table') {

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -304,7 +304,7 @@ const ChartContextMenu = (
   return ReactDOM.createPortal(
     <>
       <Dropdown
-        dropdownRender={() => (
+        popupRender={() => (
           <Menu
             className="chart-context-menu"
             data-test="chart-context-menu"

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -480,7 +480,7 @@ export default function DrillByModal({
         },
       }}
       draggable
-      destroyOnClose
+      destroyOnHidden
       maskClosable={false}
     >
       <Flex

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -137,7 +137,7 @@ export default function DrillDetailModal({
         },
       }}
       draggable
-      destroyOnClose
+      destroyOnHidden
       maskClosable={false}
     >
       <DrillDetailPane formData={formData} initialFilters={initialFilters} />

--- a/superset-frontend/src/components/Datasource/ChangeDatasourceModal.tsx
+++ b/superset-frontend/src/components/Datasource/ChangeDatasourceModal.tsx
@@ -90,7 +90,7 @@ const StyledSpan = styled.span`
   cursor: pointer;
   color: ${({ theme }) => theme.colorPrimaryText};
   &: hover {
-    color: ${({ theme }) => theme.colors.primary.dark2};
+    color: ${({ theme }) => theme.colorPrimaryTextActive};
   }
 `;
 

--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -1100,7 +1100,7 @@ class DatasourceEditor extends PureComponent {
             display: block;
             margin: ${theme.sizeUnit * 4}px auto;
             width: fit-content;
-            color: ${theme.colors.grayscale.base};
+            color: ${theme.colorText};
           `}
         >
           {t('We are working on your query')}
@@ -1116,9 +1116,7 @@ class DatasourceEditor extends PureComponent {
         target="_blank"
         rel="noopener noreferrer"
         css={theme => css`
-          color: ${isError
-            ? theme.colors.error.base
-            : theme.colors.grayscale.base};
+          color: ${isError ? theme.colorErrorText : theme.colorText};
           font-size: ${theme.fontSizeSM}px;
           text-decoration: underline;
         `}
@@ -1359,7 +1357,7 @@ class DatasourceEditor extends PureComponent {
                           <Icons.CaretRightFilled
                             iconSize="s"
                             css={theme => ({
-                              color: theme.colors.grayscale.light5,
+                              color: theme.colorIcon,
                             })}
                           />
                         </Button>
@@ -1375,7 +1373,7 @@ class DatasourceEditor extends PureComponent {
                       >
                         <span
                           css={theme => css`
-                            color: ${theme.colors.grayscale.base};
+                            color: ${theme.colorText};
                             font-size: ${theme.fontSizeSM}px;
                           `}
                         >
@@ -1386,7 +1384,7 @@ class DatasourceEditor extends PureComponent {
                         {this.renderOpenInSqlLabLink()}
                         <span
                           css={theme => css`
-                            color: ${theme.colors.grayscale.base};
+                            color: ${theme.colorText};
                             font-size: ${theme.fontSizeSM}px;
                           `}
                         >

--- a/superset-frontend/src/components/ErrorMessage/IssueCode.tsx
+++ b/superset-frontend/src/components/ErrorMessage/IssueCode.tsx
@@ -35,7 +35,7 @@ export function IssueCode({ code, message }: IssueCodeProps) {
         target="_blank"
         aria-label="Superset docs link"
       >
-        <Icons.Full iconSize="m" iconColor={theme.colors.primary.dark1} />
+        <Icons.Full iconSize="m" iconColor={theme.colorPrimary} />
       </a>
     </>
   );

--- a/superset-frontend/src/components/GridTable/Header.tsx
+++ b/superset-frontend/src/components/GridTable/Header.tsx
@@ -156,13 +156,13 @@ export const Header: React.FC<Params> = ({
                 {currentSort === 'asc' && (
                   <Icons.SortAsc
                     iconSize="xxl"
-                    iconColor={theme.colors.primary.base}
+                    iconColor={theme.colorPrimary}
                   />
                 )}
                 {currentSort === 'desc' && (
                   <Icons.SortDesc
                     iconSize="xxl"
-                    iconColor={theme.colors.primary.base}
+                    iconColor={theme.colorPrimary}
                   />
                 )}
               </IconPlaceholder>

--- a/superset-frontend/src/components/ListView/Filters/NumericalRange.tsx
+++ b/superset-frontend/src/components/ListView/Filters/NumericalRange.tsx
@@ -33,13 +33,13 @@ const InputContainer = styled.div`
 
 const StyledDivider = styled.span`
   margin: 0 ${({ theme }) => theme.sizeUnit * 2}px;
-  color: ${({ theme }) => theme.colors.grayscale.base};
+  color: ${({ theme }) => theme.colorText};
   font-weight: ${({ theme }) => theme.fontWeightNormal};
   font-size: ${({ theme }) => theme.fontSize}px;
 `;
 
 const ErrorMessage = styled.div`
-  color: ${({ theme }) => theme.colors.error.base};
+  color: ${({ theme }) => theme.colorErrorText};
   font-size: ${({ theme }) => theme.fontSizeSM}px;
   font-weight: ${({ theme }) => theme.fontWeightNormal};
   position: absolute;

--- a/superset-frontend/src/dashboard/components/CssEditor/index.tsx
+++ b/superset-frontend/src/dashboard/components/CssEditor/index.tsx
@@ -123,7 +123,7 @@ class CssEditor extends PureComponent<CssEditorProps, CssEditorState> {
         />
       );
       return (
-        <Dropdown dropdownRender={() => menu} placement="bottomRight">
+        <Dropdown popupRender={() => menu} placement="bottomRight">
           <Button>{t('Load a CSS template')}</Button>
         </Dropdown>
       );

--- a/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/index.tsx
@@ -78,7 +78,7 @@ const StyledFilterCount = styled.div`
       font-size: ${theme.fontSizeSM}px;
     }
     &:focus-visible {
-      outline: 2px solid ${theme.colors.primary.dark2};
+      outline: 2px solid ${theme.colorPrimary};
     }
   `}
 `;

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -103,7 +103,7 @@ const headerContainerStyle = theme => css`
 `;
 
 const editButtonStyle = theme => css`
-  color: ${theme.colors.primary.dark2};
+  color: ${theme.colorPrimary};
 `;
 
 const actionButtonsStyle = theme => css`

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/ViewResultsModalTrigger.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/ViewResultsModalTrigger.tsx
@@ -59,7 +59,7 @@ export const ViewResultsModalTrigger = ({
         },
       }}
       draggable
-      destroyOnClose
+      destroyOnHidden
       modalFooter={
         <>
           <Button

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -508,7 +508,7 @@ const SliceHeaderControls = (
         />
       )}
       <NoAnimationDropdown
-        dropdownRender={() => menu}
+        popupRender={() => menu}
         overlayStyle={dropdownOverlayStyle}
         trigger={['click']}
         placement="bottomRight"

--- a/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
+++ b/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
@@ -95,18 +95,12 @@ export default function URLShortLinkButton({
           <CopyToClipboard
             text={shortUrl}
             copyNode={
-              <Icons.CopyOutlined
-                iconSize="m"
-                iconColor={theme.colors.primary.dark1}
-              />
+              <Icons.CopyOutlined iconSize="m" iconColor={theme.colorPrimary} />
             }
           />
           &nbsp;&nbsp;
           <Typography.Link href={emailLink} aria-label="Email link">
-            <Icons.MailOutlined
-              iconSize="m"
-              iconColor={theme.colors.primary.dark1}
-            />
+            <Icons.MailOutlined iconSize="m" iconColor={theme.colorPrimary} />
           </Typography.Link>
         </div>
       }

--- a/superset-frontend/src/dashboard/components/filterscope/FilterScope.test.tsx
+++ b/superset-frontend/src/dashboard/components/filterscope/FilterScope.test.tsx
@@ -168,7 +168,7 @@ function getCheckboxState(name: string): CheckboxState {
   const element = screen.getByRole('link', { name });
   const svgPath = getCheckboxIcon(element).children[1].children[0].children[0];
   const fill = svgPath.getAttribute('fill');
-  return fill === supersetTheme.colors.primary.base
+  return fill === supersetTheme.colorPrimary
     ? CHECKED
     : fill === supersetTheme.colors.grayscale.light1
       ? INDETERMINATE

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingModal.tsx
@@ -312,7 +312,7 @@ export const ScopingModal = ({
       onHandledPrimaryAction={saveScoping}
       primaryButtonName={t('Save')}
       responsive
-      destroyOnClose
+      destroyOnHidden
       bodyStyle={{
         padding: 0,
         height: 700,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/VerticalCollapse.tsx
@@ -48,7 +48,7 @@ const CrossFiltersVerticalCollapse = (props: {
     <Collapse
       ghost
       defaultActiveKey="crossFilters"
-      expandIconPosition="right"
+      expandIconPosition="end"
       items={[
         {
           key: 'crossFilters',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
@@ -199,7 +199,7 @@ const FilterBarSettings = () => {
                 {selectedFilterBarOrientation ===
                   FilterBarOrientation.Vertical && (
                   <Icons.CheckOutlined
-                    iconColor={theme.colors.primary.base}
+                    iconColor={theme.colorPrimary}
                     css={css`
                       vertical-align: -${theme.sizeUnit * 0.03125}em;
                     `}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FiltersOutOfScopeCollapsible/index.tsx
@@ -34,7 +34,7 @@ export const FiltersOutOfScopeCollapsible = ({
   <Collapse
     ghost
     bordered
-    expandIconPosition="right"
+    expandIconPosition="end"
     collapsible={filtersOutOfScope.length === 0 ? 'disabled' : undefined}
     items={[
       {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -211,7 +211,7 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
               marginBottom: `${theme.sizeUnit * 3}px`,
             }}
             className="collapse-icon"
-            iconColor={theme.colors.primary.base}
+            iconColor={theme.colorPrimary}
             {...getFilterBarTestId('expand-button')}
           />
           <Icons.FilterOutlined

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
@@ -106,10 +106,7 @@ const FilterTitlePane: FC<Props> = ({
           buttonSize="default"
           buttonStyle="secondary"
           icon={
-            <Icons.FilterOutlined
-              iconColor={theme.colors.primary.dark1}
-              iconSize="m"
-            />
+            <Icons.FilterOutlined iconColor={theme.colorPrimary} iconSize="m" />
           }
           data-test="add-new-filter-button"
           onClick={() => handleOnAdd(NativeFilterType.NativeFilter)}
@@ -121,7 +118,7 @@ const FilterTitlePane: FC<Props> = ({
           buttonStyle="secondary"
           icon={
             <Icons.PicCenterOutlined
-              iconColor={theme.colors.primary.dark1}
+              iconColor={theme.colorPrimary}
               iconSize="m"
             />
           }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -899,7 +899,7 @@ const FiltersConfigForm = (
                   onChange={key => {
                     handleActiveFilterPanelChange(key);
                   }}
-                  expandIconPosition="right"
+                  expandIconPosition="end"
                   key={`native-filter-config-${filterId}`}
                   items={[
                     ...(formFilter?.filterType !== 'filter_time'

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1396,9 +1396,7 @@ const FiltersConfigForm = (
                                         >
                                           <Icons.SyncOutlined
                                             iconSize="xl"
-                                            iconColor={
-                                              theme.colors.primary.base
-                                            }
+                                            iconColor={theme.colorPrimary}
                                             css={css`
                                               margin-left: ${theme.sizeUnit *
                                               2}px;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -716,7 +716,7 @@ function FiltersConfigModal({
       maskClosable={false}
       title={t('Add and edit filters')}
       expanded={expanded}
-      destroyOnClose
+      destroyOnHidden
       onCancel={handleCancel}
       onOk={handleSave}
       centered

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -739,7 +739,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
                 {showDatasourceAlert && <DatasourceAlert />}
                 <Collapse
                   defaultActiveKey={expandedQuerySections}
-                  expandIconPosition="right"
+                  expandIconPosition="end"
                   ghost
                   bordered
                   items={[...querySections.map(renderControlPanelSection)]}
@@ -755,7 +755,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
                   children: (
                     <Collapse
                       defaultActiveKey={expandedCustomizeSections}
-                      expandIconPosition="right"
+                      expandIconPosition="end"
                       ghost
                       bordered
                       items={[

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -61,7 +61,7 @@ const propTypes = {
 };
 
 const saveButtonStyles = theme => css`
-  color: ${theme.colors.primary.dark2};
+  color: ${theme.colorPrimaryText};
   & > span[role='img'] {
     margin-right: 0;
   }

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -650,7 +650,7 @@ function ExploreViewContainer(props) {
                   transform: rotate(-90deg);
                 `}
                 className="collapse-icon"
-                iconColor={theme.colors.primary.base}
+                iconColor={theme.colorPrimary}
               />
             </span>
           </div>
@@ -679,7 +679,7 @@ function ExploreViewContainer(props) {
                     transform: rotate(90deg);
                   `}
                   className="collapse-icon"
-                  iconColor={theme.colors.primary.base}
+                  iconColor={theme.colorPrimary}
                 />
               </Tooltip>
             </span>

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
@@ -115,7 +115,7 @@ const Label = ({
         {label}{' '}
         <Tooltip title={alertTitle}>
           <Icons.WarningOutlined
-            iconColor={theme.colors.warning.base}
+            iconColor={theme.colorWarning}
             css={css`
               vertical-align: baseline;
             `}

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -431,7 +431,7 @@ class DatasourceControl extends PureComponent {
             data-test="datasource-menu"
           >
             <Icons.MoreOutlined
-              IconSize="xl"
+              iconSize="xl"
               iconColor={theme.colorPrimary}
               className="datasource-modal-trigger"
               data-test="datasource-menu-trigger"

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -432,7 +432,7 @@ class DatasourceControl extends PureComponent {
           >
             <Icons.MoreOutlined
               IconSize="xl"
-              iconColor={theme.colors.primary.base}
+              iconColor={theme.colorPrimary}
               className="datasource-modal-trigger"
               data-test="datasource-menu-trigger"
             />

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -422,7 +422,7 @@ class DatasourceControl extends PureComponent {
             <WarningIconWithTooltip warningMarkdown={extra.warning_markdown} />
           )}
           <Dropdown
-            dropdownRender={() =>
+            popupRender={() =>
               datasource.type === DatasourceType.Query
                 ? queryDatasourceMenu
                 : defaultDatasourceMenu

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelectPopoverTitle.jsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelectPopoverTitle.jsx
@@ -94,9 +94,7 @@ export const DndColumnSelectPopoverTitle = ({
         {title || defaultLabel}
         &nbsp;
         <Icons.EditOutlined
-          iconColor={
-            isHovered ? theme.colors.primary.base : theme.colors.grayscale.base
-          }
+          iconColor={isHovered ? theme.colorPrimary : theme.colorText}
           iconSize="m"
         />
       </span>

--- a/superset-frontend/src/explore/components/controls/MapViewControl/MapViewPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/MapViewControl/MapViewPopoverContent.tsx
@@ -19,7 +19,6 @@
 import { css, styled, t } from '@superset-ui/core';
 import { Button, Form } from '@superset-ui/core/components';
 import { FC, useEffect, useState } from 'react';
-import { mix } from 'polished';
 import { MapViewConfigs, MapViewPopoverContentProps } from './types';
 import { ControlFormItem } from '../ColumnConfigControl/ControlForm';
 
@@ -28,61 +27,10 @@ export const StyledButtonContainer = styled.div`
   margin: 8px;
 `;
 
-export const StyledCloseButton = styled(Button)`
-  ${({ theme }) => css`
-    flex: 1;
-    margin-right: 4px;
-    line-height: 1.5715;
-    border-radius: ${theme.borderRadius}px;
-    background-color: ${theme.colors.primary.light4};
-    color: ${theme.colorPrimaryText};
-    font-size: ${theme.fontSizeSM}px;
-    font-weight: ${theme.fontWeightStrong};
-    text-transform: uppercase;
-    min-width: ${theme.sizeUnit * 36};
-    min-height: ${theme.sizeUnit * 8};
-    box-shadow: none;
-    border-width: 0px;
-    border-style: none;
-    border-color: transparent;
-    &:hover {
-      background-color: ${mix(
-        0.1,
-        theme.colorPrimary,
-        theme.colors.primary.light4,
-      )};
-      color: ${theme.colorPrimaryText};
-    }
-  `}
-`;
-
 export const StyledControlNumberFormItem = styled(ControlFormItem)`
   ${({ theme }) => css`
     border-radius: ${theme.borderRadius}px;
     width: 100%;
-  `}
-`;
-
-export const StyledSaveButton = styled(Button)`
-  ${({ theme }) => css`
-    flex: 1;
-    margin-left: 4px;
-    line-height: 1.5715;
-    border-radius: ${theme.borderRadius}px;
-    background-color: ${theme.colorPrimary};
-    color: ${theme.colors.grayscale.light5};
-    font-size: ${theme.fontSizeSM}px;
-    font-weight: ${theme.fontWeightStrong};
-    text-transform: uppercase;
-    min-width: ${theme.sizeUnit * 36};
-    min-height: ${theme.sizeUnit * 8};
-    box-shadow: none;
-    border-width: 0px;
-    border-style: none;
-    border-color: transparent;
-    &:hover {
-      background-color: ${theme.colorPrimaryText};
-    }
   `}
 `;
 
@@ -185,12 +133,12 @@ export const MapViewPopoverContent: FC<MapViewPopoverContentProps> = ({
           max={180}
         />
         <StyledButtonContainer>
-          <StyledCloseButton type="default" onClick={onCloseClick}>
+          <Button buttonStyle="secondary" onClick={onCloseClick}>
             {closeButtonText}
-          </StyledCloseButton>
-          <StyledSaveButton type="primary" onClick={onSaveClick}>
+          </Button>
+          <Button buttonStyle="primary" onClick={onSaveClick}>
             {saveButtonText}
-          </StyledSaveButton>
+          </Button>
         </StyledButtonContainer>
       </Form>
     </div>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopoverTitle.tsx
@@ -123,7 +123,7 @@ const AdhocMetricEditPopoverTitle: FC<AdhocMetricEditPopoverTitleProps> = ({
         &nbsp;
         <Icons.EditOutlined
           iconColor={
-            isHovered ? theme.colors.primary.base : theme.colors.grayscale.base
+            isHovered ? theme.colorPrimary : theme.colors.grayscale.base
           }
           iconSize="m"
         />

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -697,7 +697,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
           onClick={clickSelector}
         />
         <Collapse
-          expandIconPosition="right"
+          expandIconPosition="end"
           ghost
           defaultActiveKey={Sections.Category}
           items={Object.keys(sectionMap).map(sectionId => {

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -93,7 +93,7 @@ export const MenuTrigger = styled(Button)`
     width: ${theme.sizeUnit * 8}px;
     height: ${theme.sizeUnit * 8}px;
     padding: 0;
-    border: 1px solid ${theme.colors.primary.dark2};
+    border: 1px solid ${theme.colorPrimary};
 
     &.ant-btn > span.anticon {
       line-height: 0;
@@ -101,7 +101,7 @@ export const MenuTrigger = styled(Button)`
     }
 
     &:hover:not(:focus) > span.anticon {
-      color: ${theme.colors.primary.light1};
+      color: ${theme.colorPrimary};
     }
   `}
 `;

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -387,7 +387,7 @@ export const useExploreAdditionalActionsMenu = (
                   />
                 }
                 maxWidth={`${theme.sizeUnit * 100}px`}
-                destroyOnClose
+                destroyOnHidden
                 responsive
               />
             </Menu.Item>

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1461,7 +1461,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       }
     >
       <Collapse
-        expandIconPosition="right"
+        expandIconPosition="end"
         defaultActiveKey="general"
         accordion
         modalMode

--- a/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
+++ b/superset-frontend/src/features/cssTemplates/CssTemplateModal.tsx
@@ -65,7 +65,7 @@ const TemplateContainer = styled.div(
 
     .required {
       margin-left: ${theme.sizeUnit / 2}px;
-      color: ${theme.colors.error.base};
+      color: ${theme.colorErrorText};
     }
 
     input[type='text'] {

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -91,7 +91,7 @@ const ExtraOptions = ({
 
   return (
     <Collapse
-      expandIconPosition="right"
+      expandIconPosition="end"
       accordion
       modalMode
       items={[

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -50,10 +50,9 @@ const columnarProps = {
   type: 'columnar',
 };
 
-beforeEach(() => {
+// Helper function to setup common mocks
+const setupMocks = () => {
   fetchMock.post('glob:*api/v1/database/1/upload/', {});
-
-  // 4 mocks below are not necessary
   fetchMock.post('glob:*api/v1/database/csv_metadata/', {});
   fetchMock.post('glob:*api/v1/database/excel_metadata/', {});
   fetchMock.post('glob:*api/v1/database/columnar_metadata/', {});
@@ -86,803 +85,516 @@ beforeEach(() => {
   fetchMock.get('glob:*api/v1/database/2/schemas/?q=(upload_allowed:!t)', {
     result: ['schema1', 'schema2'],
   });
+};
+
+// Set timeout for all tests in this file to 30 seconds
+jest.setTimeout(30000);
+
+beforeEach(() => {
+  setupMocks();
 });
 
 afterEach(() => {
   fetchMock.restore();
 });
 
-test('CSV, renders the general information elements correctly', () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
+// Helper function to get common elements
+const getCommonElements = () => ({
+  cancelButton: screen.getByRole('button', { name: 'Cancel' }),
+  uploadButton: screen.getByRole('button', { name: 'Upload' }),
+  selectButton: screen.getByRole('button', { name: 'Select' }),
+  panel1: screen.getByRole('heading', { name: /General information/i }),
+  panel2: screen.getByRole('heading', { name: /file settings/i }),
+  panel3: screen.getByRole('heading', { name: /columns/i }),
+  selectDatabase: screen.getByRole('combobox', { name: /select a database/i }),
+  inputTableName: screen.getByRole('textbox', { name: /table name/i }),
+  inputSchema: screen.getByRole('combobox', { name: /schema/i }),
+});
+
+// Helper function to check element visibility
+const expectElementsVisible = elements => {
+  elements.forEach(element => {
+    expect(element).toBeInTheDocument();
+  });
+};
+
+// Helper function to check element absence
+const expectElementsNotVisible = elements => {
+  elements.forEach(element => {
+    expect(element).not.toBeInTheDocument();
+  });
+};
+
+describe('UploadDataModal - General Information Elements', () => {
+  test('CSV renders correctly', () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    const common = getCommonElements();
+    const title = screen.getByRole('heading', { name: /csv upload/i });
+    const panel4 = screen.getByRole('heading', { name: /rows/i });
+    const selectDelimiter = screen.getByRole('combobox', {
+      name: /choose a delimiter/i,
+    });
+
+    expectElementsVisible([
+      common.cancelButton,
+      common.uploadButton,
+      common.selectButton,
+      title,
+      common.panel1,
+      common.panel2,
+      common.panel3,
+      panel4,
+      common.selectDatabase,
+      selectDelimiter,
+      common.inputTableName,
+      common.inputSchema,
+    ]);
   });
 
-  const cancelButton = screen.getByRole('button', {
-    name: 'Cancel',
-  });
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
+  test('Excel renders correctly', () => {
+    render(<UploadDataModal {...excelProps} />, { useRedux: true });
+
+    const common = getCommonElements();
+    const title = screen.getByRole('heading', { name: /excel upload/i });
+    const panel4 = screen.getByRole('heading', { name: /rows/i });
+    const selectSheetName = screen.getByRole('combobox', {
+      name: /choose sheet name/i,
+    });
+
+    expectElementsVisible([
+      common.cancelButton,
+      common.uploadButton,
+      common.selectButton,
+      title,
+      common.panel1,
+      common.panel2,
+      common.panel3,
+      panel4,
+      common.selectDatabase,
+      selectSheetName,
+      common.inputTableName,
+      common.inputSchema,
+    ]);
+
+    // Check elements that should NOT be visible
+    expect(
+      screen.queryByRole('heading', { name: /csv upload/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('combobox', { name: /choose a delimiter/i }),
+    ).not.toBeInTheDocument();
   });
 
-  const title = screen.getByRole('heading', {
-    name: /csv upload/i,
-  });
-  const panel1 = screen.getByRole('heading', {
-    name: /General information/i,
-  });
-  const panel2 = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  const panel3 = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  const panel4 = screen.getByRole('heading', {
-    name: /rows/i,
-  });
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  const selectDelimiter = screen.getByRole('combobox', {
-    name: /choose a delimiter/i,
-  });
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  const inputSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
+  test('Columnar renders correctly', () => {
+    render(<UploadDataModal {...columnarProps} />, { useRedux: true });
 
-  const visibleComponents = [
-    cancelButton,
-    uploadButton,
-    selectButton,
-    title,
-    panel1,
-    panel2,
-    panel3,
-    panel4,
-    selectDatabase,
-    selectDelimiter,
-    inputTableName,
-    inputSchema,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    const common = getCommonElements();
+    const title = screen.getByRole('heading', { name: /columnar upload/i });
+
+    expectElementsVisible([
+      common.cancelButton,
+      common.uploadButton,
+      common.selectButton,
+      title,
+      common.panel1,
+      common.panel2,
+      common.panel3,
+      common.selectDatabase,
+      common.inputTableName,
+      common.inputSchema,
+    ]);
+
+    // Check elements that should NOT be visible
+    expectElementsNotVisible([
+      screen.queryByRole('heading', { name: /csv upload/i }),
+      screen.queryByRole('heading', { name: /rows/i }),
+      screen.queryByRole('combobox', { name: /choose a delimiter/i }),
+      screen.queryByRole('combobox', { name: /choose sheet name/i }),
+    ]);
   });
 });
 
-test('Excel, renders the general information elements correctly', () => {
-  render(<UploadDataModal {...excelProps} />, {
-    useRedux: true,
+describe('UploadDataModal - File Settings Elements', () => {
+  const openFileSettings = async () => {
+    const panelHeader = screen.getByRole('heading', { name: /file settings/i });
+    await userEvent.click(panelHeader);
+  };
+
+  test('CSV file settings render correctly', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    expect(
+      screen.queryByText('If Table Already Exists'),
+    ).not.toBeInTheDocument();
+    await openFileSettings();
+
+    const elements = [
+      screen.getByRole('combobox', { name: /choose already exists/i }),
+      screen.getByTestId('skipInitialSpace'),
+      screen.getByTestId('skipBlankLines'),
+      screen.getByTestId('dayFirst'),
+      screen.getByRole('textbox', { name: /decimal character/i }),
+      screen.getByRole('combobox', { name: /null values/i }),
+    ];
+
+    expectElementsVisible(elements);
   });
 
-  const cancelButton = screen.getByRole('button', {
-    name: 'Cancel',
-  });
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
+  test('Excel file settings render correctly', async () => {
+    render(<UploadDataModal {...excelProps} />, { useRedux: true });
+
+    expect(
+      screen.queryByText('If Table Already Exists'),
+    ).not.toBeInTheDocument();
+    await openFileSettings();
+
+    const visibleElements = [
+      screen.getByRole('combobox', { name: /choose already exists/i }),
+      screen.getByRole('textbox', { name: /decimal character/i }),
+      screen.getByRole('combobox', { name: /null values/i }),
+    ];
+
+    expectElementsVisible(visibleElements);
+
+    // Check elements that should NOT be visible
+    expectElementsNotVisible([
+      screen.queryByText('skipInitialSpace'),
+      screen.queryByText('skipBlankLines'),
+      screen.queryByText('dayFirst'),
+    ]);
   });
 
-  const title = screen.getByRole('heading', {
-    name: /excel upload/i,
-  });
-  const missingTitle = screen.queryByRole('heading', {
-    name: /csv upload/i,
-  });
-  expect(missingTitle).not.toBeInTheDocument();
-  const panel1 = screen.getByRole('heading', {
-    name: /General information/i,
-  });
-  const panel2 = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  const panel3 = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  const panel4 = screen.getByRole('heading', {
-    name: /rows/i,
-  });
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  const selectDelimiter = screen.queryByRole('combobox', {
-    name: /choose a delimiter/i,
-  });
-  expect(selectDelimiter).not.toBeInTheDocument();
-  const selectSheetName = screen.getByRole('combobox', {
-    name: /choose sheet name/i,
-  });
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  const inputSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
+  test('Columnar file settings render correctly', async () => {
+    render(<UploadDataModal {...columnarProps} />, { useRedux: true });
 
-  const visibleComponents = [
-    cancelButton,
-    uploadButton,
-    selectButton,
-    title,
-    panel1,
-    panel2,
-    panel3,
-    panel4,
-    selectDatabase,
-    selectSheetName,
-    inputTableName,
-    inputSchema,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
-  });
-});
+    expect(
+      screen.queryByText('If Table Already Exists'),
+    ).not.toBeInTheDocument();
+    await openFileSettings();
 
-test('Columnar, renders the general information elements correctly', () => {
-  render(<UploadDataModal {...columnarProps} />, {
-    useRedux: true,
-  });
+    const visibleElements = [
+      screen.getByRole('combobox', { name: /choose already exists/i }),
+    ];
 
-  const cancelButton = screen.getByRole('button', {
-    name: 'Cancel',
-  });
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
-  });
+    expectElementsVisible(visibleElements);
 
-  const title = screen.getByRole('heading', {
-    name: /columnar upload/i,
-  });
-  const missingTitle = screen.queryByRole('heading', {
-    name: /csv upload/i,
-  });
-  expect(missingTitle).not.toBeInTheDocument();
-  const panel1 = screen.getByRole('heading', {
-    name: /General information/i,
-  });
-  const panel2 = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  const panel3 = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  const panel4 = screen.queryByRole('heading', {
-    name: /rows/i,
-  });
-  expect(panel4).not.toBeInTheDocument();
-
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  const selectDelimiter = screen.queryByRole('combobox', {
-    name: /choose a delimiter/i,
-  });
-  expect(selectDelimiter).not.toBeInTheDocument();
-
-  const selectSheetName = screen.queryByRole('combobox', {
-    name: /choose sheet name/i,
-  });
-  expect(selectSheetName).not.toBeInTheDocument();
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  const inputSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
-
-  const visibleComponents = [
-    cancelButton,
-    uploadButton,
-    selectButton,
-    title,
-    panel1,
-    panel2,
-    panel3,
-    selectDatabase,
-    inputTableName,
-    inputSchema,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    // Check elements that should NOT be visible
+    expectElementsNotVisible([
+      screen.queryByRole('textbox', { name: /decimal character/i }),
+      screen.queryByRole('combobox', {
+        name: /choose columns to be parsed as dates/i,
+      }),
+      screen.queryByRole('combobox', { name: /null values/i }),
+      screen.queryByText('skipInitialSpace'),
+      screen.queryByText('skipBlankLines'),
+      screen.queryByText('dayFirst'),
+    ]);
   });
 });
 
-test('CSV, renders the file settings elements correctly', () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
+describe('UploadDataModal - Columns Elements', () => {
+  const openColumns = async () => {
+    const panelHeader = screen.getByRole('heading', { name: /columns/i });
+    await userEvent.click(panelHeader);
+  };
+
+  test('CSV columns render correctly', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    await openColumns();
+    const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
+    await userEvent.click(switchDataFrameIndex);
+
+    const elements = [
+      screen.getByRole('combobox', { name: /Choose index column/i }),
+      switchDataFrameIndex,
+      screen.getByRole('textbox', { name: /Index label/i }),
+      screen.getByRole('combobox', { name: /Choose columns to read/i }),
+      screen.getByRole('textbox', { name: /Column data types/i }),
+    ];
+
+    expectElementsVisible(elements);
   });
 
-  expect(screen.queryByText('If Table Already Exists')).not.toBeInTheDocument();
-  const panelHeader = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  userEvent.click(panelHeader);
-  const selectTableAlreadyExists = screen.getByRole('combobox', {
-    name: /choose already exists/i,
-  });
-  const switchSkipInitialSpace = screen.getByTestId('skipInitialSpace');
-  const switchSkipBlankLines = screen.getByTestId('skipBlankLines');
-  const switchDayFirst = screen.getByTestId('dayFirst');
-  const inputDecimalCharacter = screen.getByRole('textbox', {
-    name: /decimal character/i,
-  });
-  const selectColumnsDates = screen.getByRole('combobox', {
-    name: /choose columns to be parsed as dates/i,
-  });
-  const selectNullValues = screen.getByRole('combobox', {
-    name: /null values/i,
-  });
-  userEvent.click(selectColumnsDates);
-  userEvent.click(selectNullValues);
-  const visibleComponents = [
-    selectTableAlreadyExists,
-    switchSkipInitialSpace,
-    switchDayFirst,
-    switchSkipBlankLines,
-    inputDecimalCharacter,
-    selectNullValues,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
-  });
-});
+  test('Excel columns render correctly', async () => {
+    render(<UploadDataModal {...excelProps} />, { useRedux: true });
 
-test('Excel, renders the file settings elements correctly', () => {
-  render(<UploadDataModal {...excelProps} />, {
-    useRedux: true,
+    await openColumns();
+    const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
+    await userEvent.click(switchDataFrameIndex);
+
+    const visibleElements = [
+      screen.getByRole('combobox', { name: /Choose index column/i }),
+      switchDataFrameIndex,
+      screen.getByRole('textbox', { name: /Index label/i }),
+      screen.getByRole('combobox', { name: /Choose columns to read/i }),
+    ];
+
+    expectElementsVisible(visibleElements);
+
+    // Check elements that should NOT be visible
+    expect(
+      screen.queryByRole('textbox', { name: /Column data types/i }),
+    ).not.toBeInTheDocument();
   });
 
-  expect(screen.queryByText('If Table Already Exists')).not.toBeInTheDocument();
-  const panelHeader = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  userEvent.click(panelHeader);
-  const selectTableAlreadyExists = screen.getByRole('combobox', {
-    name: /choose already exists/i,
-  });
-  const inputDecimalCharacter = screen.getByRole('textbox', {
-    name: /decimal character/i,
-  });
-  const selectColumnsDates = screen.getByRole('combobox', {
-    name: /choose columns to be parsed as dates/i,
-  });
-  const selectNullValues = screen.getByRole('combobox', {
-    name: /null values/i,
-  });
-  userEvent.click(selectColumnsDates);
-  userEvent.click(selectNullValues);
+  test('Columnar columns render correctly', async () => {
+    render(<UploadDataModal {...columnarProps} />, { useRedux: true });
 
-  const switchSkipInitialSpace = screen.queryByText('skipInitialSpace');
-  expect(switchSkipInitialSpace).not.toBeInTheDocument();
-  const switchSkipBlankLines = screen.queryByText('skipBlankLines');
-  expect(switchSkipBlankLines).not.toBeInTheDocument();
-  const switchDayFirst = screen.queryByText('dayFirst');
-  expect(switchDayFirst).not.toBeInTheDocument();
+    await openColumns();
+    const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
+    await userEvent.click(switchDataFrameIndex);
 
-  const visibleComponents = [
-    selectTableAlreadyExists,
-    inputDecimalCharacter,
-    selectNullValues,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    const visibleElements = [
+      switchDataFrameIndex,
+      screen.getByRole('textbox', { name: /Index label/i }),
+      screen.getByRole('combobox', { name: /Choose columns to read/i }),
+    ];
+
+    expectElementsVisible(visibleElements);
+
+    // Check elements that should NOT be visible
+    expectElementsNotVisible([
+      screen.queryByRole('combobox', { name: /Choose index column/i }),
+      screen.queryByRole('textbox', { name: /Column data types/i }),
+    ]);
   });
 });
 
-test('Columnar, renders the file settings elements correctly', () => {
-  render(<UploadDataModal {...columnarProps} />, {
-    useRedux: true,
+describe('UploadDataModal - Rows Elements', () => {
+  test('CSV/Excel rows render correctly', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    const panelHeader = screen.getByRole('heading', { name: /rows/i });
+    await userEvent.click(panelHeader);
+
+    const elements = [
+      screen.getByRole('spinbutton', { name: /header row/i }),
+      screen.getByRole('spinbutton', { name: /rows to read/i }),
+      screen.getByRole('spinbutton', { name: /skip rows/i }),
+    ];
+
+    expectElementsVisible(elements);
   });
 
-  expect(screen.queryByText('If Table Already Exists')).not.toBeInTheDocument();
-  const panelHeader = screen.getByRole('heading', {
-    name: /file settings/i,
-  });
-  userEvent.click(panelHeader);
-  const selectTableAlreadyExists = screen.getByRole('combobox', {
-    name: /choose already exists/i,
-  });
-  const inputDecimalCharacter = screen.queryByRole('textbox', {
-    name: /decimal character/i,
-  });
-  expect(inputDecimalCharacter).not.toBeInTheDocument();
-  const selectColumnsDates = screen.queryByRole('combobox', {
-    name: /choose columns to be parsed as dates/i,
-  });
-  expect(selectColumnsDates).not.toBeInTheDocument();
-  const selectNullValues = screen.queryByRole('combobox', {
-    name: /null values/i,
-  });
-  expect(selectNullValues).not.toBeInTheDocument();
+  test('Columnar does not render rows', () => {
+    render(<UploadDataModal {...columnarProps} />, { useRedux: true });
 
-  const switchSkipInitialSpace = screen.queryByText('skipInitialSpace');
-  expect(switchSkipInitialSpace).not.toBeInTheDocument();
-  const switchSkipBlankLines = screen.queryByText('skipBlankLines');
-  expect(switchSkipBlankLines).not.toBeInTheDocument();
-  const switchDayFirst = screen.queryByText('dayFirst');
-  expect(switchDayFirst).not.toBeInTheDocument();
-
-  const visibleComponents = [selectTableAlreadyExists];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    const panelHeader = screen.queryByRole('heading', { name: /rows/i });
+    expect(panelHeader).not.toBeInTheDocument();
   });
 });
 
-test('CSV, renders the columns elements correctly', () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
-  });
+describe('UploadDataModal - Database and Schema Population', () => {
+  test('database and schema are correctly populated', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
 
-  const panelHeader = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  userEvent.click(panelHeader);
-  const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
-  userEvent.click(switchDataFrameIndex);
-  const selectIndexColumn = screen.getByRole('combobox', {
-    name: /Choose index column/i,
-  });
-  const inputColumnLabels = screen.getByRole('textbox', {
-    name: /Index label/i,
-  });
-  const selectColumnsToRead = screen.getByRole('combobox', {
-    name: /Choose columns to read/i,
-  });
-  const inputColumnDataTypes = screen.getByRole('textbox', {
-    name: /Column data types/i,
-  });
-  userEvent.click(selectColumnsToRead);
+    const selectDatabase = screen.getByRole('combobox', {
+      name: /select a database/i,
+    });
+    const selectSchema = screen.getByRole('combobox', { name: /schema/i });
 
-  const visibleComponents = [
-    selectIndexColumn,
-    switchDataFrameIndex,
-    inputColumnLabels,
-    selectColumnsToRead,
-    inputColumnDataTypes,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    // Test database selection
+    await userEvent.click(selectDatabase);
+    await waitFor(() => screen.getByText('database1'));
+    await waitFor(() => screen.getByText('database2'));
+
+    // Select database1 and check schemas
+    await userEvent.click(screen.getByText('database1'));
+    await userEvent.click(selectSchema);
+    await waitFor(() => screen.getAllByText('information_schema'));
+    await waitFor(() => screen.getAllByText('public'));
+
+    // Switch to database2 and check schemas
+    await userEvent.click(selectDatabase);
+    await userEvent.click(screen.getByText('database2'));
+    await userEvent.click(selectSchema);
+    await waitFor(() => screen.getAllByText('schema1'));
+    await waitFor(() => screen.getAllByText('schema2'));
   });
 });
 
-test('Excel, renders the columns elements correctly', () => {
-  render(<UploadDataModal {...excelProps} />, {
-    useRedux: true,
-  });
+describe('UploadDataModal - Form Validation', () => {
+  test('form validation without required fields', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
 
-  const panelHeader = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  userEvent.click(panelHeader);
-  const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
-  userEvent.click(switchDataFrameIndex);
-  const selectIndexColumn = screen.getByRole('combobox', {
-    name: /Choose index column/i,
-  });
-  const inputIndexLabel = screen.getByRole('textbox', {
-    name: /Index label/i,
-  });
-  const selectColumnsToRead = screen.getByRole('combobox', {
-    name: /Choose columns to read/i,
-  });
-  userEvent.click(selectColumnsToRead);
+    const uploadButton = screen.getByRole('button', { name: 'Upload' });
+    await userEvent.click(uploadButton);
 
-  const columnDataTypes = screen.queryByRole('textbox', {
-    name: /Column data types/i,
-  });
-
-  expect(columnDataTypes).not.toBeInTheDocument();
-
-  const visibleComponents = [
-    selectIndexColumn,
-    switchDataFrameIndex,
-    inputIndexLabel,
-    selectColumnsToRead,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText('Uploading a file is required'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Selecting a database is required'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Table name is required')).toBeInTheDocument();
+    });
   });
 });
 
-test('Columnar, renders the columns elements correctly', () => {
-  render(<UploadDataModal {...columnarProps} />, {
-    useRedux: true,
+describe('UploadDataModal - Form Submission', () => {
+  // Helper function to fill out form
+  const fillForm = async (fileType, fileName, mimeType = 'text/csv') => {
+    const selectButton = screen.getByRole('button', { name: 'Select' });
+    await userEvent.click(selectButton);
+
+    const file = new File(['test'], fileName, { type: mimeType });
+    const inputElement = screen.getByTestId('model-file-input');
+    fireEvent.change(inputElement, { target: { files: [file] } });
+
+    const selectDatabase = screen.getByRole('combobox', {
+      name: /select a database/i,
+    });
+    await userEvent.click(selectDatabase);
+
+    await waitFor(() => screen.getByText('database1'));
+    await userEvent.click(screen.getByText('database1'));
+
+    const selectSchema = screen.getByRole('combobox', { name: /schema/i });
+    await userEvent.click(selectSchema);
+
+    await waitFor(() => screen.getAllByText('public'));
+    await userEvent.click(screen.getAllByText('public')[1]);
+
+    const inputTableName = screen.getByRole('textbox', { name: /table name/i });
+    await userEvent.type(inputTableName, 'table1');
+
+    const uploadButton = screen.getByRole('button', { name: 'Upload' });
+    await userEvent.click(uploadButton);
+
+    await waitFor(() => fetchMock.called('glob:*api/v1/database/1/upload/'), {
+      timeout: 10000,
+    });
+    return fetchMock.calls('glob:*api/v1/database/1/upload/')[0];
+  };
+
+  test('CSV form submission', async () => {
+    render(<UploadDataModal {...csvProps} />, { useRedux: true });
+
+    const [, options] = await fillForm('csv', 'test.csv');
+    const formData = options?.body as FormData;
+
+    expect(formData.get('type')).toBe('csv');
+    expect(formData.get('table_name')).toBe('table1');
+    expect(formData.get('schema')).toBe('public');
+    expect((formData.get('file') as File).name).toBe('test.csv');
   });
 
-  const panelHeader = screen.getByRole('heading', {
-    name: /columns/i,
-  });
-  userEvent.click(panelHeader);
-  const selectIndexColumn = screen.queryByRole('combobox', {
-    name: /Choose index column/i,
-  });
-  expect(selectIndexColumn).not.toBeInTheDocument();
-  const switchDataFrameIndex = screen.getByTestId('dataFrameIndex');
-  userEvent.click(switchDataFrameIndex);
-  const inputIndexLabel = screen.getByRole('textbox', {
-    name: /Index label/i,
-  });
-  const selectColumnsToRead = screen.getByRole('combobox', {
-    name: /Choose columns to read/i,
-  });
-  userEvent.click(selectColumnsToRead);
+  test('Excel form submission', async () => {
+    render(<UploadDataModal {...excelProps} />, { useRedux: true });
 
-  const columnDataTypes = screen.queryByRole('textbox', {
-    name: /Column data types/i,
-  });
-  expect(columnDataTypes).not.toBeInTheDocument();
+    const [, options] = await fillForm('excel', 'test.xls', 'text');
+    const formData = options?.body as FormData;
 
-  const visibleComponents = [
-    switchDataFrameIndex,
-    inputIndexLabel,
-    selectColumnsToRead,
-  ];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
-  });
-});
-
-test('renders the rows elements correctly', () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
+    expect(formData.get('type')).toBe('excel');
+    expect(formData.get('table_name')).toBe('table1');
+    expect(formData.get('schema')).toBe('public');
+    expect((formData.get('file') as File).name).toBe('test.xls');
   });
 
-  const panelHeader = screen.getByRole('heading', {
-    name: /rows/i,
-  });
-  userEvent.click(panelHeader);
-  const inputHeaderRow = screen.getByRole('spinbutton', {
-    name: /header row/i,
-  });
-  const inputRowsToRead = screen.getByRole('spinbutton', {
-    name: /rows to read/i,
-  });
-  const inputSkipRows = screen.getByRole('spinbutton', {
-    name: /skip rows/i,
-  });
+  test('Columnar form submission', async () => {
+    render(<UploadDataModal {...columnarProps} />, { useRedux: true });
 
-  const visibleComponents = [inputHeaderRow, inputRowsToRead, inputSkipRows];
-  visibleComponents.forEach(component => {
-    expect(component).toBeInTheDocument();
-  });
-});
+    const [, options] = await fillForm('columnar', 'test.parquet', 'text');
+    const formData = options?.body as FormData;
 
-test('Columnar, does not render the rows', () => {
-  render(<UploadDataModal {...columnarProps} />, {
-    useRedux: true,
-  });
-
-  const panelHeader = screen.queryByRole('heading', {
-    name: /rows/i,
-  });
-  expect(panelHeader).not.toBeInTheDocument();
-});
-
-test('database and schema are correctly populated', async () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
-  });
-
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  const selectSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
-
-  userEvent.click(selectDatabase);
-
-  await waitFor(() => screen.getByText('database1'));
-  await waitFor(() => screen.getByText('database2'));
-
-  screen.getByText('database1').click();
-
-  userEvent.click(selectSchema);
-
-  // make sure the schemas for database1 are displayed
-  await waitFor(() => screen.getAllByText('information_schema'));
-  await waitFor(() => screen.getAllByText('public'));
-
-  screen.getByText('database2').click();
-  userEvent.click(selectSchema);
-  // make sure the schemas for database2 are displayed
-  await waitFor(() => screen.getAllByText('schema1'));
-  await waitFor(() => screen.getAllByText('schema2'));
-}, 30000);
-
-test('form without required fields', async () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
-  });
-
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-
-  // Submit form without filling any fields
-  userEvent.click(uploadButton);
-
-  expect(
-    await screen.findByText('Uploading a file is required'),
-  ).toBeInTheDocument();
-  expect(
-    await screen.findByText('Selecting a database is required'),
-  ).toBeInTheDocument();
-  expect(await screen.findByText('Table name is required')).toBeInTheDocument();
-});
-
-test('CSV form post', async () => {
-  render(<UploadDataModal {...csvProps} />, {
-    useRedux: true,
-  });
-
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
-  });
-  userEvent.click(selectButton);
-
-  // Select a file from the file dialog
-  const file = new File(['test'], 'test.csv', { type: 'text/csv' });
-  const inputElement = screen.getByTestId('model-file-input');
-
-  expect(inputElement).toBeInTheDocument();
-  fireEvent.change(inputElement, { target: { files: [file] } });
-
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  userEvent.click(selectDatabase);
-
-  await screen.findByText('database1');
-  await screen.findByText('database2');
-
-  screen.getByText('database1').click();
-  const selectSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
-  userEvent.click(selectSchema);
-
-  await screen.findAllByText('public');
-  screen.getAllByText('public')[1].click();
-
-  // Fill out form fields
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  userEvent.type(inputTableName, 'table1');
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-
-  userEvent.click(uploadButton);
-  await waitFor(() => fetchMock.called('glob:*api/v1/database/1/upload/'));
-
-  // Get the matching fetch calls made
-  const matchingCalls = fetchMock.calls('glob:*api/v1/database/1/upload/');
-  expect(matchingCalls).toHaveLength(1);
-  const [, options] = matchingCalls[0];
-  const formData = options?.body as FormData;
-  expect(formData.get('type')).toBe('csv');
-  expect(formData.get('table_name')).toBe('table1');
-  expect(formData.get('schema')).toBe('public');
-  expect(formData.get('table_name')).toBe('table1');
-  const fileData = formData.get('file') as File;
-  expect(fileData.name).toBe('test.csv');
-}, 30000);
-
-test('Excel form post', async () => {
-  render(<UploadDataModal {...excelProps} />, {
-    useRedux: true,
-  });
-
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
-  });
-  userEvent.click(selectButton);
-
-  // Select a file from the file dialog
-  const file = new File(['test'], 'test.xls', { type: 'text' });
-  const inputElement = screen.getByTestId('model-file-input');
-
-  expect(inputElement).toBeInTheDocument();
-  fireEvent.change(inputElement, { target: { files: [file] } });
-
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  userEvent.click(selectDatabase);
-
-  await screen.findByText('database1');
-  await screen.findByText('database2');
-
-  screen.getByText('database1').click();
-  const selectSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
-  userEvent.click(selectSchema);
-
-  await screen.findAllByText('public');
-  screen.getAllByText('public')[1].click();
-
-  // Fill out form fields
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  userEvent.type(inputTableName, 'table1');
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-
-  userEvent.click(uploadButton);
-  await waitFor(() => fetchMock.called('glob:*api/v1/database/1/upload/'));
-
-  // Get the matching fetch calls made
-  const matchingCalls = fetchMock.calls('glob:*api/v1/database/1/upload/');
-  expect(matchingCalls).toHaveLength(1);
-  const [, options] = matchingCalls[0];
-  const formData = options?.body as FormData;
-  expect(formData.get('type')).toBe('excel');
-  expect(formData.get('table_name')).toBe('table1');
-  expect(formData.get('schema')).toBe('public');
-  expect(formData.get('table_name')).toBe('table1');
-  const fileData = formData.get('file') as File;
-  expect(fileData.name).toBe('test.xls');
-}, 30000);
-
-test('Columnar form post', async () => {
-  render(<UploadDataModal {...columnarProps} />, {
-    useRedux: true,
-  });
-
-  const selectButton = screen.getByRole('button', {
-    name: 'Select',
-  });
-  userEvent.click(selectButton);
-
-  // Select a file from the file dialog
-  const file = new File(['test'], 'test.parquet', { type: 'text' });
-  const inputElement = screen.getByTestId('model-file-input');
-
-  expect(inputElement).toBeInTheDocument();
-  fireEvent.change(inputElement, { target: { files: [file] } });
-
-  const selectDatabase = screen.getByRole('combobox', {
-    name: /select a database/i,
-  });
-  userEvent.click(selectDatabase);
-
-  await screen.findByText('database1');
-  await screen.findByText('database2');
-
-  screen.getByText('database1').click();
-  const selectSchema = screen.getByRole('combobox', {
-    name: /schema/i,
-  });
-  userEvent.click(selectSchema);
-
-  await screen.findAllByText('public');
-  screen.getAllByText('public')[1].click();
-
-  // Fill out form fields
-  const inputTableName = screen.getByRole('textbox', {
-    name: /table name/i,
-  });
-  userEvent.type(inputTableName, 'table1');
-  const uploadButton = screen.getByRole('button', {
-    name: 'Upload',
-  });
-
-  expect(uploadButton).toBeEnabled();
-  userEvent.click(uploadButton);
-  await waitFor(() => fetchMock.called('glob:*api/v1/database/1/upload/'));
-
-  // Get the matching fetch calls made
-  const matchingCalls = fetchMock.calls('glob:*api/v1/database/1/upload/');
-  expect(matchingCalls).toHaveLength(1);
-  const [, options] = matchingCalls[0];
-  const formData = options?.body as FormData;
-  expect(formData.get('type')).toBe('columnar');
-  expect(formData.get('table_name')).toBe('table1');
-  expect(formData.get('schema')).toBe('public');
-  expect(formData.get('table_name')).toBe('table1');
-  const fileData = formData.get('file') as File;
-  expect(fileData.name).toBe('test.parquet');
-}, 30000);
-
-test('CSV, validate file extension returns false', () => {
-  const invalidFileNames = ['out', 'out.exe', 'out.csv.exe', '.csv', 'out.xls'];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['csv', 'tsv'])).toBe(false);
+    expect(formData.get('type')).toBe('columnar');
+    expect(formData.get('table_name')).toBe('table1');
+    expect(formData.get('schema')).toBe('public');
+    expect((formData.get('file') as File).name).toBe('test.parquet');
   });
 });
 
-test('Excel, validate file extension returns false', () => {
-  const invalidFileNames = ['out', 'out.exe', 'out.xls.exe', '.csv', 'out.csv'];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['xls', 'xlsx'])).toBe(false);
+describe('File Extension Validation', () => {
+  const createTestFile = fileName => ({
+    name: fileName,
+    uid: 'xp',
+    size: 100,
+    type: 'text/csv',
   });
-});
 
-test('Columnar, validate file extension returns false', () => {
-  const invalidFileNames = [
-    'out',
-    'out.exe',
-    'out.parquet.exe',
-    '.parquet',
-    'out.excel',
-  ];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['parquet', 'zip'])).toBe(false);
+  describe('CSV validation', () => {
+    test('returns false for invalid extensions', () => {
+      const invalidFiles = ['out', 'out.exe', 'out.csv.exe', '.csv', 'out.xls'];
+      invalidFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), ['csv', 'tsv']),
+        ).toBe(false);
+      });
+    });
+
+    test('returns true for valid extensions', () => {
+      const validFiles = ['out.csv', 'out.tsv', 'out.exe.csv', 'out a.csv'];
+      validFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), ['csv', 'tsv']),
+        ).toBe(true);
+      });
+    });
   });
-});
 
-test('CSV, validate file extension returns true', () => {
-  const invalidFileNames = ['out.csv', 'out.tsv', 'out.exe.csv', 'out a.csv'];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['csv', 'tsv'])).toBe(true);
+  describe('Excel validation', () => {
+    test('returns false for invalid extensions', () => {
+      const invalidFiles = ['out', 'out.exe', 'out.xls.exe', '.csv', 'out.csv'];
+      invalidFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), [
+            'xls',
+            'xlsx',
+          ]),
+        ).toBe(false);
+      });
+    });
+
+    test('returns true for valid extensions', () => {
+      const validFiles = ['out.xls', 'out.xlsx', 'out.exe.xls', 'out a.xls'];
+      validFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), [
+            'xls',
+            'xlsx',
+          ]),
+        ).toBe(true);
+      });
+    });
   });
-});
 
-test('Excel, validate file extension returns true', () => {
-  const invalidFileNames = ['out.xls', 'out.xlsx', 'out.exe.xls', 'out a.xls'];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['xls', 'xlsx'])).toBe(true);
-  });
-});
+  describe('Columnar validation', () => {
+    test('returns false for invalid extensions', () => {
+      const invalidFiles = [
+        'out',
+        'out.exe',
+        'out.parquet.exe',
+        '.parquet',
+        'out.excel',
+      ];
+      invalidFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), [
+            'parquet',
+            'zip',
+          ]),
+        ).toBe(false);
+      });
+    });
 
-test('Columnar, validate file extension returns true', () => {
-  const invalidFileNames = [
-    'out.parquet',
-    'out.zip',
-    'out.exe.zip',
-    'out a.parquet',
-  ];
-  invalidFileNames.forEach(fileName => {
-    const file: UploadFile<any> = {
-      name: fileName,
-      uid: 'xp',
-      size: 100,
-      type: 'text/csv',
-    };
-    expect(validateUploadFileExtension(file, ['parquet', 'zip'])).toBe(true);
+    test('returns true for valid extensions', () => {
+      const validFiles = [
+        'out.parquet',
+        'out.zip',
+        'out.exe.zip',
+        'out a.parquet',
+      ];
+      validFiles.forEach(fileName => {
+        expect(
+          validateUploadFileExtension(createTestFile(fileName), [
+            'parquet',
+            'zip',
+          ]),
+        ).toBe(true);
+      });
+    });
   });
 });

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -27,7 +27,6 @@ import {
   userEvent,
   fireEvent,
 } from 'spec/helpers/testing-library';
-import { UploadFile } from '@superset-ui/core/components/Upload';
 
 const csvProps = {
   show: true,
@@ -112,15 +111,15 @@ const getCommonElements = () => ({
 });
 
 // Helper function to check element visibility
-const expectElementsVisible = elements => {
-  elements.forEach(element => {
+const expectElementsVisible = (elements: any[]) => {
+  elements.forEach((element: any) => {
     expect(element).toBeInTheDocument();
   });
 };
 
 // Helper function to check element absence
-const expectElementsNotVisible = elements => {
-  elements.forEach(element => {
+const expectElementsNotVisible = (elements: any[]) => {
+  elements.forEach((element: any) => {
     expect(element).not.toBeInTheDocument();
   });
 };
@@ -436,7 +435,11 @@ describe('UploadDataModal - Form Validation', () => {
 
 describe('UploadDataModal - Form Submission', () => {
   // Helper function to fill out form
-  const fillForm = async (fileType, fileName, mimeType = 'text/csv') => {
+  const fillForm = async (
+    fileType: string,
+    fileName: string,
+    mimeType = 'text/csv',
+  ) => {
     const selectButton = screen.getByRole('button', { name: 'Select' });
     await userEvent.click(selectButton);
 
@@ -508,7 +511,7 @@ describe('UploadDataModal - Form Submission', () => {
 });
 
 describe('File Extension Validation', () => {
-  const createTestFile = fileName => ({
+  const createTestFile = (fileName: string) => ({
     name: fileName,
     uid: 'xp',
     size: 100,

--- a/superset-frontend/src/features/databases/UploadDataModel/index.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/index.tsx
@@ -597,7 +597,7 @@ const UploadDataModal: FunctionComponent<UploadDataModalProps> = ({
         initialValues={defaultUploadInfo}
       >
         <Collapse
-          expandIconPosition="right"
+          expandIconPosition="end"
           accordion
           defaultActiveKey="general"
           modalMode

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -119,7 +119,7 @@ const StyledLoader = styled.div`
     text-align: center;
     font-weight: ${theme.fontWeightNormal};
     font-size: ${theme.fontSizeLG}px;
-    color: ${theme.colors.grayscale.light1};
+    color: ${theme.colorTextSecondary};
   }
   `}
 `;
@@ -154,7 +154,7 @@ const TableScrollContainer = styled.div`
 
 const StyledAlert = styled(Alert)`
   ${({ theme }) => `
-  border: 1px solid ${theme.colors.info.base};
+  border: 1px solid ${theme.colorInfoText};
   padding: ${theme.sizeUnit * 4}px;
   margin: ${theme.sizeUnit * 6}px ${theme.sizeUnit * 6}px
     ${theme.sizeUnit * 8}px;

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -119,7 +119,7 @@ const StyledSubMenu = styled(SubMenu)`
     }
     &.ant-menu-submenu-active {
       .ant-menu-title-content {
-        color: ${theme.colors.primary.base};
+        color: ${theme.colorPrimary};
       }
     }
   `}

--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -81,7 +81,7 @@ export const CardStyles = styled.div`
     text-decoration: none;
   }
   .ant-card-cover {
-    border-bottom: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+    border-bottom: 1px solid ${({ theme }) => theme.colorBorder};
     & > div {
       height: 171px;
     }
@@ -90,7 +90,7 @@ export const CardStyles = styled.div`
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
-    background-color: ${({ theme }) => theme.colors.primary.light3};
+    background-color: ${({ theme }) => theme.colorPrimaryBg};
     display: inline-block;
     width: 100%;
     height: 179px;

--- a/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
@@ -26,13 +26,13 @@ import withToasts, {
 import useQueryPreviewState from 'src/features/queries/hooks/useQueryPreviewState';
 
 const QueryTitle = styled.div`
-  color: ${({ theme }) => theme.colors.primary.light2};
+  color: ${({ theme }) => theme.colorPrimary};
   font-size: ${({ theme }) => theme.fontSizeSM}px;
   margin-bottom: 0;
 `;
 
 const QueryLabel = styled.div`
-  color: ${({ theme }) => theme.colors.grayscale.dark2};
+  color: ${({ theme }) => theme.colorTextLabel};
   font-size: ${({ theme }) => theme.fontSize}px;
   padding: 4px 0 16px 0;
 `;

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -467,7 +467,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
             invertSelection={inverseSelection && excludeFilterValues}
             options={options}
             sortComparator={sortComparator}
-            onDropdownVisibleChange={setFilterActive}
+            onOpenChange={setFilterActive}
             className="select-container"
           />
         </StyledSpace>

--- a/superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx
@@ -123,7 +123,7 @@ export default function PluginFilterTimeColumn(
           onMouseLeave={unsetHoveredFilter}
           ref={inputRef}
           options={options}
-          onDropdownVisibleChange={setFilterActive}
+          onOpenChange={setFilterActive}
         />
       </FormItem>
     </FilterPluginStyle>

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -133,7 +133,7 @@ export default function PluginFilterTimegrain(
           onMouseLeave={unsetHoveredFilter}
           ref={inputRef}
           options={options}
-          onDropdownVisibleChange={setFilterActive}
+          onOpenChange={setFilterActive}
         />
       </FormItem>
     </FilterPluginStyle>

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -297,7 +297,7 @@ export class ChartCreation extends PureComponent<
           data-test="add-chart-new-dataset-instructions"
         >
           {`${VIEW_INSTRUCTIONS_TEXT} `}
-          <Icons.Full iconSize="m" iconColor={theme.colors.primary.dark1} />
+          <Icons.Full iconSize="m" iconColor={theme.colorPrimary} />
         </a>
         .
       </span>
@@ -309,7 +309,7 @@ export class ChartCreation extends PureComponent<
           target="_blank"
         >
           {`${VIEW_INSTRUCTIONS_TEXT} `}
-          <Icons.Full iconSize="m" iconColor={theme.colors.primary.dark1} />
+          <Icons.Full iconSize="m" iconColor={theme.colorPrimary} />
         </a>
         .
       </span>

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -664,7 +664,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           placement="bottomRight"
         >
           <Icons.DownloadOutlined
-            iconColor={theme.colors.primary.dark1}
+            iconColor={theme.colorPrimary}
             data-test="import-button"
             iconSize="l"
           />

--- a/superset-frontend/src/pages/GroupsList/index.tsx
+++ b/superset-frontend/src/pages/GroupsList/index.tsx
@@ -277,7 +277,7 @@ function GroupsList({ user }: GroupsListProps) {
         name: (
           <>
             <Icons.PlusOutlined
-              iconColor={theme.colors.primary.light5}
+              iconColor={theme.colorText}
               iconSize="m"
               css={css`
                 margin: auto ${theme.sizeUnit * 2}px auto 0;
@@ -364,7 +364,7 @@ function GroupsList({ user }: GroupsListProps) {
       buttonText: (
         <>
           <Icons.PlusOutlined
-            iconColor={theme.colors.primary.light5}
+            iconColor={theme.colorText}
             iconSize="m"
             css={css`
               margin: auto ${theme.sizeUnit * 2}px auto 0;

--- a/superset-frontend/src/pages/UserInfo/index.tsx
+++ b/superset-frontend/src/pages/UserInfo/index.tsx
@@ -116,7 +116,7 @@ export function UserInfo({ user }: { user: UserWithPermissionsAndRoles }) {
       name: (
         <>
           <Icons.LockOutlined
-            iconColor={theme.colors.primary.base}
+            iconColor={theme.colorPrimary}
             iconSize="m"
             css={css`
               margin: auto ${theme.sizeUnit * 2}px auto 0;
@@ -136,7 +136,7 @@ export function UserInfo({ user }: { user: UserWithPermissionsAndRoles }) {
       name: (
         <>
           <Icons.FormOutlined
-            iconColor={theme.colors.primary.light5}
+            iconColor={theme.colorIcon}
             iconSize="m"
             css={css`
               margin: auto ${theme.sizeUnit * 2}px auto 0;


### PR DESCRIPTION
Removing some of the references to `theme.colors.*` which we're deprecating in favor of antd's native tokens.

Side mission: tackle some of the antd console deprecation warnings