### PR TITLE
fix: build issues on master with 'npm run dev'

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -24,7 +24,7 @@ import {
   getSequentialSchemeRegistry,
   CategoricalColorNamespace,
 } from '@superset-ui/core';
-import Datamap from 'datamaps/dist/datamaps.world.min';
+import Datamap from 'datamaps/dist/datamaps.all.min';
 import { ColorBy } from './utils';
 
 const propTypes = {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -319,6 +319,13 @@ const config = {
           './node_modules/@storybook/react-dom-shim/dist/react-16',
         ),
       ),
+      // Workaround for react-color trying to import non-existent icon
+      '@icons/material/UnfoldMoreHorizontalIcon': path.resolve(
+        path.join(
+          APP_DIR,
+          './node_modules/@icons/material/CubeUnfoldedIcon.js',
+        ),
+      ),
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.yml'],
     fallback: {


### PR DESCRIPTION
  ## Summary
  - Fixed webpack alias for missing `@icons/material/UnfoldMoreHorizontalIcon` in react-color dependency
  - Changed datamaps import from `datamaps.world.min` to `datamaps.all.min` in WorldMap plugin to resolve build errors
 
## Root cause: The issues likely stemmed from the recent webpack-dev-server
  upgrade from v4.15.2 to v5.2.1 (commit 11215b092a) on July 8th, which also
   included:
  - webpack upgrade from 5.98.0 to 5.99.9
  - webpack-cli upgrade from 4.10.0 to 6.0.1

  Webpack v5 has stricter module resolution and the new version likely
  exposed these existing issues:

  1. react-color issue: The @icons/material/UnfoldMoreHorizontalIcon import
  was always broken, but webpack v4 may have been more lenient about missing
   modules
  2. datamaps issue: The datamaps.world.min vs datamaps.all.min - the
  .world.min version may not exist in the current datamaps package version,
  or webpack v5's stricter resolution revealed this

  The babel plugin cleanup (commit f4754641c8) on July 12th may have
  contributed as well, but the webpack upgrade is the more likely culprit
  for module resolution issues.

  ## Test plan
  - [x] `npm run dev` builds without module resolution errors
  - [x] react-color components render correctly with fallback icon
  - [x] WorldMap plugin loads without import errors