### PR TITLE
chore(Oracle): Update oracle column length to 128

### DIFF
--- a/superset/db_engine_specs/oracle.py
+++ b/superset/db_engine_specs/oracle.py
@@ -27,7 +27,7 @@ class OracleEngineSpec(BaseEngineSpec):
     engine = "oracle"
     engine_name = "Oracle"
     force_column_alias_quotes = True
-    max_column_name_length = 30
+    max_column_name_length = 128
 
     _time_grain_expressions = {
         None: "{col}",

--- a/tests/unit_tests/db_engine_specs/test_oracle.py
+++ b/tests/unit_tests/db_engine_specs/test_oracle.py
@@ -31,7 +31,7 @@ from tests.unit_tests.fixtures.common import dttm  # noqa: F401
 @pytest.mark.parametrize(
     "column_name,expected_result",
     [
-        ("This_Is_32_Character_Column_Name", "3b26974078683be078219674eeb8f5"),
+        ("a" * 129, "b325dc1c6f5e7a2b7cf465b9feab7948"),
         ("snake_label", "snake_label"),
         ("camelLabel", "camelLabel"),
     ],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Oracle max column length is increased to 128 after release 12.2.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Check if Oracle db allows a column name with length up to 128

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33029 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
