### PR TITLE
fix(cartodiagram): add missing locales for rendering echarts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
@@ -35,8 +35,10 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^5.2.6",
+    "@reduxjs/toolkit": "*",
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
+    "@types/react-redux": "*",
     "geostyler": "^14.1.3",
     "geostyler-data": "^1.0.0",
     "geostyler-openlayers-parser": "^4.0.0",

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/ChartLayer.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/ChartLayer.tsx
@@ -52,6 +52,8 @@ export class ChartLayer extends Layer {
 
   theme: SupersetTheme;
 
+  locale: string;
+
   /**
    * Create a ChartLayer.
    *
@@ -89,6 +91,10 @@ export class ChartLayer extends Layer {
 
     if (options.theme) {
       this.theme = options.theme;
+    }
+
+    if (options.locale) {
+      this.locale = options.locale;
     }
 
     const spinner = document.createElement('img');
@@ -183,6 +189,7 @@ export class ChartLayer extends Layer {
         chartWidth,
         chartHeight,
         this.theme,
+        this.locale,
       );
       ReactDOM.render(chartComponent, container);
 
@@ -218,6 +225,7 @@ export class ChartLayer extends Layer {
         chartWidth,
         chartHeight,
         this.theme,
+        this.locale,
       );
       ReactDOM.render(chartComponent, chart.htmlElement);
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/ChartWrapper.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/ChartWrapper.tsx
@@ -16,8 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { configureStore } from '@reduxjs/toolkit';
 import { getChartComponentRegistry, ThemeProvider } from '@superset-ui/core';
 import { FC, useEffect, useState } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
 import { ChartWrapperProps } from '../types';
 
 export const ChartWrapper: FC<ChartWrapperProps> = ({
@@ -26,6 +28,7 @@ export const ChartWrapper: FC<ChartWrapperProps> = ({
   height,
   width,
   chartConfig,
+  locale,
 }) => {
   const [Chart, setChart] = useState<any>();
 
@@ -39,13 +42,21 @@ export const ChartWrapper: FC<ChartWrapperProps> = ({
     getChartFromRegistry(vizType);
   }, [vizType]);
 
+  // Create a mock store that is needed by
+  // eCharts components to access the locale.
+  const mockStore = configureStore({
+    reducer: (state = { common: { locale } }) => state,
+  });
+
   return (
     <ThemeProvider theme={theme}>
-      {Chart === undefined ? (
-        <></>
-      ) : (
-        <Chart {...chartConfig.properties} height={height} width={width} />
-      )}
+      <ReduxProvider store={mockStore}>
+        {Chart === undefined ? (
+          <></>
+        ) : (
+          <Chart {...chartConfig.properties} height={height} width={width} />
+        )}
+      </ReduxProvider>
     </ThemeProvider>
   );
 };

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/components/OlChartMap.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import Point from 'ol/geom/Point';
 import { View } from 'ol';
@@ -54,6 +55,8 @@ export const OlChartMap = (props: OlChartMapProps) => {
     setControlValue,
     theme,
   } = props;
+
+  const locale = useSelector((state: any) => state?.common?.locale);
 
   const [currentChartConfigs, setCurrentChartConfigs] =
     useState<ChartConfig>(chartConfigs);
@@ -360,6 +363,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
         onMouseOver: deactivateInteractions,
         onMouseOut: activateInteractions,
         theme,
+        locale,
       });
 
       olMap.addLayer(newChartLayer);
@@ -393,6 +397,7 @@ export const OlChartMap = (props: OlChartMapProps) => {
     chartSize.values,
     chartBackgroundColor,
     chartBackgroundBorderRadius,
+    locale,
   ]);
 
   return (

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/types.ts
@@ -195,6 +195,7 @@ export type ChartLayerOptions = {
   map?: Map | null | undefined;
   render?: RenderFunction | undefined;
   properties?: { [x: string]: any } | undefined;
+  locale: string;
 };
 
 export type CartodiagramPluginConstructorOpts = {
@@ -207,4 +208,5 @@ export type ChartWrapperProps = {
   width: number;
   height: number;
   chartConfig: ChartConfigFeature;
+  locale: string;
 };

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/chartUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/chartUtil.tsx
@@ -36,6 +36,7 @@ export const createChartComponent = (
   chartWidth: number,
   chartHeight: number,
   chartTheme: SupersetTheme,
+  chartLocale: string,
 ) => (
   <ChartWrapper
     vizType={chartVizType}
@@ -43,6 +44,7 @@ export const createChartComponent = (
     width={chartWidth}
     height={chartHeight}
     theme={chartTheme}
+    locale={chartLocale}
   />
 );
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/components/chartLayer.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/components/chartLayer.test.ts
@@ -24,6 +24,7 @@ describe('ChartLayer', () => {
   it('creates div and loading mask', () => {
     const options: ChartLayerOptions = {
       chartVizType: 'pie',
+      locale: 'en',
     };
     const chartLayer = new ChartLayer(options);
 
@@ -34,6 +35,7 @@ describe('ChartLayer', () => {
   it('can remove chart elements', () => {
     const options: ChartLayerOptions = {
       chartVizType: 'pie',
+      locale: 'en',
     };
     const chartLayer = new ChartLayer(options);
     chartLayer.charts = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This fixes rendering echarts viztypes on the cartodiagram plugin.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
before:

<img width="656" height="846" alt="image" src="https://github.com/user-attachments/assets/dae3c56a-bd9e-4708-a5ce-db1d34663a23" />

after:

<img width="983" height="833" alt="image" src="https://github.com/user-attachments/assets/bca9a0b9-9da0-4cba-813e-9377a043a4f2" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/34247
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
