### PR TITLE
fix(deps): Revert "chore(deps): update @deck.gl/aggregation-layers requirement from ^9.0.38 to ^9.1.12 in /superset-frontend/plugins/legacy-preset-chart-deckgl"

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -4046,6 +4046,25 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@deck.gl/aggregation-layers": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.1.0.tgz",
+      "integrity": "sha512-h+ynSBeZL8keYyDS5N3pUxsNS5ZYsLpGGAg+05Qj9D5XCu/aACtCXMt3raPE6g+HqJBZyeUg4vmKBJnHxKw9LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@luma.gl/constants": "^9.1.0",
+        "@luma.gl/shadertools": "^9.1.0",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "d3-hexbin": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.1.0",
+        "@deck.gl/layers": "^9.1.0",
+        "@luma.gl/core": "^9.1.0",
+        "@luma.gl/engine": "^9.1.0"
+      }
+    },
     "node_modules/@deck.gl/core": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.0.tgz",
@@ -59632,7 +59651,7 @@
       "version": "0.20.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deck.gl/aggregation-layers": "^9.1.12",
+        "@deck.gl/aggregation-layers": "^9.0.38",
         "@deck.gl/core": "^9.0.37",
         "@deck.gl/layers": "^9.0.38",
         "@deck.gl/react": "^9.1.4",
@@ -59665,76 +59684,6 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-map-gl": "^6.1.19"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.1.12.tgz",
-      "integrity": "sha512-41u5ZBnpIUzUQ+S8u/8JBWN9BHTerRUcOv+1QmjWsp8noNWZN69cvOy3/AaaPA8UgSEycdnv+y8GGIMspBLHZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@luma.gl/constants": "^9.1.5",
-        "@luma.gl/shadertools": "^9.1.5",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/web-mercator": "^4.1.0",
-        "d3-hexbin": "^0.2.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "^9.1.0",
-        "@deck.gl/layers": "^9.1.0",
-        "@luma.gl/core": "^9.1.5",
-        "@luma.gl/engine": "^9.1.5"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@luma.gl/constants": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.1.9.tgz",
-      "integrity": "sha512-yc9fml04OeTTcwK+7gmDMxoLQ67j4ZiAFXjmYvPomYyBVzS0NZxTDuwcCBmnxjLOiroOZW8FRRrVc/yOiFug2w==",
-      "license": "MIT"
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@luma.gl/core": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.1.9.tgz",
-      "integrity": "sha512-1i9N7+I/UbFjx3axSMlc3/NufA+C2iBv/7mw51gRE/ypQPgvFmY/QqXBVZRe+nthF+OhlUMhO19TBndzYFTWhA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@math.gl/types": "^4.1.0",
-        "@probe.gl/env": "^4.0.8",
-        "@probe.gl/log": "^4.0.8",
-        "@probe.gl/stats": "^4.0.8",
-        "@types/offscreencanvas": "^2019.6.4"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@luma.gl/engine": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.1.9.tgz",
-      "integrity": "sha512-n1GLK1sUMFkWxdb+aZYn6ZBFltFEMi7X+6ZPxn2pBsNT6oeF4AyvH5AyqhOpvHvUnCLDt3Zsf1UIfx3MI//YSw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/types": "^4.1.0",
-        "@probe.gl/log": "^4.0.8",
-        "@probe.gl/stats": "^4.0.8"
-      },
-      "peerDependencies": {
-        "@luma.gl/core": "^9.1.0",
-        "@luma.gl/shadertools": "^9.1.0"
-      }
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/@luma.gl/shadertools": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.1.9.tgz",
-      "integrity": "sha512-Uqp2xfgIEunRMLXTeCJ4uEMlWcUGcYMZGJ8GAOrAeDzn4bMKVRKmZDC71vkuTctnaodM3UdrI9W6s1sJlrXsxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/types": "^4.1.0",
-        "wgsl_reflect": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@luma.gl/core": "^9.1.0"
       }
     },
     "plugins/legacy-preset-chart-deckgl/node_modules/d3-array": {
@@ -59812,12 +59761,6 @@
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
       "license": "ISC"
-    },
-    "plugins/legacy-preset-chart-deckgl/node_modules/wgsl_reflect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.1.tgz",
-      "integrity": "sha512-PY6MdLqLW1NFj/V6f5/9/Nb4ultwlAF7lCLyjKOAkdnlf7LlrGXNFXzHHEV7Okg1zy4C4TpBIcc/G3PXW4py8g==",
-      "license": "MIT"
     },
     "plugins/legacy-preset-chart-nvd3": {
       "name": "@superset-ui/legacy-preset-chart-nvd3",

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/package.json
@@ -24,7 +24,7 @@
     "lib"
   ],
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.1.12",
+    "@deck.gl/aggregation-layers": "^9.0.38",
     "@deck.gl/core": "^9.0.37",
     "@deck.gl/layers": "^9.0.38",
     "@deck.gl/react": "^9.1.4",


### PR DESCRIPTION
Reverts #33485

This update broke the deck.gl Grid Chart. I couldn't find a quick fix.