### PR TITLE
fix: Fix Slice import on has_drill_by_access

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -613,6 +613,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         """
 
         from superset.connectors.sqla.models import TableColumn
+        from superset.models.slice import Slice
 
         return bool(
             form_data.get("type") != "NATIVE_FILTER"


### PR DESCRIPTION
### SUMMARY
This method was missing a local import, causing:
```
security_manager.raise_for_access(query_context=self._query_context)
  File "/home/superset/preset/superset-oss/superset/security/manager.py", line 2472, in raise_for_access
    or self.has_drill_by_access(form_data, dashboard_, datasource)
  File "/home/superset/preset/superset-oss/superset/security/manager.py", line 622, in has_drill_by_access
    slc := self.get_session.query(Slice)
NameError: name 'Slice' is not defined. Did you mean: 'slice'?
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Try drilling in embedded or using a user with RBAC .

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
