### PR TITLE
feat: support theme-aware (dark mode) sequential color palettes

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/color/SequentialSchemeRegistrySingleton.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/SequentialSchemeRegistrySingleton.ts
@@ -17,19 +17,50 @@
  * under the License.
  */
 
+import { themeObject } from '@superset-ui/core';
+import tinycolor from 'tinycolor2';
 import makeSingleton from '../utils/makeSingleton';
 import ColorSchemeRegistry from './ColorSchemeRegistry';
 import SequentialScheme from './SequentialScheme';
 import schemes from './colorSchemes/sequential/d3';
 
+function transformColor(color: string): string {
+  const tc = tinycolor(color);
+  if (!tc.isValid()) return color;
+
+  const hsl = tc.toHsl();
+  return tinycolor({
+    h: hsl.h,
+    s: hsl.s,
+    l: 1 - hsl.l,
+    a: hsl.a,
+  }).toHexString();
+}
+
+function themeAwareColors(colors: string[]): string[] {
+  if (!themeObject.isThemeDark()) {
+    return colors.map(c => tinycolor(c).toHexString());
+  }
+  return colors.map(transformColor);
+}
+
 class SequentialSchemeRegistry extends ColorSchemeRegistry<SequentialScheme> {
   constructor() {
     super();
+    schemes.forEach(s => this.registerValue(s.id, s));
+    this.setDefaultKey('SUPERSET_DEFAULT');
+  }
 
-    this.registerValue('SUPERSET_DEFAULT', schemes[0]);
+  override get(key: string): SequentialScheme {
+    const base = super.get(key);
+    if (!base) throw new Error(`Unknown sequential color scheme: ${key}`);
+
+    return new SequentialScheme({
+      ...base,
+      colors: themeAwareColors(base.colors),
+    });
   }
 }
 
 const getInstance = makeSingleton(SequentialSchemeRegistry);
-
 export default getInstance;

--- a/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/sequential/common.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/sequential/common.ts
@@ -23,7 +23,7 @@ const schemes = [
   {
     id: 'blue_white_yellow',
     label: 'blue/white/yellow',
-    colors: ['#00d1c1', 'rgba(0, 0, 0, 0)', '#ffb400'],
+    colors: ['#00d1c1', '#ffffff', '#ffb400'],
   },
   {
     id: 'fire',

--- a/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/sequential/common.ts
+++ b/superset-frontend/packages/superset-ui-core/src/color/colorSchemes/sequential/common.ts
@@ -23,7 +23,7 @@ const schemes = [
   {
     id: 'blue_white_yellow',
     label: 'blue/white/yellow',
-    colors: ['#00d1c1', 'white', '#ffb400'],
+    colors: ['#00d1c1', 'rgba(0, 0, 0, 0)', '#ffb400'],
   },
   {
     id: 'fire',


### PR DESCRIPTION
<img width="1721" alt="Screenshot 2025-07-09 at 3 54 46 PM" src="https://github.com/user-attachments/assets/80da43f1-3294-47c8-b1a3-688976a1f892" />

Opening this PR as a quick POC to test whether sequential color palettes can look good in dark mode using transparency, and it seems like they *just work* — thanks to `d3-interpolate` doing the right thing when given `rgba(...)`.

### Palette preview
<img width="330" alt="Screenshot 2025-07-09 at 3 59 19 PM" src="https://github.com/user-attachments/assets/ee7b0f60-9857-4d6b-a0d8-c9925b8715f7" />


### Initial takeaways
- A lot of existing palettes avoid going all the way to pure white or black, probably to stay somewhat neutral across themes — but that middle still ends up clashing in dark mode. Using alpha (e.g. fading to transparent) gives us a cleaner fallback.
- I don’t want to change how any existing palettes render in light mode. Changing the output given the same data would be a soft compatibility break — and making things *both* backward-compatible and theme-aware might get tricky.
- Easiest path forward: introduce new theme-aware palettes (e.g. "Safe Diverging", "Dark-Optimized Sequential") and mark older ones as “legacy”.

### Experimenting
- highjack the color scheme registry and flip the brightness (hsb) of the color if/when in dark mode
- looks ok? unclear
---

### Bonus: Categorical palettes

Our categorical palettes often cycle through a few base colors (say 5) and vary them with lightness to generate more (say 3 shades per base color → 15 total). We could explore using alpha here too — generating lighter/darker variants using opacity instead of tweaking RGB directly. Same caveats around preserving light-mode compatibility apply.
