### PR TITLE
fix(drill-to-detail): drill to detail by axis with label on axis column

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -190,7 +190,7 @@ export default function EchartsTimeseries({
               // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
               xAxis.label === DTTM_ALIAS
                 ? formData.granularitySqla
-                : xAxis.label,
+                : formData.xAxis,
             grain: formData.timeGrainSqla,
             op: '==',
             val: data[0],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When the axis column in a timeseries chart had a label set on the dataset level then the drill to detail by axis value wasnt working. The problem was that we were sending the label to the backend for filtering but the backend expected the column name.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/2a15da9c-702d-4e83-8b7c-941ebcf3fffd



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33907 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
