### PR TITLE
fix: Update geostyler to v18 to fix @babel/polyfill warning

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -70,7 +70,7 @@
         "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "geolib": "^2.0.24",
-        "geostyler": "^14.1.3",
+        "geostyler": "^18.1.2",
         "geostyler-data": "^1.0.0",
         "geostyler-openlayers-parser": "^4.3.0",
         "geostyler-qgis-parser": "2.0.1",
@@ -2899,23 +2899,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
-    },
-    "node_modules/@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
     },
     "node_modules/@babel/preset-env": {
       "version": "7.27.2",
@@ -8830,29 +8813,26 @@
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
       "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.21.0 < 1"
       }
     },
     "node_modules/@monaco-editor/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "license": "MIT",
       "dependencies": {
-        "@monaco-editor/loader": "^1.4.0"
+        "@monaco-editor/loader": "^1.5.0"
       },
       "peerDependencies": {
         "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -15659,12 +15639,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -16471,6 +16453,7 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -20130,15 +20113,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/blob": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.1.0.tgz",
-      "integrity": "sha512-k+GwK+4Rj+MPNT4qu+y6+kHp+mPmmNd+28zdrIo69QM9UvypK5Vhcw7jnRiY4KaOMAiOdn0NtPQGTb+Ox1Dtng==",
-      "license": "MIT",
-      "dependencies": {
-        "esm": "^3.2.25"
-      }
-    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -21200,9 +21174,9 @@
       }
     },
     "node_modules/chroma-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
-      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==",
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/chrome-trace-event": {
@@ -26179,15 +26153,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -27976,45 +27941,43 @@
       "integrity": "sha512-NR0AyYyEnGrFS9JvSFmmotQDxVCORJgDHdvBwSatxl5aHarOLMh3KuGI83bCvCfObjfoEiDe8Ung8GGLGAtthw=="
     },
     "node_modules/geostyler": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-14.2.0.tgz",
-      "integrity": "sha512-mcHNeds2OBvyCs+VdLHkq4vX1PrR/HKN7hnmySUVpNiZCZ4b0kDnPKe3gUOsh2wEs9pOC1soS9AbNlVC6XpH7w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/geostyler/-/geostyler-18.1.2.tgz",
+      "integrity": "sha512-gZ6yQUlluVBmoKS3HfGcvAAw2Zo0M09TqgSJMqUFs1spmd2ZU7THTy0iRd1OknHWWP2wwi2x/nUbG4ke4ZUXHg==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@ant-design/icons": "^5.3.7",
-        "@babel/polyfill": "^7.12.1",
+        "@ant-design/icons": "^5.5.1",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@monaco-editor/react": "^4.6.0",
+        "@monaco-editor/react": "^4.7.0",
         "@types/chroma-js": "^2.4.4",
         "@types/color": "^3.0.6",
         "@types/file-saver": "^2.0.7",
         "@types/geojson": "^7946.0.14",
-        "@types/lodash": "^4.17.4",
+        "@types/lodash": "^4.17.5",
         "@ungap/url-search-params": "^0.2.2",
-        "antd": "^5.17.3",
-        "blob": "^0.1.0",
-        "chroma-js": "^2.4.2",
+        "antd": "^5.25.4",
+        "chroma-js": "2.4.2",
         "color": "^4.2.3",
         "csstype": "^3.1.3",
         "file-saver": "^2.0.5",
-        "geostyler-cql-parser": "^3.0.2",
-        "geostyler-data": "^1.0.0",
-        "geostyler-geojson-parser": "^1.0.1",
-        "geostyler-mapbox-parser": "^5.0.1",
-        "geostyler-openlayers-parser": "^4.3.0",
-        "geostyler-qgis-parser": "^2.0.0",
-        "geostyler-sld-parser": "^5.3.1",
-        "geostyler-style": "^8.1.0",
-        "geostyler-wfs-parser": "^2.0.0",
-        "lodash": "^4.17.21",
-        "monaco-editor": "^0.49.0",
+        "geostyler-cql-parser": "^4.1.0",
+        "geostyler-data": "^1.1.0",
+        "geostyler-geojson-parser": "^2.0.0",
+        "geostyler-mapbox-parser": "^6.1.1",
+        "geostyler-openlayers-parser": "^5.1.2",
+        "geostyler-qgis-parser": "^4.0.2",
+        "geostyler-sld-parser": "^8.1.0",
+        "geostyler-style": "^10.3.0",
+        "geostyler-wfs-parser": "^3.0.1",
+        "lodash-es": "^4.17.21",
+        "monaco-editor": "^0.52.0",
         "proj4": "^2.11.0",
-        "typescript-json-schema": "^0.64.0"
+        "typescript-json-schema": "^0.65.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.6.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
@@ -28038,231 +28001,41 @@
       }
     },
     "node_modules/geostyler-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/geostyler-data/-/geostyler-data-1.0.0.tgz",
-      "integrity": "sha512-ctmk6OsunL427Uaa1HME/blTyBbl0Ihu+vPV1Irqz3ip80qvNLwDEr46xI5HwMeyrsWH8o76kfA0sF6oecW1BA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-data/-/geostyler-data-1.1.0.tgz",
+      "integrity": "sha512-0tUEF0RbiGM9eVqoLbMc20Bl5A1x3PHbn2Ca0yPJx65S0nh3rHfd82OmgFwHzzfsukDmqIn0VoOGJFjmQAmAcw==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.7",
-        "@types/json-schema": "7.0.3"
+        "@types/geojson": "^7946.0.7",
+        "@types/json-schema": "^7.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
       }
-    },
-    "node_modules/geostyler-data/node_modules/@types/geojson": {
-      "version": "7946.0.7",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
-      "license": "MIT"
-    },
-    "node_modules/geostyler-data/node_modules/@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
-      "license": "MIT"
     },
     "node_modules/geostyler-geojson-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-geojson-parser/-/geostyler-geojson-parser-1.0.1.tgz",
-      "integrity": "sha512-b7eJ2sCrYCC7fIDItxfbDH9r55dE58OXTQjPb/kIlXgH+7A2o2xp7pQlRXu5xCqM5lucQAAM9A7IfLLhbflznw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-geojson-parser/-/geostyler-geojson-parser-2.0.0.tgz",
+      "integrity": "sha512-FBBoVfaa9musK/L679I+2l8y+wS6EJ5C73RE9qJ4drHMmHE/JwliLS0cMFnrgrp+NlQVyu/dbv6CQs6PLFKnWA==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@babel/polyfill": "^7.4.4",
-        "@types/geojson": "^7946.0.7",
-        "@types/jest": "^24.0.18",
-        "@types/json-schema": "^7.0.3",
-        "@types/node": "^12.7.3",
         "geostyler-data": "^1.0.0"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/@types/jest": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "jest-diff": "^24.3.0"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
+        "node": ">=20.6.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/diff-sequences": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/jest-diff": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/jest-get-type": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/geostyler-geojson-parser/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
       }
     },
     "node_modules/geostyler-mapbox-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-mapbox-parser/-/geostyler-mapbox-parser-5.0.1.tgz",
-      "integrity": "sha512-uL79jfXuULPcg/Yxj9EGDU5IX0xIQmhawUL239aCwbFv4FiM9KTuTdXG1M7P5r3RV6EZsbE21ETahx4ZzojVkw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/geostyler-mapbox-parser/-/geostyler-mapbox-parser-6.1.1.tgz",
+      "integrity": "sha512-2KUoCcYzMDc3wWcgQe4FhhKgMl8nrp3NWjECWGP+vlIfk7Hf5cKW4sQwr/la8LG1DHs/KILh+g4r03caKxSZbw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/mapbox-gl": "^2.7.18",
-        "geostyler-style": "^8.0.0"
+        "geostyler-style": "^10.0.0"
       },
       "engines": {
         "node": ">=18",
@@ -28273,17 +28046,13 @@
       }
     },
     "node_modules/geostyler-mapbox-parser/node_modules/geostyler-style": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-8.1.0.tgz",
-      "integrity": "sha512-8NgtzRc63bxC+1Vgqj/mMj77GX38CXXXWQ93PeZBdoMTkY9C/H0Anz38OrrlKdUgNVFZ/GJTNYwnX4wdaO5j6A==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-10.3.0.tgz",
+      "integrity": "sha512-Ve3E98GLwg1Pu9kGAch992BNdsn4QQyrHhhE4Yqi7uChOInqynj4y5nw4+bTWPEqU9KfRUHLgyOwqYZFFDlxcQ==",
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "@types/lodash": "^4.14.201",
-        "lodash": "^4.17.21"
-      },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.6.0",
+        "npm": ">=10.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
@@ -28379,36 +28148,64 @@
       }
     },
     "node_modules/geostyler-sld-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-5.4.0.tgz",
-      "integrity": "sha512-TY/gwMoE/M8Xv8ykviC1NqygykrojvrFSCRIc/+CNww5VS0Qf9pu9JxiSQONGfR6QWDPtQrfFIoazyH67c0jTg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-8.1.0.tgz",
+      "integrity": "sha512-9iDxWAR2nkkhMgBcAe+XgbmDdw36OdTEyGfXZcac5d7XbK8/KGZbxcKiQRiE9/+gPtFGIoc5+PSjjgWoJHMaaw==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "fast-xml-parser": "^4.2.2",
-        "geostyler-style": "^8.1.0",
-        "i18next": "^23.11.5",
+        "fast-xml-parser": "^5.2.3",
+        "geostyler-style": "^10.3.0",
         "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=20.6.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
       }
     },
-    "node_modules/geostyler-sld-parser/node_modules/geostyler-style": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-8.1.0.tgz",
-      "integrity": "sha512-8NgtzRc63bxC+1Vgqj/mMj77GX38CXXXWQ93PeZBdoMTkY9C/H0Anz38OrrlKdUgNVFZ/GJTNYwnX4wdaO5j6A==",
-      "license": "BSD-2-Clause",
+    "node_modules/geostyler-sld-parser/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@types/lodash": "^4.14.201",
-        "lodash": "^4.17.21"
+        "strnum": "^2.1.0"
       },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/geostyler-sld-parser/node_modules/geostyler-style": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-10.3.0.tgz",
+      "integrity": "sha512-Ve3E98GLwg1Pu9kGAch992BNdsn4QQyrHhhE4Yqi7uChOInqynj4y5nw4+bTWPEqU9KfRUHLgyOwqYZFFDlxcQ==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.6.0",
+        "npm": ">=10.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
       }
+    },
+    "node_modules/geostyler-sld-parser/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/geostyler-style": {
       "version": "7.5.0",
@@ -28444,18 +28241,106 @@
         "url": "https://opencollective.com/geostyler"
       }
     },
-    "node_modules/geostyler/node_modules/geostyler-style": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-8.1.0.tgz",
-      "integrity": "sha512-8NgtzRc63bxC+1Vgqj/mMj77GX38CXXXWQ93PeZBdoMTkY9C/H0Anz38OrrlKdUgNVFZ/GJTNYwnX4wdaO5j6A==",
+    "node_modules/geostyler/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/geostyler/node_modules/geostyler-cql-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-cql-parser/-/geostyler-cql-parser-4.1.0.tgz",
+      "integrity": "sha512-fhjkl9UzTSlZjVpfECFujaaMfY6weNIN+BPWAcKC6sgzrCNcbcFdJ2TNRw5vOZEP4Ioli4QpddltqtKD6p9Wow==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/lodash": "^4.14.201",
+        "geostyler-style": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.6.0",
+        "npm": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
+      }
+    },
+    "node_modules/geostyler/node_modules/geostyler-openlayers-parser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-5.1.2.tgz",
+      "integrity": "sha512-iwzP1qMPTw0vz91RTCiOXsm0r58EHAkHrbUXD4rk8xtPqI0mc33k27SmpNdVYI1dIQZjzO72ZlVBuvtXAlbnKQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "css-font-parser": "^2.0.0",
+        "geostyler-style": "^10.3.0",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
+      },
+      "peerDependencies": {
+        "ol": ">=7.4"
+      }
+    },
+    "node_modules/geostyler/node_modules/geostyler-qgis-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geostyler-qgis-parser/-/geostyler-qgis-parser-4.0.2.tgz",
+      "integrity": "sha512-rRLGMgvxlclpjGlQjgMIZ6VeMuXUqZK5VFF+vdDScM4Tg+pDBIfM0+jIIbTo7+vLhsgsTddxaVyNM4axJzHibA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "color": "^4.2.3",
+        "core-js": "^3.26.1",
+        "geostyler-cql-parser": "^4.0.0",
+        "geostyler-style": "^10.0.0",
+        "string_decoder": "^1.3.0",
+        "timers": "^0.1.1",
+        "xml2js": "^0.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
+      }
+    },
+    "node_modules/geostyler/node_modules/geostyler-style": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-10.3.0.tgz",
+      "integrity": "sha512-Ve3E98GLwg1Pu9kGAch992BNdsn4QQyrHhhE4Yqi7uChOInqynj4y5nw4+bTWPEqU9KfRUHLgyOwqYZFFDlxcQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.6.0",
+        "npm": ">=10.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/geostyler"
+      }
+    },
+    "node_modules/geostyler/node_modules/geostyler-wfs-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/geostyler-wfs-parser/-/geostyler-wfs-parser-3.0.1.tgz",
+      "integrity": "sha512-U4Y9F6yTG0wRatkHnFLYBubcjXd1FwHs12zhFxLhZXzddOc4Gc25ffqe1o7x6ypmlbg0Tkb3aYsIXa3gfcNRfw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "fast-xml-parser": "^4.4.0",
+        "geostyler-data": "^1.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/geostyler"
@@ -30613,29 +30498,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.18"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -39871,9 +39733,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.49.0.tgz",
-      "integrity": "sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==",
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "license": "MIT"
     },
     "node_modules/moo": {
@@ -55617,18 +55479,18 @@
       }
     },
     "node_modules/typescript-json-schema": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.64.0.tgz",
-      "integrity": "sha512-Sew8llkYSzpxaMoGjpjD6NMFCr6DoWFHLs7Bz1LU48pzzi8ok8W+GZs9cG87IMBpC0UI7qwBMUI2um0LGxxLOg==",
+      "version": "0.65.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.65.1.tgz",
+      "integrity": "sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@types/node": "^16.9.2",
+        "@types/node": "^18.11.9",
         "glob": "^7.1.7",
         "path-equal": "^1.2.5",
         "safe-stable-stringify": "^2.2.0",
         "ts-node": "^10.9.1",
-        "typescript": "~5.1.0",
+        "typescript": "~5.5.0",
         "yargs": "^17.1.1"
       },
       "bin": {
@@ -55636,15 +55498,18 @@
       }
     },
     "node_modules/typescript-json-schema/node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
+      "version": "18.19.122",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.122.tgz",
+      "integrity": "sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/typescript-json-schema/node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -55653,6 +55518,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-json-schema/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.5.4",
@@ -58585,7 +58456,7 @@
       "devDependencies": {
         "cross-env": "^7.0.3",
         "fs-extra": "^11.3.0",
-        "jest": "^30.0.4",
+        "jest": "^30.0.5",
         "yeoman-test": "^10.1.1"
       },
       "engines": {
@@ -62794,7 +62665,7 @@
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "@types/react-redux": "*",
-        "geostyler": "^14.1.3",
+        "geostyler": "^18.1.2",
         "geostyler-data": "^1.0.0",
         "geostyler-openlayers-parser": "^4.0.0",
         "geostyler-style": "^7.2.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -138,7 +138,7 @@
     "fs-extra": "^11.2.0",
     "fuse.js": "^7.0.0",
     "geolib": "^2.0.24",
-    "geostyler": "^14.1.3",
+    "geostyler": "^18.1.2",
     "geostyler-data": "^1.0.0",
     "geostyler-openlayers-parser": "^4.3.0",
     "geostyler-qgis-parser": "2.0.1",

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/package.json
@@ -39,7 +39,7 @@
     "@superset-ui/chart-controls": "*",
     "@superset-ui/core": "*",
     "@types/react-redux": "*",
-    "geostyler": "^14.1.3",
+    "geostyler": "^18.1.2",
     "geostyler-data": "^1.0.0",
     "geostyler-openlayers-parser": "^4.0.0",
     "geostyler-style": "^7.2.0",


### PR DESCRIPTION
## Summary
Updates geostyler from v14 to v18 to resolve the @babel/polyfill deprecation warning.

## Details
The project was using geostyler v14.1.3 which depends on the deprecated `@babel/polyfill` package. Geostyler v18 removed this dependency.

This PR:
- Updates `geostyler` from v14.1.3 to v18.1.2
- Updates the cartodiagram plugin's peer dependency to match

This eliminates the deprecation warning:
```
npm warn deprecated @babel/polyfill@7.12.1: 🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime
```

## Test plan
- [x] npm install runs without the @babel/polyfill deprecation warning
- [ ] Cartodiagram plugin functionality should be tested to ensure compatibility with geostyler v18

🤖 Generated with [Claude Code](https://claude.ai/code)