### PR TITLE
fix(table chart): render bigint value in a raw mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -323,8 +323,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const getValueRange = useCallback(
     function getValueRange(key: string, alignPositiveNegative: boolean) {
-      if (typeof data?.[0]?.[key] === 'number') {
-        const nums = data.map(row => row[key]) as number[];
+      const nums = data
+        ?.map(row => row?.[key])
+        .filter(value => typeof value === 'number') as number[];
+      if (data && nums.length === data.length) {
         return (
           alignPositiveNegative
             ? [0, d3Max(nums.map(Math.abs))]

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -324,6 +324,27 @@ describe('plugin-chart-table', () => {
         expect(cells[4]).toHaveTextContent('$ 2.47k');
       });
 
+      it('render data with a bigint value in a raw record mode', () => {
+        render(
+          ProviderWrapper({
+            children: (
+              <TableChart
+                {...transformProps(testData.bigint)}
+                sticky={false}
+                isRawRecords
+              />
+            ),
+          }),
+        );
+        const cells = document.querySelectorAll('td');
+        expect(document.querySelectorAll('th')[0]).toHaveTextContent('name');
+        expect(document.querySelectorAll('th')[1]).toHaveTextContent('id');
+        expect(cells[0]).toHaveTextContent('Michael');
+        expect(cells[1]).toHaveTextContent('4312');
+        expect(cells[2]).toHaveTextContent('John');
+        expect(cells[3]).toHaveTextContent('1234567890123456789');
+      });
+
       it('render raw data', () => {
         const props = transformProps({
           ...testData.raw,

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -349,6 +349,27 @@ const empty = {
   ],
 };
 
+const bigint = {
+  ...advanced,
+  queriesData: [
+    {
+      ...basicQueryResult,
+      colnames: ['name', 'id'],
+      coltypes: [GenericDataType.String, GenericDataType.Numeric],
+      data: [
+        {
+          name: 'Michael',
+          id: 4312,
+        },
+        {
+          name: 'John',
+          id: 1234567890123456789n,
+        },
+      ],
+    },
+  ],
+};
+
 export default {
   basic,
   advanced,
@@ -357,4 +378,5 @@ export default {
   comparisonWithConfig,
   empty,
   raw,
+  bigint,
 };


### PR DESCRIPTION
### SUMMARY
If a bigint value is mixed in the middle of the raw table data, there was an issue because the logic for calculating the current value range only checked the first row for a number and then computed the max value based on that.
As a result, an error occurred when bigint values appeared in the middle of the data. This commit fixes the issue by modifying the logic so that the value range is only calculated when all rows are numbers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="604" height="742" alt="Screenshot_2025-08-05_at_9_29_36 AM" src="https://github.com/user-attachments/assets/145cc6b6-bbd2-4af2-b2b8-6fccbe8b6658" />


After:

<img width="615" height="542" alt="Screenshot_2025-08-05_at_9_29_09 AM" src="https://github.com/user-attachments/assets/f8435567-0af1-4586-aad1-b9fc3cb1b06d" />


### TESTING INSTRUCTIONS

create a data containing a bigint in the second row
Create a chart with the data and then the error is thrown

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
