### PR TITLE
fix: Apply metric d3format from dataset when currency config is {}

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/utils.ts
@@ -40,7 +40,7 @@ export const buildCustomFormatters = (
       const actualCurrencyFormat = currencyFormat?.symbol
         ? currencyFormat
         : savedCurrencyFormats[metric];
-      return actualCurrencyFormat
+      return actualCurrencyFormat?.symbol
         ? {
             ...acc,
             [metric]: new CurrencyFormatter({

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/utils.test.ts
@@ -19,6 +19,7 @@
 
 import {
   buildCustomFormatters,
+  Currency,
   CurrencyFormatter,
   getCustomFormatter,
   getNumberFormatter,
@@ -114,6 +115,19 @@ test('buildCustomFormatters uses dataset d3 format if not provided in control pa
   expect((customFormatters.sum__num as CurrencyFormatter).d3Format).toEqual(
     ',.2',
   );
+});
+
+test('buildCustomFormatters returns NumberFormatter for a d3format with currency set to {}', () => {
+  const customFormatters: Record<string, ValueFormatter> =
+    buildCustomFormatters(
+      ['count'],
+      { count: {} as Currency },
+      { count: ',.2%' },
+      undefined,
+      undefined,
+    );
+
+  expect(customFormatters.count).toBeInstanceOf(NumberFormatter);
 });
 
 test('getCustomFormatter', () => {


### PR DESCRIPTION
### SUMMARY
Now that the currency configuration for a metric is stored as a JSON, clearing it up in the UI would save it as `{}`. This is a _truthy_ value for `ts`, so the `buildCustomFormatters` logic would apply the currency formatting, as opposed to the `d3format`.

This PR fixes the issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Apply a currency configuration for any metric.
2. Clear it up via the UI.
3. Set a `d3format` for the metric.
4. Make sure it's applied.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
