### PR TITLE
chore(docker): use editable mode in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,7 @@ RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     /app/docker/pip-install.sh --requires-build-essential -r requirements/base.txt
 # Install the superset package
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
-    uv pip install .
+    uv pip install -e .
 RUN python -m compileall /app/superset
 
 USER superset
@@ -246,7 +246,7 @@ RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     /app/docker/pip-install.sh --requires-build-essential -r requirements/development.txt
 # Install the superset package
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
-    uv pip install .
+    uv pip install -e .
 
 RUN uv pip install .[postgres]
 RUN python -m compileall /app/superset


### PR DESCRIPTION
Trying to address the issue raise here: https://github.com/apache/superset/issues/34120#issuecomment-3058902853

From my analysis, it should address the issue (package installed twice in docker) by using a symlink.

The downsides are pretty minimal, with a micro os-level penalty on resolving symlinks (super minimal from my understanding), and some considerations around image size, where in editable mode we can't/couldn't strip .py files if we wanted.

This seems like a positive step.

Other alternatives would probably require 2 extra layers (an extra build layer for both dev and lean), and it's hard to keep the docker logic DRY and readable in that context. Personally I'm not willing to take this on now... With that approach, we wouldn't have `/app/superset` and would only have superset/ in `.venv`, could compile and strip `.py` to only keep `.pyc` if we wanted there. 

Doing some research, it seems python is still very much lacking around managing lean packages/bundles of bytecode only, where wheels and packages in general tend to be raw .py, and it's tricky to only pacakge .pyc if/when desired. 

---
Some benefits from the `-e` (editable mode). `/app/superset` in docker:
- easy to find, easy to alter (pros/cons), easy to alter/inject files in extra docker layers
- easily docker-mountable, mount /app/superset to your local repo and you're live-running/editing the image