### PR TITLE
fix: Slack channels and Color Palettes search

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1047,6 +1047,119 @@ test('typing and deleting the last character for a new option displays correctly
   jest.useRealTimers();
 });
 
+describe('grouped options search', () => {
+  const GROUPED_OPTIONS = [
+    {
+      label: 'Male',
+      options: OPTIONS.filter(option => option.gender === 'Male'),
+    },
+    {
+      label: 'Female',
+      options: OPTIONS.filter(option => option.gender === 'Female'),
+    },
+  ];
+
+  it('searches within grouped options and shows matching groups', async () => {
+    render(<Select {...defaultProps} options={GROUPED_OPTIONS} />);
+    await open();
+
+    await type('John');
+
+    expect(await findSelectOption('John')).toBeInTheDocument();
+    expect(await findSelectOption('Johnny')).toBeInTheDocument();
+    expect(screen.queryByText('Female')).not.toBeInTheDocument();
+    expect(screen.queryByText('Olivia')).not.toBeInTheDocument();
+    expect(screen.getByText('Male')).toBeInTheDocument();
+    expect(screen.queryByText('Female')).not.toBeInTheDocument();
+  });
+
+  it('shows multiple groups when search matches both', async () => {
+    render(<Select {...defaultProps} options={GROUPED_OPTIONS} />);
+    await open();
+
+    await type('er');
+
+    expect(screen.getByText('Male')).toBeInTheDocument();
+    expect(screen.getByText('Female')).toBeInTheDocument();
+    expect(await findSelectOption('Oliver')).toBeInTheDocument();
+    expect(await findSelectOption('Cher')).toBeInTheDocument();
+    expect(await findSelectOption('Her')).toBeInTheDocument();
+  });
+
+  it('handles case-insensitive search in grouped options', async () => {
+    render(<Select {...defaultProps} options={GROUPED_OPTIONS} />);
+    await open();
+
+    await type('EMMA');
+
+    expect(await findSelectOption('Emma')).toBeInTheDocument();
+    expect(screen.getByText('Female')).toBeInTheDocument();
+    expect(screen.queryByText('Male')).not.toBeInTheDocument();
+  });
+
+  it('shows no options when search matches nothing in any group', async () => {
+    render(<Select {...defaultProps} options={GROUPED_OPTIONS} />);
+    await open();
+
+    await type('xyz123');
+
+    expect(screen.queryByText('Male')).not.toBeInTheDocument();
+    expect(screen.queryByText('Female')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(NO_DATA, { selector: '.ant-empty-description' }),
+    ).toBeInTheDocument();
+  });
+
+  it('works in multiple selection mode with grouped options', async () => {
+    render(
+      <Select {...defaultProps} options={GROUPED_OPTIONS} mode="multiple" />,
+    );
+    await open();
+
+    await type('John');
+
+    await userEvent.click(await findSelectOption('John'));
+
+    // Clear search and search for female name
+    await clearTypedText();
+    await type('Emma');
+    await userEvent.click(await findSelectOption('Emma'));
+
+    // Both should be selected
+    const values = await findAllSelectValues();
+    expect(values).toHaveLength(2);
+    expect(values[0]).toHaveTextContent('John');
+    expect(values[1]).toHaveTextContent('Emma');
+  });
+
+  it('preserves group structure when not searching', async () => {
+    render(<Select {...defaultProps} options={GROUPED_OPTIONS} />);
+    await open();
+
+    expect(screen.getByText('Male')).toBeInTheDocument();
+    expect(screen.getByText('Female')).toBeInTheDocument();
+    expect(await findSelectOption('John')).toBeInTheDocument();
+    expect(await findSelectOption('Emma')).toBeInTheDocument();
+  });
+
+  it('handles empty groups gracefully', async () => {
+    const optionsWithEmptyGroup = [
+      ...GROUPED_OPTIONS,
+      {
+        label: 'Empty Group',
+        options: [],
+      },
+    ];
+
+    render(<Select {...defaultProps} options={optionsWithEmptyGroup} />);
+    await open();
+
+    await type('John');
+    expect(await findSelectOption('John')).toBeInTheDocument();
+    expect(screen.queryByText('Empty Group')).not.toBeInTheDocument();
+  });
+});
+
 /*
  TODO: Add tests that require scroll interaction. Needs further investigation.
  - Fetches more data when scrolling and more data is available

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -373,9 +373,27 @@ const Select = forwardRef(
         setSelectOptions(updatedOptions);
       }
 
-      const filteredOptions = updatedOptions.filter(
-        (option: AntdLabeledValue) => handleFilterOption(search, option),
-      );
+      const filteredOptions = updatedOptions
+        .map((option: any) => {
+          /*
+          If it's a group, filter its nested options and only return it
+          if it has matching options
+          */
+          if ('options' in option && Array.isArray(option.options)) {
+            const filteredGroupOptions = option.options.filter(
+              (subOption: AntdLabeledValue) =>
+                handleFilterOption(search, subOption),
+            );
+            return filteredGroupOptions.length > 0
+              ? { ...option, options: filteredGroupOptions }
+              : null;
+          }
+
+          return handleFilterOption(search, option as AntdLabeledValue)
+            ? option
+            : null;
+        })
+        .filter((option): option is AntdLabeledValue => option !== null);
 
       setVisibleOptions(filteredOptions);
       setInputValue(searchValue);

--- a/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorSchemeControl/index.tsx
@@ -36,11 +36,12 @@ import {
   type SelectOptionsType,
 } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { handleFilterOptionHelper } from '@superset-ui/core/components/Select/utils';
 import { getColorNamespace } from 'src/utils/colorScheme';
 import ColorSchemeLabel from './ColorSchemeLabel';
 
-export type OptionData = SelectOptionsType[number]['options'][number];
+export type OptionData = SelectOptionsType[number]['options'][number] & {
+  searchText?: string;
+};
 
 export interface ColorSchemes {
   [key: string]: ColorScheme;
@@ -217,6 +218,7 @@ const ColorSchemeControl = ({
             />
           ) as ReactNode,
           value,
+          searchText: currentScheme.label,
         };
         acc[currentScheme.group ?? ColorSchemeGroup.Other].options.push(option);
         return acc;
@@ -261,6 +263,7 @@ const ColorSchemeControl = ({
       options: group.options.map(opt => ({
         value: opt.value,
         label: opt.customLabel || opt.label,
+        searchText: opt.searchText,
       })),
     }));
   }, [choices, hasDashboardScheme, hasSharedLabelsColor, isLinear, schemes]);
@@ -321,14 +324,7 @@ const ColorSchemeControl = ({
         showSearch
         getPopupContainer={triggerNode => triggerNode.parentNode}
         options={options}
-        filterOption={(search, option) =>
-          handleFilterOptionHelper(
-            search,
-            option as OptionData,
-            ['label', 'value'],
-            true,
-          )
-        }
+        optionFilterProps={['label', 'value', 'searchText']}
       />
     </>
   );


### PR DESCRIPTION
### SUMMARY
This PR improves the `Select` component to properly handle search on grouped entities. This fixes the search on Slack recipients (in Alerts & Reports) and also on Color Palettes (on charts).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

https://github.com/user-attachments/assets/8223db66-d106-41b5-832a-e4b7050d1b8a

**After**

https://github.com/user-attachments/assets/89d699a0-af32-482c-8e52-242943c4a5a7

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
