### PR TITLE
fix(native filters): throws an error when a chart containing a bigint value

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -659,6 +659,10 @@ const FiltersConfigForm = (
     showDataset,
   ]);
 
+  const chartIds = useMemo(() => {
+    return Object.values(charts).map(chart => chart.id);
+  }, [charts]);
+
   const initiallyExcludedCharts = useMemo(() => {
     const excluded: number[] = [];
     if (formFilter?.dataset?.value === undefined) {
@@ -676,7 +680,7 @@ const FiltersConfigForm = (
     });
     return excluded;
   }, [
-    JSON.stringify(charts),
+    JSON.stringify(chartIds),
     formFilter?.dataset?.value,
     JSON.stringify(loadedDatasets),
   ]);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -659,10 +659,6 @@ const FiltersConfigForm = (
     showDataset,
   ]);
 
-  const chartIds = useMemo(() => {
-    return Object.values(charts).map(chart => chart.id);
-  }, [charts]);
-
   const initiallyExcludedCharts = useMemo(() => {
     const excluded: number[] = [];
     if (formFilter?.dataset?.value === undefined) {
@@ -680,7 +676,7 @@ const FiltersConfigForm = (
     });
     return excluded;
   }, [
-    JSON.stringify(chartIds),
+    JSON.stringify(Object.values(charts).map(chart => chart.id)),
     formFilter?.dataset?.value,
     JSON.stringify(loadedDatasets),
   ]);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -82,7 +82,7 @@ const bigIntChartDataState = () => {
     ...state,
     charts: {
       ...state.charts,
-      [999]: {
+      999: {
         queriesResponse: [
           {
             status: 'success',
@@ -93,8 +93,8 @@ const bigIntChartDataState = () => {
             ],
             applied_filters: [{ column: 'name' }],
           },
-        ]
-      }
+        ],
+      },
     },
   };
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -615,7 +615,7 @@ test('modifies the name of a filter', async () => {
   );
 });
 
-test.only('renders a filter with a chart containing BigInt values', async () => {
+test('renders a filter with a chart containing BigInt values', async () => {
   const nativeFilterState = [
     buildNativeFilter('NATIVE_FILTER-1', 'state', ['NATIVE_FILTER-2']),
     buildNativeFilter('NATIVE_FILTER-2', 'country', []),

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -76,6 +76,29 @@ const noTemporalColumnsState = () => {
   };
 };
 
+const bigIntChartDataState = () => {
+  const state = defaultState();
+  return {
+    ...state,
+    charts: {
+      ...state.charts,
+      [999]: {
+        queriesResponse: [
+          {
+            status: 'success',
+            data: [
+              { name: 'Abigail', count: 228 },
+              { name: 'Aaron', count: 123012930123123n },
+              { name: 'Adam', count: 454 },
+            ],
+            applied_filters: [{ column: 'name' }],
+          },
+        ]
+      }
+    },
+  };
+};
+
 const datasetResult = (id: number) => ({
   description_columns: {},
   id,
@@ -590,4 +613,25 @@ test('modifies the name of a filter', async () => {
       }),
     ),
   );
+});
+
+test.only('renders a filter with a chart containing BigInt values', async () => {
+  const nativeFilterState = [
+    buildNativeFilter('NATIVE_FILTER-1', 'state', ['NATIVE_FILTER-2']),
+    buildNativeFilter('NATIVE_FILTER-2', 'country', []),
+    buildNativeFilter('NATIVE_FILTER-3', 'product', []),
+  ];
+  const state = {
+    ...bigIntChartDataState(),
+    dashboardInfo: {
+      metadata: { native_filter_configuration: nativeFilterState },
+    },
+    dashboardLayout,
+  };
+  defaultRender(state, {
+    ...props,
+    createNewOnOpen: false,
+  });
+
+  expect(screen.getByText(FILTER_TYPE_REGEX)).toBeInTheDocument();
 });


### PR DESCRIPTION
### SUMMARY
This commit fixes an error that occurred when a big int value was included in the chart. The error was caused by inefficiency JSON.stringify comparison logic in the native filters, and this update ensures that filters now work properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/35e4cb64-f332-4426-9401-63faae3b939f


After:

https://github.com/user-attachments/assets/d1a06d36-8d3e-4e30-9b0d-ae429a83ac86

### TESTING INSTRUCTIONS

Create a chart including a bigint value in the dataset and then open a native filter to create a new filter

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
