### PR TITLE
fix: Missing ownState and isCached props in Chart.jsx

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -129,6 +129,9 @@ const Chart = props => {
   );
 
   const chart = useSelector(state => state.charts[props.id] || EMPTY_OBJECT);
+  const { queriesResponse, chartUpdateEndTime, chartStatus, annotationQuery } =
+    chart;
+
   const slice = useSelector(
     state => state.sliceEntities.slices[props.id] || EMPTY_OBJECT,
   );
@@ -162,6 +165,12 @@ const Chart = props => {
       PLACEHOLDER_DATASOURCE,
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
+
+  const isCached = useMemo(
+    // eslint-disable-next-line camelcase
+    () => queriesResponse?.map(({ is_cached }) => is_cached) || [],
+    [queriesResponse],
+  );
 
   const [descriptionHeight, setDescriptionHeight] = useState(0);
   const [height, setHeight] = useState(props.height);
@@ -249,9 +258,9 @@ const Chart = props => {
   const logExploreChart = useCallback(() => {
     boundActionCreators.logEvent(LOG_ACTIONS_EXPLORE_DASHBOARD_CHART, {
       slice_id: slice.slice_id,
-      is_cached: props.isCached,
+      is_cached: isCached,
     });
-  }, [boundActionCreators.logEvent, slice.slice_id, props.isCached]);
+  }, [boundActionCreators.logEvent, slice.slice_id, isCached]);
 
   const chartConfiguration = useSelector(
     state => state.dashboardInfo.metadata?.chart_configuration,
@@ -365,22 +374,22 @@ const Chart = props => {
           : LOG_ACTIONS_EXPORT_XLSX_DASHBOARD_CHART;
       boundActionCreators.logEvent(logAction, {
         slice_id: slice.slice_id,
-        is_cached: props.isCached,
+        is_cached: isCached,
       });
       exportChart({
         formData: isFullCSV ? { ...formData, row_limit: maxRows } : formData,
         resultType: isPivot ? 'post_processed' : 'full',
         resultFormat: format,
         force: true,
-        ownState: props.ownState,
+        ownState: dataMask[props.id]?.ownState,
       });
     },
     [
       slice.slice_id,
-      props.isCached,
+      isCached,
       formData,
       props.maxRows,
-      props.ownState,
+      dataMask[props.id]?.ownState,
       boundActionCreators.logEvent,
     ],
   );
@@ -408,7 +417,7 @@ const Chart = props => {
   const forceRefresh = useCallback(() => {
     boundActionCreators.logEvent(LOG_ACTIONS_FORCE_REFRESH_CHART, {
       slice_id: slice.slice_id,
-      is_cached: props.isCached,
+      is_cached: isCached,
     });
     return boundActionCreators.refreshChart(chart.id, true, props.dashboardId);
   }, [
@@ -416,7 +425,7 @@ const Chart = props => {
     chart.id,
     props.dashboardId,
     slice.slice_id,
-    props.isCached,
+    isCached,
     boundActionCreators.logEvent,
   ]);
 
@@ -424,11 +433,7 @@ const Chart = props => {
     return <MissingChart height={getChartHeight()} />;
   }
 
-  const { queriesResponse, chartUpdateEndTime, chartStatus, annotationQuery } =
-    chart;
   const isLoading = chartStatus === 'loading';
-  // eslint-disable-next-line camelcase
-  const isCached = queriesResponse?.map(({ is_cached }) => is_cached) || [];
   const cachedDttm =
     // eslint-disable-next-line camelcase
     queriesResponse?.map(({ cached_dttm }) => cached_dttm) || [];


### PR DESCRIPTION
### SUMMARY
After changes from PR https://github.com/apache/superset/pull/31241, `props.ownState` and `props.isCached` were undefined. This PR fixes the issue by using `ownState` and `isCached` values calculated within the component.

Thanks @rad-pat for spotting the problem!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes https://github.com/apache/superset/issues/17861
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
