### PR TITLE
chore: Rename dataset creation buttons

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
@@ -72,7 +72,7 @@ describe('Footer', () => {
     });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     expect(saveButton).toBeVisible();
@@ -83,13 +83,13 @@ describe('Footer', () => {
     render(<Footer {...mockPropsWithDataset} />, { useRedux: true });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     expect(createButton).toBeEnabled();
 
     // Check that it's a dropdown button with the correct text
-    expect(createButton).toHaveTextContent('Create dataset and create chart');
+    expect(createButton).toHaveTextContent('Create and explore dataset');
 
     // Check for the dropdown arrow
     const dropdownArrow = screen.getByRole('img', { hidden: true });
@@ -102,7 +102,7 @@ describe('Footer', () => {
     });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     expect(createButton).toBeDisabled();
@@ -117,7 +117,7 @@ describe('Footer', () => {
 
     // Check that the dropdown menu option is visible
     await waitFor(() => {
-      expect(screen.getByText('Create dataset only')).toBeVisible();
+      expect(screen.getByText('Create dataset')).toBeVisible();
     });
   });
 
@@ -127,7 +127,7 @@ describe('Footer', () => {
     render(<Footer {...mockPropsWithDataset} />, { useRedux: true });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     userEvent.click(createButton);
@@ -145,7 +145,7 @@ describe('Footer', () => {
     });
   });
 
-  test('navigates to dataset list when "Create dataset only" menu option is clicked', async () => {
+  test('navigates to dataset list when "Create dataset" menu option is clicked', async () => {
     mockCreateResource.mockResolvedValue(123);
 
     render(<Footer {...mockPropsWithDataset} />, { useRedux: true });
@@ -154,9 +154,9 @@ describe('Footer', () => {
     const dropdownTrigger = screen.getByRole('button', { name: 'down' });
     userEvent.click(dropdownTrigger);
 
-    // Click the "Create dataset only" option
+    // Click the "Create dataset" option
     await waitFor(() => {
-      const datasetOnlyOption = screen.getByText('Create dataset only');
+      const datasetOnlyOption = screen.getByText('Create dataset');
       userEvent.click(datasetOnlyOption);
     });
 
@@ -177,7 +177,7 @@ describe('Footer', () => {
     render(<Footer {...mockPropsWithDataset} />, { useRedux: true });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     userEvent.click(createButton);
@@ -203,7 +203,7 @@ describe('Footer', () => {
     render(<Footer {...mockPropsWithCatalog} />, { useRedux: true });
 
     const createButton = screen.getByRole('button', {
-      name: /Create dataset and create chart/i,
+      name: /Create and explore dataset/i,
     });
 
     userEvent.click(createButton);

--- a/superset-frontend/src/features/datasets/AddDataset/Footer/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/index.tsx
@@ -121,8 +121,8 @@ function Footer({
     onSave(false);
   };
 
-  const CREATE_DATASET_TEXT = t('Create dataset and create chart');
-  const CREATE_DATASET_ONLY_TEXT = t('Create dataset only');
+  const CREATE_DATASET_TEXT = t('Create and explore dataset');
+  const CREATE_DATASET_ONLY_TEXT = t('Create dataset');
   const disabledCheck =
     !datasetObject?.table_name ||
     !hasColumns ||


### PR DESCRIPTION
### SUMMARY
Follow up to https://github.com/apache/superset/pull/34380, this is re-naming the text used in the buttons at the footer of the dataset creation modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

<img width="1785" height="987" alt="image" src="https://github.com/user-attachments/assets/e8768aef-71cc-43cf-84ea-a334c7c584c0" />

**After**

<img width="1784" height="982" alt="image" src="https://github.com/user-attachments/assets/756a2ffa-702e-4651-b153-170482b33eaa" />

### TESTING INSTRUCTIONS
N/A.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
