### PR TITLE
chore: Use select_columns on chart's dashboard filter

### DIFF
--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -282,7 +282,7 @@ function ChartList(props: ChartListProps) {
         }
       : {};
     const queryParams = rison.encode({
-      columns: ['dashboard_title', 'id'],
+      select_columns: ['dashboard_title', 'id'],
       keys: ['none'],
       order_column: 'dashboard_title',
       order_direction: 'asc',


### PR DESCRIPTION
### SUMMARY
This is a follow up to https://github.com/apache/superset/pull/28609.

The Charts list has a "Dashboard" filter. It's currently using the `columns` query parameter, which only filters the API response (but all `list_columns` are still queried from the DB). This PR updates the logic to use `select_columns` instead, to improve performance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Access the Charts list.
2. Open the Developer Tools in the browser.
3. Access the Network tab.
4. Click on the Dashboard filter, and confirm the query parameters for the `/api/v1/dashboard/` use `select_columns`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
