### PR TITLE
fix(DatabaseModal): Don't set activeKey to undefined repeatedly

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -120,7 +120,8 @@ const ExtraOptions = ({
     if (!expandableModalIsOpen && activeKey !== undefined) {
       setActiveKey(undefined);
     }
-  }, [expandableModalIsOpen, activeKey]);
+    // See issue #34630 for why we omit `activeKey` from the dependency array
+  }, [expandableModalIsOpen]);
 
   return (
     <Collapse


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See https://github.com/apache/superset/issues/34630#issuecomment-3174535345 for the issue this pr solves. Removing the activeKey from dependency array corrects the mistake in the previous pr and also closes collapse component.
 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Connect a database
2. Select PostgreSQL
3. Click Connect this database with a SQLAlchemy URI string instead on the bottom
4. Go to Advanced Tab
5. Collapse for each sectin should work correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #34630
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
