### PR TITLE
fix: Saved queries list break if one query can't be parsed

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -48,7 +48,7 @@ from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql.elements import ColumnElement, literal_column
 
 from superset import security_manager
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import SupersetParseError, SupersetSecurityException
 from superset.jinja_context import BaseTemplateProcessor, get_template_processor
 from superset.models.helpers import (
     AuditMixinNullable,
@@ -85,7 +85,7 @@ class SqlTablesMixin:  # pylint: disable=too-few-public-methods
                     self.database,  # type: ignore
                 )
             )
-        except (SupersetSecurityException, TemplateError):
+        except (SupersetSecurityException, SupersetParseError, TemplateError):
             return []
 
 

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -22,7 +22,7 @@ from jinja2.exceptions import TemplateError
 from pytest_mock import MockerFixture
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import SupersetParseError, SupersetSecurityException
 from superset.models.sql_lab import Query, SavedQuery
 
 
@@ -43,6 +43,13 @@ from superset.models.sql_lab import Query, SavedQuery
                 level=ErrorLevel.ERROR,
             )
         ),
+        SupersetParseError(
+            SupersetError(
+                error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+                message="Invalid SQL syntax",
+                level=ErrorLevel.ERROR,
+            )
+        ),
         TemplateError,
     ],
 )
@@ -57,3 +64,45 @@ def test_sql_tables_mixin_sql_tables_exception(
     )
 
     assert klass(sql="SELECT 1", database=MagicMock()).sql_tables == []
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        Query,
+        SavedQuery,
+    ],
+)
+@pytest.mark.parametrize(
+    "invalid_sql",
+    [
+        "SELECT * FROM table WHERE invalid syntax",
+        "INVALID SQL STATEMENT",
+        "SELECT * FROM; DROP TABLE users;",
+        "",
+        None,
+    ],
+)
+def test_sql_tables_mixin_invalid_sql_returns_empty_list(
+    klass: type[Model],
+    invalid_sql: str,
+    mocker: MockerFixture,
+) -> None:
+    """Test that SqlTablesMixin returns empty list when SQL parsing fails."""
+    mocker.patch(
+        "superset.models.sql_lab.extract_tables_from_jinja_sql",
+        side_effect=SupersetParseError(
+            SupersetError(
+                error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+                message=f"Failed to parse SQL: {invalid_sql}",
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    instance = (
+        klass(sql=invalid_sql, database=MagicMock())
+        if invalid_sql is not None
+        else klass(database=MagicMock())
+    )
+    assert instance.sql_tables == []

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -44,11 +44,8 @@ from superset.models.sql_lab import Query, SavedQuery
             )
         ),
         SupersetParseError(
-            SupersetError(
-                error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
-                message="Invalid SQL syntax",
-                level=ErrorLevel.ERROR,
-            )
+            sql="INVALID SQL",
+            message="Invalid SQL syntax",
         ),
         TemplateError,
     ],
@@ -92,11 +89,8 @@ def test_sql_tables_mixin_invalid_sql_returns_empty_list(
     mocker.patch(
         "superset.models.sql_lab.extract_tables_from_jinja_sql",
         side_effect=SupersetParseError(
-            SupersetError(
-                error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
-                message=f"Failed to parse SQL: {invalid_sql}",
-                level=ErrorLevel.ERROR,
-            )
+            sql=invalid_sql or "INVALID SQL",
+            message=f"Failed to parse SQL: {invalid_sql}",
         ),
     )
 


### PR DESCRIPTION
### SUMMARY
If a saved query can't be parsed by SQL Glot to extract the table names, the whole listing page breaks with the following error:

```
An error occurred while fetching Saved queries: list index out of range
```

Fixes https://github.com/apache/superset/issues/34019.

### TESTING INSTRUCTIONS
1. Save a query.
2. Edit the query with invalid SQL.
3. Go to the saved queries list.
4. The list should render normally and the problematic SQL should have nothing in the Tables column.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
