### PR TITLE
fix(csv_tests): Import from utils

### DIFF
--- a/tests/unit_tests/utils/csv_tests.py
+++ b/tests/unit_tests/utils/csv_tests.py
@@ -15,14 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 
 import pandas as pd
 import pyarrow as pa
 import pytest  # noqa: F401
 from pandas.api.types import is_datetime64_any_dtype
 
-from superset.utils import csv
+from superset.utils import csv, json
 from superset.utils.core import GenericDataType
 from superset.utils.csv import (
     df_to_escaped_csv,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Import `json` from utils instead of importing directly, which is banned in linter.
https://github.com/apache/superset/pull/32663#issuecomment-3181207311

Check pre-commit failures for the error this fixes
https://github.com/apache/superset/actions/runs/16922122521/job/47950478588?pr=34585

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run pre-commit hooks

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
