### PR TITLE
fix(sqllab): query deletion not updating UI in query history

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -38,6 +38,7 @@ import {
 import { LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY } from 'src/logger/LogUtils';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { logEvent } from 'src/logger/actions';
+import { api } from 'src/hooks/apiResources/queryApi';
 import { newQueryTabName } from '../utils/newQueryTabName';
 import getInitialState from '../reducers/getInitialState';
 import { rehydratePersistedState } from '../utils/reduxStateToLocalStorageHelper';
@@ -765,7 +766,11 @@ export function removeQuery(query) {
       : Promise.resolve();
 
     return sync
-      .then(() => dispatch({ type: REMOVE_QUERY, query }))
+      .then(() => {
+        dispatch({ type: REMOVE_QUERY, query });
+        // Invalidate RTK Query cache to update the UI
+        dispatch(api.util.invalidateTags(['EditorQueries']));
+      })
       .catch(() =>
         dispatch(
           addDangerToast(


### PR DESCRIPTION
The delete API call succeeded but the RTK Query cache wasn't invalidated, causing deleted queries to remain visible until page refresh. Added cache invalidation to immediately update the UI.

Also fixing various issues in `Query History`, ordering was wrong, failed status wasn't reported properly, ...

----
Actually deadended here, will require more time/attention to fix