### PR TITLE
fix(echart): initial chart animation

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -174,6 +174,8 @@ function Echart(
       if (!chartRef.current) {
         chartRef.current = init(divRef.current, null, { locale });
       }
+      // did mount
+      handleSizeChange({ width, height });
       setDidMount(true);
     });
   }, [locale]);
@@ -235,9 +237,6 @@ function Echart(
         echartOptions,
       );
       chartRef.current?.setOption(themedEchartOptions, true);
-
-      // did mount
-      handleSizeChange({ width, height });
     }
   }, [didMount, echartOptions, eventHandlers, zrEventHandlers, theme]);
 


### PR DESCRIPTION
### SUMMARY
During the process of applying the echart locale patch for #31751, superset encountered an issue where the initial animation of all echarts disappeared. This problem occurred because the logic to call `handleSizeChange`, which was [previously located in the component's didMount](https://github.com/apache/superset/pull/31751/files#diff-100d187c8e95ad7ec2213d0618115f67234e59ef488555c13d5a358e7f794f71L172-L176), was moved to execute i[mmediately after setOptions within a useEffect](https://github.com/apache/superset/pull/31751/files#diff-100d187c8e95ad7ec2213d0618115f67234e59ef488555c13d5a358e7f794f71R175-R178) that has multiple dependencies.
As a result, when the animation was triggered, handleSizeChange caused a re-render, interrupting the animation process.
This commit resolves the issue by moving handleSizeChange back to the mounting phase, ensuring that the initial animation is no longer interrupted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/a1027f28-cfab-4f89-88f2-c30e0a20c7d9

After:

https://github.com/user-attachments/assets/442d2f78-0515-41ee-a24a-03be5ba481d6


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
