### PR TITLE
fix(Dashboards): Tabs highlight and dataset contrast in darkmode issues

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
@@ -50,8 +50,8 @@ export const DatasetTypeLabel: React.FC<DatasetTypeLabelProps> = ({
       type={labelType}
       style={{
         color:
-          labelType === 'primary'
-            ? theme.colors.primary.dark2
+          datasetType === 'physical'
+            ? theme.colorPrimaryText
             : theme.colorPrimary,
       }}
     >

--- a/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Label/reusable/DatasetTypeLabel.tsx
@@ -45,7 +45,16 @@ export const DatasetTypeLabel: React.FC<DatasetTypeLabelProps> = ({
   const labelType = datasetType === 'physical' ? 'primary' : 'default';
 
   return (
-    <Label icon={icon} type={labelType}>
+    <Label
+      icon={icon}
+      type={labelType}
+      style={{
+        color:
+          labelType === 'primary'
+            ? theme.colors.primary.dark2
+            : theme.colorPrimary,
+      }}
+    >
       {label}
     </Label>
   );

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -79,7 +79,7 @@ const defaultProps = {
 
 const TabTitleContainer = styled.div`
   ${({ isHighlighted, theme: { sizeUnit, colors } }) => `
-    padding: ${sizeUnit}px ${sizeUnit * 2}px;
+    padding: ${sizeUnit}px ${sizeUnit * 8}px ${sizeUnit}px ${sizeUnit * 2}px;
     margin: ${-sizeUnit}px ${sizeUnit * -2}px;
     transition: box-shadow 0.2s ease-in-out;
     ${


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes some visual issues introduced with theming:

- Tabs in dashboard  highlight border missaligned
- Datasets lists physical tag contrast was off using dark theme.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
<img width="1512" height="507" alt="image" src="https://github.com/user-attachments/assets/0961ce6b-6f50-4782-b33c-778b8bf07f1d" />

AFTER:
<img width="1509" height="515" alt="image" src="https://github.com/user-attachments/assets/f0ba6eab-dded-48b2-b947-76afcc0311c1" />

BEFORE:
<img width="1485" height="192" alt="image" src="https://github.com/user-attachments/assets/3f749bba-4f2f-4e87-b517-f1032819ff4b" />
AFTER:
<img width="2972" height="476" alt="image" src="https://github.com/user-attachments/assets/629ac594-c9f1-48ee-9bc6-7917dd08ef62" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
