### PR TITLE
fix(filters): Enable decimal values in Range filter slider

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -322,7 +322,7 @@ describe('RangeFilterPlugin', () => {
   });
 
   describe('Decimal value handling', () => {
-    it('should handle decimal ranges correctly (0.03 to 1.08)', () => {
+    test('should handle decimal ranges correctly (0.03 to 1.08)', () => {
       const decimalProps = {
         queriesData: [
           {
@@ -348,7 +348,7 @@ describe('RangeFilterPlugin', () => {
       expect(sliders.length).toBeGreaterThan(0);
     });
 
-    it('should calculate appropriate step size for small decimal ranges', () => {
+    test('should calculate appropriate step size for small decimal ranges', () => {
       const smallRangeProps = {
         queriesData: [
           {
@@ -369,7 +369,7 @@ describe('RangeFilterPlugin', () => {
       expect(inputs[1]).toHaveValue('0.008');
     });
 
-    it('should handle very large ranges with appropriate step size', () => {
+    test('should handle very large ranges with appropriate step size', () => {
       const largeRangeProps = {
         queriesData: [
           {
@@ -390,7 +390,7 @@ describe('RangeFilterPlugin', () => {
       expect(inputs[1]).toHaveValue('500000');
     });
 
-    it('should handle negative decimal ranges', () => {
+    test('should handle negative decimal ranges', () => {
       const negativeDecimalProps = {
         queriesData: [
           {
@@ -411,7 +411,7 @@ describe('RangeFilterPlugin', () => {
       expect(inputs[1]).toHaveValue('1.5');
     });
 
-    it('should allow decimal input via keyboard', async () => {
+    test('should allow decimal input via keyboard', async () => {
       const decimalProps = {
         queriesData: [
           {

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -430,9 +430,9 @@ describe('RangeFilterPlugin', () => {
       const inputs = screen.getAllByRole('spinbutton');
       const fromInput = inputs[0];
 
-      userEvent.clear(fromInput);
-      userEvent.type(fromInput, '2.5');
-      userEvent.tab();
+      await userEvent.clear(fromInput);
+      await userEvent.type(fromInput, '2.5');
+      await userEvent.tab();
 
       expect(setDataMask).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -20,7 +20,7 @@ import { AppSection } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
-import RangeFilterPlugin from './RangeFilterPlugin';
+import RangeFilterPlugin, { calculateStep } from './RangeFilterPlugin';
 import { RangeDisplayMode, type PluginFilterRangeProps } from './types';
 import { SingleValueType } from './SingleValueType';
 import transformProps from './transformProps';
@@ -443,4 +443,38 @@ describe('RangeFilterPlugin', () => {
       );
     });
   });
+});
+
+test('calculateStep returns ~100 steps for integer ranges', () => {
+  // 0..100 -> 1, 0..1000 -> 10
+  expect(calculateStep(0, 100)).toBe(1);
+  expect(calculateStep(0, 1000)).toBe(10);
+});
+
+test('calculateStep produces sub-unit steps for small decimal ranges', () => {
+  // 0..1 -> ~0.01, giving roughly 100 increments
+  expect(calculateStep(0, 1)).toBeCloseTo(0.01, 10);
+  // 0..0.1 -> ~0.001
+  expect(calculateStep(0, 0.1)).toBeCloseTo(0.001, 10);
+});
+
+test('calculateStep is numerically stable for floating-point ranges', () => {
+  // 0.05..0.07 computes to 0.020000000000000004 internally; should still
+  // yield a sensible step rather than over-counting decimal places.
+  const step = calculateStep(0.05, 0.07);
+  expect(step).toBeGreaterThan(0);
+  expect(step).toBeLessThanOrEqual(0.01);
+});
+
+test('calculateStep handles negative and offset decimal ranges', () => {
+  expect(calculateStep(-1, 1)).toBeCloseTo(0.02, 10);
+});
+
+test('calculateStep never returns 0 for tiny ranges', () => {
+  expect(calculateStep(0, 0.0000001)).toBeGreaterThan(0);
+});
+
+test('calculateStep falls back for non-positive ranges', () => {
+  expect(calculateStep(5, 5)).toBe(0.01);
+  expect(calculateStep(10, 5)).toBe(0.01);
 });

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -236,31 +236,21 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
   const { min, max }: { min: number; max: number } = row;
 
   // Calculate appropriate step size for decimal values
+  // Uses a consistent approach for all ranges to avoid floating-point string parsing issues
   const calculateStep = useCallback((minValue: number, maxValue: number) => {
     const range = maxValue - minValue;
+    if (range <= 0) return 0.01;
 
-    // If the range is very small (less than 1), use smaller steps
-    if (range < 1) {
-      // Find the number of decimal places needed
-      const rangeStr = range.toString();
-      const decimalMatch = rangeStr.match(/\.(\d+)/);
-      if (decimalMatch) {
-        const decimalPlaces = decimalMatch[1].length;
-        // Use a step that gives approximately 100 steps across the range
-        return Math.pow(10, -Math.min(decimalPlaces + 1, 6));
-      }
-      return 0.01;
-    }
-
-    // For larger ranges, calculate step to give approximately 100-1000 steps
+    // Calculate step to give approximately 100 steps across the range
     const idealSteps = 100;
     let step = range / idealSteps;
 
-    // Round step to a nice value (0.001, 0.01, 0.1, 1, 10, etc.)
+    // Round step to a nice value (0.0001, 0.001, 0.01, 0.1, 1, 10, etc.)
     const magnitude = Math.pow(10, Math.floor(Math.log10(step)));
     step = Math.round(step / magnitude) * magnitude;
 
-    return step;
+    // Ensure we don't return 0 for very small ranges
+    return step || 0.0001;
   }, []);
 
   const sliderStep = useMemo(

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -234,6 +234,40 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
   const [row] = data;
   // @ts-expect-error
   const { min, max }: { min: number; max: number } = row;
+
+  // Calculate appropriate step size for decimal values
+  const calculateStep = useCallback((minValue: number, maxValue: number) => {
+    const range = maxValue - minValue;
+
+    // If the range is very small (less than 1), use smaller steps
+    if (range < 1) {
+      // Find the number of decimal places needed
+      const rangeStr = range.toString();
+      const decimalMatch = rangeStr.match(/\.(\d+)/);
+      if (decimalMatch) {
+        const decimalPlaces = decimalMatch[1].length;
+        // Use a step that gives approximately 100 steps across the range
+        return Math.pow(10, -Math.min(decimalPlaces + 1, 6)) || 0.001;
+      }
+      return 0.01;
+    }
+
+    // For larger ranges, calculate step to give approximately 100-1000 steps
+    const idealSteps = 100;
+    let step = range / idealSteps;
+
+    // Round step to a nice value (0.001, 0.01, 0.1, 1, 10, etc.)
+    const magnitude = Math.pow(10, Math.floor(Math.log10(step)));
+    step = Math.ceil(step / magnitude) * magnitude;
+
+    return step;
+  }, []);
+
+  const sliderStep = useMemo(
+    () =>
+      min !== undefined && max !== undefined ? calculateStep(min, max) : 0.01,
+    [min, max, calculateStep],
+  );
   const { groupby, enableSingleValue, enableEmptyFilter, defaultValue } =
     formData;
 
@@ -548,6 +582,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
           <Slider
             min={min}
             max={max}
+            step={sliderStep}
             value={Array.isArray(sliderValue) ? sliderValue[0] : sliderValue}
             onChange={handleSliderChange}
             tooltip={{
@@ -562,6 +597,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
         <Slider
           min={min}
           max={max}
+          step={sliderStep}
           range
           value={Array.isArray(sliderValue) ? sliderValue : [min, sliderValue]}
           onChange={handleSliderChange}

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -247,7 +247,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
       if (decimalMatch) {
         const decimalPlaces = decimalMatch[1].length;
         // Use a step that gives approximately 100 steps across the range
-        return Math.pow(10, -Math.min(decimalPlaces + 1, 6)) || 0.001;
+        return Math.pow(10, -Math.min(decimalPlaces + 1, 6));
       }
       return 0.01;
     }
@@ -258,7 +258,7 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
 
     // Round step to a nice value (0.001, 0.01, 0.1, 1, 10, etc.)
     const magnitude = Math.pow(10, Math.floor(Math.log10(step)));
-    step = Math.ceil(step / magnitude) * magnitude;
+    step = Math.round(step / magnitude) * magnitude;
 
     return step;
   }, []);

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -143,6 +143,24 @@ const getLabel = (
   return '';
 };
 
+// Calculate appropriate step size for decimal values.
+// Uses a consistent approach for all ranges to avoid floating-point string parsing issues.
+export const calculateStep = (minValue: number, maxValue: number): number => {
+  const range = maxValue - minValue;
+  if (range <= 0) return 0.01;
+
+  // Calculate step to give approximately 100 steps across the range
+  const idealSteps = 100;
+  let step = range / idealSteps;
+
+  // Round step to a nice value (0.0001, 0.001, 0.01, 0.1, 1, 10, etc.)
+  const magnitude = Math.pow(10, Math.floor(Math.log10(step)));
+  step = Math.round(step / magnitude) * magnitude;
+
+  // Ensure we don't return 0 for very small ranges
+  return step || 0.0001;
+};
+
 const validateRange = (
   values: RangeValue,
   min: number,
@@ -235,28 +253,10 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
   // @ts-expect-error
   const { min, max }: { min: number; max: number } = row;
 
-  // Calculate appropriate step size for decimal values
-  // Uses a consistent approach for all ranges to avoid floating-point string parsing issues
-  const calculateStep = useCallback((minValue: number, maxValue: number) => {
-    const range = maxValue - minValue;
-    if (range <= 0) return 0.01;
-
-    // Calculate step to give approximately 100 steps across the range
-    const idealSteps = 100;
-    let step = range / idealSteps;
-
-    // Round step to a nice value (0.0001, 0.001, 0.01, 0.1, 1, 10, etc.)
-    const magnitude = Math.pow(10, Math.floor(Math.log10(step)));
-    step = Math.round(step / magnitude) * magnitude;
-
-    // Ensure we don't return 0 for very small ranges
-    return step || 0.0001;
-  }, []);
-
   const sliderStep = useMemo(
     () =>
       min !== undefined && max !== undefined ? calculateStep(min, max) : 0.01,
-    [min, max, calculateStep],
+    [min, max],
   );
   const { groupby, enableSingleValue, enableEmptyFilter, defaultValue } =
     formData;


### PR DESCRIPTION
## Summary

This PR fixes the Range filter to properly handle decimal values. Previously, the slider component defaulted to integer steps, making it impossible to select decimal values through the slider interface.

Fixes #34737

## Changes

- Added dynamic step size calculation based on the data range
- For small decimal ranges (< 1), calculates appropriate decimal precision 
- For larger ranges, uses steps that provide approximately 100 increments
- Ensures step values are "nice" numbers (0.001, 0.01, 0.1, 1, 10, etc.)
- Added comprehensive tests for decimal value handling

## Test Plan

1. Create a dataset with a decimal column (e.g., values between 0.03 and 1.08)
2. Add a Range filter for that column to a dashboard
3. Verify that the slider now allows selecting decimal values
4. Test with various ranges:
   - Small decimals (0.001 to 0.01)
   - Medium decimals (0.03 to 1.08) 
   - Large ranges (0 to 1000000)
   - Negative decimals (-1.5 to 2.5)

All new tests have been added and are passing:
```bash
npm run test -- src/filters/components/Range/RangeFilterPlugin.test.tsx
```

🤖 Generated with [Claude Code](https://claude.ai/code)