### PR TITLE
fix(theming): World map tooltip color

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/ReactWorldMap.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/ReactWorldMap.jsx
@@ -42,4 +42,8 @@ export default styled(WorldMapComponent)`
       background-color: ${({ theme }) => theme.colors.grayscale.light5};
     }
   }
+  .hoverinfo {
+    background-color: ${({ theme }) => theme.colorBgElevated};
+    color: ${({ theme }) => theme.colorTextSecondary};
+  }
 `;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the tooltip colors on the world map chart.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
See the attached issue screenshot
After:
<img width="958" height="409" alt="image" src="https://github.com/user-attachments/assets/8c096803-a9ff-4636-a642-d5348361c55d" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to World Bank's Data dashboard and hover over a country in the world map.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #34170
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
