### PR TITLE
chore: Change button labels to sentence case

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigPane.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterConfigPane.test.tsx
@@ -96,14 +96,14 @@ test('remove filter', async () => {
 test('add filter', async () => {
   defaultRender();
   // First trash icon
-  const addFilterButton = await screen.findByText('Add Filter');
+  const addFilterButton = await screen.findByText('Add filter');
   userEvent.click(addFilterButton);
   expect(defaultProps.onAdd).toHaveBeenCalledWith('NATIVE_FILTER');
 });
 
 test('add divider', async () => {
   defaultRender();
-  const addFilterButton = await screen.findByText('Add Divider');
+  const addFilterButton = await screen.findByText('Add divider');
   userEvent.click(addFilterButton);
   expect(defaultProps.onAdd).toHaveBeenCalledWith('DIVIDER');
 });
@@ -128,7 +128,7 @@ test('filter container should scroll to bottom when adding items', async () => {
 
   defaultRender(state, props);
 
-  const addFilterButton = await screen.findByText('Add Filter');
+  const addFilterButton = await screen.findByText('Add filter');
 
   userEvent.click(addFilterButton);
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitlePane.tsx
@@ -111,7 +111,7 @@ const FilterTitlePane: FC<Props> = ({
           data-test="add-new-filter-button"
           onClick={() => handleOnAdd(NativeFilterType.NativeFilter)}
         >
-          {t('Add Filter')}
+          {t('Add filter')}
         </Button>
         <Button
           buttonSize="default"
@@ -125,7 +125,7 @@ const FilterTitlePane: FC<Props> = ({
           data-test="add-new-divider-button"
           onClick={() => handleOnAdd(NativeFilterType.Divider)}
         >
-          {t('Add Divider')}
+          {t('Add divider')}
         </Button>
       </div>
     </TabsContainer>


### PR DESCRIPTION
### SUMMARY
Update "Add Filter" and "Add Divider" button labels to use sentence case ("Add filter" and "Add divider") for better consistency with UI standards and modern design patterns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** "Add Filter" and "Add Divider"  
**After:** "Add filter" and "Add divider"

### TESTING INSTRUCTIONS
1. Navigate to a dashboard in edit mode
2. Open the native filters configuration modal
3. Verify that the buttons now display "Add filter" and "Add divider" (sentence case)
4. Run the frontend tests to ensure they pass:
   ```bash
   npm test FilterConfigPane.test.tsx
   ```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Note:** Translation files will need to be updated separately through the i18n process.

🤖 Generated with [Claude Code](https://claude.ai/code)