### PR TITLE
fix(bootstrapData): Missing application_root data throws an error

### DIFF
--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -106,5 +106,32 @@ describe('getBootstrapData and helpers', () => {
       expect(applicationRoot()).toEqual(expectedAppRoot);
       expect(staticAssetsPrefix()).toEqual(expectedStaticPrefix);
     });
+
+    it('should defaults without trailing slashes when #app element does not include application_root or static_assets_prefix', async () => {
+      // Set up the fake #app element
+      const customData = {
+        common: {
+          my_custom_property: 'custom-value',
+        },
+      };
+      document.body.innerHTML = `<div id="app" data-bootstrap='${JSON.stringify(customData)}'></div>`;
+
+      // Reset modules and re-import the module so that cachedBootstrapData is clear.
+      jest.resetModules();
+      const {
+        default: getBootstrapData,
+        applicationRoot,
+        staticAssetsPrefix,
+      } = await import('./getBootstrapData');
+      const bootstrapData = getBootstrapData();
+      expect(bootstrapData).toEqual(customData);
+      const expectedAppRoot =
+        DEFAULT_BOOTSTRAP_DATA.common.application_root.replace(/\/$/, '');
+      const expectedStaticPrefix =
+        DEFAULT_BOOTSTRAP_DATA.common.static_assets_prefix.replace(/\/$/, '');
+
+      expect(applicationRoot()).toEqual(expectedAppRoot);
+      expect(staticAssetsPrefix()).toEqual(expectedStaticPrefix);
+    });
   });
 });

--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -33,11 +33,15 @@ export default function getBootstrapData(): BootstrapData {
   return cachedBootstrapData ?? DEFAULT_BOOTSTRAP_DATA;
 }
 
-const APPLICATION_ROOT_NO_TRAILING_SLASH =
-  getBootstrapData().common.application_root.replace(/\/$/, '');
+const APPLICATION_ROOT_NO_TRAILING_SLASH = (
+  getBootstrapData().common.application_root ??
+  DEFAULT_BOOTSTRAP_DATA.common.application_root
+).replace(/\/$/, '');
 
-const STATIC_ASSETS_PREFIX_NO_TRAILING_SLASH =
-  getBootstrapData().common.static_assets_prefix.replace(/\/$/, '');
+const STATIC_ASSETS_PREFIX_NO_TRAILING_SLASH = (
+  getBootstrapData().common.static_assets_prefix ??
+  DEFAULT_BOOTSTRAP_DATA.common.static_assets_prefix
+).replace(/\/$/, '');
 
 /**
  * @returns The configured application root

--- a/superset-frontend/src/utils/getBootstrapData.ts
+++ b/superset-frontend/src/utils/getBootstrapData.ts
@@ -33,15 +33,20 @@ export default function getBootstrapData(): BootstrapData {
   return cachedBootstrapData ?? DEFAULT_BOOTSTRAP_DATA;
 }
 
-const APPLICATION_ROOT_NO_TRAILING_SLASH = (
-  getBootstrapData().common.application_root ??
-  DEFAULT_BOOTSTRAP_DATA.common.application_root
-).replace(/\/$/, '');
+const normalizePathWithFallback = (
+  path: string | undefined,
+  fallback: string,
+): string => (path ?? fallback).replace(/\/$/, '');
 
-const STATIC_ASSETS_PREFIX_NO_TRAILING_SLASH = (
-  getBootstrapData().common.static_assets_prefix ??
-  DEFAULT_BOOTSTRAP_DATA.common.static_assets_prefix
-).replace(/\/$/, '');
+const APPLICATION_ROOT_NO_TRAILING_SLASH = normalizePathWithFallback(
+  getBootstrapData().common.application_root,
+  DEFAULT_BOOTSTRAP_DATA.common.application_root,
+);
+
+const STATIC_ASSETS_PREFIX_NO_TRAILING_SLASH = normalizePathWithFallback(
+  getBootstrapData().common.static_assets_prefix,
+  DEFAULT_BOOTSTRAP_DATA.common.static_assets_prefix,
+);
 
 /**
  * @returns The configured application root


### PR DESCRIPTION
### SUMMARY
When adding the `application_root` bootstrap data in #30134, an issue arose where the frontend would always throw an error if this data was not previously included. This commit fixes the error by referencing the default value when the bootstrap data is not provided, just as it does for other default values.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1016" height="882" alt="_DEV__Superset" src="https://github.com/user-attachments/assets/c0095da1-613e-4a67-b2a6-e16bd1e5c134" />

After:

<img width="995" height="909" alt="_DEV__Superset" src="https://github.com/user-attachments/assets/e7285d83-2200-4808-aa7d-4488a9abb8dd" />


### TESTING INSTRUCTIONS

Run superset without configure the `SUPERSET_APP_ROOT`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
