### PR TITLE
fix(echarts): rename time series shifted without dimensions

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -85,7 +85,8 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
         ComparisonType.Percentage,
         ComparisonType.Ratio,
       ].includes(formData.comparison_type) &&
-      metrics.length === 1
+      metrics.length === 1 &&
+      renamePairs.length === 0
     ) {
       renamePairs.push([getMetricLabel(metrics[0]), null]);
     }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -42,12 +42,10 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
 
   // remove or rename top level of column name(metric name) in the MultiIndex when
   // 1) at least 1 metric
-  // 2) dimension exist
-  // 3) xAxis exist
-  // 4) truncate_metric in form_data and truncate_metric is true
+  // 2) xAxis exist
+  // 3) truncate_metric in form_data and truncate_metric is true
   if (
     metrics.length > 0 &&
-    columns.length > 0 &&
     xAxisLabel &&
     truncate_metric !== undefined &&
     !!truncate_metric

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -36,16 +36,19 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
   const columns = ensureIsArray(
     queryObject.series_columns || queryObject.columns,
   );
+  const timeOffsets = ensureIsArray(formData.time_compare);
   const { truncate_metric } = formData;
   const xAxisLabel = getXAxisLabel(formData);
   const isTimeComparisonValue = isTimeComparison(formData, queryObject);
 
   // remove or rename top level of column name(metric name) in the MultiIndex when
   // 1) at least 1 metric
-  // 2) xAxis exist
-  // 3) truncate_metric in form_data and truncate_metric is true
+  // 2) dimension exist or multiple time shift metrics exist
+  // 3) xAxis exist
+  // 4) truncate_metric in form_data and truncate_metric is true
   if (
     metrics.length > 0 &&
+    (columns.length > 0 || timeOffsets.length > 1) &&
     xAxisLabel &&
     truncate_metric !== undefined &&
     !!truncate_metric

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -54,17 +54,6 @@ test('should skip renameOperator for empty metrics', () => {
   ).toEqual(undefined);
 });
 
-test('should skip renameOperator if series does not exist', () => {
-  expect(
-    renameOperator(formData, {
-      ...queryObject,
-      ...{
-        columns: [],
-      },
-    }),
-  ).toEqual(undefined);
-});
-
 test('should skip renameOperator if does not exist x_axis and is_timeseries', () => {
   expect(
     renameOperator(
@@ -88,6 +77,20 @@ test('should skip renameOperator if not is_timeseries and multi metrics', () => 
 
 test('should add renameOperator', () => {
   expect(renameOperator(formData, queryObject)).toEqual({
+    operation: 'rename',
+    options: { columns: { 'count(*)': null }, inplace: true, level: 0 },
+  });
+});
+
+test('should add renameOperator only if a metric exists and no series columns are present', () => {
+  expect(
+    renameOperator(formData, {
+      ...queryObject,
+      ...{
+        columns: [],
+      },
+    }),
+  ).toEqual({
     operation: 'rename',
     options: { columns: { 'count(*)': null }, inplace: true, level: 0 },
   });

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -210,7 +210,6 @@ test('should add renameOperator if exist "actual value" time comparison', () => 
     operation: 'rename',
     options: {
       columns: {
-        'count(*)': null,
         'count(*)__1 year ago': '1 year ago',
         'count(*)__1 year later': '1 year later',
       },

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -107,7 +107,7 @@ test('should add renameOperator', () => {
   });
 });
 
-test('should add renameOperator if a metric exists and multiple time shift ', () => {
+test('should add renameOperator if a metric exists and multiple time shift', () => {
   expect(
     renameOperator(
       {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -54,6 +54,31 @@ test('should skip renameOperator for empty metrics', () => {
   ).toEqual(undefined);
 });
 
+test('should skip renameOperator if series does not exist', () => {
+  expect(
+    renameOperator(formData, {
+      ...queryObject,
+      ...{
+        columns: [],
+      },
+    }),
+  ).toEqual(undefined);
+});
+
+test('should skip renameOperator if series does not exist and a single time shift exists', () => {
+  expect(
+    renameOperator(
+      { ...formData, ...{ time_compare: ['1 year ago'] } },
+      {
+        ...queryObject,
+        ...{
+          columns: [],
+        },
+      },
+    ),
+  ).toEqual(undefined);
+});
+
 test('should skip renameOperator if does not exist x_axis and is_timeseries', () => {
   expect(
     renameOperator(
@@ -82,14 +107,20 @@ test('should add renameOperator', () => {
   });
 });
 
-test('should add renameOperator only if a metric exists and no series columns are present', () => {
+test('should add renameOperator if a metric exists and multiple time shift ', () => {
   expect(
-    renameOperator(formData, {
-      ...queryObject,
-      ...{
-        columns: [],
+    renameOperator(
+      {
+        ...formData,
+        ...{ time_compare: ['1 year ago', '2 years ago'] },
       },
-    }),
+      {
+        ...queryObject,
+        ...{
+          columns: [],
+        },
+      },
+    ),
   ).toEqual({
     operation: 'rename',
     options: { columns: { 'count(*)': null }, inplace: true, level: 0 },


### PR DESCRIPTION
### SUMMARY

This commit updates [the rename operator logic](https://github.com/apache/superset/pull/33269) to handle cases that contain only metrics without dimensions but **contain multiple time shifts**.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before (single metric):

<img width="1103" height="874" alt="Screenshot_2025-08-04_at_4_33_49 PM" src="https://github.com/user-attachments/assets/3b020719-2afa-496e-97ed-c9eedc187fc4" />

After (single metric):

<img width="951" height="741" alt="Screenshot_2025-08-04_at_4_33_54 PM" src="https://github.com/user-attachments/assets/f37e921b-e94a-44e0-b2db-1bb7608902da" />

Before (multiple metrics):

<img width="1107" height="890" alt="Screenshot_2025-08-04_at_4_32_58 PM" src="https://github.com/user-attachments/assets/3fe68cc9-db46-4926-b873-ffcd3f5cabfb" />

After (multiple metrics):

<img width="952" height="763" alt="Screenshot_2025-08-04_at_4_32_52 PM" src="https://github.com/user-attachments/assets/3180e4e2-d23a-4516-9e12-6f871294b29c" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
