### PR TITLE
feat(theming): add dynamic theme-aware login page background and login form branding

### DIFF
--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -249,6 +249,7 @@ THEME_DEFAULT = {
         "loginPageBackgroundImageUrl": "/static/assets/images/login-background.jpg",
         "loginFormBrandLogoUrl": "/static/assets/images/superset-logo-horiz.png",
         "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)",
+        "loginPageBackgroundBlur": "3px"
         # ... other theme tokens
     }
 }
@@ -261,7 +262,8 @@ Or directly via the CRUD interface on the Themes page.
    "token": {
         "loginPageBackgroundImageUrl": "/static/assets/images/login-background.jpg",
         "loginFormBrandLogoUrl": "/static/assets/images/superset-logo-horiz.png",
-        "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)"
+        "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)",
+        "loginPageBackgroundBlur": "3px"
     }
 }
 ```

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -220,11 +220,12 @@ Superset provides the capability for dynamic, theme-driven branding of its login
 
 ### Customizing the Login Page via Theme Tokens in Theme JSON
 
-Superset supports the following theme tokens to customize the login page appearance:
+Superset supports the following optional theme tokens to customize the login page appearance:
 
 - `loginPageBackgroundImageUrl`: URL of the login page background image  
 - `loginFormBrandLogoUrl`: URL of the logo displayed on the login form  
-- `loginPageBackgroundOverlayColor`: overlay color applied on top of the background image to improve contrast and readability  
+- `loginPageBackgroundOverlayColor`: overlay color applied on top of the background image to improve contrast and readability
+- `loginPageBackgroundBlur`: CSS blur radius applied to the login page background image (e.g., `4px`, `0.25rem`, `1em`, `10vw`)  
 
 If these tokens are omitted, Superset's default login page styling is used.
 
@@ -236,7 +237,7 @@ The `loginPageBackgroundOverlayColor` token accepts any valid CSS color format, 
 - HSL/HSLA (e.g., `hsla(0, 0%, 0%, 0.5)`)  
 - Named colors (e.g., `black`)  
 
-If `loginPageBackgroundImageUrl` is provided but `loginPageBackgroundOverlayColor` is omitted, the overlay defaults to a semi-transparent black: `rgba(0, 0, 0, 0.5)`.
+If `loginPageBackgroundImageUrl` is provided but `loginPageBackgroundOverlayColor` is omitted, the overlay defaults to a semi-transparent black: `rgba(0, 0, 0, 0.5)`. The default value for `loginPageBackgroundBlur` is `0px` (no blur effect on the background image).
 
 Tokens for login page customization can be set within the JSON theme configuration defined either in `superset_config.py`: 
 

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -214,6 +214,57 @@ Font URLs are validated against a configurable allowlist. By default, fonts from
 
 This feature works with the stock Docker image - no custom build required!
 
+## Login Page Customization
+
+Superset provides the capability for dynamic, theme-driven branding of its login page, enabling organizations to personalize the login screen with custom background images and login form logos.
+
+### Customizing the Login Page via Theme Tokens in Theme JSON
+
+Superset supports the following theme tokens to customize the login page appearance:
+
+- `loginPageBackgroundImageUrl`: URL of the login page background image  
+- `loginFormBrandLogoUrl`: URL of the logo displayed on the login form  
+- `loginPageBackgroundOverlayColor`: overlay color applied on top of the background image to improve contrast and readability  
+
+If these tokens are omitted, Superset's default login page styling is used.
+
+The `loginPageBackgroundOverlayColor` token accepts any valid CSS color format, including:
+
+- Hex (e.g., `#000000`)  
+- Hex with alpha (e.g., `#00000080`)  
+- RGB/RGBA (e.g., `rgba(0, 0, 0, 0.5)`)  
+- HSL/HSLA (e.g., `hsla(0, 0%, 0%, 0.5)`)  
+- Named colors (e.g., `black`)  
+
+If `loginPageBackgroundImageUrl` is provided but `loginPageBackgroundOverlayColor` is omitted, the overlay defaults to a semi-transparent black: `rgba(0, 0, 0, 0.5)`.
+
+Tokens for login page customization can be set within the JSON theme configuration defined either in `superset_config.py`: 
+
+```python
+# superset_config.py
+
+THEME_DEFAULT = {
+    "token": {
+        "loginPageBackgroundImageUrl": "/static/assets/images/login-background.jpg",
+        "loginFormBrandLogoUrl": "/static/assets/images/superset-logo-horiz.png",
+        "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)",
+        # ... other theme tokens
+    }
+}
+```
+
+Or directly via the CRUD interface on the Themes page.
+
+```json
+{
+   "token": {
+        "loginPageBackgroundImageUrl": "/static/assets/images/login-background.jpg",
+        "loginFormBrandLogoUrl": "/static/assets/images/superset-logo-horiz.png",
+        "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)"
+    }
+}
+```
+
 ## ECharts Configuration Overrides
 
 :::note
@@ -436,6 +487,7 @@ This feature provides powerful theming capabilities while maintaining the flexib
 - **Custom Fonts**: Load external fonts via configuration without rebuilding
 - **OS Dark Mode Detection**: Automatically switches themes based on system preferences
 - **Theme Import/Export**: Share themes between instances via YAML files
+- **Login Page Customization**: Customize login page visuals through theme tokens
 
 ## API Access
 

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -222,24 +222,24 @@ Superset provides the capability for dynamic, theme-driven branding of its login
 
 Superset supports the following optional theme tokens to customize the login page appearance:
 
-- `loginPageBackgroundImageUrl`: URL of the login page background image  
-- `loginFormBrandLogoUrl`: URL of the logo displayed on the login form  
+- `loginPageBackgroundImageUrl`: URL of the login page background image
+- `loginFormBrandLogoUrl`: URL of the logo displayed on the login form
 - `loginPageBackgroundOverlayColor`: overlay color applied on top of the background image to improve contrast and readability
-- `loginPageBackgroundBlur`: CSS blur radius applied to the login page background image (e.g., `4px`, `0.25rem`, `1em`, `10vw`)  
+- `loginPageBackgroundBlur`: CSS blur radius applied to the login page background image (e.g., `4px`, `0.25rem`, `1em`, `10vw`)
 
 If these tokens are omitted, Superset's default login page styling is used.
 
 The `loginPageBackgroundOverlayColor` token accepts any valid CSS color format, including:
 
-- Hex (e.g., `#000000`)  
-- Hex with alpha (e.g., `#00000080`)  
-- RGB/RGBA (e.g., `rgba(0, 0, 0, 0.5)`)  
-- HSL/HSLA (e.g., `hsla(0, 0%, 0%, 0.5)`)  
-- Named colors (e.g., `black`)  
+- Hex (e.g., `#000000`)
+- Hex with alpha (e.g., `#00000080`)
+- RGB/RGBA (e.g., `rgba(0, 0, 0, 0.5)`)
+- HSL/HSLA (e.g., `hsla(0, 0%, 0%, 0.5)`)
+- Named colors (e.g., `black`)
 
 If `loginPageBackgroundImageUrl` is provided but `loginPageBackgroundOverlayColor` is omitted, the overlay defaults to a semi-transparent black: `rgba(0, 0, 0, 0.5)`. The default value for `loginPageBackgroundBlur` is `0px` (no blur effect on the background image).
 
-Tokens for login page customization can be set within the JSON theme configuration defined either in `superset_config.py`: 
+Tokens for login page customization can be set within the JSON theme configuration defined either in `superset_config.py`:
 
 ```python
 # superset_config.py

--- a/superset-frontend/packages/superset-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/theme/types.ts
@@ -272,6 +272,7 @@ export interface SupersetSpecificTokens {
   loginPageBackgroundImageUrl?: string;
   loginFormBrandLogoUrl?: string;
   loginPageBackgroundOverlayColor?: string;
+  loginPageBackgroundBlur?: string;
 }
 
 /**

--- a/superset-frontend/packages/superset-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/theme/types.ts
@@ -268,6 +268,10 @@ export interface SupersetSpecificTokens {
   resultsGridHeaderFontSize?: number;
   resultsGridBorderRadius?: number;
   resultsGridNoStriping?: boolean;
+  // Login page customization
+  loginPageBackgroundImageUrl?: string;
+  loginFormBrandLogoUrl?: string;
+  loginPageBackgroundOverlayColor?: string;
 }
 
 /**

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -19,7 +19,7 @@
 
 import { t } from '@apache-superset/core/translation';
 import { SupersetClient } from '@superset-ui/core';
-import { styled, css } from '@apache-superset/core/theme';
+import { styled, css, useTheme } from '@apache-superset/core/theme';
 import {
   Button,
   Card,
@@ -80,7 +80,46 @@ const StyledLabel = styled(Typography.Text)`
   `}
 `;
 
+const StyledBackground = styled.div`
+  ${({ theme }) => {
+    const bgImageUrl = theme.loginPageBackgroundImageUrl;
+    const overlayColor =
+      theme.loginPageBackgroundOverlayColor || 'rgba(0, 0, 0, 0.5)';
+    return bgImageUrl
+      ? css`
+          background-image: url(${bgImageUrl});
+          background-size: cover;
+          background-position: center;
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100vw;
+          height: 100vh;
+          &::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: ${overlayColor};
+          }
+        `
+      : '';
+  }}
+`;
+
+const StyledBrandLogo = styled.img`
+  display: block;
+  max-width: 160px;
+  max-height: 64px;
+  margin: 0;
+  object-fit: contain;
+`;
+
 export default function Login() {
+  const theme = useTheme();
+
   const [form] = Form.useForm<LoginForm>();
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
@@ -154,121 +193,156 @@ export default function Login() {
   };
 
   return (
-    <Flex
-      justify="center"
-      align="center"
-      data-test="login-form"
-      css={css`
-        width: 100%;
-        height: calc(100vh - 200px);
-      `}
-    >
-      <StyledCard title={t('Sign in')} padded>
-        {authType === AuthType.AuthOID && (
-          <Flex justify="center" vertical gap="middle">
-            <Form layout="vertical" requiredMark="optional" form={form}>
-              {providers.map((provider: OIDProvider) => (
-                <Form.Item<LoginForm>>
-                  <Button
-                    href={buildProviderLoginUrl(provider.name)}
-                    block
-                    iconPosition="start"
-                    icon={getAuthIconElement(provider.name)}
-                  >
-                    {t('Sign in with')} {capitalize(provider.name)}
-                  </Button>
-                </Form.Item>
-              ))}
-            </Form>
-          </Flex>
-        )}
-        {(authType === AuthType.AuthOauth ||
-          authType === AuthType.AuthSAML) && (
-          <Flex justify="center" gap={0} vertical>
-            <Form layout="vertical" requiredMark="optional" form={form}>
-              {providers.map((provider: OAuthProvider) => (
-                <Form.Item<LoginForm>>
-                  <Button
-                    href={buildProviderLoginUrl(provider.name)}
-                    block
-                    iconPosition="start"
-                    icon={getAuthIconElement(provider.name)}
-                  >
-                    {t('Sign in with')} {capitalize(provider.name)}
-                  </Button>
-                </Form.Item>
-              ))}
-            </Form>
-          </Flex>
-        )}
+    <>
+      <StyledBackground />
+      <Flex
+        justify="center"
+        align="center"
+        data-test="login-form"
+        css={css`
+          width: 100%;
+          height: calc(100vh - 200px);
+        `}
+      >
+        <StyledCard
+          padded
+          title={
+            <Flex vertical align="start" gap="middle">
+              {theme.loginFormBrandLogoUrl && (
+                <StyledBrandLogo
+                  src={theme.loginFormBrandLogoUrl}
+                  alt={theme.brandLogoAlt || 'Apache Superset'}
+                  style={{ marginTop: theme.sizeUnit * 4 }}
+                />
+              )}
+              <Typography.Title
+                level={4}
+                style={{
+                  marginTop: 0,
+                  marginBottom: theme.loginFormBrandLogoUrl
+                    ? theme.sizeUnit * 2
+                    : 0,
+                  marginLeft: 0,
+                  marginRight: 0,
+                }}
+              >
+                {t('Sign in')}
+              </Typography.Title>
+            </Flex>
+          }
+        >
+          {authType === AuthType.AuthOID && (
+            <Flex justify="center" vertical gap="middle">
+              <Form layout="vertical" requiredMark="optional" form={form}>
+                {providers.map((provider: OIDProvider) => (
+                  <Form.Item<LoginForm>>
+                    <Button
+                      href={buildProviderLoginUrl(provider.name)}
+                      block
+                      iconPosition="start"
+                      icon={getAuthIconElement(provider.name)}
+                    >
+                      {t('Sign in with')} {capitalize(provider.name)}
+                    </Button>
+                  </Form.Item>
+                ))}
+              </Form>
+            </Flex>
+          )}
+          {(authType === AuthType.AuthOauth ||
+            authType === AuthType.AuthSAML) && (
+            <Flex justify="center" gap={0} vertical>
+              <Form layout="vertical" requiredMark="optional" form={form}>
+                {providers.map((provider: OAuthProvider) => (
+                  <Form.Item<LoginForm>>
+                    <Button
+                      href={buildProviderLoginUrl(provider.name)}
+                      block
+                      iconPosition="start"
+                      icon={getAuthIconElement(provider.name)}
+                    >
+                      {t('Sign in with')} {capitalize(provider.name)}
+                    </Button>
+                  </Form.Item>
+                ))}
+              </Form>
+            </Flex>
+          )}
 
-        {(authType === AuthType.AuthDB || authType === AuthType.AuthLDAP) && (
-          <Flex justify="center" vertical gap="middle">
-            <Typography.Text type="secondary">
-              {t('Enter your login and password below:')}
-            </Typography.Text>
-            <Form
-              layout="vertical"
-              requiredMark="optional"
-              form={form}
-              onFinish={onFinish}
-            >
-              <Form.Item<LoginForm>
-                label={<StyledLabel>{t('Username:')}</StyledLabel>}
-                name="username"
-                rules={[
-                  { required: true, message: t('Please enter your username') },
-                ]}
+          {(authType === AuthType.AuthDB || authType === AuthType.AuthLDAP) && (
+            <Flex justify="center" vertical gap="middle">
+              <Typography.Text type="secondary">
+                {t('Enter your login and password below:')}
+              </Typography.Text>
+              <Form
+                layout="vertical"
+                requiredMark="optional"
+                form={form}
+                onFinish={onFinish}
               >
-                <Input
-                  autoFocus
-                  prefix={<Icons.UserOutlined iconSize="l" />}
-                  data-test="username-input"
-                />
-              </Form.Item>
-              <Form.Item<LoginForm>
-                label={<StyledLabel>{t('Password:')}</StyledLabel>}
-                name="password"
-                rules={[
-                  { required: true, message: t('Please enter your password') },
-                ]}
-              >
-                <Input.Password
-                  prefix={<Icons.KeyOutlined iconSize="l" />}
-                  data-test="password-input"
-                />
-              </Form.Item>
-              <Form.Item label={null}>
-                <Flex
-                  css={css`
-                    width: 100%;
-                  `}
+                <Form.Item<LoginForm>
+                  label={<StyledLabel>{t('Username:')}</StyledLabel>}
+                  name="username"
+                  rules={[
+                    {
+                      required: true,
+                      message: t('Please enter your username'),
+                    },
+                  ]}
                 >
-                  <Button
-                    block
-                    type="primary"
-                    htmlType="submit"
-                    loading={loading}
-                    data-test="login-button"
+                  <Input
+                    autoFocus
+                    prefix={<Icons.UserOutlined iconSize="l" />}
+                    data-test="username-input"
+                  />
+                </Form.Item>
+                <Form.Item<LoginForm>
+                  label={<StyledLabel>{t('Password:')}</StyledLabel>}
+                  name="password"
+                  rules={[
+                    {
+                      required: true,
+                      message: t('Please enter your password'),
+                    },
+                  ]}
+                >
+                  <Input.Password
+                    prefix={<Icons.KeyOutlined iconSize="l" />}
+                    data-test="password-input"
+                  />
+                </Form.Item>
+                <Form.Item label={null}>
+                  <Flex
+                    css={css`
+                      width: 100%;
+                    `}
                   >
-                    {t('Sign in')}
-                  </Button>
-                  {authRegistration && (
                     <Button
                       block
-                      type="default"
-                      href={ensureAppRoot('/register/')}
-                      data-test="register-button"
+                      type="primary"
+                      htmlType="submit"
+                      loading={loading}
+                      data-test="login-button"
                     >
-                      {t('Register')}
+                      {t('Sign in')}
                     </Button>
-                  )}
-                </Flex>
-              </Form.Item>
-            </Form>
-          </Flex>
-        )}
-      </StyledCard>
-    </Flex>
+                    {authRegistration && (
+                      <Button
+                        block
+                        type="default"
+                        href={ensureAppRoot('/register/')}
+                        data-test="register-button"
+                      >
+                        {t('Register')}
+                      </Button>
+                    )}
+                  </Flex>
+                </Form.Item>
+              </Form>
+            </Flex>
+          )}
+        </StyledCard>
+      </Flex>
+    </>
   );
 }

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -85,16 +85,31 @@ const StyledBackground = styled.div`
     const bgImageUrl = theme.loginPageBackgroundImageUrl;
     const overlayColor =
       theme.loginPageBackgroundOverlayColor || 'rgba(0, 0, 0, 0.5)';
+    const blurAmount = theme.loginPageBackgroundBlur || '0px';
     return bgImageUrl
       ? css`
-          background-image: url(${bgImageUrl});
-          background-size: cover;
-          background-position: center;
           position: fixed;
           top: 0;
           left: 0;
           width: 100vw;
           height: 100vh;
+          z-index: 0;
+          pointer-events: none;
+
+          &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-image: url(${bgImageUrl});
+            background-size: cover;
+            background-position: center;
+            filter: blur(${blurAmount});
+            z-index: -1;
+          }
+
           &::after {
             content: '';
             position: absolute;
@@ -103,6 +118,7 @@ const StyledBackground = styled.div`
             width: 100%;
             height: 100%;
             background-color: ${overlayColor};
+            z-index: 1;
           }
         `
       : '';


### PR DESCRIPTION
### SUMMARY
This PR introduces dynamic, theme-driven customization/branding of Apache Superset's login page.  The goal was to provide organizations with the ability to personalize their Superset login screen with a custom background and login form logo, similar to how Microsoft 365 allows company-specific branding on its sign-in pages.

**Key Changes:**
- Added support for theme tokens to control login background and login form logo
- Introduced new optional tokens: `loginPageBackgroundImageUrl`, `loginFormBrandLogoUrl`, `loginPageBackgroundOverlayColor`, `loginPageBackgroundBlur` 
- When tokens are omitted, the login page has Superset’s default styling
- `loginPageBackgroundBlur`: CSS blur radius applied to the login page background image (e.g., `4px`, `0.25rem`, `1em`, `10vw`)
- `loginPageBackgroundOverlayColor` is an optional theme token that specifies the overlay color applied on top of the login page background image. It accepts any valid CSS color value, including:
	- Hex without alpha (e.g. `#000000`)
	- Hex with alpha (e.g. `#00000080`)
	- RGB / RGBA (e.g. rgba(`0, 0, 0, 0.5`))
	- HSL / HSLA (e.g. hsla(`0, 0%, 0%, 0.5`))
	- Named colors (e.g. `black`)
- If `loginPageBackgroundImageUrl` is set, but loginPageBackgroundOverlayColor is omitted, the overlay color defaults to `rgba(0, 0, 0, 0.5)`, i.e., a half-transparent black overlay. The default value for `loginPageBackgroundBlur` is `0px` (no blur effect on the background image).


**Notes:**
One visible difference in the login form’s appearance is that the "Sign in" title text is larger than in the default styling. Additionally, I manually handled the margins for this section, which may make the code feel somewhat cumbersome and spacing inconsistent with the rest of the Superset's UI. Both of these choices stem from the need to inject both the logo and the title into the card header to accommodate the new branding elements. If anyone has suggestions on how to implement this more consistently with Superset’s standards, I’d be happy to update the implementation accordingly.

I’ve aimed to follow Superset’s existing styling and component conventions, but please let me know if anything feels inconsistent. This is my first contribution to the project, and I’m still getting familiar with Superset, so it probably isn't done perfectly. Looking forward to your feedback!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
For demonstration purposes, I’ve used Superset’s default logo and a placeholder background image sourced from the internet. These are not intended as final assets, but they should give a clear idea of how organizations can apply their own branding using theme tokens.

**Before:**

Light:
<img width="1920" height="879" alt="chrome_F4W1ZNxjHZ" src="https://github.com/user-attachments/assets/9a6f154f-5551-4b36-a76b-3306281efdaa" />

Dark:
<img width="1920" height="879" alt="chrome_jdl83pBwet" src="https://github.com/user-attachments/assets/aaf5739f-2bca-4867-9417-0e20f3ec37f9" />


**After:**

Light:
<img width="1920" height="879" alt="chrome_CcXqgbbuiB" src="https://github.com/user-attachments/assets/e10d7725-329d-4840-a24d-dc863c49b390" />

Dark:
<img width="1920" height="879" alt="chrome_KMsjrGoAJZ" src="https://github.com/user-attachments/assets/cb080262-048a-4732-94c5-8470e057959a" />

Dark + Blur Effect:
<img width="1920" height="879" alt="chrome_E6nHKMcgpC" src="https://github.com/user-attachments/assets/ebffe2a4-07df-435f-ac78-96816011fcda" />

Reference - Microsoft 365’s company-branded sign-in screen:
![Microsoft365 branded login](https://github.com/user-attachments/assets/351bac89-b85e-43e2-9482-4966fd98e29b)

### TESTING INSTRUCTIONS

1. Place your background and logo images in the following folder: `/superset-frontend/src/assets/images`
2. Reference Images in Theme JSON:
   - Superset's Theme CRUD UI → Settings > Theme > JSON Editor
   - `superset_config.py` → using the THEME config
3. Example theme JSON:
```
{
  "algorithm": "dark",
  "token": {
    "loginPageBackgroundImageUrl": "/static/assets/images/login-background.jpg",
    "loginFormBrandLogoUrl": "/static/assets/images/superset-logo-horiz.png",
    "loginPageBackgroundOverlayColor": "rgba(0, 0, 0, 0.6)",
    "loginPageBackgroundBlur": "3px"
  }
}
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ x] Has associated issue: https://github.com/apache/superset/issues/23466
- [ ] Required feature flags:
- [x ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

