### PR TITLE
fix: docs eslint command

### DIFF
--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -28,6 +28,9 @@ const globals = require('globals');
 const { defineConfig, globalIgnores } = require('eslint/config');
 
 module.exports = defineConfig([
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+  },
   globalIgnores(['build/**/*', '.docusaurus/**/*', 'node_modules/**/*']),
   js.configs.recommended,
   ...ts.configs.recommended,
@@ -36,7 +39,7 @@ module.exports = defineConfig([
     files: ['eslint.config.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
-    }
+    },
   },
   {
     languageOptions: {
@@ -68,5 +71,5 @@ module.exports = defineConfig([
         version: 'detect',
       },
     },
-  }
-])
+  },
+]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "eslint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "eslint": "eslint ."
   },
   "dependencies": {
     "@ant-design/icons": "^6.0.0",


### PR DESCRIPTION
### SUMMARY
When I started cleaning up the extensions draft PR with `pre-commit run --all-files`, I noticed lots of unrelated warnings/errors. This is the first of a few more to clean those up.

On the docs, we've upgraded from ESLint v8 v9 in #34207, but we're still using an option `--ext` in our `eslint` command that's been removed in v9. See discussion on the changes here: https://github.com/eslint/eslint/issues/17931#issuecomment-1873432288.

### BEFORE

```shell
$ yarn eslint
yarn run v1.22.22
$ eslint . --ext .js,.jsx,.ts,.tsx
Invalid option '--ext' - perhaps you meant '-c'?
You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Command failed: node /Users/ville/.yvm/versions/v1.22.22/bin/yarn.js eslint
```

### AFTER

```shell
$ yarn eslint
yarn run v1.22.22
$ eslint .
✨  Done in 0.91s.
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
