### PR TITLE
feat: Add configurable query identifiers for Mixed Timeseries charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -366,7 +366,7 @@ const config: ControlPanelConfig = {
               type: 'CheckboxControl',
               label: t('Show query identifiers'),
               description: t(
-                'Add Query A and Query B identifiers to legend and tooltip to help differentiate series',
+                'Add Query A and Query B identifiers to tooltips to help differentiate series',
               ),
               default: false,
               renderTrigger: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -358,7 +358,22 @@ const config: ControlPanelConfig = {
         ['x_axis_time_format'],
         [xAxisLabelRotation],
         [xAxisLabelInterval],
-        ...richTooltipSection,
+        [<ControlSubSectionHeader>{t('Tooltip')}</ControlSubSectionHeader>],
+        [
+          {
+            name: 'show_query_identifiers',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show query identifiers'),
+              description: t(
+                'Add Query A and Query B identifiers to legend and tooltip to help differentiate series',
+              ),
+              default: false,
+              renderTrigger: true,
+            },
+          },
+        ],
+        ...richTooltipSection.slice(1), // Skip the tooltip header since we added our own
         // eslint-disable-next-line react/jsx-key
         [<ControlSubSectionHeader>{t('Y Axis')}</ControlSubSectionHeader>],
         [

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -409,12 +409,12 @@ export default function transformProps(
       displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
-      displayName = showQueryIdentifiers
-        ? `${entryName} (Query A)`
-        : entryName;
+      displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
     }
-    
-    console.log(`DEBUG Query A: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`);
+
+    console.log(
+      `DEBUG Query A: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`,
+    );
 
     const seriesFormatter = getFormatter(
       customFormatters,
@@ -478,12 +478,12 @@ export default function transformProps(
       displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
-      displayName = showQueryIdentifiers
-        ? `${entryName} (Query B)`
-        : entryName;
+      displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;
     }
-    
-    console.log(`DEBUG Query B: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`);
+
+    console.log(
+      `DEBUG Query B: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`,
+    );
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -243,9 +243,6 @@ export default function transformProps(
   const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
   const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
 
-  // Debug logging
-  console.log('DEBUG: showQueryIdentifiers =', showQueryIdentifiers);
-
   const [rawSeriesA, sortedTotalValuesA] = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
     xAxis: xAxisLabel,
@@ -412,10 +409,6 @@ export default function transformProps(
       displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
     }
 
-    console.log(
-      `DEBUG Query A: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`,
-    );
-
     const seriesFormatter = getFormatter(
       customFormatters,
       formatter,
@@ -480,10 +473,6 @@ export default function transformProps(
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;
     }
-
-    console.log(
-      `DEBUG Query B: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`,
-    );
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -212,7 +212,7 @@ export default function transformProps(
     sortSeriesAscendingB,
     timeGrainSqla,
     percentageThreshold,
-    show_query_identifiers = false,
+    showQueryIdentifiers = false,
     metrics = [],
     metricsB = [],
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
@@ -244,8 +244,7 @@ export default function transformProps(
   const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
 
   // Debug logging
-  console.log('DEBUG: show_query_identifiers =', show_query_identifiers);
-  console.log('DEBUG: formData contains:', Object.keys(formData));
+  console.log('DEBUG: showQueryIdentifiers =', showQueryIdentifiers);
 
   const [rawSeriesA, sortedTotalValuesA] = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
@@ -404,18 +403,18 @@ export default function transformProps(
 
     if (groupby.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = show_query_identifiers
+      const metricPart = showQueryIdentifiers
         ? `${MetricDisplayNameA} (Query A)`
         : MetricDisplayNameA;
       displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
-      displayName = show_query_identifiers
+      displayName = showQueryIdentifiers
         ? `${entryName} (Query A)`
         : entryName;
     }
     
-    console.log(`DEBUG Query A: entryName="${entryName}", displayName="${displayName}", show_query_identifiers=${show_query_identifiers}`);
+    console.log(`DEBUG Query A: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`);
 
     const seriesFormatter = getFormatter(
       customFormatters,
@@ -473,18 +472,18 @@ export default function transformProps(
 
     if (groupbyB.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = show_query_identifiers
+      const metricPart = showQueryIdentifiers
         ? `${MetricDisplayNameB} (Query B)`
         : MetricDisplayNameB;
       displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
-      displayName = show_query_identifiers
+      displayName = showQueryIdentifiers
         ? `${entryName} (Query B)`
         : entryName;
     }
     
-    console.log(`DEBUG Query B: entryName="${entryName}", displayName="${displayName}", show_query_identifiers=${show_query_identifiers}`);
+    console.log(`DEBUG Query B: entryName="${entryName}", displayName="${displayName}", showQueryIdentifiers=${showQueryIdentifiers}`);
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -212,6 +212,7 @@ export default function transformProps(
     sortSeriesAscendingB,
     timeGrainSqla,
     percentageThreshold,
+    show_query_identifiers = false,
     metrics = [],
     metricsB = [],
   }: EchartsMixedTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
@@ -395,10 +396,19 @@ export default function transformProps(
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
 
-    let displayName = `${entryName} (Query A)`;
+    let displayName: string;
 
     if (groupby.length > 0) {
-      displayName = `${MetricDisplayNameA} (Query A), ${entryName}`;
+      // When we have groupby, format as "metric, dimension"
+      const metricPart = show_query_identifiers
+        ? `${MetricDisplayNameA} (Query A)`
+        : MetricDisplayNameA;
+      displayName = `${metricPart}, ${entryName}`;
+    } else {
+      // When no groupby, format as just the entry name with optional query identifier
+      displayName = show_query_identifiers
+        ? `${entryName} (Query A)`
+        : entryName;
     }
 
     const seriesFormatter = getFormatter(
@@ -453,10 +463,19 @@ export default function transformProps(
     const seriesName = `${seriesEntry} (1)`;
     const colorScaleKey = getOriginalSeries(seriesEntry, array);
 
-    let displayName = `${entryName} (Query B)`;
+    let displayName: string;
 
     if (groupbyB.length > 0) {
-      displayName = `${MetricDisplayNameB} (Query B), ${entryName}`;
+      // When we have groupby, format as "metric, dimension"
+      const metricPart = show_query_identifiers
+        ? `${MetricDisplayNameB} (Query B)`
+        : MetricDisplayNameB;
+      displayName = `${metricPart}, ${entryName}`;
+    } else {
+      // When no groupby, format as just the entry name with optional query identifier
+      displayName = show_query_identifiers
+        ? `${entryName} (Query B)`
+        : entryName;
     }
 
     const seriesFormatter = getFormatter(
@@ -696,14 +715,13 @@ export default function transformProps(
         zoomable,
       ),
       // @ts-ignore
-      data: rawSeriesA
-        .concat(rawSeriesB)
+      data: series
         .filter(
           entry =>
             extractForecastSeriesContext((entry.name || '') as string).type ===
             ForecastSeriesEnum.Observation,
         )
-        .map(entry => entry.name || '')
+        .map(entry => entry.id || entry.name || '')
         .concat(extractAnnotationLabels(annotationLayers, annotationData)),
     },
     series: dedupSeries(reorderForecastSeries(series) as SeriesOption[]),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -243,6 +243,10 @@ export default function transformProps(
   const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
   const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
 
+  // Debug logging
+  console.log('DEBUG: show_query_identifiers =', show_query_identifiers);
+  console.log('DEBUG: formData contains:', Object.keys(formData));
+
   const [rawSeriesA, sortedTotalValuesA] = extractSeries(rebasedDataA, {
     fillNeighborValue: stack ? 0 : undefined,
     xAxis: xAxisLabel,
@@ -410,6 +414,8 @@ export default function transformProps(
         ? `${entryName} (Query A)`
         : entryName;
     }
+    
+    console.log(`DEBUG Query A: entryName="${entryName}", displayName="${displayName}", show_query_identifiers=${show_query_identifiers}`);
 
     const seriesFormatter = getFormatter(
       customFormatters,
@@ -477,6 +483,8 @@ export default function transformProps(
         ? `${entryName} (Query B)`
         : entryName;
     }
+    
+    console.log(`DEBUG Query B: entryName="${entryName}", displayName="${displayName}", show_query_identifiers=${show_query_identifiers}`);
 
     const seriesFormatter = getFormatter(
       customFormattersSecondary,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -60,6 +60,7 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   tooltipTimeFormat?: string;
   zoomable: boolean;
   richTooltip: boolean;
+  show_query_identifiers?: boolean;
   xAxisLabelRotation: number;
   xAxisLabelInterval?: number | string;
   colorScheme?: string;
@@ -133,6 +134,7 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   groupbyB: [],
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
+  show_query_identifiers: false,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
   xAxisLabelInterval: TIMESERIES_DEFAULTS.xAxisLabelInterval,
   ...DEFAULT_TITLE_FORM_DATA,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -60,7 +60,7 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   tooltipTimeFormat?: string;
   zoomable: boolean;
   richTooltip: boolean;
-  show_query_identifiers?: boolean;
+  showQueryIdentifiers?: boolean;
   xAxisLabelRotation: number;
   xAxisLabelInterval?: number | string;
   colorScheme?: string;
@@ -134,7 +134,7 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   groupbyB: [],
   zoomable: TIMESERIES_DEFAULTS.zoomable,
   richTooltip: TIMESERIES_DEFAULTS.richTooltip,
-  show_query_identifiers: false,
+  showQueryIdentifiers: false,
   xAxisLabelRotation: TIMESERIES_DEFAULTS.xAxisLabelRotation,
   xAxisLabelInterval: TIMESERIES_DEFAULTS.xAxisLabelInterval,
   ...DEFAULT_TITLE_FORM_DATA,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -116,49 +116,44 @@ const chartPropsConfig = {
   theme: supersetTheme,
 };
 
-it('should transform chart props for viz', () => {
-  const chartProps = new ChartProps(chartPropsConfig);
+it('should transform chart props for viz with showQueryIdentifiers=false', () => {
+  const chartPropsConfigWithoutIdentifiers = {
+    ...chartPropsConfig,
+    formData: {
+      ...formData,
+      showQueryIdentifiers: false,
+    },
+  };
+  const chartProps = new ChartProps(chartPropsConfigWithoutIdentifiers);
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
-  expect(transformed).toEqual(
-    expect.objectContaining({
-      echartOptions: expect.objectContaining({
-        series: expect.arrayContaining([
-          expect.objectContaining({
-            data: [
-              [599616000000, 1],
-              [599916000000, 3],
-            ],
-            id: 'sum__num (Query A), boy',
-            stack: 'obs\na',
-          }),
-          expect.objectContaining({
-            data: [
-              [599616000000, 2],
-              [599916000000, 4],
-            ],
-            id: 'sum__num (Query A), girl',
-            stack: 'obs\na',
-          }),
-          // Query B — Bar series
-          expect.objectContaining({
-            data: [
-              [599616000000, 1],
-              [599916000000, 3],
-            ],
-            id: 'sum__num (Query B), boy',
-            stack: 'obs\nb',
-          }),
-          expect.objectContaining({
-            data: [
-              [599616000000, 2],
-              [599916000000, 4],
-            ],
-            id: 'sum__num (Query B), girl',
-            stack: 'obs\nb',
-          }),
-        ]),
-      }),
-    }),
-  );
+  // Check that series IDs don't include query identifiers
+  const seriesIds = transformed.echartOptions.series.map((s: any) => s.id);
+  expect(seriesIds).toContain('sum__num, girl');
+  expect(seriesIds).toContain('sum__num, boy');
+  expect(seriesIds).not.toContain('sum__num (Query A), girl');
+  expect(seriesIds).not.toContain('sum__num (Query A), boy');
+  expect(seriesIds).not.toContain('sum__num (Query B), girl');
+  expect(seriesIds).not.toContain('sum__num (Query B), boy');
+});
+
+it('should transform chart props for viz with showQueryIdentifiers=true', () => {
+  const chartPropsConfigWithIdentifiers = {
+    ...chartPropsConfig,
+    formData: {
+      ...formData,
+      showQueryIdentifiers: true,
+    },
+  };
+  const chartProps = new ChartProps(chartPropsConfigWithIdentifiers);
+  const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
+
+  // Check that series IDs include query identifiers
+  const seriesIds = transformed.echartOptions.series.map((s: any) => s.id);
+  expect(seriesIds).toContain('sum__num (Query A), girl');
+  expect(seriesIds).toContain('sum__num (Query A), boy');
+  expect(seriesIds).toContain('sum__num (Query B), girl');
+  expect(seriesIds).toContain('sum__num (Query B), boy');
+  expect(seriesIds).not.toContain('sum__num, girl');
+  expect(seriesIds).not.toContain('sum__num, boy');
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -128,7 +128,9 @@ it('should transform chart props for viz with showQueryIdentifiers=false', () =>
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
   // Check that series IDs don't include query identifiers
-  const seriesIds = (transformed.echartOptions.series as any[]).map((s: any) => s.id);
+  const seriesIds = (transformed.echartOptions.series as any[]).map(
+    (s: any) => s.id,
+  );
   expect(seriesIds).toContain('sum__num, girl');
   expect(seriesIds).toContain('sum__num, boy');
   expect(seriesIds).not.toContain('sum__num (Query A), girl');
@@ -149,7 +151,9 @@ it('should transform chart props for viz with showQueryIdentifiers=true', () => 
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
   // Check that series IDs include query identifiers
-  const seriesIds = (transformed.echartOptions.series as any[]).map((s: any) => s.id);
+  const seriesIds = (transformed.echartOptions.series as any[]).map(
+    (s: any) => s.id,
+  );
   expect(seriesIds).toContain('sum__num (Query A), girl');
   expect(seriesIds).toContain('sum__num (Query A), boy');
   expect(seriesIds).toContain('sum__num (Query B), girl');

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -128,7 +128,7 @@ it('should transform chart props for viz with showQueryIdentifiers=false', () =>
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
   // Check that series IDs don't include query identifiers
-  const seriesIds = transformed.echartOptions.series.map((s: any) => s.id);
+  const seriesIds = (transformed.echartOptions.series as any[]).map((s: any) => s.id);
   expect(seriesIds).toContain('sum__num, girl');
   expect(seriesIds).toContain('sum__num, boy');
   expect(seriesIds).not.toContain('sum__num (Query A), girl');
@@ -149,7 +149,7 @@ it('should transform chart props for viz with showQueryIdentifiers=true', () => 
   const transformed = transformProps(chartProps as EchartsMixedTimeseriesProps);
 
   // Check that series IDs include query identifiers
-  const seriesIds = transformed.echartOptions.series.map((s: any) => s.id);
+  const seriesIds = (transformed.echartOptions.series as any[]).map((s: any) => s.id);
   expect(seriesIds).toContain('sum__num (Query A), girl');
   expect(seriesIds).toContain('sum__num (Query A), boy');
   expect(seriesIds).toContain('sum__num (Query B), girl');


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a new configuration option "Show query identifiers" to Mixed Timeseries charts, allowing users to control whether "(Query A)" and "(Query B)" identifiers appear in tooltips.
Following the implementation of query identifiers in https://github.com/apache/superset/pull/33519, some customers provided feedback that they prefer not to see these identifiers in their charts. This PR makes the feature configurable.

Changes
Added "Show query identifiers" checkbox control in the Customize tab
Default behavior: identifiers are hidden
When enabled: shows the existing "(Query A)" and "(Query B)" behavior

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="981" height="710" alt="image" src="https://github.com/user-attachments/assets/f197e620-700b-41ce-8dcd-f3b5c0ea8248" />
<img width="977" height="658" alt="image" src="https://github.com/user-attachments/assets/ce3e0590-9f60-4aa6-a09f-bf7ba3acebc4" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create a mixed chart
- Check that the default behavior is that the identifiers are hidden
- Check that the control shows/hides the identifiers

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
