### PR TITLE
fix(NavBar): Add brand text back

### DIFF
--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -612,3 +612,42 @@ test('should render an extension component if one is supplied', async () => {
 
   expect(extension[0]).toBeInTheDocument();
 });
+
+test('should render the brand text if available', async () => {
+  useSelectorMock.mockReturnValue({ roles: [] });
+
+  const modifiedProps = {
+    ...mockedProps,
+    data: {
+      ...mockedProps.data,
+      brand: {
+        ...mockedProps.data.brand,
+        text: 'Welcome to Superset',
+      },
+    },
+  };
+
+  render(<Menu {...modifiedProps} />, {
+    useRouter: true,
+    useQueryParams: true,
+    useRedux: true,
+    useTheme: true,
+  });
+
+  const brandText = await screen.findByText('Welcome to Superset');
+  expect(brandText).toBeInTheDocument();
+});
+
+test('should not render the brand text if not available', async () => {
+  useSelectorMock.mockReturnValue({ roles: [] });
+  const text = 'Welcome to Superset';
+  render(<Menu {...mockedProps} />, {
+    useRouter: true,
+    useQueryParams: true,
+    useRedux: true,
+    useTheme: true,
+  });
+
+  const brandText = screen.queryByText(text);
+  expect(brandText).not.toBeInTheDocument();
+});

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -52,6 +52,8 @@ const StyledHeader = styled.header`
         display: none;
       }
       & .ant-image{
+        display: contents;
+        height: 100%;
         padding: ${theme.sizeUnit}px
           ${theme.sizeUnit * 2}px
           ${theme.sizeUnit}px
@@ -87,7 +89,7 @@ const StyledHeader = styled.header`
         padding-left: ${theme.sizeUnit * 4}px;
         padding-right: ${theme.sizeUnit * 4}px;
         margin-right: ${theme.sizeUnit * 6}px;
-        font-size: ${theme.sizeUnit * 4}px;
+        font-size: ${theme.fontSizeLG}px;
         float: left;
         display: flex;
         flex-direction: column;
@@ -322,6 +324,11 @@ export function Menu({
           >
             {renderBrand()}
           </Tooltip>
+          {brand.text && (
+            <div className="navbar-brand-text">
+              <span>{brand.text}</span>
+            </div>
+          )}
           <MainNav
             mode={showMenu}
             data-test="navbar-top"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adds the navbar brand text that was lost in the theming refactor

### AFTER
<img width="1930" height="228" alt="Screenshot 2025-07-28 at 11 31 04" src="https://github.com/user-attachments/assets/e314eea2-af8f-4b32-b859-fde9cb4d8d95" />

### TESTING INSTRUCTIONS
1. Set `LOGO_RIGHT_TEXT` in the config (such as "Hello world" in the screenshot)
2. The text should show right to the logo

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
