### PR TITLE
fix(Table Chart): render null dates properly

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -936,7 +936,10 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             },
             className: [
               className,
-              value == null || (value instanceof DateWithFormatter && value.input == null) ? 'dt-is-null' : '',
+              value == null ||
+              (value instanceof DateWithFormatter && value.input == null)
+                ? 'dt-is-null'
+                : '',
               isActiveFilterValue(key, value) ? ' dt-is-active-filter' : '',
             ].join(' '),
             tabIndex: 0,

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -89,6 +89,7 @@ import { formatColumnValue } from './utils/formatValue';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { updateTableOwnState } from './DataTable/utils/externalAPIs';
 import getScrollBarSize from './DataTable/utils/getScrollBarSize';
+import DateWithFormatter from './utils/DateWithFormatter';
 
 type ValueRange = [number, number];
 
@@ -935,7 +936,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             },
             className: [
               className,
-              value == null ? 'dt-is-null' : '',
+              value == null || (value instanceof DateWithFormatter && value.input == null) ? 'dt-is-null' : '',
               isActiveFilterValue(key, value) ? ' dt-is-active-filter' : '',
             ].join(' '),
             tabIndex: 0,


### PR DESCRIPTION
### SUMMARY

Null values are normally displayed as a grayed-out "N/A"; dates were an exception and were not grayed out.
This PR fixes that issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="225" height="389" alt="image" src="https://github.com/user-attachments/assets/1a0f8544-4e1c-4117-8d51-f63c4b087444" />

After:

<img width="201" height="411" alt="image" src="https://github.com/user-attachments/assets/e94b421f-757d-440a-a8d0-1041ea2e1a3a" />


### TESTING INSTRUCTIONS

Build a table chart with a Date column displaying null values.
