### PR TITLE
fix(explore): Fix missing await for async buildV1ChartDataPayload calls

### DIFF
--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -491,8 +491,8 @@ describe('getSlicePayload', () => {
     dashboards: [],
   };
 
-  test('should return the correct payload when no adhoc_filters are present in formDataWithNativeFilters', () => {
-    const result = getSlicePayload(
+  test('should return the correct payload when no adhoc_filters are present in formDataWithNativeFilters', async () => {
+    const result = await getSlicePayload(
       sliceName,
       formDataWithNativeFilters,
       dashboards,
@@ -515,7 +515,7 @@ describe('getSlicePayload', () => {
     );
   });
 
-  test('should return the correct payload when adhoc_filters are present in formDataWithNativeFilters', () => {
+  test('should return the correct payload when adhoc_filters are present in formDataWithNativeFilters', async () => {
     const formDataWithAdhocFilters: QueryFormData = {
       ...formDataWithNativeFilters,
       adhoc_filters: [
@@ -528,7 +528,7 @@ describe('getSlicePayload', () => {
         },
       ],
     };
-    const result = getSlicePayload(
+    const result = await getSlicePayload(
       sliceName,
       formDataWithAdhocFilters,
       dashboards,
@@ -551,7 +551,7 @@ describe('getSlicePayload', () => {
     );
   });
 
-  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true', () => {
+  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true', async () => {
     const formDataWithAdhocFiltersWithExtra: QueryFormData = {
       ...formDataWithNativeFilters,
       adhoc_filters: [
@@ -564,7 +564,7 @@ describe('getSlicePayload', () => {
         },
       ],
     };
-    const result = getSlicePayload(
+    const result = await getSlicePayload(
       sliceName,
       formDataWithAdhocFiltersWithExtra,
       dashboards,
@@ -587,7 +587,7 @@ describe('getSlicePayload', () => {
     );
   });
 
-  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true in mixed chart', () => {
+  test('should return the correct payload when formDataWithNativeFilters has a filter with isExtra set to true in mixed chart', async () => {
     const formDataFromSliceWithAdhocFilterB: QueryFormData = {
       ...formDataFromSlice,
       adhoc_filters_b: [
@@ -625,7 +625,7 @@ describe('getSlicePayload', () => {
         },
       ],
     };
-    const result = getSlicePayload(
+    const result = await getSlicePayload(
       sliceName,
       formDataWithAdhocFiltersWithExtra,
       dashboards,
@@ -641,7 +641,7 @@ describe('getSlicePayload', () => {
     );
   });
 
-  test('should return the correct payload when formDataFromSliceWithAdhocFilter has no time range filters in mixed chart', () => {
+  test('should return the correct payload when formDataFromSliceWithAdhocFilter has no time range filters in mixed chart', async () => {
     const formDataFromSliceWithAdhocFilterB: QueryFormData = {
       ...formDataFromSlice,
       adhoc_filters: [],
@@ -672,7 +672,7 @@ describe('getSlicePayload', () => {
         },
       ],
     };
-    const result = getSlicePayload(
+    const result = await getSlicePayload(
       sliceName,
       formDataWithAdhocFiltersWithExtra,
       dashboards,
@@ -690,7 +690,7 @@ describe('getSlicePayload', () => {
     expect(hasTemporalRange).toBe(true);
   });
 
-  test('should reset isExtra flag to false for temporal filter when saving as a new chart', () => {
+  test('should reset isExtra flag to false for temporal filter when saving as a new chart', async () => {
     const formDataWithTemporalFilterWithExtra: QueryFormData = {
       ...formDataWithNativeFilters,
       adhoc_filters: [
@@ -705,7 +705,7 @@ describe('getSlicePayload', () => {
       ],
     };
 
-    const result = getSlicePayload(
+    const result = await getSlicePayload(
       sliceName,
       formDataWithTemporalFilterWithExtra,
       dashboards,

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -83,13 +83,13 @@ const hasTemporalRangeFilter = (formData: Partial<QueryFormData>): boolean =>
     (filter: SimpleAdhocFilter) => filter.operator === Operators.TemporalRange,
   );
 
-export const getSlicePayload = (
+export const getSlicePayload = async (
   sliceName: string,
   formDataWithNativeFilters: QueryFormData = {} as QueryFormData,
   dashboards: number[],
   owners: [],
   formDataFromSlice: QueryFormData = {} as QueryFormData,
-): Partial<PayloadSlice> => {
+): Promise<Partial<PayloadSlice>> => {
   const adhocFilters: Partial<QueryFormData> = extractAdhocFiltersFromFormData(
     formDataWithNativeFilters,
   );
@@ -168,7 +168,7 @@ export const getSlicePayload = (
     dashboards,
     owners,
     query_context: JSON.stringify(
-      buildV1ChartDataPayload({
+      await buildV1ChartDataPayload({
         formData,
         force: false,
         resultFormat: 'json',
@@ -242,7 +242,7 @@ export const updateSlice =
     try {
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
-        jsonPayload: getSlicePayload(
+        jsonPayload: await getSlicePayload(
           sliceName,
           formData,
           dashboards,
@@ -274,7 +274,7 @@ export const createSlice =
     try {
       const response = await SupersetClient.post({
         endpoint: `/api/v1/chart/`,
-        jsonPayload: getSlicePayload(
+        jsonPayload: await getSlicePayload(
           sliceName,
           formData,
           dashboards,

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.jsx
@@ -160,7 +160,7 @@ const ExploreChartPanel = ({
   const updateQueryContext = useCallback(
     async function fetchChartData() {
       if (slice && slice.query_context === null) {
-        const queryContext = buildV1ChartDataPayload({
+        const queryContext = await buildV1ChartDataPayload({
           formData: slice.form_data,
           force,
           resultFormat: 'json',


### PR DESCRIPTION
PR #34383 made buildV1ChartDataPayload async to support complex chart logic, but missed updating two critical call sites to await the Promise:

1. In saveModalActions.ts - getSlicePayload was calling buildV1ChartDataPayload without await, causing query_context to be saved as "{}" (stringified Promise)

2. In ExploreChartPanel/index.jsx - updateQueryContext was also missing await

This caused all charts created after PR #34383 to have invalid query_context, leading to "Error loading chart datasources" warnings in dashboards.

Fixes:
- Made getSlicePayload async and added await for buildV1ChartDataPayload
- Updated all callers of getSlicePayload to await it
- Added await in ExploreChartPanel's updateQueryContext
- Updated all related tests to handle async behavior

This ensures charts are saved with proper query_context instead of a stringified Promise.

Fixes regression from #34383
