### PR TITLE
feat: re-order CRUD list view action buttons

### DIFF
--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -429,6 +429,15 @@ function AlertList({
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
+  if (canDelete) {
+    subMenuButtons.push({
+      name: t('Bulk select'),
+      onClick: toggleBulkSelect,
+      buttonStyle: 'secondary',
+      'data-test': 'bulk-select-toggle',
+    });
+  }
+
   if (canCreate) {
     subMenuButtons.push({
       icon: <Icons.PlusOutlined iconSize="m" />,
@@ -437,14 +446,6 @@ function AlertList({
       onClick: () => {
         handleAlertEdit(null);
       },
-    });
-  }
-  if (canDelete) {
-    subMenuButtons.push({
-      name: t('Bulk select'),
-      onClick: toggleBulkSelect,
-      buttonStyle: 'secondary',
-      'data-test': 'bulk-select-toggle',
     });
   }
 

--- a/superset-frontend/src/pages/AnnotationLayerList/index.tsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/index.tsx
@@ -226,6 +226,14 @@ function AnnotationLayersList({
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
+  if (canDelete) {
+    subMenuButtons.push({
+      name: t('Bulk select'),
+      onClick: toggleBulkSelect,
+      buttonStyle: 'secondary',
+    });
+  }
+
   if (canCreate) {
     subMenuButtons.push({
       icon: <Icons.PlusOutlined iconSize="m" />,
@@ -234,14 +242,6 @@ function AnnotationLayersList({
       onClick: () => {
         handleAnnotationLayerEdit(null);
       },
-    });
-  }
-
-  if (canDelete) {
-    subMenuButtons.push({
-      name: t('Bulk select'),
-      onClick: toggleBulkSelect,
-      buttonStyle: 'secondary',
     });
   }
 

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -765,24 +765,8 @@ function ChartList(props: ChartListProps) {
   );
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
-  if (canDelete || canExport) {
-    subMenuButtons.push({
-      name: t('Bulk select'),
-      buttonStyle: 'secondary',
-      'data-test': 'bulk-select',
-      onClick: toggleBulkSelect,
-    });
-  }
-  if (canCreate) {
-    subMenuButtons.push({
-      icon: <Icons.PlusOutlined iconSize="m" />,
-      name: t('Chart'),
-      buttonStyle: 'primary',
-      onClick: () => {
-        history.push('/chart/add');
-      },
-    });
 
+  if (canCreate) {
     subMenuButtons.push({
       name: (
         <Tooltip
@@ -795,6 +779,26 @@ function ChartList(props: ChartListProps) {
       ),
       buttonStyle: 'link',
       onClick: openChartImportModal,
+    });
+  }
+
+  if (canDelete || canExport) {
+    subMenuButtons.push({
+      name: t('Bulk select'),
+      buttonStyle: 'secondary',
+      'data-test': 'bulk-select',
+      onClick: toggleBulkSelect,
+    });
+  }
+
+  if (canCreate) {
+    subMenuButtons.push({
+      icon: <Icons.PlusOutlined iconSize="m" />,
+      name: t('Chart'),
+      buttonStyle: 'primary',
+      onClick: () => {
+        history.push('/chart/add');
+      },
     });
   }
 

--- a/superset-frontend/src/pages/CssTemplateList/index.tsx
+++ b/superset-frontend/src/pages/CssTemplateList/index.tsx
@@ -200,6 +200,14 @@ function CssTemplatesList({
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
+  if (canDelete) {
+    subMenuButtons.push({
+      name: t('Bulk select'),
+      onClick: toggleBulkSelect,
+      buttonStyle: 'secondary',
+    });
+  }
+
   if (canCreate) {
     subMenuButtons.push({
       name: <>{t('CSS template')}</>,
@@ -209,14 +217,6 @@ function CssTemplatesList({
         setCurrentCssTemplate(null);
         setCssTemplateModalOpen(true);
       },
-    });
-  }
-
-  if (canDelete) {
-    subMenuButtons.push({
-      name: t('Bulk select'),
-      onClick: toggleBulkSelect,
-      buttonStyle: 'secondary',
     });
   }
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -686,24 +686,8 @@ function DashboardList(props: DashboardListProps) {
   );
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
-  if (canDelete || canExport) {
-    subMenuButtons.push({
-      name: t('Bulk select'),
-      buttonStyle: 'secondary',
-      'data-test': 'bulk-select',
-      onClick: toggleBulkSelect,
-    });
-  }
-  if (canCreate) {
-    subMenuButtons.push({
-      icon: <Icons.PlusOutlined iconSize="m" />,
-      name: t('Dashboard'),
-      buttonStyle: 'primary',
-      onClick: () => {
-        navigateTo('/dashboard/new', { assign: true });
-      },
-    });
 
+  if (canCreate) {
     subMenuButtons.push({
       name: (
         <Tooltip
@@ -716,6 +700,26 @@ function DashboardList(props: DashboardListProps) {
       ),
       buttonStyle: 'link',
       onClick: openDashboardImportModal,
+    });
+  }
+
+  if (canDelete || canExport) {
+    subMenuButtons.push({
+      name: t('Bulk select'),
+      buttonStyle: 'secondary',
+      'data-test': 'bulk-select',
+      onClick: toggleBulkSelect,
+    });
+  }
+
+  if (canCreate) {
+    subMenuButtons.push({
+      icon: <Icons.PlusOutlined iconSize="m" />,
+      name: t('Dashboard'),
+      buttonStyle: 'primary',
+      onClick: () => {
+        navigateTo('/dashboard/new', { assign: true });
+      },
     });
   }
   return (

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -634,24 +634,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   const buttonArr: Array<ButtonProps> = [];
 
-  if (canDelete || canExport) {
-    buttonArr.push({
-      name: t('Bulk select'),
-      onClick: toggleBulkSelect,
-      buttonStyle: 'secondary',
-    });
-  }
-
   if (canCreate) {
-    buttonArr.push({
-      icon: <Icons.PlusOutlined iconSize="m" />,
-      name: t('Dataset'),
-      onClick: () => {
-        history.push('/dataset/add/');
-      },
-      buttonStyle: 'primary',
-    });
-
     buttonArr.push({
       name: (
         <Tooltip
@@ -668,6 +651,25 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
       ),
       buttonStyle: 'link',
       onClick: openDatasetImportModal,
+    });
+  }
+
+  if (canDelete || canExport) {
+    buttonArr.push({
+      name: t('Bulk select'),
+      onClick: toggleBulkSelect,
+      buttonStyle: 'secondary',
+    });
+  }
+
+  if (canCreate) {
+    buttonArr.push({
+      icon: <Icons.PlusOutlined iconSize="m" />,
+      name: t('Dataset'),
+      onClick: () => {
+        history.push('/dataset/add/');
+      },
+      buttonStyle: 'primary',
     });
   }
 

--- a/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
@@ -314,16 +314,16 @@ function RowLevelSecurityList(props: RLSProps) {
 
   if (canWrite) {
     subMenuButtons.push({
-      name: t('Rule'),
-      icon: <Icons.PlusOutlined iconSize="m" data-test="add-rule" />,
-      buttonStyle: 'primary',
-      onClick: () => handleRuleEdit(null),
-    });
-    subMenuButtons.push({
       name: t('Bulk select'),
       buttonStyle: 'secondary',
       'data-test': 'bulk-select',
       onClick: toggleBulkSelect,
+    });
+    subMenuButtons.push({
+      name: t('Rule'),
+      icon: <Icons.PlusOutlined iconSize="m" data-test="add-rule" />,
+      buttonStyle: 'primary',
+      onClick: () => handleRuleEdit(null),
     });
   }
 

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -190,6 +190,24 @@ function SavedQueryList({
 
   const subMenuButtons: Array<ButtonProps> = [];
 
+  if (canCreate) {
+    subMenuButtons.push({
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import queries')}
+          placement="bottomRight"
+          data-test="import-tooltip-test"
+        >
+          <Icons.DownloadOutlined data-test="import-icon" iconSize="l" />
+        </Tooltip>
+      ),
+      buttonStyle: 'link',
+      onClick: openSavedQueryImportModal,
+      'data-test': 'import-button',
+    });
+  }
+
   if (canDelete) {
     subMenuButtons.push({
       name: t('Bulk select'),
@@ -210,23 +228,6 @@ function SavedQueryList({
       history.push('/sqllab?new=true');
     },
   });
-  if (canCreate) {
-    subMenuButtons.push({
-      name: (
-        <Tooltip
-          id="import-tooltip"
-          title={t('Import queries')}
-          placement="bottomRight"
-          data-test="import-tooltip-test"
-        >
-          <Icons.DownloadOutlined data-test="import-icon" iconSize="l" />
-        </Tooltip>
-      ),
-      buttonStyle: 'link',
-      onClick: openSavedQueryImportModal,
-      'data-test': 'import-button',
-    });
-  }
 
   menuData.buttons = subMenuButtons;
 


### PR DESCRIPTION

<img width="402" height="193" alt="Screenshot 2025-07-23 at 8 41 56 PM" src="https://github.com/user-attachments/assets/97dcec0c-cd62-43f0-9ee7-836149ad13dc" />

OCD in action, I'm repositioning the buttons in most CRUD views:
- import Icon is put left-most
- primary "add new" button is right-most