### PR TITLE
fix(echart): broken aggregator due to bigint value

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -184,7 +184,7 @@ export class EchartsChartPlugin<
     super({
       ...restProps,
       metadata: new ChartMetadata({
-        parseMethod: 'json-bigint',
+        parseMethod: 'json',
         ...metadata,
       }),
     });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/index.test.ts
@@ -125,6 +125,6 @@ test('@superset-ui/plugin-chart-echarts-parsemethod-validation', () => {
   ];
 
   plugins.forEach(plugin => {
-    expect(plugin.metadata.parseMethod).toEqual('json-bigint');
+    expect(plugin.metadata.parseMethod).toEqual('json');
   });
 });


### PR DESCRIPTION
### SUMMARY
In PR #32549, we updated the widely parseMethod to use `json-bigint` in order to support bigint values. However, this caused a regression issue in the aggregator when ECharts processed data containing bigint values (for example, data size in bytes). Until proper support for bigint aggregation is implemented, we plan to revert the parseMethod in ECharts back to the original json.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="629" height="234" alt="Screenshot 2025-08-06 at 10 14 26 AM" src="https://github.com/user-attachments/assets/fbed554f-e329-4a7e-ad83-3b32d5b1a52b" />

After:

<img width="628" height="706" alt="Notification_Center" src="https://github.com/user-attachments/assets/70722bce-1422-45cf-a804-bb41c3b25da8" />


### TESTING INSTRUCTIONS
Create a record having a bigint value like data size in bytes
and then create a bar/line chart with a metric including aggregation

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
