### PR TITLE
chore: use logger on all migrations

### DIFF
--- a/superset/migrations/shared/catalogs.py
+++ b/superset/migrations/shared/catalogs.py
@@ -37,7 +37,7 @@ from superset.migrations.shared.security_converge import (
 )
 from superset.models.core import Database
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 Base: Type[Any] = declarative_base()
 

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -28,7 +28,7 @@ from superset.migrations.shared.utils import paginated_update, try_load_json
 from superset.utils import json
 from superset.utils.date_parser import get_since_until
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 Base = declarative_base()
 

--- a/superset/migrations/shared/security_converge.py
+++ b/superset/migrations/shared/security_converge.py
@@ -29,7 +29,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Load, relationship, Session
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("alembic.env")
 
 Base = declarative_base()
 

--- a/superset/migrations/shared/utils.py
+++ b/superset/migrations/shared/utils.py
@@ -49,7 +49,7 @@ YELLOW = "\033[33m"
 RED = "\033[31m"
 LRED = "\033[91m"
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 DEFAULT_BATCH_SIZE = int(os.environ.get("BATCH_SIZE", 1000))
 

--- a/superset/migrations/versions/2016-05-27_15-03_1226819ee0e3_fix_wrong_constraint_on_table_columns.py
+++ b/superset/migrations/versions/2016-05-27_15-03_1226819ee0e3_fix_wrong_constraint_on_table_columns.py
@@ -33,6 +33,8 @@ from superset.utils.core import generic_find_constraint_name
 revision = "1226819ee0e3"
 down_revision = "956a063c52b3"
 
+logger = logging.getLogger("alembic.env")
+
 
 naming_convention = {
     "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"
@@ -61,7 +63,7 @@ def upgrade():
                 ["datasource_name"],
             )
     except:  # noqa: E722
-        logging.warning("Could not find or drop constraint on `columns`")
+        logger.warning("Could not find or drop constraint on `columns`")
 
 
 def downgrade():

--- a/superset/migrations/versions/2016-09-22_10-21_3b626e2a6783_sync_db_with_models.py
+++ b/superset/migrations/versions/2016-09-22_10-21_3b626e2a6783_sync_db_with_models.py
@@ -38,6 +38,8 @@ from superset.utils.core import generic_find_constraint_name
 revision = "3b626e2a6783"
 down_revision = "eca4694defa7"
 
+logger = logging.getLogger("alembic.env")
+
 
 def upgrade():
     # cleanup after: https://github.com/airbnb/superset/pull/1078
@@ -60,7 +62,7 @@ def upgrade():
             batch_op.drop_column("druid_datasource_id")
             batch_op.drop_column("table_id")
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
     # fixed issue: https://github.com/airbnb/superset/issues/466
     try:
@@ -69,18 +71,18 @@ def upgrade():
                 None, "datasources", ["datasource_name"], ["datasource_name"]
             )
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
     try:
         with op.batch_alter_table("query") as batch_op:
             batch_op.create_unique_constraint("client_id", ["client_id"])
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
     try:
         with op.batch_alter_table("query") as batch_op:
             batch_op.drop_column("name")
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
 
 def downgrade():
@@ -88,7 +90,7 @@ def downgrade():
         with op.batch_alter_table("tables") as batch_op:
             batch_op.create_index("table_name", ["table_name"], unique=True)
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
     try:
         with op.batch_alter_table("slices") as batch_op:
@@ -113,7 +115,7 @@ def downgrade():
             )
             batch_op.create_foreign_key("slices_ibfk_2", "tables", ["table_id"], ["id"])
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
     try:
         fk_columns = generic_find_constraint_name(
@@ -125,11 +127,11 @@ def downgrade():
         with op.batch_alter_table("columns") as batch_op:
             batch_op.drop_constraint(fk_columns, type_="foreignkey")
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))
 
     op.add_column("query", sa.Column("name", sa.String(length=256), nullable=True))
     try:
         with op.batch_alter_table("query") as batch_op:
             batch_op.drop_constraint("client_id", type_="unique")
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))

--- a/superset/migrations/versions/2016-10-05_11-30_b46fa1b0b39e_add_params_to_tables.py
+++ b/superset/migrations/versions/2016-10-05_11-30_b46fa1b0b39e_add_params_to_tables.py
@@ -31,6 +31,8 @@ import logging  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 
+logger = logging.getLogger("alembic.env")
+
 
 def upgrade():
     op.add_column("tables", sa.Column("params", sa.Text(), nullable=True))
@@ -40,4 +42,4 @@ def downgrade():
     try:
         op.drop_column("tables", "params")
     except Exception as ex:
-        logging.warning(str(ex))
+        logger.warning(str(ex))

--- a/superset/migrations/versions/2017-03-16_18-10_db527d8c4c78_add_db_verbose_name.py
+++ b/superset/migrations/versions/2017-03-16_18-10_db527d8c4c78_add_db_verbose_name.py
@@ -31,6 +31,8 @@ import logging  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
 from alembic import op  # noqa: E402
 
+logger = logging.getLogger("alembic.env")
+
 
 def upgrade():
     op.add_column(
@@ -44,7 +46,7 @@ def upgrade():
         op.create_unique_constraint(None, "dbs", ["verbose_name"])
         op.create_unique_constraint(None, "clusters", ["verbose_name"])
     except Exception:
-        logging.info("Constraint not created, expected when using sqlite")
+        logger.info("Constraint not created, expected when using sqlite")
 
 
 def downgrade():
@@ -52,4 +54,4 @@ def downgrade():
         op.drop_column("dbs", "verbose_name")
         op.drop_column("clusters", "verbose_name")
     except Exception as ex:
-        logging.exception(ex)
+        logger.exception(ex)

--- a/superset/migrations/versions/2017-10-03_14-37_4736ec66ce19_.py
+++ b/superset/migrations/versions/2017-10-03_14-37_4736ec66ce19_.py
@@ -37,6 +37,8 @@ from superset.utils.core import (
 revision = "4736ec66ce19"
 down_revision = "f959a6652acd"
 
+logger = logging.getLogger("alembic.env")
+
 conv = {
     "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
     "uq": "uq_%(table_name)s_%(column_0_name)s",
@@ -119,13 +121,13 @@ def upgrade():
                 type_="unique",
             )
     except Exception as ex:
-        logging.warning(
+        logger.warning(
             "Constraint drop failed, you may want to do this "
             "manually on your database. For context, this is a known "
             "issue around nondeterministic constraint names on Postgres "
             "and perhaps more databases through SQLAlchemy."
         )
-        logging.exception(ex)
+        logger.exception(ex)
 
 
 def downgrade():

--- a/superset/migrations/versions/2018-05-09_23-45_e502db2af7be_add_template_params_to_tables.py
+++ b/superset/migrations/versions/2018-05-09_23-45_e502db2af7be_add_template_params_to_tables.py
@@ -22,12 +22,16 @@ Create Date: 2018-05-09 23:45:14.296283
 
 """
 
+import logging
+
+import sqlalchemy as sa  # noqa: E402
+from alembic import op  # noqa: E402
+
 # revision identifiers, used by Alembic.
 revision = "e502db2af7be"
 down_revision = "5ccf602336a0"
 
-import sqlalchemy as sa  # noqa: E402
-from alembic import op  # noqa: E402
+logger = logging.getLogger("alembic.env")
 
 
 def upgrade():
@@ -38,4 +42,4 @@ def downgrade():
     try:
         op.drop_column("tables", "template_params")
     except Exception as ex:
-        logging.warning(str(ex))  # noqa: F821
+        logger.warning(str(ex))

--- a/superset/migrations/versions/2018-12-11_22-03_fb13d49b72f9_better_filters.py
+++ b/superset/migrations/versions/2018-12-11_22-03_fb13d49b72f9_better_filters.py
@@ -35,6 +35,8 @@ from superset.utils import json
 revision = "fb13d49b72f9"
 down_revision = "de021a1ca60d"
 
+logger = logging.getLogger("alembic.env")
+
 Base = declarative_base()
 
 
@@ -49,7 +51,7 @@ class Slice(Base):
 
 def upgrade_slice(slc):
     params = json.loads(slc.params)
-    logging.info(f"Upgrading {slc.slice_name}")
+    logger.info(f"Upgrading {slc.slice_name}")
     cols = params.get("groupby")
     metric = params.get("metric")
     if cols:
@@ -79,8 +81,8 @@ def upgrade():
     for slc in filter_box_slices.all():
         try:
             upgrade_slice(slc)
-        except Exception:
-            logging.exception(e)  # noqa: F821
+        except Exception as e:
+            logger.exception(e)
 
     session.commit()
     session.close()
@@ -94,7 +96,7 @@ def downgrade():
     for slc in filter_box_slices.all():
         try:
             params = json.loads(slc.params)
-            logging.info(f"Downgrading {slc.slice_name}")
+            logger.info(f"Downgrading {slc.slice_name}")
             flts = params.get("filter_configs")
             if not flts:
                 continue
@@ -102,7 +104,7 @@ def downgrade():
             params["groupby"] = [o.get("column") for o in flts]
             slc.params = json.dumps(params, sort_keys=True)
         except Exception as ex:
-            logging.exception(ex)
+            logger.exception(ex)
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2019-11-06_15-23_78ee127d0d1d_reconvert_legacy_filters_into_adhoc.py
+++ b/superset/migrations/versions/2019-11-06_15-23_78ee127d0d1d_reconvert_legacy_filters_into_adhoc.py
@@ -41,6 +41,8 @@ from superset.utils.core import (  # noqa: E402
 
 Base = declarative_base()
 
+logger = logging.getLogger("alembic.env")
+
 
 class Slice(Base):
     __tablename__ = "slices"
@@ -63,7 +65,7 @@ def upgrade():
                 if source != target:
                     slc.params = json.dumps(target, sort_keys=True)
             except Exception as ex:
-                logging.warn(ex)
+                logger.warning(ex)
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2020-02-07_14-13_3325d4caccc8_dashboard_scoped_filters.py
+++ b/superset/migrations/versions/2020-02-07_14-13_3325d4caccc8_dashboard_scoped_filters.py
@@ -37,6 +37,8 @@ from superset.utils.dashboard_filter_scopes_converter import convert_filter_scop
 revision = "3325d4caccc8"
 down_revision = "e96dbf2cfef0"
 
+logger = logging.getLogger("alembic.env")
+
 Base = declarative_base()
 
 
@@ -86,7 +88,7 @@ def upgrade():
             if filters:
                 filter_scopes = convert_filter_scopes(json_metadata, filters)
                 json_metadata["filter_scopes"] = filter_scopes
-                logging.info(
+                logger.info(
                     f"Adding filter_scopes for dashboard {dashboard.id}: {json.dumps(filter_scopes)}"  # noqa: E501
                 )
 
@@ -100,7 +102,7 @@ def upgrade():
             else:
                 dashboard.json_metadata = None
         except Exception as ex:
-            logging.exception(f"dashboard {dashboard.id} has error: {ex}")
+            logger.exception(f"dashboard {dashboard.id} has error: {ex}")
 
     session.commit()
     session.close()

--- a/superset/migrations/versions/2021-02-18_09-13_c501b7c653a3_add_missing_uuid_column.py
+++ b/superset/migrations/versions/2021-02-18_09-13_c501b7c653a3_add_missing_uuid_column.py
@@ -38,6 +38,8 @@ from sqlalchemy_utils import UUIDType  # noqa: E402
 
 from superset import db  # noqa: E402
 
+logger = logging.getLogger("alembic.env")
+
 add_uuid_column_to_import_mixin = import_module(
     "superset.migrations.versions."
     "2020-09-28_17-57_b56500de1855_add_uuid_column_to_import_mixin",
@@ -52,9 +54,9 @@ def has_uuid_column(table_name, bind):
     columns = {column["name"] for column in inspector.get_columns(table_name)}
     has_uuid_column = "uuid" in columns
     if has_uuid_column:
-        logging.info("Table %s already has uuid column, skipping...", table_name)
+        logger.info("Table %s already has uuid column, skipping...", table_name)
     else:
-        logging.info("Table %s doesn't have uuid column, adding...", table_name)
+        logger.info("Table %s doesn't have uuid column, adding...", table_name)
     return has_uuid_column
 
 

--- a/superset/migrations/versions/2021-08-02_16-39_e323605f370a_fix_schemas_allowed_for_csv_upload.py
+++ b/superset/migrations/versions/2021-08-02_16-39_e323605f370a_fix_schemas_allowed_for_csv_upload.py
@@ -38,6 +38,8 @@ down_revision = "31b2a1039d4a"
 
 Base = declarative_base()
 
+logger = logging.getLogger("alembic.env")
+
 
 class Database(Base):
     __tablename__ = "dbs"
@@ -56,7 +58,7 @@ def upgrade():
         try:
             extra = json.loads(database.extra)
         except json.JSONDecodeError as ex:
-            logging.warning(str(ex))
+            logger.warning(str(ex))
             continue
 
         schemas_allowed_for_csv_upload = extra.get("schemas_allowed_for_csv_upload")

--- a/superset/migrations/versions/2021-08-09_17-32_07071313dd52_change_fetch_values_predicate_to_text.py
+++ b/superset/migrations/versions/2021-08-09_17-32_07071313dd52_change_fetch_values_predicate_to_text.py
@@ -35,6 +35,8 @@ from sqlalchemy import func  # noqa: E402
 from superset import db  # noqa: E402
 from superset.connectors.sqla.models import SqlaTable  # noqa: E402
 
+logger = logging.getLogger("alembic.env")
+
 
 def upgrade():
     with op.batch_alter_table("tables") as batch_op:
@@ -62,12 +64,12 @@ def remove_value_if_too_long():
         for row in rows:
             row.fetch_values_predicate = None
 
-        logging.info("%d values deleted", len(rows))
+        logger.info("%d values deleted", len(rows))
 
         session.commit()
         session.close()
     except Exception as ex:
-        logging.warning(ex)
+        logger.warning(ex)
 
 
 def downgrade():

--- a/superset/migrations/versions/2021-08-31_11-37_021b81fe4fbb_add_type_to_native_filter_configuration.py
+++ b/superset/migrations/versions/2021-08-31_11-37_021b81fe4fbb_add_type_to_native_filter_configuration.py
@@ -37,7 +37,7 @@ from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 
 class Dashboard(Base):

--- a/superset/migrations/versions/2021-11-11_04-18_0ca9e5f1dacd_rename_to_schemas_allowed_for_file_.py
+++ b/superset/migrations/versions/2021-11-11_04-18_0ca9e5f1dacd_rename_to_schemas_allowed_for_file_.py
@@ -37,6 +37,8 @@ from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
 
+logger = logging.getLogger("alembic.env")
+
 
 class Database(Base):
     __tablename__ = "dbs"
@@ -52,7 +54,7 @@ def upgrade():
         try:
             extra = json.loads(database.extra)
         except json.JSONDecodeError as ex:
-            logging.warning(str(ex))
+            logger.warning(str(ex))
             continue
 
         if "schemas_allowed_for_csv_upload" in extra:
@@ -74,7 +76,7 @@ def downgrade():
         try:
             extra = json.loads(database.extra)
         except json.JSONDecodeError as ex:
-            logging.warning(str(ex))
+            logger.warning(str(ex))
             continue
 
         if "schemas_allowed_for_file_upload" in extra:

--- a/superset/migrations/versions/2021-12-13_14-06_fe23025b9441_rename_big_viz_total_form_data_fields.py
+++ b/superset/migrations/versions/2021-12-13_14-06_fe23025b9441_rename_big_viz_total_form_data_fields.py
@@ -37,7 +37,7 @@ from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 
 class Slice(Base):

--- a/superset/migrations/versions/2021-12-17_16-56_31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
+++ b/superset/migrations/versions/2021-12-17_16-56_31bb738bd1d2_move_pivot_table_v2_legacy_order_by_to_.py
@@ -38,7 +38,7 @@ from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
 
-logger = logging.getLogger("alembic")
+logger = logging.getLogger("alembic.env")
 
 
 class Slice(Base):

--- a/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
+++ b/superset/migrations/versions/2023-03-27_12-30_7e67aecbf3f1_chart_ds_constraint.py
@@ -37,7 +37,7 @@ from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("alembic.env")
 
 
 class Slice(Base):  # type: ignore

--- a/superset/migrations/versions/2023-05-11_12-41_4ea966691069_cross_filter_global_scoping.py
+++ b/superset/migrations/versions/2023-05-11_12-41_4ea966691069_cross_filter_global_scoping.py
@@ -38,7 +38,7 @@ from superset.migrations.shared.utils import paginated_update  # noqa: E402
 from superset.utils import json  # noqa: E402
 
 Base = declarative_base()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("alembic.env")
 
 
 class Dashboard(Base):

--- a/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
+++ b/superset/migrations/versions/2024-05-10_18-02_f84fde59123a_update_charts_with_old_time_comparison.py
@@ -41,7 +41,7 @@ from superset.utils.date_parser import get_since_until
 revision = "f84fde59123a"
 down_revision = "9621c6d56ffb"
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("alembic.env")
 Base = declarative_base()
 
 

--- a/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
+++ b/superset/migrations/versions/2024-07-19_16-11_df3d7e2eb9a4_remove__customer_location_uc.py
@@ -34,7 +34,7 @@ from superset.utils.core import generic_find_uq_constraint_name
 revision = "df3d7e2eb9a4"
 down_revision = "48cbb571fa3a"
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("alembic.env")
 
 
 def upgrade():

--- a/superset/migrations/versions/2025-06-06_00-39_363a9b1e8992_convert_metric_currencies_from_str_to_json.py
+++ b/superset/migrations/versions/2025-06-06_00-39_363a9b1e8992_convert_metric_currencies_from_str_to_json.py
@@ -32,8 +32,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from superset import db
 from superset.migrations.shared.utils import paginated_update
 
-logger = logging.getLogger("alembic")
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("alembic.env")
 
 # revision identifiers, used by Alembic.
 revision = "363a9b1e8992"


### PR DESCRIPTION
### SUMMARY
I noticed we're using many different variants of logging in migrations. This PR unifies the following:
- fix a few instances, where we were logging without the import
- always use a `logger` instead of `logging` directly
- replace deprecated calls, like `logger.warn()` with `logger.warning()`
- always use the `alembic.env` logger which is defined in the `env.py` file: https://github.com/apache/superset/blob/1a7a381bd574665d4694be4a7554962f8edd98ad/superset/migrations/env.py#L37

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
