### PR TITLE
docs(development): Fix typo in the documentation

### DIFF
--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -78,7 +78,7 @@ Affecting the Docker build process:
 
 - **SUPERSET_BUILD_TARGET (default=dev):** which --target to build, either `lean` or `dev` are commonly used
 - **INCLUDE_FIREFOX (default=false):** whether to include the Firefox headless browser in the build
-- **INCLUDE_CHROMIUM (default=false):** whether to include the Firefox headless browser in the build
+- **INCLUDE_CHROMIUM (default=false):** whether to include the Chromium headless browser in the build
 - **BUILD_TRANSLATIONS(default=false):** whether to compile the translations from the .po files available
 - **SUPERSET_LOAD_EXAMPLES (default=yes):** whether to load the examples into the database upon startup,
   save some precious time on startup by `SUPERSET_LOAD_EXAMPLES=no docker compose up`


### PR DESCRIPTION
### SUMMARY
Fix a typo in the documentation

### ADDITIONAL INFORMATION
- [ x ] Changes UI
