### PR TITLE
feat(extension): Add extension for chart header

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -23,7 +23,7 @@ import {
   ComponentType,
 } from 'react';
 import type { Editor } from 'brace';
-import { QueryData } from 'src/chart';
+import { QueryData } from '../chart/types/QueryResponse';
 import { BaseFormData, LatestQueryFormData, QueryFormData } from '../query';
 import { JsonResponse } from '../connection';
 

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -224,6 +224,19 @@ export interface DateFilterControlProps {
   isOverflowingFilterBar?: boolean;
 }
 
+export interface ExploreChartHeaderProps {
+  chartId: number;
+  queriesResponse: QueryData[] | null;
+  sliceFormData: QueryFormData | null;
+  queryFormData: QueryFormData;
+  lastRendered: number;
+  latestQueryFormData: LatestQueryFormData;
+  chartUpdateEndTime: number | null;
+  chartUpdateStartTime: number;
+  queryController: AbortController | null;
+  triggerQuery: boolean;
+}
+
 export type Extensions = Partial<{
   'alertsreports.header.icon': ComponentType;
   'load.drillby.options': LoadDrillByOptions;
@@ -256,16 +269,5 @@ export type Extensions = Partial<{
     ComponentType<SQLTablePreviewExtensionProps>,
   ][];
   'filter.dateFilterControl': ComponentType<DateFilterControlProps>;
-  'explore.chart.header': ComponentType<{
-    chartId: number;
-    queriesResponse: QueryData[] | null;
-    sliceFormData: QueryFormData | null;
-    queryFormData: QueryFormData;
-    lastRendered: number;
-    latestQueryFormData: LatestQueryFormData;
-    chartUpdateEndTime: number | null;
-    chartUpdateStartTime: number;
-    queryController: AbortController | null;
-    triggerQuery: boolean;
-  }>;
+  'explore.chart.header': ComponentType<ExploreChartHeaderProps>;
 }>;

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -23,9 +23,13 @@ import {
   ComponentType,
 } from 'react';
 import type { Editor } from 'brace';
-import { QueryData } from '../chart/types/QueryResponse';
-import { BaseFormData, LatestQueryFormData, QueryFormData } from '../query';
-import { JsonResponse } from '../connection';
+import type { QueryData } from '../chart/types/QueryResponse';
+import type {
+  BaseFormData,
+  LatestQueryFormData,
+  QueryFormData,
+} from '../query';
+import type { JsonResponse } from '../connection';
 
 /**
  * A function which returns text (or marked-up text)

--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -23,7 +23,8 @@ import {
   ComponentType,
 } from 'react';
 import type { Editor } from 'brace';
-import { BaseFormData } from '../query';
+import { QueryData } from 'src/chart';
+import { BaseFormData, LatestQueryFormData, QueryFormData } from '../query';
 import { JsonResponse } from '../connection';
 
 /**
@@ -251,4 +252,16 @@ export type Extensions = Partial<{
     ComponentType<SQLTablePreviewExtensionProps>,
   ][];
   'filter.dateFilterControl': ComponentType<DateFilterControlProps>;
+  'explore.chart.header': ComponentType<{
+    chartId: number;
+    queriesResponse: QueryData[] | null;
+    sliceFormData: QueryFormData | null;
+    queryFormData: QueryFormData;
+    lastRendered: number;
+    latestQueryFormData: LatestQueryFormData;
+    chartUpdateEndTime: number | null;
+    chartUpdateStartTime: number;
+    queryController: AbortController | null;
+    triggerQuery: boolean;
+  }>;
 }>;

--- a/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/index.tsx
@@ -31,6 +31,7 @@ import {
   useTheme,
   QueryFormData,
   JsonObject,
+  getExtensionsRegistry,
 } from '@superset-ui/core';
 import ChartContainer from 'src/components/Chart/ChartContainer';
 import {
@@ -49,6 +50,9 @@ import { DataTablesPane } from '../DataTablesPane';
 import { ChartPills } from '../ChartPills';
 import { ExploreAlert } from '../ExploreAlert';
 import useResizeDetectorByObserver from './useResizeDetectorByObserver';
+
+const extensionsRegistry = getExtensionsRegistry();
+const DefaultHeader: React.FC = ({ children }) => <>{children}</>;
 
 export interface ExploreChartPanelProps {
   actions: {
@@ -149,6 +153,9 @@ const ExploreChartPanel = ({
     width: chartPanelWidth,
     height: chartPanelHeight,
   } = useResizeDetectorByObserver();
+
+  const ChartHeaderExtension =
+    extensionsRegistry.get('explore.chart.header') ?? DefaultHeader;
   const [splitSizes, setSplitSizes] = useState<PanelSizes>(
     isFeatureEnabled(FeatureFlag.DatapanelClosedByDefault)
       ? INITIAL_SIZES
@@ -367,16 +374,29 @@ const ExploreChartPanel = ({
             `}
           />
         )}
-        <ChartPills
+        <ChartHeaderExtension
+          chartId={chart.id}
+          queriesResponse={chart.queriesResponse}
+          sliceFormData={slice?.form_data ?? null}
+          queryFormData={formData}
+          lastRendered={chart.lastRendered}
+          latestQueryFormData={chart.latestQueryFormData}
+          chartUpdateEndTime={chart.chartUpdateEndTime ?? 0}
           chartUpdateStartTime={chart.chartUpdateStartTime}
-          chartUpdateEndTime={chart.chartUpdateEndTime ?? undefined}
-          refreshCachedQuery={refreshCachedQuery}
-          rowLimit={formData?.row_limit ?? undefined}
-          {...(chart.queriesResponse && {
-            queriesResponse: chart.queriesResponse,
-          })}
-          {...(chart.chartStatus && { chartStatus: chart.chartStatus })}
-        />
+          queryController={chart.queryController}
+          triggerQuery={chart.triggerQuery}
+        >
+          <ChartPills
+            chartUpdateStartTime={chart.chartUpdateStartTime}
+            chartUpdateEndTime={chart.chartUpdateEndTime ?? 0}
+            refreshCachedQuery={refreshCachedQuery}
+            rowLimit={formData?.row_limit ?? 0}
+            {...(chart.queriesResponse && {
+              queriesResponse: chart.queriesResponse,
+            })}
+            {...(chart.chartStatus && { chartStatus: chart.chartStatus })}
+          />
+        </ChartHeaderExtension>
         {renderChart()}
       </div>
     ),


### PR DESCRIPTION
### SUMMARY
This commit adds a new frontend config override for the chart's header.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

<img width="1466" height="937" alt="Weekly_Messages" src="https://github.com/user-attachments/assets/64b47255-6153-4483-b966-2c94441b38c4" />

After (with custom extensions):

<img width="1477" height="964" alt="Screenshot 2025-08-13 at 9 51 03 AM" src="https://github.com/user-attachments/assets/1a792845-3dd6-4718-90a8-c2dfa27ffa37" />

### TESTING INSTRUCTIONS
locally tested

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
