### PR TITLE
fix: proper handling of boolean filters with snowflake

### DIFF
--- a/superset/advanced_data_type/plugins/internet_address.py
+++ b/superset/advanced_data_type/plugins/internet_address.py
@@ -87,40 +87,40 @@ def cidr_translate_filter_func(  # noqa: C901
     if operator in (FilterOperator.IN, FilterOperator.NOT_IN):
         dict_items = [val for val in values if isinstance(val, dict)]
         single_values = [val for val in values if not isinstance(val, dict)]
-        if operator == FilterOperator.IN.value:
+        if operator == FilterOperator.IN:
             cond = col.in_(single_values)
             for dictionary in dict_items:
                 cond = cond | (col <= dictionary["end"]) & (col >= dictionary["start"])
-        elif operator == FilterOperator.NOT_IN.value:
+        elif operator == FilterOperator.NOT_IN:
             cond = ~(col.in_(single_values))
             for dictionary in dict_items:
                 cond = cond & (col > dictionary["end"]) & (col < dictionary["start"])
         return_expression = cond
     if len(values) == 1:
         value = values[0]
-        if operator == FilterOperator.EQUALS.value:
+        if operator == FilterOperator.EQUALS:
             return_expression = (
                 col == value
                 if not isinstance(value, dict)
                 else (col <= value["end"]) & (col >= value["start"])
             )
-        if operator == FilterOperator.GREATER_THAN_OR_EQUALS.value:
+        if operator == FilterOperator.GREATER_THAN_OR_EQUALS:
             return_expression = (
                 col >= value if not isinstance(value, dict) else col >= value["end"]
             )
-        if operator == FilterOperator.GREATER_THAN.value:
+        if operator == FilterOperator.GREATER_THAN:
             return_expression = (
                 col > value if not isinstance(value, dict) else col > value["end"]
             )
-        if operator == FilterOperator.LESS_THAN.value:
+        if operator == FilterOperator.LESS_THAN:
             return_expression = (
                 col < value if not isinstance(value, dict) else col < value["start"]
             )
-        if operator == FilterOperator.LESS_THAN_OR_EQUALS.value:
+        if operator == FilterOperator.LESS_THAN_OR_EQUALS:
             return_expression = (
                 col <= value if not isinstance(value, dict) else col <= value["start"]
             )
-        if operator == FilterOperator.NOT_EQUALS.value:
+        if operator == FilterOperator.NOT_EQUALS:
             return_expression = (
                 col != value
                 if not isinstance(value, dict)

--- a/superset/advanced_data_type/plugins/internet_port.py
+++ b/superset/advanced_data_type/plugins/internet_port.py
@@ -114,25 +114,25 @@ def port_translate_filter_func(  # noqa: C901
     return_expression: Any
     if operator in (FilterOperator.IN, FilterOperator.NOT_IN):
         vals_list = itertools.chain.from_iterable(values)
-        if operator == FilterOperator.IN.value:
+        if operator == FilterOperator.IN:
             cond = col.in_(vals_list)
-        elif operator == FilterOperator.NOT_IN.value:
+        elif operator == FilterOperator.NOT_IN:
             cond = ~(col.in_(vals_list))
         return_expression = cond
     if len(values) == 1:
         value = values[0]
         value.sort()
-        if operator == FilterOperator.EQUALS.value:
+        if operator == FilterOperator.EQUALS:
             return_expression = col.in_(value)
-        if operator == FilterOperator.GREATER_THAN_OR_EQUALS.value:
+        if operator == FilterOperator.GREATER_THAN_OR_EQUALS:
             return_expression = col >= value[0]
-        if operator == FilterOperator.GREATER_THAN.value:
+        if operator == FilterOperator.GREATER_THAN:
             return_expression = col > value[0]
-        if operator == FilterOperator.LESS_THAN.value:
+        if operator == FilterOperator.LESS_THAN:
             return_expression = col < value[-1]
-        if operator == FilterOperator.LESS_THAN_OR_EQUALS.value:
+        if operator == FilterOperator.LESS_THAN_OR_EQUALS:
             return_expression = col <= value[-1]
-        if operator == FilterOperator.NOT_EQUALS.value:
+        if operator == FilterOperator.NOT_EQUALS:
             return_expression = ~col.in_(value)
     return return_expression
 

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -541,9 +541,7 @@ class QueryContextProcessor:
                 # Lets find the first temporal filter in the filters array and change
                 # its val to be the result of get_since_until with the offset
                 for flt in query_object_clone.filter:
-                    if flt.get(
-                        "op"
-                    ) == FilterOperator.TEMPORAL_RANGE.value and isinstance(
+                    if flt.get("op") == FilterOperator.TEMPORAL_RANGE and isinstance(
                         flt.get("val"), str
                     ):
                         time_range = cast(str, flt.get("val"))

--- a/superset/common/utils/time_range_utils.py
+++ b/superset/common/utils/time_range_utils.py
@@ -66,7 +66,7 @@ def get_since_until_from_query_object(
 
     time_range = None
     for flt in query_object.filter:
-        if flt.get("op") == FilterOperator.TEMPORAL_RANGE.value and isinstance(
+        if flt.get("op") == FilterOperator.TEMPORAL_RANGE and isinstance(
             flt.get("val"), str
         ):
             time_range = cast(str, flt.get("val"))

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1259,17 +1259,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         from superset.utils import core as utils
 
-        if op == utils.FilterOperator.EQUALS.value:
+        if op == utils.FilterOperator.EQUALS:
             return sqla_col == value
-        elif op == utils.FilterOperator.NOT_EQUALS.value:
+        elif op == utils.FilterOperator.NOT_EQUALS:
             return sqla_col != value
-        elif op == utils.FilterOperator.GREATER_THAN.value:
+        elif op == utils.FilterOperator.GREATER_THAN:
             return sqla_col > value
-        elif op == utils.FilterOperator.LESS_THAN.value:
+        elif op == utils.FilterOperator.LESS_THAN:
             return sqla_col < value
-        elif op == utils.FilterOperator.GREATER_THAN_OR_EQUALS.value:
+        elif op == utils.FilterOperator.GREATER_THAN_OR_EQUALS:
             return sqla_col >= value
-        elif op == utils.FilterOperator.LESS_THAN_OR_EQUALS.value:
+        elif op == utils.FilterOperator.LESS_THAN_OR_EQUALS:
             return sqla_col <= value
         else:
             raise ValueError(f"Invalid comparison filter operator: {op}")

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1231,7 +1231,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     def handle_null_filter(
         cls,
         sqla_col: Any,
-        op: utils.FilterOperator.IS_NULL | utils.FilterOperator.IS_NOT_NULL,
+        op: utils.FilterOperator,
     ) -> BinaryExpression:
         """
         Handle null/not null filter operations.

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1251,7 +1251,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def handle_comparison_filter(
-        cls, sqla_col: Any, op: str, value: Any
+        cls, sqla_col: Any, op: utils.FilterOperator, value: Any
     ) -> BinaryExpression:
         """
         Handle comparison filter operations (=, !=, >, <, >=, <=).

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1242,9 +1242,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         from superset.utils import core as utils
 
-        if op == utils.FilterOperator.IS_NULL.value:
+        if op == utils.FilterOperator.IS_NULL:
             return sqla_col.is_(None)
-        elif op == utils.FilterOperator.IS_NOT_NULL.value:
+        elif op == utils.FilterOperator.IS_NOT_NULL:
             return sqla_col.isnot(None)
         else:
             raise ValueError(f"Invalid null filter operator: {op}")

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1228,7 +1228,11 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             return sqla_col.is_(value)
 
     @classmethod
-    def handle_null_filter(cls, sqla_col: Any, op: str) -> BinaryExpression:
+    def handle_null_filter(
+        cls,
+        sqla_col: Any,
+        op: utils.FilterOperator.IS_NULL | utils.FilterOperator.IS_NOT_NULL,
+    ) -> BinaryExpression:
         """
         Handle null/not null filter operations.
 

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -54,7 +54,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import literal_column, quoted_name, text
-from sqlalchemy.sql.expression import ColumnClause, Select, TextClause
+from sqlalchemy.sql.expression import BinaryExpression, ColumnClause, Select, TextClause
 from sqlalchemy.types import TypeEngine
 
 from superset import db
@@ -1207,7 +1207,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return None
 
     @classmethod
-    def handle_boolean_filter(cls, sqla_col: Any, op: str, value: bool) -> Any:
+    def handle_boolean_filter(
+        cls, sqla_col: Any, op: str, value: bool
+    ) -> BinaryExpression:
         """
         Handle boolean filter operations with engine-specific logic.
 
@@ -1226,7 +1228,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             return sqla_col.is_(value)
 
     @classmethod
-    def handle_null_filter(cls, sqla_col: Any, op: str) -> Any:
+    def handle_null_filter(cls, sqla_col: Any, op: str) -> BinaryExpression:
         """
         Handle null/not null filter operations.
 
@@ -1244,7 +1246,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             raise ValueError(f"Invalid null filter operator: {op}")
 
     @classmethod
-    def handle_comparison_filter(cls, sqla_col: Any, op: str, value: Any) -> Any:
+    def handle_comparison_filter(
+        cls, sqla_col: Any, op: str, value: Any
+    ) -> BinaryExpression:
         """
         Handle comparison filter operations (=, !=, >, <, >=, <=).
 

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -83,6 +83,9 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
     force_column_alias_quotes = True
     max_column_name_length = 256
 
+    # Snowflake doesn't support IS true/false syntax, use = true/false instead
+    use_equality_for_boolean_filters = True
+
     parameters_schema = SnowflakeParametersSchema()
     default_driver = "snowflake"
     sqlalchemy_uri_placeholder = "snowflake://"

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -409,8 +409,8 @@ class ExtraCache:
                     # IS_NULL and IS_NOT_NULL operators do not have a value
                     or op
                     in (
-                        FilterOperator.IS_NULL.value,
-                        FilterOperator.IS_NOT_NULL.value,
+                        FilterOperator.IS_NULL,
+                        FilterOperator.IS_NOT_NULL,
                     )
                 )
             ):
@@ -421,8 +421,8 @@ class ExtraCache:
                     self.applied_filters.append(column)
 
                 if op in (
-                    FilterOperator.IN.value,
-                    FilterOperator.NOT_IN.value,
+                    FilterOperator.IN,
+                    FilterOperator.NOT_IN,
                 ) and not isinstance(val, list):
                     val = [val]
 

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1853,14 +1853,21 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     if op == utils.FilterOperator.NOT_IN.value:
                         cond = ~cond
                     where_clause_and.append(cond)
-                elif op == utils.FilterOperator.IS_NULL.value:
-                    where_clause_and.append(sqla_col.is_(None))
-                elif op == utils.FilterOperator.IS_NOT_NULL.value:
-                    where_clause_and.append(sqla_col.isnot(None))
+                elif op in {
+                    utils.FilterOperator.IS_NULL.value,
+                    utils.FilterOperator.IS_NOT_NULL.value,
+                }:
+                    where_clause_and.append(
+                        db_engine_spec.handle_null_filter(sqla_col, op)
+                    )
                 elif op == utils.FilterOperator.IS_TRUE.value:
-                    where_clause_and.append(sqla_col.is_(True))
+                    where_clause_and.append(
+                        db_engine_spec.handle_boolean_filter(sqla_col, op, True)
+                    )
                 elif op == utils.FilterOperator.IS_FALSE.value:
-                    where_clause_and.append(sqla_col.is_(False))
+                    where_clause_and.append(
+                        db_engine_spec.handle_boolean_filter(sqla_col, op, False)
+                    )
                 else:
                     if (
                         op
@@ -1876,18 +1883,17 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                                 "with comparison operators"
                             )
                         )
-                    if op == utils.FilterOperator.EQUALS.value:
-                        where_clause_and.append(sqla_col == eq)
-                    elif op == utils.FilterOperator.NOT_EQUALS.value:
-                        where_clause_and.append(sqla_col != eq)
-                    elif op == utils.FilterOperator.GREATER_THAN.value:
-                        where_clause_and.append(sqla_col > eq)
-                    elif op == utils.FilterOperator.LESS_THAN.value:
-                        where_clause_and.append(sqla_col < eq)
-                    elif op == utils.FilterOperator.GREATER_THAN_OR_EQUALS.value:
-                        where_clause_and.append(sqla_col >= eq)
-                    elif op == utils.FilterOperator.LESS_THAN_OR_EQUALS.value:
-                        where_clause_and.append(sqla_col <= eq)
+                    if op in {
+                        utils.FilterOperator.EQUALS.value,
+                        utils.FilterOperator.NOT_EQUALS.value,
+                        utils.FilterOperator.GREATER_THAN.value,
+                        utils.FilterOperator.LESS_THAN.value,
+                        utils.FilterOperator.GREATER_THAN_OR_EQUALS.value,
+                        utils.FilterOperator.LESS_THAN_OR_EQUALS.value,
+                    }:
+                        where_clause_and.append(
+                            db_engine_spec.handle_comparison_filter(sqla_col, op, eq)
+                        )
                     elif op in {
                         utils.FilterOperator.ILIKE.value,
                         utils.FilterOperator.LIKE.value,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1884,12 +1884,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             )
                         )
                     if op in {
-                        utils.FilterOperator.EQUALS.value,
-                        utils.FilterOperator.NOT_EQUALS.value,
-                        utils.FilterOperator.GREATER_THAN.value,
-                        utils.FilterOperator.LESS_THAN.value,
-                        utils.FilterOperator.GREATER_THAN_OR_EQUALS.value,
-                        utils.FilterOperator.LESS_THAN_OR_EQUALS.value,
+                        utils.FilterOperator.EQUALS,
+                        utils.FilterOperator.NOT_EQUALS,
+                        utils.FilterOperator.GREATER_THAN,
+                        utils.FilterOperator.LESS_THAN,
+                        utils.FilterOperator.GREATER_THAN_OR_EQUALS,
+                        utils.FilterOperator.LESS_THAN_OR_EQUALS,
                     }:
                         where_clause_and.append(
                             db_engine_spec.handle_comparison_filter(sqla_col, op, eq)

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1756,7 +1756,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             flt_col = flt["col"]
             val = flt.get("val")
             flt_grain = flt.get("grain")
-            op = flt["op"].upper()
+            op = utils.FilterOperator(flt["op"].upper())
             col_obj: Optional["TableColumn"] = None
             sqla_col: Optional[Column] = None
             if flt_col == utils.DTTM_ALIAS and is_timeseries and dttm_col:
@@ -1790,8 +1790,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 col_type = col_obj.type if col_obj else None
                 col_spec = db_engine_spec.get_column_spec(native_type=col_type)
                 is_list_target = op in (
-                    utils.FilterOperator.IN.value,
-                    utils.FilterOperator.NOT_IN.value,
+                    utils.FilterOperator.IN,
+                    utils.FilterOperator.NOT_IN,
                 )
 
                 col_advanced_data_type = col_obj.advanced_data_type if col_obj else ""
@@ -1850,7 +1850,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             cond = is_null_cond
                     else:
                         cond = sqla_col.in_(eq)
-                    if op == utils.FilterOperator.NOT_IN.value:
+                    if op == utils.FilterOperator.NOT_IN:
                         cond = ~cond
                     where_clause_and.append(cond)
                 elif op in {
@@ -1860,11 +1860,11 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     where_clause_and.append(
                         db_engine_spec.handle_null_filter(sqla_col, op)
                     )
-                elif op == utils.FilterOperator.IS_TRUE.value:
+                elif op == utils.FilterOperator.IS_TRUE:
                     where_clause_and.append(
                         db_engine_spec.handle_boolean_filter(sqla_col, op, True)
                     )
-                elif op == utils.FilterOperator.IS_FALSE.value:
+                elif op == utils.FilterOperator.IS_FALSE:
                     where_clause_and.append(
                         db_engine_spec.handle_boolean_filter(sqla_col, op, False)
                     )
@@ -1872,8 +1872,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     if (
                         op
                         not in {
-                            utils.FilterOperator.EQUALS.value,
-                            utils.FilterOperator.NOT_EQUALS.value,
+                            utils.FilterOperator.EQUALS,
+                            utils.FilterOperator.NOT_EQUALS,
                         }
                         and eq is None
                     ):
@@ -1895,23 +1895,23 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             db_engine_spec.handle_comparison_filter(sqla_col, op, eq)
                         )
                     elif op in {
-                        utils.FilterOperator.ILIKE.value,
-                        utils.FilterOperator.LIKE.value,
+                        utils.FilterOperator.ILIKE,
+                        utils.FilterOperator.LIKE,
                     }:
                         if target_generic_type != GenericDataType.STRING:
                             sqla_col = sa.cast(sqla_col, sa.String)
 
-                        if op == utils.FilterOperator.LIKE.value:
+                        if op == utils.FilterOperator.LIKE:
                             where_clause_and.append(sqla_col.like(eq))
                         else:
                             where_clause_and.append(sqla_col.ilike(eq))
-                    elif op in {utils.FilterOperator.NOT_LIKE.value}:
+                    elif op in {utils.FilterOperator.NOT_LIKE}:
                         if target_generic_type != GenericDataType.STRING:
                             sqla_col = sa.cast(sqla_col, sa.String)
 
                         where_clause_and.append(sqla_col.not_like(eq))
                     elif (
-                        op == utils.FilterOperator.TEMPORAL_RANGE.value
+                        op == utils.FilterOperator.TEMPORAL_RANGE
                         and isinstance(eq, str)
                         and col_obj is not None
                     ):

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1854,8 +1854,8 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         cond = ~cond
                     where_clause_and.append(cond)
                 elif op in {
-                    utils.FilterOperator.IS_NULL.value,
-                    utils.FilterOperator.IS_NOT_NULL.value,
+                    utils.FilterOperator.IS_NULL,
+                    utils.FilterOperator.IS_NOT_NULL,
                 }:
                     where_clause_and.append(
                         db_engine_spec.handle_null_filter(sqla_col, op)

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -749,12 +749,12 @@ def test_should_generate_closed_and_open_time_filter_range(login_as_admin):
 def test_none_operand_in_filter(login_as_admin, physical_dataset):
     expected_results = [
         {
-            "operator": FilterOperator.EQUALS.value,
+            "operator": FilterOperator.EQUALS,
             "count": 10,
             "sql_should_contain": "COL4 IS NULL",
         },
         {
-            "operator": FilterOperator.NOT_EQUALS.value,
+            "operator": FilterOperator.NOT_EQUALS,
             "count": 0,
             "sql_should_contain": "COL4 IS NOT NULL",
         },
@@ -1122,12 +1122,12 @@ def test__temporal_range_operator_in_adhoc_filter(physical_dataset):
                 {
                     "col": "col5",
                     "val": "2000-01-05 : 2000-01-06",
-                    "op": FilterOperator.TEMPORAL_RANGE.value,
+                    "op": FilterOperator.TEMPORAL_RANGE,
                 },
                 {
                     "col": "col6",
                     "val": "2002-05-11 : 2002-05-12",
-                    "op": FilterOperator.TEMPORAL_RANGE.value,
+                    "op": FilterOperator.TEMPORAL_RANGE,
                 },
             ],
             "is_timeseries": False,

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -423,3 +423,113 @@ def test_impersonate_user_no_database(mocker: MockerFixture) -> None:
         "alice",
         "SECRET",
     )
+
+
+def test_handle_boolean_filter_default_behavior() -> None:
+    """
+    Test that BaseEngineSpec uses IS operators for boolean filters by default.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    # Create a mock SQLAlchemy column
+    bool_col = Column("test_col", Boolean)
+
+    # Test IS_TRUE filter - should use IS operator by default
+    result_true = BaseEngineSpec.handle_boolean_filter(bool_col, "IS TRUE", True)
+    assert hasattr(result_true, "left")  # IS comparison has left/right attributes
+    assert hasattr(result_true, "right")
+
+    # Test IS_FALSE filter - should use IS operator by default
+    result_false = BaseEngineSpec.handle_boolean_filter(bool_col, "IS FALSE", False)
+    assert hasattr(result_false, "left")
+    assert hasattr(result_false, "right")
+
+
+def test_handle_boolean_filter_with_equality() -> None:
+    """
+    Test that BaseEngineSpec can use equality operators when configured.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    # Create a test engine spec that uses equality
+    class TestEngineSpec(BaseEngineSpec):
+        use_equality_for_boolean_filters = True
+
+    bool_col = Column("test_col", Boolean)
+
+    # Test with equality enabled
+    result_true = TestEngineSpec.handle_boolean_filter(bool_col, "IS TRUE", True)
+    # Equality comparison should have different structure than IS comparison
+    assert str(type(result_true)).endswith("BinaryExpression'>")
+
+    result_false = TestEngineSpec.handle_boolean_filter(bool_col, "IS FALSE", False)
+    assert str(type(result_false)).endswith("BinaryExpression'>")
+
+
+def test_handle_null_filter() -> None:
+    """
+    Test null/not null filter handling.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    bool_col = Column("test_col", Boolean)
+
+    # Test IS_NULL
+    result_null = BaseEngineSpec.handle_null_filter(bool_col, "IS NULL")
+    assert hasattr(result_null, "left")
+    assert hasattr(result_null, "right")
+
+    # Test IS_NOT_NULL
+    result_not_null = BaseEngineSpec.handle_null_filter(bool_col, "IS NOT NULL")
+    assert hasattr(result_not_null, "left")
+    assert hasattr(result_not_null, "right")
+
+    # Test invalid operator
+    with pytest.raises(ValueError, match="Invalid null filter operator"):
+        BaseEngineSpec.handle_null_filter(bool_col, "INVALID")
+
+
+def test_handle_comparison_filter() -> None:
+    """
+    Test comparison filter handling for all operators.
+    """
+    from sqlalchemy import Column, Integer
+
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    int_col = Column("test_col", Integer)
+
+    # Test all comparison operators
+    operators_and_values = [
+        ("EQUALS", 5),
+        ("NOT_EQUALS", 5),
+        ("GREATER_THAN", 5),
+        ("LESS_THAN", 5),
+        ("GREATER_THAN_OR_EQUALS", 5),
+        ("LESS_THAN_OR_EQUALS", 5),
+    ]
+
+    for op, value in operators_and_values:
+        result = BaseEngineSpec.handle_comparison_filter(int_col, op, value)
+        # All comparison operators should return binary expressions
+        assert str(type(result)).endswith("BinaryExpression'>")
+
+    # Test invalid operator
+    with pytest.raises(ValueError, match="Invalid comparison filter operator"):
+        BaseEngineSpec.handle_comparison_filter(int_col, "INVALID", 5)
+
+
+def test_use_equality_for_boolean_filters_property() -> None:
+    """
+    Test that BaseEngineSpec has the correct default value for boolean filter property.
+    """
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    # Default should be False (use IS operators)
+    assert BaseEngineSpec.use_equality_for_boolean_filters is False

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -480,13 +480,19 @@ def test_handle_null_filter() -> None:
 
     bool_col = Column("test_col", Boolean)
 
-    # Test IS_NULL
-    result_null = BaseEngineSpec.handle_null_filter(bool_col, "IS NULL")
+    # Test IS_NULL - use actual FilterOperator values
+    from superset.utils.core import FilterOperator
+
+    result_null = BaseEngineSpec.handle_null_filter(
+        bool_col, FilterOperator.IS_NULL.value
+    )
     assert hasattr(result_null, "left")
     assert hasattr(result_null, "right")
 
     # Test IS_NOT_NULL
-    result_not_null = BaseEngineSpec.handle_null_filter(bool_col, "IS NOT NULL")
+    result_not_null = BaseEngineSpec.handle_null_filter(
+        bool_col, FilterOperator.IS_NOT_NULL.value
+    )
     assert hasattr(result_not_null, "left")
     assert hasattr(result_not_null, "right")
 
@@ -505,14 +511,16 @@ def test_handle_comparison_filter() -> None:
 
     int_col = Column("test_col", Integer)
 
-    # Test all comparison operators
+    # Test all comparison operators - use actual FilterOperator values
+    from superset.utils.core import FilterOperator
+
     operators_and_values = [
-        ("EQUALS", 5),
-        ("NOT_EQUALS", 5),
-        ("GREATER_THAN", 5),
-        ("LESS_THAN", 5),
-        ("GREATER_THAN_OR_EQUALS", 5),
-        ("LESS_THAN_OR_EQUALS", 5),
+        (FilterOperator.EQUALS.value, 5),
+        (FilterOperator.NOT_EQUALS.value, 5),
+        (FilterOperator.GREATER_THAN.value, 5),
+        (FilterOperator.LESS_THAN.value, 5),
+        (FilterOperator.GREATER_THAN_OR_EQUALS.value, 5),
+        (FilterOperator.LESS_THAN_OR_EQUALS.value, 5),
     ]
 
     for op, value in operators_and_values:

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -483,22 +483,20 @@ def test_handle_null_filter() -> None:
     # Test IS_NULL - use actual FilterOperator values
     from superset.utils.core import FilterOperator
 
-    result_null = BaseEngineSpec.handle_null_filter(
-        bool_col, FilterOperator.IS_NULL.value
-    )
+    result_null = BaseEngineSpec.handle_null_filter(bool_col, FilterOperator.IS_NULL)
     assert hasattr(result_null, "left")
     assert hasattr(result_null, "right")
 
     # Test IS_NOT_NULL
     result_not_null = BaseEngineSpec.handle_null_filter(
-        bool_col, FilterOperator.IS_NOT_NULL.value
+        bool_col, FilterOperator.IS_NOT_NULL
     )
     assert hasattr(result_not_null, "left")
     assert hasattr(result_not_null, "right")
 
     # Test invalid operator
     with pytest.raises(ValueError, match="Invalid null filter operator"):
-        BaseEngineSpec.handle_null_filter(bool_col, "INVALID")
+        BaseEngineSpec.handle_null_filter(bool_col, "INVALID")  # type: ignore[arg-type]
 
 
 def test_handle_comparison_filter() -> None:
@@ -515,12 +513,12 @@ def test_handle_comparison_filter() -> None:
     from superset.utils.core import FilterOperator
 
     operators_and_values = [
-        (FilterOperator.EQUALS.value, 5),
-        (FilterOperator.NOT_EQUALS.value, 5),
-        (FilterOperator.GREATER_THAN.value, 5),
-        (FilterOperator.LESS_THAN.value, 5),
-        (FilterOperator.GREATER_THAN_OR_EQUALS.value, 5),
-        (FilterOperator.LESS_THAN_OR_EQUALS.value, 5),
+        (FilterOperator.EQUALS, 5),
+        (FilterOperator.NOT_EQUALS, 5),
+        (FilterOperator.GREATER_THAN, 5),
+        (FilterOperator.LESS_THAN, 5),
+        (FilterOperator.GREATER_THAN_OR_EQUALS, 5),
+        (FilterOperator.LESS_THAN_OR_EQUALS, 5),
     ]
 
     for op, value in operators_and_values:
@@ -530,7 +528,7 @@ def test_handle_comparison_filter() -> None:
 
     # Test invalid operator
     with pytest.raises(ValueError, match="Invalid comparison filter operator"):
-        BaseEngineSpec.handle_comparison_filter(int_col, "INVALID", 5)
+        BaseEngineSpec.handle_comparison_filter(int_col, "INVALID", 5)  # type: ignore[arg-type]
 
 
 def test_use_equality_for_boolean_filters_property() -> None:

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -352,6 +352,44 @@ def test_mask_encrypted_extra_no_fields() -> None:
     )
 
 
+def test_handle_boolean_filter() -> None:
+    """
+    Test that Snowflake uses equality operators for boolean filters instead of IS.
+    """
+    from sqlalchemy import Boolean, Column
+
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+
+    # Create a mock SQLAlchemy column
+    bool_col = Column("test_col", Boolean)
+
+    # Test IS_TRUE filter
+    result_true = SnowflakeEngineSpec.handle_boolean_filter(bool_col, "IS TRUE", True)
+    # The result should be a equality comparison, not an IS comparison
+    assert (
+        str(result_true.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = true"
+    )
+
+    # Test IS_FALSE filter
+    result_false = SnowflakeEngineSpec.handle_boolean_filter(
+        bool_col, "IS FALSE", False
+    )
+    assert (
+        str(result_false.compile(compile_kwargs={"literal_binds": True}))
+        == "test_col = false"
+    )
+
+
+def test_use_equality_for_boolean_filters_property() -> None:
+    """
+    Test that Snowflake has the use_equality_for_boolean_filters property set to True.
+    """
+    from superset.db_engine_specs.snowflake import SnowflakeEngineSpec
+
+    assert SnowflakeEngineSpec.use_equality_for_boolean_filters is True
+
+
 def test_unmask_encrypted_extra() -> None:
     """
     Test that the private keys can be reused from the previous `encrypted_extra`.

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -367,7 +367,7 @@ def test_handle_boolean_filter() -> None:
     from superset.utils.core import FilterOperator
 
     result_true = SnowflakeEngineSpec.handle_boolean_filter(
-        bool_col, FilterOperator.IS_TRUE.value, True
+        bool_col, FilterOperator.IS_TRUE, True
     )
     # The result should be a equality comparison, not an IS comparison
     assert (
@@ -377,7 +377,7 @@ def test_handle_boolean_filter() -> None:
 
     # Test IS_FALSE filter
     result_false = SnowflakeEngineSpec.handle_boolean_filter(
-        bool_col, FilterOperator.IS_FALSE.value, False
+        bool_col, FilterOperator.IS_FALSE, False
     )
     assert (
         str(result_false.compile(compile_kwargs={"literal_binds": True}))

--- a/tests/unit_tests/db_engine_specs/test_snowflake.py
+++ b/tests/unit_tests/db_engine_specs/test_snowflake.py
@@ -363,8 +363,12 @@ def test_handle_boolean_filter() -> None:
     # Create a mock SQLAlchemy column
     bool_col = Column("test_col", Boolean)
 
-    # Test IS_TRUE filter
-    result_true = SnowflakeEngineSpec.handle_boolean_filter(bool_col, "IS TRUE", True)
+    # Test IS_TRUE filter - use actual FilterOperator values
+    from superset.utils.core import FilterOperator
+
+    result_true = SnowflakeEngineSpec.handle_boolean_filter(
+        bool_col, FilterOperator.IS_TRUE.value, True
+    )
     # The result should be a equality comparison, not an IS comparison
     assert (
         str(result_true.compile(compile_kwargs={"literal_binds": True}))
@@ -373,7 +377,7 @@ def test_handle_boolean_filter() -> None:
 
     # Test IS_FALSE filter
     result_false = SnowflakeEngineSpec.handle_boolean_filter(
-        bool_col, "IS FALSE", False
+        bool_col, FilterOperator.IS_FALSE.value, False
     )
     assert (
         str(result_false.compile(compile_kwargs={"literal_binds": True}))


### PR DESCRIPTION
 ## Summary

  Fixes boolean column filtering for Snowflake databases by generating `= true/false` instead of `IS true/false` SQL syntax.

  - Add `use_equality_for_boolean_filters` property to `BaseEngineSpec` (default: `False`)
  - Add `handle_boolean_filter` method for engine-specific boolean filter handling
  - Override property in `SnowflakeEngineSpec` to use equality operators
  - Refactor filter handling in `helpers.py` to use new engine-specific methods

  ## Problem

  Snowflake doesn't support `IS true/false` syntax for boolean filters, causing queries like:
  ```sql
  SELECT * FROM table WHERE column IS true  -- ❌ Invalid in Snowflake

  Solution

  Generate Snowflake-compatible SQL while maintaining backward compatibility:
  SELECT * FROM table WHERE column = true   -- ✅ Valid in Snowflake

  Other databases continue using IS true/false as before.

  Test Plan

  - Added unit tests for boolean filter handling
  - Verified Snowflake generates = true/false
  - Verified other engines still use IS true/false
  - All existing tests pass
  - Ruff linting passes

  Fixes #33235