### PR TITLE
feat(theming): Introduce bootstrap-driven Superset theme configurations

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ThemeSelect/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemeSelect/index.tsx
@@ -22,22 +22,22 @@ import { t } from '@superset-ui/core';
 import { ThemeMode } from '../../theme/types';
 
 export interface ThemeSelectProps {
-  changeThemeMode: (newMode: ThemeMode) => void;
+  setThemeMode: (newMode: ThemeMode) => void;
   tooltipTitle?: string;
   themeMode: ThemeMode;
 }
 
 const ThemeSelect: React.FC<ThemeSelectProps> = ({
-  changeThemeMode,
+  setThemeMode,
   tooltipTitle = 'Select theme',
   themeMode,
 }) => {
   const handleSelect = (mode: ThemeMode) => {
-    changeThemeMode(mode);
+    setThemeMode(mode);
   };
 
   const themeIconMap: Record<ThemeMode, React.ReactNode> = {
-    [ThemeMode.LIGHT]: <Icons.SunOutlined />,
+    [ThemeMode.DEFAULT]: <Icons.SunOutlined />,
     [ThemeMode.DARK]: <Icons.MoonOutlined />,
     [ThemeMode.SYSTEM]: <Icons.FormatPainterOutlined />,
     [ThemeMode.COMPACT]: <Icons.CompressOutlined />,
@@ -49,9 +49,9 @@ const ThemeSelect: React.FC<ThemeSelectProps> = ({
         menu={{
           items: [
             {
-              key: ThemeMode.LIGHT,
+              key: ThemeMode.DEFAULT,
               label: t('Light'),
-              onClick: () => handleSelect(ThemeMode.LIGHT),
+              onClick: () => handleSelect(ThemeMode.DEFAULT),
               icon: <Icons.SunOutlined />,
             },
             {

--- a/superset-frontend/packages/superset-ui-core/src/components/ThemeSelect/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemeSelect/index.tsx
@@ -19,7 +19,7 @@
 import { Tooltip } from 'antd';
 import { Dropdown, Icons } from '@superset-ui/core/components';
 import { t } from '@superset-ui/core';
-import { ThemeMode } from '../../theme/types';
+import { ThemeAlgorithm, ThemeMode } from '../../theme/types';
 
 export interface ThemeSelectProps {
   setThemeMode: (newMode: ThemeMode) => void;
@@ -36,11 +36,11 @@ const ThemeSelect: React.FC<ThemeSelectProps> = ({
     setThemeMode(mode);
   };
 
-  const themeIconMap: Record<ThemeMode, React.ReactNode> = {
-    [ThemeMode.DEFAULT]: <Icons.SunOutlined />,
-    [ThemeMode.DARK]: <Icons.MoonOutlined />,
+  const themeIconMap: Record<ThemeAlgorithm | ThemeMode, React.ReactNode> = {
+    [ThemeAlgorithm.DEFAULT]: <Icons.SunOutlined />,
+    [ThemeAlgorithm.DARK]: <Icons.MoonOutlined />,
     [ThemeMode.SYSTEM]: <Icons.FormatPainterOutlined />,
-    [ThemeMode.COMPACT]: <Icons.CompressOutlined />,
+    [ThemeAlgorithm.COMPACT]: <Icons.CompressOutlined />,
   };
 
   return (

--- a/superset-frontend/packages/superset-ui-core/src/theme/Theme.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/Theme.test.tsx
@@ -18,7 +18,7 @@
  */
 import { theme as antdThemeImport } from 'antd';
 import { Theme } from './Theme';
-import { AnyThemeConfig } from './types';
+import { AnyThemeConfig, ThemeAlgorithm } from './types';
 
 // Mock emotion's cache to avoid actual DOM operations
 jest.mock('@emotion/cache', () => ({
@@ -44,7 +44,7 @@ describe('Theme', () => {
       const parsedJson = JSON.parse(jsonString);
 
       expect(parsedJson.token?.colorPrimary).toBe('#ff0000');
-      expect(parsedJson.algorithm).toBe('dark');
+      expect(parsedJson.algorithm).toBe(ThemeAlgorithm.DARK);
     });
   });
 
@@ -91,7 +91,7 @@ describe('Theme', () => {
 
       // Verify dark mode by using the serialized config from the public method
       const serialized = theme.toSerializedConfig();
-      expect(serialized.algorithm).toBe('dark');
+      expect(serialized.algorithm).toBe(ThemeAlgorithm.DARK);
     });
   });
 
@@ -137,7 +137,7 @@ describe('Theme', () => {
 
       // Verify the algorithm was updated
       const serialized = theme.toSerializedConfig();
-      expect(serialized.algorithm).toBe('dark');
+      expect(serialized.algorithm).toBe(ThemeAlgorithm.DARK);
     });
   });
 
@@ -150,7 +150,7 @@ describe('Theme', () => {
 
       // Verify dark algorithm is used
       const serialized = theme.toSerializedConfig();
-      expect(serialized.algorithm).toBe('dark');
+      expect(serialized.algorithm).toBe(ThemeAlgorithm.DARK);
     });
 
     it('switches to default algorithm when toggling dark mode off', () => {
@@ -164,7 +164,7 @@ describe('Theme', () => {
 
       // Verify default algorithm is used
       const serialized = theme.toSerializedConfig();
-      expect(serialized.algorithm).toBe('default');
+      expect(serialized.algorithm).toBe(ThemeAlgorithm.DEFAULT);
     });
 
     it('preserves other algorithms when toggling dark mode', () => {
@@ -181,10 +181,11 @@ describe('Theme', () => {
 
       // Verify default algorithm replaces dark but compact is preserved
       const serialized = theme.toSerializedConfig();
+
       expect(Array.isArray(serialized.algorithm)).toBe(true);
-      expect(serialized.algorithm).toContain('default');
-      expect(serialized.algorithm).toContain('compact');
-      expect(serialized.algorithm).not.toContain('dark');
+      expect(serialized.algorithm).toContain(ThemeAlgorithm.DEFAULT);
+      expect(serialized.algorithm).toContain(ThemeAlgorithm.COMPACT);
+      expect(serialized.algorithm).not.toContain(ThemeAlgorithm.DARK);
     });
   });
 
@@ -218,7 +219,7 @@ describe('Theme', () => {
       const serialized = theme.toSerializedConfig();
 
       expect(serialized.token?.colorPrimary).toBe('#ff0000');
-      expect(serialized.algorithm).toBe('dark');
+      expect(serialized.algorithm).toBe(ThemeAlgorithm.DARK);
     });
   });
 });

--- a/superset-frontend/packages/superset-ui-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/Theme.tsx
@@ -19,7 +19,11 @@
 /* eslint-disable react-prefer-function-component/react-prefer-function-component */
 // eslint-disable-next-line no-restricted-syntax
 import React from 'react';
-import { theme as antdThemeImport, ConfigProvider } from 'antd';
+import {
+  theme as antdThemeImport,
+  ConfigProvider,
+  type ThemeConfig,
+} from 'antd';
 import tinycolor from 'tinycolor2';
 
 // @fontsource/* v5.1+ doesn't play nice with eslint-import plugin v2.31+
@@ -160,7 +164,7 @@ export class Theme {
    * Dark mode should be specified via the algorithm property in the config
    */
   setConfig(config: AnyThemeConfig): void {
-    const antdConfig = normalizeThemeConfig(config);
+    const antdConfig: ThemeConfig = normalizeThemeConfig(config);
 
     // Apply default tokens to token property
     antdConfig.token = {
@@ -169,7 +173,7 @@ export class Theme {
     };
 
     // First phase: Let Ant Design compute the tokens
-    const tokens = Theme.getFilteredAntdTheme(antdConfig);
+    const tokens: SharedAntdTokens = Theme.getFilteredAntdTheme(antdConfig);
 
     // Set the base theme properties
     this.antdConfig = antdConfig;

--- a/superset-frontend/packages/superset-ui-core/src/theme/Theme.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/Theme.tsx
@@ -19,11 +19,7 @@
 /* eslint-disable react-prefer-function-component/react-prefer-function-component */
 // eslint-disable-next-line no-restricted-syntax
 import React from 'react';
-import {
-  theme as antdThemeImport,
-  ConfigProvider,
-  type ThemeConfig,
-} from 'antd';
+import { theme as antdThemeImport, ConfigProvider } from 'antd';
 import tinycolor from 'tinycolor2';
 
 // @fontsource/* v5.1+ doesn't play nice with eslint-import plugin v2.31+
@@ -164,7 +160,7 @@ export class Theme {
    * Dark mode should be specified via the algorithm property in the config
    */
   setConfig(config: AnyThemeConfig): void {
-    const antdConfig: ThemeConfig = normalizeThemeConfig(config);
+    const antdConfig = normalizeThemeConfig(config);
 
     // Apply default tokens to token property
     antdConfig.token = {
@@ -173,7 +169,7 @@ export class Theme {
     };
 
     // First phase: Let Ant Design compute the tokens
-    const tokens: SharedAntdTokens = Theme.getFilteredAntdTheme(antdConfig);
+    const tokens = Theme.getFilteredAntdTheme(antdConfig);
 
     // Set the base theme properties
     this.antdConfig = antdConfig;

--- a/superset-frontend/packages/superset-ui-core/src/theme/exampleThemes.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/exampleThemes.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable theme-colors/no-literal-colors */
-import { type SerializableThemeConfig, ThemeMode } from './types';
+import { type SerializableThemeConfig, ThemeAlgorithm } from './types';
 
 const exampleThemes: Record<string, SerializableThemeConfig> = {
   superset: {
@@ -27,11 +27,11 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
   },
   supersetDark: {
     token: {},
-    algorithm: ThemeMode.DARK,
+    algorithm: ThemeAlgorithm.DARK,
   },
   supersetCompact: {
     token: {},
-    algorithm: ThemeMode.COMPACT,
+    algorithm: ThemeAlgorithm.COMPACT,
   },
   funky: {
     token: {
@@ -43,7 +43,7 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
       borderRadius: 12,
       fontFamily: 'Comic Sans MS, cursive',
     },
-    algorithm: ThemeMode.DEFAULT,
+    algorithm: ThemeAlgorithm.DEFAULT,
   },
   funkyDark: {
     token: {
@@ -55,7 +55,7 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
       borderRadius: 12,
       fontFamily: 'Comic Sans MS, cursive',
     },
-    algorithm: ThemeMode.DARK,
+    algorithm: ThemeAlgorithm.DARK,
   },
 };
 export default exampleThemes;

--- a/superset-frontend/packages/superset-ui-core/src/theme/exampleThemes.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/exampleThemes.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-disable theme-colors/no-literal-colors */
-import { SerializableThemeConfig } from './types';
+import { type SerializableThemeConfig, ThemeMode } from './types';
 
 const exampleThemes: Record<string, SerializableThemeConfig> = {
   superset: {
@@ -27,11 +27,11 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
   },
   supersetDark: {
     token: {},
-    algorithm: 'dark',
+    algorithm: ThemeMode.DARK,
   },
   supersetCompact: {
     token: {},
-    algorithm: 'compact',
+    algorithm: ThemeMode.COMPACT,
   },
   funky: {
     token: {
@@ -43,7 +43,7 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
       borderRadius: 12,
       fontFamily: 'Comic Sans MS, cursive',
     },
-    algorithm: 'default',
+    algorithm: ThemeMode.DEFAULT,
   },
   funkyDark: {
     token: {
@@ -55,7 +55,7 @@ const exampleThemes: Record<string, SerializableThemeConfig> = {
       borderRadius: 12,
       fontFamily: 'Comic Sans MS, cursive',
     },
-    algorithm: 'dark',
+    algorithm: ThemeMode.DARK,
   },
 };
 export default exampleThemes;

--- a/superset-frontend/packages/superset-ui-core/src/theme/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/index.tsx
@@ -26,7 +26,7 @@ import {
   type ThemeStorage,
   type ThemeControllerOptions,
   type ThemeContextType,
-  ThemeMode,
+  ThemeAlgorithm,
 } from './types';
 
 export {
@@ -59,7 +59,9 @@ export function useTheme() {
 const styled: CreateStyled = emotionStyled;
 
 // launching in in dark mode for now while iterating
-const themeObject: Theme = Theme.fromConfig({ algorithm: ThemeMode.DEFAULT });
+const themeObject: Theme = Theme.fromConfig({
+  algorithm: ThemeAlgorithm.DEFAULT,
+});
 
 const { theme } = themeObject;
 const supersetTheme = theme;

--- a/superset-frontend/packages/superset-ui-core/src/theme/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/index.tsx
@@ -16,17 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import emotionStyled from '@emotion/styled';
+import emotionStyled, { CreateStyled } from '@emotion/styled';
 import { useTheme as useThemeBasic } from '@emotion/react';
-// import { theme as antdThemeImport } from 'antd';
 import { Theme } from './Theme';
-import type {
-  SupersetTheme,
-  SerializableThemeConfig,
-  AnyThemeConfig,
-  ThemeStorage,
-  ThemeControllerOptions,
-  ThemeContextType,
+import {
+  type SupersetTheme,
+  type SerializableThemeConfig,
+  type AnyThemeConfig,
+  type ThemeStorage,
+  type ThemeControllerOptions,
+  type ThemeContextType,
+  ThemeMode,
 } from './types';
 
 export {
@@ -56,10 +56,10 @@ export function useTheme() {
   return theme;
 }
 
-const styled = emotionStyled;
+const styled: CreateStyled = emotionStyled;
 
 // launching in in dark mode for now while iterating
-const themeObject = Theme.fromConfig({ algorithm: 'default' });
+const themeObject: Theme = Theme.fromConfig({ algorithm: ThemeMode.DEFAULT });
 
 const { theme } = themeObject;
 const supersetTheme = theme;

--- a/superset-frontend/packages/superset-ui-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/types.ts
@@ -34,17 +34,32 @@ export type AntdTokens = ReturnType<typeof antdThemeImport.getDesignToken>;
 export type AntdThemeConfig = ThemeConfig;
 
 /**
+ * A combination of theme modes that can be used in theme config.
+ * This is used to define which algorithms are allow to be applied together.
+ */
+export type ThemeAlgorithmCombination = (
+  | ThemeMode.DEFAULT
+  | ThemeMode.DARK
+  | ThemeMode.COMPACT
+)[];
+
+/**
+ * All valid algorithm values that can be used in theme config.
+ */
+export type ThemeAlgorithmOption =
+  | ThemeMode.DEFAULT
+  | ThemeMode.DARK
+  | ThemeMode.COMPACT
+  | ThemeAlgorithmCombination;
+
+/**
  * A serializable version of Ant Design's ThemeConfig
  * Compatible with theme editor exports
  */
 export type SerializableThemeConfig = {
   token?: Record<string, any>;
   components?: Record<string, any>;
-  algorithm?:
-    | 'default'
-    | 'dark'
-    | 'compact'
-    | ('default' | 'dark' | 'compact')[];
+  algorithm?: ThemeAlgorithmOption;
   hashed?: boolean;
   inherit?: boolean;
 };
@@ -359,7 +374,7 @@ export type AllowedAntdTokenKeys = Extract<
 >;
 
 export enum ThemeMode {
-  LIGHT = 'light',
+  DEFAULT = 'default',
   DARK = 'dark',
   SYSTEM = 'system',
   COMPACT = 'compact',
@@ -379,7 +394,7 @@ export interface ThemeStorage {
 }
 
 export interface ThemeControllerOptions {
-  themeObject: Theme;
+  themeObject?: Theme;
   storage?: ThemeStorage;
   storageKey?: string;
   modeStorageKey?: string;
@@ -393,6 +408,6 @@ export interface ThemeContextType {
   theme: Theme;
   themeMode: ThemeMode;
   setTheme: (config: AnyThemeConfig) => void;
-  changeThemeMode: (newMode: ThemeMode) => void;
+  setThemeMode: (newMode: ThemeMode) => void;
   resetTheme: () => void;
 }

--- a/superset-frontend/packages/superset-ui-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/types.ts
@@ -34,23 +34,39 @@ export type AntdTokens = ReturnType<typeof antdThemeImport.getDesignToken>;
 export type AntdThemeConfig = ThemeConfig;
 
 /**
- * A combination of theme modes that can be used in theme config.
- * This is used to define which algorithms are allow to be applied together.
+ * Theme algorithms supported by Antd.
+ * They can be used individually or in combination.
+ * - DEFAULT: Default light theme
+ * - DARK: Dark theme
+ * - COMPACT: Compact theme (smaller spacing)
  */
-export type ThemeAlgorithmCombination = (
-  | ThemeMode.DEFAULT
-  | ThemeMode.DARK
-  | ThemeMode.COMPACT
-)[];
+export enum ThemeAlgorithm {
+  DEFAULT = 'default',
+  DARK = 'dark',
+  COMPACT = 'compact',
+}
+
+/**
+ * Represents the current theme mode of the app.
+ * It can be one of the following:
+ * - DEFAULT: Light theme
+ * - DARK: Dark theme
+ * - SYSTEM: System theme (auto-detects based on system settings)
+ */
+export enum ThemeMode {
+  DEFAULT = 'default',
+  DARK = 'dark',
+  SYSTEM = 'system',
+}
 
 /**
  * All valid algorithm values that can be used in theme config.
  */
 export type ThemeAlgorithmOption =
-  | ThemeMode.DEFAULT
-  | ThemeMode.DARK
-  | ThemeMode.COMPACT
-  | ThemeAlgorithmCombination;
+  | ThemeAlgorithm.DEFAULT
+  | ThemeAlgorithm.DARK
+  | ThemeAlgorithm.COMPACT
+  | ThemeAlgorithm[];
 
 /**
  * A serializable version of Ant Design's ThemeConfig
@@ -372,13 +388,6 @@ export type AllowedAntdTokenKeys = Extract<
   (typeof allowedAntdTokens)[number],
   keyof AntdTokens
 >;
-
-export enum ThemeMode {
-  DEFAULT = 'default',
-  DARK = 'dark',
-  SYSTEM = 'system',
-  COMPACT = 'compact',
-}
 
 export type SharedAntdTokens = Pick<AntdTokens, AllowedAntdTokenKeys>;
 

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
@@ -28,9 +28,10 @@ import {
   genDeprecatedColorVariations,
 } from './utils';
 import {
-  AnyThemeConfig,
-  SerializableThemeConfig,
-  AntdThemeConfig,
+  type AnyThemeConfig,
+  type SerializableThemeConfig,
+  type AntdThemeConfig,
+  ThemeMode,
 } from './types';
 
 // Mock tinycolor2 for consistent testing
@@ -56,7 +57,7 @@ describe('Theme utilities', () => {
     it('returns true when algorithm is a string', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'dark',
+        algorithm: ThemeMode.DARK,
       };
       expect(isSerializableConfig(config)).toBe(true);
     });
@@ -64,7 +65,7 @@ describe('Theme utilities', () => {
     it('returns true when algorithm is an array of strings', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ['dark', 'compact'],
+        algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
       };
       expect(isSerializableConfig(config)).toBe(true);
     });
@@ -81,7 +82,7 @@ describe('Theme utilities', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
         // @ts-ignore
-        algorithm: [antdThemeImport.darkAlgorithm, 'compact'],
+        algorithm: [antdThemeImport.darkAlgorithm, ThemeMode.COMPACT],
       };
       expect(isSerializableConfig(config)).toBe(false);
     });
@@ -91,7 +92,7 @@ describe('Theme utilities', () => {
     it('converts string algorithm to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'dark',
+        algorithm: ThemeMode.DARK,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);
@@ -100,7 +101,7 @@ describe('Theme utilities', () => {
     it('converts array of string algorithms to function references', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ['dark', 'compact'],
+        algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
       };
       const result = deserializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
@@ -111,7 +112,7 @@ describe('Theme utilities', () => {
     it('preserves other configuration properties', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'dark',
+        algorithm: ThemeMode.DARK,
         hashed: true,
       };
       const result = deserializeThemeConfig(config);
@@ -130,7 +131,7 @@ describe('Theme utilities', () => {
     it('converts default algorithm string to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'default',
+        algorithm: ThemeMode.DEFAULT,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.defaultAlgorithm);
@@ -139,7 +140,7 @@ describe('Theme utilities', () => {
     it('converts compact algorithm string to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'compact',
+        algorithm: ThemeMode.COMPACT,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.compactAlgorithm);
@@ -153,7 +154,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.darkAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe('dark');
+      expect(result.algorithm).toBe(ThemeMode.DARK);
     });
 
     it('converts array of function algorithms to strings', () => {
@@ -166,8 +167,8 @@ describe('Theme utilities', () => {
       };
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
-      expect(result.algorithm).toContain('dark');
-      expect(result.algorithm).toContain('compact');
+      expect(result.algorithm).toContain(ThemeMode.DARK);
+      expect(result.algorithm).toContain(ThemeMode.COMPACT);
     });
 
     it('preserves other configuration properties', () => {
@@ -197,7 +198,7 @@ describe('Theme utilities', () => {
         algorithm: unknownAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe('default');
+      expect(result.algorithm).toBe(ThemeMode.DEFAULT);
     });
 
     it('converts default algorithm function to string', () => {
@@ -206,7 +207,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.defaultAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe('default');
+      expect(result.algorithm).toBe(ThemeMode.DEFAULT);
     });
 
     it('converts compact algorithm function to string', () => {
@@ -215,7 +216,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.compactAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe('compact');
+      expect(result.algorithm).toBe(ThemeMode.COMPACT);
     });
 
     it('defaults each unknown algorithm in array to "default"', () => {
@@ -227,7 +228,7 @@ describe('Theme utilities', () => {
       };
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
-      expect(result.algorithm).toEqual(['dark', 'default']);
+      expect(result.algorithm).toEqual([ThemeMode.DARK, ThemeMode.DEFAULT]);
     });
 
     it('handles mixed known and unknown algorithms in array', () => {
@@ -247,10 +248,10 @@ describe('Theme utilities', () => {
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toEqual([
-        'dark',
-        'default',
-        'compact',
-        'default',
+        ThemeMode.DARK,
+        ThemeMode.DEFAULT,
+        ThemeMode.COMPACT,
+        ThemeMode.DEFAULT,
       ]);
     });
   });
@@ -268,7 +269,7 @@ describe('Theme utilities', () => {
     it('deserializes serializable configs', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: 'dark',
+        algorithm: ThemeMode.DARK,
       };
       const result = normalizeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
@@ -31,7 +31,7 @@ import {
   type AnyThemeConfig,
   type SerializableThemeConfig,
   type AntdThemeConfig,
-  ThemeMode,
+  ThemeAlgorithm,
 } from './types';
 
 // Mock tinycolor2 for consistent testing
@@ -57,7 +57,7 @@ describe('Theme utilities', () => {
     it('returns true when algorithm is a string', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.DARK,
+        algorithm: ThemeAlgorithm.DARK,
       };
       expect(isSerializableConfig(config)).toBe(true);
     });
@@ -65,7 +65,10 @@ describe('Theme utilities', () => {
     it('returns true when algorithm is an array of strings', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+        algorithm: [
+          ThemeAlgorithm.DARK,
+          ThemeAlgorithm.COMPACT,
+        ] as ThemeAlgorithm[],
       };
       expect(isSerializableConfig(config)).toBe(true);
     });
@@ -82,7 +85,7 @@ describe('Theme utilities', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
         // @ts-ignore
-        algorithm: [antdThemeImport.darkAlgorithm, ThemeMode.COMPACT],
+        algorithm: [antdThemeImport.darkAlgorithm, ThemeAlgorithm.COMPACT],
       };
       expect(isSerializableConfig(config)).toBe(false);
     });
@@ -92,7 +95,7 @@ describe('Theme utilities', () => {
     it('converts string algorithm to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.DARK,
+        algorithm: ThemeAlgorithm.DARK,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);
@@ -101,7 +104,7 @@ describe('Theme utilities', () => {
     it('converts array of string algorithms to function references', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+        algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
       };
       const result = deserializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
@@ -112,7 +115,7 @@ describe('Theme utilities', () => {
     it('preserves other configuration properties', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.DARK,
+        algorithm: ThemeAlgorithm.DARK,
         hashed: true,
       };
       const result = deserializeThemeConfig(config);
@@ -131,7 +134,7 @@ describe('Theme utilities', () => {
     it('converts default algorithm string to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.DEFAULT,
+        algorithm: ThemeAlgorithm.DEFAULT,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.defaultAlgorithm);
@@ -140,7 +143,7 @@ describe('Theme utilities', () => {
     it('converts compact algorithm string to function reference', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.COMPACT,
+        algorithm: ThemeAlgorithm.COMPACT,
       };
       const result = deserializeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.compactAlgorithm);
@@ -154,7 +157,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.darkAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe(ThemeMode.DARK);
+      expect(result.algorithm).toBe(ThemeAlgorithm.DARK);
     });
 
     it('converts array of function algorithms to strings', () => {
@@ -167,8 +170,8 @@ describe('Theme utilities', () => {
       };
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
-      expect(result.algorithm).toContain(ThemeMode.DARK);
-      expect(result.algorithm).toContain(ThemeMode.COMPACT);
+      expect(result.algorithm).toContain(ThemeAlgorithm.DARK);
+      expect(result.algorithm).toContain(ThemeAlgorithm.COMPACT);
     });
 
     it('preserves other configuration properties', () => {
@@ -198,7 +201,7 @@ describe('Theme utilities', () => {
         algorithm: unknownAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe(ThemeMode.DEFAULT);
+      expect(result.algorithm).toBe(ThemeAlgorithm.DEFAULT);
     });
 
     it('converts default algorithm function to string', () => {
@@ -207,7 +210,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.defaultAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe(ThemeMode.DEFAULT);
+      expect(result.algorithm).toBe(ThemeAlgorithm.DEFAULT);
     });
 
     it('converts compact algorithm function to string', () => {
@@ -216,7 +219,7 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.compactAlgorithm,
       };
       const result = serializeThemeConfig(config);
-      expect(result.algorithm).toBe(ThemeMode.COMPACT);
+      expect(result.algorithm).toBe(ThemeAlgorithm.COMPACT);
     });
 
     it('defaults each unknown algorithm in array to "default"', () => {
@@ -228,7 +231,10 @@ describe('Theme utilities', () => {
       };
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
-      expect(result.algorithm).toEqual([ThemeMode.DARK, ThemeMode.DEFAULT]);
+      expect(result.algorithm).toEqual([
+        ThemeAlgorithm.DARK,
+        ThemeAlgorithm.DEFAULT,
+      ]);
     });
 
     it('handles mixed known and unknown algorithms in array', () => {
@@ -248,10 +254,10 @@ describe('Theme utilities', () => {
       const result = serializeThemeConfig(config);
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toEqual([
-        ThemeMode.DARK,
-        ThemeMode.DEFAULT,
-        ThemeMode.COMPACT,
-        ThemeMode.DEFAULT,
+        ThemeAlgorithm.DARK,
+        ThemeAlgorithm.DEFAULT,
+        ThemeAlgorithm.COMPACT,
+        ThemeAlgorithm.DEFAULT,
       ]);
     });
   });
@@ -269,7 +275,7 @@ describe('Theme utilities', () => {
     it('deserializes serializable configs', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: ThemeMode.DARK,
+        algorithm: ThemeAlgorithm.DARK,
       };
       const result = normalizeThemeConfig(config);
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
@@ -51,6 +51,7 @@ describe('Theme utilities', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
       };
+
       expect(isSerializableConfig(config)).toBe(true);
     });
 
@@ -59,17 +60,16 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: ThemeAlgorithm.DARK,
       };
+
       expect(isSerializableConfig(config)).toBe(true);
     });
 
     it('returns true when algorithm is an array of strings', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        algorithm: [
-          ThemeAlgorithm.DARK,
-          ThemeAlgorithm.COMPACT,
-        ] as ThemeAlgorithm[],
+        algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
       };
+
       expect(isSerializableConfig(config)).toBe(true);
     });
 
@@ -78,15 +78,19 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: antdThemeImport.darkAlgorithm,
       };
+
       expect(isSerializableConfig(config)).toBe(false);
     });
 
     it('returns false when algorithm is an array containing a function', () => {
       const config: AnyThemeConfig = {
         token: { colorPrimary: '#ff0000' },
-        // @ts-ignore
-        algorithm: [antdThemeImport.darkAlgorithm, ThemeAlgorithm.COMPACT],
+        algorithm: [
+          antdThemeImport.darkAlgorithm,
+          antdThemeImport.compactAlgorithm,
+        ],
       };
+
       expect(isSerializableConfig(config)).toBe(false);
     });
   });
@@ -97,7 +101,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: ThemeAlgorithm.DARK,
       };
+
       const result = deserializeThemeConfig(config);
+
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);
     });
 
@@ -106,7 +112,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
       };
+
       const result = deserializeThemeConfig(config);
+
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toContain(antdThemeImport.darkAlgorithm);
       expect(result.algorithm).toContain(antdThemeImport.compactAlgorithm);
@@ -118,7 +126,9 @@ describe('Theme utilities', () => {
         algorithm: ThemeAlgorithm.DARK,
         hashed: true,
       };
+
       const result = deserializeThemeConfig(config);
+
       expect(result.token).toEqual({ colorPrimary: '#ff0000' });
       expect(result.hashed).toBe(true);
     });
@@ -127,8 +137,10 @@ describe('Theme utilities', () => {
       const config: SerializableThemeConfig = {
         token: { colorPrimary: '#ff0000' },
       };
+
       const result = deserializeThemeConfig(config);
-      expect(result.algorithm).toBeUndefined();
+
+      expect(result.algorithm).toBe(antdThemeImport.defaultAlgorithm);
     });
 
     it('converts default algorithm string to function reference', () => {
@@ -136,7 +148,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: ThemeAlgorithm.DEFAULT,
       };
+
       const result = deserializeThemeConfig(config);
+
       expect(result.algorithm).toBe(antdThemeImport.defaultAlgorithm);
     });
 
@@ -145,7 +159,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: ThemeAlgorithm.COMPACT,
       };
+
       const result = deserializeThemeConfig(config);
+
       expect(result.algorithm).toBe(antdThemeImport.compactAlgorithm);
     });
   });
@@ -156,7 +172,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: antdThemeImport.darkAlgorithm,
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.algorithm).toBe(ThemeAlgorithm.DARK);
     });
 
@@ -168,7 +186,9 @@ describe('Theme utilities', () => {
           antdThemeImport.compactAlgorithm,
         ],
       };
+
       const result = serializeThemeConfig(config);
+
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toContain(ThemeAlgorithm.DARK);
       expect(result.algorithm).toContain(ThemeAlgorithm.COMPACT);
@@ -180,7 +200,9 @@ describe('Theme utilities', () => {
         algorithm: antdThemeImport.darkAlgorithm,
         hashed: true,
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.token).toEqual({ colorPrimary: '#ff0000' });
       expect(result.hashed).toBe(true);
     });
@@ -189,7 +211,9 @@ describe('Theme utilities', () => {
       const config: AntdThemeConfig = {
         token: { colorPrimary: '#ff0000' },
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.algorithm).toBeUndefined();
     });
 
@@ -200,7 +224,9 @@ describe('Theme utilities', () => {
         // @ts-ignore
         algorithm: unknownAlgorithm,
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.algorithm).toBe(ThemeAlgorithm.DEFAULT);
     });
 
@@ -209,7 +235,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: antdThemeImport.defaultAlgorithm,
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.algorithm).toBe(ThemeAlgorithm.DEFAULT);
     });
 
@@ -218,7 +246,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: antdThemeImport.compactAlgorithm,
       };
+
       const result = serializeThemeConfig(config);
+
       expect(result.algorithm).toBe(ThemeAlgorithm.COMPACT);
     });
 
@@ -229,7 +259,9 @@ describe('Theme utilities', () => {
         // @ts-ignore
         algorithm: [antdThemeImport.darkAlgorithm, unknownAlgorithm],
       };
+
       const result = serializeThemeConfig(config);
+
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toEqual([
         ThemeAlgorithm.DARK,
@@ -251,7 +283,9 @@ describe('Theme utilities', () => {
           unknownAlgorithm2,
         ],
       };
+
       const result = serializeThemeConfig(config);
+
       expect(Array.isArray(result.algorithm)).toBe(true);
       expect(result.algorithm).toEqual([
         ThemeAlgorithm.DARK,
@@ -268,7 +302,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: antdThemeImport.darkAlgorithm,
       };
+
       const result = normalizeThemeConfig(config);
+
       expect(result).toBe(config);
     });
 
@@ -277,7 +313,9 @@ describe('Theme utilities', () => {
         token: { colorPrimary: '#ff0000' },
         algorithm: ThemeAlgorithm.DARK,
       };
+
       const result = normalizeThemeConfig(config);
+
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);
     });
   });
@@ -285,14 +323,18 @@ describe('Theme utilities', () => {
   describe('getAntdConfig', () => {
     it('returns config with default algorithm for light mode', () => {
       const seed = { colorPrimary: '#ff0000' };
+
       const result = getAntdConfig(seed, false);
+
       expect(result.token).toBe(seed);
       expect(result.algorithm).toBe(antdThemeImport.defaultAlgorithm);
     });
 
     it('returns config with dark algorithm for dark mode', () => {
       const seed = { colorPrimary: '#ff0000' };
+
       const result = getAntdConfig(seed, true);
+
       expect(result.token).toBe(seed);
       expect(result.algorithm).toBe(antdThemeImport.darkAlgorithm);
     });
@@ -308,7 +350,9 @@ describe('Theme utilities', () => {
         colorInfo: '#info',
         otherToken: 'ignore-me',
       };
+
       const result = getSystemColors(tokens);
+
       expect(result).toEqual({
         colorPrimary: '#primary',
         colorError: '#error',
@@ -322,6 +366,7 @@ describe('Theme utilities', () => {
   describe('genDeprecatedColorVariations', () => {
     it('generates color variations for light mode', () => {
       const result = genDeprecatedColorVariations('#base-color', false);
+
       expect(result.base).toBe('#base-color');
       expect(result.light1).toBe('#mixed-color');
       expect(result.dark1).toBe('#mixed-color');
@@ -329,6 +374,7 @@ describe('Theme utilities', () => {
 
     it('generates color variations for dark mode', () => {
       const result = genDeprecatedColorVariations('#base-color', true);
+
       expect(result.base).toBe('#base-color');
       expect(result.light1).toBe('#mixed-color');
       expect(result.dark1).toBe('#mixed-color');
@@ -344,7 +390,9 @@ describe('Theme utilities', () => {
         colorSuccess: '#success',
         colorInfo: '#info',
       };
+
       const result = getDeprecatedColors(systemColors, false);
+
       expect(result.primary.base).toBe('#primary');
       expect(result.error.base).toBe('#error');
       expect(result.warning.base).toBe('#warning');

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
@@ -26,8 +26,7 @@ import {
   type DeprecatedThemeColors,
   type SystemColors,
   type SupersetTheme,
-  type ThemeAlgorithmCombination,
-  ThemeMode,
+  ThemeAlgorithm,
 } from './types';
 
 /**
@@ -61,7 +60,9 @@ export function deserializeThemeConfig(
 
   let resolvedAlgorithm;
   if (Array.isArray(algorithm))
-    resolvedAlgorithm = algorithm.map((alg: ThemeMode) => algorithmMap[alg]);
+    resolvedAlgorithm = algorithm.map(
+      (alg: ThemeAlgorithm) => algorithmMap[alg],
+    );
   else if (algorithm) resolvedAlgorithm = algorithmMap[algorithm];
 
   return {
@@ -82,19 +83,21 @@ export function serializeThemeConfig(
 
   if (Array.isArray(algorithm)) {
     serializedAlgorithm = algorithm.map(alg => {
-      if (alg === antdThemeImport.defaultAlgorithm) return ThemeMode.DEFAULT;
-      if (alg === antdThemeImport.darkAlgorithm) return ThemeMode.DARK;
-      if (alg === antdThemeImport.compactAlgorithm) return ThemeMode.COMPACT;
-      return ThemeMode.DEFAULT; // Fallback
-    }) as ThemeAlgorithmCombination;
+      if (alg === antdThemeImport.defaultAlgorithm)
+        return ThemeAlgorithm.DEFAULT;
+      if (alg === antdThemeImport.darkAlgorithm) return ThemeAlgorithm.DARK;
+      if (alg === antdThemeImport.compactAlgorithm)
+        return ThemeAlgorithm.COMPACT;
+      return ThemeAlgorithm.DEFAULT; // Fallback
+    }) as ThemeAlgorithm[];
   } else if (algorithm) {
     if (algorithm === antdThemeImport.defaultAlgorithm)
-      serializedAlgorithm = ThemeMode.DEFAULT;
+      serializedAlgorithm = ThemeAlgorithm.DEFAULT;
     else if (algorithm === antdThemeImport.darkAlgorithm)
-      serializedAlgorithm = ThemeMode.DARK;
+      serializedAlgorithm = ThemeAlgorithm.DARK;
     else if (algorithm === antdThemeImport.compactAlgorithm)
-      serializedAlgorithm = ThemeMode.COMPACT;
-    else serializedAlgorithm = ThemeMode.DEFAULT; // Fallback
+      serializedAlgorithm = ThemeAlgorithm.COMPACT;
+    else serializedAlgorithm = ThemeAlgorithm.DEFAULT; // Fallback
   }
 
   return {

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
@@ -19,13 +19,15 @@
 import { theme as antdThemeImport } from 'antd';
 import tinycolor from 'tinycolor2';
 import {
-  AntdThemeConfig,
-  AnyThemeConfig,
-  SerializableThemeConfig,
-  DeprecatedColorVariations,
-  DeprecatedThemeColors,
-  SystemColors,
-  SupersetTheme,
+  type AntdThemeConfig,
+  type AnyThemeConfig,
+  type SerializableThemeConfig,
+  type DeprecatedColorVariations,
+  type DeprecatedThemeColors,
+  type SystemColors,
+  type SupersetTheme,
+  type ThemeAlgorithmCombination,
+  ThemeMode,
 } from './types';
 
 /**
@@ -38,9 +40,8 @@ export function isSerializableConfig(
 
   if (algorithm === undefined) return true;
 
-  if (Array.isArray(algorithm)) {
+  if (Array.isArray(algorithm))
     return (algorithm as unknown[]).every(alg => typeof alg === 'string');
-  }
 
   return typeof algorithm === 'string';
 }
@@ -59,11 +60,9 @@ export function deserializeThemeConfig(
   };
 
   let resolvedAlgorithm;
-  if (Array.isArray(algorithm)) {
-    resolvedAlgorithm = algorithm.map(alg => algorithmMap[alg]);
-  } else if (algorithm) {
-    resolvedAlgorithm = algorithmMap[algorithm];
-  }
+  if (Array.isArray(algorithm))
+    resolvedAlgorithm = algorithm.map((alg: ThemeMode) => algorithmMap[alg]);
+  else if (algorithm) resolvedAlgorithm = algorithmMap[algorithm];
 
   return {
     ...rest,
@@ -83,19 +82,19 @@ export function serializeThemeConfig(
 
   if (Array.isArray(algorithm)) {
     serializedAlgorithm = algorithm.map(alg => {
-      if (alg === antdThemeImport.defaultAlgorithm) return 'default';
-      if (alg === antdThemeImport.darkAlgorithm) return 'dark';
-      if (alg === antdThemeImport.compactAlgorithm) return 'compact';
-      return 'default'; // Fallback
-    }) as ('default' | 'dark' | 'compact')[];
+      if (alg === antdThemeImport.defaultAlgorithm) return ThemeMode.DEFAULT;
+      if (alg === antdThemeImport.darkAlgorithm) return ThemeMode.DARK;
+      if (alg === antdThemeImport.compactAlgorithm) return ThemeMode.COMPACT;
+      return ThemeMode.DEFAULT; // Fallback
+    }) as ThemeAlgorithmCombination;
   } else if (algorithm) {
     if (algorithm === antdThemeImport.defaultAlgorithm)
-      serializedAlgorithm = 'default';
+      serializedAlgorithm = ThemeMode.DEFAULT;
     else if (algorithm === antdThemeImport.darkAlgorithm)
-      serializedAlgorithm = 'dark';
+      serializedAlgorithm = ThemeMode.DARK;
     else if (algorithm === antdThemeImport.compactAlgorithm)
-      serializedAlgorithm = 'compact';
-    else serializedAlgorithm = 'default'; // Fallback
+      serializedAlgorithm = ThemeMode.COMPACT;
+    else serializedAlgorithm = ThemeMode.DEFAULT; // Fallback
   }
 
   return {
@@ -109,9 +108,8 @@ export function serializeThemeConfig(
  * This automatically detects and converts serializable configs
  */
 export function normalizeThemeConfig(config: AnyThemeConfig): AntdThemeConfig {
-  if (isSerializableConfig(config)) {
-    return deserializeThemeConfig(config);
-  }
+  if (isSerializableConfig(config)) return deserializeThemeConfig(config);
+
   return config as AntdThemeConfig;
 }
 
@@ -164,7 +162,7 @@ export function getDeprecatedColors(
   systemColors: SystemColors,
   isDark: boolean,
 ): DeprecatedThemeColors {
-  const sc = systemColors;
+  const sc: SystemColors = systemColors;
   return {
     primary: genDeprecatedColorVariations(sc.colorPrimary, isDark),
     error: genDeprecatedColorVariations(sc.colorError, isDark),

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.ts
@@ -59,11 +59,23 @@ export function deserializeThemeConfig(
   };
 
   let resolvedAlgorithm;
-  if (Array.isArray(algorithm))
-    resolvedAlgorithm = algorithm.map(
-      (alg: ThemeAlgorithm) => algorithmMap[alg],
-    );
-  else if (algorithm) resolvedAlgorithm = algorithmMap[algorithm];
+  if (Array.isArray(algorithm)) {
+    const validAlgorithms = algorithm
+      .map((alg: ThemeAlgorithm) => algorithmMap[alg])
+      .filter(Boolean);
+
+    // If we have valid algorithms, use them; otherwise fallback to default
+    if (validAlgorithms.length > 0) {
+      resolvedAlgorithm =
+        validAlgorithms.length === 1 ? validAlgorithms[0] : validAlgorithms;
+    } else {
+      resolvedAlgorithm = antdThemeImport.defaultAlgorithm;
+    }
+  } else if (algorithm && algorithmMap[algorithm]) {
+    resolvedAlgorithm = algorithmMap[algorithm];
+  } else {
+    resolvedAlgorithm = antdThemeImport.defaultAlgorithm;
+  }
 
   return {
     ...rest,

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { DEFAULT_D3_FORMAT, DEFAULT_D3_TIME_FORMAT } from '@superset-ui/core';
-
 import { BootstrapData, CommonBootstrapData } from './types/bootstrapTypes';
 
 export const DATETIME_WITH_TIME_ZONE = 'YYYY-MM-DD HH:mm:ssZ';
@@ -141,7 +140,11 @@ export const DEFAULT_COMMON_BOOTSTRAP_DATA: CommonBootstrapData = {
   },
   extra_categorical_color_schemes: [],
   extra_sequential_color_schemes: [],
-  theme: {},
+  theme: {
+    default: {},
+    dark: {},
+    settings: {},
+  },
   menu_data: {
     menu: [],
     brand: {

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -187,7 +187,7 @@ const RightMenu = ({
   const {
     theme: themeEditorTheme,
     setTheme,
-    changeThemeMode,
+    setThemeMode,
     themeMode,
   } = useThemeContext();
   const dropdownItems: MenuObjectProps[] = [
@@ -501,10 +501,7 @@ const RightMenu = ({
         )}
         {isFeatureEnabled(FeatureFlag.ThemeEnableDarkThemeSwitch) && (
           <span>
-            <ThemeSelect
-              changeThemeMode={changeThemeMode}
-              themeMode={themeMode}
-            />
+            <ThemeSelect setThemeMode={setThemeMode} themeMode={themeMode} />
           </span>
         )}
 

--- a/superset-frontend/src/theme/ThemeProvider.tsx
+++ b/superset-frontend/src/theme/ThemeProvider.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import {
   createContext,
   useCallback,
@@ -62,8 +61,8 @@ export function SupersetThemeProvider({
     [themeController],
   );
 
-  const changeThemeMode = useCallback(
-    (newMode: ThemeMode) => themeController.changeThemeMode(newMode),
+  const setThemeMode = useCallback(
+    (newMode: ThemeMode) => themeController.setThemeMode(newMode),
     [themeController],
   );
 
@@ -77,10 +76,10 @@ export function SupersetThemeProvider({
       theme: currentTheme,
       themeMode: currentThemeMode,
       setTheme,
-      changeThemeMode,
+      setThemeMode,
       resetTheme,
     }),
-    [currentTheme, currentThemeMode, setTheme, changeThemeMode, resetTheme],
+    [currentTheme, currentThemeMode, setTheme, setThemeMode, resetTheme],
   );
 
   return (
@@ -96,9 +95,10 @@ export function SupersetThemeProvider({
  * React hook to use the theme context
  */
 export function useThemeContext(): ThemeContextType {
-  const context = useContext(ThemeContext);
-  if (!context) {
+  const context: ThemeContextType | null = useContext(ThemeContext);
+
+  if (!context)
     throw new Error('useThemeContext must be used within a ThemeProvider');
-  }
+
   return context;
 }

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -1,0 +1,1031 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Theme } from '@superset-ui/core';
+import {
+  BootstrapThemeDataConfig,
+  CommonBootstrapData,
+} from 'src/types/bootstrapTypes';
+import {
+  ThemeAlgorithmCombination,
+  ThemeMode,
+} from '@superset-ui/core/theme/types';
+import getBootstrapData from 'src/utils/getBootstrapData';
+import { LocalStorageAdapter, ThemeController } from '../ThemeController';
+
+jest.mock('../../utils/getBootstrapData');
+const mockGetBootstrapData = getBootstrapData as jest.MockedFunction<
+  typeof getBootstrapData
+>;
+
+const mockLocalStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+
+const mockMatchMedia = jest.fn();
+const mockThemeFromConfig = jest.fn();
+const mockSetConfig = jest.fn();
+
+// Mock data constants
+const DEFAULT_THEME = {
+  token: {
+    colorBgBase: '#ededed',
+    colorTextBase: '#120f0f',
+    colorLink: '#0062ec',
+    colorPrimary: '#c96f0f',
+    colorInfo: '#c96f0f',
+    colorSuccess: '#3c7c1b',
+    colorWarning: '#dc9811',
+  },
+};
+
+const DARK_THEME = {
+  token: {
+    colorBgBase: '#141118',
+    colorTextBase: '#fdc7c7',
+    colorLink: '#0062ec',
+    colorPrimary: '#c96f0f',
+    colorInfo: '#c96f0f',
+    colorSuccess: '#3c7c1b',
+    colorWarning: '#dc9811',
+  },
+  algorithm: ThemeMode.DARK,
+};
+
+const THEME_SETTINGS = {
+  enforced: false,
+  allowSwitching: true,
+  allowOSPreference: true,
+};
+
+// BootstrapData common template generator
+const createMockBootstrapData = (
+  themeConfig: BootstrapThemeDataConfig = {
+    default: DEFAULT_THEME,
+    dark: DARK_THEME,
+    settings: THEME_SETTINGS,
+  },
+): { common: CommonBootstrapData } => ({
+  common: {
+    application_root: '/',
+    static_assets_prefix: '/static/assets/',
+    flash_messages: [],
+    conf: {},
+    locale: 'en',
+    feature_flags: {},
+    language_pack: {},
+    extra_categorical_color_schemes: [],
+    extra_sequential_color_schemes: [],
+    theme: themeConfig,
+    menu_data: {},
+    d3_format: {},
+    d3_time_format: {},
+  } as any as CommonBootstrapData,
+});
+
+const mockThemeObject = {
+  setConfig: mockSetConfig,
+  theme: DEFAULT_THEME,
+} as unknown as Theme;
+
+describe('LocalStorageAdapter', () => {
+  let adapter: LocalStorageAdapter;
+  const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+  beforeEach(() => {
+    adapter = new LocalStorageAdapter();
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('should return item from localStorage', () => {
+    mockLocalStorage.getItem.mockReturnValue('test-value');
+
+    const result = adapter.getItem('test-key');
+
+    expect(mockLocalStorage.getItem).toHaveBeenCalledTimes(1);
+    expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key');
+    expect(result).toBe('test-value');
+  });
+
+  it('should set item in localStorage', () => {
+    adapter.setItem('test-key', 'test-value');
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'test-key',
+      'test-value',
+    );
+  });
+
+  it('should handle localStorage errors while setting an item', () => {
+    mockLocalStorage.setItem.mockImplementation(() => {
+      throw new Error('Storage error');
+    });
+
+    adapter.setItem('test-key', 'test-value');
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to write to localStorage:',
+      expect.any(Error),
+    );
+  });
+
+  it('should remove item from localStorage', () => {
+    adapter.removeItem('test-key');
+
+    expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test-key');
+  });
+
+  it('should handle localStorage errors while removing an item', () => {
+    mockLocalStorage.removeItem.mockImplementation(() => {
+      throw new Error('Storage error');
+    });
+
+    adapter.removeItem('test-key');
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to remove from localStorage:',
+      expect.any(Error),
+    );
+  });
+});
+
+describe('ThemeController', () => {
+  let controller: ThemeController;
+  const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup DOM environment
+    Object.defineProperty(window, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+    });
+
+    Object.defineProperty(window, 'matchMedia', {
+      value: mockMatchMedia,
+      writable: true,
+    });
+
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+
+    mockSetConfig.mockImplementation(() => {});
+    mockThemeFromConfig.mockReturnValue(mockThemeObject);
+
+    // Mock Theme constructor
+    (Theme as any).fromConfig = mockThemeFromConfig;
+
+    // Reset localStorage mocks
+    mockLocalStorage.getItem.mockReturnValue(null);
+    mockLocalStorage.setItem.mockImplementation(() => {});
+    mockLocalStorage.removeItem.mockImplementation(() => {});
+
+    // Default BootstrapData
+    mockGetBootstrapData.mockReturnValue(createMockBootstrapData());
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should initialize with default options', () => {
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    expect(controller.getTheme()).toBe(mockThemeObject);
+  });
+
+  it('should use BootsrapData themes when available', () => {
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    expect(mockThemeFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockThemeFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          colorBgBase: '#ededed',
+          colorPrimary: '#c96f0f',
+        }),
+      }),
+    );
+  });
+
+  it('should fallback to Superset default theme when BootsrapData themes are empty', () => {
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: {},
+      }),
+    );
+
+    const fallbackTheme = {
+      token: {
+        colorBgBase: '#ffffff',
+        colorPrimary: '#1890ff',
+      },
+    };
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+      defaultTheme: fallbackTheme,
+    });
+
+    expect(mockThemeFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockThemeFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...fallbackTheme,
+        algorithm: ThemeMode.DEFAULT,
+      }),
+    );
+  });
+
+  it('should respect enforced theme settings', () => {
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: { enforced: true, allowSwitching: false },
+      }),
+    );
+
+    mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+    expect(controller.canSetTheme()).toBe(false);
+    expect(controller.canSetMode()).toBe(false);
+  });
+
+  it('should handle system theme preference', () => {
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: { allowOSPreference: true },
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+  });
+
+  it('should handle only default theme', () => {
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: DEFAULT_THEME,
+        dark: {},
+        settings: {},
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    // Clear the call from initialization
+    jest.clearAllMocks();
+
+    controller.setThemeMode(ThemeMode.DARK);
+
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining(DEFAULT_THEME),
+    );
+  });
+
+  it('should handle only dark theme', () => {
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: DARK_THEME,
+        settings: {},
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+    });
+
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining(DARK_THEME),
+    );
+  });
+
+  it('should handle only settings', () => {
+    const fallbackTheme = {
+      token: {
+        colorBgBase: '#ffffff',
+        colorPrimary: '#1890ff',
+      },
+    };
+
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: { enforced: true },
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+      defaultTheme: fallbackTheme,
+    });
+
+    expect(controller.canSetTheme()).toBe(false);
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          colorBgBase: '#ffffff',
+          colorPrimary: '#1890ff',
+        }),
+        algorithm: ThemeMode.DEFAULT,
+      }),
+    );
+  });
+
+  it('should handle completely empty BootstrapData', () => {
+    const fallbackTheme = {
+      token: {
+        colorBgBase: '#ffffff',
+        colorPrimary: '#1890ff',
+      },
+    };
+
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: {},
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+      defaultTheme: fallbackTheme,
+    });
+
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          colorBgBase: '#ffffff',
+          colorPrimary: '#1890ff',
+        }),
+        algorithm: ThemeMode.DEFAULT,
+      }),
+    );
+  });
+
+  it('should handle missing theme object', () => {
+    const fallbackTheme = { token: { colorPrimary: '#fallback' } };
+
+    mockGetBootstrapData.mockReturnValue({
+      common: {
+        application_root: '/',
+        static_assets_prefix: '/static/assets/',
+        flash_messages: [],
+        conf: {},
+        locale: 'en',
+        feature_flags: {},
+        language_pack: {},
+        extra_categorical_color_schemes: [],
+        extra_sequential_color_schemes: [],
+        menu_data: {},
+        d3_format: {},
+        d3_time_format: {},
+      } as any,
+    });
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+      defaultTheme: fallbackTheme,
+    });
+
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          colorPrimary: '#fallback',
+        }),
+        algorithm: ThemeMode.DEFAULT,
+      }),
+    );
+  });
+
+  it('should allow theme switching if there is no bootstrap themes', () => {
+    const fallbackTheme = {
+      token: {
+        colorBgBase: '#ffffff',
+        colorPrimary: '#1890ff',
+      },
+    };
+
+    mockGetBootstrapData.mockReturnValue(
+      createMockBootstrapData({
+        default: {},
+        dark: {},
+        settings: {},
+      }),
+    );
+
+    controller = new ThemeController({
+      themeObject: mockThemeObject,
+      defaultTheme: fallbackTheme,
+    });
+
+    // Clear initialization calls
+    jest.clearAllMocks();
+
+    // Switch to dark mode
+    controller.setThemeMode(ThemeMode.DARK);
+
+    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+    expect(mockSetConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...fallbackTheme,
+        algorithm: ThemeMode.DARK,
+      }),
+    );
+  });
+
+  describe('Theme Management', () => {
+    beforeEach(() => {
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should update theme when allowed', () => {
+      const newTheme = {
+        token: {
+          colorBgBase: '#000000',
+          colorPrimary: '#ff0000',
+        },
+      };
+
+      controller.setTheme(newTheme);
+
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining(newTheme),
+      );
+    });
+
+    it('should throw error when theme updates are not allowed', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: {},
+          dark: {},
+          settings: { enforced: true },
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(() => {
+        controller.setTheme({
+          token: {
+            colorBgBase: '#000000',
+            colorPrimary: '#ff0000',
+          },
+        });
+      }).toThrow('User does not have permission to update the theme');
+    });
+
+    it('should change theme mode when allowed', () => {
+      // Clear initialization calls
+      jest.clearAllMocks();
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+      expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        'superset-theme-mode',
+        ThemeMode.DARK,
+      );
+    });
+
+    it('should throw error when mode updates are not allowed', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: DEFAULT_THEME,
+          dark: DARK_THEME,
+          settings: { allowSwitching: false },
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(() => {
+        controller.setThemeMode(ThemeMode.DARK);
+      }).toThrow('User does not have permission to update the theme mode');
+    });
+
+    it('should throw error when system mode is not allowed', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: DEFAULT_THEME,
+          dark: DARK_THEME,
+          settings: {
+            allowOSPreference: false,
+            allowSwitching: true,
+            enforced: false,
+          },
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(() => {
+        controller.setThemeMode(ThemeMode.SYSTEM);
+      }).toThrow('System theme mode is not allowed');
+    });
+
+    it('should handle missing theme gracefully', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: DEFAULT_THEME,
+          dark: {},
+          settings: THEME_SETTINGS,
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not change mode if already set', () => {
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      jest.clearAllMocks();
+
+      // Try to change to the same mode (DEFAULT)
+      controller.setThemeMode(ThemeMode.SYSTEM);
+
+      // Should not call setItem since mode didn't change
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('should reset to default theme', () => {
+      controller.setThemeMode(ThemeMode.DARK);
+      controller.resetTheme();
+
+      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            colorBgBase: '#141118',
+            colorTextBase: '#fdc7c7',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('System Theme Changes', () => {
+    let mockMediaQuery: any;
+
+    beforeEach(() => {
+      mockMediaQuery = {
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      };
+
+      mockMatchMedia.mockReturnValue(mockMediaQuery);
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should listen to system theme changes', () => {
+      expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+      expect(mockMediaQuery.addEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('should update theme when system preference changes and mode is SYSTEM', () => {
+      controller.setThemeMode(ThemeMode.SYSTEM);
+
+      // Simulate system theme change
+      mockMediaQuery.matches = true;
+      const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
+
+      changeHandler();
+
+      expect(mockSetConfig).toHaveBeenCalled();
+    });
+
+    it('should not update theme when mode is not SYSTEM', () => {
+      controller.setThemeMode(ThemeMode.DEFAULT);
+
+      const initialCallCount = mockSetConfig.mock.calls.length;
+
+      // Simulate system theme change
+      mockMediaQuery.matches = true;
+      const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
+
+      changeHandler();
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(initialCallCount);
+    });
+  });
+
+  describe('Persistence', () => {
+    beforeEach(() => {
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should save theme mode to localStorage', () => {
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        'superset-theme-mode',
+        ThemeMode.DARK,
+      );
+    });
+
+    it('should load saved theme mode from localStorage', () => {
+      mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+    });
+
+    it('should handle invalid saved theme mode', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: {},
+          dark: {},
+          settings: { allowOSPreference: false },
+        }),
+      );
+
+      mockLocalStorage.getItem.mockReturnValue('invalid-mode' as any);
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+    });
+  });
+
+  describe('Theme Structure', () => {
+    beforeEach(() => {
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should handle theme with token structure', () => {
+      const customTheme = {
+        token: {
+          colorBgBase: '#ff0000',
+          colorTextBase: '#ffffff',
+          colorPrimary: '#00ff00',
+        },
+      };
+
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setTheme(customTheme);
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(1);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            colorBgBase: '#ff0000',
+            colorTextBase: '#ffffff',
+            colorPrimary: '#00ff00',
+          }),
+        }),
+      );
+    });
+
+    it('should preserve algorithm property from dark theme', () => {
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(1);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          algorithm: ThemeMode.DARK,
+          token: expect.objectContaining({
+            colorBgBase: '#141118',
+            colorTextBase: '#fdc7c7',
+          }),
+        }),
+      );
+    });
+
+    it('should handle theme without algorithm property', () => {
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setThemeMode(ThemeMode.DEFAULT);
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(1);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            colorBgBase: '#ededed',
+            colorTextBase: '#120f0f',
+          }),
+        }),
+      );
+
+      // Should not have algorithm property or should be overridden
+      const lastCall =
+        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+
+      expect(lastCall.algorithm).toBe(ThemeMode.DEFAULT);
+    });
+
+    it('should handle color tokens correctly in theme switching', () => {
+      // Start with default theme
+      controller.setThemeMode(ThemeMode.DEFAULT);
+
+      let lastCall =
+        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+
+      expect(lastCall.token.colorBgBase).toBe('#ededed');
+      expect(lastCall.token.colorTextBase).toBe('#120f0f');
+
+      // Switch to dark theme
+      controller.setThemeMode(ThemeMode.DARK);
+
+      lastCall =
+        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+
+      expect(lastCall.token.colorBgBase).toBe('#141118');
+      expect(lastCall.token.colorTextBase).toBe('#fdc7c7');
+    });
+  });
+
+  describe('Algorithm Combinations', () => {
+    beforeEach(() => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: {
+            ...DEFAULT_THEME,
+            algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+          },
+          dark: DARK_THEME,
+          settings: THEME_SETTINGS,
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should handle valid algorithm combinations', () => {
+      const themeWithAlgorithm = {
+        ...DEFAULT_THEME,
+        algorithm: [
+          ThemeMode.DARK,
+          ThemeMode.COMPACT,
+        ] as ThemeAlgorithmCombination,
+      };
+
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setTheme(themeWithAlgorithm);
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(1);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: expect.objectContaining({
+            colorBgBase: '#ededed',
+            colorPrimary: '#c96f0f',
+          }),
+          algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+        }),
+      );
+    });
+
+    it('should handle invalid algorithm combinations', () => {
+      const themeWithInvalidAlgorithm = {
+        ...DEFAULT_THEME,
+        algorithm: [
+          'invalid',
+          'combination',
+        ] as any as ThemeAlgorithmCombination,
+      };
+
+      // Clear the call from controller initialization
+      jest.clearAllMocks();
+
+      controller.setTheme(themeWithInvalidAlgorithm);
+
+      expect(mockSetConfig).toHaveBeenCalledTimes(1);
+      expect(mockSetConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          algorithm: ThemeMode.DEFAULT,
+        }),
+      );
+    });
+  });
+
+  describe('Change Callbacks', () => {
+    let callback: jest.Mock;
+    let unsubscribe: () => void;
+
+    beforeEach(() => {
+      callback = jest.fn();
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+        onChange: callback,
+      });
+    });
+
+    it('should call callback on theme change', () => {
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(mockThemeObject);
+    });
+
+    it('should register additional callbacks', () => {
+      const additionalCallback = jest.fn();
+      unsubscribe = controller.onChange(additionalCallback);
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(callback).toHaveBeenCalled();
+      expect(additionalCallback).toHaveBeenCalled();
+    });
+
+    it('should unsubscribe callbacks', () => {
+      const additionalCallback = jest.fn();
+      unsubscribe = controller.onChange(additionalCallback);
+
+      unsubscribe();
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(additionalCallback).not.toHaveBeenCalled();
+    });
+
+    it('should handle callback errors', () => {
+      const errorCallback = jest.fn().mockImplementation(() => {
+        throw new Error('Callback error');
+      });
+
+      controller.onChange(errorCallback);
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error in theme change callback:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(() => {
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should handle theme application errors', () => {
+      // Mock setConfig to throw an error
+      mockSetConfig.mockImplementationOnce(() => {
+        throw new Error('Theme application error');
+      });
+
+      // Mock fallbackToDefaultMode to avoid infinite recursion
+      const fallbackSpy = jest.spyOn(
+        controller as any,
+        'fallbackToDefaultMode',
+      );
+      fallbackSpy.mockImplementation(() => {
+        // Just set basic properties without calling updateTheme
+        (controller as any).customizations = DEFAULT_THEME;
+        (controller as any).currentMode = ThemeMode.DEFAULT;
+      });
+
+      controller.setThemeMode(ThemeMode.DARK);
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to apply theme:',
+        expect.any(Error),
+      );
+      expect(fallbackSpy).toHaveBeenCalled();
+
+      fallbackSpy.mockRestore();
+    });
+  });
+
+  describe('Cleanup', () => {
+    let mockMediaQueryInstance: any;
+
+    beforeEach(() => {
+      mockMediaQueryInstance = {
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      };
+
+      mockMatchMedia.mockReturnValue(mockMediaQueryInstance);
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+    });
+
+    it('should clean up listeners on destroy', () => {
+      controller.destroy();
+
+      expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { theme as antdThemeImport } from 'antd';
 import { Theme } from '@superset-ui/core';
 import type {
   BootstrapThemeDataConfig,
@@ -270,7 +271,7 @@ describe('ThemeController', () => {
     expect(mockThemeFromConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         ...fallbackTheme,
-        algorithm: ThemeMode.DEFAULT,
+        algorithm: antdThemeImport.defaultAlgorithm,
       }),
     );
   });
@@ -350,7 +351,10 @@ describe('ThemeController', () => {
 
     expect(mockSetConfig).toHaveBeenCalledTimes(1);
     expect(mockSetConfig).toHaveBeenCalledWith(
-      expect.objectContaining(DARK_THEME),
+      expect.objectContaining({
+        ...DARK_THEME,
+        algorithm: antdThemeImport.darkAlgorithm,
+      }),
     );
   });
 
@@ -383,7 +387,7 @@ describe('ThemeController', () => {
           colorBgBase: '#ffffff',
           colorPrimary: '#1890ff',
         }),
-        algorithm: ThemeMode.DEFAULT,
+        algorithm: antdThemeImport.defaultAlgorithm,
       }),
     );
   });
@@ -416,7 +420,7 @@ describe('ThemeController', () => {
           colorBgBase: '#ffffff',
           colorPrimary: '#1890ff',
         }),
-        algorithm: ThemeMode.DEFAULT,
+        algorithm: antdThemeImport.defaultAlgorithm,
       }),
     );
   });
@@ -452,7 +456,7 @@ describe('ThemeController', () => {
         token: expect.objectContaining({
           colorPrimary: '#fallback',
         }),
-        algorithm: ThemeMode.DEFAULT,
+        algorithm: antdThemeImport.defaultAlgorithm,
       }),
     );
   });
@@ -488,7 +492,7 @@ describe('ThemeController', () => {
     expect(mockSetConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         ...fallbackTheme,
-        algorithm: ThemeMode.DARK,
+        algorithm: antdThemeImport.darkAlgorithm,
       }),
     );
   });
@@ -804,7 +808,7 @@ describe('ThemeController', () => {
       expect(mockSetConfig).toHaveBeenCalledTimes(1);
       expect(mockSetConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          algorithm: ThemeMode.DARK,
+          algorithm: antdThemeImport.darkAlgorithm,
           token: expect.objectContaining({
             colorBgBase: '#141118',
             colorTextBase: '#fdc7c7',
@@ -833,7 +837,7 @@ describe('ThemeController', () => {
       const lastCall =
         mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
 
-      expect(lastCall.algorithm).toBe(ThemeMode.DEFAULT);
+      expect(lastCall.algorithm).toBe(antdThemeImport.defaultAlgorithm);
     });
 
     it('should handle color tokens correctly in theme switching', () => {
@@ -896,7 +900,10 @@ describe('ThemeController', () => {
             colorBgBase: '#ededed',
             colorPrimary: '#c96f0f',
           }),
-          algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
+          algorithm: [
+            antdThemeImport.darkAlgorithm,
+            antdThemeImport.compactAlgorithm,
+          ],
         }),
       );
     });
@@ -915,7 +922,7 @@ describe('ThemeController', () => {
       expect(mockSetConfig).toHaveBeenCalledTimes(1);
       expect(mockSetConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          algorithm: ThemeMode.DEFAULT,
+          algorithm: antdThemeImport.defaultAlgorithm,
         }),
       );
     });

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -17,14 +17,11 @@
  * under the License.
  */
 import { Theme } from '@superset-ui/core';
-import {
+import type {
   BootstrapThemeDataConfig,
   CommonBootstrapData,
 } from 'src/types/bootstrapTypes';
-import {
-  ThemeAlgorithmCombination,
-  ThemeMode,
-} from '@superset-ui/core/theme/types';
+import { ThemeAlgorithm, ThemeMode } from '@superset-ui/core/theme/types';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { LocalStorageAdapter, ThemeController } from '../ThemeController';
 
@@ -555,12 +552,32 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should throw error when mode updates are not allowed', () => {
+    it('should throw error when mode updates are not allowed but OS preference is', () => {
       mockGetBootstrapData.mockReturnValue(
         createMockBootstrapData({
           default: DEFAULT_THEME,
           dark: DARK_THEME,
           settings: { allowSwitching: false },
+        }),
+      );
+
+      controller = new ThemeController({
+        themeObject: mockThemeObject,
+      });
+
+      expect(() => {
+        controller.setThemeMode(ThemeMode.DARK);
+      }).toThrow(
+        'Theme mode changes are not allowed when OS preference is enforced',
+      );
+    });
+
+    it('should throw error when mode updates and OS preference are not allowed', () => {
+      mockGetBootstrapData.mockReturnValue(
+        createMockBootstrapData({
+          default: DEFAULT_THEME,
+          dark: DARK_THEME,
+          settings: { allowOSPreference: false, allowSwitching: false },
         }),
       );
 
@@ -846,7 +863,7 @@ describe('ThemeController', () => {
         createMockBootstrapData({
           default: {
             ...DEFAULT_THEME,
-            algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+            algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
           },
           dark: DARK_THEME,
           settings: THEME_SETTINGS,
@@ -862,9 +879,9 @@ describe('ThemeController', () => {
       const themeWithAlgorithm = {
         ...DEFAULT_THEME,
         algorithm: [
-          ThemeMode.DARK,
-          ThemeMode.COMPACT,
-        ] as ThemeAlgorithmCombination,
+          ThemeAlgorithm.DARK,
+          ThemeAlgorithm.COMPACT,
+        ] as ThemeAlgorithm[],
       };
 
       // Clear the call from controller initialization
@@ -879,7 +896,7 @@ describe('ThemeController', () => {
             colorBgBase: '#ededed',
             colorPrimary: '#c96f0f',
           }),
-          algorithm: [ThemeMode.DARK, ThemeMode.COMPACT],
+          algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
         }),
       );
     });
@@ -887,10 +904,7 @@ describe('ThemeController', () => {
     it('should handle invalid algorithm combinations', () => {
       const themeWithInvalidAlgorithm = {
         ...DEFAULT_THEME,
-        algorithm: [
-          'invalid',
-          'combination',
-        ] as any as ThemeAlgorithmCombination,
+        algorithm: ['invalid', 'combination'] as any as ThemeAlgorithm[],
       };
 
       // Clear the call from controller initialization

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ReactNode } from 'react';
+import { Theme } from '@superset-ui/core';
+import { ThemeContextType, ThemeMode } from '@superset-ui/core/theme/types';
+import { act, render, screen } from '@superset-ui/core/spec';
+import { renderHook } from '@testing-library/react-hooks';
+import { SupersetThemeProvider, useThemeContext } from '../ThemeProvider';
+import { ThemeController } from '../ThemeController';
+
+jest.mock('../ThemeController');
+const MockThemeController = ThemeController as jest.MockedClass<
+  typeof ThemeController
+>;
+
+// Mock theme objects
+const mockTheme = {
+  SupersetThemeProvider: ({ children }: { children: ReactNode }) => (
+    <div data-test="superset-theme-provider">{children}</div>
+  ),
+  theme: {
+    token: {
+      colorPrimary: '#1890ff',
+      colorBgBase: '#ffffff',
+    },
+  },
+} as unknown as Theme;
+
+const mockDarkTheme = {
+  SupersetThemeProvider: ({ children }: { children: ReactNode }) => (
+    <div data-test="superset-dark-theme-provider">{children}</div>
+  ),
+  theme: {
+    token: {
+      colorPrimary: '#1890ff',
+      colorBgBase: '#000000',
+    },
+  },
+} as unknown as Theme;
+
+const createWrapper =
+  (controller: jest.Mocked<ThemeController>) =>
+  ({ children }: { children: ReactNode }) => (
+    <SupersetThemeProvider themeController={controller}>
+      {children}
+    </SupersetThemeProvider>
+  );
+
+describe('SupersetThemeProvider', () => {
+  let mockThemeController: jest.Mocked<ThemeController>;
+  let mockOnChangeCallback: jest.Mock;
+
+  beforeEach(() => {
+    mockOnChangeCallback = jest.fn();
+    mockThemeController = {
+      getTheme: jest.fn().mockReturnValue(mockTheme),
+      getCurrentMode: jest.fn().mockReturnValue(ThemeMode.DEFAULT),
+      setTheme: jest.fn(),
+      setThemeMode: jest.fn(),
+      resetTheme: jest.fn(),
+      onChange: jest.fn().mockReturnValue(jest.fn()),
+      canUpdateTheme: jest.fn().mockReturnValue(true),
+      canUpdateMode: jest.fn().mockReturnValue(true),
+      destroy: jest.fn(),
+    } as unknown as jest.Mocked<ThemeController>;
+
+    mockThemeController.onChange.mockImplementation(callback => {
+      mockOnChangeCallback.mockImplementation(callback);
+      return jest.fn();
+    });
+
+    MockThemeController.mockImplementation(() => mockThemeController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Provider Initialization', () => {
+    it('should render children within theme provider wrapper', () => {
+      render(
+        <SupersetThemeProvider themeController={mockThemeController}>
+          <div data-test="test-child">Hello Superset</div>
+        </SupersetThemeProvider>,
+      );
+
+      expect(screen.getByTestId('superset-theme-provider')).toBeInTheDocument();
+      expect(screen.getByTestId('test-child')).toBeInTheDocument();
+    });
+
+    it('should initialize theme state from controller', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      expect(mockThemeController.getTheme).toHaveBeenCalled();
+      expect(mockThemeController.getCurrentMode).toHaveBeenCalled();
+      expect(result.current.theme).toBe(mockTheme);
+      expect(result.current.themeMode).toBe(ThemeMode.DEFAULT);
+    });
+
+    it('should register onChange listener on mount', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      renderHook((): ThemeContextType => useThemeContext(), { wrapper });
+
+      expect(mockThemeController.onChange).toHaveBeenCalledWith(
+        expect.any(Function),
+      );
+    });
+
+    it('should unregister onChange listener on unmount', () => {
+      const unsubscribeMock = jest.fn();
+      mockThemeController.onChange.mockReturnValue(unsubscribeMock);
+
+      const wrapper = createWrapper(mockThemeController);
+
+      const { unmount } = renderHook(
+        (): ThemeContextType => useThemeContext(),
+        { wrapper },
+      );
+
+      unmount();
+
+      expect(unsubscribeMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('Theme State Updates', () => {
+    it('should update theme state when controller notifies change', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      // Initial state
+      expect(result.current.themeMode).toBe(ThemeMode.DEFAULT);
+      expect(result.current.theme).toBe(mockTheme);
+
+      // Simulate theme change from controller
+      act(() => {
+        mockThemeController.getCurrentMode.mockReturnValue(ThemeMode.DARK);
+        mockOnChangeCallback(mockDarkTheme);
+      });
+
+      // State should update
+      expect(result.current.themeMode).toBe(ThemeMode.DARK);
+      expect(result.current.theme).toBe(mockDarkTheme);
+    });
+
+    it('should update both theme and mode when controller changes', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      act(() => {
+        mockThemeController.getCurrentMode.mockReturnValue(ThemeMode.SYSTEM);
+        mockOnChangeCallback(mockDarkTheme);
+      });
+
+      expect(result.current.themeMode).toBe(ThemeMode.SYSTEM);
+      expect(result.current.theme).toBe(mockDarkTheme);
+    });
+  });
+
+  describe('Theme Actions', () => {
+    it('should call setTheme when invoked', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      const customTheme = {
+        token: {
+          colorPrimary: '#ff0000',
+          colorBgBase: '#000000',
+        },
+      };
+
+      act(() => {
+        result.current.setTheme(customTheme);
+      });
+
+      expect(mockThemeController.setTheme).toHaveBeenCalledWith(customTheme);
+    });
+
+    it('should call setThemeMode when invoked', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      act(() => {
+        result.current.setThemeMode(ThemeMode.DARK);
+      });
+
+      expect(mockThemeController.setThemeMode).toHaveBeenCalledWith(
+        ThemeMode.DARK,
+      );
+    });
+
+    it('should call resetTheme when invoked', () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      act(() => {
+        result.current.resetTheme();
+      });
+
+      expect(mockThemeController.resetTheme).toHaveBeenCalled();
+    });
+  });
+});

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -1,17 +1,3 @@
-import {
-  ColorSchemeConfig,
-  FeatureFlagMap,
-  JsonObject,
-  LanguagePack,
-  Locale,
-  SequentialSchemeConfig,
-} from '@superset-ui/core';
-import { FormatLocaleDefinition } from 'd3-format';
-import { TimeLocaleDefinition } from 'd3-time-format';
-import { isPlainObject } from 'lodash';
-import { Languages } from 'src/features/home/LanguagePicker';
-import type { FlashMessage } from 'src/components';
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -30,6 +16,24 @@ import type { FlashMessage } from 'src/components';
  * specific language governing permissions and limitations
  * under the License.
  */
+import {
+  ColorSchemeConfig,
+  FeatureFlagMap,
+  JsonObject,
+  LanguagePack,
+  Locale,
+  SequentialSchemeConfig,
+} from '@superset-ui/core';
+import { FormatLocaleDefinition } from 'd3-format';
+import { TimeLocaleDefinition } from 'd3-time-format';
+import { isPlainObject } from 'lodash';
+import { Languages } from 'src/features/home/LanguagePicker';
+import type { FlashMessage } from 'src/components';
+import type {
+  AnyThemeConfig,
+  SerializableThemeConfig,
+} from '@superset-ui/core/theme/types';
+
 export type User = {
   createdOn?: string;
   email?: string;
@@ -143,6 +147,18 @@ export interface MenuData {
   };
 }
 
+export interface SerializableThemeSettings {
+  enforced?: boolean;
+  allowSwitching?: boolean;
+  allowOSPreference?: boolean;
+}
+
+export interface BootstrapThemeDataConfig {
+  default: SerializableThemeConfig | {};
+  dark: SerializableThemeConfig | {};
+  settings: SerializableThemeSettings | {};
+}
+
 export interface CommonBootstrapData {
   application_root: string;
   static_assets_prefix: string;
@@ -153,7 +169,7 @@ export interface CommonBootstrapData {
   language_pack: LanguagePack;
   extra_categorical_color_schemes: ColorSchemeConfig[];
   extra_sequential_color_schemes: SequentialSchemeConfig[];
-  theme: JsonObject;
+  theme: BootstrapThemeDataConfig;
   menu_data: MenuData;
   d3_format: Partial<FormatLocaleDefinition>;
   d3_time_format: Partial<TimeLocaleDefinition>;
@@ -167,6 +183,13 @@ export interface BootstrapData {
     dashboard_id: string;
   };
   requested_query?: JsonObject;
+}
+
+export interface BootstrapThemeData {
+  bootstrapDefaultTheme: AnyThemeConfig | null;
+  bootstrapDarkTheme: AnyThemeConfig | null;
+  bootstrapThemeSettings: SerializableThemeSettings | null;
+  hasBootstrapThemes: boolean;
 }
 
 export function isUser(user: any): user is User {

--- a/superset-frontend/src/views/RootContextProviders.tsx
+++ b/superset-frontend/src/views/RootContextProviders.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Route } from 'react-router-dom';
-import { getExtensionsRegistry, themeObject } from '@superset-ui/core';
+import { getExtensionsRegistry } from '@superset-ui/core';
 import { Provider as ReduxProvider } from 'react-redux';
 import { QueryParamProvider } from 'use-query-params';
 import { DndProvider } from 'react-dnd';
@@ -32,17 +32,14 @@ import { store } from './store';
 import '../preamble';
 
 const { common } = getBootstrapData();
-
-if (Object.keys(common?.theme || {}).length > 0) {
-  themeObject.setConfig(common.theme);
-}
-const themeController = new ThemeController({ themeObject });
-
+const themeController = new ThemeController();
 const extensionsRegistry = getExtensionsRegistry();
+
 export const RootContextProviders: React.FC = ({ children }) => {
   const RootContextProviderExtension = extensionsRegistry.get(
     'root.context.provider',
   );
+
   return (
     <SupersetThemeProvider themeController={themeController}>
       <ReduxProvider store={store}>

--- a/superset/config.py
+++ b/superset/config.py
@@ -568,7 +568,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Adds a switch to the navbar to easily switch between light and dark themes.
     # This is intended to use for development, visual review, and theming-debugging
     # purposes.
-    "THEME_ENABLE_DARK_THEME_SWITCH": True,
+    "THEME_ENABLE_DARK_THEME_SWITCH": False,
     # Adds a theme editor as a modal dialog in the navbar. Allows people to type in JSON
     # and see the changes applied to the current theme.
     # This is intended to use for theme creation, visual review and theming-debugging
@@ -725,8 +725,8 @@ THEME_DARK: Theme = {}
 # Example:
 # THEME_SETTINGS = {
 #     "enforced": False,         # If True, forces the default theme and ignores user preferences  # noqa: E501
-#     "allowSwitching": True,    # Allow user to switch between themes (default and dark)  # noqa: E501
-#     "allowOSPreference": True, # Allow the app to Auto-detect and set system theme preference  # noqa: E501
+#     "allowSwitching": True,    # Allows user to switch between themes (default and dark)  # noqa: E501
+#     "allowOSPreference": True, # Allows the app to Auto-detect and set system theme preference  # noqa: E501
 # }
 THEME_SETTINGS: ThemeSettings = {}
 # ---------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -57,6 +57,7 @@ from superset.key_value.types import JsonKeyValueCodec
 from superset.stats_logger import DummyStatsLogger
 from superset.superset_typing import CacheConfig
 from superset.tasks.types import ExecutorType
+from superset.themes.types import Theme, ThemeSettings
 from superset.utils import core as utils
 from superset.utils.core import NO_TIME_RANGE, parse_boolean_string, QuerySource
 from superset.utils.encrypt import SQLAlchemyUtilsAdapter
@@ -567,7 +568,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # Adds a switch to the navbar to easily switch between light and dark themes.
     # This is intended to use for development, visual review, and theming-debugging
     # purposes.
-    "THEME_ENABLE_DARK_THEME_SWITCH": False,
+    "THEME_ENABLE_DARK_THEME_SWITCH": True,
     # Adds a theme editor as a modal dialog in the navbar. Allows people to type in JSON
     # and see the changes applied to the current theme.
     # This is intended to use for theme creation, visual review and theming-debugging
@@ -677,18 +678,58 @@ COMMON_BOOTSTRAP_OVERRIDES_FUNC: Callable[  # noqa: E731
 # This is merely a default
 EXTRA_CATEGORICAL_COLOR_SCHEMES: list[dict[str, Any]] = []
 
-# THEME is used for setting a custom theme to Superset, it follows the ant design
-# theme structure
-# You can use the AntDesign theme editor to generate a theme structure
-# https://ant.design/theme-editor
+# ---------------------------------------------------
+# Theme Configuration for Superset
+# ---------------------------------------------------
+# Superset supports custom theming through Ant Design's theme structure.
+# This allows users to customize colors, fonts, and other UI elements.
+#
+# Theme Generation:
+# - Use the Ant Design theme editor: https://ant.design/theme-editor
+# - Export or coypt the generated theme JSON and assign to the variables below
+#
 # To expose a JSON theme editor modal that can be triggered from the navbar
 # set the `ENABLE_THEME_EDITOR` feature flag to True.
 #
-# To set up the dark theme:
-# THEME = {"algorithm": "dark"}
+# Theme Structure:
+# Each theme should follow Ant Design's theme format
+# Example:
+# THEME_DEFAULT = {
+#       "token": {
+#            "colorPrimary": "#2893B3",
+#            "colorSuccess": "#5ac189",
+#            "colorWarning": "#fcc700",
+#            "colorError": "#e04355",
+#            "fontFamily": "'Inter', Helvetica, Arial",
+#            ... # other tokens
+#       },
+#       ... # other theme properties
+# }
 
-THEME: dict[str, Any] = {}
 
+# Default theme configuration
+# Leave empty to use Superset's default theme
+THEME_DEFAULT: Theme = {}
+
+# Dark theme configuration
+# Applied when user selects dark mode
+THEME_DARK: Theme = {}
+
+# Theme behavior and user preference settings
+# Controls how themes are applied and what options users have
+# - enforced: Forces the default theme always, overriding all other settings
+# - allowSwitching: Allows users to manually switch between default and dark themes.
+#   To expose a theme switcher in the UI, set `THEME_ENABLE_DARK_THEME_SWITCH` feature flag to True.  # noqa: E501
+# - allowOSPreference: Allows the app to automatically use the system's preferred theme mode  # noqa: E501
+#
+# Example:
+# THEME_SETTINGS = {
+#     "enforced": False,         # If True, forces the default theme and ignores user preferences  # noqa: E501
+#     "allowSwitching": True,    # Allow user to switch between themes (default and dark)  # noqa: E501
+#     "allowOSPreference": True, # Allow the app to Auto-detect and set system theme preference  # noqa: E501
+# }
+THEME_SETTINGS: ThemeSettings = {}
+# ---------------------------------------------------
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES is used for adding custom sequential color schemes
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES =  [
 #     {

--- a/superset/themes/__init__.py
+++ b/superset/themes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/themes/types.py
+++ b/superset/themes/types.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+
+ThemeAlgorithmCombination = List[
+    Union[Literal["default"], Literal["dark"], Literal["compact"]]
+]
+
+
+ThemeAlgorithmOption = Union[
+    Literal["default"], Literal["dark"], Literal["compact"], ThemeAlgorithmCombination
+]
+
+
+class Theme(TypedDict, total=False):
+    """
+    Represents a theme configuration.
+    token: Optional[Dict[str, Any]]
+    components: Optional[Dict[str, Any]]
+    algorithm: Optional[ThemeAlgorithmOption]
+    hashed: Optional[bool]
+    inherit: Optional[bool]
+    """
+
+    token: Dict[str, Any]
+    components: Optional[Dict[str, Any]]
+    algorithm: Optional[ThemeAlgorithmOption]
+    hashed: Optional[bool]
+    inherit: Optional[bool]
+
+
+class ThemeSettings(TypedDict, total=False):
+    """
+    Represents the settings for themes in the application.
+    """
+
+    enforced: Optional[bool]
+    allowSwitching: Optional[bool]
+    allowOSPreference: Optional[bool]
+
+
+class ThemeMode(str, Enum):
+    DEFAULT = "default"
+    DARK = "dark"
+    SYSTEM = "system"
+    COMPACT = "compact"
+
+
+class ThemeSettingsKey(str, Enum):
+    ENFORCED = "enforced"
+    ALLOW_SWITCHING = "allowSwitching"
+    ALLOW_OS_PREFERENCE = "allowOSPreference"

--- a/superset/themes/utils.py
+++ b/superset/themes/utils.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, Dict
+
+from superset.themes.types import ThemeMode, ThemeSettingsKey
+
+
+def _is_valid_theme_mode(mode: str) -> bool:
+    """Check if a string is a valid theme mode"""
+    try:
+        ThemeMode(mode)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_algorithm(algorithm: Any) -> bool:
+    """Helper function to validate theme algorithm"""
+    if isinstance(algorithm, str):
+        return _is_valid_theme_mode(algorithm) or algorithm == ThemeMode.SYSTEM
+    elif isinstance(algorithm, list):
+        return all(
+            isinstance(alg, str) and _is_valid_theme_mode(alg) for alg in algorithm
+        )
+    else:
+        return False
+
+
+def is_valid_theme(theme: Dict[str, Any]) -> bool:
+    """Check if a theme is valid"""
+    try:
+        if not isinstance(theme, dict):
+            return False
+
+        # Empty dict is valid
+        if not theme:
+            return True
+
+        # Validate each field type
+        validations = [
+            ("token", dict),
+            ("components", dict),
+            ("hashed", bool),
+            ("inherit", bool),
+        ]
+
+        for field, expected_type in validations:
+            if field in theme and not isinstance(theme[field], expected_type):
+                return False
+
+        # Validate algorithm field separately due to its complexity
+        if "algorithm" in theme and not _is_valid_algorithm(theme["algorithm"]):
+            return False
+
+        return True
+    except Exception:
+        return False
+
+
+def is_valid_theme_settings(settings: Dict[str, Any]) -> bool:
+    """Check if theme settings are valid"""
+    try:
+        if not isinstance(settings, dict):
+            return False
+
+        # Empty dict is valid
+        if not settings:
+            return True
+
+        # Check if all keys are valid
+        valid_keys = {setting.value for setting in ThemeSettingsKey}
+        for key in settings.keys():
+            if key not in valid_keys:
+                return False
+
+        # Type check values - all must be booleans
+        for _key, value in settings.items():
+            if not isinstance(value, bool):
+                return False
+
+        return True
+    except Exception:
+        return False

--- a/superset/themes/utils.py
+++ b/superset/themes/utils.py
@@ -20,7 +20,14 @@ from superset.themes.types import ThemeMode, ThemeSettingsKey
 
 
 def _is_valid_theme_mode(mode: str) -> bool:
-    """Check if a string is a valid theme mode"""
+    """Validate if a string represents a valid theme mode.
+
+    Args:
+    mode: String to validate against ThemeMode enum
+
+    Returns:
+    bool: True if mode is a valid ThemeMode value, False otherwise
+    """
     try:
         ThemeMode(mode)
         return True
@@ -41,7 +48,18 @@ def _is_valid_algorithm(algorithm: Any) -> bool:
 
 
 def is_valid_theme(theme: Dict[str, Any]) -> bool:
-    """Check if a theme is valid"""
+    """Validate theme dictionary structure and types.
+
+    A valid theme can be empty or must contain properly typed fields:
+
+    token (dict)
+    components (dict)
+    hashed (bool)
+    inherit (bool)
+    algorithm (str or list of str matching ThemeMode)
+    Returns:
+    bool: True if theme structure is valid, False otherwise
+    """
     try:
         if not isinstance(theme, dict):
             return False

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -68,7 +68,13 @@ from superset.utils import core as utils, json
 from superset.utils.filters import get_dataset_access_filters
 from superset.views.error_handling import json_error_response
 
-from .utils import bootstrap_user_data
+from .utils import bootstrap_user_data, get_config_value
+
+DEFAULT_THEME_SETTINGS = {
+    "enforced": False,
+    "allowSwitching": True,
+    "allowOSPreference": True,
+}
 
 FRONTEND_CONF_KEYS = (
     "SUPERSET_WEBSERVER_TIMEOUT",
@@ -298,36 +304,28 @@ def get_theme_bootstrap_data() -> dict[str, Any]:
     Returns the theme data to be sent to the client.
     """
     # Get theme configs
-    default_theme = (
-        conf["THEME_DEFAULT"]()
-        if callable(conf["THEME_DEFAULT"])
-        else conf["THEME_DEFAULT"]
-    )
-    dark_theme = (
-        conf["THEME_DARK"]() if callable(conf["THEME_DARK"]) else conf["THEME_DARK"]
-    )
-    theme_settings = (
-        conf["THEME_SETTINGS"]()
-        if callable(conf["THEME_SETTINGS"])
-        else conf["THEME_SETTINGS"]
-    )
+    default_theme = get_config_value(conf, "THEME_DEFAULT")
+    dark_theme = get_config_value(conf, "THEME_DARK")
+    theme_settings = get_config_value(conf, "THEME_SETTINGS")
 
     # Validate and warn if invalid
     if not is_valid_theme(default_theme):
-        logger.warning("Invalid THEME_DEFAULT configuration, using empty theme")
+        logger.warning(
+            "Invalid THEME_DEFAULT configuration: %s, using empty theme", default_theme
+        )
         default_theme = {}
 
     if not is_valid_theme(dark_theme):
-        logger.warning("Invalid THEME_DARK configuration, using empty theme")
+        logger.warning(
+            "Invalid THEME_DARK configuration: %s, using empty theme", dark_theme
+        )
         dark_theme = {}
 
     if not is_valid_theme_settings(theme_settings):
-        logger.warning("Invalid THEME_SETTINGS configuration, using defaults")
-        theme_settings = {
-            "enforced": False,
-            "allowSwitching": True,
-            "allowOSPreference": True,
-        }
+        logger.warning(
+            "Invalid THEME_SETTINGS configuration: %s, using defaults", theme_settings
+        )
+        theme_settings = DEFAULT_THEME_SETTINGS
 
     return {
         "theme": {

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -63,7 +63,6 @@ from superset.extensions import cache_manager
 from superset.reports.models import ReportRecipientType
 from superset.superset_typing import FlaskResponse
 from superset.themes.utils import is_valid_theme, is_valid_theme_settings
-from superset.translations.utils import get_language_pack
 from superset.utils import core as utils, json
 from superset.utils.filters import get_dataset_access_filters
 from superset.views.error_handling import json_error_response

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -101,6 +101,11 @@ def bootstrap_user_data(user: User, include_perms: bool = False) -> dict[str, An
     return payload
 
 
+def get_config_value(conf: Any, key: str) -> Any:
+    value = conf[key]
+    return value() if callable(value) else value
+
+
 def get_permissions(
     user: User,
 ) -> tuple[dict[str, list[tuple[str]]], DefaultDict[str, list[str]]]:

--- a/tests/unit_tests/themes/test_utils.py
+++ b/tests/unit_tests/themes/test_utils.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from superset.themes.types import ThemeMode, ThemeSettingsKey
+from superset.themes.utils import (
+    _is_valid_algorithm,
+    _is_valid_theme_mode,
+    is_valid_theme,
+    is_valid_theme_settings,
+)
+
+
+@pytest.mark.parametrize(
+    "mode, expected",
+    [
+        (ThemeMode.DEFAULT.value, True),
+        (ThemeMode.DARK.value, True),
+        (ThemeMode.SYSTEM.value, True),
+        ("foo", False),
+    ],
+)
+def test_is_valid_theme_mode(mode, expected):
+    assert _is_valid_theme_mode(mode) is expected
+
+
+@pytest.mark.parametrize(
+    "algorithm, expected",
+    [
+        ("default", True),
+        (ThemeMode.SYSTEM.value, True),
+        ([ThemeMode.DEFAULT.value, ThemeMode.DARK.value], True),
+        ([ThemeMode.DEFAULT.value, "foo"], False),
+        (123, False),
+        ([ThemeMode.DEFAULT.value, 123], False),
+    ],
+)
+def test_is_valid_algorithm(algorithm, expected):
+    assert _is_valid_algorithm(algorithm) is expected
+
+
+@pytest.mark.parametrize(
+    "theme, expected",
+    [
+        ([], False),  # not a dict
+        ("string", False),
+        ({}, True),  # empty dict
+        ({"token": {}, "components": {}, "hashed": True, "inherit": False}, True),
+        (
+            {
+                "token": [],
+            },
+            False,
+        ),  # wrong type for token
+        ({"algorithm": "default"}, True),
+        ({"algorithm": "foo"}, False),
+        ({"algorithm": ["default", "dark"]}, True),
+        ({"algorithm": ["default", "foo"]}, False),
+    ],
+)
+def test_is_valid_theme(theme, expected):
+    assert is_valid_theme(theme) is expected
+
+
+@pytest.mark.parametrize(
+    "settings, expected",
+    [
+        ([], False),  # not a dict
+        ("string", False),
+        ({}, True),  # empty
+        ({key.value: True for key in ThemeSettingsKey}, True),
+        ({"enforced": True, "foo": False}, False),  # invalid key
+        ({"enforced": "yes"}, False),  # invalid value type
+    ],
+)
+def test_is_valid_theme_settings(settings, expected):
+    assert is_valid_theme_settings(settings) is expected


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds full support for Superset’s bootstrap-provided theme objects (default, dark, and settings) and integrates them into the existing ThemeController API.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Pass a valid `Theme` dict to `THEME_DEFAULT` and or `THEME_DARK` (you can generate one in the Ant Design theme editor: https://ant.design/theme-editor)
2. Reload the frontend app
3. Watch the magic happens 

For `THEME_SETTINGS`:
1. Pass a valid `ThemeSettings` dict
E.g.:
```
THEME_SETTINGS = {
    "enforced": True,            # If True, forces the default theme and ignores user preferences
    "allowSwitching": True,      # Allow user to switch between themes (default and dark)
    "allowOSPreference": True,   # Allow the app to Auto-detect and set system theme preference
}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
