### PR TITLE
fix: navigate to SQL Lab due to router api updates

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -154,7 +154,8 @@ test('navigates to SQL Lab when View in SQL Lab button is clicked', () => {
   const viewInSQLLabButton = screen.getByText('View in SQL Lab');
   fireEvent.click(viewInSQLLabButton);
 
-  expect(mockHistoryPush).toHaveBeenCalledWith('/sqllab', {
+  expect(mockHistoryPush).toHaveBeenCalledWith({
+    pathname: '/sqllab',
     state: {
       requestedQuery: {
         datasourceKey: mockProps.datasource,
@@ -174,7 +175,7 @@ test('opens SQL Lab in a new tab when View in SQL Lab button is clicked with met
 
   const { datasource, sql } = mockProps;
   expect(window.open).toHaveBeenCalledWith(
-    `/sqllab?datasourceKey=${datasource}&sql=${sql}`,
+    `/sqllab?datasourceKey=${datasource}&sql=${encodeURIComponent(sql)}`,
     '_blank',
   );
 });

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -125,11 +125,11 @@ const ViewQuery: FC<ViewQueryProps> = props => {
       if (domEvent.metaKey || domEvent.ctrlKey) {
         domEvent.preventDefault();
         window.open(
-          `/sqllab?datasourceKey=${datasource}&sql=${currentSQL}`,
+          `/sqllab?datasourceKey=${datasource}&sql=${encodeURIComponent(currentSQL)}`,
           '_blank',
         );
       } else {
-        history.push('/sqllab', { state: { requestedQuery } });
+        history.push({ pathname: '/sqllab', state: { requestedQuery } });
       }
     },
     [history, datasource, currentSQL],


### PR DESCRIPTION
### SUMMARY
Due to the react-router version upgrade, there's a api updates for passing router state.
This commit fixes the bug of "view in sqllab" feature in https://github.com/apache/superset/pull/33341

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="439" height="81" alt="Screenshot 2025-08-05 at 6 16 34 PM" src="https://github.com/user-attachments/assets/a588cc32-2f15-4677-91e0-fce4b0dce4e4" />

After:

<img width="436" height="281" alt="Screenshot 2025-08-05 at 6 05 55 PM" src="https://github.com/user-attachments/assets/ff53c00d-e906-4e96-b11d-f9ffcea0c161" />

### TESTING INSTRUCTIONS

Open a "View query"  and then click "View in Sql Lab"


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
