### PR TITLE
feat: Don't show the row limit warning for embedded dashboards by default

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -46,6 +46,7 @@ export type UiConfigType = {
   urlParams?: {
     [key: string]: any;
   };
+  showRowLimitWarning?: boolean;
 };
 
 export type EmbedDashboardParams = {
@@ -132,6 +133,9 @@ export async function embedDashboard({
       }
       if (dashboardUiConfig.emitDataMasks) {
         configNumber += 16;
+      }
+      if (dashboardUiConfig.showRowLimitWarning) {
+        configNumber += 32;
       }
     }
     return configNumber;

--- a/superset-frontend/src/components/UiConfigContext/index.tsx
+++ b/superset-frontend/src/components/UiConfigContext/index.tsx
@@ -26,8 +26,9 @@ interface UiConfigType {
   hideTab: boolean;
   hideNav: boolean;
   hideChartControls: boolean;
-  // Only used in superset-embedded-sdk to emit data masks to the parent window
-  emitDataMasks: boolean;
+  // superset-embedded-sdk specific
+  emitDataMasks: boolean; // emit data masks to the parent window
+  showRowLimitWarning: boolean; // show the row limit warning
 }
 interface EmbeddedUiConfigProviderProps {
   children: JSX.Element;
@@ -39,6 +40,7 @@ export const UiConfigContext = createContext<UiConfigType>({
   hideNav: false,
   hideChartControls: false,
   emitDataMasks: false,
+  showRowLimitWarning: false,
 });
 
 export const useUiConfig = () => useContext(UiConfigContext);
@@ -53,6 +55,7 @@ export const EmbeddedUiConfigProvider: FC<EmbeddedUiConfigProviderProps> = ({
     hideNav: (config & 4) !== 0,
     hideChartControls: (config & 8) !== 0,
     emitDataMasks: (config & 16) !== 0,
+    showRowLimitWarning: (config & 32) !== 0,
   });
 
   return (

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -34,6 +34,7 @@ import {
   useTheme,
 } from '@superset-ui/core';
 import { useUiConfig } from 'src/components/UiConfigContext';
+import { isEmbedded } from 'src/dashboard/util/isEmbedded';
 import { Tooltip, EditableTitle, Icons } from '@superset-ui/core/components';
 import { useSelector } from 'react-redux';
 import SliceHeaderControls from 'src/dashboard/components/SliceHeaderControls';
@@ -173,6 +174,8 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
       'dashboard.slice.header',
     );
     const uiConfig = useUiConfig();
+    const shouldShowRowLimitWarning =
+      !isEmbedded() || uiConfig.showRowLimitWarning;
     const dashboardPageId = useContext(DashboardPageIdContext);
     const [headerTooltip, setHeaderTooltip] = useState<ReactNode | null>(null);
     const headerRef = useRef<HTMLDivElement>(null);
@@ -296,7 +299,7 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
                 <FiltersBadge chartId={slice.slice_id} />
               )}
 
-              {sqlRowCount === rowLimit && (
+              {shouldShowRowLimitWarning && sqlRowCount === rowLimit && (
                 <RowCountLabel
                   rowcount={sqlRowCount}
                   limit={rowLimit}


### PR DESCRIPTION
### SUMMARY
This is a follow up to https://github.com/apache/superset/pull/33781.

Embedded dashboards are typically exposed for external audience, and in this case you might not want to indicate to end users that the row limit was reached. 

This PR adds a new `dashboardUiConfig.showRowLimitWarning` config to the embedded SDK. By default, the warning is not visible in embedded but can be enabled through this new config.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Dashboard loaded in Superset directly**
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/24bdaba8-84f7-4d48-bbba-1f87281a2e35" />

**Same dashboard in embedded mode**
<img width="943" alt="image" src="https://github.com/user-attachments/assets/a6b22ff1-336f-46ab-8005-dced9738194d" />

### TESTING INSTRUCTIONS
Frontend test added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
