### PR TITLE
fix(sqllab): ensure SQL_QUERY_MUTATOR is called when MUTATE_AFTER_SPLIT=True

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -431,7 +431,7 @@ def execute_sql_statements(  # noqa: C901
     for statement in parsed_script.statements:
         apply_limit(query, statement)
 
-    # some databases (like BigQuery and Kusto) do not persist state across mmultiple
+    # some databases (like BigQuery and Kusto) do not persist state across multiple
     # statements if they're run separately (especially when using `NullPool`), so we run
     # the query as a single block.
     if db_engine_spec.run_multiple_statements_as_one:
@@ -475,7 +475,7 @@ def execute_sql_statements(  # noqa: C901
             db.session.commit()
 
             # Hook to allow environment-specific mutation (usually comments) to the SQL
-            query.executed_sql = database.mutate_sql_based_on_config(block)
+            query.executed_sql = database.mutate_sql_based_on_config(block, is_split=config["MUTATE_AFTER_SPLIT"])
 
             try:
                 result_set = execute_query(query, cursor, log_params)

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -475,7 +475,9 @@ def execute_sql_statements(  # noqa: C901
             db.session.commit()
 
             # Hook to allow environment-specific mutation (usually comments) to the SQL
-            query.executed_sql = database.mutate_sql_based_on_config(block, is_split=config["MUTATE_AFTER_SPLIT"])
+            query.executed_sql = database.mutate_sql_based_on_config(
+                block, is_split=config["MUTATE_AFTER_SPLIT"]
+            )
 
             try:
                 result_set = execute_query(query, cursor, log_params)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Very simple fix for bug described in: #30169
Currently all queries in sqllab are mutated like this:
`query.executed_sql = database.mutate_sql_based_on_config(block)`

```
def mutate_sql_based_on_config(self, sql_: str, is_split: bool = False) -> str:
        sql_mutator = config["SQL_QUERY_MUTATOR"]
        if sql_mutator and (is_split == config["MUTATE_AFTER_SPLIT"]):
            return sql_mutator(
                sql_,
                security_manager=security_manager,
                database=self,
            )
        return sql_
```

This means `is_split` is always `False` -> We always use the sql_mutator when `MUTATE_AFTER_SPLIT` is False, and never when it's True.

The fix passes the value of `MUTATE_AFTER_SPLIT` to the `mutate_sql_based_on_config` function, so `is_split == config["MUTATE_AFTER_SPLIT"]` always evaluates to True.

This does not break current implementations and fix the bug.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
In config.py:

```
MUTATE_AFTER_SPLIT = True


def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
    sql: str, **kwargs
) -> str:
    print("Query mutator called") ## will now print during SQLab sessions
    return sql
```
Run query in sql lab -> Now prints message when `MUTATE_AFTER_SPLIT` = True or False

### ADDITIONAL INFORMATION
Fixes #30169
- [x] Has associated issue: #30169
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
