### PR TITLE
feat: Add ESLint rule to enforce sentence case in button text

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -403,6 +403,7 @@ module.exports = {
     'theme-colors/no-literal-colors': 'error',
     'icons/no-fa-icons-usage': 'error',
     'i18n-strings/no-template-vars': ['error', true],
+    'i18n-strings/sentence-case-buttons': 'error',
     camelcase: [
       'error',
       {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/nativeFilters.test.ts
@@ -22,7 +22,6 @@ import {
   dataTestChartName,
 } from 'cypress/support/directories';
 
-import { waitForChartLoad } from 'cypress/utils';
 import {
   addParentFilterWithValue,
   applyNativeFilterValueWithIndex,
@@ -344,7 +343,7 @@ describe('Native filters', () => {
     it('User can delete a native filter', () => {
       enterNativeFilterEditModal(false);
       cy.get(nativeFilters.filtersList.removeIcon).first().click();
-      cy.contains('Restore Filter').should('not.exist', { timeout: 10000 });
+      cy.contains('Restore filter').should('not.exist', { timeout: 10000 });
     });
 
     it('User can cancel creating a new filter', () => {

--- a/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.js
+++ b/superset-frontend/eslint-rules/eslint-plugin-i18n-strings/index.js
@@ -41,11 +41,73 @@ module.exports = {
               context.report({
                 node,
                 message:
-                  "Don't use variables in translation string templates. Flask-babel is a static translation service, so it can’t handle strings that include variables",
+                  "Don't use variables in translation string templates. Flask-babel is a static translation service, so it can't handle strings that include variables",
               });
             }
           }
         }
+        return {
+          "CallExpression[callee.name='t']": handler,
+          "CallExpression[callee.name='tn']": handler,
+        };
+      },
+    },
+    'sentence-case-buttons': {
+      create(context) {
+        function isTitleCase(str) {
+          // Match "Delete Dataset", "Create Chart", etc. (2+ title-cased words)
+          return /^[A-Z][a-z]+(\s+[A-Z][a-z]*)+$/.test(str);
+        }
+
+        function isButtonContext(node) {
+          const { parent } = node;
+          if (!parent) return false;
+
+          // Check for button-specific props
+          if (parent.type === 'Property') {
+            const key = parent.key.name;
+            return [
+              'primaryButtonName',
+              'secondaryButtonName',
+              'confirmButtonText',
+              'cancelButtonText',
+            ].includes(key);
+          }
+
+          // Check for Button components
+          if (parent.type === 'JSXExpressionContainer') {
+            const jsx = parent.parent;
+            if (jsx?.type === 'JSXElement') {
+              const elementName = jsx.openingElement.name.name;
+              return elementName === 'Button';
+            }
+          }
+
+          return false;
+        }
+
+        function handler(node) {
+          if (node.arguments.length) {
+            const firstArg = node.arguments[0];
+            if (
+              firstArg.type === 'Literal' &&
+              typeof firstArg.value === 'string'
+            ) {
+              const text = firstArg.value;
+
+              if (isButtonContext(node) && isTitleCase(text)) {
+                const sentenceCase = text
+                  .toLowerCase()
+                  .replace(/^\w/, c => c.toUpperCase());
+                context.report({
+                  node: firstArg,
+                  message: `Button text should use sentence case: "${text}" should be "${sentenceCase}"`,
+                });
+              }
+            }
+          }
+        }
+
         return {
           "CallExpression[callee.name='t']": handler,
           "CallExpression[callee.name='tn']": handler,

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
@@ -36,17 +36,17 @@ describe('ExploreResultsButton', () => {
     const { queryByText } = setup(jest.fn(), {
       database: { allows_subquery: true },
     });
-    expect(queryByText('Create Chart')).toBeInTheDocument();
+    expect(queryByText('Create chart')).toBeInTheDocument();
     // Updated line to match the actual button name that includes the icon
-    expect(screen.getByRole('button', { name: /Create Chart/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Create chart/i })).toBeEnabled();
   });
 
   it('renders disabled if subquery not allowed', async () => {
     const { queryByText } = setup(jest.fn());
-    expect(queryByText('Create Chart')).toBeInTheDocument();
+    expect(queryByText('Create chart')).toBeInTheDocument();
     // Updated line to match the actual button name that includes the icon
     expect(
-      screen.getByRole('button', { name: /Create Chart/i }),
+      screen.getByRole('button', { name: /Create chart/i }),
     ).toBeDisabled();
   });
 });

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/index.tsx
@@ -46,7 +46,7 @@ const ExploreResultsButton = ({
       tooltip={t('Explore the result set in the data exploration view')}
       data-test="explore-results-button"
     >
-      {t('Create Chart')}
+      {t('Create chart')}
     </Button>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/RemovedFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/RemovedFilter.tsx
@@ -43,7 +43,7 @@ const RemovedFilter: FC<RemovedFilterProps> = ({ onClick }) => (
         buttonStyle="primary"
         onClick={onClick}
       >
-        {t('Restore Filter')}
+        {t('Restore filter')}
       </Button>
     </div>
   </RemovedContent>

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.jsx
@@ -849,7 +849,7 @@ class AnnotationLayer extends PureComponent {
               buttonSize="xsmall"
               onClick={() => this.setState({ color: AUTOMATIC_COLOR })}
             >
-              {t('Automatic Color')}
+              {t('Automatic color')}
             </Button>
           </div>
         </div>

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/AnnotationLayer.test.tsx
@@ -220,7 +220,7 @@ test('keeps apply disabled when missing required fields', async () => {
   expect(await screen.findByText('Chart A')).toBeInTheDocument();
   userEvent.click(screen.getByText('Chart A'));
   await screen.findByText(/title column/i);
-  userEvent.click(screen.getByRole('button', { name: 'Automatic Color' }));
+  userEvent.click(screen.getByRole('button', { name: 'Automatic color' }));
   userEvent.click(
     screen.getByRole('combobox', { name: 'Annotation layer title column' }),
   );

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -816,11 +816,11 @@ msgid "Add Dashboard"
 msgstr "إضافة لوحة معلومات"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "مقسم"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "إضافة فلتر"
 
 #, fuzzy
@@ -1804,7 +1804,7 @@ msgstr "فلاتر الإكمال التلقائي"
 msgid "Autocomplete query predicate"
 msgstr "استعلام الإكمال التلقائي المسند"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "اللون التلقائي"
 
 #, fuzzy
@@ -3253,7 +3253,7 @@ msgstr "خريطة البلد"
 msgid "Create"
 msgstr "خلق"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "إنشاء مخطط"
 
 msgid "Create a dataset"
@@ -8839,7 +8839,7 @@ msgstr "يحتوي المورد بالفعل على تقرير مرفق."
 msgid "Resource was not found."
 msgstr "لم يتم العثور على المورد."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "عامل تصفية الاستعادة"
 
 msgid "Results"

--- a/superset/translations/ca/LC_MESSAGES/messages.po
+++ b/superset/translations/ca/LC_MESSAGES/messages.po
@@ -843,10 +843,10 @@ msgstr "Afegir plantilla CSS"
 msgid "Add Dashboard"
 msgstr "Afegir Dashboard"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Afegir Divisor"
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Afegir Filtre"
 
 msgid "Add Layer"
@@ -1822,7 +1822,7 @@ msgstr "Filtres d'autocompletat"
 msgid "Autocomplete query predicate"
 msgstr "Predicat de consulta d'autocompletat"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Color Automàtic"
 
 msgid "Autosize Column"
@@ -3234,7 +3234,7 @@ msgstr "Mapa de País"
 msgid "Create"
 msgstr "Crear"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Crear Gràfic"
 
 msgid "Create a dataset"
@@ -8642,7 +8642,7 @@ msgstr "El recurs ja té un informe adjunt."
 msgid "Resource was not found."
 msgstr "No s'ha trobat el recurs."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Restaurar Filtre"
 
 msgid "Results"

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -858,11 +858,11 @@ msgid "Add Dashboard"
 msgstr "Dashboard hinzufügen"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Trenner"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Filter hinzufügen"
 
 #, fuzzy
@@ -1887,7 +1887,7 @@ msgstr "Auto-Vervollständigen-Filter"
 msgid "Autocomplete query predicate"
 msgstr "Abfrageprädikat für die automatische Vervollständigung"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Automatische Farbe"
 
 #, fuzzy
@@ -3372,7 +3372,7 @@ msgstr "Länderkarte"
 msgid "Create"
 msgstr "Erstellen"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Diagramm erstellen"
 
 msgid "Create a dataset"
@@ -9008,7 +9008,7 @@ msgstr "Resource verfügt bereits über einen angefügten Bericht."
 msgid "Resource was not found."
 msgstr "Ressource wurde nicht gefunden."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Filter wiederherstellen"
 
 msgid "Results"

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -752,10 +752,10 @@ msgstr ""
 msgid "Add Dashboard"
 msgstr ""
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr ""
 
 msgid "Add Layer"
@@ -1679,7 +1679,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 msgid "Autosize Column"
@@ -3020,7 +3020,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr ""
 
 #, fuzzy
@@ -8192,7 +8192,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr ""
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr ""
 
 msgid "Results"

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -752,10 +752,10 @@ msgstr "Añadir plantilla CSS"
 msgid "Add Dashboard"
 msgstr "Añadir panel de control"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Añadir separador"
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Añadir filtro"
 
 msgid "Add Layer"
@@ -1679,7 +1679,7 @@ msgstr "Autocompletar filtros"
 msgid "Autocomplete query predicate"
 msgstr "Autocompletar predicado de consulta"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Color automático"
 
 msgid "Autosize Column"
@@ -3020,7 +3020,7 @@ msgstr "Mapa del país"
 msgid "Create"
 msgstr "Crear"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Crear gráfico"
 
 #, -ERR:PROP-NOT-FOUND-
@@ -8192,7 +8192,7 @@ msgstr "El recurso ya tiene un informe adjunto."
 msgid "Resource was not found."
 msgstr "No se ha encontrado el recurso."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Restablecer filtro"
 
 msgid "Results"

--- a/superset/translations/fa/LC_MESSAGES/messages.po
+++ b/superset/translations/fa/LC_MESSAGES/messages.po
@@ -833,11 +833,11 @@ msgid "Add Dashboard"
 msgstr "افزودن داشبورد"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "تقسیم‌کننده"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "فیلتر اضافه کنید"
 
 #, fuzzy
@@ -1817,7 +1817,7 @@ msgstr "فیلترهای تکمیل خودکار"
 msgid "Autocomplete query predicate"
 msgstr "پیشنهاد خودکار کوئری"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "رنگ خودکار"
 
 #, fuzzy
@@ -3255,7 +3255,7 @@ msgstr "نقشه کشور"
 msgid "Create"
 msgstr "ایجاد کنید"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "چارت ایجاد کن"
 
 msgid "Create a dataset"
@@ -8767,7 +8767,7 @@ msgstr "منبع قبلاً یک گزارش ضمایم شده دارد."
 msgid "Resource was not found."
 msgstr "منبع پیدا نشد."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "بازیابی فیلتر"
 
 msgid "Results"

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -854,11 +854,11 @@ msgid "Add Dashboard"
 msgstr "Ajouter un tableau de bord"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Diviseur"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Ajouter un filtre"
 
 msgid "Add Group"
@@ -1950,7 +1950,7 @@ msgstr "Remplir automatiquement les filtres"
 msgid "Autocomplete query predicate"
 msgstr "Prédicat d'autocomplétion de la requête"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Couleur automatique"
 
 #, fuzzy
@@ -3542,7 +3542,7 @@ msgid "Create"
 msgstr "Créer"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Créer un graphique"
 
 #, fuzzy
@@ -9712,7 +9712,7 @@ msgstr "La ressource a déjà un rapport joint."
 msgid "Resource was not found."
 msgstr "Base de données non trouvée."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Restaurer le filtre"
 
 msgid "Results"

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -788,11 +788,11 @@ msgstr "Template CSS"
 msgid "Add Dashboard"
 msgstr ""
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Aggiungi filtro"
 
 #, fuzzy
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 #, fuzzy
@@ -3239,7 +3239,7 @@ msgid "Create"
 msgstr "Creato il"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Esplora grafico"
 
 #, fuzzy
@@ -8833,7 +8833,7 @@ msgid "Resource was not found."
 msgstr "Template CSS"
 
 #, fuzzy
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Cerca / Filtra"
 
 msgid "Results"

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -788,10 +788,10 @@ msgstr "CSSテンプレートを追加"
 msgid "Add Dashboard"
 msgstr "ダッシュボードを追加"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "仕切りを追加"
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "フィルターを追加"
 
 msgid "Add Layer"
@@ -1722,7 +1722,7 @@ msgstr "自動補完 フィルタ"
 msgid "Autocomplete query predicate"
 msgstr "自動補完のクエリ述語"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "自動カラー"
 
 msgid "Autosize Column"
@@ -3090,7 +3090,7 @@ msgstr "国別地図"
 msgid "Create"
 msgstr "作成"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "チャートを作成"
 
 msgid "Create a dataset"
@@ -8313,7 +8313,7 @@ msgstr "リソースにはすでにレポートが添付されています。"
 msgid "Resource was not found."
 msgstr "リソースが見つかりませんでした。"
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "フィルタを復元"
 
 msgid "Results"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -783,11 +783,11 @@ msgstr "CSS 템플릿"
 msgid "Add Dashboard"
 msgstr "대시보드 추가"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "테이블 추가"
 
 #, fuzzy
@@ -1773,7 +1773,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 #, fuzzy
@@ -3217,7 +3217,7 @@ msgid "Create"
 msgstr ""
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "차트 보기"
 
 #, fuzzy
@@ -8738,7 +8738,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr "데이터베이스를 찾을 수 없습니다."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr ""
 
 msgid "Results"

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -758,10 +758,10 @@ msgstr ""
 msgid "Add Dashboard"
 msgstr ""
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr ""
 
 msgid "Add Layer"
@@ -1683,7 +1683,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 msgid "Autosize Column"
@@ -3024,7 +3024,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr ""
 
 msgid "Create a dataset"
@@ -8186,7 +8186,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr ""
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr ""
 
 msgid "Results"

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -824,11 +824,11 @@ msgid "Add Dashboard"
 msgstr "Voeg Dashboard toe"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Verdeler"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Filter toevoegen"
 
 #, fuzzy
@@ -1848,7 +1848,7 @@ msgstr "Filters automatisch aanvullen"
 msgid "Autocomplete query predicate"
 msgstr "Autocomplete query predicaat"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Automatische kleur"
 
 #, fuzzy
@@ -3318,7 +3318,7 @@ msgstr "Landenkaart"
 msgid "Create"
 msgstr "Maak"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Grafiek aanmaken"
 
 msgid "Create a dataset"
@@ -8913,7 +8913,7 @@ msgstr "Deze bron heeft al een bijgevoegd rapport."
 msgid "Resource was not found."
 msgstr "Bron is niet gevonden."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Herstel Filter"
 
 msgid "Results"

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -869,11 +869,11 @@ msgid "Add Dashboard"
 msgstr "Dodaj pulpit"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Separator"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Dodaj filtr"
 
 #, fuzzy
@@ -1914,7 +1914,7 @@ msgstr "Autouzupełnianie filtrów"
 msgid "Autocomplete query predicate"
 msgstr "Predykat zapytania autouzupełniania"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Automatyczny kolor"
 
 #, fuzzy
@@ -3415,7 +3415,7 @@ msgid "Create"
 msgstr "Utwórz"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Utwórz wykres"
 
 #, fuzzy
@@ -9277,7 +9277,7 @@ msgstr "Zasób ma już przypisany raport."
 msgid "Resource was not found."
 msgstr "Nie znaleziono zasobu."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Przywróć filtr"
 
 msgid "Results"

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -795,11 +795,11 @@ msgstr "Modelos CSS"
 msgid "Add Dashboard"
 msgstr "Adicionar Dashboard"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Adicionar filtro"
 
 #, fuzzy
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr "Carregar Valores de Predicado"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 #, fuzzy
@@ -3277,7 +3277,7 @@ msgid "Create"
 msgstr "Criado em"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Crie uma nova visualização"
 
 #, fuzzy
@@ -8955,7 +8955,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr "Dashboard"
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Filtros de resultados"
 
 msgid "Results"

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -836,11 +836,11 @@ msgid "Add Dashboard"
 msgstr "Adicionar Painel"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Divisor"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Adicionar filtro"
 
 #, fuzzy
@@ -1879,7 +1879,7 @@ msgstr "Filtros de preenchimento automático"
 msgid "Autocomplete query predicate"
 msgstr "Predicado de consulta de preenchimento automático"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Cor Automática"
 
 #, fuzzy
@@ -3369,7 +3369,7 @@ msgstr "Mapa do País"
 msgid "Create"
 msgstr "Criar"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Criar gráfico"
 
 msgid "Create a dataset"
@@ -9042,7 +9042,7 @@ msgstr "Recurso já tem um relatório anexado."
 msgid "Resource was not found."
 msgstr "O recurso não foi encontrado."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Restaurar filtro"
 
 msgid "Results"

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -832,11 +832,11 @@ msgid "Add Dashboard"
 msgstr "Добавить дашборд"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Разделитель"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Добавить фильтр"
 
 #, fuzzy
@@ -1833,7 +1833,7 @@ msgstr "Фильтры автозаполнения"
 msgid "Autocomplete query predicate"
 msgstr "Предикат запроса автозаполнения"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Автоматический цвет"
 
 #, fuzzy
@@ -3288,7 +3288,7 @@ msgstr "Карта страны"
 msgid "Create"
 msgstr "Создать"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Создать диаграмму"
 
 msgid "Create a dataset"
@@ -8879,7 +8879,7 @@ msgstr "Для этого компонента уже создан отчет"
 msgid "Resource was not found."
 msgstr "Источник не был найден"
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Восстановить фильтр"
 
 msgid "Results"

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -756,10 +756,10 @@ msgstr ""
 msgid "Add Dashboard"
 msgstr ""
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
-msgid "Add Filter"
+msgid "Add filter"
 msgstr ""
 
 msgid "Add Layer"
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 msgid "Autosize Column"
@@ -3050,7 +3050,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr ""
 
 #, fuzzy
@@ -8273,7 +8273,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr ""
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr ""
 
 msgid "Results"

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -851,11 +851,11 @@ msgid "Add Dashboard"
 msgstr "Dodaj nadzorno ploščo"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Ločilnik"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Dodaj filter"
 
 #, fuzzy
@@ -1855,7 +1855,7 @@ msgstr "Samodokončaj filtre"
 msgid "Autocomplete query predicate"
 msgstr "Predikat za samodokončanje poizvedb"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Samodejne barve"
 
 #, fuzzy
@@ -3284,7 +3284,7 @@ msgstr "Zemljevid držav"
 msgid "Create"
 msgstr "Ustvari"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Ustvarite grafikon"
 
 msgid "Create a dataset"
@@ -8806,7 +8806,7 @@ msgstr "Vir že ima povezano poročilo."
 msgid "Resource was not found."
 msgstr "Vir ni bil najden."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Povrni filter"
 
 msgid "Results"

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -756,11 +756,11 @@ msgstr "CSS şablonu ekle"
 msgid "Add Dashboard"
 msgstr "Dashboard Ekle"
 
-msgid "Add Divider"
+msgid "Add divider"
 msgstr ""
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Filtre ekle"
 
 #, fuzzy
@@ -1693,7 +1693,7 @@ msgstr "Otomatik tamamlama filtreleri"
 msgid "Autocomplete query predicate"
 msgstr ""
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr ""
 
 msgid "Autosize Column"
@@ -3061,7 +3061,7 @@ msgstr "Ülke Haritası"
 msgid "Create"
 msgstr "Oluştur"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Grafik Oluştur"
 
 msgid "Create a dataset"
@@ -8313,7 +8313,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr ""
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr ""
 
 msgid "Results"

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -826,11 +826,11 @@ msgid "Add Dashboard"
 msgstr "Додайте Інформаційну панель"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "Роздільник"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "Додати фільтр"
 
 #, fuzzy
@@ -1834,7 +1834,7 @@ msgstr "Автоматичні фільтри"
 msgid "Autocomplete query predicate"
 msgstr "Auto -Complete Query Prediac"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "Автоматичний колір"
 
 #, fuzzy
@@ -3305,7 +3305,7 @@ msgstr "Карта країни"
 msgid "Create"
 msgstr "Створити"
 
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "Створити діаграму"
 
 msgid "Create a dataset"
@@ -8928,7 +8928,7 @@ msgstr "Ресурс вже має доданий звіт."
 msgid "Resource was not found."
 msgstr "Ресурс не був знайдений."
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "Відновити фільтр"
 
 msgid "Results"

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -802,11 +802,11 @@ msgid "Add Dashboard"
 msgstr "新增看板"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "分隔"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "增加过滤条件"
 
 #, fuzzy
@@ -1788,7 +1788,7 @@ msgstr "自适配过滤条件"
 msgid "Autocomplete query predicate"
 msgstr "自动补全查询谓词"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "自动配色"
 
 #, fuzzy
@@ -3256,7 +3256,7 @@ msgid "Create"
 msgstr "创建"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "创建图表"
 
 #, fuzzy
@@ -8861,7 +8861,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr "资源没有找到"
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "还原过滤条件"
 
 msgid "Results"

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -801,11 +801,11 @@ msgid "Add Dashboard"
 msgstr "新增看板"
 
 #, fuzzy
-msgid "Add Divider"
+msgid "Add divider"
 msgstr "分隔"
 
 #, fuzzy
-msgid "Add Filter"
+msgid "Add filter"
 msgstr "增加過濾條件"
 
 #, fuzzy
@@ -1789,7 +1789,7 @@ msgstr "自適配過濾條件"
 msgid "Autocomplete query predicate"
 msgstr "自動補全查詢谓詞"
 
-msgid "Automatic Color"
+msgid "Automatic color"
 msgstr "自動配色"
 
 #, fuzzy
@@ -3259,7 +3259,7 @@ msgid "Create"
 msgstr "創建"
 
 #, fuzzy
-msgid "Create Chart"
+msgid "Create chart"
 msgstr "創建圖表"
 
 #, fuzzy
@@ -8875,7 +8875,7 @@ msgstr ""
 msgid "Resource was not found."
 msgstr "資源没有找到"
 
-msgid "Restore Filter"
+msgid "Restore filter"
 msgstr "還原過濾條件"
 
 msgid "Results"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a new ESLint rule 'sentence-case-buttons' to the i18n-strings plugin that:
- Detects title case button text like "Create Chart", "Delete Dataset"
- Only applies to button contexts (primaryButtonName, Button components, etc.)
- Suggests sentence case alternatives: "Create chart", "Delete dataset"
- Avoids false positives for page titles, menu items, and labels

This helps maintain consistency with the design system preference for sentence case in UI actions while preserving title case where appropriate in navigation and headers.

🤖 Generated with [Claude Code](https://claude.ai/code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
