### PR TITLE
fix(sqllab): access legacy kv record

### DIFF
--- a/superset/commands/sql_lab/permalink/get.py
+++ b/superset/commands/sql_lab/permalink/get.py
@@ -42,7 +42,7 @@ class GetSqlLabPermalinkCommand(BaseSqlLabPermalinkCommand):
     def run(self) -> Optional[SqlLabPermalinkValue]:
         self.validate()
         if self.key.startswith("kv:"):
-            id = int(self.key[3])
+            id = int(self.key[3:])
             try:
                 kv = db.session.query(models.KeyValue).filter_by(id=id).scalar()
                 if not kv:


### PR DESCRIPTION
### SUMMARY
In the logic for accessing sqllab legacy kv records, there was a bug in the ㅑㅇ extraction process that caused only the first digit of the ID to be retrieved. this commit addresses this issue.

### TESTING INSTRUCTIONS
locally tested

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
