### PR TITLE
fix(dataset): trigger `onChange` when switching to physical dataset to clear SQL

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceEditor.jsx
@@ -717,7 +717,9 @@ class DatasourceEditor extends PureComponent {
   }
 
   onDatasourceTypeChange(datasourceType) {
-    this.setState({ datasourceType });
+    // Call onChange after setting datasourceType to ensure
+    // SQL is cleared when switching to a physical dataset
+    this.setState({ datasourceType }, this.onChange);
   }
 
   setColumns(obj) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#### Problem
When switching from a virtual dataset to a physical dataset, the SQL editor is cleared in the UI but this change was not propagated to the parent component via `onChange`.

#### Solution
Added a call to `this.onChange` in the `onDatasourceTypeChange` handler, ensuring that SQL string is cleared when switching to physical dataset.
```python
this.setState({ datasourceType }, this.onChange);
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
https://github.com/user-attachments/assets/5588957f-6e0e-41f0-8e8d-d137560e4acd

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33906 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
