### PR TITLE
fix(sqllab): Invisible grid table due to the invalid height

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { type ReactChild } from 'react';
 import {
   render,
   screen,
@@ -44,6 +45,13 @@ import {
 jest.mock('src/components/ErrorMessage', () => ({
   ErrorMessageWithStackTrace: () => <div data-test="error-message">Error</div>,
 }));
+
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({ children }: { children: (params: { height: number }) => ReactChild }) =>
+      children({ height: 500 }),
+);
 
 const mockedProps = {
   cache: true,

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -116,6 +116,7 @@ const ResultContainer = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: ${({ theme }) => theme.sizeUnit * 2}px;
+  height: 100%;
 `;
 
 const ResultlessStyles = styled.div`

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -466,6 +466,7 @@ const ResultSet = ({
           {!limitReached && shouldUseDefaultDropdownAlert && (
             <div>
               <Alert
+                closable
                 type="warning"
                 message={t(
                   'The number of rows displayed is limited to %(rows)d by the dropdown.',
@@ -477,6 +478,7 @@ const ResultSet = ({
           {limitReached && (
             <div>
               <Alert
+                closable
                 type="warning"
                 message={
                   isAdmin

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -586,21 +586,12 @@ const SqlEditor: FC<Props> = ({
   });
 
   useEffect(() => {
-    // We need to measure the height of the sql editor post render to figure the height of
-    // the south pane so it gets rendered properly
-    setHeight(getSqlEditorHeight());
-    const handleWindowResizeWithThrottle = throttle(
-      () => setHeight(getSqlEditorHeight()),
-      WINDOW_RESIZE_THROTTLE_MS,
-    );
     if (isActive) {
       loadQueryEditor();
-      window.addEventListener('resize', handleWindowResizeWithThrottle);
       window.addEventListener('beforeunload', onBeforeUnload);
     }
 
     return () => {
-      window.removeEventListener('resize', handleWindowResizeWithThrottle);
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
     // TODO: Remove useEffectEvent deps once https://github.com/facebook/react/pull/25881 is released
@@ -982,6 +973,7 @@ const SqlEditor: FC<Props> = ({
   );
 
   const queryPane = () => {
+    const height = getSqlEditorHeight();
     const { aceEditorHeight, southPaneHeight } =
       getAceEditorAndSouthPaneHeights(height, northPercent, southPercent);
     return (

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -50,7 +50,7 @@ import type {
   CursorPosition,
 } from 'src/SqlLab/types';
 import type { DatabaseObject } from 'src/features/databases/types';
-import { debounce, throttle, isEmpty } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import Mousetrap from 'mousetrap';
 import {
   Alert,
@@ -98,7 +98,6 @@ import {
   INITIAL_NORTH_PERCENT,
   INITIAL_SOUTH_PERCENT,
   SET_QUERY_EDITOR_SQL_DEBOUNCE_MS,
-  WINDOW_RESIZE_THROTTLE_MS,
 } from 'src/SqlLab/constants';
 import {
   getItem,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -300,7 +300,6 @@ const SqlEditor: FC<Props> = ({
 
   const logAction = useLogAction({ queryEditorId: queryEditor.id });
   const isActive = currentQueryEditorId === queryEditor.id;
-  const [height, setHeight] = useState(0);
   const [autorun, setAutorun] = useState(queryEditor.autorun);
   const [ctas, setCtas] = useState('');
   const [northPercent, setNorthPercent] = useState(

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isValidElement, type ReactChild } from 'react';
+import { isValidElement } from 'react';
 import {
   render,
   screen,
@@ -25,13 +25,6 @@ import {
 } from 'spec/helpers/testing-library';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { FilterableTable } from '.';
-
-jest.mock(
-  'react-virtualized-auto-sizer',
-  () =>
-    ({ children }: { children: (params: { height: number }) => ReactChild }) =>
-      children({ height: 500 }),
-);
 
 describe('FilterableTable', () => {
   beforeAll(() => {

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isValidElement } from 'react';
+import { isValidElement, type ReactChild } from 'react';
 import {
   render,
   screen,
@@ -25,6 +25,13 @@ import {
 } from 'spec/helpers/testing-library';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { FilterableTable } from '.';
+
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({ children }: { children: (params: { height: number }) => ReactChild }) =>
+      children({ height: 500 }),
+);
 
 describe('FilterableTable', () => {
   beforeAll(() => {

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -17,8 +17,6 @@
  * under the License.
  */
 import { useMemo, useRef, useCallback } from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
-import { styled } from '@superset-ui/core';
 import { GridSize } from 'src/components/GridTable/constants';
 import { GridTable } from 'src/components/GridTable';
 import { type ColDef } from 'src/components/GridTable/types';
@@ -31,11 +29,6 @@ import type { FilterableTableProps, Datum, CellDataType } from './types';
 // exponential notation, NaN, and Infinity.
 // See https://stackoverflow.com/a/30987109 for more details
 const ONLY_NUMBER_REGEX = /^(NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity))$/;
-
-const StyledFilterableTable = styled.div`
-  flex: 1 1 auto;
-  overflow: hidden;
-`;
 
 const parseNumberFromString = (value: string | number | null) => {
   if (typeof value === 'string' && ONLY_NUMBER_REGEX.test(value)) {
@@ -67,6 +60,7 @@ const sortResults = (valueA: string | number, valueB: string | number) => {
 export const FilterableTable = ({
   orderedColumnKeys,
   data,
+  height,
   filterText = '',
   expandedColumns = [],
   allowHTML = true,
@@ -126,27 +120,20 @@ export const FilterableTable = ({
   }, []);
 
   return (
-    <StyledFilterableTable
-      className="filterable-table-container"
-      data-test="table-container"
-    >
-      <AutoSizer disableWidth>
-        {({ height }) => (
-          <GridTable
-            size={GridSize.Small}
-            usePagination={false}
-            height={height}
-            columns={columns}
-            data={data}
-            externalFilter={keywordFilter}
-            showRowNumber
-            striped={striped}
-            enableActions
-            columnReorderable
-          />
-        )}
-      </AutoSizer>
-    </StyledFilterableTable>
+    <div className="filterable-table-container" data-test="table-container">
+      <GridTable
+        size={GridSize.Small}
+        usePagination={false}
+        height={height}
+        columns={columns}
+        data={data}
+        externalFilter={keywordFilter}
+        showRowNumber
+        striped={striped}
+        enableActions
+        columnReorderable
+      />
+    </div>
   );
 };
 

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { useMemo, useRef, useCallback } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import { styled } from '@superset-ui/core';
 import { GridSize } from 'src/components/GridTable/constants';
 import { GridTable } from 'src/components/GridTable';
@@ -32,7 +33,7 @@ import type { FilterableTableProps, Datum, CellDataType } from './types';
 const ONLY_NUMBER_REGEX = /^(NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity))$/;
 
 const StyledFilterableTable = styled.div`
-  height: 100%;
+  flex: 1 1 auto;
   overflow: hidden;
 `;
 
@@ -66,7 +67,6 @@ const sortResults = (valueA: string | number, valueB: string | number) => {
 export const FilterableTable = ({
   orderedColumnKeys,
   data,
-  height,
   filterText = '',
   expandedColumns = [],
   allowHTML = true,
@@ -130,18 +130,22 @@ export const FilterableTable = ({
       className="filterable-table-container"
       data-test="table-container"
     >
-      <GridTable
-        size={GridSize.Small}
-        height={height}
-        usePagination={false}
-        columns={columns}
-        data={data}
-        externalFilter={keywordFilter}
-        showRowNumber
-        striped={striped}
-        enableActions
-        columnReorderable
-      />
+      <AutoSizer disableWidth>
+        {({ height }) => (
+          <GridTable
+            size={GridSize.Small}
+            usePagination={false}
+            height={height}
+            columns={columns}
+            data={data}
+            externalFilter={keywordFilter}
+            showRowNumber
+            striped={striped}
+            enableActions
+            columnReorderable
+          />
+        )}
+      </AutoSizer>
     </StyledFilterableTable>
   );
 };


### PR DESCRIPTION
### SUMMARY
Due to changes in the way antd renders tab content, there was an issue where the height could not be calculated correctly when switching tabs, as setHeight was being called each time a tab changed.
To resolve this, this commit modifies the logic so that the height is calculated when the query panel is rendered. Additionally, this commit updates the result table to automatically adjust its height based on the current panel height.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/d7f98080-0b4e-447b-9512-1f555695aa0b

After:

https://github.com/user-attachments/assets/715fadba-2026-4c3c-b698-4c6e0643195d


### TESTING INSTRUCTIONS
Run a query and then switch tabs 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
