### PR TITLE
fix(sqllab): prevent strings with angle brackets from being hidden

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -49,6 +49,21 @@ describe('isProbablyHTML', () => {
     const trickyText = 'a <= 10 and b > 10';
     expect(isProbablyHTML(trickyText)).toBe(false);
   });
+
+  it('should return false for strings with angle brackets that are not HTML', () => {
+    // Test case from issue #25561
+    expect(isProbablyHTML('<abcdef:12345>')).toBe(false);
+
+    // Other similar cases
+    expect(isProbablyHTML('<foo:bar>')).toBe(false);
+    expect(isProbablyHTML('<123>')).toBe(false);
+    expect(isProbablyHTML('<test@example.com>')).toBe(false);
+    expect(isProbablyHTML('<custom-element>')).toBe(false);
+
+    // Mathematical expressions
+    expect(isProbablyHTML('if x < 5 and y > 10')).toBe(false);
+    expect(isProbablyHTML('price < $100')).toBe(false);
+  });
 });
 
 describe('sanitizeHtmlIfNeeded', () => {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -68,9 +68,87 @@ export function isProbablyHTML(text: string) {
     return true;
   }
 
+  // Check if the string contains common HTML patterns
+  if (!hasHtmlTagPattern(text)) {
+    return false;
+  }
+
   const parser = new DOMParser();
   const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+
+  // Check if parsing created actual HTML elements (not just text nodes)
+  const elements = Array.from(doc.body.childNodes).filter(
+    node => node.nodeType === 1,
+  ) as Element[];
+
+  // If no elements were created, it's not HTML
+  if (elements.length === 0) {
+    return false;
+  }
+
+  // Check if the elements are known HTML tags (not custom/unknown tags)
+  // This prevents strings like "<abcdef:12345>" from being treated as HTML
+  return elements.some(element => {
+    const tagName = element.tagName.toLowerCase();
+    // List of common HTML tags we want to recognize
+    const knownHtmlTags = [
+      'div',
+      'span',
+      'p',
+      'a',
+      'b',
+      'i',
+      'u',
+      'em',
+      'strong',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'table',
+      'tr',
+      'td',
+      'th',
+      'tbody',
+      'thead',
+      'tfoot',
+      'ul',
+      'ol',
+      'li',
+      'img',
+      'br',
+      'hr',
+      'pre',
+      'code',
+      'blockquote',
+      'section',
+      'article',
+      'nav',
+      'header',
+      'footer',
+      'form',
+      'input',
+      'button',
+      'select',
+      'option',
+      'textarea',
+      'label',
+      'fieldset',
+      'legend',
+      'video',
+      'audio',
+      'canvas',
+      'iframe',
+      'script',
+      'style',
+      'link',
+      'meta',
+      'title',
+    ];
+    return knownHtmlTags.includes(tagName);
+  });
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue where strings containing angle brackets (e.g., `<abcdef:12345>`) were not displaying in SQL Lab query results.

The root cause was that the `isProbablyHTML` function was too aggressive in detecting HTML content. It would treat any string that created DOM elements when parsed as HTML, even if those elements were unknown/custom tags. This caused strings like `<abcdef:12345>` to be rendered using `dangerouslySetInnerHTML`, which browsers ignore for unknown tags, making the content disappear.

**Changes:**
- Enhanced `isProbablyHTML` to check against a whitelist of known HTML tags
- Added early return if the string doesn't match common HTML patterns
- Added comprehensive test cases for various edge cases

Fixes #25561

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Strings like `<abcdef:12345>` would not display in query results
**After:** These strings now display correctly as plain text

### TESTING INSTRUCTIONS
1. Go to SQL Lab
2. Run a query that returns strings with angle brackets:
   ```sql
   SELECT '<abcdef:12345>' as test_str
   UNION ALL
   SELECT '<foo:bar>' as test_str
   UNION ALL
   SELECT 'normal text' as test_str
   UNION ALL
   SELECT '<div>actual html</div>' as test_str
   ```
3. Verify that:
   - `<abcdef:12345>` and `<foo:bar>` display as plain text
   - `normal text` displays normally
   - `<div>actual html</div>` still renders as HTML (maintaining existing functionality)

### ADDITIONAL INFORMATION
- [x] Has associated issue: #25561
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)