### PR TITLE
fix(deckgl): fix deck.gl color breakpoints Control

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Hex/controlPanel.ts
@@ -35,6 +35,7 @@ import {
   spatial,
   viewport,
 } from '../../utilities/Shared_DeckGL';
+import { COLOR_SCHEME_TYPES } from '../../utilities/utils';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -53,7 +54,10 @@ const config: ControlPanelConfig = {
       label: t('Map'),
       controlSetRows: [
         [mapboxStyle],
-        ...generateDeckGLColorSchemeControls({}),
+        ...generateDeckGLColorSchemeControls({
+          defaultSchemeType: COLOR_SCHEME_TYPES.categorical_palette,
+          disableCategoricalColumn: true,
+        }),
         [viewport],
         [autozoom],
         [gridSize],

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/utils.ts
@@ -37,4 +37,4 @@ export function formatSelectOptions(options: (string | number)[]) {
 export const isColorSchemeTypeVisible = (
   controls: ControlStateMapping,
   colorSchemeType: ColorSchemeType,
-) => controls.color_scheme_type.value === colorSchemeType;
+) => controls.color_scheme_type?.value === colorSchemeType;

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.tsx
@@ -76,7 +76,7 @@ const determineErrorMap = (
     return errorMap;
   }
 
-  if (newMinValue >= newMaxValue) {
+  if (newMinValue > newMaxValue) {
     errorMap.minValue.push(
       t('Min value should be smaller or equal to max value'),
     );


### PR DESCRIPTION
### SUMMARY
A couple of issues were identified after QA of the new color breakpoints Control. This is the PR that fixes them.
1. Couldn't set the breakpoint min and max to the same values
2. Hexagon Chart shouldn't have the categorical color Control
3. isColorSchemeTypeVisible throws error when color scheme type Control is missing

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
