### PR TITLE
fix(mixed-chart): tooltip displaying numbers incorrectly with secondary y-axis format

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -648,36 +648,40 @@ export default function transformProps(
           .filter(key => keys.includes(key))
           .forEach(key => {
             const value = forecastValues[key];
-            // if there are no dimensions, key is a verbose name of a metric,
-            // otherwise it is a comma separated string where the first part is metric name
+
+            const isQueryB = key.includes('(Query B)');
+
+            // Set formatterKey based on which query this belongs to
             let formatterKey;
-            if (primarySeries.has(key)) {
-              formatterKey =
-                groupby.length === 0 ? inverted[key] : labelMap[key]?.[0];
-            } else {
+            if (isQueryB) {
               formatterKey =
                 groupbyB.length === 0 ? inverted[key] : labelMapB[key]?.[0];
+            } else {
+              formatterKey =
+                groupby.length === 0 ? inverted[key] : labelMap[key]?.[0];
             }
-            const tooltipFormatter = getFormatter(
-              customFormatters,
-              formatter,
-              metrics,
-              formatterKey,
-              !!contributionMode,
-            );
-            const tooltipFormatterSecondary = getFormatter(
-              customFormattersSecondary,
-              formatterSecondary,
-              metricsB,
-              formatterKey,
-              !!contributionMode,
-            );
+
+            // Use the correct formatter based on query type
+            const selectedFormatter = isQueryB
+              ? getFormatter(
+                  customFormattersSecondary,
+                  formatterSecondary,
+                  metricsB,
+                  formatterKey,
+                  !!contributionMode,
+                )
+              : getFormatter(
+                  customFormatters,
+                  formatter,
+                  metrics,
+                  formatterKey,
+                  !!contributionMode,
+                );
+
             const row = formatForecastTooltipSeries({
               ...value,
               seriesName: key,
-              formatter: primarySeries.has(key)
-                ? tooltipFormatter
-                : tooltipFormatterSecondary,
+              formatter: selectedFormatter,
             });
             rows.push(row);
             if (key === focusedSeries) {


### PR DESCRIPTION
Fixes: #34030

### Repro steps:

**Create a mixed chart**

1. In one of the queries, set the metric to use a number. In the other, set it to use a %
2. In the Customize tab, set the Primary y-axis format and Secondary y-axis format. One should use something numeric and the other should use something with a %
3. Hover over the tooltips on the chart
![Image](https://private-user-images.githubusercontent.com/10627051/461772569-e7a53698-7281-488b-838f-0df769766f5f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTMzNDE3NjIsIm5iZiI6MTc1MzM0MTQ2MiwicGF0aCI6Ii8xMDYyNzA1MS80NjE3NzI1NjktZTdhNTM2OTgtNzI4MS00ODhiLTgzOGYtMGRmNzY5NzY2ZjVmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzI0VDA3MTc0MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTM1MzQ5MzcwZDdhYTgxZjFjYWQwZmRjODIwZWJhNDE2MzNhMTQ2ZTBmZjQzODcwOGNkOGZiMjA3N2YzMjYyNDAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.rwfcxsT6dGJUnK_ogm_xQtShRxhXVjO5kO1NBk9NEfw)



### SUMMARY
Fixed a bug in mixed charts where tooltips were displaying primary axis values with secondary axis formatting. When Query A used numeric formatting (e.g., `",d"`) and Query B used percentage formatting (e.g., `",.1%"`), tooltips would incorrectly show primary axis values like `4724163` as `472416260.0%`.

**Root Cause:** The tooltip formatter had two critical issues:
1. **Series identification failure**: `primarySeries.has(key)` always returned `false` because tooltip keys included "(Query A/B)" suffixes but series sets only contained base metric names
2. **Wrong formatter selection**: Due to the failed check, all tooltips defaulted to using the secondary axis formatter

**Solution:** Updated the tooltip formatter to identify series by checking for "(Query B)" in the tooltip key name, ensuring each query uses its correct y-axis format.

## BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
### Before (Buggy Behavior):
<img width="1147" height="618" alt="Screenshot 2025-07-24 at 1 00 22 PM" src="https://github.com/user-attachments/assets/e527afc8-3a31-499b-a138-b889cef8e56d" />

<br>

### After (Fixed Behavior):

Hovering over Query A data point shows: `SUM(sales): 1,029,838` (correct numeric)
Hovering over Query B data point shows: `COUNT(*): 29,600.0%` (correct %)
<img width="1171" height="712" alt="Screenshot 2025-07-24 at 12 54 16 PM" src="https://github.com/user-attachments/assets/0046f9ce-152a-47b2-bd0a-c0b507edf1c8" />



### TESTING INSTRUCTIONS
1. Create a mixed chart with two queries
2. Set different formats for each query:
  - Query A: Numeric metric with primary y-axis format `",d"`
  - Query B: Any metric with secondary y-axis format `",.1%"`
3. Hover over data points from both queries
5. Verify tooltips display correct formatting:
  - Query A tooltips use primary y-axis format (numeric)
  - Query B tooltips use secondary y-axis format (percentage)
6. Test with various format combinations (currency, percentage, scientific notation)



### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #34030
- [ ] Required feature flags:
- [x] Changes UI (tooltip display formatting)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Files Modified:**
- `superset-frontend/src/visualizations/plugins/plugin-chart-echarts/MixedTimeseries/transformProps.ts`

**Technical Details:**
- **Old logic**: `primarySeries.has(key)` check failed because series sets contained `['SUM(sales)']` but tooltip keys were `'SUM(sales) (Query A)'`
- **New logic**: `key.includes('(Query B)')` correctly identifies secondary series
- **Impact**: Ensures proper formatter selection without breaking existing functionality
