### PR TITLE
fix(deck.gl): add webpack rule to define module global for deck.gl charts

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -363,6 +363,13 @@ const config = {
         },
       },
       {
+        test: /node_modules\/(@deck\.gl|@luma\.gl).*\.js$/,
+        loader: 'imports-loader',
+        options: {
+          additionalCode: 'var module = module || {exports: {}};',
+        },
+      },
+      {
         test: /\.tsx?$/,
         exclude: [/\.test.tsx?$/],
         use: [


### PR DESCRIPTION
## Bug: deck.gl aggregated charts fail with "ReferenceError: module is not defined"

  ### Problem
  All deck.gl aggregated chart types (Grid, Contour, Hexagon, Screengrid, Heatmap, Calendar Heatmap) were failing to render with a "module is not defined" error. This occurred because deck.gl's distribution files contain code that references the Node.js `module` global, which doesn't exist in browser environments. This PR fixes issue #34681 

  ### Root Cause
  The deck.gl library's bundled JavaScript files in `node_modules/@deck.gl/*/dist/*.js` contain references to `module.exports`, expecting a CommonJS environment. When webpack processes these files for the browser, the `module` global is undefined, causing a ReferenceError.

  ### Solution
  Added a webpack rule using `imports-loader` to inject `var module = module || {exports: {}};` at the top of all deck.gl and luma.gl JavaScript files. This ensures the `module` object exists before any code tries to access it, preventing the runtime error.

  ### Testing
  - Verified all affected deck.gl aggregated charts (Grid, Contour, Hexagon, Screengrid, Heatmap, Calendar Heatmap) now render correctly
  - Confirmed non-aggregated deck.gl charts (Arc, Path, etc.) continue to work as expected
  - No impact on build performance or bundle size