### PR TITLE
fix: subquery alias in RLS

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1851,7 +1851,7 @@ FROM (
   FROM some_table
   WHERE
     id = 42
-) AS some_table
+) AS "some_table"
 WHERE
   1 = 1
             """.strip(),
@@ -1868,7 +1868,7 @@ FROM (
   FROM table
   WHERE
     id = 42
-) AS table
+) AS "table"
 WHERE
   1 = 1
             """.strip(),
@@ -1925,7 +1925,7 @@ JOIN (
   FROM other_table
   WHERE
     id = 42
-) AS other_table
+) AS "other_table"
   ON table.id = other_table.id
             """.strip(),
         ),
@@ -1961,7 +1961,7 @@ FROM (
     FROM some_table
     WHERE
       id = 42
-  ) AS some_table
+  ) AS "some_table"
 )
             """.strip(),
         ),
@@ -1977,7 +1977,7 @@ FROM (
   FROM table
   WHERE
     id = 42
-) AS table
+) AS "table"
 UNION ALL
 SELECT
   *
@@ -2000,7 +2000,7 @@ FROM (
   FROM other_table
   WHERE
     id = 42
-) AS other_table
+) AS "other_table"
             """.strip(),
         ),
         (
@@ -2038,6 +2038,22 @@ FROM (
 INNER JOIN tbl_b AS b
   ON a.col = b.col
             """.strip(),
+        ),
+        (
+            "SELECT * FROM public.flights LIMIT 100",
+            {Table("flights", "public", "catalog1"): "\"AIRLINE\" like 'A%'"},
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM public.flights
+  WHERE
+    "AIRLINE" LIKE 'A%'
+) AS "public.flights"
+LIMIT 100
+        """.strip(),
         ),
     ],
 )

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -259,13 +259,13 @@ FROM (
   FROM t1
   WHERE
     c1 = 1
-) AS t1, (
+) AS "t1", (
   SELECT
     *
   FROM t2
   WHERE
     c2 = 2
-) AS t2
+) AS "t2"
         """.strip()
     )
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix an issue with RLS when the dataset is fully qualified, where a query like this:

```sql
SELECT * FROM public.flights LIMIT 100;
```

Would get transformed incorrectly to:

```sql
SELECT
  *
FROM (
  SELECT
    *
  FROM public.flights
  WHERE
    "AIRLINE" LIKE 'A%'
) AS public.flights  -- NOT A THING, NEEDS QUOTES!
LIMIT 100
```

Fixes https://github.com/apache/superset/issues/32564.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit test covering the regression.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
