### PR TITLE
fix(chart-download): ensure full table or handlebar chart is captured in image export

### DIFF
--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -23,6 +23,8 @@ import { kebabCase } from 'lodash';
 import { SupersetTheme, t } from '@superset-ui/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
 
+const IMAGE_DOWNLOAD_QUALITY = 0.95;
+
 /**
  * generate a consistent file stem from a description and date
  *
@@ -266,7 +268,7 @@ export default function downloadAsImageOptimized(
       const dataUrl = await domToImage.toJpeg(clone, {
         bgcolor: theme?.colors.grayscale.light4,
         filter,
-        quality: 0.95,
+        quality: IMAGE_DOWNLOAD_QUALITY,
         height: clone.scrollHeight,
         width: clone.scrollWidth,
         cacheBust: true,

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -70,9 +70,41 @@ export default function downloadAsImage(
       return true;
     };
 
+    // Check if element is scrollable
+    const isScrollable = hasScrollableDescendant(elementToPrint as HTMLElement);
+    let targetElement = elementToPrint as HTMLElement;
+    let cloned: HTMLElement | null = null;
+    const extraPadding = theme?.sizeUnit ? theme.sizeUnit * 2 : 16;
+    if (isScrollable) {
+      cloned = elementToPrint.cloneNode(true) as HTMLElement;
+      cloned.style.overflow = 'visible';
+      cloned.style.maxHeight = 'none';
+      cloned.style.height = 'auto';
+      cloned.style.width = `${elementToPrint.scrollWidth}px`;
+
+      cloned.querySelectorAll<HTMLElement>('*').forEach(el => {
+        // eslint-disable-next-line no-param-reassign
+        el.style.overflow = 'visible';
+        // eslint-disable-next-line no-param-reassign
+        el.style.maxHeight = 'none';
+        // eslint-disable-next-line no-param-reassign
+        el.style.height = 'auto';
+      });
+
+      // Render off-screen
+      cloned.style.position = 'absolute';
+      cloned.style.top = '-9999px';
+      cloned.style.left = '-9999px';
+      document.body.appendChild(cloned);
+
+      targetElement = cloned;
+    }
+
     return domToImage
-      .toJpeg(elementToPrint, {
+      .toJpeg(targetElement, {
         bgcolor: theme?.colors.grayscale.light4,
+        height: targetElement.scrollHeight + extraPadding,
+        width: targetElement.scrollWidth,
         filter,
       })
       .then((dataUrl: string) => {
@@ -83,6 +115,38 @@ export default function downloadAsImage(
       })
       .catch((e: Error) => {
         console.error('Creating image failed', e);
+      })
+      .finally(() => {
+        if (cloned) {
+          document.body.removeChild(cloned);
+        }
       });
   };
+}
+
+/**
+ * Check if an element or any of its child elements is scrollable
+ *
+ * @param el - The HTMLElement to check for scrollable descendants.
+ * @returns `true` if any descendant has scrollable overflow; otherwise `false`.
+ */
+function hasScrollableDescendant(el: HTMLElement): boolean {
+  const treeWalker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT);
+  let node = treeWalker.nextNode();
+
+  while (node) {
+    const element = node as HTMLElement;
+
+    // Skip if element is .header-controls or inside .header-controls
+    if (element.closest('.header-controls')) {
+      node = treeWalker.nextNode();
+      continue;
+    }
+
+    if (element.scrollHeight > element.clientHeight) {
+      return true;
+    }
+    node = treeWalker.nextNode();
+  }
+  return false;
 }

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -33,6 +33,88 @@ const generateFileStem = (description: string, date = new Date()) =>
   `${kebabCase(description)}-${date.toISOString().replace(/[: ]/g, '-')}`;
 
 /**
+ * Enhanced clone function that preserves all visual elements including cell bars
+ */
+const createEnhancedClone = (originalElement: Element): HTMLElement => {
+  const clone = originalElement.cloneNode(true) as HTMLElement;
+
+  // Create container for the clone
+  const tempContainer = document.createElement('div');
+  tempContainer.style.position = 'absolute';
+  tempContainer.style.left = '-20000px';
+  tempContainer.style.top = '-20000px';
+  tempContainer.style.visibility = 'hidden';
+  tempContainer.style.pointerEvents = 'none';
+  tempContainer.style.zIndex = '-1000';
+
+  // Copy computed styles recursively
+  const copyComputedStyles = (source: Element, target: Element) => {
+    const sourceComputed = window.getComputedStyle(source);
+    const targetElement = target as HTMLElement;
+
+    // Copy essential styles
+    for (let i = 0; i < sourceComputed.length; i += 1) {
+      const property = sourceComputed[i];
+      const value = sourceComputed.getPropertyValue(property);
+      targetElement.style.setProperty(property, value);
+    }
+  };
+
+  tempContainer.appendChild(clone);
+  document.body.appendChild(tempContainer);
+
+  // Copy styles from original to clone recursively
+  const copyStylesRecursively = (originalNode: Element, cloneNode: Element) => {
+    copyComputedStyles(originalNode, cloneNode);
+
+    const originalChildren = originalNode.children;
+    const cloneChildren = cloneNode.children;
+
+    for (
+      let i = 0;
+      i < originalChildren.length && i < cloneChildren.length;
+      i += 1
+    ) {
+      copyStylesRecursively(originalChildren[i], cloneChildren[i]);
+    }
+  };
+
+  copyStylesRecursively(originalElement, clone);
+
+  clone.style.height = 'auto';
+
+  // Handle scrollable containers
+  const scrollableElements = clone.querySelectorAll(
+    '[style*="overflow"], .scrollable, .table-responsive, .ant-table-body, .table-container, .ant-table-container, .table-wrapper, .ant-table-tbody, tbody, .table-body',
+  );
+
+  scrollableElements.forEach(el => {
+    const element = el as HTMLElement;
+    element.style.overflow = 'visible';
+    element.style.height = 'auto';
+    element.style.maxHeight = 'none';
+  });
+
+  // Center tables and ensure proper display
+  const tables = clone.querySelectorAll('table, .ant-table, .table-container');
+  tables.forEach(table => {
+    const tableElement = table as HTMLElement;
+    tableElement.style.margin = '0 auto';
+    tableElement.style.display = 'table';
+  });
+
+  // Ensure all rows are visible
+  const allRows = clone.querySelectorAll('tr, .ant-table-row, .table-row');
+  allRows.forEach(row => {
+    const rowElement = row as HTMLElement;
+    rowElement.style.display = 'table-row';
+    rowElement.style.visibility = 'visible';
+  });
+
+  return clone;
+};
+
+/**
  * Create an event handler for turning an element into an image
  *
  * @param selector css selector of the parent element which should be turned into image
@@ -58,6 +140,9 @@ export default function downloadAsImage(
       );
     }
 
+    // Create enhanced clone with full content and preserved cell bars
+    const clonedElement = createEnhancedClone(elementToPrint);
+
     // Mapbox controls are loaded from different origin, causing CORS error
     // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL#exceptions
     const filter = (node: Element) => {
@@ -70,83 +155,36 @@ export default function downloadAsImage(
       return true;
     };
 
-    // Check if element is scrollable
-    const isScrollable = hasScrollableDescendant(elementToPrint as HTMLElement);
-    let targetElement = elementToPrint as HTMLElement;
-    let cloned: HTMLElement | null = null;
-    const extraPadding = theme?.sizeUnit ? theme.sizeUnit * 2 : 16;
-    if (isScrollable) {
-      cloned = elementToPrint.cloneNode(true) as HTMLElement;
-      cloned.style.overflow = 'visible';
-      cloned.style.maxHeight = 'none';
-      cloned.style.height = 'auto';
-      cloned.style.width = `${elementToPrint.scrollWidth}px`;
-
-      cloned.querySelectorAll<HTMLElement>('*').forEach(el => {
-        // eslint-disable-next-line no-param-reassign
-        el.style.overflow = 'visible';
-        // eslint-disable-next-line no-param-reassign
-        el.style.maxHeight = 'none';
-        // eslint-disable-next-line no-param-reassign
-        el.style.height = 'auto';
-      });
-
-      // Render off-screen
-      cloned.style.position = 'absolute';
-      cloned.style.top = '-9999px';
-      cloned.style.left = '-9999px';
-      document.body.appendChild(cloned);
-
-      targetElement = cloned;
-    }
-
     return domToImage
-      .toJpeg(targetElement, {
+      .toJpeg(clonedElement, {
         bgcolor: theme?.colors.grayscale.light4,
-        height: targetElement.scrollHeight + extraPadding,
-        width: targetElement.scrollWidth,
         filter,
+        quality: 0.95,
+        height: clonedElement.scrollHeight,
+        width: clonedElement.scrollWidth,
       })
       .then((dataUrl: string) => {
+        // Clean up the cloned element
+        const tempContainer = clonedElement.parentElement;
+        if (tempContainer && tempContainer.parentElement) {
+          tempContainer.parentElement.removeChild(tempContainer);
+        }
+
         const link = document.createElement('a');
         link.download = `${generateFileStem(description)}.jpg`;
         link.href = dataUrl;
         link.click();
       })
       .catch((e: Error) => {
-        console.error('Creating image failed', e);
-      })
-      .finally(() => {
-        if (cloned) {
-          document.body.removeChild(cloned);
+        // Clean up the cloned element in case of error
+        const tempContainer = clonedElement.parentElement;
+        if (tempContainer && tempContainer.parentElement) {
+          tempContainer.parentElement.removeChild(tempContainer);
         }
+        console.error('Creating image failed', e);
+        addWarningToast(
+          t('Image download failed, please refresh and try again.'),
+        );
       });
   };
-}
-
-/**
- * Check if an element or any of its child elements is scrollable
- *
- * @param el - The HTMLElement to check for scrollable descendants.
- * @returns `true` if any descendant has scrollable overflow; otherwise `false`.
- */
-function hasScrollableDescendant(el: HTMLElement): boolean {
-  const treeWalker = document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT);
-  let node = treeWalker.nextNode();
-
-  while (node) {
-    const element = node as HTMLElement;
-
-    // Skip if element is .header-controls or inside .header-controls
-    if (element.closest('.header-controls')) {
-      node = treeWalker.nextNode();
-      continue;
-    }
-
-    if (element.scrollHeight > element.clientHeight) {
-      return true;
-    }
-    node = treeWalker.nextNode();
-  }
-  return false;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Fixes: #33904 
### SUMMARY
This PR resolves an issue where using the "Download as Image" option on a table chart or handlebar chart within a dashboard only captures the visible portion of the chart (i.e., the section within the scroll view), instead of the entire chart content. This results in incomplete image exports when the chart content exceeds the visible area.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1241" height="979" alt="Screenshot 2025-07-19 at 1 50 57 PM" src="https://github.com/user-attachments/assets/466f59f0-5b85-41a2-8f12-a107b572c9d4" />


#### BEFORE
The downloaded image only includes the part of the table that is visible within the dashboard scroll area.
![top-15-languages-spoken-at-home-2025-07-19T08-59-11 312Z](https://github.com/user-attachments/assets/437677bf-6910-4884-8ba6-b0c2ed568454)


#### AFTER
The downloaded image now includes the full chart content, including data outside the visible scroll area.
![chatTableWithRoeBar](https://github.com/user-attachments/assets/1f9d67bb-2c30-4b1b-ad80-e635fb58628a)




### CHANGES

- Introduced logic to **detect scrollable elements or descendants** within the chart.
- If scrollable, the element is **cloned**, and styles are adjusted to:
  - Remove height constraints.
  - Make all content visible (including overflow).
  - Preserve the full scrollable area.
- The cloned element is rendered **off-screen** to allow full-content rendering without affecting layout.
- Used the adjusted element to generate the image via **`dom-to-image`**, capturing the **entire scrollable content**.



