### PR TITLE
fix: improve login page placement and width

### DIFF
--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -57,8 +57,10 @@ enum AuthType {
 
 const StyledCard = styled(Card)`
   ${({ theme }) => css`
-    width: 40%;
+    max-width: 400px;
+    width: 100%;
     margin-top: ${theme.marginXL}px;
+    color: ${theme.colorBgContainer};
     background: ${theme.colorBgBase};
     .antd5-form-item-label label {
       color: ${theme.colorPrimary};
@@ -110,9 +112,11 @@ export default function Login() {
   return (
     <Flex
       justify="center"
+      align="center"
       data-test="login-form"
       css={css`
         width: 100%;
+        height: calc(100vh - 200px);
       `}
     >
       <StyledCard title={t('Sign in')} padded>

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -176,6 +176,7 @@ export default function Login() {
                 ]}
               >
                 <Input
+                  autoFocus
                   prefix={<Icons.UserOutlined iconSize="l" />}
                   data-test="username-input"
                 />


### PR DESCRIPTION
Some small adjustments to make the login page look more standard.

- Width set to 400px, should be plenty
- centering the card vertically
- making sure things look decent on mobile using max-width
- autofocus on username

### before
<img width="1717" alt="Screenshot 2025-07-08 at 5 18 44 PM" src="https://github.com/user-attachments/assets/3331d13d-1281-462d-9c4c-bef598249a4c" />

### after
<img width="1728" alt="Screenshot 2025-07-08 at 5 13 20 PM" src="https://github.com/user-attachments/assets/28947651-20b0-458d-a987-1e4260846adb" />
<img width="497" alt="Screenshot 2025-07-08 at 5 13 31 PM" src="https://github.com/user-attachments/assets/c1018c3a-92d6-434f-b944-fa516792160d" />
<img width="503" alt="Screenshot 2025-07-08 at 5 13 43 PM" src="https://github.com/user-attachments/assets/10f2059e-7225-4d98-b79d-51a4dab38292" />
