### PR TITLE
fix: Update table chart configuration labels to sentence case

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -589,7 +589,7 @@ const config: ControlPanelConfig = {
             name: 'show_cell_bars',
             config: {
               type: 'CheckboxControl',
-              label: t('Show Cell bars'),
+              label: t('Show cell bars'),
               renderTrigger: true,
               default: true,
               description: t(
@@ -617,7 +617,7 @@ const config: ControlPanelConfig = {
             name: 'color_pn',
             config: {
               type: 'CheckboxControl',
-              label: t('add colors to cell bars for +/-'),
+              label: t('Add colors to cell bars for +/-'),
               renderTrigger: true,
               default: true,
               description: t(
@@ -631,7 +631,7 @@ const config: ControlPanelConfig = {
             name: 'comparison_color_enabled',
             config: {
               type: 'CheckboxControl',
-              label: t('basic conditional formatting'),
+              label: t('Basic conditional formatting'),
               renderTrigger: true,
               visibility: ({ controls }) =>
                 !isEmpty(controls?.time_compare?.value),
@@ -672,7 +672,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
-              label: t('Custom Conditional Formatting'),
+              label: t('Custom conditional formatting'),
               extraColorChoices: [
                 {
                   value: ColorSchemeEnum.Green,

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -646,7 +646,7 @@ const config: ControlPanelConfig = {
             name: 'show_cell_bars',
             config: {
               type: 'CheckboxControl',
-              label: t('Show Cell bars'),
+              label: t('Show cell bars'),
               renderTrigger: true,
               default: true,
               description: t(
@@ -674,7 +674,7 @@ const config: ControlPanelConfig = {
             name: 'color_pn',
             config: {
               type: 'CheckboxControl',
-              label: t('add colors to cell bars for +/-'),
+              label: t('Add colors to cell bars for +/-'),
               renderTrigger: true,
               default: true,
               description: t(
@@ -688,7 +688,7 @@ const config: ControlPanelConfig = {
             name: 'comparison_color_enabled',
             config: {
               type: 'CheckboxControl',
-              label: t('basic conditional formatting'),
+              label: t('Basic conditional formatting'),
               renderTrigger: true,
               visibility: ({ controls }) =>
                 !isEmpty(controls?.time_compare?.value),
@@ -729,7 +729,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
-              label: t('Custom Conditional Formatting'),
+              label: t('Custom conditional formatting'),
               extraColorChoices: [
                 {
                   value: ColorSchemeEnum.Green,

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -3382,7 +3382,7 @@ msgid "Custom"
 msgstr "تقليد"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "التنسيق الشرطي"
 
 msgid "Custom Plugin"
@@ -9862,7 +9862,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "عرض بيان إنشاء عرض"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "عرض أشرطة الخلايا"
 
 msgid "Show Dashboard"
@@ -13915,7 +13915,7 @@ msgstr "يجب أن يكون `row_offset` أكبر من أو يساوي 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "يجب أن يكون «العرض» أكبر أو يساوي 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13962,7 +13962,7 @@ msgid "background"
 msgstr "خلفية"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "التنسيق الشرطي"
 
 msgid "basis"

--- a/superset/translations/ca/LC_MESSAGES/messages.po
+++ b/superset/translations/ca/LC_MESSAGES/messages.po
@@ -3353,7 +3353,7 @@ msgstr "Actualment renderitzat: %s"
 msgid "Custom"
 msgstr "Personalitzat"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Format Condicional Personalitzat"
 
 msgid "Custom Plugin"
@@ -9647,7 +9647,7 @@ msgstr "Mostrar Bombolles"
 msgid "Show CREATE VIEW statement"
 msgstr "Mostrar sentència CREATE VIEW"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Mostrar barres de cel·la"
 
 msgid "Show Dashboard"
@@ -13708,7 +13708,7 @@ msgstr "`row_offset` ha de ser major o igual a 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` ha de ser major o igual a 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "afegir colors a les barres de cel·la per +/-"
 
 msgid "aggregate"
@@ -13753,7 +13753,7 @@ msgstr "auto"
 msgid "background"
 msgstr "fons"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "formatat condicional bàsic"
 
 msgid "basis"

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -3494,7 +3494,7 @@ msgstr "Derzeit dargestellt: %s"
 msgid "Custom"
 msgstr "Angepasst"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Benutzerdefinierte bedingte Formatierung"
 
 msgid "Custom Plugin"
@@ -10043,7 +10043,7 @@ msgstr "Blasen anzeigen"
 msgid "Show CREATE VIEW statement"
 msgstr "CREATE VIEW-Anweisung anzeigen"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Zellenbalken anzeigen"
 
 msgid "Show Dashboard"
@@ -14358,7 +14358,7 @@ msgstr "\"row_offset\" muss größer oder gleich 0 sein"
 msgid "`width` must be greater or equal to 0"
 msgstr "\"Breite\" muss größer oder gleich 0 sein"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "Farben zu den Zellenbalken für +/- hinzufügen"
 
 msgid "aggregate"
@@ -14403,7 +14403,7 @@ msgstr "automatisch"
 msgid "background"
 msgstr "Hintergrund"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "grundlegende bedingte Formatierung"
 
 msgid "basis"

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -3138,7 +3138,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr ""
 
 msgid "Custom Plugin"
@@ -9141,7 +9141,7 @@ msgstr ""
 msgid "Show CREATE VIEW statement"
 msgstr ""
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr ""
 
 msgid "Show Dashboard"
@@ -12795,7 +12795,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -12840,7 +12840,7 @@ msgstr ""
 msgid "background"
 msgstr ""
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr ""
 
 msgid "basis"

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -3138,7 +3138,7 @@ msgstr "Actualmente renderizado: %s"
 msgid "Custom"
 msgstr "Personalizado"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Formato condicional personalizado"
 
 msgid "Custom Plugin"
@@ -9141,7 +9141,7 @@ msgstr "Mostrar burbujas"
 msgid "Show CREATE VIEW statement"
 msgstr "Mostrar instrucción CREAR VISTA"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Mostrar barras de celda"
 
 msgid "Show Dashboard"
@@ -12795,7 +12795,7 @@ msgstr "«row_offset» debe ser mayor o igual a 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "«width» debe ser mayor o igual a 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "añade colores a las barras de celdas para +/-"
 
 msgid "aggregate"
@@ -12840,7 +12840,7 @@ msgstr "automático"
 msgid "background"
 msgstr "fondo"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "formato condicional básico"
 
 msgid "basis"

--- a/superset/translations/fa/LC_MESSAGES/messages.po
+++ b/superset/translations/fa/LC_MESSAGES/messages.po
@@ -3376,7 +3376,7 @@ msgstr "در حال حاضر رندر شده: %s"
 msgid "Custom"
 msgstr "سفارشی"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "قالب‌بندی شرطی سفارشی"
 
 msgid "Custom Plugin"
@@ -9784,7 +9784,7 @@ msgstr "نمایش حباب‌ها"
 msgid "Show CREATE VIEW statement"
 msgstr "بیان CREATE VIEW را نشان بدهید"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "نمودار میله‌ای سلول‌ها را نمایش بدهید"
 
 msgid "Show Dashboard"
@@ -13905,7 +13905,7 @@ msgstr "`row_offset` باید بزرگتر از یا برابر با ۰ باشد
 msgid "`width` must be greater or equal to 0"
 msgstr "`عرض` باید بزرگتر یا برابر با ۰ باشد."
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "رنگ‌ها را به نوارهای سلول برای + و - اضافه کنید"
 
 msgid "aggregate"
@@ -13950,7 +13950,7 @@ msgstr "خودکار"
 msgid "background"
 msgstr "پس‌زمینه"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "فرمت‌بندی شرطی پایه"
 
 msgid "basis"

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -3681,7 +3681,7 @@ msgid "Custom"
 msgstr "Personnalisé"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Formatage conditionnel"
 
 msgid "Custom Plugin"
@@ -10819,7 +10819,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "Afficher l’énoncé CREATE VIEW"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Afficher les barres de cellules"
 
 msgid "Show Dashboard"
@@ -15453,7 +15453,7 @@ msgstr "« row_offset » doit être plus grand ou égal à 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "« width » doit être plus grand ou égal à 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "ajouter des couleurs aux barres de cellules pour +/-"
 
 msgid "aggregate"
@@ -15496,7 +15496,7 @@ msgstr "auto"
 msgid "background"
 msgstr "contexte"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "formatage conditionnel basique"
 
 #, fuzzy

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -3374,7 +3374,7 @@ msgid "Custom"
 msgstr ""
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Formato Datetime"
 
 msgid "Custom Plugin"
@@ -9873,7 +9873,7 @@ msgid "Show CREATE VIEW statement"
 msgstr ""
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Grafico a Proiettile"
 
 msgid "Show Dashboard"
@@ -13738,7 +13738,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13787,7 +13787,7 @@ msgid "background"
 msgstr ""
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Formato Datetime"
 
 msgid "basis"

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -3209,7 +3209,7 @@ msgstr "現在レンダリング中: %s"
 msgid "Custom"
 msgstr "カスタム"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "カスタム条件付き書式"
 
 msgid "Custom Plugin"
@@ -9277,7 +9277,7 @@ msgstr "バブルを表示"
 msgid "Show CREATE VIEW statement"
 msgstr "CREATE VIEW文を表示"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "セルバーを表示"
 
 msgid "Show Dashboard"
@@ -13058,7 +13058,7 @@ msgstr "「row_offset」は 0 以上でなければなりません。"
 msgid "`width` must be greater or equal to 0"
 msgstr "「幅」は 0 以上でなければなりません。"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13103,7 +13103,7 @@ msgstr "自動"
 msgid "background"
 msgstr "背景"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "基本的な条件付き書式"
 
 msgid "basis"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -3352,7 +3352,7 @@ msgid "Custom"
 msgstr ""
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "주석"
 
 msgid "Custom Plugin"
@@ -9773,7 +9773,7 @@ msgid "Show CREATE VIEW statement"
 msgstr ""
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "차트 추가"
 
 msgid "Show Dashboard"
@@ -13592,7 +13592,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13641,7 +13641,7 @@ msgid "background"
 msgstr ""
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "주석"
 
 msgid "basis"

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr ""
 
 msgid "Custom Plugin"
@@ -9128,7 +9128,7 @@ msgstr ""
 msgid "Show CREATE VIEW statement"
 msgstr ""
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr ""
 
 msgid "Show Dashboard"
@@ -12780,7 +12780,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -12825,7 +12825,7 @@ msgstr ""
 msgid "background"
 msgstr ""
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr ""
 
 msgid "basis"

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -3442,7 +3442,7 @@ msgid "Custom"
 msgstr "Aangepast"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Voorwaardelijke opmaak"
 
 msgid "Custom Plugin"
@@ -9958,7 +9958,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "Toon CREATE VIEW statement"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Toon cel balken"
 
 msgid "Show Dashboard"
@@ -14170,7 +14170,7 @@ msgstr "`rij_offset` moet groter zijn dan of gelijk aan 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`breedte` moet groter of gelijk zijn aan 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -14217,7 +14217,7 @@ msgid "background"
 msgstr "achtergrond"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Voorwaardelijke opmaak"
 
 msgid "basis"

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -3557,7 +3557,7 @@ msgid "Custom"
 msgstr "Niestandardowy"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Niestandardowe formatowanie warunkowe"
 
 msgid "Custom Plugin"
@@ -10392,7 +10392,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "Pokaż instrukcję CREATE VIEW"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Pokaż paski komórek"
 
 msgid "Show Dashboard"
@@ -14786,7 +14786,7 @@ msgstr "`row_offset` musi być większe lub równe 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` musi być większe lub równe 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "dodaj kolory do pasków komórek dla +/-"
 
 msgid "aggregate"
@@ -14835,7 +14835,7 @@ msgid "background"
 msgstr "tło"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Podstawowe formatowanie warunkowe"
 
 #, fuzzy

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -3416,7 +3416,7 @@ msgid "Custom"
 msgstr ""
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Metadados adicionais"
 
 msgid "Custom Plugin"
@@ -10009,7 +10009,7 @@ msgid "Show CREATE VIEW statement"
 msgstr ""
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Gráfico de bala"
 
 msgid "Show Dashboard"
@@ -13939,7 +13939,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13987,7 +13987,7 @@ msgid "background"
 msgstr ""
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Metadados adicionais"
 
 msgid "basis"

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3502,7 +3502,7 @@ msgid "Custom"
 msgstr "Personalizado"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Formatação condicional"
 
 msgid "Custom Plugin"
@@ -10106,7 +10106,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "Mostrar instrução CREATE VIEW"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Mostrar barras de células"
 
 msgid "Show Dashboard"
@@ -14348,7 +14348,7 @@ msgstr "`row_offset` deve ser maior ou igual a 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`largura` deve ser maior ou igual a 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "adicionar cores para as barras para +/-"
 
 msgid "aggregate"
@@ -14396,7 +14396,7 @@ msgid "background"
 msgstr "fundo"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "formatação condicional básica"
 
 msgid "basis"

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -3410,7 +3410,7 @@ msgstr "Сейчас отрисовано: %s"
 msgid "Custom"
 msgstr "Пользовательский"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Условное форматирование"
 
 msgid "Custom Plugin"
@@ -9909,7 +9909,7 @@ msgstr "Показать пузыри"
 msgid "Show CREATE VIEW statement"
 msgstr "Показать выражение CREATE VIEW"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Наложить гистограммы на ячейки"
 
 msgid "Show Dashboard"
@@ -14016,7 +14016,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr "Ширина должна быть не менее нуля"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "Окрасить столбцы для +/-"
 
 msgid "aggregate"
@@ -14062,7 +14062,7 @@ msgstr "автоматически"
 msgid "background"
 msgstr ""
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Простое условное форматирование"
 
 #, fuzzy

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr ""
 
 msgid "Custom Plugin"
@@ -9249,7 +9249,7 @@ msgid "Show CREATE VIEW statement"
 msgstr ""
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Importovať dashboard"
 
 msgid "Show Dashboard"
@@ -12929,7 +12929,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -12974,7 +12974,7 @@ msgstr ""
 msgid "background"
 msgstr ""
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr ""
 
 msgid "basis"

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -3406,7 +3406,7 @@ msgstr "Trenutno izrisano: %s"
 msgid "Custom"
 msgstr "Prilagojen"
 
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Prilagojeno pogojno oblikovanje"
 
 msgid "Custom Plugin"
@@ -9819,7 +9819,7 @@ msgstr "Prikaži mehurčke"
 msgid "Show CREATE VIEW statement"
 msgstr "Prikaži CREATE VIEW stavek"
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Prikaži grafe v celicah"
 
 msgid "Show Dashboard"
@@ -13928,7 +13928,7 @@ msgstr "`row_offset` mora biti večja ali enaka 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` mora biti večja ali enaka 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr "dodajte barvo za graf v celici za +/-"
 
 msgid "aggregate"
@@ -13973,7 +13973,7 @@ msgstr "samodejno"
 msgid "background"
 msgstr "ozadje"
 
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "osnovno pogojno oblikovanje"
 
 msgid "basis"

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -3184,7 +3184,7 @@ msgid "Custom"
 msgstr ""
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Ek bilgi"
 
 msgid "Custom Plugin"
@@ -9284,7 +9284,7 @@ msgstr ""
 msgid "Show CREATE VIEW statement"
 msgstr ""
 
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr ""
 
 msgid "Show Dashboard"
@@ -12972,7 +12972,7 @@ msgstr ""
 msgid "`width` must be greater or equal to 0"
 msgstr ""
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13019,7 +13019,7 @@ msgid "background"
 msgstr ""
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Ek bilgi"
 
 msgid "basis"

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -3436,7 +3436,7 @@ msgid "Custom"
 msgstr "Звичайний"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "Умовне форматування"
 
 msgid "Custom Plugin"
@@ -9968,7 +9968,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "Показати заяву про створення перегляду"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "Показати стільникові смуги"
 
 msgid "Show Dashboard"
@@ -14148,7 +14148,7 @@ msgstr "`row_offset` повинен бути більшим або рівним 
 msgid "`width` must be greater or equal to 0"
 msgstr "`width` повинна бути більшою або рівною 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -14195,7 +14195,7 @@ msgid "background"
 msgstr "фон"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "Умовне форматування"
 
 msgid "basis"

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -3393,7 +3393,7 @@ msgid "Custom"
 msgstr "自定义"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "条件格式设置"
 
 msgid "Custom Plugin"
@@ -9908,7 +9908,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "显示 CREATE VIEW 语句"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "显示单元格的柱"
 
 msgid "Show Dashboard"
@@ -13820,7 +13820,7 @@ msgstr "`行偏移量` 必须大于或等于0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`宽度` 必须大于或等于0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13870,7 +13870,7 @@ msgid "background"
 msgstr "背景"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "条件格式设置"
 
 #, fuzzy

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -3396,7 +3396,7 @@ msgid "Custom"
 msgstr "自定義"
 
 #, fuzzy
-msgid "Custom Conditional Formatting"
+msgid "Custom conditional formatting"
 msgstr "條件格式設定"
 
 msgid "Custom Plugin"
@@ -9922,7 +9922,7 @@ msgid "Show CREATE VIEW statement"
 msgstr "顯示 CREATE VIEW 語句"
 
 #, fuzzy
-msgid "Show Cell bars"
+msgid "Show cell bars"
 msgstr "顯示單元格的柱"
 
 msgid "Show Dashboard"
@@ -13834,7 +13834,7 @@ msgstr "`行偏移量` 必須大於或等於 0"
 msgid "`width` must be greater or equal to 0"
 msgstr "`寬度` 必須大於或等於 0"
 
-msgid "add colors to cell bars for +/-"
+msgid "Add colors to cell bars for +/-"
 msgstr ""
 
 msgid "aggregate"
@@ -13884,7 +13884,7 @@ msgid "background"
 msgstr "背景"
 
 #, fuzzy
-msgid "basic conditional formatting"
+msgid "Basic conditional formatting"
 msgstr "條件格式設定"
 
 #, fuzzy


### PR DESCRIPTION
## Summary
- Updated capitalization of table chart configuration options in the Customize tab to use proper sentence case
- Fixes inconsistent capitalization across table configuration options

## Changes Made
- **"Show Cell bars"** → **"Show cell bars"** (lowercase "cell")
- **"add colors to cell bars for +/-"** → **"Add colors to cell bars for +/-"** (capitalize "Add")  
- **"basic conditional formatting"** → **"Basic conditional formatting"** (capitalize "Basic")
- **"Custom Conditional Formatting"** → **"Custom conditional formatting"** (lowercase "conditional formatting")

## Files Updated
- `superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx`
- `superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx`
- All translation files (`messages.pot` and 21 language-specific `.po` files)

## Screenshots
Before: 
<img width="327" height="738" alt="image" src="https://github.com/user-attachments/assets/42cc0e75-5793-44b9-8b2b-2efbca031f93" />


After: 


## Test plan
- [ ] Verify table chart configuration options display with correct capitalization in the UI
- [ ] Confirm both regular table and AG Grid table charts show updated labels
- [ ] Check that internationalization still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)