### PR TITLE
fix(migrations): prevent theme seeding before themes table exists

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -494,7 +494,8 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         # Seed system themes from configuration
         from superset.commands.theme.seed import SeedSystemThemesCommand
 
-        SeedSystemThemesCommand().run()
+        if inspector.has_table("themes"):
+            SeedSystemThemesCommand().run()
 
     def init_app_in_ctx(self) -> None:
         """


### PR DESCRIPTION
During database migrations, the theme seeding command attempts to query the themes table before it has been created, causing PostgreSQL to throw a "relation does not exist" error.

This fix adds a check to ensure the themes table exists before attempting to seed system themes, preventing the migration failure while still allowing themes to be seeded after the table is created.

Fixes #34403

🤖 Generated with [Claude Code](https://claude.ai/code)
