### PR TITLE
fix: Bar chart crash when switching from Big Number

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonArray, t } from '@superset-ui/core';
+import { ensureIsArray, JsonArray, t } from '@superset-ui/core';
 import {
   ControlPanelConfig,
   ControlPanelsContainerProps,
@@ -343,8 +343,9 @@ const config: ControlPanelConfig = {
                 chartState,
               ) => true,
               mapStateToProps: (state, controlState, chartState) => {
-                const value: JsonArray = state.controls.groupby
-                  .value as JsonArray;
+                const value: JsonArray = ensureIsArray(
+                  state.controls.groupby?.value,
+                ) as JsonArray;
                 const valueAsStringArr: string[][] = value.map(v => {
                   if (v) return [v.toString(), v.toString()];
                   return ['', ''];


### PR DESCRIPTION
### SUMMARY
When you try to switch viz types from a chart that doesn't have a groupby control (like Big Number), Bar Chart would crash because of undefined error. This PR adds a null check.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/d2c38e65-4fab-436a-a283-5fce11e3f383

After:

https://github.com/user-attachments/assets/f225ddc4-8d93-419a-82f9-991044e6f99a


### TESTING INSTRUCTIONS
1. Create and save a bar chart
2. Switch to big number
3. Switch back to bar chart
4. Verify that it doesn't crash

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
