### PR TITLE
fix: modify the dataset macro to adapt to oracle

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -948,7 +948,12 @@ def dataset_macro(
     }
     sqla_query = dataset.get_query_str_extended(query_obj, mutate=False)
     sql = sqla_query.sql
-    return f"(\n{sql}\n) AS dataset_{dataset_id}"
+    # Check database type to determine whether to use AS keyword
+    database_type = dataset.database.backend.lower()
+    if database_type == 'oracle':
+        return f"(\n{sql}\n) dataset_{dataset_id}"
+    else:
+        return f"(\n{sql}\n) AS dataset_{dataset_id}"
 
 
 def get_dataset_id_from_context(metric_key: str) -> int:


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The {{dataset()}} macro in Superset always uses the AS keyword to generate SQL with aliases, such as (SELECT...) AS dataset_1, independent of the database. Oracle does not allow AS to use table aliases in subqueries. Therefore, using the {{dataset()}} macro in oracle will result in the ORA-00907 error.

Modify the code of the dataset macro part in superset/jinja_context.py to generate the correct aliasing syntax for Oracle. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
