### PR TITLE
fix(sqllab): show actual execution duration in Query History

### DIFF
--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -256,15 +256,18 @@ function QueryList({ addDangerToast }: QueryListProps) {
         size: 'xl',
         Cell: ({
           row: {
-            original: { status, start_time, end_time },
+            original: { status, start_time, start_running_time, end_time },
           },
         }: any) => {
           const timerType = status === QueryState.Failed ? 'danger' : status;
-          const timerTime = end_time
-            ? extendedDayjs(extendedDayjs.utc(end_time - start_time)).format(
-                TIME_WITH_MS,
-              )
-            : '00:00:00.000';
+          // Use start_running_time if available for more accurate duration
+          const startTime = start_running_time || start_time;
+          const timerTime =
+            end_time && startTime
+              ? extendedDayjs(extendedDayjs.utc(end_time - startTime)).format(
+                  TIME_WITH_MS,
+                )
+              : '00:00:00.000';
           return (
             <TimerLabel type={timerType} role="timer">
               {timerTime}

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -104,6 +104,7 @@ export interface QueryObject {
     username: string;
   };
   start_time: number;
+  start_running_time: number | null;
   end_time: number;
   rows: number;
   tmp_table_name: string;
@@ -125,6 +126,7 @@ export enum QueryObjectColumns {
   User = 'user',
   UserFirstName = 'user.first_name',
   StartTime = 'start_time',
+  StartRunningTime = 'start_running_time',
   EndTime = 'end_time',
   Rows = 'rows',
   TmpTableName = 'tmp_table_name',

--- a/superset/queries/api.py
+++ b/superset/queries/api.py
@@ -91,6 +91,7 @@ class QueryRestApi(BaseSupersetModelRestApi):
         "user.id",
         "user.last_name",
         "start_time",
+        "start_running_time",
         "end_time",
         "tmp_table_name",
         "tracking_url",


### PR DESCRIPTION
### SUMMARY
This PR fixes the duration display in SQL Lab's Query History tab to show only the actual query execution time rather than the total time including queue/scheduling delays.

The issue was that the duration calculation used `end_time - start_time`, which includes the time a query spends in various states (pending, scheduled, etc.) before actually executing. This fix updates the calculation to use `start_running_time` when available, which represents when the query actually began executing.

**Changes:**
- Added `start_running_time` to the API response in `QueryRestApi.list_columns`
- Updated TypeScript interfaces to include the new field
- Modified the duration calculation in QueryHistoryList to prefer `start_running_time` over `start_time`

Fixes #30894

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Duration shows total time including queue/wait time
**After:** Duration shows only actual execution time

### TESTING INSTRUCTIONS
1. Go to SQL Lab
2. Run several queries of varying complexity
3. Navigate to the "Query History" tab
4. Verify that the Duration column shows reasonable execution times (e.g., simple SELECT queries should show durations under a second)
5. For queries that were queued or scheduled, verify the duration reflects only the actual execution time

### ADDITIONAL INFORMATION
- [x] Has associated issue: #30894
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)