### PR TITLE
fix: Remove deprecated @types/classnames package

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -175,7 +175,6 @@
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^12.8.3",
-        "@types/classnames": "^2.3.4",
         "@types/dom-to-image": "^2.6.7",
         "@types/jest": "^29.5.14",
         "@types/js-levenshtein": "^1.1.3",
@@ -15258,6 +15257,7 @@
       "integrity": "sha512-dwmfrMMQb9ujX1uYGvB5ERDlOzBNywnZAZBtOe107/hORWP05ESgU4QyaanZMWYYfd2BzrG78y13/Bju8IQcMQ==",
       "deprecated": "This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "classnames": "*"
       }
@@ -61644,7 +61644,7 @@
         "@storybook/types": "8.4.7",
         "@types/react-loadable": "^5.5.11",
         "core-js": "3.40.0",
-        "gh-pages": "^6.2.0",
+        "gh-pages": "^6.3.0",
         "jquery": "^3.7.1",
         "memoize-one": "^5.2.1",
         "react": "^17.0.2",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -243,7 +243,6 @@
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.8.3",
-    "@types/classnames": "^2.3.4",
     "@types/dom-to-image": "^2.6.7",
     "@types/jest": "^29.5.14",
     "@types/js-levenshtein": "^1.1.3",


### PR DESCRIPTION
## Summary
Removes the deprecated `@types/classnames` npm package to fix npm warning.

## Details
The classnames library provides its own TypeScript definitions, so the separate `@types/classnames` package is unnecessary and deprecated. This PR removes it from package.json to eliminate the following npm warning:

```
npm warn deprecated @types/classnames@2.3.4: This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.
```

## Test plan
- [x] npm install runs without the @types/classnames deprecation warning
- [x] TypeScript compilation still works correctly (classnames provides its own types)

🤖 Generated with [Claude Code](https://claude.ai/code)