### PR TITLE
feat: optimize setup-backend to go faster on py 3.12

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -28,7 +28,6 @@ runs:
         if [ "${{ inputs.python-version }}" = "current" ]; then
           echo "PYTHON_VERSION=3.11" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "next" ]; then
-          # currently disabled in GHA matrixes because of library compatibility issues
           echo "PYTHON_VERSION=3.12" >> $GITHUB_ENV
         elif [ "${{ inputs.python-version }}" = "previous" ]; then
           echo "PYTHON_VERSION=3.10" >> $GITHUB_ENV
@@ -40,7 +39,17 @@ runs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: ${{ inputs.cache }}
+    - name: Cache uv packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-python${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements/development.txt', 'requirements/base.txt') }}
+        restore-keys: |
+          uv-${{ runner.os }}-python${{ env.PYTHON_VERSION }}-
     - name: Install dependencies
+      env:
+        UV_CACHE_DIR: ~/.cache/uv
+        UV_PREFER_BINARY: "1"
       run: |
         if [ "${{ inputs.install-superset }}" = "true" ]; then
           sudo apt-get update && sudo apt-get -y install libldap2-dev libsasl2-dev
@@ -48,11 +57,11 @@ runs:
           pip install --upgrade pip setuptools wheel uv
 
           if [ "${{ inputs.requirements-type }}" = "dev" ]; then
-            uv pip install --system -r requirements/development.txt
+            uv pip install --system --prefer-binary -r requirements/development.txt
           elif [ "${{ inputs.requirements-type }}" = "base" ]; then
-            uv pip install --system -r requirements/base.txt
+            uv pip install --system --prefer-binary -r requirements/base.txt
           fi
 
-          uv pip install --system -e .
+          uv pip install --system --prefer-binary -e .
         fi
       shell: bash

--- a/superset/config.py
+++ b/superset/config.py
@@ -598,8 +598,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This is intended to use for theme creation, visual review and theming-debugging
     # purposes.
     "THEME_ALLOW_THEME_EDITOR_BETA": False,
-    # Allow users to optionally specify date formats in email subjects, which will
-    # be parsed if enabled
+    # Allow users to optionally specify date formats in email subjects, which
+    # will be parsed if enabled
     "DATE_FORMAT_IN_EMAIL_SUBJECT": False,
     # Allow metrics and columns to be grouped into (potentially nested) folders in the
     # chart builder


### PR DESCRIPTION

  ## Summary

  Optimizes CI build times for Python 3.12 by addressing missing wheel availability that was causing 10+ minute longer build times compared to other Python versions.

  ## Changes

  - **Added uv package caching**: Implements caching for uv packages using `~/.cache/uv` to avoid repeated downloads
  - **Enabled `--prefer-binary` flag**: Forces uv to prefer pre-built binary wheels over source compilation for all pip install commands
  - **Removed outdated comment**: Cleaned up comment about Python 3.12 being disabled due to compatibility issues

  ## Performance Impact

  - **Before**: Python 3.12 builds took 10+ minutes longer than other versions due to compiling packages from source
  - **After**: Should match performance of other Python versions by using pre-built wheels when available

  ## Technical Details

  The root cause was Python 3.12's newer release meant fewer packages had pre-built wheels available, forcing compilation from source. The `--prefer-binary` flag tells uv to prioritize binary wheels, and the caching ensures we don't
  re-download packages across CI runs.