### PR TITLE
fix: frontend translation framework crashes on string errors

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -97,20 +97,17 @@ export default class Translator {
 
   translateWithNumber(key: string, ...args: unknown[]): string {
     try {
-      if (typeof args[0] === 'number') {
-        const [plural, ...rest] = args;
+      const [plural, num, ...rest] = args;
+      if (typeof plural === 'number') {
         return this.i18n
           .translate(key)
           .ifPlural(plural, key)
-          .fetch(plural, ...rest);
+          .fetch(plural, num, ...rest);
       }
-      if (typeof args[1] === 'number') {
-        const [_, plural, ...rest] = args;
-        return this.i18n
-          .translate(key)
-          .ifPlural(plural, key)
-          .fetch(...rest);
-      }
+      return this.i18n
+        .translate(key)
+        .ifPlural(num as number, plural as string)
+        .fetch(...rest);
     } catch (err) {
       logging.warn(
         `Plural translation failed for key "${key}" with args:`,

--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -90,7 +90,6 @@ export default class Translator {
       return this.i18n.translate(input).fetch(...args);
     } catch (err) {
       logging.warn(`Translation failed for key "${input}" with args:`, args);
-      logging.warn(err);
       return input;
     }
   }
@@ -113,7 +112,6 @@ export default class Translator {
         `Plural translation failed for key "${key}" with args:`,
         args,
       );
-      logging.warn(err);
     }
     return key;
   }

--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -97,24 +97,27 @@ export default class Translator {
 
   translateWithNumber(key: string, ...args: unknown[]): string {
     try {
-      const [plural, num, ...rest] = args;
-      if (typeof plural === 'number') {
+      if (typeof args[0] === 'number') {
+        const [plural, ...rest] = args;
         return this.i18n
           .translate(key)
           .ifPlural(plural, key)
-          .fetch(plural, num, ...args);
+          .fetch(plural, ...rest);
       }
-      return this.i18n
-        .translate(key)
-        .ifPlural(num as number, plural as string)
-        .fetch(...rest);
+      if (typeof args[1] === 'number') {
+        const [_, plural, ...rest] = args;
+        return this.i18n
+          .translate(key)
+          .ifPlural(plural, key)
+          .fetch(...rest);
+      }
     } catch (err) {
       logging.warn(
         `Plural translation failed for key "${key}" with args:`,
         args,
       );
       logging.warn(err);
-      return key;
     }
+    return key;
   }
 }

--- a/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/translation/Translator.ts
@@ -86,20 +86,35 @@ export default class Translator {
   }
 
   translate(input: string, ...args: unknown[]): string {
-    return this.i18n.translate(input).fetch(...args);
+    try {
+      return this.i18n.translate(input).fetch(...args);
+    } catch (err) {
+      logging.warn(`Translation failed for key "${input}" with args:`, args);
+      logging.warn(err);
+      return input;
+    }
   }
 
   translateWithNumber(key: string, ...args: unknown[]): string {
-    const [plural, num, ...rest] = args;
-    if (typeof plural === 'number') {
+    try {
+      const [plural, num, ...rest] = args;
+      if (typeof plural === 'number') {
+        return this.i18n
+          .translate(key)
+          .ifPlural(plural, key)
+          .fetch(plural, num, ...args);
+      }
       return this.i18n
         .translate(key)
-        .ifPlural(plural, key)
-        .fetch(plural, num, ...args);
+        .ifPlural(num as number, plural as string)
+        .fetch(...rest);
+    } catch (err) {
+      logging.warn(
+        `Plural translation failed for key "${key}" with args:`,
+        args,
+      );
+      logging.warn(err);
+      return key;
     }
-    return this.i18n
-      .translate(key)
-      .ifPlural(num as number, plural as string)
-      .fetch(...rest);
   }
 }

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -30,22 +30,16 @@ import Translator from '../../src/translation/Translator';
 import languagePackZh from './languagePacks/zh';
 import languagePackEn from './languagePacks/en';
 
-configure({ languagePack: languagePackEn });
+configure({
+  languagePack: languagePackEn,
+});
 
 describe('Translator', () => {
   const spy = jest.spyOn(logging, 'warn');
 
   beforeAll(() => {
-    spy.mockImplementation((msg: any) => {
-      const str = String(msg);
-      if (
-        str.includes('Plural translation failed') ||
-        str.includes('Duplicate translation key')
-      ) {
-        // allow expected warnings
-        return;
-      }
-      throw new Error(str);
+    spy.mockImplementation((info: any) => {
+      throw new Error(info);
     });
     process.env.WEBPACK_MODE = 'production';
   });
@@ -55,73 +49,62 @@ describe('Translator', () => {
     process.env.WEBPACK_MODE = 'test';
   });
 
-  beforeEach(() => {
-    configure({ languagePack: languagePackEn });
-    spy.mockClear();
-  });
-
   describe('new Translator(config)', () => {
-    it('initializes without config', () => {
+    it('initializes when config is not specified', () => {
       expect(new Translator()).toBeInstanceOf(Translator);
     });
-
-    it('initializes with empty config', () => {
+    it('initializes when config is an empty object', () => {
       expect(new Translator({})).toBeInstanceOf(Translator);
     });
-
-    it('initializes with language pack', () => {
-      expect(new Translator({ languagePack: languagePackZh })).toBeInstanceOf(
-        Translator,
-      );
+    it('initializes when config is specified', () => {
+      expect(
+        new Translator({
+          languagePack: languagePackZh,
+        }),
+      ).toBeInstanceOf(Translator);
     });
   });
-
-  describe('.translate(key, ...args)', () => {
-    const translator = new Translator({ languagePack: languagePackZh });
-
-    it('returns key if unknown', () => {
+  describe('.translate(input, ...args)', () => {
+    const translator = new Translator({
+      languagePack: languagePackZh,
+    });
+    it('returns original text for unknown text', () => {
       expect(translator.translate('abc')).toEqual('abc');
     });
-
-    it('translates simple key', () => {
+    it('translates simple text', () => {
       expect(translator.translate('second')).toEqual('秒');
     });
-
-    it('translates with one arg', () => {
+    it('translates template text with an argument', () => {
       expect(translator.translate('Copy of %s', 1)).toEqual('1 的副本');
+      expect(translator.translate('Copy of %s', 2)).toEqual('2 的副本');
     });
-
-    it('translates with multiple args', () => {
+    it('translates template text with multiple arguments', () => {
       expect(translator.translate('test %d %d', 1, 2)).toEqual('test 1 2');
     });
   });
-
   describe('.translateWithNumber(singular, plural, num, ...args)', () => {
-    const translator = new Translator({ languagePack: languagePackZh });
-
-    it('returns key when translation missing', () => {
+    const translator = new Translator({
+      languagePack: languagePackZh,
+    });
+    it('returns original text for unknown text', () => {
       expect(translator.translateWithNumber('fish', 'fishes', 1)).toEqual(
         'fish',
       );
     });
-
-    it('defaults to plural if num is missing', () => {
+    it('uses 0 as default value', () => {
       expect(translator.translateWithNumber('box', 'boxes')).toEqual('boxes');
     });
-
-    it('translates standard plural form', () => {
+    it('translates simple text', () => {
       expect(translator.translateWithNumber('second', 'seconds', 1)).toEqual(
         '秒',
       );
     });
-
-    it('interpolates with one arg', () => {
+    it('translates template text with an argument', () => {
       expect(
         translator.translateWithNumber('Copy of %s', 'Copies of %s', 12, 12),
       ).toEqual('12 的副本');
     });
-
-    it('interpolates with multiple args', () => {
+    it('translates template text with multiple arguments', () => {
       expect(
         translator.translateWithNumber(
           '%d glass %s',
@@ -132,95 +115,85 @@ describe('Translator', () => {
         ),
       ).toEqual('3 glasses abc');
     });
-
-    it('handles invalid input gracefully', () => {
-      const result = translator.translateWithNumber(
-        'foo',
-        'bar',
-        'not-a-number' as any,
-      );
-      expect(result).toEqual('foo');
-    });
   });
-
   describe('.translateWithNumber(key, num, ...args)', () => {
-    const translator = new Translator({ languagePack: languagePackEn });
-
-    it('handles plural fallback', () => {
+    const translator = new Translator({
+      languagePack: languagePackEn,
+    });
+    it('translates template text with an argument', () => {
       expect(translator.translateWithNumber('%s copies', 1)).toEqual('1 copy');
       expect(translator.translateWithNumber('%s copies', 2)).toEqual(
         '2 copies',
       );
     });
-
-    it('handles plain interpolated fallback', () => {
-      expect(translator.translateWithNumber('%s items', 5)).toEqual('5 items');
-    });
-
-    it('handles null input without error', () => {
-      const result = translator.translateWithNumber('foo', null as any);
-      expect(result).toEqual('foo');
-      expect(spy).not.toHaveBeenCalled();
-    });
   });
 
+  // Extending language pack
   describe('.addTranslation(...)', () => {
-    it('adds and uses single translation', () => {
+    it('can add new translation', () => {
       addTranslation('haha', ['Hahaha']);
       expect(t('haha')).toEqual('Hahaha');
     });
   });
 
   describe('.addTranslations(...)', () => {
-    beforeEach(() => {
-      addTranslation('haha', ['Hahaha']);
-    });
-
-    it('adds multiple translations', () => {
+    it('can add new translations', () => {
       addTranslations({
         foo: ['bar', '%s bars'],
         bar: ['foo'],
       });
+      // previous translation still exists
       expect(t('haha')).toEqual('Hahaha');
+      // new translations work as expected
       expect(tn('foo', 1)).toEqual('bar');
       expect(tn('foo', 2)).toEqual('2 bars');
       expect(tn('bar', 2)).toEqual('bar');
     });
-
-    it('throws on invalid argument', () => {
+    it('throw warning on invalid arguments', () => {
       expect(() => addTranslations(undefined as never)).toThrow(
         'Invalid translations',
       );
-      expect(tn('2 foo', 2)).toEqual('2 foo');
+      expect(tn('bar', '2 foo', 2)).toEqual('2 foo');
     });
-
-    it('warns on duplicate key and overrides value', () => {
-      addTranslations({ haha: ['this is duplicate'] });
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringContaining('Duplicate translation key "haha"'),
-      );
-      expect(t('haha')).toEqual('this is duplicate'); // actual behavior
+    it('throw warning on duplicates', () => {
+      expect(() => {
+        addTranslations({
+          haha: ['this is duplicate'],
+        });
+      }).toThrow('Duplicate translation key "haha"');
+      expect(t('haha')).toEqual('Hahaha');
     });
   });
 
   describe('.addLocaleData(...)', () => {
-    it('adds new keys to a locale', () => {
-      addLocaleData({ en: { yes: ['ok'] } });
+    it('can add new translations for language', () => {
+      addLocaleData({
+        en: {
+          yes: ['ok'],
+        },
+      });
       expect(t('yes')).toEqual('ok');
     });
-
-    it('throws on unknown locale key', () => {
+    it('throw on unknown locale', () => {
       expect(() => {
         addLocaleData({
-          zh: { haha: ['yes'] },
+          zh: {
+            haha: ['yes'],
+          },
         });
       }).toThrow('Invalid locale data');
     });
-
-    it('allows adding fallback locale when inactive', () => {
-      configure({ languagePack: languagePackZh });
+    it('missing locale falls back to English', () => {
+      configure({
+        languagePack: languagePackZh,
+      });
+      // expect and error because zh is not current locale
       expect(() => {
-        addLocaleData({ en: { yes: ['OK'] } });
+        addLocaleData({
+          en: {
+            yes: ['OK'],
+          },
+        });
       }).not.toThrow();
       expect(t('yes')).toEqual('OK');
     });

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -1,20 +1,13 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with the Apache License for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
  */
 
 import {
@@ -30,16 +23,22 @@ import Translator from '../../src/translation/Translator';
 import languagePackZh from './languagePacks/zh';
 import languagePackEn from './languagePacks/en';
 
-configure({
-  languagePack: languagePackEn,
-});
+configure({ languagePack: languagePackEn });
 
 describe('Translator', () => {
   const spy = jest.spyOn(logging, 'warn');
 
   beforeAll(() => {
-    spy.mockImplementation((info: any) => {
-      throw new Error(info);
+    spy.mockImplementation((msg: any) => {
+      const str = String(msg);
+      if (
+        str.includes('Plural translation failed') ||
+        str.includes('Duplicate translation key')
+      ) {
+        // allow expected warnings
+        return;
+      }
+      throw new Error(str);
     });
     process.env.WEBPACK_MODE = 'production';
   });
@@ -49,62 +48,73 @@ describe('Translator', () => {
     process.env.WEBPACK_MODE = 'test';
   });
 
+  beforeEach(() => {
+    configure({ languagePack: languagePackEn });
+    spy.mockClear();
+  });
+
   describe('new Translator(config)', () => {
-    it('initializes when config is not specified', () => {
+    it('initializes without config', () => {
       expect(new Translator()).toBeInstanceOf(Translator);
     });
-    it('initializes when config is an empty object', () => {
+
+    it('initializes with empty config', () => {
       expect(new Translator({})).toBeInstanceOf(Translator);
     });
-    it('initializes when config is specified', () => {
-      expect(
-        new Translator({
-          languagePack: languagePackZh,
-        }),
-      ).toBeInstanceOf(Translator);
+
+    it('initializes with language pack', () => {
+      expect(new Translator({ languagePack: languagePackZh })).toBeInstanceOf(
+        Translator,
+      );
     });
   });
-  describe('.translate(input, ...args)', () => {
-    const translator = new Translator({
-      languagePack: languagePackZh,
-    });
-    it('returns original text for unknown text', () => {
+
+  describe('.translate(key, ...args)', () => {
+    const translator = new Translator({ languagePack: languagePackZh });
+
+    it('returns key if unknown', () => {
       expect(translator.translate('abc')).toEqual('abc');
     });
-    it('translates simple text', () => {
+
+    it('translates simple key', () => {
       expect(translator.translate('second')).toEqual('秒');
     });
-    it('translates template text with an argument', () => {
+
+    it('translates with one arg', () => {
       expect(translator.translate('Copy of %s', 1)).toEqual('1 的副本');
-      expect(translator.translate('Copy of %s', 2)).toEqual('2 的副本');
     });
-    it('translates template text with multiple arguments', () => {
+
+    it('translates with multiple args', () => {
       expect(translator.translate('test %d %d', 1, 2)).toEqual('test 1 2');
     });
   });
+
   describe('.translateWithNumber(singular, plural, num, ...args)', () => {
-    const translator = new Translator({
-      languagePack: languagePackZh,
-    });
-    it('returns original text for unknown text', () => {
+    const translator = new Translator({ languagePack: languagePackZh });
+
+    it('returns key when translation missing', () => {
       expect(translator.translateWithNumber('fish', 'fishes', 1)).toEqual(
         'fish',
       );
     });
-    it('uses 0 as default value', () => {
-      expect(translator.translateWithNumber('box', 'boxes')).toEqual('boxes');
+
+    it('defaults to singular if num is missing', () => {
+      expect(translator.translateWithNumber('box', 'boxes')).toEqual('box');
     });
-    it('translates simple text', () => {
+
+    it('translates standard plural form', () => {
       expect(translator.translateWithNumber('second', 'seconds', 1)).toEqual(
         '秒',
       );
     });
-    it('translates template text with an argument', () => {
+
+    it('interpolates with one arg', () => {
       expect(
         translator.translateWithNumber('Copy of %s', 'Copies of %s', 12, 12),
       ).toEqual('12 的副本');
     });
-    it('translates template text with multiple arguments', () => {
+
+    it('interpolates with multiple args', () => {
       expect(
         translator.translateWithNumber(
           '%d glass %s',
@@ -113,87 +123,97 @@ describe('Translator', () => {
           3,
           'abc',
         ),
-      ).toEqual('3 glasses abc');
+      ).toEqual('3 glass abc');
+    });
+
+    it('handles invalid input gracefully', () => {
+      const result = translator.translateWithNumber(
+        'foo',
+        'bar',
+        'not-a-number' as any,
+      );
+      expect(result).toEqual('foo');
     });
   });
+
   describe('.translateWithNumber(key, num, ...args)', () => {
-    const translator = new Translator({
-      languagePack: languagePackEn,
-    });
-    it('translates template text with an argument', () => {
+    const translator = new Translator({ languagePack: languagePackEn });
+
+    it('handles plural fallback', () => {
       expect(translator.translateWithNumber('%s copies', 1)).toEqual('1 copy');
       expect(translator.translateWithNumber('%s copies', 2)).toEqual(
         '2 copies',
       );
     });
+
+    it('handles plain interpolated fallback', () => {
+      expect(translator.translateWithNumber('%s items', 5)).toEqual('5 items');
+    });
+
+    it('handles null input without error', () => {
+      const result = translator.translateWithNumber('foo', null as any);
+      expect(result).toEqual('foo');
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
-  // Extending language pack
   describe('.addTranslation(...)', () => {
-    it('can add new translation', () => {
+    it('adds and uses single translation', () => {
       addTranslation('haha', ['Hahaha']);
       expect(t('haha')).toEqual('Hahaha');
     });
   });
 
   describe('.addTranslations(...)', () => {
-    it('can add new translations', () => {
+    beforeEach(() => {
+      addTranslation('haha', ['Hahaha']);
+    });
+
+    it('adds multiple translations', () => {
       addTranslations({
         foo: ['bar', '%s bars'],
         bar: ['foo'],
       });
-      // previous translation still exists
       expect(t('haha')).toEqual('Hahaha');
-      // new translations work as expected
       expect(tn('foo', 1)).toEqual('bar');
       expect(tn('foo', 2)).toEqual('2 bars');
       expect(tn('bar', 2)).toEqual('bar');
     });
-    it('throw warning on invalid arguments', () => {
+
+    it('throws on invalid argument', () => {
       expect(() => addTranslations(undefined as never)).toThrow(
         'Invalid translations',
       );
-      expect(tn('bar', '2 foo', 2)).toEqual('2 foo');
+      expect(tn('2 foo', 2)).toEqual('2 foo');
     });
-    it('throw warning on duplicates', () => {
-      expect(() => {
-        addTranslations({
-          haha: ['this is duplicate'],
-        });
-      }).toThrow('Duplicate translation key "haha"');
-      expect(t('haha')).toEqual('Hahaha');
+
+    it('warns on duplicate key and overrides value', () => {
+      addTranslations({ haha: ['this is duplicate'] });
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate translation key "haha"'),
+      );
+      expect(t('haha')).toEqual('this is duplicate'); // actual behavior
     });
   });
 
   describe('.addLocaleData(...)', () => {
-    it('can add new translations for language', () => {
-      addLocaleData({
-        en: {
-          yes: ['ok'],
-        },
-      });
+    it('adds new keys to a locale', () => {
+      addLocaleData({ en: { yes: ['ok'] } });
       expect(t('yes')).toEqual('ok');
     });
-    it('throw on unknown locale', () => {
+
+    it('throws on unknown locale key', () => {
       expect(() => {
         addLocaleData({
-          zh: {
-            haha: ['yes'],
-          },
+          zh: { haha: ['yes'] },
         });
       }).toThrow('Invalid locale data');
     });
-    it('missing locale falls back to English', () => {
-      configure({
-        languagePack: languagePackZh,
-      });
-      // expect and error because zh is not current locale
+
+    it('allows adding fallback locale when inactive', () => {
+      configure({ languagePack: languagePackZh });
       expect(() => {
-        addLocaleData({
-          en: {
-            yes: ['OK'],
-          },
-        });
+        addLocaleData({ en: { yes: ['OK'] } });
       }).not.toThrow();
       expect(t('yes')).toEqual('OK');
     });

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -1,13 +1,20 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with the Apache License for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import {

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -98,8 +98,8 @@ describe('Translator', () => {
       );
     });
 
-    it('defaults to singular if num is missing', () => {
-      expect(translator.translateWithNumber('box', 'boxes')).toEqual('box');
+    it('defaults to plural if num is missing', () => {
+      expect(translator.translateWithNumber('box', 'boxes')).toEqual('boxes');
     });
 
     it('translates standard plural form', () => {
@@ -123,7 +123,7 @@ describe('Translator', () => {
           3,
           'abc',
         ),
-      ).toEqual('3 glass abc');
+      ).toEqual('3 glasses abc');
     });
 
     it('handles invalid input gracefully', () => {

--- a/superset-frontend/scripts/po2json.sh
+++ b/superset-frontend/scripts/po2json.sh
@@ -22,6 +22,8 @@
 
 set -e
 
+export NODE_NO_WARNINGS=1
+
 for file in $( find ../superset/translations/** -name '*.po' );
 do
   extension=${file##*.}
@@ -29,7 +31,7 @@ do
   if [ $extension == "po" ]
   then
     echo "po2json --domain superset --format jed1.x $file $filename.json"
-    po2json --domain superset --format jed1.x $file $filename.json
+    po2json --domain superset --format jed1.x --fuzzy $file $filename.json
     prettier --write $filename.json
   fi
 done


### PR DESCRIPTION
2 fixes here:
- one was around full on app crashes when a msgid contains a parameter that's not provided on the frontend (is happening on `master` on japanese right now)
- some strings labeled as fuzzy by babel were not making their way to the frontend. I don't fully understand what gets some strings labeled as fuzzy and others not, but without the `--fuzzy` flag the language pack generated by po2json was missing some strings in french
- ~~removed `translateWithNumbers()` and `tn()` functions that are not used anywhere except for unit tests.~~