### PR TITLE
feat: Add configurable query identifiers for Mixed Timeseries charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -359,6 +359,19 @@ const config: ControlPanelConfig = {
         [xAxisLabelRotation],
         [xAxisLabelInterval],
         ...richTooltipSection,
+        [
+        {
+          name: 'show_query_identifiers',
+          config: {
+            type: 'CheckboxControl',
+            label: t('Show query identifiers'),
+            description: t('Adds Query A and Query B identifiers to metrics to help differentiate series'),
+            default: false,
+            renderTrigger: true,
+            visibility: ({ controls }) => Boolean(controls?.rich_tooltip?.value),
+          },
+        },
+      ],
         // eslint-disable-next-line react/jsx-key
         [<ControlSubSectionHeader>{t('Y Axis')}</ControlSubSectionHeader>],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -360,18 +360,18 @@ const config: ControlPanelConfig = {
         [xAxisLabelInterval],
         ...richTooltipSection,
         [
-        {
-          name: 'show_query_identifiers',
-          config: {
-            type: 'CheckboxControl',
-            label: t('Show query identifiers'),
-            description: t('Adds Query A and Query B identifiers to metrics to help differentiate series'),
-            default: false,
-            renderTrigger: true,
-            visibility: ({ controls }) => Boolean(controls?.rich_tooltip?.value),
+          {
+            name: 'show_query_identifiers',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show query identifiers'),
+              description: t('Adds Query A and Query B identifiers to metrics to help differentiate series'),
+              default: false,
+              renderTrigger: true,
+              visibility: ({ controls }) => Boolean(controls?.rich_tooltip?.value),
+            },
           },
-        },
-      ],
+        ],
         // eslint-disable-next-line react/jsx-key
         [<ControlSubSectionHeader>{t('Y Axis')}</ControlSubSectionHeader>],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -365,10 +365,13 @@ const config: ControlPanelConfig = {
             config: {
               type: 'CheckboxControl',
               label: t('Show query identifiers'),
-              description: t('Adds Query A and Query B identifiers to metrics to help differentiate series'),
+              description: t(
+                'Adds Query A and Query B identifiers to help differentiate series',
+              ),
               default: false,
               renderTrigger: true,
-              visibility: ({ controls }) => Boolean(controls?.rich_tooltip?.value),
+              visibility: ({ controls }) =>
+                Boolean(controls?.rich_tooltip?.value),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -396,18 +396,19 @@ export default function transformProps(
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
 
-    let displayName = entryName;
-
-    if (show_query_identifiers) {
-      displayName = `${entryName} (Query A)`;
-    }
+    let displayName: string;
 
     if (groupby.length > 0) {
-      if (show_query_identifiers) {
-        displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
-      } else {
-        displayName = `${MetricDisplayNameA}, ${entryName}`;
-      }
+      // When we have groupby, format as "metric, dimension"
+      const metricPart = show_query_identifiers
+        ? `${MetricDisplayNameA} (Query A)`
+        : MetricDisplayNameA;
+      displayName = `${metricPart}, ${entryName}`;
+    } else {
+      // When no groupby, format as just the entry name with optional query identifier
+      displayName = show_query_identifiers
+        ? `${entryName} (Query A)`
+        : entryName;
     }
 
     const seriesFormatter = getFormatter(
@@ -462,18 +463,19 @@ export default function transformProps(
     const seriesName = `${seriesEntry} (1)`;
     const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
-    let displayName = entryName;
-
-    if (show_query_identifiers) {
-      displayName = `${entryName} (Query B)`;
-    }
+    let displayName: string;
 
     if (groupbyB.length > 0) {
-      if (show_query_identifiers) {
-        displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
-      } else {
-        displayName = `${MetricDisplayNameB}, ${entryName}`;
-      }
+      // When we have groupby, format as "metric, dimension"
+      const metricPart = show_query_identifiers
+        ? `${MetricDisplayNameB} (Query B)`
+        : MetricDisplayNameB;
+      displayName = `${metricPart}, ${entryName}`;
+    } else {
+      // When no groupby, format as just the entry name with optional query identifier
+      displayName = show_query_identifiers
+        ? `${entryName} (Query B)`
+        : entryName;
     }
 
     const seriesFormatter = getFormatter(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -212,6 +212,7 @@ export default function transformProps(
     sortSeriesAscendingB,
     timeGrainSqla,
     percentageThreshold,
+    show_query_identifiers = false,
     metrics = [],
     metricsB = [],
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
@@ -391,15 +392,24 @@ export default function transformProps(
   const inverted = invert(verboseMap);
 
   rawSeriesA.forEach(entry => {
-    const entryName = String(entry.name || '');
-    const seriesName = inverted[entryName] || entryName;
-    const colorScaleKey = getOriginalSeries(seriesName, array);
+  const entryName = String(entry.name || '');
+  const seriesName = inverted[entryName] || entryName;
+  const colorScaleKey = getOriginalSeries(seriesName, array);
 
-    let displayName = `${entryName} (Query A)`;
+  // NEW CONDITIONAL LOGIC FOR QUERY A:
+  let displayName = entryName;
 
-    if (groupby.length > 0) {
+  if (show_query_identifiers) {
+    displayName = `${entryName} (Query A)`;
+  }
+
+  if (groupby.length > 0) {
+    if (show_query_identifiers) {
       displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
+    } else {
+      displayName = `${MetricDisplayNameA}, ${entryName}`;
     }
+  }
 
     const seriesFormatter = getFormatter(
       customFormatters,
@@ -448,16 +458,25 @@ export default function transformProps(
   });
 
   rawSeriesB.forEach(entry => {
-    const entryName = String(entry.name || '');
-    const seriesEntry = inverted[entryName] || entryName;
-    const seriesName = `${seriesEntry} (1)`;
-    const colorScaleKey = getOriginalSeries(seriesEntry, array);
+  const entryName = String(entry.name || '');
+  const seriesEntry = inverted[entryName] || entryName;
+  const seriesName = `${seriesEntry} (1)`;
+  const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
-    let displayName = `${entryName} (Query B)`;
+  // NEW CONDITIONAL LOGIC FOR QUERY B:
+  let displayName = entryName;
 
-    if (groupbyB.length > 0) {
+  if (show_query_identifiers) {
+    displayName = `${entryName} (Query B)`;
+  }
+
+  if (groupbyB.length > 0) {
+    if (show_query_identifiers) {
       displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
+    } else {
+      displayName = `${MetricDisplayNameB}, ${entryName}`;
     }
+  }
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -392,24 +392,23 @@ export default function transformProps(
   const inverted = invert(verboseMap);
 
   rawSeriesA.forEach(entry => {
-  const entryName = String(entry.name || '');
-  const seriesName = inverted[entryName] || entryName;
-  const colorScaleKey = getOriginalSeries(seriesName, array);
+    const entryName = String(entry.name || '');
+    const seriesName = inverted[entryName] || entryName;
+    const colorScaleKey = getOriginalSeries(seriesName, array);
 
-  // NEW CONDITIONAL LOGIC FOR QUERY A:
-  let displayName = entryName;
+    let displayName = entryName;
 
-  if (show_query_identifiers) {
-    displayName = `${entryName} (Query A)`;
-  }
-
-  if (groupby.length > 0) {
     if (show_query_identifiers) {
-      displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
-    } else {
-      displayName = `${MetricDisplayNameA}, ${entryName}`;
+      displayName = `${entryName} (Query A)`;
     }
-  }
+
+    if (groupby.length > 0) {
+      if (show_query_identifiers) {
+        displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
+      } else {
+        displayName = `${MetricDisplayNameA}, ${entryName}`;
+      }
+    }
 
     const seriesFormatter = getFormatter(
       customFormatters,
@@ -458,25 +457,24 @@ export default function transformProps(
   });
 
   rawSeriesB.forEach(entry => {
-  const entryName = String(entry.name || '');
-  const seriesEntry = inverted[entryName] || entryName;
-  const seriesName = `${seriesEntry} (1)`;
-  const colorScaleKey = getOriginalSeries(seriesEntry, array);
+    const entryName = String(entry.name || '');
+    const seriesEntry = inverted[entryName] || entryName;
+    const seriesName = `${seriesEntry} (1)`;
+    const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
-  // NEW CONDITIONAL LOGIC FOR QUERY B:
-  let displayName = entryName;
+    let displayName = entryName;
 
-  if (show_query_identifiers) {
-    displayName = `${entryName} (Query B)`;
-  }
-
-  if (groupbyB.length > 0) {
     if (show_query_identifiers) {
-      displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
-    } else {
-      displayName = `${MetricDisplayNameB}, ${entryName}`;
+      displayName = `${entryName} (Query B)`;
     }
-  }
+
+    if (groupbyB.length > 0) {
+      if (show_query_identifiers) {
+        displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
+      } else {
+        displayName = `${MetricDisplayNameB}, ${entryName}`;
+      }
+    }
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -60,6 +60,7 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   tooltipTimeFormat?: string;
   zoomable: boolean;
   richTooltip: boolean;
+  show_query_identifiers?: boolean;
   xAxisLabelRotation: number;
   xAxisLabelInterval?: number | string;
   colorScheme?: string;
@@ -133,6 +134,7 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   groupbyB: [],
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
+  show_query_identifiers: false,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
   xAxisLabelInterval: TIMESERIES_DEFAULTS.xAxisLabelInterval,
   ...DEFAULT_TITLE_FORM_DATA,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -111,6 +111,7 @@ const queriesData = [
 
 describe('MixedTimeseries transformProps', () => {
   it('should transform chart props for viz with query identifiers disabled', () => {
+    const formData = { ...baseFormData, show_query_identifiers: false };
     const chartPropsConfig = {
       formData,
       width: 800,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -28,7 +28,7 @@ import {
   EchartsMixedTimeseriesProps,
 } from '../../src/MixedTimeseries/types';
 
-const formData: EchartsMixedTimeseriesFormData = {
+const baseFormData: EchartsMixedTimeseriesFormData = {
   annotationLayers: [],
   area: false,
   areaB: false,
@@ -81,6 +81,7 @@ const formData: EchartsMixedTimeseriesFormData = {
   forecastPeriods: [],
   forecastInterval: 0,
   forecastSeasonalityDaily: 0,
+  show_query_identifiers: false,
 };
 
 const queriesData = [
@@ -108,57 +109,117 @@ const queriesData = [
   },
 ];
 
-const chartPropsConfig = {
-  formData,
-  width: 800,
-  height: 600,
-  queriesData,
-  theme: supersetTheme,
-};
+describe('MixedTimeseries transformProps', () => {
+  it('should transform chart props for viz with query identifiers disabled', () => {
+    const chartPropsConfig = {
+      formData,
+      width: 800,
+      height: 600,
+      queriesData,
+      theme: supersetTheme,
+    };
+    const chartProps = new ChartProps({ ...chartPropsConfig, formData });
+    const transformed = transformProps(
+      chartProps as EchartsMixedTimeseriesProps,
+    );
 
-it('should transform chart props for viz', () => {
-  const chartProps = new ChartProps(chartPropsConfig);
-  const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
-
-  expect(transformed).toEqual(
-    expect.objectContaining({
-      echartOptions: expect.objectContaining({
-        series: expect.arrayContaining([
-          expect.objectContaining({
-            data: [
-              [599616000000, 1],
-              [599916000000, 3],
-            ],
-            id: 'sum__num (Query A), boy',
-            stack: 'obs\na',
-          }),
-          expect.objectContaining({
-            data: [
-              [599616000000, 2],
-              [599916000000, 4],
-            ],
-            id: 'sum__num (Query A), girl',
-            stack: 'obs\na',
-          }),
-          // Query B — Bar series
-          expect.objectContaining({
-            data: [
-              [599616000000, 1],
-              [599916000000, 3],
-            ],
-            id: 'sum__num (Query B), boy',
-            stack: 'obs\nb',
-          }),
-          expect.objectContaining({
-            data: [
-              [599616000000, 2],
-              [599916000000, 4],
-            ],
-            id: 'sum__num (Query B), girl',
-            stack: 'obs\nb',
-          }),
-        ]),
+    expect(transformed).toEqual(
+      expect.objectContaining({
+        echartOptions: expect.objectContaining({
+          series: expect.arrayContaining([
+            expect.objectContaining({
+              data: [
+                [599616000000, 1],
+                [599916000000, 3],
+              ],
+              id: 'sum__num, boy',
+              stack: 'obs\na',
+            }),
+            expect.objectContaining({
+              data: [
+                [599616000000, 2],
+                [599916000000, 4],
+              ],
+              id: 'sum__num, girl',
+              stack: 'obs\na',
+            }),
+            // Query B — Bar series
+            expect.objectContaining({
+              data: [
+                [599616000000, 1],
+                [599916000000, 3],
+              ],
+              id: 'sum__num, boy',
+              stack: 'obs\nb',
+            }),
+            expect.objectContaining({
+              data: [
+                [599616000000, 2],
+                [599916000000, 4],
+              ],
+              id: 'sum__num, girl',
+              stack: 'obs\nb',
+            }),
+          ]),
+        }),
       }),
-    }),
-  );
+    );
+  });
+
+  it('should transform chart props for viz with query identifiers enabled', () => {
+    const formData = { ...baseFormData, show_query_identifiers: true };
+    const chartPropsConfig = {
+      formData,
+      width: 800,
+      height: 600,
+      queriesData,
+      theme: supersetTheme,
+    };
+    const chartProps = new ChartProps({ ...chartPropsConfig, formData });
+    const transformed = transformProps(
+      chartProps as EchartsMixedTimeseriesProps,
+    );
+
+    expect(transformed).toEqual(
+      expect.objectContaining({
+        echartOptions: expect.objectContaining({
+          series: expect.arrayContaining([
+            expect.objectContaining({
+              data: [
+                [599616000000, 1],
+                [599916000000, 3],
+              ],
+              id: 'sum__num (Query A), boy',
+              stack: 'obs\na',
+            }),
+            expect.objectContaining({
+              data: [
+                [599616000000, 2],
+                [599916000000, 4],
+              ],
+              id: 'sum__num (Query A), girl',
+              stack: 'obs\na',
+            }),
+            // Query B — Bar series
+            expect.objectContaining({
+              data: [
+                [599616000000, 1],
+                [599916000000, 3],
+              ],
+              id: 'sum__num (Query B), boy',
+              stack: 'obs\nb',
+            }),
+            expect.objectContaining({
+              data: [
+                [599616000000, 2],
+                [599916000000, 4],
+              ],
+              id: 'sum__num (Query B), girl',
+              stack: 'obs\nb',
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new configuration option "Show query identifiers" to Mixed Timeseries charts, allowing users to control whether "(Query A)" and "(Query B)" identifiers appear in tooltips and legends.
Following the implementation of query identifiers in #33519, some customers provided feedback that they prefer not to see these identifiers in their charts. This PR makes the feature configurable.

## Changes
- Added "Show query identifiers" checkbox control in the Customize tab
- Control appears between "Rich tooltip" and "Tooltip sort by metric" options
- Default behavior: identifiers are hidden (maintaining cleaner appearance)
- When enabled: shows the existing "(Query A)" and "(Query B)" behavior
- Control only visible when rich tooltip is enabled

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Verify default behavior hides query identifiers
- Verify enabling the option shows identifiers as expected
- Test with both grouped and ungrouped metrics
- Confirm control positioning and visibility conditions

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
