### PR TITLE
fix: Avoid null `scrollLeft` in `VirtualTable`

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Table/VirtualTable.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/VirtualTable.tsx
@@ -132,7 +132,7 @@ const VirtualTable = <RecordType extends object>(
         if (gridRef.current) {
           return gridRef.current?.state?.scrollLeft;
         }
-        return null;
+        return 0;
       },
       set: (scrollLeft: number) => {
         if (gridRef.current) {


### PR DESCRIPTION
### SUMMARY
Removing the drill to detail by filter via the UI would throw a `Cannot read properties of null (reading 'scrollLeft')`. This PR fixes the issue (vibe coded with Claude Code).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

https://github.com/user-attachments/assets/849e7fcc-3eab-48a0-bc4c-e4627913e2d9

**After**

https://github.com/user-attachments/assets/a69943bf-922c-4cd9-b8e0-c5fd08fd16f3

### TESTING INSTRUCTIONS
Drill to detail by in a chart, then remove the filter in the modal.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
