### PR TITLE
chore(deps): downgrade pyarrow to v16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
     "python-dateutil",
     "python-dotenv", # optional dependencies for Flask but required for Superset, see https://flask.palletsprojects.com/en/stable/installation/#optional-dependencies
     "python-geohash",
-    "pyarrow>=18.1.0, <19",
+    "pyarrow>=16.1.0, <17",
     "pyyaml>=6.0.0, <7.0.0",
     "PyJWT>=2.4.0, <3.0",
     "redis>=4.6.0, <5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
     "python-dateutil",
     "python-dotenv", # optional dependencies for Flask but required for Superset, see https://flask.palletsprojects.com/en/stable/installation/#optional-dependencies
     "python-geohash",
-    "pyarrow>=16.1.0, <17",
+    "pyarrow>=16.1.0, <17", # before upgrading pyarrow, check that all db dependencies support this, see e.g. https://github.com/apache/superset/pull/34693
     "pyyaml>=6.0.0, <7.0.0",
     "PyJWT>=2.4.0, <3.0",
     "redis>=4.6.0, <5.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -276,7 +276,7 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.51
     # via click-repl
-pyarrow==18.1.0
+pyarrow==16.1.0
     # via apache-superset (pyproject.toml)
 pyasn1==0.6.1
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -588,7 +588,7 @@ psutil==6.1.0
     # via apache-superset
 psycopg2-binary==2.9.6
     # via apache-superset
-pyarrow==18.1.0
+pyarrow==16.1.0
     # via
     #   -c requirements/base.txt
     #   apache-superset


### PR DESCRIPTION
### SUMMARY

some database connectors are not supporting the newer pyarrow version (introduced in https://github.com/apache/superset/pull/31476) yet, or require first an upgrade to SQLAlchemy 2.0. see https://github.com/apache/superset/pull/34692

fyi @phillipleblanc

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
