### PR TITLE
fix: rate limiting issues with example data hosted on github.com

### DIFF
--- a/superset/commands/dataset/importers/v1/utils.py
+++ b/superset/commands/dataset/importers/v1/utils.py
@@ -199,6 +199,11 @@ def load_data(data_uri: str, dataset: SqlaTable, database: Database) -> None:
     :raises DatasetUnAllowedDataURI: If a dataset is trying
     to load data from a URI that is not allowed.
     """
+    from superset.examples.helpers import normalize_example_data_url
+
+    # Convert example URLs to align with configuration
+    data_uri = normalize_example_data_url(data_uri)
+
     validate_data_uri(data_uri)
     logger.info("Downloading data from %s", data_uri)
     data = request.urlopen(data_uri)  # pylint: disable=consider-using-with  # noqa: S310

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -190,6 +190,12 @@ def load_configs(
                         db_ssh_tunnel_priv_key_passws[config["uuid"]]
                     )
 
+                # Normalize example data URLs before schema validation
+                if prefix == "datasets" and "data" in config:
+                    from superset.examples.helpers import normalize_example_data_url
+
+                    config["data"] = normalize_example_data_url(config["data"])
+
                 schema.load(config)
                 configs[file_name] = config
             except ValidationError as exc:

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -305,7 +305,7 @@ class ImportV1DatasetSchema(Schema):
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))
     version = fields.String(required=True)
     database_uuid = fields.UUID(required=True)
-    data = fields.URL(schemes={"http", "https", "ftp", "ftps", "examples"})
+    data = fields.URL()
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
     normalize_columns = fields.Boolean(load_default=False)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -305,7 +305,7 @@ class ImportV1DatasetSchema(Schema):
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))
     version = fields.String(required=True)
     database_uuid = fields.UUID(required=True)
-    data = fields.URL()
+    data = fields.URL(schemes={"http", "https", "ftp", "ftps", "examples"})
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
     normalize_columns = fields.Boolean(load_default=False)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -284,12 +284,6 @@ class ImportV1DatasetSchema(Schema):
             except ValueError:
                 data["extra"] = None
 
-        # Normalize example data URLs
-        if data.get("data") and data["data"].startswith("examples://"):
-            from superset.examples.helpers import normalize_example_data_url
-
-            data["data"] = normalize_example_data_url(data["data"])
-
         return data
 
     table_name = fields.String(required=True)

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -284,6 +284,12 @@ class ImportV1DatasetSchema(Schema):
             except ValueError:
                 data["extra"] = None
 
+        # Normalize example data URLs
+        if data.get("data") and data["data"].startswith("examples://"):
+            from superset.examples.helpers import normalize_example_data_url
+
+            data["data"] = normalize_example_data_url(data["data"])
+
         return data
 
     table_name = fields.String(required=True)

--- a/superset/examples/bart_lines.py
+++ b/superset/examples/bart_lines.py
@@ -38,7 +38,7 @@ def load_bart_lines(only_metadata: bool = False, force: bool = False) -> None:
 
         if not only_metadata and (not table_exists or force):
             df = read_example_data(
-                "bart-lines.json.gz", encoding="latin-1", compression="gzip"
+                "examples://bart-lines.json.gz", encoding="latin-1", compression="gzip"
             )
             df["path_json"] = df.path.map(json.dumps)
             df["polyline"] = df.path.map(polyline.encode)

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -57,7 +57,7 @@ def gen_filter(
 
 
 def load_data(tbl_name: str, database: Database, sample: bool = False) -> None:
-    pdf = read_example_data("birth_names2.json.gz", compression="gzip")
+    pdf = read_example_data("examples://birth_names2.json.gz", compression="gzip")
 
     # TODO(bkyryliuk): move load examples data into the pytest fixture
     if database.backend == "presto":
@@ -584,8 +584,8 @@ def create_dashboard(slices: list[Slice]) -> Dashboard:
         }
     }"""
     )
-    # pylint: disable=echarts_timeseries_line-too-long
-    pos = json.loads(
+    # pylint: disable=line-too-long
+    pos = json.loads(  # noqa: TID251
         textwrap.dedent(
             """\
         {
@@ -859,11 +859,11 @@ def create_dashboard(slices: list[Slice]) -> Dashboard:
         """  # noqa: E501
         )
     )
-    # pylint: enable=echarts_timeseries_line-too-long
+    # pylint: enable=line-too-long
     # dashboard v2 doesn't allow add markup slice
     dash.slices = [slc for slc in slices if slc.viz_type != "markup"]
     update_slice_ids(pos)
     dash.dashboard_title = "USA Births Names"
-    dash.position_json = json.dumps(pos, indent=4)
+    dash.position_json = json.dumps(pos, indent=4)  # noqa: TID251
     dash.slug = "births"
     return dash

--- a/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
+++ b/superset/examples/configs/datasets/examples/FCC_2018_Survey.yaml
@@ -1490,4 +1490,4 @@ columns:
     python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://github.com/apache-superset/examples-data/raw/master/datasets/examples/fcc_survey_2018.csv.gz
+data: examples://datasets/examples/fcc_survey_2018.csv.gz

--- a/superset/examples/configs/datasets/examples/channel_members.yaml
+++ b/superset/examples/configs/datasets/examples/channel_members.yaml
@@ -60,4 +60,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/channel_members.csv
+data: examples://datasets/examples/slack/channel_members.csv

--- a/superset/examples/configs/datasets/examples/channels.yaml
+++ b/superset/examples/configs/datasets/examples/channels.yaml
@@ -360,4 +360,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/channels.csv
+data: examples://datasets/examples/slack/channels.csv

--- a/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
+++ b/superset/examples/configs/datasets/examples/cleaned_sales_data.yaml
@@ -344,4 +344,4 @@ columns:
   extra: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/lowercase_columns_examples/datasets/examples/sales.csv
+data: examples://datasets/examples/sales.csv

--- a/superset/examples/configs/datasets/examples/covid_vaccines.yaml
+++ b/superset/examples/configs/datasets/examples/covid_vaccines.yaml
@@ -204,4 +204,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/lowercase_columns_examples/datasets/examples/covid_vaccines.csv
+data: examples://datasets/examples/covid_vaccines.csv

--- a/superset/examples/configs/datasets/examples/exported_stats.yaml
+++ b/superset/examples/configs/datasets/examples/exported_stats.yaml
@@ -260,4 +260,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/exported_stats.csv
+data: examples://datasets/examples/slack/exported_stats.csv

--- a/superset/examples/configs/datasets/examples/messages.yaml
+++ b/superset/examples/configs/datasets/examples/messages.yaml
@@ -480,4 +480,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/messages.csv
+data: examples://datasets/examples/slack/messages.csv

--- a/superset/examples/configs/datasets/examples/threads.yaml
+++ b/superset/examples/configs/datasets/examples/threads.yaml
@@ -180,4 +180,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/threads.csv
+data: examples://datasets/examples/slack/threads.csv

--- a/superset/examples/configs/datasets/examples/unicode_test.test.yaml
+++ b/superset/examples/configs/datasets/examples/unicode_test.test.yaml
@@ -90,4 +90,4 @@ columns:
   python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/unicode_test.csv
+data: examples://datasets/examples/unicode_test.csv

--- a/superset/examples/configs/datasets/examples/users.yaml
+++ b/superset/examples/configs/datasets/examples/users.yaml
@@ -220,4 +220,4 @@ columns:
     python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/users.csv
+data: examples://datasets/examples/slack/users.csv

--- a/superset/examples/configs/datasets/examples/users_channels.yaml
+++ b/superset/examples/configs/datasets/examples/users_channels.yaml
@@ -60,4 +60,4 @@ columns:
     python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://raw.githubusercontent.com/apache-superset/examples-data/master/datasets/examples/slack/users_channels.csv
+data: examples://datasets/examples/slack/users_channels.csv

--- a/superset/examples/configs/datasets/examples/video_game_sales.yaml
+++ b/superset/examples/configs/datasets/examples/video_game_sales.yaml
@@ -153,4 +153,4 @@ columns:
     python_date_format: null
 version: 1.0.0
 database_uuid: a2dc77af-e654-49bb-b321-40f6b559a1ee
-data: https://github.com/apache-superset/examples-data/raw/lowercase_columns_examples/datasets/examples/video_game_sales.csv
+data: examples://datasets/examples/video_game_sales.csv

--- a/superset/examples/country_map.py
+++ b/superset/examples/country_map.py
@@ -49,7 +49,7 @@ def load_country_map_data(only_metadata: bool = False, force: bool = False) -> N
 
         if not only_metadata and (not table_exists or force):
             data = read_example_data(
-                "birth_france_data_for_country_map.csv", encoding="utf-8"
+                "examples://birth_france_data_for_country_map.csv", encoding="utf-8"
             )
             data["dttm"] = datetime.datetime.now().date()
             data.to_sql(

--- a/superset/examples/energy.py
+++ b/superset/examples/energy.py
@@ -50,7 +50,7 @@ def load_energy(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_data("energy.json.gz", compression="gzip")
+            pdf = read_example_data("examples://energy.json.gz", compression="gzip")
             pdf = pdf.head(100) if sample else pdf
             pdf.to_sql(
                 tbl_name,

--- a/superset/examples/flights.py
+++ b/superset/examples/flights.py
@@ -38,12 +38,12 @@ def load_flights(only_metadata: bool = False, force: bool = False) -> None:
 
         if not only_metadata and (not table_exists or force):
             pdf = read_example_data(
-                "flight_data.csv.gz", encoding="latin-1", compression="gzip"
+                "examples://flight_data.csv.gz", encoding="latin-1", compression="gzip"
             )
 
             # Loading airports info to join and get lat/long
             airports = read_example_data(
-                "airports.csv.gz", encoding="latin-1", compression="gzip"
+                "examples://airports.csv.gz", encoding="latin-1", compression="gzip"
             )
             airports = airports.set_index("IATA_CODE")
 

--- a/superset/examples/helpers.py
+++ b/superset/examples/helpers.py
@@ -125,6 +125,20 @@ def get_example_url(filepath: str) -> str:
     return f"{BASE_URL}{filepath}"
 
 
+def normalize_example_data_url(url: str) -> str:
+    """Convert example data URLs to use the configured CDN.
+
+    Transforms examples:// URLs to the configured CDN URL.
+    Non-example URLs are returned unchanged.
+    """
+    if url.startswith("examples://"):
+        relative_path = url[11:]  # Remove 'examples://'
+        return get_example_url(relative_path)
+
+    # Not an examples URL, return unchanged
+    return url
+
+
 def read_example_data(
     filepath: str,
     max_attempts: int = 5,
@@ -132,9 +146,7 @@ def read_example_data(
     **kwargs: Any,
 ) -> pd.DataFrame:
     """Load CSV or JSON from example data mirror with retry/backoff."""
-    from superset.examples.helpers import get_example_url
-
-    url = get_example_url(filepath)
+    url = normalize_example_data_url(filepath)
     is_json = filepath.endswith(".json") or filepath.endswith(".json.gz")
 
     for attempt in range(1, max_attempts + 1):

--- a/superset/examples/helpers.py
+++ b/superset/examples/helpers.py
@@ -54,6 +54,8 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
 from superset.utils import json
 
+EXAMPLES_PROTOCOL = "examples://"
+
 # ---------------------------------------------------------------------------
 # Public sample‑data mirror configuration
 # ---------------------------------------------------------------------------
@@ -131,8 +133,8 @@ def normalize_example_data_url(url: str) -> str:
     Transforms examples:// URLs to the configured CDN URL.
     Non-example URLs are returned unchanged.
     """
-    if url.startswith("examples://"):
-        relative_path = url[11:]  # Remove 'examples://'
+    if url.startswith(EXAMPLES_PROTOCOL):
+        relative_path = url[len(EXAMPLES_PROTOCOL) :]
         return get_example_url(relative_path)
 
     # Not an examples URL, return unchanged

--- a/superset/examples/long_lat.py
+++ b/superset/examples/long_lat.py
@@ -48,7 +48,7 @@ def load_long_lat_data(only_metadata: bool = False, force: bool = False) -> None
 
         if not only_metadata and (not table_exists or force):
             pdf = read_example_data(
-                "san_francisco.csv.gz", encoding="utf-8", compression="gzip"
+                "examples://san_francisco.csv.gz", encoding="utf-8", compression="gzip"
             )
             start = datetime.datetime.now().replace(
                 hour=0, minute=0, second=0, microsecond=0

--- a/superset/examples/multiformat_time_series.py
+++ b/superset/examples/multiformat_time_series.py
@@ -49,7 +49,7 @@ def load_multiformat_time_series(  # pylint: disable=too-many-locals
 
         if not only_metadata and (not table_exists or force):
             pdf = read_example_data(
-                "multiformat_time_series.json.gz", compression="gzip"
+                "examples://multiformat_time_series.json.gz", compression="gzip"
             )
 
             # TODO(bkyryliuk): move load examples data into the pytest fixture

--- a/superset/examples/paris.py
+++ b/superset/examples/paris.py
@@ -37,7 +37,7 @@ def load_paris_iris_geojson(only_metadata: bool = False, force: bool = False) ->
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            df = read_example_data("paris_iris.json.gz", compression="gzip")
+            df = read_example_data("examples://paris_iris.json.gz", compression="gzip")
             df["features"] = df.features.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/random_time_series.py
+++ b/superset/examples/random_time_series.py
@@ -46,7 +46,9 @@ def load_random_time_series_data(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_data("random_time_series.json.gz", compression="gzip")
+            pdf = read_example_data(
+                "examples://random_time_series.json.gz", compression="gzip"
+            )
             if database.backend == "presto":
                 pdf.ds = pd.to_datetime(pdf.ds, unit="s")
                 pdf.ds = pdf.ds.dt.strftime("%Y-%m-%d %H:%M%:%S")

--- a/superset/examples/sf_population_polygons.py
+++ b/superset/examples/sf_population_polygons.py
@@ -39,7 +39,9 @@ def load_sf_population_polygons(
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            df = read_example_data("sf_population.json.gz", compression="gzip")
+            df = read_example_data(
+                "examples://sf_population.json.gz", compression="gzip"
+            )
             df["contour"] = df.contour.map(json.dumps)
 
             df.to_sql(

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -55,7 +55,7 @@ def load_world_bank_health_n_pop(  # pylint: disable=too-many-locals
         table_exists = database.has_table(Table(tbl_name, schema))
 
         if not only_metadata and (not table_exists or force):
-            pdf = read_example_data("countries.json.gz", compression="gzip")
+            pdf = read_example_data("examples://countries.json.gz", compression="gzip")
             pdf.columns = [col.replace(".", "_") for col in pdf.columns]
             if database.backend == "presto":
                 pdf.year = pd.to_datetime(pdf.year)


### PR DESCRIPTION
  ## Summary

  Introduces `examples://` protocol to fix GitHub rate limiting (503 errors) when loading example datasets.

  ### Changes

  - Replace hardcoded GitHub URLs with `examples://` "protocol" across all example files
  - Use jsDelivr CDN by default (configurable via `SUPERSET_EXAMPLES_BASE_URL`)
  - Add `normalize_example_data_url()` to handle URL transformation
  - Update 12 YAML configs and 11 Python files to use new protocol

  ### Benefits

  - No more 503 errors from GitHub rate limits
  - Easy CDN switching via environment variables
  - Respects `SUPERSET_EXAMPLES_DATA_REF` for version pinning

  ## Testing

  - [ ] Example data loads successfully in docker-compose-light
  - [ ] External (non-example) URLs still work unchanged
