### PR TITLE
fix: Avoid dataset drill request if no perm

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -161,6 +161,7 @@ const ChartContextMenu = (
     formData.datasource,
     dashboardId,
     formData,
+    !canDrillToDetail && !canDrillBy,
   );
 
   const isLoadingDataset = datasetResource.status === ResourceStatus.Loading;

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -32,11 +32,11 @@ export type Dataset = {
     first_name: string;
     last_name: string;
   };
-  changed_on_humanized: string;
-  created_on_humanized: string;
-  description: string;
-  table_name: string;
-  owners: {
+  changed_on_humanized?: string;
+  created_on_humanized?: string;
+  description?: string;
+  table_name?: string;
+  owners?: {
     first_name: string;
     last_name: string;
   }[];

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -20,8 +20,14 @@
 import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import { FeatureFlag, VizType } from '@superset-ui/core';
 import mockState from 'spec/fixtures/mockState';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import SliceHeaderControls, { SliceHeaderControlsProps } from '.';
 
+jest.mock('src/utils/cachedSupersetGet');
+
+const mockCachedSupersetGet = cachedSupersetGet as jest.MockedFunction<
+  typeof cachedSupersetGet
+>;
 const SLICE_ID = 371;
 
 const createProps = (viz_type = VizType.Sunburst) =>
@@ -115,6 +121,19 @@ const renderWrapper = (
 const openMenu = () => {
   userEvent.click(screen.getByRole('button', { name: 'More Options' }));
 };
+
+beforeEach(() => {
+  mockCachedSupersetGet.mockClear();
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        columns: [],
+        metrics: [],
+      },
+    },
+  });
+});
 
 test('Should render', () => {
   renderWrapper();
@@ -525,4 +544,38 @@ test('Should not show the "Edit chart" button', () => {
   });
   openMenu();
   expect(screen.queryByText('Edit chart')).not.toBeInTheDocument();
+});
+
+test('Dataset drill info API call is made when user has drill permissions', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+  };
+  renderWrapper(undefined, {
+    Admin: [
+      ['can_samples', 'Datasource'],
+      ['can_explore', 'Superset'],
+      ['can_get_drill_info', 'Dataset'],
+    ],
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(mockCachedSupersetGet).toHaveBeenCalledWith({
+    endpoint: expect.stringContaining(
+      '/api/v1/dataset/58/drill_info/?q=(dashboard_id:26)',
+    ),
+  });
+});
+
+test('Dataset drill info API call is not made when user lacks drill permissions', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+  };
+  renderWrapper(undefined, {
+    Admin: [['invalid_permission', 'Dashboard']],
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(mockCachedSupersetGet).not.toHaveBeenCalled();
 });

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -184,6 +184,7 @@ const SliceHeaderControls = (
     props.slice.datasource,
     props.dashboardId,
     props.formData,
+    !canDrillToDetail,
   );
 
   const datasetWithVerboseMap =

--- a/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.tsx
+++ b/superset-frontend/src/features/datasets/metadataBar/useDatasetMetadataBar.tsx
@@ -60,23 +60,23 @@ export const useDatasetMetadataBar = ({
         ? `${changed_by.first_name} ${changed_by.last_name}`
         : notAvailable;
       const formattedOwners =
-        owners?.length > 0
+        owners && owners.length > 0
           ? owners.map(owner => `${owner.first_name} ${owner.last_name}`)
           : [notAvailable];
       items.push({
         type: MetadataType.Table,
-        title: table_name,
+        title: table_name || notAvailable,
       });
       items.push({
         type: MetadataType.LastModified,
-        value: changed_on_humanized,
+        value: changed_on_humanized || notAvailable,
         modifiedBy,
       });
       items.push({
         type: MetadataType.Owner,
         createdBy,
         owners: formattedOwners,
-        createdOn: created_on_humanized,
+        createdOn: created_on_humanized || notAvailable,
       });
       if (description) {
         items.push({

--- a/superset-frontend/src/hooks/apiResources/datasets.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.ts
@@ -63,6 +63,7 @@ export const useDatasetDrillInfo = (
   datasetId: string | number,
   dashboardId: number,
   formData?: QueryFormData,
+  skip: boolean = false,
 ): Resource<Dataset> => {
   const [resource, setResource] = useState<Resource<Dataset>>({
     status: ResourceStatus.Loading,
@@ -71,6 +72,15 @@ export const useDatasetDrillInfo = (
   });
 
   useEffect(() => {
+    if (skip) {
+      // short circuit if `skip` is `true`
+      setResource({
+        status: ResourceStatus.Complete,
+        result: {} as Dataset,
+        error: null,
+      });
+      return;
+    }
     const fetchDataset = async () => {
       try {
         const numericDatasetId = getDatasetId(datasetId);
@@ -115,7 +125,7 @@ export const useDatasetDrillInfo = (
     };
 
     fetchDataset();
-  }, [datasetId, dashboardId, formData]);
+  }, [datasetId, dashboardId, formData, skip]);
 
   return resource;
 };


### PR DESCRIPTION
### SUMMARY
This is a follow up to https://github.com/apache/superset/pull/34620. Users might not have drilling access, and in this case the API request would return a `403`. While this is expected, having failed requests is suboptimal for embedded use-cases, so I've added a `skip` flag to the method (since we can't conditionally call it).

Unsure if it's the best way to solve this -- but open to feedback.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
Test coverage added.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
