### PR TITLE
fix(superset-ui-core): Include appRoot in endpoint of SupersetClientClass.postForm action

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/auth/login.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/auth/login.test.ts
@@ -19,7 +19,7 @@
 import { LOGIN } from 'cypress/utils/urls';
 
 function interceptLogin() {
-  cy.intercept('POST', '/login/').as('login');
+  cy.intercept('POST', '**/login/').as('login');
 }
 
 describe('Login view', () => {

--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -115,11 +115,15 @@ export default class SupersetClientClass {
     return this.getCSRFToken();
   }
 
-  async postForm(url: string, payload: Record<string, any>, target = '_blank') {
-    if (url) {
+  async postForm(
+    endpoint: string,
+    payload: Record<string, any>,
+    target = '_blank',
+  ) {
+    if (endpoint) {
       await this.ensureAuth();
       const hiddenForm = document.createElement('form');
-      hiddenForm.action = url;
+      hiddenForm.action = this.getUrl({ endpoint });
       hiddenForm.method = 'POST';
       hiddenForm.target = target;
       const payloadWithToken: Record<string, any> = {


### PR DESCRIPTION
### SUMMARY

[SupersetClientClass.request](https://github.com/apache/superset/blob/6006a21378bfaf9d851491e0901327058ae61ccc/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts#L185) uses `SupersetClientClass.getUrl` to construct the correct endpoint, including an optional `appRoot` if set.

[SupersetClientClass.postForm](https://github.com/apache/superset/blob/6006a21378bfaf9d851491e0901327058ae61ccc/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts#L118) used the `url` as passed to it and subsequently failed if `appRoot` is not empty. 

With this change `postForm` also uses `getUrl` to ensure the appropriate endpoint is created.

<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

This can be verified using the docker compose development setup. 

Set a non-empty root:

```sh
echo SUPERSET_APP_ROOT=/prefix >> docker/.env-local
```

Bring up the light docker compose config:

```sh
docker compose -f docker-compose-light.yml up -d
```

When the frontend has finished building go to http://localhost:9001/prefix and login with "admin:admin". Before these changes the successful login would redirect to http://localhost:9001/login rather than http://localhost:9001/prefix/login.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
