### PR TITLE
fix: Hide View in SQL Lab for users without access

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -25,6 +25,7 @@ import {
 } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import copyTextToClipboard from 'src/utils/copy';
+import { RootState } from 'src/dashboard/types';
 import ViewQuery, { ViewQueryProps } from './ViewQuery';
 
 const mockHistoryPush = jest.fn();
@@ -37,8 +38,29 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('src/utils/copy');
 
-function setup(props: ViewQueryProps) {
-  return render(<ViewQuery {...props} />, { useRouter: true, useRedux: true });
+const mockState = (
+  roles: Record<string, [string, string][]> = {
+    Admin: [['menu_access', 'SQL Lab']],
+  },
+) =>
+  ({
+    user: {
+      firstName: 'Test',
+      isActive: true,
+      isAnonymous: false,
+      lastName: 'User',
+      username: 'testuser',
+      permissions: {} as Record<string, any>,
+      roles,
+    },
+  }) as Partial<RootState>;
+
+function setup(props: ViewQueryProps, state: Partial<RootState> = mockState()) {
+  return render(<ViewQuery {...props} />, {
+    useRouter: true,
+    useRedux: true,
+    initialState: state,
+  });
 }
 
 const mockProps = {
@@ -155,4 +177,16 @@ test('opens SQL Lab in a new tab when View in SQL Lab button is clicked with met
     `/sqllab?datasourceKey=${datasource}&sql=${sql}`,
     '_blank',
   );
+});
+
+test('hides View in SQL Lab button when user does not have SQL Lab access', () => {
+  setup(
+    mockProps,
+    mockState({
+      Basic: [['menu_access', 'Dashboard']],
+    }),
+  );
+
+  expect(screen.queryByText('View in SQL Lab')).not.toBeInTheDocument();
+  expect(screen.getByText('Copy')).toBeInTheDocument(); // Copy button should still be visible
 });

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -24,11 +24,14 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { useSelector } from 'react-redux';
 import rison from 'rison';
 import { styled, SupersetClient, t } from '@superset-ui/core';
 import { Icons, Switch, Button, Skeleton } from '@superset-ui/core/components';
 import { CopyToClipboard } from 'src/components';
+import { RootState } from 'src/dashboard/types';
 import { CopyButton } from 'src/explore/components/DataTableControl';
+import { findPermission } from 'src/utils/findPermission';
 import CodeSyntaxHighlighter, {
   SupportedLanguage,
   preloadLanguages,
@@ -89,6 +92,9 @@ const ViewQuery: FC<ViewQueryProps> = props => {
   const [showFormatSQL, setShowFormatSQL] = useState(true);
   const history = useHistory();
   const currentSQL = (showFormatSQL ? formattedSQL : sql) ?? sql;
+  const canAccessSQLLab = useSelector((state: RootState) =>
+    findPermission('menu_access', 'SQL Lab', state.user?.roles),
+  );
 
   // Preload the language when component mounts to ensure smooth experience
   useEffect(() => {
@@ -162,7 +168,9 @@ const ViewQuery: FC<ViewQueryProps> = props => {
               </CopyButtonViewQuery>
             }
           />
-          <Button onClick={navToSQLLab}>{t('View in SQL Lab')}</Button>
+          {canAccessSQLLab && (
+            <Button onClick={navToSQLLab}>{t('View in SQL Lab')}</Button>
+          )}
         </StyledHeaderActionContainer>
         <StyledHeaderActionContainer>
           <Switch


### PR DESCRIPTION
### SUMMARY
The **View query** modal was always showing a **View in SQL Lab** button, regardless if the user has access to SQL Lab. This PR hides the button in case the user does not have access to it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="893" height="742" alt="image" src="https://github.com/user-attachments/assets/ba738de8-441d-45a0-b424-53690c4455b7" />

### TESTING INSTRUCTIONS
Frontend test added. For manual testing:
1. Create a test account that does not have the `menu access on SQL Lab` permission.
2. Open a dashboard and click on the chart ellipses > **View query**.
3. Validate the modal loads up properly but the **View in SQL Lab button** is not displayed.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
