### PR TITLE
fix(DrillBy): make drill by work with multi metric charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -209,12 +209,18 @@ export default function EchartsTimeseries({
           }),
         );
         groupBy.forEach((dimension, i) => {
-          const val = labelMap[seriesName][i];
+          const dimensionValues = labelMap[seriesName] ?? [];
+
+          // Skip the metric values at the beginning and get the actual dimension value
+          // If we have multiple metrics, they come first, then the dimension values
+          const metricsCount = dimensionValues.length - groupBy.length;
+          const val = dimensionValues[metricsCount + i];
+
           drillByFilters.push({
             col: dimension,
             op: '==',
             val,
-            formattedVal: formatSeriesName(values[i], {
+            formattedVal: formatSeriesName(val, {
               timeFormatter: getTimeFormatter(formData.dateFormat),
               numberFormatter: getNumberFormatter(formData.numberFormat),
               coltype: coltypeMapping?.[getColumnLabel(dimension)],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Drill By was not working properly for charts with more than one metric and at least one dimension, this pr aims to fix that by checking if more than 1 metric exists and setting the value accordingly

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


1. Create a Bar Chart using the cleaned_sales_data dataset.
2. Add a column as the X-Axis, two metrics, and one dimension.
3. Save the chart to a dashboard.
4. In the dashboard, try drilling by any other column.

Run the testing suite

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
