### PR TITLE
feat(sqllab): introduce splitter for adjusting sidebar and query panel

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -302,7 +302,6 @@ const QueryTable = ({
                 <ResultSet
                   showSql
                   queryId={query.id}
-                  height={400}
                   displayLimit={displayLimit}
                   defaultQueryLimit={1000}
                 />

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -104,7 +104,6 @@ export interface ResultSetProps {
   csv?: boolean;
   database?: Record<string, any>;
   displayLimit: number;
-  height: number;
   queryId: string;
   search?: boolean;
   showSql?: boolean;
@@ -176,7 +175,6 @@ const ResultSet = ({
   csv = true,
   database = {},
   displayLimit,
-  height,
   queryId,
   search = true,
   showSql = false,

--- a/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
@@ -25,11 +25,8 @@ import { SqlLabRootState } from 'src/SqlLab/types';
 import ResultSet from '../ResultSet';
 import { LOCALSTORAGE_MAX_QUERY_AGE_MS } from '../../constants';
 
-const EXTRA_HEIGHT_RESULTS = 8; // we need extra height in RESULTS tab. because the height from props was calculated based on PREVIEW tab.
-
 type Props = {
   latestQueryId?: string;
-  height: number;
   displayLimit: number;
   defaultQueryLimit: number;
 };
@@ -47,7 +44,6 @@ const StyledEmptyStateWrapper = styled.div`
 
 const Results: FC<Props> = ({
   latestQueryId,
-  height,
   displayLimit,
   defaultQueryLimit,
 }) => {
@@ -92,7 +88,6 @@ const Results: FC<Props> = ({
     <ResultSet
       search
       queryId={latestQuery.id}
-      height={height + EXTRA_HEIGHT_RESULTS}
       database={databases[latestQuery.dbId]}
       displayLimit={displayLimit}
       defaultQueryLimit={defaultQueryLimit}

--- a/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/index.tsx
@@ -37,8 +37,6 @@ import {
 import Results from './Results';
 import TablePreview from '../TablePreview';
 
-const TAB_HEIGHT = 130;
-
 /*
     editorQueries are queries executed by users passed from SqlEditor component
     dataPreviewQueries are all queries executed for preview of table data (from SqlEditorLeft)
@@ -46,23 +44,18 @@ const TAB_HEIGHT = 130;
 export interface SouthPaneProps {
   queryEditorId: string;
   latestQueryId?: string;
-  height: number;
   displayLimit: number;
   defaultQueryLimit: number;
 }
-
-type StyledPaneProps = {
-  height: number;
-};
 
 const TABS_KEYS = {
   RESULTS: 'Results',
   HISTORY: 'History',
 };
 
-const StyledPane = styled.div<StyledPaneProps>`
+const StyledPane = styled.div`
   width: 100%;
-  height: ${props => props.height}px;
+  height: 100%;
   .ant-tabs .ant-tabs-content-holder {
     overflow: visible;
   }
@@ -93,7 +86,6 @@ const StyledPane = styled.div<StyledPaneProps>`
 const SouthPane = ({
   queryEditorId,
   latestQueryId,
-  height,
   displayLimit,
   defaultQueryLimit,
 }: SouthPaneProps) => {
@@ -127,7 +119,6 @@ const SouthPane = ({
       ),
     [pinnedTables],
   );
-  const innerTabContentHeight = height - TAB_HEIGHT;
   const southPaneRef = createRef<HTMLDivElement>();
   const switchTab = (id: string) => {
     dispatch(setActiveSouthPaneTab(id));
@@ -159,7 +150,6 @@ const SouthPane = ({
       label: t('Results'),
       children: (
         <Results
-          height={innerTabContentHeight}
           latestQueryId={latestQueryId}
           displayLimit={displayLimit}
           defaultQueryLimit={defaultQueryLimit}
@@ -205,12 +195,7 @@ const SouthPane = ({
   ];
 
   return (
-    <StyledPane
-      data-test="south-pane"
-      className="SouthPane"
-      height={height}
-      ref={southPaneRef}
-    >
+    <StyledPane data-test="south-pane" className="SouthPane" ref={southPaneRef}>
       <Tabs
         type="editable-card"
         activeKey={pinnedTableKeys[activeSouthPaneTab] || activeSouthPaneTab}

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -45,6 +45,16 @@ import setupExtensions from 'src/setup/setupExtensions';
 import type { Action, Middleware, Store } from 'redux';
 import SqlEditor, { Props } from '.';
 
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({
+      children,
+    }: {
+      children: (params: { height: number }) => React.ReactChild;
+    }) =>
+      children({ height: 500 }),
+);
 jest.mock('@superset-ui/core/components/AsyncAceEditor', () => ({
   ...jest.requireActual('@superset-ui/core/components/AsyncAceEditor'),
   FullSQLEditor: ({

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -980,6 +980,11 @@ const SqlEditor: FC<Props> = ({
       const [updatedWidth] = sizes;
       if (hideLeftBar || updatedWidth === 0) {
         dispatch(toggleLeftBar({ id: queryEditor.id, hideLeftBar }));
+        if (hideLeftBar) {
+          // Due to a bug in the splitter, the width must be changed
+          // in order to properly restore the previous size
+          setWidth(width + 0.01);
+        }
       } else {
         setWidth(updatedWidth);
       }
@@ -992,7 +997,7 @@ const SqlEditor: FC<Props> = ({
       <Splitter lazy onResizeEnd={onSidebarChange} onResize={noop}>
         <Splitter.Panel
           collapsible
-          size={hideLeftBar ? 0 : Math.floor(width)}
+          size={hideLeftBar ? 0 : width}
           min={SQL_EDITOR_LEFTBAR_WIDTH}
         >
           <StyledSidebar>

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -907,62 +907,60 @@ const SqlEditor: FC<Props> = ({
     />
   );
 
-  const queryPane = () => {
-    return (
-      <Splitter
-        layout="vertical"
-        onResizeStart={onResizeStart}
-        onResizeEnd={onResizeEnd}
+  const queryPane = () => (
+    <Splitter
+      layout="vertical"
+      onResizeStart={onResizeStart}
+      onResizeEnd={onResizeEnd}
+    >
+      <Splitter.Panel
+        min={queryEditor.isDataset ? 400 : 200}
+        defaultSize={`${northPercent}%`}
+        className="queryPane"
       >
-        <Splitter.Panel
-          min={queryEditor.isDataset ? 400 : 200}
-          defaultSize={`${northPercent}%`}
-          className="queryPane"
-        >
-          <div className="north-pane">
-            {SqlFormExtension && (
-              <SqlFormExtension
-                queryEditorId={queryEditor.id}
-                setQueryEditorAndSaveSqlWithDebounce={
-                  setQueryEditorAndSaveSqlWithDebounce
-                }
-                startQuery={startQuery}
-              />
-            )}
-            {queryEditor.isDataset && renderDatasetWarning()}
-            <div className="sql-container">
-              <AutoSizer disableWidth>
-                {({ height }) =>
-                  isActive && (
-                    <AceEditorWrapper
-                      autocomplete={
-                        autocompleteEnabled && !isTempId(queryEditor.id)
-                      }
-                      onBlur={onSqlChanged}
-                      onChange={onSqlChanged}
-                      queryEditorId={queryEditor.id}
-                      onCursorPositionChange={handleCursorPositionChange}
-                      height={`${height}px`}
-                      hotkeys={hotkeys}
-                    />
-                  )
-                }
-              </AutoSizer>
-            </div>
-            {renderEditorBottomBar(showEmptyState)}
+        <div className="north-pane">
+          {SqlFormExtension && (
+            <SqlFormExtension
+              queryEditorId={queryEditor.id}
+              setQueryEditorAndSaveSqlWithDebounce={
+                setQueryEditorAndSaveSqlWithDebounce
+              }
+              startQuery={startQuery}
+            />
+          )}
+          {queryEditor.isDataset && renderDatasetWarning()}
+          <div className="sql-container">
+            <AutoSizer disableWidth>
+              {({ height }) =>
+                isActive && (
+                  <AceEditorWrapper
+                    autocomplete={
+                      autocompleteEnabled && !isTempId(queryEditor.id)
+                    }
+                    onBlur={onSqlChanged}
+                    onChange={onSqlChanged}
+                    queryEditorId={queryEditor.id}
+                    onCursorPositionChange={handleCursorPositionChange}
+                    height={`${height}px`}
+                    hotkeys={hotkeys}
+                  />
+                )
+              }
+            </AutoSizer>
           </div>
-        </Splitter.Panel>
-        <Splitter.Panel className="queryPane">
-          <SouthPane
-            queryEditorId={queryEditor.id}
-            latestQueryId={latestQuery?.id}
-            displayLimit={displayLimit}
-            defaultQueryLimit={defaultQueryLimit}
-          />
-        </Splitter.Panel>
-      </Splitter>
-    );
-  };
+          {renderEditorBottomBar(showEmptyState)}
+        </div>
+      </Splitter.Panel>
+      <Splitter.Panel className="queryPane">
+        <SouthPane
+          queryEditorId={queryEditor.id}
+          latestQueryId={latestQuery?.id}
+          displayLimit={displayLimit}
+          defaultQueryLimit={defaultQueryLimit}
+        />
+      </Splitter.Panel>
+    </Splitter>
+  );
 
   const createViewModalTitle =
     createAs === CtasEnum.View ? 'CREATE VIEW AS' : 'CREATE TABLE AS';

--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -86,7 +86,6 @@ const MENUS = [
   },
 ];
 const TAB_HEADER_HEIGHT = 80;
-const PREVIEW_TOP_ACTION_HEIGHT = 30;
 const PREVIEW_QUERY_LIMIT = 100;
 
 const Title = styled.div`

--- a/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/index.tsx
@@ -382,9 +382,6 @@ const TablePreview: FC<Props> = ({ dbId, catalog, schema, tableName }) => {
                         visualize={false}
                         csv={false}
                         cache
-                        height={
-                          height - TAB_HEADER_HEIGHT - PREVIEW_TOP_ACTION_HEIGHT
-                        }
                         displayLimit={PREVIEW_QUERY_LIMIT}
                         defaultQueryLimit={PREVIEW_QUERY_LIMIT}
                       />

--- a/superset-frontend/src/SqlLab/constants.ts
+++ b/superset-frontend/src/SqlLab/constants.ts
@@ -66,13 +66,9 @@ export const TIME_OPTIONS = [
 ];
 
 // SqlEditor layout constants
-export const SQL_EDITOR_GUTTER_HEIGHT = 5;
-export const SQL_EDITOR_GUTTER_MARGIN = 3;
-export const SQL_TOOLBAR_HEIGHT = 51;
+export const SQL_EDITOR_GUTTER_HEIGHT = 4;
 export const SQL_EDITOR_LEFTBAR_WIDTH = 400;
-export const SQL_EDITOR_PADDING = 10;
 export const INITIAL_NORTH_PERCENT = 30;
-export const INITIAL_SOUTH_PERCENT = 70;
 export const SET_QUERY_EDITOR_SQL_DEBOUNCE_MS = 2000;
 export const VALIDATION_DEBOUNCE_MS = 600;
 export const WINDOW_RESIZE_THROTTLE_MS = 100;

--- a/superset-frontend/src/components/Splitter/index.tsx
+++ b/superset-frontend/src/components/Splitter/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { Splitter } from 'antd';
+export type { SplitterProps } from 'antd/es/splitter';


### PR DESCRIPTION
### SUMMARY
Previously, the resizable sidebar and react-splitter were managed separately, but now panel resizing is handled through the splitter provided by Ant Design.
Additionally, this commit updates the functionality so that, besides the existing menu, user can collapse or expand the panel using the buttons provided by the splitter.

Furthermore, since the results height is already calculated using [autosizer](https://github.com/apache/superset/pull/34683/files#diff-407b1e72d7f4462c85eca33d215cd9981b18db050f649dfaaac5748a262d09b8R701-R715), this commit removes related height calculation logic, making the size management simpler.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:

https://github.com/user-attachments/assets/57301174-489b-47ce-bac4-d9dd8626cdac


### TESTING INSTRUCTIONS
Open SQL Lab and then adjust side panel and south panel sizes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
