### PR TITLE
fix: Invalid error tooltip if control label is function

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -700,6 +700,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
               title={props.errorMessage}
             >
               <Icons.CloseCircleOutlined
+                data-test="query-error-tooltip-trigger"
                 iconColor={theme.colorErrorText}
                 iconSize="s"
               />

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,170 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+// Component tests for the errorMessage behavior
+test('does not show error indicator when no controls have validation errors', async () => {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
+  });
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      controls: {
+        ...reduxState.explore.controls,
+        metric: { value: 'count', label: 'Metric' },
+        groupby: { value: ['category'], label: 'Group by' },
+      },
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  await waitFor(() => {
+    const errorIndicator = screen.queryByTestId('query-error-tooltip-trigger');
+    expect(errorIndicator).not.toBeInTheDocument();
+  });
+});
+
+test('shows error indicator when controls have validation errors', async () => {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
+  });
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      controls: {
+        ...reduxState.explore.controls,
+        metric: {
+          value: '',
+          label: 'Metric',
+          validationErrors: ['Metric is required'],
+        },
+      },
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const errorIndicator = await screen.findByTestId(
+    'query-error-tooltip-trigger',
+  );
+
+  userEvent.hover(errorIndicator);
+
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toBeInTheDocument();
+
+  const errorMessage = await screen.findByText(/Metric is required/);
+  expect(errorMessage).toBeInTheDocument();
+});
+
+test('shows error indicator for multiple controls with validation errors', async () => {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
+  });
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      controls: {
+        ...reduxState.explore.controls,
+        metric: {
+          value: '',
+          label: 'Metric',
+          validationErrors: ['Field is required'],
+        },
+        groupby: {
+          value: [],
+          label: 'Group by',
+          validationErrors: ['Field is required'],
+        },
+      },
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const errorIndicator = await screen.findByTestId(
+    'query-error-tooltip-trigger',
+  );
+
+  userEvent.hover(errorIndicator);
+
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toBeInTheDocument();
+
+  expect(await screen.findByText(/Field is required/)).toBeInTheDocument();
+});
+
+test('shows error indicator for control with multiple validation errors', async () => {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
+  });
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      controls: {
+        ...reduxState.explore.controls,
+        metric: {
+          value: '',
+          label: 'Metric',
+          validationErrors: ['Field is required', 'Invalid format'],
+        },
+      },
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const errorIndicator = await screen.findByTestId(
+    'query-error-tooltip-trigger',
+  );
+
+  userEvent.hover(errorIndicator);
+
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toBeInTheDocument();
+
+  expect(await screen.findByText(/Field is required/)).toBeInTheDocument();
+  expect(await screen.findByText(/Invalid format/)).toBeInTheDocument();
+});
+
+test('shows error indicator with function labels', async () => {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
+  });
+  // Ensure the explore state passed to the label function contains the expected property
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      someState: 'test',
+      controls: {
+        ...reduxState.explore.controls,
+        metric: {
+          value: '',
+          label: (exploreState: { someState: string }) =>
+            `Dynamic Metric (${exploreState.someState})`,
+          validationErrors: ['Metric is required'],
+        },
+      },
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const errorIndicator = await screen.findByTestId(
+    'query-error-tooltip-trigger',
+  );
+
+  userEvent.hover(errorIndicator);
+
+  const tooltip = await screen.findByRole('tooltip');
+  expect(tooltip).toBeInTheDocument();
+
+  expect(await screen.findByText(/Metric is required/)).toBeInTheDocument();
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -541,7 +541,11 @@ function ExploreViewContainer(props) {
       .map(message => {
         const matchingLabels = controlsWithErrors
           .filter(control => control.validationErrors?.includes(message))
-          .map(control => control.label);
+          .map(control =>
+            typeof control.label === 'function'
+              ? control.label(props.exploreState)
+              : control.label,
+          );
         return [matchingLabels, message];
       })
       .map(([labels, message]) => (

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.tsx
@@ -87,17 +87,6 @@ export const useHeaderReportMenuItems = ({
     const resourceTypeReports = reportsState[resourceType] || {};
     const reportData = resourceTypeReports[resourceId];
 
-    // Debug logging to understand what's happening
-    console.log('Report selector called:', {
-      resourceId,
-      resourceType,
-      reportsState: Object.keys(reportsState),
-      resourceTypeReports: Object.keys(resourceTypeReports),
-      reportData: reportData
-        ? { id: reportData.id, name: reportData.name }
-        : null,
-    });
-
     return reportData || null;
   });
 


### PR DESCRIPTION
### SUMMARY
If a control's label is a function instead of a string (like for example x axis control), the error tooltip at the top of control panel didn't display it properly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="443" height="191" alt="image" src="https://github.com/user-attachments/assets/becd6e8f-9ac9-4695-9321-725910279680" />

After:

<img width="415" height="136" alt="image" src="https://github.com/user-attachments/assets/19c3e345-8feb-4847-8d87-a21bd1783ae1" />


### TESTING INSTRUCTIONS
1. Create a new chart with x axis control, like Line Chart
2. Before adding any controls, hover over the error icon next to Data tab and verify that the message is correct

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
