### PR TITLE
feat(docker): do not include chromium (headless browser) by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ RUN mkdir -p \
     && touch superset/static/version_info.json
 
 # Install Playwright and optionally setup headless browsers
-ARG INCLUDE_CHROMIUM="true"
+ARG INCLUDE_CHROMIUM="false"
 ARG INCLUDE_FIREFOX="false"
 RUN --mount=type=cache,target=${SUPERSET_HOME}/.cache/uv \
     if [ "$INCLUDE_CHROMIUM" = "true" ] || [ "$INCLUDE_FIREFOX" = "true" ]; then \

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,7 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
+- [34258](https://github.com/apache/superset/pull/34258) changing the default in Dockerfile to INCLUDE_CHROMIUM="false" (from "true") in the past. This ensures the `lean` layer is lean by default, and people can opt-in to the `chromium` layer by setting the build arg `INCLUDE_CHROMIUM=true`. This is a breaking change for anyone using the `lean` layer, as it will no longer include Chromium by default.
 - [34204](https://github.com/apache/superset/pull/33603) OpenStreetView has been promoted as the new default for Deck.gl visualization since it can be enabled by default without requiring an API key. If you have Mapbox set up and want to disable OpenStreeView in your environment, please follow the steps documented here [https://superset.apache.org/docs/configuration/map-tiles].
 - [33116](https://github.com/apache/superset/pull/33116) In Echarts Series charts (e.g. Line, Area, Bar, etc.) charts, the `x_axis_sort_series` and `x_axis_sort_series_ascending` form data items have been renamed with `x_axis_sort` and `x_axis_sort_asc`.
   There's a migration added that can potentially affect a significant number of existing charts.


### PR DESCRIPTION
closes: https://github.com/apache/superset/issues/34161

@agologan reported that previous `lean` docker builds prior to 5.0 did not include headless browser, and that as of 5.0 it does, bloating the image size.

This PR makes the default to keep the image leaner, but may have impacts on people's build, so I'm adding a note in UPDATING.md to clarify the change in default/behavior

Noting that `supersetbot` changes could be related to the regression -> https://github.com/apache-superset/supersetbot/blob/main/src/docker.js#L130 . Lots of things have changed over the past year around Superset CI and builds... In theory we could keep the defaults as they are in the Dockerfile and change the `supersetbot` command to behave differently, but seems INCLUDE_CHROMIUM=false is a better default overall.

Note: this may require re-building/re-releasing maintained release branches.