### PR TITLE
fix: time grain and DB dropdowns

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -177,6 +177,7 @@ const granularity: SharedControlConfig<'SelectControl'> = {
       'can type and use simple natural language as in `10 seconds`, ' +
       '`1 day` or `56 weeks`',
   ),
+  sortComparator: () => 0, // Disable frontend sorting to preserve backend order
 };
 
 const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
@@ -204,6 +205,7 @@ const time_grain_sqla: SharedControlConfig<'SelectControl'> = {
     choices: (datasource as Dataset)?.time_grain_sqla || [],
   }),
   visibility: displayTimeRelatedControls,
+  sortComparator: () => 0, // Disable frontend sorting to preserve backend order
 };
 
 const time_range: SharedControlConfig<'DateFilterControl'> = {

--- a/superset-frontend/src/features/databases/DatabaseModal/index.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.tsx
@@ -1087,18 +1087,27 @@ const DatabaseModal: FunctionComponent<DatabaseModalProps> = ({
         onChange={setDatabaseModel}
         placeholder={t('Choose a database...')}
         options={[
-          ...(availableDbs?.databases || [])
-            .sort((a: DatabaseForm, b: DatabaseForm) =>
-              a.name.localeCompare(b.name),
-            )
-            .map((database: DatabaseForm, index: number) => ({
+          ...(availableDbs?.databases || []).map(
+            (database: DatabaseForm, index: number) => ({
               value: database.name,
               label: database.name,
               key: `database-${index}`,
-            })),
+            }),
+          ),
           { value: 'Other', label: t('Other'), key: 'Other' },
         ]}
         showSearch
+        sortComparator={(a, b) => {
+          // Always put "Other" at the end
+          if (a.value === 'Other') return 1;
+          if (b.value === 'Other') return -1;
+          // For all other options, sort alphabetically
+          return String(a.label).localeCompare(String(b.label));
+        }}
+        getPopupContainer={triggerNode =>
+          triggerNode.parentElement || document.body
+        }
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
       />
       <Alert
         showIcon

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -134,6 +134,7 @@ export default function PluginFilterTimegrain(
           ref={inputRef}
           options={options}
           onOpenChange={setFilterActive}
+          sortComparator={() => 0} // Disable frontend sorting to preserve backend order
         />
       </FormItem>
     </FilterPluginStyle>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I found two bugs in our dropdowns:

1. The time grain dropdown is sorted alphabetically, meaning "hour" comes before "second".
2. The DB selector dropdown no longer has "Other" at the end, and is not showing the last option (it's cutoff).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

<img width="396" height="417" alt="Screenshot 2025-07-31 at 11 31 54 AM" src="https://github.com/user-attachments/assets/de24dbf5-e1e8-4a15-80af-523bd6865539" />

<img width="610" height="271" alt="Screenshot 2025-07-31 at 11 32 37 AM" src="https://github.com/user-attachments/assets/2dce8998-56e7-4060-832a-a84b056908a0" />

In the screenshot above note how it's stops in "Presto", after I've scrolled all the way to the bottom. It's missing "Shillelagh", "SQLite", and "Trino".

After:

<img width="392" height="412" alt="Screenshot 2025-07-31 at 11 31 01 AM" src="https://github.com/user-attachments/assets/41116bf8-6809-483b-9328-d9dc5ebe6ed8" />

<img width="612" height="272" alt="Screenshot 2025-07-31 at 11 30 36 AM" src="https://github.com/user-attachments/assets/b7ffebf3-8ad3-401a-9720-d2f4c55a40b3" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
