### PR TITLE
fix(theming): Superset default theme Fallback

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/types.ts
@@ -419,4 +419,5 @@ export interface ThemeContextType {
   setTheme: (config: AnyThemeConfig) => void;
   setThemeMode: (newMode: ThemeMode) => void;
   resetTheme: () => void;
+  canSetThemeMode: () => boolean;
 }

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -53,7 +53,6 @@ export enum FeatureFlag {
   SqlValidatorsByEngine = 'SQL_VALIDATORS_BY_ENGINE',
   SshTunneling = 'SSH_TUNNELING',
   TaggingSystem = 'TAGGING_SYSTEM',
-  ThemeEnableDarkThemeSwitch = 'THEME_ENABLE_DARK_THEME_SWITCH',
   ThemeAllowThemeEditorBeta = 'THEME_ALLOW_THEME_EDITOR_BETA',
   Thumbnails = 'THUMBNAILS',
   UseAnalogousColors = 'USE_ANALOGOUS_COLORS',

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -189,6 +189,7 @@ const RightMenu = ({
     setTheme,
     setThemeMode,
     themeMode,
+    canSetThemeMode,
   } = useThemeContext();
   const dropdownItems: MenuObjectProps[] = [
     {
@@ -499,7 +500,7 @@ const RightMenu = ({
             <ThemeEditor theme={themeEditorTheme} setTheme={setTheme} />
           </span>
         )}
-        {isFeatureEnabled(FeatureFlag.ThemeEnableDarkThemeSwitch) && (
+        {canSetThemeMode() && (
           <span>
             <ThemeSelect setThemeMode={setThemeMode} themeMode={themeMode} />
           </span>

--- a/superset-frontend/src/theme/ThemeProvider.tsx
+++ b/superset-frontend/src/theme/ThemeProvider.tsx
@@ -71,6 +71,11 @@ export function SupersetThemeProvider({
     [themeController],
   );
 
+  const canSetThemeMode = useCallback(
+    () => themeController.canSetThemeMode(),
+    [themeController],
+  );
+
   const contextValue = useMemo(
     () => ({
       theme: currentTheme,
@@ -78,8 +83,16 @@ export function SupersetThemeProvider({
       setTheme,
       setThemeMode,
       resetTheme,
+      canSetThemeMode,
     }),
-    [currentTheme, currentThemeMode, setTheme, setThemeMode, resetTheme],
+    [
+      currentTheme,
+      currentThemeMode,
+      setTheme,
+      setThemeMode,
+      resetTheme,
+      canSetThemeMode,
+    ],
   );
 
   return (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a critical issue where users providing partial Bootstrap theme configurations (e.g., only THEME_DEFAULT defined with empty THEME_DARK) couldn't switch to dark mode (nothing got changed since it wasn't a `THEME_DARK` been set. The solution was to implement a fallback logic that uses Superset's built-in themes with proper Ant Design algorithms when Bootstrap themes are incomplete or missing.

Also I've replaced the `THEME_ENABLE_DARK_THEME_SWITCH` feature flag to start using the `THEME_SETTINGS` approach.

  Changes:
  - Replaced `THEME_ENABLE_DARK_THEME_SWITCH` feature flag with `THEME_SETTINGS.allowSwitching`
  - Updated `RightMenu.tsx` to use theme context's `canSetThemeMode()` instead of feature flag checks
  - Added `canSetThemeMode()` method to theme context interface

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Go to `superset/config.py` and only define a `THEME_DEFAULT`.
E.g.:
```
THEME_DEFAULT: Theme = {"token": {"brandLogoUrl": "https://picsum.photos/200"}}
```
2. Since the default for `THEME_SETTINGS.allowSwitching` is `true` if no theme settings are defined
3. Reload the UI and change the theme mode to dark mode
4. You should see how the UI defaults to the superset dark mode theme since we didn't pass a `THEME_DARK` from configs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
