### PR TITLE
fix(RightMenu): Move RightMenu carets to the right side

### DIFF
--- a/superset-frontend/src/features/home/LanguagePicker.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.tsx
@@ -79,6 +79,7 @@ export const useLanguageMenuItems = ({
       ),
       icon: <Icons.CaretDownOutlined iconSize="xs" />,
       children: items,
+      className: 'submenu-with-caret',
       popupClassName: 'language-picker-popup',
     };
   }, [languages, locale]);

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -577,6 +577,7 @@ const RightMenu = ({
             data-test="new-dropdown-icon"
           />
         ),
+        className: 'submenu-with-caret',
         icon: <Icons.CaretDownOutlined iconSize="xs" />,
         children: buildNewDropdownItems(),
         ...{ 'data-test': 'new-dropdown' },
@@ -596,6 +597,7 @@ const RightMenu = ({
       label: t('Settings'),
       icon: <Icons.CaretDownOutlined iconSize="xs" />,
       children: buildSettingsMenuItems(),
+      className: 'submenu-with-caret',
     });
 
     return items;
@@ -680,6 +682,12 @@ const RightMenu = ({
           display: flex;
           flex-direction: row;
           align-items: center;
+
+          .submenu-with-caret > .ant-menu-submenu-title {
+            display: flex;
+            gap: ${theme.sizeUnit * 2}px;
+            flex-direction: row-reverse;
+          }
         `}
         selectable={false}
         mode="horizontal"

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -683,10 +683,13 @@ const RightMenu = ({
           flex-direction: row;
           align-items: center;
 
-          .submenu-with-caret > .ant-menu-submenu-title {
-            display: flex;
-            gap: ${theme.sizeUnit * 2}px;
-            flex-direction: row-reverse;
+          .submenu-with-caret {
+            padding: 0 ${theme.paddingSM}px;
+            .ant-menu-submenu-title {
+              display: flex;
+              gap: ${theme.sizeUnit * 2}px;
+              flex-direction: row-reverse;
+            }
           }
         `}
         selectable={false}

--- a/superset-frontend/src/hooks/useThemeMenuItems.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.tsx
@@ -134,6 +134,7 @@ export const useThemeMenuItems = ({
     key: 'theme-sub-menu',
     label: selectedThemeModeIcon,
     icon: <Icons.CaretDownOutlined iconSize="xs" />,
+    className: 'submenu-with-caret',
     children,
   };
 };


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move right menu carets to the right side

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
1. Right menu caret positions
Before:
<img width="565" height="60" alt="image" src="https://github.com/user-attachments/assets/fe6e9b52-6a8b-4180-94e4-0252fcff40f3" />


After:
<img width="565" height="60" alt="image" src="https://github.com/user-attachments/assets/72cc69dd-36cf-462d-9a9a-0fd09c5b8f71" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the testing suite

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
