### PR TITLE
fix(styles): Remove custom z-indexes

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/GlobalStyles.tsx
@@ -58,17 +58,6 @@ export const GlobalStyles = () => {
           display: none !important;
         }
 
-        .ant-dropdown,
-        .ant-dropdown,
-        .ant-select-dropdown,
-        .ant-modal-wrap,
-        .ant-modal-mask,
-        .ant-picker-dropdown,
-        .ant-popover,
-        .ant-popover {
-          z-index: ${theme.zIndexPopupBase} !important;
-        }
-
         .no-wrap {
           white-space: nowrap;
         }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ant design's z-index calculations should be enough to handle modals tooltips and popovers, removed the custom z-indexes from global styles.
https://github.com/apache/superset/pull/34028#pullrequestreview-2986197893

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![image](https://github.com/user-attachments/assets/427544d1-1632-42a3-a5b4-f096f338ab8e)

After:
![image](https://github.com/user-attachments/assets/9549920b-c057-4487-b64c-7d013110f34f)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Test any of the components that use z-index visually, run the testing suite

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
