### PR TITLE
fix(table): hide conditional formatting color options without time comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -673,16 +673,6 @@ const config: ControlPanelConfig = {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
               label: t('Custom conditional formatting'),
-              extraColorChoices: [
-                {
-                  value: ColorSchemeEnum.Green,
-                  label: t('Green for increase, red for decrease'),
-                },
-                {
-                  value: ColorSchemeEnum.Red,
-                  label: t('Red for increase, green for decrease'),
-                },
-              ],
               description: t(
                 'Apply conditional color formatting to numeric columns',
               ),
@@ -695,6 +685,23 @@ const config: ControlPanelConfig = {
                 )
                   ? (explore?.datasource as Dataset)?.verbose_map
                   : (explore?.datasource?.columns ?? {});
+
+                // Only show increase/decrease color options when time comparison is active
+                const hasTimeComparison = !isEmpty(
+                  explore?.form_data?.time_compare,
+                );
+                const extraColorChoices = hasTimeComparison
+                  ? [
+                      {
+                        value: ColorSchemeEnum.Green,
+                        label: t('Green for increase, red for decrease'),
+                      },
+                      {
+                        value: ColorSchemeEnum.Red,
+                        label: t('Red for increase, green for decrease'),
+                      },
+                    ]
+                  : [];
                 const chartStatus = chart?.chartStatus;
                 const { colnames, coltypes } =
                   chart?.queriesResponse?.[0] ?? {};
@@ -725,6 +732,7 @@ const config: ControlPanelConfig = {
                   removeIrrelevantConditions: chartStatus === 'success',
                   columnOptions,
                   verboseMap,
+                  extraColorChoices,
                 };
               },
             },

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -730,16 +730,6 @@ const config: ControlPanelConfig = {
               type: 'ConditionalFormattingControl',
               renderTrigger: true,
               label: t('Custom conditional formatting'),
-              extraColorChoices: [
-                {
-                  value: ColorSchemeEnum.Green,
-                  label: t('Green for increase, red for decrease'),
-                },
-                {
-                  value: ColorSchemeEnum.Red,
-                  label: t('Red for increase, green for decrease'),
-                },
-              ],
               description: t(
                 'Apply conditional color formatting to numeric columns',
               ),
@@ -752,6 +742,23 @@ const config: ControlPanelConfig = {
                 )
                   ? (explore?.datasource as Dataset)?.verbose_map
                   : (explore?.datasource?.columns ?? {});
+
+                // Only show increase/decrease color options when time comparison is active
+                const hasTimeComparison = !isEmpty(
+                  explore?.form_data?.time_compare,
+                );
+                const extraColorChoices = hasTimeComparison
+                  ? [
+                      {
+                        value: ColorSchemeEnum.Green,
+                        label: t('Green for increase, red for decrease'),
+                      },
+                      {
+                        value: ColorSchemeEnum.Red,
+                        label: t('Red for increase, green for decrease'),
+                      },
+                    ]
+                  : [];
                 const chartStatus = chart?.chartStatus;
                 const { colnames, coltypes } =
                   chart?.queriesResponse?.[0] ?? {};
@@ -782,6 +789,7 @@ const config: ControlPanelConfig = {
                   removeIrrelevantConditions: chartStatus === 'success',
                   columnOptions,
                   verboseMap,
+                  extraColorChoices,
                 };
               },
             },


### PR DESCRIPTION
### SUMMARY
Fixes issue #34141 where conditional formatting color scheme options for "Green for increase, red for decrease" and "Red for increase, green for decrease" were showing in table charts even when no time comparison was active. These color options only work with time comparison data, so they should be hidden when time_compare is empty.

The fix modifies both table chart control panels to dynamically show/hide these color options based on whether time comparison is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Color scheme options "Green for increase, red for decrease" and "Red for increase, green for decrease" appeared in conditional formatting dropdowns even without time comparison enabled.

**After:** These color scheme options only appear when time comparison is active (time_compare has a value).

### TESTING INSTRUCTIONS
1. Create a new table chart without time comparison enabled
2. Go to Visual formatting -> Custom conditional formatting  
3. Create a new conditional formatting rule
4. Check the color scheme dropdown - should NOT see "Green for increase, red for decrease" options
5. Enable time comparison in the chart configuration
6. Return to conditional formatting - should now see the increase/decrease color options

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #34141
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API