### PR TITLE
chore: Add bottom border to top navigation menu

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -43,6 +43,7 @@ interface MenuProps {
 const StyledHeader = styled.header`
   ${({ theme }) => `
       background-color: ${theme.colorBgContainer};
+      border-bottom: 1px solid ${theme.colorBorderSecondary};
       z-index: 10;
 
       &:nth-last-of-type(2) nav {


### PR DESCRIPTION
### SUMMARY
Add a subtle bottom border to the main navigation header for better visual separation between the navigation and page content.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1260" height="129" alt="image" src="https://github.com/user-attachments/assets/e1e04603-8dee-48f4-a23d-20968b2d4bc5" />

### TESTING INSTRUCTIONS
1. Start the development server
2. Navigate to any page in Superset
3. Verify that the top navigation menu now has a subtle bottom border
4. Test across different themes (light/dark) to ensure the border color is appropriate

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)