### PR TITLE
fix: Matching errorType on superset api error with SupersetError

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -256,14 +256,14 @@ export type ErrorSource = 'dashboard' | 'explore' | 'sqllab' | 'crud';
 export type SupersetError<ExtraType = Record<string, any> | null> =
   | {
       error_type: ErrorType;
-      errorType: undefined;
+      errorType?: undefined;
       extra: ExtraType;
       level: ErrorLevel;
       message: string;
     }
   | {
       errorType: ErrorType;
-      error_type: undefined;
+      error_type?: undefined;
       extra: ExtraType;
       level: ErrorLevel;
       message: string;

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -255,7 +255,6 @@ export type ErrorSource = 'dashboard' | 'explore' | 'sqllab' | 'crud';
 
 export type SupersetError<ExtraType = Record<string, any> | null> = {
   error_type: ErrorType;
-  errorType?: ErrorType;
   extra: ExtraType;
   level: ErrorLevel;
   message: string;

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -253,21 +253,13 @@ export type ErrorLevel = 'info' | 'warning' | 'error';
 
 export type ErrorSource = 'dashboard' | 'explore' | 'sqllab' | 'crud';
 
-export type SupersetError<ExtraType = Record<string, any> | null> =
-  | {
-      error_type: ErrorType;
-      errorType?: undefined;
-      extra: ExtraType;
-      level: ErrorLevel;
-      message: string;
-    }
-  | {
-      errorType: ErrorType;
-      error_type?: undefined;
-      extra: ExtraType;
-      level: ErrorLevel;
-      message: string;
-    };
+export type SupersetError<ExtraType = Record<string, any> | null> = {
+  error_type: ErrorType;
+  errorType?: ErrorType;
+  extra: ExtraType;
+  level: ErrorLevel;
+  message: string;
+};
 
 export const CtasEnum = {
   TABLE: 'TABLE',

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -253,12 +253,21 @@ export type ErrorLevel = 'info' | 'warning' | 'error';
 
 export type ErrorSource = 'dashboard' | 'explore' | 'sqllab' | 'crud';
 
-export type SupersetError<ExtraType = Record<string, any> | null> = {
-  error_type: ErrorType;
-  extra: ExtraType;
-  level: ErrorLevel;
-  message: string;
-};
+export type SupersetError<ExtraType = Record<string, any> | null> =
+  | {
+      error_type: ErrorType;
+      errorType: undefined;
+      extra: ExtraType;
+      level: ErrorLevel;
+      message: string;
+    }
+  | {
+      errorType: ErrorType;
+      error_type: undefined;
+      extra: ExtraType;
+      level: ErrorLevel;
+      message: string;
+    };
 
 export const CtasEnum = {
   TABLE: 'TABLE',

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -54,6 +54,7 @@ export function ErrorMessageWithStackTrace({
   // Check if a custom error message component was registered for this message
   if (error) {
     const ErrorMessageComponent = getErrorMessageComponentRegistry().get(
+      // @ts-ignore: plan to modify this part so that all errors in Superset 6.0 are standardized as Superset API error types
       error.errorType ?? error.error_type,
     );
     if (ErrorMessageComponent) {

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -54,7 +54,7 @@ export function ErrorMessageWithStackTrace({
   // Check if a custom error message component was registered for this message
   if (error) {
     const ErrorMessageComponent = getErrorMessageComponentRegistry().get(
-      error.error_type ?? error.errorType,
+      error.errorType ?? error.error_type,
     );
     if (ErrorMessageComponent) {
       return (

--- a/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorMessageWithStackTrace.tsx
@@ -54,7 +54,7 @@ export function ErrorMessageWithStackTrace({
   // Check if a custom error message component was registered for this message
   if (error) {
     const ErrorMessageComponent = getErrorMessageComponentRegistry().get(
-      error.error_type,
+      error.error_type ?? error.errorType,
     );
     if (ErrorMessageComponent) {
       return (

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -95,6 +95,7 @@ const Styles = styled.div`
   }
   .error-alert {
     margin: ${({ theme }) => 2 * theme.sizeUnit}px;
+    min-height: 150px;
   }
   .ant-dropdown-trigger {
     margin-left: ${({ theme }) => 2 * theme.sizeUnit}px;
@@ -454,16 +455,14 @@ class DatasourceControl extends PureComponent {
         {isMissingDatasource && !isMissingParams && (
           <div className="error-alert">
             {extra?.error ? (
-              <div className="error-alert">
-                <ErrorMessageWithStackTrace
-                  title={extra.error.statusText || extra.error.message}
-                  subtitle={
-                    extra.error.statusText ? extra.error.message : undefined
-                  }
-                  error={extra.error}
-                  source="explore"
-                />
-              </div>
+              <ErrorMessageWithStackTrace
+                title={extra.error.statusText || extra.error.message}
+                subtitle={
+                  extra.error.statusText ? extra.error.message : undefined
+                }
+                error={extra.error}
+                source="explore"
+              />
             ) : (
               <ErrorAlert
                 type="warning"


### PR DESCRIPTION
### SUMMARY

For Airbnb, we display custom errors according to the error_type. However, in the current Superset API, unlike the query result API, SupersetApiError is thrown, and [error_type is mapped to errorType](https://github.com/apache/superset/blob/b24aca0304b53cdf6f92bf600b64152015cafa30/superset-frontend/packages/superset-ui-core/src/query/api/v1/types.ts#L110), which causes custom overrides to not work properly. In this PR, I have resolved the issue by correcting the type of the errorType value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1151" height="1040" alt="Screenshot 2025-07-21 at 1 45 19 PM" src="https://github.com/user-attachments/assets/16384b08-e9a8-4033-a509-b905c33b08cb" />

After:
<img width="1152" height="925" alt="Screenshot 2025-07-21 at 1 45 02 PM" src="https://github.com/user-attachments/assets/a4a2b55e-509b-4ff2-8c45-59e7609a06ab" />


### TESTING INSTRUCTIONS
locally
