### PR TITLE
feat: Enable drilling in embedded

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -32,6 +32,7 @@ assists people when migrating to a new version.
 - [32317](https://github.com/apache/superset/pull/32317) The horizontal filter bar feature is now out of testing/beta development and its feature flag `HORIZONTAL_FILTER_BAR` has been removed.
 - [31590](https://github.com/apache/superset/pull/31590) Marks the begining of intricate work around supporting dynamic Theming, and breaks support for [THEME_OVERRIDES](https://github.com/apache/superset/blob/732de4ac7fae88e29b7f123b6cbb2d7cd411b0e4/superset/config.py#L671) in favor of a new theming system based on AntD V5. Likely this will be in disrepair until settling over the 5.x lifecycle.
 - [32432](https://github.com/apache/superset/pull/31260) Moves the List Roles FAB view to the frontend and requires `FAB_ADD_SECURITY_API` to be enabled in the configuration and `superset init` to be executed.
+- [34319](https://github.com/apache/superset/pull/34319) Drill to Detail and Drill By is now supported in Embedded mode, and also with the `DASHBOARD_RBAC` FF. If you don't want to expose these features in Embedded / `DASHBOARD_RBAC`, make sure the roles used for Embedded / `DASHBOARD_RBAC`don't have the required permissions to perform D2D actions.
 
 ## 5.0.0
 

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -31,6 +31,51 @@ import {
   interceptFormDataKey,
 } from '../explore/utils';
 
+const interceptDrillInfo = () => {
+  cy.intercept('GET', '**/api/v1/dataset/*/drill_info/*', {
+    statusCode: 200,
+    body: {
+      result: {
+        id: 1,
+        changed_on_humanized: '2 days ago',
+        created_on_humanized: 'a week ago',
+        table_name: 'birth_names',
+        changed_by: {
+          first_name: 'Admin',
+          last_name: 'User',
+        },
+        created_by: {
+          first_name: 'Admin',
+          last_name: 'User',
+        },
+        owners: [
+          {
+            first_name: 'Admin',
+            last_name: 'User',
+          },
+        ],
+        columns: [
+          {
+            column_name: 'state',
+            verbose_name: 'State',
+            groupby: true,
+          },
+          {
+            column_name: 'name',
+            verbose_name: 'Name',
+            groupby: true,
+          },
+          {
+            column_name: 'ds',
+            verbose_name: 'Date',
+            groupby: true,
+          },
+        ],
+      },
+    },
+  }).as('drillInfo');
+};
+
 const closeModal = () => {
   cy.get('body').then($body => {
     if ($body.find('[data-test="close-drill-by-modal"]').length) {
@@ -62,6 +107,7 @@ const drillBy = (targetDrillByColumn: string, isLegacy = false) => {
 
   cy.get(
     '.ant-dropdown-menu-submenu:not(.ant-dropdown-menu-submenu-hidden) [data-test="drill-by-submenu"]',
+    { timeout: 15000 },
   )
     .should('be.visible')
     .find('[role="menuitem"]')
@@ -235,12 +281,14 @@ describe('Drill by modal', () => {
     closeModal();
   });
   before(() => {
+    interceptDrillInfo();
     cy.visit(SUPPORTED_CHARTS_DASHBOARD);
   });
 
   describe('Modal actions + Table', () => {
     before(() => {
       closeModal();
+      interceptDrillInfo();
       openTopLevelTab('Tier 1');
       SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
     });
@@ -389,6 +437,7 @@ describe('Drill by modal', () => {
   describe('Tier 1 charts', () => {
     before(() => {
       closeModal();
+      interceptDrillInfo();
       openTopLevelTab('Tier 1');
       SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
     });
@@ -552,6 +601,7 @@ describe('Drill by modal', () => {
   describe('Tier 2 charts', () => {
     before(() => {
       closeModal();
+      interceptDrillInfo();
       openTopLevelTab('Tier 2');
       SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
     });

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -56,21 +56,23 @@ const interceptDrillInfo = () => {
         ],
         columns: [
           {
+            column_name: 'gender',
+            verbose_name: null,
+          },
+          {
             column_name: 'state',
-            verbose_name: 'State',
-            groupby: true,
+            verbose_name: null,
           },
           {
             column_name: 'name',
-            verbose_name: 'Name',
-            groupby: true,
+            verbose_name: null,
           },
           {
             column_name: 'ds',
-            verbose_name: 'Date',
-            groupby: true,
+            verbose_name: null,
           },
         ],
+        verbose_map: {},
       },
     },
   }).as('drillInfo');

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -72,7 +72,6 @@ const interceptDrillInfo = () => {
             verbose_name: null,
           },
         ],
-        verbose_map: {},
       },
     },
   }).as('drillInfo');

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -41,6 +41,7 @@ export enum FeatureFlag {
   EmbeddableCharts = 'EMBEDDABLE_CHARTS',
   EmbeddedSuperset = 'EMBEDDED_SUPERSET',
   EnableAdvancedDataTypes = 'ENABLE_ADVANCED_DATA_TYPES',
+  DrillingInEmbedded = 'DRILLING_IN_EMBEDDED',
   /** @deprecated */
   EnableJavascriptControls = 'ENABLE_JAVASCRIPT_CONTROLS',
   EnableTemplateProcessing = 'ENABLE_TEMPLATE_PROCESSING',

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -41,7 +41,6 @@ export enum FeatureFlag {
   EmbeddableCharts = 'EMBEDDABLE_CHARTS',
   EmbeddedSuperset = 'EMBEDDED_SUPERSET',
   EnableAdvancedDataTypes = 'ENABLE_ADVANCED_DATA_TYPES',
-  DrillingInEmbedded = 'DRILLING_IN_EMBEDDED',
   /** @deprecated */
   EnableJavascriptControls = 'ENABLE_JAVASCRIPT_CONTROLS',
   EnableTemplateProcessing = 'ENABLE_TEMPLATE_PROCESSING',

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -146,7 +146,7 @@ const ChartContextMenu = (
     setShowDrillByModal(true);
   }, []);
 
-  const loadDrillByOptions = getExtensionsRegistry().get(
+  const loadDrillByOptionsExtension = getExtensionsRegistry().get(
     'load.drillby.options',
   );
 
@@ -175,8 +175,8 @@ const ChartContextMenu = (
         setIsLoadingDataset(true);
         let response;
 
-        if (loadDrillByOptions) {
-          response = await loadDrillByOptions(datasetId, formData);
+        if (loadDrillByOptionsExtension) {
+          response = await loadDrillByOptionsExtension(datasetId, formData);
         } else {
           const endpoint = `/api/v1/dataset/${datasetId}/drill_info/?q=(dashboard_id:${dashboardId})`;
           response = await cachedSupersetGet({ endpoint });
@@ -200,18 +200,18 @@ const ChartContextMenu = (
     showDrillBy,
     showDrillToDetail,
     formData.datasource,
-    loadDrillByOptions,
+    loadDrillByOptionsExtension,
     dashboardId,
   ]);
 
-  // Compute filtered dataset with drillable_columns whenever dataset or filters change
+  // Compute filteredDataset with all columns returned + a filtered list of valid drillable options
   const filteredDataset = useMemo(() => {
     if (!dataset || !showDrillBy) return dataset;
 
     const filteredColumns = ensureIsArray(dataset.columns).filter(
       column =>
-        // If using extensions, also filter by column.groupby since extensions might not do this
-        (!loadDrillByOptions || column.groupby) &&
+        // If using an extension, also filter by column.groupby since the extension might not do this
+        (!loadDrillByOptionsExtension || column.groupby) &&
         !ensureIsArray(
           formData[filters?.drillBy?.groupbyFieldName ?? ''],
         ).includes(column.column_name) &&
@@ -232,7 +232,7 @@ const ChartContextMenu = (
     formData.x_axis,
     formData[filters?.drillBy?.groupbyFieldName ?? ''],
     additionalConfig?.drillBy?.excludedColumns,
-    loadDrillByOptions,
+    loadDrillByOptionsExtension,
   ]);
 
   const showCrossFilters = isDisplayed(ContextMenuItem.CrossFilter);

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -55,7 +55,6 @@ import {
   cachedSupersetGet,
   supersetGetCache,
 } from 'src/utils/cachedSupersetGet';
-import { isEmbedded } from 'src/dashboard/util/isEmbedded';
 import { DrillDetailMenuItems } from '../DrillDetail';
 import { getMenuAdjustedY } from '../utils';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
@@ -159,16 +158,12 @@ const ChartContextMenu = (
   const showDrillToDetail =
     isFeatureEnabled(FeatureFlag.DrillToDetail) &&
     canDrillToDetail &&
-    (!isEmbedded() ||
-      (isEmbedded() && isFeatureEnabled(FeatureFlag.DrillingInEmbedded)));
-  isDisplayed(ContextMenuItem.DrillToDetail);
+    isDisplayed(ContextMenuItem.DrillToDetail);
 
   const showDrillBy =
     isFeatureEnabled(FeatureFlag.DrillBy) &&
     canDrillBy &&
-    (!isEmbedded() ||
-      (isEmbedded() && isFeatureEnabled(FeatureFlag.DrillingInEmbedded)));
-  isDisplayed(ContextMenuItem.DrillBy);
+    isDisplayed(ContextMenuItem.DrillBy);
 
   useEffect(() => {
     async function fetchDataset() {

--- a/superset-frontend/src/components/Chart/ChartContextMenu/useContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/useContextMenu.test.tsx
@@ -64,6 +64,7 @@ const setup = ({
             ['can_explore', 'Superset'],
             ['can_samples', 'Datasource'],
             ['can_write', 'ExploreFormDataRestApi'],
+            ['can_get_drill_info', 'Dataset'],
           ],
         },
       },
@@ -92,12 +93,13 @@ test('Context menu contains all displayed items only', () => {
   expect(screen.getByText('Drill by')).toBeInTheDocument();
 });
 
-test('Context menu shows "Drill by" with `can_explore` & `can_write` perms', () => {
+test('Context menu shows "Drill by" with `can_drill`, `can_write` & `can_get_drill_info`  perms', () => {
   const result = setup({
     roles: {
       Admin: [
         ['can_write', 'ExploreFormDataRestApi'],
-        ['can_explore', 'Superset'],
+        ['can_drill', 'Dashboard'],
+        ['can_get_drill_info', 'Dataset'],
       ],
     },
   });
@@ -105,26 +107,14 @@ test('Context menu shows "Drill by" with `can_explore` & `can_write` perms', () 
   expect(screen.getByText('Drill by')).toBeInTheDocument();
 });
 
-test('Context menu shows "Drill by" with `can_drill` & `can_write` perms', () => {
-  const result = setup({
-    roles: {
-      Admin: [
-        ['can_write', 'ExploreFormDataRestApi'],
-        ['can_drill', 'Dashboard'],
-      ],
-    },
-  });
-  result.current.onContextMenu(0, 0, {});
-  expect(screen.getByText('Drill by')).toBeInTheDocument();
-});
-
-test('Context menu shows "Drill by" with `can_drill` & `can_explore` + `can_write` perms', () => {
+test('Context menu shows "Drill by" with `can_drill`, `can_get_drill_info` & `can_explore` + `can_write` perms', () => {
   const result = setup({
     roles: {
       Admin: [
         ['can_write', 'ExploreFormDataRestApi'],
         ['can_explore', 'Superset'],
         ['can_drill', 'Dashboard'],
+        ['can_get_drill_info', 'Dataset'],
       ],
     },
   });
@@ -152,12 +142,40 @@ test('Context menu does not show "Drill by" with just `can_dril` perm', () => {
   expect(screen.queryByText('Drill by')).not.toBeInTheDocument();
 });
 
-test('Context menu shows "Drill to detail" with `can_samples` and `can_explore` perms', () => {
+test('Context menu does not show "Drill by" with just `can_dril` & `can_write` perms', () => {
+  const result = setup({
+    roles: {
+      Admin: [
+        ['can_drill', 'Dashboard'],
+        ['can_write', 'ExploreFormDataRestApi'],
+      ],
+    },
+  });
+  result.current.onContextMenu(0, 0, {});
+  expect(screen.queryByText('Drill by')).not.toBeInTheDocument();
+});
+
+test('Context menu does not show "Drill by" with just `can_drill`, `can_explore` & `can_write` perms', () => {
+  const result = setup({
+    roles: {
+      Admin: [
+        ['can_write', 'ExploreFormDataRestApi'],
+        ['can_explore', 'Superset'],
+        ['can_drill', 'Dashboard'],
+      ],
+    },
+  });
+  result.current.onContextMenu(0, 0, {});
+  expect(screen.queryByText('Drill by')).not.toBeInTheDocument();
+});
+
+test('Context menu shows "Drill to detail" with `can_samples`, `can_explore` & `can_get_drill_info` perms', () => {
   const result = setup({
     roles: {
       Admin: [
         ['can_samples', 'Datasource'],
         ['can_explore', 'Superset'],
+        ['can_get_drill_info', 'Dataset'],
       ],
     },
   });
@@ -165,12 +183,13 @@ test('Context menu shows "Drill to detail" with `can_samples` and `can_explore` 
   expect(screen.getByText('Drill to detail')).toBeInTheDocument();
 });
 
-test('Context menu shows "Drill to detail" with `can_drill` & `can_samples` perms', () => {
+test('Context menu shows "Drill to detail" with `can_drill`, `can_samples` & `can_get_drill_info` perms', () => {
   const result = setup({
     roles: {
       Admin: [
         ['can_samples', 'Datasource'],
         ['can_drill', 'Dashboard'],
+        ['can_get_drill_info', 'Dataset'],
       ],
     },
   });
@@ -178,13 +197,14 @@ test('Context menu shows "Drill to detail" with `can_drill` & `can_samples` perm
   expect(screen.getByText('Drill to detail')).toBeInTheDocument();
 });
 
-test('Context menu shows "Drill to detail" with `can_drill` & `can_explore` + `can_write` perms', () => {
+test('Context menu shows "Drill to detail" with `can_drill`, `can_get_drill_info` & `can_explore` + `can_samples` perms', () => {
   const result = setup({
     roles: {
       Admin: [
         ['can_samples', 'Datasource'],
         ['can_explore', 'Superset'],
         ['can_drill', 'Dashboard'],
+        ['can_get_drill_info', 'Dataset'],
       ],
     },
   });
@@ -202,10 +222,50 @@ test('Context menu does not show "Drill to detail" with neither of required perm
   expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
 });
 
-test('Context menu does not show "Drill to detail" with just `can_dril` perm', () => {
+test('Context menu does not show "Drill to detail" with just `can_drill` perm', () => {
   const result = setup({
     roles: {
       Admin: [['can_drill', 'Dashboard']],
+    },
+  });
+  result.current.onContextMenu(0, 0, {});
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Context menu does not show "Drill to detail" with just `can_drill` & `can_samples` perms', () => {
+  const result = setup({
+    roles: {
+      Admin: [
+        ['can_drill', 'Dashboard'],
+        ['can_samples', 'Datasource'],
+      ],
+    },
+  });
+  result.current.onContextMenu(0, 0, {});
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Context menu does not show "Drill to detail" with `can_samples` & `can_explore` perms', () => {
+  const result = setup({
+    roles: {
+      Admin: [
+        ['can_samples', 'Datasource'],
+        ['can_explore', 'Superset'],
+      ],
+    },
+  });
+  result.current.onContextMenu(0, 0, {});
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Context menu does not show "Drill to detail" with `can_drill`, `can_explore` + `can_samples` perms', () => {
+  const result = setup({
+    roles: {
+      Admin: [
+        ['can_samples', 'Datasource'],
+        ['can_explore', 'Superset'],
+        ['can_drill', 'Dashboard'],
+      ],
     },
   });
   result.current.onContextMenu(0, 0, {});

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -250,7 +250,6 @@ test('Do not display excluded column in the menu', async () => {
   );
   const datasetWithFilteredColumns = {
     ...mockDataset,
-    columns: filteredColumns,
     drillable_columns: filteredColumns,
   };
   renderMenu({

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.test.tsx
@@ -62,6 +62,7 @@ const mockDataset = {
   id: 7,
   table_name: 'test_table',
   columns: defaultColumns,
+  drillable_columns: defaultColumns,
   changed_on_humanized: '1 day ago',
   created_on_humanized: '2 days ago',
   description: 'Test dataset',
@@ -162,7 +163,7 @@ test('render enabled menu item for supported chart, no filters', async () => {
 });
 
 test('render disabled menu item for supported chart, no columns', async () => {
-  const emptyDataset = { ...mockDataset, columns: [] };
+  const emptyDataset = { ...mockDataset, columns: [], drillable_columns: [] };
   renderMenu({ dataset: emptyDataset });
   await expectDrillByEnabled();
   screen.getByText('No columns found');
@@ -170,7 +171,11 @@ test('render disabled menu item for supported chart, no columns', async () => {
 
 test('render menu item with submenu without searchbox', async () => {
   const slicedColumns = defaultColumns.slice(0, 9);
-  const datasetWithSlicedColumns = { ...mockDataset, columns: slicedColumns };
+  const datasetWithSlicedColumns = {
+    ...mockDataset,
+    columns: slicedColumns,
+    drillable_columns: slicedColumns,
+  };
   renderMenu({ dataset: datasetWithSlicedColumns });
   await expectDrillByEnabled();
 
@@ -246,6 +251,7 @@ test('Do not display excluded column in the menu', async () => {
   const datasetWithFilteredColumns = {
     ...mockDataset,
     columns: filteredColumns,
+    drillable_columns: filteredColumns,
   };
   renderMenu({
     dataset: datasetWithFilteredColumns,

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -32,25 +32,16 @@ import {
   Behavior,
   Column,
   ContextMenuFilters,
-  JsonResponse,
   css,
   ensureIsArray,
   getChartMetadataRegistry,
-  getExtensionsRegistry,
-  logging,
   t,
   useTheme,
 } from '@superset-ui/core';
 import { Constants, Input, Loading } from '@superset-ui/core/components';
-import rison from 'rison';
 import { debounce } from 'lodash';
 import { FixedSizeList as List } from 'react-window';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { useToasts } from 'src/components/MessageToasts/withToasts';
-import {
-  cachedSupersetGet,
-  supersetGetCache,
-} from 'src/utils/cachedSupersetGet';
 import { InputRef } from 'antd';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 import { getSubmenuYOffset } from '../utils';
@@ -73,26 +64,9 @@ export interface DrillByMenuItemsProps {
   excludedColumns?: Column[];
   open: boolean;
   onDrillBy?: (column: Column, dataset: Dataset) => void;
+  dataset?: Dataset;
+  isLoadingDataset?: boolean;
 }
-
-const loadDrillByOptions = getExtensionsRegistry().get('load.drillby.options');
-
-const queryString = rison.encode({
-  columns: [
-    'table_name',
-    'owners.first_name',
-    'owners.last_name',
-    'created_by.first_name',
-    'created_by.last_name',
-    'created_on_humanized',
-    'changed_by.first_name',
-    'changed_by.last_name',
-    'changed_on_humanized',
-    'columns.column_name',
-    'columns.verbose_name',
-    'columns.groupby',
-  ],
-});
 
 export const DrillByMenuItems = ({
   drillByConfig,
@@ -106,18 +80,16 @@ export const DrillByMenuItems = ({
   openNewModal = true,
   open,
   onDrillBy,
+  dataset,
+  isLoadingDataset = false,
   ...rest
 }: DrillByMenuItemsProps) => {
   const theme = useTheme();
-  const { addDangerToast } = useToasts();
-  const [isLoadingColumns, setIsLoadingColumns] = useState(true);
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchInput, setDebouncedSearchInput] = useState('');
-  const [dataset, setDataset] = useState<Dataset>();
-  const [columns, setColumns] = useState<Column[]>([]);
   const ref = useRef<InputRef>(null);
-  const showSearch =
-    loadDrillByOptions || columns.length > SHOW_COLUMNS_SEARCH_THRESHOLD;
+  const columns = dataset ? ensureIsArray(dataset.columns) : [];
+  const showSearch = columns.length > SHOW_COLUMNS_SEARCH_THRESHOLD;
 
   const handleSelection = useCallback(
     (event, column) => {
@@ -150,56 +122,6 @@ export const DrillByMenuItems = ({
         ?.behaviors.find(behavior => behavior === Behavior.DrillBy),
     [formData.viz_type],
   );
-
-  useEffect(() => {
-    async function loadOptions() {
-      const datasetId = Number(formData.datasource.split('__')[0]);
-      try {
-        setIsLoadingColumns(true);
-        let response: JsonResponse;
-        if (loadDrillByOptions) {
-          response = await loadDrillByOptions(datasetId, formData);
-        } else {
-          response = await cachedSupersetGet({
-            endpoint: `/api/v1/dataset/${datasetId}?q=${queryString}`,
-          });
-        }
-        const { json } = response;
-        const { result } = json;
-        setDataset(result);
-        setColumns(
-          ensureIsArray(result.columns)
-            .filter(column => column.groupby)
-            .filter(
-              column =>
-                !ensureIsArray(
-                  formData[drillByConfig?.groupbyFieldName ?? ''],
-                ).includes(column.column_name) &&
-                column.column_name !== formData.x_axis &&
-                ensureIsArray(excludedColumns)?.every(
-                  excludedCol => excludedCol.column_name !== column.column_name,
-                ),
-            ),
-        );
-      } catch (error) {
-        logging.error(error);
-        supersetGetCache.delete(`/api/v1/dataset/${datasetId}`);
-        addDangerToast(t('Failed to load dimensions for drill by'));
-      } finally {
-        setIsLoadingColumns(false);
-      }
-    }
-    if (handlesDimensionContextMenu && hasDrillBy) {
-      loadOptions();
-    }
-  }, [
-    addDangerToast,
-    drillByConfig?.groupbyFieldName,
-    excludedColumns,
-    formData,
-    handlesDimensionContextMenu,
-    hasDrillBy,
-  ]);
 
   const debouncedSetSearchInput = useMemo(
     () =>
@@ -316,7 +238,7 @@ export const DrillByMenuItems = ({
               value={searchInput}
             />
           )}
-          {isLoadingColumns ? (
+          {isLoadingDataset ? (
             <div
               css={css`
                 padding: ${theme.sizeUnit * 3}px 0;

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByMenuItems.tsx
@@ -88,7 +88,7 @@ export const DrillByMenuItems = ({
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearchInput, setDebouncedSearchInput] = useState('');
   const ref = useRef<InputRef>(null);
-  const columns = dataset ? ensureIsArray(dataset.columns) : [];
+  const columns = dataset ? ensureIsArray(dataset.drillable_columns) : [];
   const showSearch = columns.length > SHOW_COLUMNS_SEARCH_THRESHOLD;
 
   const handleSelection = useCallback(

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -72,9 +72,14 @@ const dataset = {
   columns: [
     {
       column_name: 'gender',
+      verbose_name: null,
     },
-    { column_name: 'name' },
+    {
+      column_name: 'name',
+      verbose_name: null,
+    },
   ],
+  verbose_map: {},
 };
 
 const renderModal = async (
@@ -164,7 +169,7 @@ test('should render alert banner when results fail to load', async () => {
 
 test('should generate Explore url', async () => {
   await renderModal({
-    column: { column_name: 'name' },
+    column: { column_name: 'name', verbose_name: null },
     drillByConfig: {
       filters: [{ col: 'gender', op: '==', val: 'boy' }],
       groupbyFieldName: 'groupby',
@@ -227,7 +232,7 @@ test('should render radio buttons', async () => {
 
 test('render breadcrumbs', async () => {
   await renderModal({
-    column: { column_name: 'name' },
+    column: { column_name: 'name', verbose_name: null },
     drillByConfig: {
       filters: [{ col: 'gender', op: '==', val: 'boy' }],
       groupbyFieldName: 'groupby',
@@ -304,7 +309,7 @@ describe('Embedded mode behavior', () => {
     (isEmbedded as jest.Mock).mockReturnValue(true);
 
     await renderModal({
-      column: { column_name: 'name' },
+      column: { column_name: 'name', verbose_name: null },
       drillByConfig: {
         filters: [{ col: 'gender', op: '==', val: 'boy' }],
         groupbyFieldName: 'groupby',
@@ -330,7 +335,7 @@ describe('Embedded mode behavior', () => {
     (isEmbedded as jest.Mock).mockReturnValue(false);
 
     await renderModal({
-      column: { column_name: 'name' },
+      column: { column_name: 'name', verbose_name: null },
       drillByConfig: {
         filters: [{ col: 'gender', op: '==', val: 'boy' }],
         groupbyFieldName: 'groupby',

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -32,6 +32,11 @@ import mockState from 'spec/fixtures/mockState';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import DrillByModal, { DrillByModalProps } from './DrillByModal';
 
+// Mock the isEmbedded function
+jest.mock('src/dashboard/util/isEmbedded', () => ({
+  isEmbedded: jest.fn(() => false),
+}));
+
 const CHART_DATA_ENDPOINT = 'glob:*/api/v1/chart/data*';
 const FORM_DATA_KEY_ENDPOINT = 'glob:*/api/v1/explore/form_data';
 
@@ -269,4 +274,80 @@ test('should render "Edit chart" enabled with can_explore permission', async () 
     },
   );
   expect(screen.getByRole('button', { name: 'Edit chart' })).toBeEnabled();
+});
+
+describe('Embedded mode behavior', () => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const { isEmbedded } = require('src/dashboard/util/isEmbedded');
+
+  beforeEach(() => {
+    (isEmbedded as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    (isEmbedded as jest.Mock).mockReturnValue(false);
+  });
+
+  test('should not render "Edit chart" button in embedded mode', async () => {
+    (isEmbedded as jest.Mock).mockReturnValue(true);
+
+    await renderModal();
+
+    expect(
+      screen.queryByRole('button', { name: 'Edit chart' }),
+    ).not.toBeInTheDocument();
+    const footerCloseButton = screen.getByTestId('close-drill-by-modal');
+    expect(footerCloseButton).toHaveTextContent('Close');
+  });
+
+  test('should not call postFormData API in embedded mode', async () => {
+    (isEmbedded as jest.Mock).mockReturnValue(true);
+
+    await renderModal({
+      column: { column_name: 'name' },
+      drillByConfig: {
+        filters: [{ col: 'gender', op: '==', val: 'boy' }],
+        groupbyFieldName: 'groupby',
+      },
+    });
+
+    await waitFor(() => fetchMock.called(CHART_DATA_ENDPOINT));
+
+    expect(fetchMock.called(FORM_DATA_KEY_ENDPOINT)).toBe(false);
+  });
+
+  test('should render "Edit chart" button in non-embedded mode', async () => {
+    (isEmbedded as jest.Mock).mockReturnValue(false);
+
+    await renderModal();
+
+    expect(
+      screen.getByRole('button', { name: 'Edit chart' }),
+    ).toBeInTheDocument();
+  });
+
+  test('should call postFormData API in non-embedded mode', async () => {
+    (isEmbedded as jest.Mock).mockReturnValue(false);
+
+    await renderModal({
+      column: { column_name: 'name' },
+      drillByConfig: {
+        filters: [{ col: 'gender', op: '==', val: 'boy' }],
+        groupbyFieldName: 'groupby',
+      },
+    });
+
+    await waitFor(() => fetchMock.called(CHART_DATA_ENDPOINT));
+
+    await waitFor(() => {
+      expect(fetchMock.called(FORM_DATA_KEY_ENDPOINT)).toBe(true);
+    });
+
+    expect(
+      await screen.findByRole('link', { name: 'Edit chart' }),
+    ).toHaveAttribute(
+      'href',
+      '/explore/?form_data_key=123&dashboard_page_id=1',
+    );
+  });
 });

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -56,6 +56,7 @@ import {
 } from 'src/logger/LogUtils';
 import { findPermission } from 'src/utils/findPermission';
 import { getQuerySettings } from 'src/explore/exploreUtils';
+import { isEmbedded } from 'src/dashboard/util/isEmbedded';
 import { Dataset, DrillByType } from '../types';
 import DrillByChart from './DrillByChart';
 import { ContextMenuItem } from '../ChartContextMenu/ChartContextMenu';
@@ -93,6 +94,8 @@ const ModalFooter = ({ formData, closeModal }: ModalFooterProps) => {
 
   const [datasource_id, datasource_type] = formData.datasource.split('__');
   useEffect(() => {
+    // short circuit if the user is embedded as explore is not available
+    if (isEmbedded()) return;
     postFormData(Number(datasource_id), datasource_type, formData, 0)
       .then(key => {
         setUrl(
@@ -113,28 +116,30 @@ const ModalFooter = ({ formData, closeModal }: ModalFooterProps) => {
 
   return (
     <>
-      <Button
-        buttonStyle="secondary"
-        buttonSize="small"
-        onClick={onEditChartClick}
-        disabled={isEditDisabled}
-        tooltip={
-          isEditDisabled
-            ? t('You do not have sufficient permissions to edit the chart')
-            : undefined
-        }
-      >
-        <Link
-          css={css`
-            &:hover {
-              text-decoration: none;
-            }
-          `}
-          to={url}
+      {!isEmbedded() && (
+        <Button
+          buttonStyle="secondary"
+          buttonSize="small"
+          onClick={onEditChartClick}
+          disabled={isEditDisabled}
+          tooltip={
+            isEditDisabled
+              ? t('You do not have sufficient permissions to edit the chart')
+              : undefined
+          }
         >
-          {t('Edit chart')}
-        </Link>
-      </Button>
+          <Link
+            css={css`
+              &:hover {
+                text-decoration: none;
+              }
+            `}
+            to={url}
+          >
+            {t('Edit chart')}
+          </Link>
+        </Button>
+      )}
 
       <Button
         buttonStyle="primary"

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailMenuItems.tsx
@@ -42,6 +42,7 @@ import { RootState } from 'src/dashboard/types';
 import { getSubmenuYOffset } from '../utils';
 import { MenuItemTooltip } from '../DisabledMenuItemTooltip';
 import { MenuItemWithTruncation } from '../MenuItemWithTruncation';
+import { Dataset } from '../types';
 
 const DRILL_TO_DETAIL = t('Drill to detail');
 const DRILL_TO_DETAIL_BY = t('Drill to detail by');
@@ -113,6 +114,8 @@ export type DrillDetailMenuItemsProps = {
   setShowModal: (show: boolean) => void;
   key?: string;
   forceSubmenuRender?: boolean;
+  dataset?: Dataset;
+  isLoadingDataset?: boolean;
 };
 
 const DrillDetailMenuItems = ({

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -32,6 +32,7 @@ import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
 import { Slice } from 'src/types/Chart';
 import { RootState } from 'src/dashboard/types';
 import { findPermission } from 'src/utils/findPermission';
+import { Dataset } from '../types';
 import DrillDetailPane from './DrillDetailPane';
 
 interface ModalFooterProps {
@@ -83,6 +84,7 @@ interface DrillDetailModalProps {
   initialFilters: BinaryQueryObjectFilterClause[];
   showModal: boolean;
   onHideModal: () => void;
+  dataset?: Dataset;
 }
 
 export default function DrillDetailModal({
@@ -91,6 +93,7 @@ export default function DrillDetailModal({
   initialFilters,
   showModal,
   onHideModal,
+  dataset,
 }: DrillDetailModalProps) {
   const theme = useTheme();
   const history = useHistory();
@@ -141,7 +144,11 @@ export default function DrillDetailModal({
       destroyOnHidden
       maskClosable={false}
     >
-      <DrillDetailPane formData={formData} initialFilters={initialFilters} />
+      <DrillDetailPane
+        formData={formData}
+        initialFilters={initialFilters}
+        dataset={dataset}
+      />
     </Modal>
   );
 }

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -29,6 +29,7 @@ import {
 import { Button, Modal } from '@superset-ui/core/components';
 import { useSelector } from 'react-redux';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
+import { isEmbedded } from 'src/dashboard/util/isEmbedded';
 import { Slice } from 'src/types/Chart';
 import { RootState } from 'src/dashboard/types';
 import { findPermission } from 'src/utils/findPermission';
@@ -50,19 +51,21 @@ const ModalFooter = ({
 
   return (
     <>
-      <Button
-        buttonStyle="secondary"
-        buttonSize="small"
-        onClick={exploreChart}
-        disabled={!canExplore}
-        tooltip={
-          !canExplore
-            ? t('You do not have sufficient permissions to edit the chart')
-            : undefined
-        }
-      >
-        {t('Edit chart')}
-      </Button>
+      {!isEmbedded() && (
+        <Button
+          buttonStyle="secondary"
+          buttonSize="small"
+          onClick={exploreChart}
+          disabled={!canExplore}
+          tooltip={
+            !canExplore
+              ? t('You do not have sufficient permissions to edit the chart')
+              : undefined
+          }
+        >
+          {t('Edit chart')}
+        </Button>
+      )}
       <Button
         buttonStyle="primary"
         buttonSize="small"

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.test.tsx
@@ -164,7 +164,7 @@ test('should render the "No results" components', async () => {
 
 test('should render the metadata bar', async () => {
   fetchWithNoData();
-  setup();
+  setup({ dataset: MOCKED_DATASET });
   expect(
     await screen.findByText(MOCKED_DATASET.table_name),
   ).toBeInTheDocument();
@@ -178,15 +178,6 @@ test('should render the metadata bar', async () => {
   ).toBeInTheDocument();
   expect(
     await screen.findByText(MOCKED_DATASET.changed_on_humanized),
-  ).toBeInTheDocument();
-});
-
-test('should render an error message when fails to load the metadata', async () => {
-  fetchWithNoData();
-  fetchMock.get(DATASET_ENDPOINT, { status: 400 }, { overwriteRoutes: true });
-  setup();
-  expect(
-    await screen.findByText('There was an error loading the dataset metadata'),
   ).toBeInTheDocument();
 });
 

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -46,6 +46,7 @@ import Table, {
   ColumnsType,
   TableSize,
 } from '@superset-ui/core/components/Table';
+import { RootState } from 'src/dashboard/types';
 import HeaderWithRadioGroup from '@superset-ui/core/components/Table/header-renderers/HeaderWithRadioGroup';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
 import { Dataset } from '../types';
@@ -97,6 +98,10 @@ export default function DrillDetailPane({
   const [timeFormatting, setTimeFormatting] = useState<
     Record<string, TimeFormatting>
   >({});
+
+  const dashboardId = useSelector<RootState, number>(
+    ({ dashboardInfo }) => dashboardInfo.id,
+  );
 
   const SAMPLES_ROW_LIMIT = useSelector(
     (state: { common: { conf: JsonObject } }) =>
@@ -234,6 +239,7 @@ export default function DrillDetailPane({
         jsonPayload,
         PAGE_SIZE,
         pageIndex + 1,
+        dashboardId,
       )
         .then(response => {
           setResultsPages(

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -47,8 +47,8 @@ import Table, {
   TableSize,
 } from '@superset-ui/core/components/Table';
 import HeaderWithRadioGroup from '@superset-ui/core/components/Table/header-renderers/HeaderWithRadioGroup';
-import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
+import { Dataset } from '../types';
 import TableControls from './DrillDetailTableControls';
 import { getDrillPayload } from './utils';
 import { ResultsPage } from './types';
@@ -79,9 +79,11 @@ enum TimeFormatting {
 export default function DrillDetailPane({
   formData,
   initialFilters,
+  dataset,
 }: {
   formData: QueryFormData;
   initialFilters: BinaryQueryObjectFilterClause[];
+  dataset?: Dataset;
 }) {
   const theme = useTheme();
   const [pageIndex, setPageIndex] = useState(0);
@@ -107,9 +109,10 @@ export default function DrillDetailPane({
     [formData.datasource],
   );
 
-  const { metadataBar, status: metadataBarStatus } = useDatasetMetadataBar({
-    datasetId: datasourceId,
+  const { metadataBar: metadataBarComponent } = useDatasetMetadataBar({
+    dataset,
   });
+
   // Get page of results
   const resultsPage = useMemo(() => {
     const nextResultsPage = resultsPages.get(pageIndex);
@@ -268,9 +271,7 @@ export default function DrillDetailPane({
     resultsPages,
   ]);
 
-  const bootstrapping =
-    (!responseError && !resultsPages.size) ||
-    metadataBarStatus === ResourceStatus.Loading;
+  const bootstrapping = !responseError && !resultsPages.size;
 
   const allowHTML = formData.allow_render_html ?? true;
 
@@ -318,7 +319,7 @@ export default function DrillDetailPane({
 
   return (
     <>
-      {!bootstrapping && metadataBar}
+      {!bootstrapping && metadataBarComponent}
       {!bootstrapping && (
         <TableControls
           filters={filters}

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -601,6 +601,7 @@ export const getDatasourceSamples = async (
   jsonPayload,
   perPage,
   page,
+  dashboardId,
 ) => {
   try {
     const searchParams = {
@@ -608,6 +609,10 @@ export const getDatasourceSamples = async (
       datasource_type: datasourceType,
       datasource_id: datasourceId,
     };
+
+    if (isDefined(dashboardId)) {
+      searchParams.dashboard_id = dashboardId;
+    }
 
     if (isDefined(perPage) && isDefined(page)) {
       searchParams.per_page = perPage;

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -41,6 +41,7 @@ export type Dataset = {
     last_name: string;
   }[];
   columns?: Column[];
+  drillable_columns?: Column[];
   metrics?: Metric[];
   verbose_map?: Record<string, string>;
 };

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -310,7 +310,7 @@ test('Drill to detail modal is under featureflag', () => {
   expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
 });
 
-test('Should show "Drill to detail" with `can_explore` & `can_samples` perms', () => {
+test('Should show "Drill to detail" with `can_explore`, `can_samples` & `can_get_drill_info` perms', () => {
   (global as any).featureFlags = {
     [FeatureFlag.DrillToDetail]: true,
   };
@@ -320,13 +320,14 @@ test('Should show "Drill to detail" with `can_explore` & `can_samples` perms', (
     Admin: [
       ['can_samples', 'Datasource'],
       ['can_explore', 'Superset'],
+      ['can_get_drill_info', 'Dataset'],
     ],
   });
   openMenu();
   expect(screen.getByText('Drill to detail')).toBeInTheDocument();
 });
 
-test('Should show "Drill to detail" with `can_drill` & `can_samples` perms', () => {
+test('Should show "Drill to detail" with `can_drill` & `can_samples` & `can_get_drill_info` perms', () => {
   (global as any).featureFlags = {
     [FeatureFlag.DrillToDetail]: true,
   };
@@ -339,13 +340,14 @@ test('Should show "Drill to detail" with `can_drill` & `can_samples` perms', () 
     Admin: [
       ['can_samples', 'Datasource'],
       ['can_drill', 'Dashboard'],
+      ['can_get_drill_info', 'Dataset'],
     ],
   });
   openMenu();
   expect(screen.getByText('Drill to detail')).toBeInTheDocument();
 });
 
-test('Should show "Drill to detail" with both `canexplore` + `can_drill` & `can_samples` perms', () => {
+test('Should show "Drill to detail" with both `canexplore` + `can_drill` & `can_samples` & `can_get_drill_info` perms', () => {
   (global as any).featureFlags = {
     [FeatureFlag.DrillToDetail]: true,
   };
@@ -357,7 +359,9 @@ test('Should show "Drill to detail" with both `canexplore` + `can_drill` & `can_
   renderWrapper(props, {
     Admin: [
       ['can_samples', 'Datasource'],
+      ['can_explore', 'Superset'],
       ['can_drill', 'Dashboard'],
+      ['can_get_drill_info', 'Dataset'],
     ],
   });
   openMenu();
@@ -380,7 +384,7 @@ test('Should not show "Drill to detail" with neither of required perms', () => {
   expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
 });
 
-test('Should not show "Drill to detail" only `can_dril` perm', () => {
+test('Should not show "Drill to detail" only `can_drill` perm', () => {
   (global as any).featureFlags = {
     [FeatureFlag.DrillToDetail]: true,
   };
@@ -391,6 +395,64 @@ test('Should not show "Drill to detail" only `can_dril` perm', () => {
   props.slice.slice_id = 18;
   renderWrapper(props, {
     Admin: [['can_drill', 'Dashboard']],
+  });
+  openMenu();
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Should not show "Drill to detail" with only `can_drill` & `can_samples` perms', () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+  };
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  props.slice.slice_id = 18;
+  renderWrapper(props, {
+    Admin: [
+      ['can_drill', 'Dashboard'],
+      ['can_samples', 'Datasource'],
+    ],
+  });
+  openMenu();
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Should not show "Drill to detail" with only `can_explore` & `can_samples` perms', () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+  };
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  props.slice.slice_id = 18;
+  renderWrapper(props, {
+    Admin: [
+      ['can_explore', 'Superset'],
+      ['can_samples', 'Datasource'],
+    ],
+  });
+  openMenu();
+  expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();
+});
+
+test('Should not show "Drill to detail" with only `can_explore`, `can_drill` & `can_samples` perms', () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+  };
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  props.slice.slice_id = 18;
+  renderWrapper(props, {
+    Admin: [
+      ['can_explore', 'Superset'],
+      ['can_samples', 'Datasource'],
+      ['can_drill', 'Dashboard'],
+    ],
   });
   openMenu();
   expect(screen.queryByText('Drill to detail')).not.toBeInTheDocument();

--- a/superset-frontend/src/features/datasets/metadataBar/DatasetMetadataBar.skipped-stories.tsx
+++ b/superset-frontend/src/features/datasets/metadataBar/DatasetMetadataBar.skipped-stories.tsx
@@ -52,7 +52,23 @@ export default {
 export const DatasetSpecific = () => {
   SupersetClient.reset();
   SupersetClient.configure({ csrfToken: '1234' }).init();
-  const { metadataBar } = useDatasetMetadataBar({ datasetId: 1 });
+
+  const mockDataset = {
+    changed_on: '2023-01-26T12:06:58.733316',
+    changed_on_humanized: 'a month ago',
+    changed_by: { first_name: 'Han', last_name: 'Solo' },
+    created_by: { first_name: 'Luke', last_name: 'Skywalker' },
+    created_on: '2023-01-26T12:06:54.965034',
+    created_on_humanized: 'a month ago',
+    table_name: `This is dataset's name`,
+    owners: [
+      { first_name: 'John', last_name: 'Doe' },
+      { first_name: 'Luke', last_name: 'Skywalker' },
+    ],
+    description: 'This is a dataset description',
+  };
+
+  const { metadataBar } = useDatasetMetadataBar({ dataset: mockDataset });
   const { width, height, ref } = useResizeDetector();
   // eslint-disable-next-line no-param-reassign
   return (

--- a/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.test.tsx
+++ b/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.test.tsx
@@ -43,35 +43,7 @@ afterEach(() => {
   supersetGetCache.clear();
 });
 
-test('renders dataset metadata bar from request', async () => {
-  fetchMock.get('glob:*/api/v1/dataset/1', {
-    result: MOCK_DATASET,
-  });
-
-  const { result, waitForValueToChange } = renderHook(
-    () => useDatasetMetadataBar({ datasetId: 1 }),
-    {
-      wrapper: createWrapper(),
-    },
-  );
-  expect(result.current.status).toEqual('loading');
-  await waitForValueToChange(() => result.current.status);
-  expect(result.current.status).toEqual('complete');
-
-  expect(fetchMock.called()).toBeTruthy();
-  const { findByText, findAllByRole } = render(result.current.metadataBar);
-  expect(await findByText(`This is dataset's name`)).toBeVisible();
-  expect(await findByText('This is a dataset description')).toBeVisible();
-  expect(await findByText('Luke Skywalker')).toBeVisible();
-  expect(await findByText('a month ago')).toBeVisible();
-  expect(await findAllByRole('img')).toHaveLength(4);
-});
-
-test('renders dataset metadata bar without request', async () => {
-  fetchMock.get('glob:*/api/v1/dataset/1', {
-    result: {},
-  });
-
+test('renders dataset metadata bar with dataset prop', async () => {
   const { result } = renderHook(
     () => useDatasetMetadataBar({ dataset: MOCK_DATASET }),
     {
@@ -79,10 +51,8 @@ test('renders dataset metadata bar without request', async () => {
     },
   );
 
-  expect(result.current.status).toEqual('complete');
-
-  expect(fetchMock.called()).toBeFalsy();
-  const { findByText, findAllByRole } = render(result.current.metadataBar);
+  expect(result.current.metadataBar).not.toBeNull();
+  const { findByText, findAllByRole } = render(result.current.metadataBar!);
   expect(await findByText(`This is dataset's name`)).toBeVisible();
   expect(await findByText('This is a dataset description')).toBeVisible();
   expect(await findByText('Luke Skywalker')).toBeVisible();
@@ -90,30 +60,27 @@ test('renders dataset metadata bar without request', async () => {
   expect(await findAllByRole('img')).toHaveLength(4);
 });
 
-test('renders dataset metadata bar without description and owners', async () => {
-  fetchMock.get('glob:*/api/v1/dataset/1', {
-    result: {
-      changed_on: '2023-01-26T12:06:58.733316',
-      changed_on_humanized: 'a month ago',
-      created_on: '2023-01-26T12:06:54.965034',
-      created_on_humanized: 'a month ago',
-      table_name: `This is dataset's name`,
-    },
-  });
+test('renders dataset metadata bar with minimal dataset', async () => {
+  const minimalDataset = {
+    changed_on: '2023-01-26T12:06:58.733316',
+    changed_on_humanized: 'a month ago',
+    created_on: '2023-01-26T12:06:54.965034',
+    created_on_humanized: 'a month ago',
+    table_name: `This is dataset's name`,
+    description: undefined,
+    owners: [],
+  } as any;
 
-  const { result, waitForValueToChange } = renderHook(
-    () => useDatasetMetadataBar({ datasetId: 1 }),
+  const { result } = renderHook(
+    () => useDatasetMetadataBar({ dataset: minimalDataset }),
     {
       wrapper: createWrapper(),
     },
   );
-  expect(result.current.status).toEqual('loading');
-  await waitForValueToChange(() => result.current.status);
-  expect(result.current.status).toEqual('complete');
 
-  expect(fetchMock.called()).toBeTruthy();
+  expect(result.current.metadataBar).not.toBeNull();
   const { findByText, queryByText, findAllByRole } = render(
-    result.current.metadataBar,
+    result.current.metadataBar!,
   );
   expect(await findByText(`This is dataset's name`)).toBeVisible();
   expect(queryByText('This is a dataset description')).not.toBeInTheDocument();

--- a/superset-frontend/src/hooks/usePermissions.ts
+++ b/superset-frontend/src/hooks/usePermissions.ts
@@ -36,8 +36,13 @@ export const usePermissions = () => {
   const canDrill = useSelector((state: RootState) =>
     findPermission('can_drill', 'Dashboard', state.user?.roles),
   );
-  const canDrillBy = (canExplore || canDrill) && canWriteExploreFormData;
-  const canDrillToDetail = (canExplore || canDrill) && canDatasourceSamples;
+  const canGetDrillInfo = useSelector((state: RootState) =>
+    findPermission('can_get_drill_info', 'Dataset', state.user?.roles),
+  );
+  const canDrillBy =
+    (canExplore || canDrill) && canWriteExploreFormData && canGetDrillInfo;
+  const canDrillToDetail =
+    (canExplore || canDrill) && canDatasourceSamples && canGetDrillInfo;
   const canViewQuery = useSelector((state: RootState) =>
     findPermission('can_view_query', 'Dashboard', state.user?.roles),
   );

--- a/superset/config.py
+++ b/superset/config.py
@@ -531,7 +531,6 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This feature flag is stil in beta and is not recommended for production use.
     "GLOBAL_ASYNC_QUERIES": False,
     "EMBEDDED_SUPERSET": False,
-    "DRILLING_IN_EMBEDDED": False,
     # Enables Alerts and reports new implementation
     "ALERT_REPORTS": False,
     "ALERT_REPORT_TABS": False,

--- a/superset/config.py
+++ b/superset/config.py
@@ -279,10 +279,11 @@ WTF_CSRF_ENABLED = True
 
 # Add endpoints that need to be exempt from CSRF protection
 WTF_CSRF_EXEMPT_LIST = [
-    "superset.views.core.log",
-    "superset.views.core.explore_json",
     "superset.charts.data.api.data",
     "superset.dashboards.api.cache_dashboard_screenshot",
+    "superset.views.core.explore_json",
+    "superset.views.core.log",
+    "superset.views.datasource.views.samples",
 ]
 
 # Whether to run the web server in debug mode or not
@@ -530,6 +531,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This feature flag is stil in beta and is not recommended for production use.
     "GLOBAL_ASYNC_QUERIES": False,
     "EMBEDDED_SUPERSET": False,
+    "DRILLING_IN_EMBEDDED": False,
     # Enables Alerts and reports new implementation
     "ALERT_REPORTS": False,
     "ALERT_REPORT_TABS": False,

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -65,7 +65,7 @@ from superset.datasets.filters import DatasetCertifiedFilter, DatasetIsNullOrEmp
 from superset.datasets.schemas import (
     DatasetCacheWarmUpRequestSchema,
     DatasetCacheWarmUpResponseSchema,
-    DatasetDrillInfo,
+    DatasetDrillInfoSchema,
     DatasetDuplicateSchema,
     DatasetPostSchema,
     DatasetPutSchema,
@@ -1231,7 +1231,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             "columns.verbose_name",
             "columns.groupby",
         ]
-        dataset_schema = DatasetDrillInfo()
+        dataset_schema = DatasetDrillInfoSchema()
 
         # First try with regular access
         dataset: SqlaTable | None = self.datamodel.get(

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -35,7 +35,7 @@ from flask_babel import ngettext
 from jinja2.exceptions import TemplateSyntaxError
 from marshmallow import ValidationError
 
-from superset import event_logger, is_feature_enabled
+from superset import event_logger, is_feature_enabled, security_manager
 from superset.commands.dataset.create import CreateDatasetCommand
 from superset.commands.dataset.delete import DeleteDatasetCommand
 from superset.commands.dataset.duplicate import DuplicateDatasetCommand
@@ -58,17 +58,20 @@ from superset.commands.importers.exceptions import NoValidFilesFoundError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
+from superset.daos.dashboard import DashboardDAO
 from superset.daos.dataset import DatasetDAO
 from superset.databases.filters import DatabaseFilter
 from superset.datasets.filters import DatasetCertifiedFilter, DatasetIsNullOrEmptyFilter
 from superset.datasets.schemas import (
     DatasetCacheWarmUpRequestSchema,
     DatasetCacheWarmUpResponseSchema,
+    DatasetDrillInfo,
     DatasetDuplicateSchema,
     DatasetPostSchema,
     DatasetPutSchema,
     DatasetRelatedObjectsResponse,
     get_delete_ids_schema,
+    get_drill_info_schema,
     get_export_ids_schema,
     GetOrCreateDatasetSchema,
     openapi_spec_methods_override,
@@ -110,6 +113,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "duplicate",
         "get_or_create_dataset",
         "warm_up_cache",
+        "get_drill_info",
     }
     list_columns = [
         "id",
@@ -1173,6 +1177,95 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             except SupersetTemplateException as ex:
                 return self.response_400(message=str(ex))
         return self.response(200, **response)
+
+    @expose("/<int:pk>/drill_info/", methods=("GET",))
+    @protect()
+    @rison(get_drill_info_schema)
+    @safe
+    @statsd_metrics
+    def get_drill_info(self, pk: int, **kwargs: Any) -> Response:
+        """Get dataset drill info.
+        ---
+        get:
+          summary: Get dataset drill info
+          parameters:
+          - in: path
+            schema:
+              type: integer
+            name: pk
+            description: The dataset ID
+          responses:
+            200:
+              description: Dataset drill info
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            422:
+              $ref: '#/components/responses/422'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        dashboard_id = kwargs["rison"].get("dashboard_id")
+        embedded_user = security_manager.is_guest_user()
+        embedded_drilling_enabled = is_feature_enabled("DRILLING_IN_EMBEDDED")
+        # Short circuit embedded access if disabled
+        if embedded_user and not embedded_drilling_enabled:
+            return self.response_403()
+
+        drill_info_select_columns = [
+            "id",
+            "table_name",
+            "owners.first_name",
+            "owners.last_name",
+            "created_by.first_name",
+            "created_by.last_name",
+            "created_on_humanized",
+            "changed_by.first_name",
+            "changed_by.last_name",
+            "changed_on_humanized",
+            "columns.column_name",
+            "columns.verbose_name",
+            "columns.groupby",
+        ]
+        # First try with regular access
+        dataset: SqlaTable | None = self.datamodel.get(
+            pk,
+            self._base_filters,
+            drill_info_select_columns,
+            self.show_outer_default_load,
+        )
+        if not dataset and dashboard_id:
+            # Lazy load the dashboard and dataset for RBAC/embedded access check
+            dashboard = DashboardDAO.find_by_id(dashboard_id, skip_base_filter=True)
+            dataset_ = DatasetDAO.find_by_id(pk, skip_base_filter=True)
+            if not dashboard or not dataset_:
+                return self.response_404()
+            if security_manager.can_drill_dataset_via_dashboard_access(
+                dataset_,
+                dashboard,
+            ):
+                # Load dataset again skipping base filters
+                # We don't use `dataset_` to avoid lazy loading columns
+                dataset = self.datamodel.get(
+                    pk,
+                    None,
+                    drill_info_select_columns,
+                    self.show_outer_default_load,
+                )
+        if not dataset:
+            return self.response_404()
+        dataset_schema = DatasetDrillInfo()
+        return self.response(200, result=dataset_schema.dump(dataset))
 
     @staticmethod
     def render_dataset_fields(

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1183,6 +1183,12 @@ class DatasetRestApi(BaseSupersetModelRestApi):
     @rison(get_drill_info_schema)
     @safe
     @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self,
+        *args,
+        **kwargs: f"{self.__class__.__name__}.get_drill_info",
+        log_to_statsd=False,
+    )
     def get_drill_info(self, pk: int, **kwargs: Any) -> Response:
         """Get dataset drill info.
         ---

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -390,7 +390,7 @@ class DatasetCacheWarmUpResponseSchema(Schema):
     )
 
 
-class DatasetColumnDrillInfo(Schema):
+class DatasetColumnDrillInfoSchema(Schema):
     column_name = fields.String(required=True)
     verbose_name = fields.String(required=False)
 
@@ -400,9 +400,9 @@ class UserSchema(Schema):
     last_name = fields.String()
 
 
-class DatasetDrillInfo(Schema):
+class DatasetDrillInfoSchema(Schema):
     id = fields.Integer()
-    columns = fields.List(fields.Nested(DatasetColumnDrillInfo))
+    columns = fields.List(fields.Nested(DatasetColumnDrillInfoSchema))
     table_name = fields.String()
     owners = fields.List(fields.Nested(UserSchema))
     created_by = fields.Nested(UserSchema)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -19,14 +19,29 @@ from typing import Any
 
 from dateutil.parser import isoparse
 from flask_babel import lazy_gettext as _
-from marshmallow import fields, pre_load, Schema, validates_schema, ValidationError
+from marshmallow import (
+    fields,
+    post_dump,
+    pre_load,
+    Schema,
+    validates_schema,
+    ValidationError,
+)
 from marshmallow.validate import Length, OneOf
 
+from superset import security_manager
+from superset.connectors.sqla.models import SqlaTable
 from superset.exceptions import SupersetMarshmallowValidationError
 from superset.utils import json
 
 get_delete_ids_schema = {"type": "array", "items": {"type": "integer"}}
 get_export_ids_schema = {"type": "array", "items": {"type": "integer"}}
+get_drill_info_schema = {
+    "type": "object",
+    "properties": {
+        "dashboard_id": {"type": "integer"},
+    },
+}
 
 openapi_spec_methods_override = {
     "get_list": {
@@ -373,3 +388,48 @@ class DatasetCacheWarmUpResponseSchema(Schema):
             "description": "A list of each chart's warmup status and errors if any"
         },
     )
+
+
+class DatasetColumnDrillInfo(Schema):
+    column_name = fields.String(required=True)
+    verbose_name = fields.String(required=False)
+
+
+class UserSchema(Schema):
+    first_name = fields.String()
+    last_name = fields.String()
+
+
+class DatasetDrillInfo(Schema):
+    id = fields.Integer()
+    columns = fields.List(fields.Nested(DatasetColumnDrillInfo))
+    table_name = fields.String()
+    owners = fields.List(fields.Nested(UserSchema))
+    created_by = fields.Nested(UserSchema)
+    created_on_humanized = fields.String()
+    changed_by = fields.Nested(UserSchema)
+    changed_on_humanized = fields.String()
+
+    # pylint: disable=unused-argument
+    @post_dump(pass_original=True)
+    def post_dump(
+        self, serialized: dict[str, Any], obj: SqlaTable, **kwargs: Any
+    ) -> dict[str, Any]:
+        """
+        Clear API response to avoid exposing sensitive information for embedded users,
+        and filter columns to only include those with groupby=True for drill operations.
+        """
+        dimensions = {
+            col.column_name
+            for col in getattr(obj, "columns", [])
+            if getattr(col, "groupby", False)
+        }
+        serialized["columns"] = [
+            col
+            for col in serialized.get("columns", [])
+            if col["column_name"] in dimensions
+        ]
+
+        if security_manager.is_guest_user():
+            return {"id": serialized["id"], "columns": serialized["columns"]}
+        return serialized

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -117,3 +117,4 @@ class SamplesRequestSchema(Schema):
         if "per_page" not in data:
             data["per_page"] = app.config.get("SAMPLES_ROW_LIMIT", 1000)
         return data
+    dashboard_id = fields.Integer(required=False, allow_none=True, load_default=None)

--- a/superset/views/datasource/schemas.py
+++ b/superset/views/datasource/schemas.py
@@ -103,6 +103,7 @@ class SamplesRequestSchema(Schema):
         validate=validate.Range(min=1, max=1000),
         load_default=None,
     )
+    dashboard_id = fields.Integer(required=False, allow_none=True, load_default=None)
 
     @pre_load
     def set_default_per_page(
@@ -117,4 +118,3 @@ class SamplesRequestSchema(Schema):
         if "per_page" not in data:
             data["per_page"] = app.config.get("SAMPLES_ROW_LIMIT", 1000)
         return data
-    dashboard_id = fields.Integer(required=False, allow_none=True, load_default=None)

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -25,7 +25,7 @@ from flask_babel import _
 from marshmallow import ValidationError
 from sqlalchemy.exc import NoResultFound, NoSuchTableError
 
-from superset import db, event_logger, feature_flag_manager, security_manager
+from superset import db, event_logger, security_manager
 from superset.commands.dataset.exceptions import (
     DatasetForbiddenError,
     DatasetNotFoundError,
@@ -33,6 +33,8 @@ from superset.commands.dataset.exceptions import (
 from superset.commands.utils import populate_owner_list
 from superset.connectors.sqla.models import SqlaTable
 from superset.connectors.sqla.utils import get_physical_table_metadata
+from superset.daos.dashboard import DashboardDAO
+from superset.daos.dataset import DatasetDAO
 from superset.daos.datasource import DatasourceDAO
 from superset.exceptions import SupersetException, SupersetSecurityException
 from superset.models.core import Database
@@ -194,18 +196,28 @@ class Datasource(BaseSupersetView):
     @api
     @handle_api_exception
     def samples(self) -> FlaskResponse:
-        if (
-            security_manager.is_guest_user()
-            and not feature_flag_manager.is_feature_enabled("DRILLING_IN_EMBEDDED")
-        ):
-            return json_error_response(
-                _("Drill by is not available for embedded users"), status=403
-            )
         try:
             params = SamplesRequestSchema().load(request.args)
             payload = SamplesPayloadSchema().load(request.json)
         except ValidationError as err:
             return json_error_response(err.messages, status=400)
+
+        if security_manager.is_guest_user():
+            if not params["dashboard_id"]:
+                return json_error_response(_("Forbidden"), status=403)
+            dataset = DatasetDAO.find_by_id(
+                params["datasource_id"], skip_base_filter=True
+            )
+            dashboard = DashboardDAO.find_by_id(
+                params["dashboard_id"], skip_base_filter=True
+            )
+            if not (dashboard and dataset):
+                return self.response_404()
+            if not security_manager.can_drill_dataset_via_dashboard_access(
+                dataset,
+                dashboard,
+            ):
+                return json_error_response(_("Forbidden"), status=403)
 
         rv = get_samples(
             datasource_type=params["datasource_type"],

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -973,9 +973,9 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         assert list(result["data"][0].keys()) == ["name", "num divide by 10"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    def test_drill_by_allowed_column_regular_user(self):
+    def test_drill_by_allowed_column(self):
         """
-        Chart data API: Test that regular user can drill by column with
+        Chart data API: Test that user can drill by column with
         isDimension set to True
         """
         self.query_context_payload["queries"][0]["columns"] = ["name"]
@@ -985,41 +985,23 @@ class TestPostChartDataApi(BaseTestChartDataApi):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_drill_by_disallowed_column_regular_user(self):
         """
-        Chart data API: Test that regular user can't drill by column with
-        isDimension set to False
+        Chart data API: Test that user can still drill by column with
+        isDimension set to False (given the dataset access)
         """
         self.query_context_payload["queries"][0]["columns"] = ["num_girls"]
         rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
-        assert rv.status_code == 403
+        assert rv.status_code == 200
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
     @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
-    @with_feature_flags(D2D_IN_EMBEDDED=False)
-    def test_embedded_user_drill_by_disabled_ff(
-        self, mock_is_guest_user, mock_has_guest_access
-    ):
-        """
-        Chart data API: Test that embedded user cannot drill when
-        DRILLING_IN_EMBEDDED FF is disabled
-        """
-        g.user.rls = []
-        mock_has_guest_access.return_value = True
-        mock_is_guest_user.return_value = True
-        self.query_context_payload["queries"][0]["columns"] = ["name"]
-        rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
-        assert rv.status_code == 403
-
-    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
-    @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
-    @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
-    @with_feature_flags(D2D_IN_EMBEDDED=True)
-    def test_embedded_user_drill_by_enabled_ff_allowed_column(
+    @with_feature_flags(EMBEDDED_SUPERSET=True)
+    def test_embedded_user_drill_by_allowed_column(
         self, mock_is_guest_user, mock_has_guest_access
     ):
         """
         Chart data API: Test that embedded user can drill by column with
-        isDimension set to True when DRILLING_IN_EMBEDDED FF is enabled
+        isDimension set to True.
         """
         g.user.rls = []
         mock_has_guest_access.return_value = True
@@ -1031,13 +1013,13 @@ class TestPostChartDataApi(BaseTestChartDataApi):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
     @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
-    @with_feature_flags(D2D_IN_EMBEDDED=True)
-    def test_embedded_user_drill_by_enabled_ff_disallowed_column(
+    @with_feature_flags(EMBEDDED_SUPERSET=True)
+    def test_embedded_user_drill_by_disallowed_column(
         self, mock_is_guest_user, mock_has_guest_access
     ):
         """
         Chart data API: Test that embedded user can't drill by column with
-        isDimension set to False and DRILLING_IN_EMBEDDED FF is enabled
+        isDimension set to False.
         """
         g.user.rls = []
         mock_has_guest_access.return_value = True

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3253,7 +3253,7 @@ class TestDatasetApi(SupersetTestCase):
             uri = f"api/v1/dataset/{dataset.id}/drill_info/"
             rv = self.client.get(uri)
 
-            assert rv.status_code == 404
+            assert rv.status_code == 403
 
         self.items_to_delete = [dashboard, chart, dataset]
 

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3341,6 +3341,7 @@ class TestDatasetApi(SupersetTestCase):
                 published=True,
             )
 
+            self.logout()
             self.login(test_user.username)
 
             uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dash.id})"
@@ -3395,6 +3396,8 @@ class TestDatasetApi(SupersetTestCase):
                 roles=user_role_ids,
                 published=True,
             )
+
+            self.logout()
             self.login(test_user.username)
 
             uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dash.id})"
@@ -3479,6 +3482,7 @@ class TestDatasetApi(SupersetTestCase):
                 published=True,
             )
 
+            self.logout()
             self.login(test_user.username)
 
             uri = f"api/v1/dataset/{dataset.id}/drill_info/"

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3455,7 +3455,6 @@ class TestDatasetApi(SupersetTestCase):
         """
         with self.temporary_user(
             clone_user=security_manager.find_user(username=GAMMA_USERNAME),
-            extra_pvms=[("can_get_drill_info", "Dataset")],
         ) as test_user:
             self.login(ADMIN_USERNAME)
             user_role_ids = [role.id for role in test_user.roles]

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3094,7 +3094,7 @@ class TestDatasetApi(SupersetTestCase):
 
         # Log in as admin but remove pvm access
         with self.temporary_user(
-            clone_user=security_manager.find_user(username=ADMIN_USERNAME),
+            clone_user=security_manager.find_user(username=ALPHA_USERNAME),
             pvms_to_remove=[("can_get_drill_info", "Dataset")],
             login=True,
         ):

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -84,16 +84,21 @@ class TestDatasetApi(SupersetTestCase):
     def insert_dataset(
         table_name: str,
         owners: list[int],
-        database: Database,
+        database: Database | None = None,
         sql: str | None = None,
         schema: str | None = None,
         catalog: str | None = None,
         fetch_metadata: bool = True,
+        columns: list[TableColumn] | None = None,
+        metrics: list[SqlMetric] | None = None,
+        extra: str | None = None,
     ) -> SqlaTable:
         obj_owners = list()  # noqa: C408
         for owner in owners:
             user = db.session.query(security_manager.user_model).get(owner)
             obj_owners.append(user)
+        database = database or get_example_database()
+        schema = schema or get_example_default_schema()
         table = SqlaTable(
             table_name=table_name,
             schema=schema,
@@ -101,12 +106,35 @@ class TestDatasetApi(SupersetTestCase):
             database=database,
             sql=sql,
             catalog=catalog,
+            extra=extra,
         )
+        if columns:
+            table.columns = columns
+        if metrics:
+            table.metrics = metrics
         db.session.add(table)
         db.session.commit()
         if fetch_metadata:
             table.fetch_metadata()
         return table
+
+    @staticmethod
+    def insert_chart(
+        chart_title: str,
+        dataset_id: int,
+        viz_type: str = "bar",
+        params: str = "{}",
+    ) -> Slice:
+        chart = Slice(
+            slice_name=chart_title,
+            datasource_id=dataset_id,
+            datasource_type="table",
+            viz_type=viz_type,
+            params=params,
+        )
+        db.session.add(chart)
+        db.session.commit()
+        return chart
 
     def insert_default_dataset(self):
         return self.insert_dataset(
@@ -177,6 +205,24 @@ class TestDatasetApi(SupersetTestCase):
                 if not state.was_deleted:
                     db.session.delete(dataset)
             db.session.commit()
+
+    @pytest.fixture
+    def gamma_role_with_drill_perm(self):
+        """
+        Add `can_get_drill_info` permission to Gamma role.
+
+        We're using the Gamma role for these tests to simulate the embedded role.
+        """
+        with self.create_app().app_context():
+            drill_info_perm = security_manager.add_permission_view_menu(
+                "can_get_drill_info", "Dataset"
+            )
+            gamma_role = security_manager.find_role("Gamma")
+            security_manager.add_permission_role(gamma_role, drill_info_perm)
+
+            yield gamma_role
+
+            security_manager.del_permission_role(gamma_role, drill_info_perm)
 
     @staticmethod
     def get_energy_usage_dataset():
@@ -421,12 +467,11 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test get dataset with the render parameter.
         """
-        database = get_example_database()
-        dataset = SqlaTable(
+        dataset = self.insert_dataset(
             table_name="test_sql_table_with_jinja",
-            database=database,
-            schema=get_example_default_schema(),
-            main_dttm_col="default_dttm",
+            owners=[],
+            sql="SELECT {{ current_user_id() }} as my_user_id",
+            fetch_metadata=False,
             columns=[
                 TableColumn(
                     column_name="my_user_id",
@@ -446,10 +491,7 @@ class TestDatasetApi(SupersetTestCase):
                     expression="{{ url_param('multiplier') }} * 1.4",
                 )
             ],
-            sql="SELECT {{ current_user_id() }} as my_user_id",
         )
-        db.session.add(dataset)
-        db.session.commit()
 
         self.login(ADMIN_USERNAME)
         admin = self.get_user(ADMIN_USERNAME)
@@ -493,12 +535,11 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test get dataset with the render parameter
         when rendering raises an exception.
         """
-        database = get_example_database()
-        dataset = SqlaTable(
+        dataset = self.insert_dataset(
             table_name="test_sql_table_with_incorrect_jinja",
-            database=database,
-            schema=get_example_default_schema(),
-            main_dttm_col="default_dttm",
+            owners=[],
+            sql="SELECT {{ current_user_id() } as my_user_id",
+            fetch_metadata=False,
             columns=[
                 TableColumn(
                     column_name="my_user_id",
@@ -518,10 +559,7 @@ class TestDatasetApi(SupersetTestCase):
                     expression="{{ url_param('multiplier') } * 1.4",
                 )
             ],
-            sql="SELECT {{ current_user_id() } as my_user_id",
         )
-        db.session.add(dataset)
-        db.session.commit()
 
         self.login(ADMIN_USERNAME)
 
@@ -679,6 +717,7 @@ class TestDatasetApi(SupersetTestCase):
             "can_duplicate",
             "can_get_or_create_dataset",
             "can_warm_up_cache",
+            "can_get_drill_info",
         }
 
     def test_create_dataset_item(self):
@@ -2716,17 +2755,12 @@ class TestDatasetApi(SupersetTestCase):
         """
         Dataset API: Test custom dataset_is_certified filter
         """
-
-        table_w_certification = SqlaTable(
+        table_w_certification = self.insert_dataset(
             table_name="foo",
-            schema=None,
             owners=[],
-            database=get_main_database(),
-            sql=None,
+            fetch_metadata=False,
             extra='{"certification": 1}',
         )
-        db.session.add(table_w_certification)
-        db.session.commit()
 
         arguments = {
             "filters": [{"col": "id", "opr": "dataset_is_certified", "value": True}]
@@ -2999,3 +3033,353 @@ class TestDatasetApi(SupersetTestCase):
         assert data == {
             "message": "The provided table was not found in the provided database"
         }
+
+    def test_get_drill_info_admin_user(self):
+        """
+        Dataset API: Test drill_info endpoint returns metadata for admin users, even
+        without a dashboard param.
+        """
+        self.login(ADMIN_USERNAME)
+        dataset = self.insert_dataset(
+            table_name="test_drill_dataset",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="category",
+                    type="VARCHAR(255)",
+                    verbose_name="Category Column",
+                    groupby=True,
+                ),
+                TableColumn(
+                    column_name="region",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+                TableColumn(
+                    column_name="value",
+                    type="VARCHAR(255)",
+                    groupby=False,
+                ),
+                TableColumn(
+                    column_name="description",
+                    type="VARCHAR(255)",
+                    groupby=False,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+
+        # Test the drill_info endpoint
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/"
+        rv = self.get_assert_metric(uri, "get_drill_info")
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+
+        # Verify admin gets full dataset metadata
+        assert "created_by" in result
+        assert "created_on_humanized" in result
+        assert "changed_by" in result
+        assert "changed_on_humanized" in result
+        assert result["id"] == dataset.id
+        assert result["table_name"] == "test_drill_dataset"
+        assert result["owners"] == []
+        assert len(result["columns"]) == 2
+        assert result["columns"] == [
+            {"column_name": "category", "verbose_name": "Category Column"},
+            {"column_name": "region", "verbose_name": None},
+        ]
+
+        self.items_to_delete = [dataset]
+
+    def test_get_drill_info_dataset_not_found(self):
+        """
+        Dataset API: Test drill_info endpoint returns 404 for non-existent dataset
+        """
+        self.login(ADMIN_USERNAME)
+        uri = "api/v1/dataset/99999/drill_info/"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 404
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @with_feature_flags(EMBEDDED_SUPERSET=True, DRILLING_IN_EMBEDDED=False)
+    def test_get_drill_info_embedded_user_feature_disabled(
+        self, mock_is_guest_user, mock_has_guest_access
+    ):
+        """
+        Dataset API: Test drill_info endpoint returns 403 for embedded users when
+        FF is disabled.
+        """
+        # Log the user as Gamma but mock ``is_guest_user``
+        self.login(GAMMA_USERNAME)
+        mock_is_guest_user.return_value = True
+        mock_has_guest_access.return_value = True
+
+        dataset = self.insert_dataset(table_name="foo", owners=[], fetch_metadata=False)
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 403
+
+        self.items_to_delete = [dataset]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @with_feature_flags(EMBEDDED_SUPERSET=True, DRILLING_IN_EMBEDDED=True)
+    def test_get_drill_info_embedded_user_with_dashboard_id(
+        self, mock_is_guest_user, mock_has_guest_access
+    ):
+        """
+        Dataset API: Test drill_info endpoint with dashboard ID parameter for
+        embedded users.
+        """
+        # Log the user as Gamma but mock ``is_guest_user``
+        self.login(GAMMA_USERNAME)
+        mock_is_guest_user.return_value = True
+        mock_has_guest_access.return_value = True
+
+        dataset = self.insert_dataset(
+            table_name="test_embedded_dataset",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="category",
+                    type="VARCHAR(255)",
+                    verbose_name="Category Column",
+                    groupby=True,
+                ),
+                TableColumn(
+                    column_name="region",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+
+        chart = self.insert_chart("Test Embedded Chart", dataset.id)
+        dashboard = self.insert_dashboard(
+            "Embedded Test Dashboard", "embedded-test-dashboard", [], slices=[chart]
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dashboard.id})"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+        assert result == {
+            "id": dataset.id,
+            "columns": [
+                {"column_name": "category", "verbose_name": "Category Column"},
+                {"column_name": "region", "verbose_name": None},
+            ],
+        }
+
+        self.items_to_delete = [dataset, dashboard, chart]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @with_feature_flags(EMBEDDED_SUPERSET=True, DRILLING_IN_EMBEDDED=True)
+    def test_get_drill_info_embedded_user_without_dashboard_parameter(
+        self, mock_is_guest_user, mock_has_guest_access
+    ):
+        """
+        Dataset API: Test drill_info endpoint without dashboard ID parameter
+        for embedded users.
+        """
+        # Log the user as Gamma but mock ``is_guest_user``
+        self.login(GAMMA_USERNAME)
+        mock_is_guest_user.return_value = True
+        mock_has_guest_access.return_value = True
+
+        dataset = self.insert_dataset(
+            table_name="test_no_dashboard_param",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="category",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 404
+
+        self.items_to_delete = [dataset]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @with_feature_flags(EMBEDDED_SUPERSET=True, DRILLING_IN_EMBEDDED=True)
+    def test_get_drill_info_embedded_user_dashboard_without_dataset(
+        self, mock_is_guest_user, mock_has_guest_access
+    ):
+        """
+        Dataset API: Test drill_info with dashboard ID that user has access to but
+        does not contain the dataset.
+        """
+        # Log the user as Gamma but mock ``is_guest_user``
+        self.login(GAMMA_USERNAME)
+        mock_is_guest_user.return_value = True
+        mock_has_guest_access.return_value = True
+
+        dataset = self.insert_dataset(
+            table_name="test_d2d_table",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="category",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+        dashboard_dataset = self.insert_dataset(
+            table_name="test_dashboard_dataset",
+            owners=[],
+            fetch_metadata=False,
+        )
+        chart = self.insert_chart("Dashboard Chart", dashboard_dataset.id)
+        dashboard = self.insert_dashboard(
+            "Dashboard Without Test Dataset",
+            "dashboard-without-test-dataset",
+            [],
+            slices=[chart],
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dashboard.id})"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 404
+
+        self.items_to_delete = [dataset, dashboard_dataset, dashboard, chart]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @with_feature_flags(DASHBOARD_RBAC=True)
+    def test_get_drill_info_dashboard_rbac_access_granted(self):
+        """
+        Dataset API: Test drill_info with dashboard parameter when user has access
+        via the DASHBOARD_RBAC FF.
+        """
+        self.login(GAMMA_USERNAME)
+        gamma_role = security_manager.find_role("Gamma")
+
+        dataset = self.insert_dataset(
+            table_name="test_rbac_dataset",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="restricted_column",
+                    type="VARCHAR(255)",
+                    verbose_name="Restricted Column",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+        chart = self.insert_chart("Test RBAC Chart", dataset.id)
+        dashboard = self.insert_dashboard(
+            "RBAC Test Dashboard",
+            "rbac-test-dashboard",
+            [],
+            roles=[gamma_role.id],
+            slices=[chart],
+            published=True,
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dashboard.id})"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 200
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+
+        assert "created_by" in result
+        assert "created_on_humanized" in result
+        assert "changed_by" in result
+        assert "changed_on_humanized" in result
+        assert result["id"] == dataset.id
+        assert result["table_name"] == "test_rbac_dataset"
+        assert len(result["columns"]) == 1
+        assert result["columns"][0]["column_name"] == "restricted_column"
+
+        self.items_to_delete = [dashboard, chart, dataset]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @with_feature_flags(DASHBOARD_RBAC=True)
+    def test_get_drill_info_dashboard_rbac_access_denied(self):
+        """
+        Dataset API: Test drill_info with dashboard parameter when user has
+        no access via the DASHBOARD_RBAC FF.
+        """
+        self.login(GAMMA_USERNAME)
+
+        dataset = self.insert_dataset(
+            table_name="test_rbac_dataset_denied",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="restricted_column",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+        chart = self.insert_chart("Test RBAC Chart second", dataset.id)
+        dashboard = self.insert_dashboard(
+            "RBAC Test Dashboard 2",
+            "rbac-test-dashboard-2",
+            [],
+            slices=[chart],
+            published=True,
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/?q=(dashboard_id:{dashboard.id})"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 404
+
+        self.items_to_delete = [dashboard, chart, dataset]
+
+    @pytest.mark.usefixtures("gamma_role_with_drill_perm")
+    @with_feature_flags(DASHBOARD_RBAC=True)
+    def test_get_drill_info_dashboard_rbac_no_dashboard_id(self):
+        """
+        Dataset API: Test drill_info without dashboard ID parameter falls back
+        to regular access control.
+        """
+        self.login(GAMMA_USERNAME)
+
+        dataset = self.insert_dataset(
+            table_name="test_no_dashboard_id",
+            owners=[],
+            columns=[
+                TableColumn(
+                    column_name="restricted_column",
+                    type="VARCHAR(255)",
+                    groupby=True,
+                ),
+            ],
+            fetch_metadata=False,
+        )
+
+        uri = f"api/v1/dataset/{dataset.id}/drill_info/"
+        rv = self.client.get(uri)
+
+        assert rv.status_code == 404
+
+        self.items_to_delete = [dataset]

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3092,7 +3092,7 @@ class TestDatasetApi(SupersetTestCase):
         """
         dataset = self.insert_dataset(table_name="foo", owners=[], fetch_metadata=False)
 
-        # Log in as admin but remove pvm access
+        # Log in as alpha for dataset access but remove pvm access
         with self.temporary_user(
             clone_user=security_manager.find_user(username=ALPHA_USERNAME),
             pvms_to_remove=[("can_get_drill_info", "Dataset")],

--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -525,13 +525,17 @@ class TestDatasource(SupersetTestCase):
         "superset.security.manager.SupersetSecurityManager.get_guest_rls_filters"
     )
     @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
     @with_feature_flags(EMBEDDED_SUPERSET=True)
-    def test_get_samples_embedded_user(self, mock_is_guest_user, mock_rls):
+    def test_get_samples_embedded_user(
+        self, mock_has_guest_access, mock_is_guest_user, mock_rls
+    ):
         """
         Embedded user can access the /samples view.
         """
-        self.login(GAMMA_USERNAME)
+        self.login(ADMIN_USERNAME)
         mock_is_guest_user.return_value = True
+        mock_has_guest_access.return_value = True
         mock_rls.return_value = []
         tbl = self.get_table(name="birth_names")
         dash = self.get_dash_by_slug("births")


### PR DESCRIPTION
### SUMMARY
This PR exposes drilling capabilities to embedded users. Highlights:

**New API endpoint**
A new API endpoint was created for drilling: `/api/v1/dataset/{{pk}}/drill_info/`. Previously, the drilling context (columns to drill, dataset info to display in the `useDatasetMetadataBar` etc) were loaded from `/api/v1/dataset/{{pk}}`. Exposing this entire endpoint to embedded users is not ideal, as it exposes a lot of metadata.

**Server-side validations**
* Previously, the backend would return all dataset columns, and then the client would filter out columns that have `groupby=False`. This would allow embedded users to find out names of other columns that should not be exposed, so the list of columns is now filtered in the backend. 
* Specifically for embedded users, there's also server-side validation to prevent a user to manipulate the API call and drill by a column that has `groupby=False`.
* Implemented additional validation to make sure that embedded users can only drill datasets that are associated with a dashboard they have access to.

**Bonus**
* This PR also **_partially_** fixes drilling for `DASHBOARD_RBAC`. Full fix might require migrating `/datasource/samples` to `/api/v1/`.
* Improves performance by reducing repetitive calls. The call to load the drill context was moved up to `ChartContextMenu` and it's passed to `DrillDetail`, `DrillBy` and `useDatasetMetadataBar`.
* The new API endpoint relies on FAB's `select_columns`, to filter the returned columns at the SQL query level (not at the response level) which also improves performance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Embedded experience**

https://github.com/user-attachments/assets/d858d6d9-ebbd-45a0-b977-8cfc28de03d3

Highlights:
- API response just includes the list of columns and dataset ID.
- The metadata bar is not exposed to avoid sharing additional context about the underlying data.

**Non-embedded experience**

https://github.com/user-attachments/assets/23948631-1434-4886-b517-4a6edc1fd627

Highlights:
- New endpoint to expose drill-related info.
- Less API calls to load data.

### TESTING INSTRUCTIONS
Test coverage added. For manual testing:
1. Make sure the embedded role has the required permissions to perform drilling operations.
2. Load a dashboard in embedded mode.
3. Validate the right-click menu on a chart exposes the drilling options.
4. Confirm the dialogs don't expose additional information or not useful buttons.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
