### PR TITLE
fix(saved_query_url): restore the legacy link for backup

### DIFF
--- a/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.jsx
+++ b/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.jsx
@@ -376,9 +376,9 @@ describe('RTL', () => {
     // Wait for the tooltip to pop up
     await screen.findByRole('tooltip');
 
-    // Grab and assert that "Copy query URl" tooltip is in the document
+    // Grab and assert that "Copy current query URl" tooltip is in the document
     const copyTooltip = screen.getByRole('tooltip', {
-      name: /Copy query URL/i,
+      name: /Copy current query URL/i,
     });
     expect(copyTooltip).toBeInTheDocument();
   });

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -52,6 +52,7 @@ import { Tooltip } from 'src/components/Tooltip';
 import { commonMenuData } from 'src/features/home/commonMenuData';
 import { QueryObjectColumns, SavedQueryObject } from 'src/views/CRUD/types';
 import Tag from 'src/types/TagType';
+import copyTextToClipboard from 'src/utils/copy';
 import ImportModelsModal from 'src/components/ImportModal/index';
 import { ModifiedInfo } from 'src/components/AuditInfo';
 import { loadTags } from 'src/components/Tags/utils';
@@ -231,6 +232,21 @@ function SavedQueryList({
     }
   };
 
+  const copySavedQueryLink = useCallback(
+    (id: number) => {
+      copyTextToClipboard(() =>
+        Promise.resolve(`${window.location.origin}/sqllab?savedQueryId=${id}`),
+      )
+        .then(() => {
+          addSuccessToast(t('Link Copied!'));
+        })
+        .catch(() => {
+          addDangerToast(t('Sorry, your browser does not support copying.'));
+        });
+    },
+    [addDangerToast, addSuccessToast],
+  );
+
   const copyQueryLink = useCallback(
     async (savedQuery: SavedQueryObject) => {
       try {
@@ -407,6 +423,7 @@ function SavedQueryList({
           };
           const handleEdit = ({ metaKey }: MouseEvent) =>
             openInSqlLab(original.id, Boolean(metaKey));
+          const handleCopyLink = () => copySavedQueryLink(original.id);
           const handleCopy = () => copyQueryLink(original);
           const handleExport = () => handleBulkSavedQueryExport([original]);
           const handleDelete = () => setQueryCurrentlyDeleting(original);
@@ -427,8 +444,15 @@ function SavedQueryList({
               onClick: handleEdit,
             },
             {
+              label: 'copy-link-action',
+              tooltip: t('Share link'),
+              placement: 'bottom',
+              icon: 'Link',
+              onClick: handleCopyLink,
+            },
+            {
               label: 'copy-action',
-              tooltip: t('Copy query URL'),
+              tooltip: t('Copy current query URL'),
               placement: 'bottom',
               icon: 'Copy',
               onClick: handleCopy,


### PR DESCRIPTION
### SUMMARY

In #31421 the existing saved query link ID has been replaced with a new permalink API. This change is currently impacting Airbnb services that reference the previous saved query links.

To address this, in 5.0, we restored the original query link functionality to a "share link" action, while keeping the updated functionality for "copy query URL."
Additionally, please note that a saved query ID always reflects the latest information when a saved query is edited. In contrast, the "copy query URL" uses the permalink method, which means it does not capture any changes made to the query after the URL is generated. To clarify this behavior, this commit updates the label to "copy current query URL."

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

<img width="274" height="252" alt="Screenshot 2025-08-05 at 10 10 16 AM" src="https://github.com/user-attachments/assets/80070aee-0c99-4c28-a868-245649699073" />

<img width="266" height="253" alt="Screenshot 2025-08-05 at 10 10 20 AM" src="https://github.com/user-attachments/assets/0ff1a857-14cd-49da-9a86-512b45eb9810" />


### TESTING INSTRUCTIONS

Go to Saved queries and then check the actions

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
