### PR TITLE
fix(pie chart): Total now positioned correctly with all Legend positions, and respects theming

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -220,7 +220,7 @@ export default function transformProps(
         name: otherName,
         value: otherSum,
         itemStyle: {
-          color: theme.colors.grayscale.dark1,
+          color: theme.colorText,
           opacity:
             filterState.selectedValues &&
             !filterState.selectedValues.includes(otherName)
@@ -368,7 +368,7 @@ export default function transformProps(
   const defaultLabel = {
     formatter,
     show: showLabels,
-    color: theme.colors.grayscale.dark2,
+    color: theme.colorText,
   };
 
   const chartPadding = getChartPadding(
@@ -403,7 +403,7 @@ export default function transformProps(
         label: {
           show: true,
           fontWeight: 'bold',
-          backgroundColor: theme.colors.grayscale.light5,
+          backgroundColor: theme.colorBgContainer,
         },
       },
       data: transformedData,
@@ -445,7 +445,7 @@ export default function transformProps(
             text: t('Total: %s', numberFormatter(totalValue)),
             fontSize: 16,
             fontWeight: 'bold',
-            fill: theme.colors.grayscale.dark2,
+            fill: theme.colorText,
           },
           z: 10,
         }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -95,27 +95,27 @@ function getTotalValuePadding({
     top: donut ? 'middle' : '0',
     left: 'center',
   };
-  const LEGEND_HEIGHT = 15;
-  const LEGEND_WIDTH = 215;
   if (chartPadding.top) {
     padding.top = donut
-      ? `${50 + ((chartPadding.top - LEGEND_HEIGHT) / height / 2) * 100}%`
-      : `${((chartPadding.top + LEGEND_HEIGHT) / height) * 100}%`;
+      ? `${50 + (chartPadding.top / height / 2) * 100}%`
+      : `${(chartPadding.top / height) * 100}%`;
   }
   if (chartPadding.bottom) {
     padding.top = donut
-      ? `${50 - ((chartPadding.bottom + LEGEND_HEIGHT) / height / 2) * 100}%`
+      ? `${50 - (chartPadding.bottom / height / 2) * 100}%`
       : '0';
   }
   if (chartPadding.left) {
-    padding.left = `${
-      50 + ((chartPadding.left - LEGEND_WIDTH) / width / 2) * 100
-    }%`;
+    // When legend is on the left, shift text right to center it in the available space
+    const leftPaddingPercent = (chartPadding.left / width) * 100;
+    const adjustedLeftPercent = 50 + (leftPaddingPercent * 0.25);
+    padding.left = `${adjustedLeftPercent}%`;
   }
   if (chartPadding.right) {
-    padding.left = `${
-      50 - ((chartPadding.right + LEGEND_WIDTH) / width / 2) * 100
-    }%`;
+    // When legend is on the right, shift text left to center it in the available space
+    const rightPaddingPercent = (chartPadding.right / width) * 100;
+    const adjustedLeftPercent = 50 - (rightPaddingPercent * 0.75);
+    padding.left = `${adjustedLeftPercent}%`;
   }
   return padding;
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -108,13 +108,13 @@ function getTotalValuePadding({
   if (chartPadding.left) {
     // When legend is on the left, shift text right to center it in the available space
     const leftPaddingPercent = (chartPadding.left / width) * 100;
-    const adjustedLeftPercent = 50 + (leftPaddingPercent * 0.25);
+    const adjustedLeftPercent = 50 + leftPaddingPercent * 0.25;
     padding.left = `${adjustedLeftPercent}%`;
   }
   if (chartPadding.right) {
     // When legend is on the right, shift text left to center it in the available space
     const rightPaddingPercent = (chartPadding.right / width) * 100;
-    const adjustedLeftPercent = 50 - (rightPaddingPercent * 0.75);
+    const adjustedLeftPercent = 50 - rightPaddingPercent * 0.75;
     padding.left = `${adjustedLeftPercent}%`;
   }
   return padding;
@@ -445,6 +445,7 @@ export default function transformProps(
             text: t('Total: %s', numberFormatter(totalValue)),
             fontSize: 16,
             fontWeight: 'bold',
+            fill: theme.colors.grayscale.dark2,
           },
           z: 10,
         }

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -221,6 +221,156 @@ describe('Pie label string template', () => {
   });
 });
 
+describe('Total value positioning with legends', () => {
+  const getChartPropsWithLegend = (
+    showTotal = true,
+    showLegend = true,
+    legendOrientation = 'right',
+    donut = true,
+  ): EchartsPieChartProps => {
+    const formData: SqlaFormData = {
+      colorScheme: 'bnbColors',
+      datasource: '3__table',
+      granularity_sqla: 'ds',
+      metric: 'sum__num',
+      groupby: ['category'],
+      viz_type: 'pie',
+      show_total: showTotal,
+      show_legend: showLegend,
+      legend_orientation: legendOrientation,
+      donut,
+    };
+
+    return new ChartProps({
+      formData,
+      width: 800,
+      height: 600,
+      queriesData: [
+        {
+          data: [
+            { category: 'A', sum__num: 10, sum__num__contribution: 0.4 },
+            { category: 'B', sum__num: 15, sum__num__contribution: 0.6 },
+          ],
+        },
+      ],
+      theme: supersetTheme,
+    }) as EchartsPieChartProps;
+  };
+
+  it('should center total text when legend is on the right', () => {
+    const props = getChartPropsWithLegend(true, true, 'right', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        left: expect.stringMatching(/^\d+(\.\d+)?%$/),
+        top: 'middle',
+        style: expect.objectContaining({
+          text: expect.stringContaining('Total:'),
+        }),
+      }),
+    );
+
+    // The left position should be less than 50% (shifted left)
+    const leftValue = parseFloat(
+      (transformed.echartOptions.graphic as any).left.replace('%', ''),
+    );
+    expect(leftValue).toBeLessThan(50);
+    expect(leftValue).toBeGreaterThan(30); // Should be reasonable positioning
+  });
+
+  it('should center total text when legend is on the left', () => {
+    const props = getChartPropsWithLegend(true, true, 'left', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        left: expect.stringMatching(/^\d+(\.\d+)?%$/),
+        top: 'middle',
+      }),
+    );
+
+    // The left position should be greater than 50% (shifted right)
+    const leftValue = parseFloat(
+      (transformed.echartOptions.graphic as any).left.replace('%', ''),
+    );
+    expect(leftValue).toBeGreaterThan(50);
+    expect(leftValue).toBeLessThan(70); // Should be reasonable positioning
+  });
+
+  it('should center total text when legend is on top', () => {
+    const props = getChartPropsWithLegend(true, true, 'top', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        left: 'center',
+        top: expect.stringMatching(/^\d+(\.\d+)?%$/),
+      }),
+    );
+
+    // The top position should be adjusted for top legend
+    const topValue = parseFloat(
+      (transformed.echartOptions.graphic as any).top.replace('%', ''),
+    );
+    expect(topValue).toBeGreaterThan(50); // Shifted down for top legend
+  });
+
+  it('should center total text when legend is on bottom', () => {
+    const props = getChartPropsWithLegend(true, true, 'bottom', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        left: 'center',
+        top: expect.stringMatching(/^\d+(\.\d+)?%$/),
+      }),
+    );
+
+    // The top position should be adjusted for bottom legend
+    const topValue = parseFloat(
+      (transformed.echartOptions.graphic as any).top.replace('%', ''),
+    );
+    expect(topValue).toBeLessThan(50); // Shifted up for bottom legend
+  });
+
+  it('should use default positioning when no legend is shown', () => {
+    const props = getChartPropsWithLegend(true, false, 'right', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        left: 'center',
+        top: 'middle',
+      }),
+    );
+  });
+
+  it('should handle regular pie chart (non-donut) positioning', () => {
+    const props = getChartPropsWithLegend(true, true, 'right', false);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        top: expect.stringMatching(/^\d+(\.\d+)?%$/), // Should be percentage, not 'middle'
+      }),
+    );
+  });
+
+  it('should not show total graphic when showTotal is false', () => {
+    const props = getChartPropsWithLegend(false, true, 'right', true);
+    const transformed = transformProps(props);
+
+    expect(transformed.echartOptions.graphic).toBeNull();
+  });
+});
+
 describe('Other category', () => {
   const defaultFormData: SqlaFormData = {
     colorScheme: 'bnbColors',

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -358,7 +358,8 @@ describe('Total value positioning with legends', () => {
     expect(transformed.echartOptions.graphic).toEqual(
       expect.objectContaining({
         type: 'text',
-        top: expect.stringMatching(/^\d+(\.\d+)?%$/), // Should be percentage, not 'middle'
+        top: '0', // Non-donut charts use '0' as default top position
+        left: expect.stringMatching(/^\d+(\.\d+)?%$/), // Should still adjust left for right legend
       }),
     );
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before, if the Legend position was Right or Left, the Total number was off center. 
Before, if you set Superset to "dark" theme, the total was always black.

Now, the Total is centered in all Label positions, and turns lighter gray in Dark Mode.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
After:
<img width="903" height="643" alt="image" src="https://github.com/user-attachments/assets/92800dd9-5350-4198-acd5-2f324b0eb319" />
<img width="839" height="693" alt="image" src="https://github.com/user-attachments/assets/00b06f41-90e3-47f4-a1f4-0363b59124ab" />
<img width="961" height="636" alt="image" src="https://github.com/user-attachments/assets/5e1994f6-5bac-48f9-90ee-ab715e086785" />
<img width="987" height="641" alt="image" src="https://github.com/user-attachments/assets/ccc37192-affd-4235-b63c-40ec6aaaa8a5" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes https://github.com/apache/superset/issues/26226
- [ ] Required feature flags: 
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
