### PR TITLE
feat(snowflake): Support Snowflake private keys w/o passphrase

### DIFF
--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -394,9 +394,11 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
             else:
                 with open(auth_params["privatekey_path"], "rb") as key_temp:
                     key = key_temp.read()
+            privatekey_pass = auth_params.get("privatekey_pass", None)
+            password = privatekey_pass.encode() if privatekey_pass is not None else None
             p_key = serialization.load_pem_private_key(
                 key,
-                password=auth_params["privatekey_pass"].encode(),
+                password=password,
                 backend=default_backend(),
             )
             pkb = p_key.private_bytes(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Accept Snowflake private keys with no passphrase.

Previously private keys with no passphrase didn't work as described in #23264.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Follow instructions in <https://superset.apache.org/docs/configuration/databases/#snowflake>
  to create a Snowflake database connection.
1. Put `snowflake://{user}@{account}.{region}/{database}?role={role}&warehouse={warehouse}` in
  the SQLAlchemy URI field. Note that no `password` is specified.
1. Put the following JSON in `ADVANCED` > `Security` > `SECURE EXTRA` field.

    ```json
    {
      "auth_method": "keypair",
      "auth_params": {
        "privatekey_body": "-----BEGIN PRIVATE KEY-----\n**********\n-----END PRIVATE KEY-----\n"
      }
    }
    ```

1. Click `Test Connection` and verify that the connection is successful.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #23264
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
