### PR TITLE
fix(theme-list): reorder buttons to place import leftmost

### DIFF
--- a/superset-frontend/src/pages/ThemeList/index.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.tsx
@@ -338,6 +338,22 @@ function ThemesList({
 
   const subMenuButtons: SubMenuProps['buttons'] = [];
 
+  if (canImport) {
+    subMenuButtons.push({
+      name: (
+        <Tooltip
+          id="import-tooltip"
+          title={t('Import themes')}
+          placement="bottomRight"
+        >
+          <Icons.DownloadOutlined iconSize="l" data-test="import-button" />
+        </Tooltip>
+      ),
+      buttonStyle: 'link',
+      onClick: openThemeImportModal,
+    });
+  }
+
   if (canDelete || canExport) {
     subMenuButtons.push({
       name: t('Bulk select'),
@@ -355,22 +371,6 @@ function ThemesList({
         setCurrentTheme(null);
         setThemeModalOpen(true);
       },
-    });
-  }
-
-  if (canImport) {
-    subMenuButtons.push({
-      name: (
-        <Tooltip
-          id="import-tooltip"
-          title={t('Import themes')}
-          placement="bottomRight"
-        >
-          <Icons.DownloadOutlined iconSize="l" data-test="import-button" />
-        </Tooltip>
-      ),
-      buttonStyle: 'link',
-      onClick: openThemeImportModal,
     });
   }
 


### PR DESCRIPTION
## Summary
- Reordered buttons in the Theme CRUD interface to improve UI consistency
- Import button is now leftmost in the button group
- Add theme button remains rightmost as the primary action

## Test plan
- Navigate to `/theme/list` in Superset
- Verify that the import button (download icon) appears as the leftmost button
- Verify that the "Theme" add button appears as the rightmost button
- Confirm all buttons function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)