### PR TITLE
fix: preserve correct column order when table layout is changed with time comparison enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -629,7 +629,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const startPosition = value[0];
       const colSpan = value.length;
       // Retrieve the originalLabel from the first column in this group
-      const firstColumnInGroup = filteredColumnsMeta[value[0]];
+      const firstColumnInGroup = filteredColumnsMeta[startPosition];
       const originalLabel = firstColumnInGroup
         ? columnsMeta.find(col => col.key === firstColumnInGroup.key)
             ?.originalLabel || key

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -629,7 +629,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const startPosition = value[0];
       const colSpan = value.length;
       // Retrieve the originalLabel from the first column in this group
-      const originalLabel = filteredColumnsMeta[value[0]]?.originalLabel || key;
+      const firstColumnInGroup = filteredColumnsMeta[value[0]];
+      const originalLabel = firstColumnInGroup
+        ? columnsMeta.find(col => col.key === firstColumnInGroup.key)
+            ?.originalLabel || key
+        : key;
 
       // Add placeholder <th> for columns before this header
       for (let i = currentColumnIndex; i < startPosition; i += 1) {

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -629,7 +629,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const startPosition = value[0];
       const colSpan = value.length;
       // Retrieve the originalLabel from the first column in this group
-      const originalLabel = columnsMeta[value[0]]?.originalLabel || key;
+      const originalLabel = filteredColumnsMeta[value[0]]?.originalLabel || key;
 
       // Add placeholder <th> for columns before this header
       for (let i = currentColumnIndex; i < startPosition; i += 1) {


### PR DESCRIPTION
SUMMARY
This PR fixes a bug where the column names in an aggregated Table chart get displayed in the wrong order after changing the layout, especially when the Time Comparison feature is enabled. The issue was causing column headers to become misaligned or overlapped, leading to confusion when interpreting the data.

Fixes #34134
Fixes #34300

Design decisions:
Introduced logic to consistently map metric columns and time comparison columns in the correct order during layout updates.

Ensured the internal data structure reflects the original metric ordering regardless of layout toggles.

BEFORE/AFTER SCREENSHOTS
Before:
<img width="1084" height="403" alt="image" src="https://github.com/user-attachments/assets/e187a613-25be-45cc-aa1f-022530b6b4ca" />

Column names appear in the wrong order or overlapped after layout change.

After:

<img width="2178" height="944" alt="image" src="https://github.com/user-attachments/assets/1a847122-eb95-4d62-aefb-dfc45f6195b1" />

Column names remain consistent and correctly ordered even after changing the layout.

TESTING INSTRUCTIONS
- [ ] Create a Table chart with aggregated data and multiple metrics.
- [ ] Assign a date filter interval.
- [ ] Enable the Time Comparison feature (e.g., “Previous period” or “1 year ago”).
- [ ] Add the chart to a dashboard.
- [ ] Use the dashboard layout editor to hide/show comparison columns.
- [ ] Verify that the column names remain correctly ordered and are not overlapping.

ADDITIONAL INFORMATION
Has associated issue: Fixes #34134
