### PR TITLE
feat(helm): add extraConfigsFiles support for file-based ConfigMap injection

### DIFF
--- a/helm/superset/README.md
+++ b/helm/superset/README.md
@@ -67,6 +67,7 @@ On helm this can be set on `extraSecretEnv.SUPERSET_SECRET_KEY` or `configOverri
 | envFromSecrets | list | `[]` | This can be a list of templated strings |
 | extraConfigMountPath | string | `"/app/configs"` |  |
 | extraConfigs | object | `{}` | Extra files to be mounted as ConfigMap on the path specified in `extraConfigMountPath` |
+| extraConfigsFiles | object | `{}` | Same as above but the values are files |
 | extraEnv | object | `{}` | Extra environment variables that will be passed into pods |
 | extraEnvRaw | list | `[]` | Extra environment variables in RAW format that will be passed into pods |
 | extraLabels | object | `{}` | Labels to be added to all resources |

--- a/helm/superset/templates/configmap-superset.yaml
+++ b/helm/superset/templates/configmap-superset.yaml
@@ -17,6 +17,10 @@
 
 */}}
 
+{{- if and .Values.extraConfigsFiles .Values.extraConfigs }}
+{{ fail "❌ Cannot use both extraConfigs and extraConfigsFiles at the same time. Please set only one." }}
+{{- end }}
+
 {{- if .Values.extraConfigs }}
 apiVersion: v1
 kind: ConfigMap
@@ -36,4 +40,22 @@ data:
   {{ $path }}: |
     {{- tpl $config $ | nindent 4 -}}
   {{- end -}}
-{{- end -}}
+{{- end }}
+
+{{- if .Values.extraConfigsFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "superset.fullname" . }}-extra-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "superset.name" . }}
+    chart: {{ template "superset.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- range $filename, $filepath := .Values.extraConfigsFiles }}
+  {{ $filename }}: |
+    {{- $.Files.Get $filepath | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/superset/templates/deployment-beat.yaml
+++ b/helm/superset/templates/deployment-beat.yaml
@@ -47,6 +47,7 @@ spec:
         checksum/superset_bootstrap.sh: {{ tpl .Values.bootstrapScript . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraConfigsFiles: {{ .Values.extraConfigsFiles | toYaml | sha256sum }}           
         checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}

--- a/helm/superset/templates/deployment-worker.yaml
+++ b/helm/superset/templates/deployment-worker.yaml
@@ -53,6 +53,7 @@ spec:
         checksum/superset_bootstrap.sh: {{ tpl .Values.bootstrapScript . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraConfigsFiles: {{ .Values.extraConfigsFiles | toYaml | sha256sum }}           
         checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
@@ -117,7 +118,7 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
-            {{- if .Values.extraConfigs }}
+            {{- if or .Values.extraConfigs .Values.extraConfigsFiles }}
             - name: superset-extra-config
               mountPath: {{ .Values.extraConfigMountPath | quote }}
               readOnly: true
@@ -177,7 +178,7 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
-        {{- if .Values.extraConfigs }}
+        {{- if or .Values.extraConfigs .Values.extraConfigsFiles }}
         - name: superset-extra-config
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config

--- a/helm/superset/templates/deployment.yaml
+++ b/helm/superset/templates/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         checksum/superset_bootstrap.sh: {{ tpl .Values.bootstrapScript . | sha256sum }}
         checksum/connections: {{ .Values.supersetNode.connections | toYaml | sha256sum }}
         checksum/extraConfigs: {{ .Values.extraConfigs | toYaml | sha256sum }}
+        checksum/extraConfigsFiles: {{ .Values.extraConfigsFiles | toYaml | sha256sum }}        
         checksum/extraSecrets: {{ .Values.extraSecrets | toYaml | sha256sum }}
         checksum/extraSecretEnv: {{ .Values.extraSecretEnv | toYaml | sha256sum }}
         checksum/configOverrides: {{ .Values.configOverrides | toYaml | sha256sum }}
@@ -123,7 +124,7 @@ spec:
             - name: superset-config
               mountPath: {{ .Values.configMountPath | quote }}
               readOnly: true
-            {{- if .Values.extraConfigs }}
+            {{- if or .Values.extraConfigs .Values.extraConfigsFiles }}
             - name: superset-extra-config
               mountPath: {{ .Values.extraConfigMountPath | quote }}
               readOnly: true
@@ -187,7 +188,7 @@ spec:
         - name: superset-config
           secret:
             secretName: {{ tpl .Values.configFromSecret . }}
-        {{- if .Values.extraConfigs }}
+       {{- if or .Values.extraConfigs .Values.extraConfigsFiles }}
         - name: superset-extra-config
           configMap:
             name: {{ template "superset.fullname" . }}-extra-config

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -119,6 +119,8 @@ extraConfigs: {}
   #         }"
   #       sqlalchemy_uri: example://example-db.local
   #       tables: []
+extraConfigsFiles: {}
+  # import_datasources.yaml: files/import_datasources.yaml
 
 # -- Extra files to be mounted as Secrets on the path specified in `configMountPath`
 extraSecrets: {}


### PR DESCRIPTION
### SUMMARY
Adds `extraConfigsFiles` support to the Superset Helm Chart, enabling users to inject ConfigMap values using file-based configurations.


### TESTING INSTRUCTIONS
Place a YAML file (e.g., `files/user_rbac.yml`) under your Helm chart.

In `values.yaml`, add:

```yaml
extraConfigsFiles:
  user_rbac.yml: files/user_rbac.yml
extraConfigMountPath: "/app/configs"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [x] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
