### PR TITLE
fix: dataset endpoint `/rowlevelsecurity/related/tables` doesn't apply filters as expected

### DIFF
--- a/superset/row_level_security/api.py
+++ b/superset/row_level_security/api.py
@@ -55,6 +55,7 @@ from superset.views.filters import (
     BaseFilterRelatedRoles,
     BaseFilterRelatedUsers,
     FilterRelatedOwners,
+    FilterRelatedTables,
 )
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,7 @@ class RLSRestApi(BaseSupersetModelRestApi):
 
     allowed_rel_fields = {"tables", "roles", "created_by", "changed_by"}
     related_field_filters = {
+        "tables": RelatedFieldFilter("table_name", FilterRelatedTables),
         "changed_by": RelatedFieldFilter("first_name", FilterRelatedOwners),
     }
     base_related_field_filters = {

--- a/superset/views/filters.py
+++ b/superset/views/filters.py
@@ -102,3 +102,22 @@ class BaseFilterRelatedRoles(BaseFilter):  # pylint: disable=too-few-public-meth
             return extra_filters(query)
 
         return query
+
+
+class FilterRelatedTables(BaseFilter):  # pylint: disable=too-few-public-methods
+    """
+    A filter to allow searching for related tables.
+    Use in the api by adding something like:
+    related_field_filters = {
+      "tables": RelatedFieldFilter("table_name", FilterRelatedTables),
+    }
+    """
+
+    name = lazy_gettext("Table")
+    arg_name = "tables"
+
+    def apply(self, query: Query, value: Optional[Any]) -> Query:
+        from superset.connectors.sqla.models import SqlaTable
+
+        like_value = "%" + cast(str, value) + "%"
+        return query.filter(SqlaTable.table_name.ilike(like_value))

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -555,7 +555,7 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
         assert len(result) == len(db_tables)
         assert db_table_names == received_tables
 
-    def test_rls_tables_related_api_with_filter(self):
+    def test_rls_tables_related_api_with_filter_matching_birth(self):
         self.login(ADMIN_USERNAME)
         # Test with filter that should match 'birth_names'
         params = prison.dumps({"filter": "birth", "page": 0, "page_size": 100})
@@ -568,6 +568,8 @@ class TestRowLevelSecurityWithRelatedAPI(SupersetTestCase):
         assert all("birth" in table_name.lower() for table_name in received_tables)
         assert len(result) >= 1  # At least birth_names should be returned
 
+    def test_rls_tables_related_api_with_filter_no_matches(self):
+        self.login(ADMIN_USERNAME)
         # Test with filter that should match nothing
         params = prison.dumps({"filter": "nonexistent", "page": 0, "page_size": 100})
         rv = self.client.get(f"/api/v1/rowlevelsecurity/related/tables?q={params}")


### PR DESCRIPTION


  ## Summary

  This PR fixes an issue where the filter parameter in the Row Level Security (RLS) related tables endpoint
  (`/api/v1/rowlevelsecurity/related/tables`) was not being applied. When users tried to search for specific tables
  in the RLS CRUD UI, all tables were returned regardless of the filter value.

  ## Problem

  The `/api/v1/rowlevelsecurity/related/tables?q=(filter:mult,page:1,page_size:100)` endpoint was ignoring the
  `filter` parameter because:
  - The RLS API was missing the proper filter configuration for the `tables` field
  - Without this configuration, the `_get_related_filter` method in the base API didn't know which field to filter on

  ## Solution

  1. **Created a new filter class** `FilterRelatedTables` in `superset/views/filters.py` that:
     - Performs case-insensitive substring matching using SQLAlchemy's `ilike` with wildcards
     - Filters tables by their `table_name` field - Follows the same pattern as other "contains" filters in the codebase (e.g., `FilterRelatedOwners`, `DashboardTitleOrSlugFilter`)

  2. **Updated the RLS API configuration** to use this filter: ```python related_field_filters = { "tables": RelatedFieldFilter("table_name", FilterRelatedTables), "changed_by": RelatedFieldFilter("first_name", FilterRelatedOwners), }

  Testing

  Added a new test test_rls_tables_related_api_with_filter that verifies:
  - Filtering with a matching substring returns only tables containing that substring
  - Filtering with a non-existent substring returns no results
  - The filter is case-insensitive

  Changes

  - superset/views/filters.py: Added FilterRelatedTables class
  - superset/row_level_security/api.py: Added filter configuration for tables field
  - tests/integration_tests/security/row_level_security_tests.py: Added test for filter functionality

  Impact

  This fix improves the user experience in the RLS CRUD interface by allowing users to efficiently search and filter
  tables when creating or editing row-level security rules.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
