### PR TITLE
fix(theming): Remove leftover antd5 prefix

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/PopoverDropdown/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/PopoverDropdown/index.tsx
@@ -45,7 +45,7 @@ interface HandleSelectProps {
 }
 
 const menuItemStyles = (theme: any) => css`
-  &.antd5-menu-item {
+  &.ant-menu-item {
     height: auto;
     line-height: 1.4;
 

--- a/superset-frontend/packages/superset-ui-core/src/components/Radio/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Radio/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import {
-  Radio as Antd5Radio,
+  Radio as AntRadio,
   type CheckboxOptionType,
   type RadioGroupProps,
 } from 'antd';
@@ -40,19 +40,19 @@ const RadioGroup = ({
   ...props
 }: RadioGroupWrapperProps) => {
   const content = options.map((option: CheckboxOptionType) => (
-    <Antd5Radio key={option.value} value={option.value}>
+    <AntRadio key={option.value} value={option.value}>
       {option.label}
-    </Antd5Radio>
+    </AntRadio>
   ));
   return (
-    <Antd5Radio.Group {...props}>
+    <AntRadio.Group {...props}>
       {spaceConfig ? <Space {...spaceConfig}>{content}</Space> : content}
-    </Antd5Radio.Group>
+    </AntRadio.Group>
   );
 };
-export const Radio = Object.assign(Antd5Radio, {
+export const Radio = Object.assign(AntRadio, {
   GroupWrapper: RadioGroup,
-  Button: Antd5Radio.Button,
+  Button: AntRadio.Button,
 });
 export type {
   RadioChangeEvent,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -926,7 +926,7 @@ const SqlEditor: FC<Props> = ({
       css={css`
         margin-bottom: ${theme.sizeUnit * 2}px;
         padding-top: ${theme.sizeUnit * 4}px;
-        .antd5-alert-action {
+        .ant-alert-action {
           align-self: center;
         }
       `}

--- a/superset-frontend/src/features/groups/GroupListModal.tsx
+++ b/superset-frontend/src/features/groups/GroupListModal.tsx
@@ -132,7 +132,7 @@ function GroupListModal({
             value: role.id,
             label: role.name,
           }))}
-          getPopupContainer={trigger => trigger.closest('.antd5-modal-content')}
+          getPopupContainer={trigger => trigger.closest('.ant-modal-content')}
         />
       </FormItem>
       <FormItem name="users" label={t('Users')}>

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -54,7 +54,7 @@ const Wrapper = styled.div`
   justify-content: space-between;
   width: 100%;
 
-  .antd5-input-number {
+  .ant-input-number {
     min-width: 80px;
     position: relative;
   }

--- a/superset-frontend/src/pages/ActionLog/index.tsx
+++ b/superset-frontend/src/pages/ActionLog/index.tsx
@@ -196,10 +196,10 @@ function ActionLogList() {
         }: any) => (
           <Typography.Text
             css={css`
-              .antd5-typography-copy {
+              .ant-typography-copy {
                 visibility: hidden;
               }
-              &:hover .antd5-typography-copy {
+              &:hover .ant-typography-copy {
                 visibility: visible;
               }
             `}
@@ -224,10 +224,10 @@ function ActionLogList() {
         }: any) => (
           <Typography.Text
             css={css`
-              .antd5-typography-copy {
+              .ant-typography-copy {
                 visibility: hidden;
               }
-              &:hover .antd5-typography-copy {
+              &:hover .ant-typography-copy {
                 visibility: visible;
               }
             `}

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -62,7 +62,7 @@ const StyledCard = styled(Card)`
     margin-top: ${theme.marginXL}px;
     color: ${theme.colorBgContainer};
     background: ${theme.colorBgBase};
-    .antd5-form-item-label label {
+    .ant-form-item-label label {
       color: ${theme.colorPrimary};
     }
   `}

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -45,7 +45,7 @@ const StyledCard = styled(Card)`
     width: 50%;
     margin-top: ${theme.marginXL}px;
     background: ${theme.colorBgBase};
-    .antd5-form-item-label label {
+    .ant-form-item-label label {
       color: ${theme.colorPrimary};
     }
   `}

--- a/superset-frontend/src/pages/UserInfo/index.tsx
+++ b/superset-frontend/src/pages/UserInfo/index.tsx
@@ -54,11 +54,11 @@ const DescriptionsContainer = styled.div`
 
 const StyledLayout = styled.div`
   ${({ theme }) => css`
-    .antd5-row {
+    .ant-row {
       margin: 0px ${theme.sizeUnit * 3}px ${theme.sizeUnit * 6}px
         ${theme.sizeUnit * 3}px;
     }
-    && .menu > .antd5-menu {
+    && .menu > .ant-menu {
       padding: 0px;
     }
     && .nav-right {

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -108,8 +108,8 @@ class WebDriverPlaywright(WebDriverProxy):
                 alert_div.get_by_role("button").click()
 
                 # wait for modal to show up
-                page.locator(".antd5-modal-content").wait_for(state="visible")
-                err_msg_div = page.locator(".antd5-modal-content .antd5-modal-body")
+                page.locator(".ant-modal-content").wait_for(state="visible")
+                err_msg_div = page.locator(".ant-modal-content .ant-modal-body")
                 #
                 # # collect error message
                 error_messages.append(err_msg_div.text_content())
@@ -118,10 +118,10 @@ class WebDriverPlaywright(WebDriverProxy):
                 error_as_html = err_msg_div.inner_html().replace("'", "\\'")
                 #
                 # # close modal after collecting error messages
-                page.locator(".antd5-modal-content .antd5-modal-close").click()
+                page.locator(".ant-modal-content .ant-modal-close").click()
                 #
                 # # wait until the modal becomes invisible
-                page.locator(".antd5-modal-content").wait_for(state="detached")
+                page.locator(".ant-modal-content").wait_for(state="detached")
                 try:
                     # Even if some errors can't be updated in the screenshot,
                     # keep all the errors in the server log and do not fail the loop
@@ -347,17 +347,17 @@ class WebDriverSelenium(WebDriverProxy):
                     current_app.config["SCREENSHOT_WAIT_FOR_ERROR_MODAL_VISIBLE"],
                 ).until(
                     EC.visibility_of_any_elements_located(
-                        (By.CLASS_NAME, "antd5-modal-content")
+                        (By.CLASS_NAME, "ant-modal-content")
                     )
                 )[0]
 
-                err_msg_div = modal.find_element(By.CLASS_NAME, "antd5-modal-body")
+                err_msg_div = modal.find_element(By.CLASS_NAME, "ant-modal-body")
 
                 # collect error message
                 error_messages.append(err_msg_div.text)
 
                 # close modal after collecting error messages
-                modal.find_element(By.CLASS_NAME, "antd5-modal-close").click()
+                modal.find_element(By.CLASS_NAME, "ant-modal-close").click()
 
                 # wait until the modal becomes invisible
                 WebDriverWait(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There were some leftover antd5 prefix probably from merge conflicts etc. This pr moves antd5-ant on those.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the testing suite

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
