### PR TITLE
fix(sqllab): Fix save query modal closing prematurely on new tabs

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -254,13 +254,10 @@ describe('SavedQuery', () => {
 
     const mockOnSave = jest.fn().mockImplementation(() => savePromise);
 
-    render(
-      <SaveQuery {...mockedProps} onSave={mockOnSave} />,
-      {
-        useRedux: true,
-        store: mockStore(mockState),
-      },
-    );
+    render(<SaveQuery {...mockedProps} onSave={mockOnSave} />, {
+      useRedux: true,
+      store: mockStore(mockState),
+    });
 
     // Open the modal
     const saveBtn = screen.getByRole('button', { name: /save/i });
@@ -307,7 +304,7 @@ describe('SavedQuery', () => {
             dbId: 1,
             catalog: null,
             schema: 'main',
-            sql: 'SELECT ...',  // Default SQL for new tabs
+            sql: 'SELECT ...', // Default SQL for new tabs
             name: undefined,
             description: undefined,
           },
@@ -315,13 +312,10 @@ describe('SavedQuery', () => {
       },
     };
 
-    render(
-      <SaveQuery {...mockedProps} onSave={mockOnSave} />,
-      {
-        useRedux: true,
-        store: mockStore(newTabState),
-      },
-    );
+    render(<SaveQuery {...mockedProps} onSave={mockOnSave} />, {
+      useRedux: true,
+      store: mockStore(newTabState),
+    });
 
     // Open the modal
     const saveBtn = screen.getByRole('button', { name: /save/i });
@@ -334,7 +328,7 @@ describe('SavedQuery', () => {
 
     // The name field should have "Undefined" as default
     const nameInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
-    expect(nameInput.value).toBe('Undefined');
+    expect(nameInput).toHaveValue('Undefined');
 
     // Click save button
     const modalSaveBtn = screen.getAllByRole('button', { name: /save/i })[1];

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -245,4 +245,110 @@ describe('SavedQuery', () => {
     expect(overwriteCombobox).toBeInTheDocument();
     expect(overwritePlaceholderText).toBeInTheDocument();
   });
+
+  it('modal stays open while save is in progress and closes after completion', async () => {
+    let resolveSave: () => void;
+    const savePromise = new Promise<void>(resolve => {
+      resolveSave = resolve;
+    });
+
+    const mockOnSave = jest.fn().mockImplementation(() => savePromise);
+
+    render(
+      <SaveQuery {...mockedProps} onSave={mockOnSave} />,
+      {
+        useRedux: true,
+        store: mockStore(mockState),
+      },
+    );
+
+    // Open the modal
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    userEvent.click(saveBtn);
+
+    // Verify modal is open
+    expect(
+      screen.getByRole('heading', { name: /save query/i }),
+    ).toBeInTheDocument();
+
+    // Click save button in the modal
+    const modalSaveBtn = screen.getAllByRole('button', { name: /save/i })[1];
+    userEvent.click(modalSaveBtn);
+
+    // Modal should still be open while save is in progress
+    expect(
+      screen.getByRole('heading', { name: /save query/i }),
+    ).toBeInTheDocument();
+
+    // Resolve the save promise
+    resolveSave!();
+
+    // Wait for modal to close after save completes
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: /save query/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(mockOnSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles save with a new tab that has no changes', async () => {
+    const mockOnSave = jest.fn().mockResolvedValue(undefined);
+
+    // Mock state for a new tab with default SQL
+    const newTabState = {
+      ...mockState,
+      sqlLab: {
+        ...mockState.sqlLab,
+        queryEditors: [
+          {
+            id: mockedProps.queryEditorId,
+            dbId: 1,
+            catalog: null,
+            schema: 'main',
+            sql: 'SELECT ...',  // Default SQL for new tabs
+            name: undefined,
+            description: undefined,
+          },
+        ],
+      },
+    };
+
+    render(
+      <SaveQuery {...mockedProps} onSave={mockOnSave} />,
+      {
+        useRedux: true,
+        store: mockStore(newTabState),
+      },
+    );
+
+    // Open the modal
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    userEvent.click(saveBtn);
+
+    // Modal should open
+    expect(
+      screen.getByRole('heading', { name: /save query/i }),
+    ).toBeInTheDocument();
+
+    // The name field should have "Undefined" as default
+    const nameInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    expect(nameInput.value).toBe('Undefined');
+
+    // Click save button
+    const modalSaveBtn = screen.getAllByRole('button', { name: /save/i })[1];
+    userEvent.click(modalSaveBtn);
+
+    // Wait for save to complete and modal to close
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: /save query/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -147,14 +147,14 @@ const SaveQuery = ({
 
   const close = () => setShowSave(false);
 
-  const onSaveWrapper = () => {
+  const onSaveWrapper = async () => {
     logAction(LOG_ACTIONS_SQLLAB_SAVE_QUERY, {});
-    onSave(queryPayload(), query.id);
+    await onSave(queryPayload(), query.id);
     close();
   };
 
-  const onUpdateWrapper = () => {
-    onUpdate(queryPayload(), query.id);
+  const onUpdateWrapper = async () => {
+    await onUpdate(queryPayload(), query.id);
     close();
   };
 
@@ -220,9 +220,7 @@ const SaveQuery = ({
       />
       <Modal
         className="save-query-modal"
-        onHandledPrimaryAction={onSaveWrapper}
         onHide={close}
-        primaryButtonName={isSaved ? t('Save') : t('Save as')}
         width="620px"
         show={showSave}
         name={t('Save query')}


### PR DESCRIPTION
## Summary

Fixes the issue where the Save Query modal would close immediately when clicking save on a new tab that has no changes made to it.

## Root Cause

The SaveQuery component was using both:
1. `onHandledPrimaryAction` prop on the Modal component
2. A custom footer with buttons that also call the same save function

This caused the save function to be called twice, leading to the modal closing prematurely before the save operation could complete.

## Solution

- Removed the conflicting `onHandledPrimaryAction` and `primaryButtonName` props from the Modal
- Made the save operations properly async to wait for completion before closing the modal
- Added comprehensive tests to verify the fix

## Testing

- Added test to verify modal stays open during save operation and only closes after completion
- Added test to specifically handle the case of saving a new tab with default content
- Both existing and new tests should pass

## Test plan

1. Go to SQL Lab
2. Click "add query" to create a new tab
3. Click the "Save" button to open the save modal
4. Fill in a name and click "Save" in the modal
5. Verify the modal stays open during the save process and only closes after the query is successfully saved

Fixes #31767

🤖 Generated with [Claude Code](https://claude.ai/code)