### PR TITLE
fix(sqllab): Reduce flushing caused by ID updates

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -1252,15 +1252,10 @@ describe('async actions', () => {
             // new qe has a different id
             newQueryEditor: {
               ...oldQueryEditor,
-              id: '1',
+              tabViewId: '1',
               inLocalStorage: false,
               loaded: true,
             },
-          },
-          {
-            type: actions.MIGRATE_TAB_HISTORY,
-            newId: '1',
-            oldId: 'abcd',
           },
           {
             type: actions.MIGRATE_TABLE,

--- a/superset-frontend/src/SqlLab/components/EditorAutoSync/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorAutoSync/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useRef, useEffect, FC } from 'react';
+import { useRef, useEffect, FC, useMemo } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { logging } from '@superset-ui/core';
@@ -69,6 +69,15 @@ const EditorAutoSync: FC = () => {
   const queryEditors = useSelector<SqlLabRootState, QueryEditor[]>(
     state => state.sqlLab.queryEditors,
   );
+  const queryEditorsById = useMemo(() => {
+    return queryEditors.reduce(
+      (acc, queryEditor) => {
+        acc[queryEditor.id] = queryEditor;
+        return acc;
+      },
+      {} as Record<string, QueryEditor>,
+    );
+  }, [queryEditors]);
   const unsavedQueryEditor = useSelector<SqlLabRootState, UnsavedQueryEditor>(
     state => state.sqlLab.unsavedQueryEditor,
   );
@@ -120,7 +129,10 @@ const EditorAutoSync: FC = () => {
       !queryEditors.find(({ id }) => id === currentQueryEditorId)
         ?.inLocalStorage
     ) {
-      updateCurrentSqlEditor(currentQueryEditorId).then(() => {
+      const queryEditorId =
+        queryEditorsById[currentQueryEditorId]?.tabViewId ??
+        currentQueryEditorId;
+      updateCurrentSqlEditor(queryEditorId).then(() => {
         dispatch(setLastUpdatedActiveTab(currentQueryEditorId));
       });
     }
@@ -129,7 +141,8 @@ const EditorAutoSync: FC = () => {
   const syncDeletedQueryEditor = useEffectEvent(() => {
     if (Object.keys(destroyedQueryEditors).length > 0) {
       Object.keys(destroyedQueryEditors).forEach(id => {
-        deleteSqlEditor(id)
+        const queryEditorId = queryEditorsById[id]?.tabViewId ?? id;
+        deleteSqlEditor(queryEditorId)
           .then(() => {
             dispatch(clearDestoryedQueryEditor(id));
           })

--- a/superset-frontend/src/SqlLab/components/EditorAutoSync/index.tsx
+++ b/superset-frontend/src/SqlLab/components/EditorAutoSync/index.tsx
@@ -69,15 +69,17 @@ const EditorAutoSync: FC = () => {
   const queryEditors = useSelector<SqlLabRootState, QueryEditor[]>(
     state => state.sqlLab.queryEditors,
   );
-  const queryEditorsById = useMemo(() => {
-    return queryEditors.reduce(
-      (acc, queryEditor) => {
-        acc[queryEditor.id] = queryEditor;
-        return acc;
-      },
-      {} as Record<string, QueryEditor>,
-    );
-  }, [queryEditors]);
+  const queryEditorsById = useMemo(
+    () =>
+      queryEditors.reduce(
+        (acc, queryEditor) => {
+          acc[queryEditor.id] = queryEditor;
+          return acc;
+        },
+        {} as Record<string, QueryEditor>,
+      ),
+    [queryEditors],
+  );
   const unsavedQueryEditor = useSelector<SqlLabRootState, UnsavedQueryEditor>(
     state => state.sqlLab.unsavedQueryEditor,
   );

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -32,6 +32,7 @@ import QueryTable from 'src/SqlLab/components/QueryTable';
 import { SqlLabRootState } from 'src/SqlLab/types';
 import { useEditorQueriesQuery } from 'src/hooks/apiResources/queries';
 import useEffectEvent from 'src/hooks/useEffectEvent';
+import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 
 interface QueryHistoryProps {
   queryEditorId: string | number;
@@ -63,6 +64,10 @@ const QueryHistory = ({
   displayLimit,
   latestQueryId,
 }: QueryHistoryProps) => {
+  const { id, tabViewId } = useQueryEditor(String(queryEditorId), [
+    'tabViewId',
+  ]);
+  const editorId = tabViewId ?? id;
   const [ref, hasReachedBottom] = useInView({ threshold: 0 });
   const [pageIndex, setPageIndex] = useState(0);
   const queries = useSelector(
@@ -74,7 +79,7 @@ const QueryHistory = ({
     isLoading,
     isFetching,
   } = useEditorQueriesQuery(
-    { editorId: `${queryEditorId}`, pageIndex },
+    { editorId, pageIndex },
     {
       skip: !isFeatureEnabled(FeatureFlag.SqllabBackendPersistence),
     },
@@ -87,12 +92,12 @@ const QueryHistory = ({
               queries,
               data.result.map(({ id }) => id),
             ),
-            queryEditorId,
+            editorId,
           )
             .concat(data.result)
             .reverse()
-        : getEditorQueries(queries, queryEditorId),
-    [queries, data, queryEditorId],
+        : getEditorQueries(queries, editorId),
+    [queries, data, editorId],
   );
 
   const loadNext = useEffectEvent(() => {

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -27,6 +27,7 @@ import { removeTables, setActiveSouthPaneTab } from 'src/SqlLab/actions/sqlLab';
 import { Label } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { SqlLabRootState } from 'src/SqlLab/types';
+import useQueryEditor from 'src/SqlLab/hooks/useQueryEditor';
 import QueryHistory from '../QueryHistory';
 import {
   STATUS_OPTIONS,
@@ -96,6 +97,8 @@ const SouthPane = ({
   displayLimit,
   defaultQueryLimit,
 }: SouthPaneProps) => {
+  const { id, tabViewId } = useQueryEditor(queryEditorId, ['tabViewId']);
+  const editorId = tabViewId ?? id;
   const theme = useTheme();
   const dispatch = useDispatch();
   const { offline, tables } = useSelector(
@@ -111,11 +114,8 @@ const SouthPane = ({
     ) ?? 'Results';
 
   const pinnedTables = useMemo(
-    () =>
-      tables.filter(
-        ({ queryEditorId: qeId }) => String(queryEditorId) === qeId,
-      ),
-    [queryEditorId, tables],
+    () => tables.filter(({ queryEditorId: qeId }) => String(editorId) === qeId),
+    [editorId, tables],
   );
   const pinnedTableKeys = useMemo(
     () =>

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -216,6 +216,14 @@ export const extraQueryEditor2 = {
   name: 'Untitled Query 3',
 };
 
+export const extraQueryEditor3 = {
+  ...defaultQueryEditor,
+  id: 'kvk23',
+  sql: '',
+  name: 'Untitled Query 4',
+  tabViewId: 37,
+};
+
 export const queries = [
   {
     dbId: 1,

--- a/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
+++ b/superset-frontend/src/SqlLab/hooks/useQueryEditor/index.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { pick } from 'lodash';
+import { useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { SqlLabRootState, QueryEditor } from 'src/SqlLab/types';
 
@@ -24,11 +25,20 @@ export default function useQueryEditor<T extends keyof QueryEditor>(
   sqlEditorId: string,
   attributes: ReadonlyArray<T>,
 ) {
+  const queryEditors = useSelector<SqlLabRootState, QueryEditor[]>(
+    ({ sqlLab: { queryEditors } }) => queryEditors,
+    shallowEqual,
+  );
+  const queryEditorsById = useMemo(
+    () => Object.fromEntries(queryEditors.map(editor => [editor.id, editor])),
+    [queryEditors.map(({ id }) => id).join(',')],
+  );
+
   return useSelector<SqlLabRootState, Pick<QueryEditor, T | 'id'>>(
-    ({ sqlLab: { unsavedQueryEditor, queryEditors } }) =>
+    ({ sqlLab: { unsavedQueryEditor } }) =>
       pick(
         {
-          ...queryEditors.find(({ id }) => id === sqlEditorId),
+          ...queryEditorsById[sqlEditorId],
           ...(sqlEditorId === unsavedQueryEditor?.id && unsavedQueryEditor),
         },
         ['id'].concat(attributes),

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -171,8 +171,9 @@ export default function getInitialState({
         // add query editors and tables to state with a special flag so they can
         // be migrated if the `SQLLAB_BACKEND_PERSISTENCE` feature flag is on
         sqlLab.queryEditors.forEach(qe => {
-          const hasConflictFromBackend = Boolean(queryEditors[qe.id]);
-          const unsavedUpdatedAt = queryEditors[qe.id]?.updatedAt;
+          const sqlEditorId = qe.tabViewId ?? qe.id;
+          const hasConflictFromBackend = Boolean(queryEditors[sqlEditorId]);
+          const unsavedUpdatedAt = queryEditors[sqlEditorId]?.updatedAt;
           const hasUnsavedUpdateSinceLastSave =
             qe.updatedAt &&
             (!unsavedUpdatedAt || qe.updatedAt > unsavedUpdatedAt);
@@ -180,13 +181,13 @@ export default function getInitialState({
             !hasConflictFromBackend || hasUnsavedUpdateSinceLastSave ? qe : {};
           queryEditors = {
             ...queryEditors,
-            [qe.id]: {
-              ...queryEditors[qe.id],
+            [sqlEditorId]: {
+              ...queryEditors[sqlEditorId],
               ...cachedQueryEditor,
               name:
                 cachedQueryEditor.title ||
                 cachedQueryEditor.name ||
-                queryEditors[qe.id]?.name,
+                queryEditors[sqlEditorId]?.name,
               ...(cachedQueryEditor.id &&
                 unsavedQueryEditor.id === qe.id &&
                 unsavedQueryEditor),

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -167,7 +167,7 @@ export default function sqlLabReducer(state = {}, action) {
         },
         destroyedQueryEditors: {
           ...newState.destroyedQueryEditors,
-          [queryEditor.id]: Date.now(),
+          ...(!queryEditor.inLocalStorage && { [queryEditor.id]: Date.now() }),
         },
       };
       return newState;
@@ -317,10 +317,17 @@ export default function sqlLabReducer(state = {}, action) {
     },
     [actions.START_QUERY]() {
       let newState = { ...state };
+      let sqlEditorId;
       if (action.query.sqlEditorId) {
+        const queryEditorByTabId = getFromArr(
+          state.queryEditors,
+          action.query.sqlEditorId,
+          'tabViewId',
+        );
+        sqlEditorId = queryEditorByTabId?.id ?? action.query.sqlEditorId;
         const qe = {
-          ...getFromArr(state.queryEditors, action.query.sqlEditorId),
-          ...(action.query.sqlEditorId === state.unsavedQueryEditor.id &&
+          ...getFromArr(state.queryEditors, sqlEditorId),
+          ...(sqlEditorId === state.unsavedQueryEditor.id &&
             state.unsavedQueryEditor),
         };
         if (qe.latestQueryId && state.queries[qe.latestQueryId]) {
@@ -343,7 +350,7 @@ export default function sqlLabReducer(state = {}, action) {
           {
             latestQueryId: action.query.id,
           },
-          action.query.sqlEditorId,
+          sqlEditorId,
           action.query.isDataPreview,
         ),
       };
@@ -494,12 +501,6 @@ export default function sqlLabReducer(state = {}, action) {
         'tables',
         action.newTable,
       );
-    },
-    [actions.MIGRATE_TAB_HISTORY]() {
-      const tabHistory = state.tabHistory.map(tabId =>
-        tabId === action.oldId ? action.newId : tabId,
-      );
-      return { ...state, tabHistory };
     },
     [actions.MIGRATE_QUERY]() {
       const query = {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -255,18 +255,6 @@ describe('sqlLabReducer', () => {
       expect(newState.queryEditors[index].id).toEqual('updatedNewId');
       expect(newState.queryEditors[index]).toEqual(newQueryEditor);
     });
-    it('should migrate tab history by new query editor id', () => {
-      expect(newState.tabHistory).toContain(qe.id);
-      const action = {
-        type: actions.MIGRATE_TAB_HISTORY,
-        oldId: qe.id,
-        newId: 'updatedNewId',
-      };
-      newState = sqlLabReducer(newState, action);
-
-      expect(newState.tabHistory).toContain('updatedNewId');
-      expect(newState.tabHistory).not.toContain(qe.id);
-    });
     it('should clear the destroyed query editors', () => {
       const expectedQEId = '1233289';
       const action = {

--- a/superset-frontend/src/SqlLab/types.ts
+++ b/superset-frontend/src/SqlLab/types.ts
@@ -70,6 +70,7 @@ export interface QueryEditor {
   updatedAt?: number;
   cursorPosition?: CursorPosition;
   isDataset?: boolean;
+  tabViewId?: string;
 }
 
 export type toastState = {

--- a/superset-frontend/src/hooks/apiResources/sqlEditorTabs.ts
+++ b/superset-frontend/src/hooks/apiResources/sqlEditorTabs.ts
@@ -43,11 +43,12 @@ const sqlEditorApi = api.injectEndpoints({
           templateParams,
           autorun,
           updatedAt,
+          tabViewId,
         },
         extra,
       }) => ({
         method: 'PUT',
-        endpoint: encodeURI(`/tabstateview/${id}`),
+        endpoint: encodeURI(`/tabstateview/${tabViewId ?? id}`),
         postPayload: pickBy(
           {
             database_id: dbId,
@@ -66,14 +67,14 @@ const sqlEditorApi = api.injectEndpoints({
         ),
       }),
     }),
-    updateCurrentSqlEditorTab: builder.mutation<string, string>({
+    updateCurrentSqlEditorTab: builder.mutation<string, string | number>({
       query: queryEditorId => ({
         method: 'POST',
         endpoint: encodeURI(`/tabstateview/${queryEditorId}/activate`),
         transformResponse: () => queryEditorId,
       }),
     }),
-    deleteSqlEditorTab: builder.mutation<void, string>({
+    deleteSqlEditorTab: builder.mutation<void, string | number>({
       query: queryEditorId => ({
         method: 'DELETE',
         endpoint: encodeURI(`/tabstateview/${queryEditorId}`),

--- a/superset-frontend/src/reduxUtils.ts
+++ b/superset-frontend/src/reduxUtils.ts
@@ -83,10 +83,14 @@ export function removeFromArr(
   return { ...state, [arrKey]: newArr };
 }
 
-export function getFromArr(arr: Record<string, any>[], id: string) {
+export function getFromArr(
+  arr: Record<string, any>[],
+  id: string,
+  idKey = 'id',
+) {
   let obj;
   arr.forEach(o => {
-    if (o.id === id) {
+    if (o[idKey] === id) {
       obj = o;
     }
   });


### PR DESCRIPTION
### SUMMARY
When using the improved SQLLab persistence mode, an ID value is initially generated to manage the tab in localStorage when the tab is created. After syncing with the server, this ID is immediately replaced with the server’s tabViewId, and subsequent data synchronization uses this new ID. Since this ID serves as the key for the SQLLab tab, updating the value causes React to treat it as a new tab, resulting in the component being re-rendered.
To solve this issue, we now preserve the ID for the duration of the session and additionally store the tabViewId. We have modified the system to use tabViewId specifically for data synchronization, which resolves the problem of tab flushing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/61ac3220-aa7d-461e-bfec-c3063860a47e

After:

https://github.com/user-attachments/assets/9266eb7f-aea9-47f2-870b-778970767565


### TESTING INSTRUCTIONS
Create a new tab, and then observe that the tab is flushed a few seconds later.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
