### PR TITLE
fix(dashboard): enable undo/redo buttons for layout changes

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -18,19 +18,17 @@
  */
 import * as redux from 'redux';
 import { useUnsavedChangesPrompt } from 'src/hooks/useUnsavedChangesPrompt';
-import {
-  render,
-  screen,
-  fireEvent,
-  userEvent,
-  within,
-} from 'spec/helpers/testing-library';
+import { screen, userEvent, within, waitFor } from '@superset-ui/core/spec';
+import { ActionCreators as UndoActionCreators } from 'redux-undo';
 import fetchMock from 'fetch-mock';
 import { getExtensionsRegistry, JsonObject } from '@superset-ui/core';
 import setupExtensions from 'src/setup/setupExtensions';
 import getOwnerName from 'src/utils/getOwnerName';
+import { render, createStore } from 'spec/helpers/testing-library';
+import reducerIndex from 'spec/helpers/reducerIndex';
 import Header from '.';
 import { DASHBOARD_HEADER_ID } from '../../util/constants';
+import { UPDATE_COMPONENTS } from '../../actions/dashboardLayout';
 
 const initialState = {
   dashboardInfo: {
@@ -116,15 +114,7 @@ const undoState = {
   ...editableState,
   dashboardLayout: {
     ...initialState.dashboardLayout,
-    past: [{}],
-  },
-};
-
-const redoState = {
-  ...editableState,
-  dashboardLayout: {
-    ...initialState.dashboardLayout,
-    future: [{}],
+    past: [initialState.dashboardLayout.present],
   },
 };
 
@@ -280,19 +270,15 @@ test('should render the "Undo" action as disabled', () => {
   expect(screen.getByTestId('undo-action').parentElement).toBeDisabled();
 });
 
-test('should undo', () => {
+test('should undo when past actions exist', () => {
   setup(undoState);
   const undo = screen.getByTestId('undo-action');
-  expect(onUndo).not.toHaveBeenCalled();
-  userEvent.click(undo);
-  expect(onUndo).toHaveBeenCalledTimes(1);
-});
+  const undoButton = undo.parentElement;
 
-test('should undo with key listener', () => {
-  onUndo.mockReset();
-  setup(undoState);
+  expect(undoButton).toBeEnabled();
   expect(onUndo).not.toHaveBeenCalled();
-  fireEvent.keyDown(document.body, { key: 'z', code: 'KeyZ', ctrlKey: true });
+
+  userEvent.click(undo);
   expect(onUndo).toHaveBeenCalledTimes(1);
 });
 
@@ -301,19 +287,157 @@ test('should render the "Redo" action as disabled', () => {
   expect(screen.getByTestId('redo-action').parentElement).toBeDisabled();
 });
 
-test('should redo', () => {
-  setup(redoState);
+test('should have correct redo button structure', () => {
+  setup(editableState);
+
   const redo = screen.getByTestId('redo-action');
+  const redoButton = redo.parentElement;
+
+  expect(redoButton).toBeInTheDocument();
+  expect(redo).toBeInTheDocument();
+  expect(redoButton).toBeDisabled();
+});
+
+test('should enable undo button when past actions exist', () => {
+  setup(undoState);
+
+  const undoButton = screen.getByTestId('undo-action').parentElement;
+  const redoButton = screen.getByTestId('redo-action').parentElement;
+
+  expect(undoButton).toBeEnabled();
+  expect(redoButton).toBeDisabled();
+  expect(onUndo).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getByTestId('undo-action'));
+  expect(onUndo).toHaveBeenCalledTimes(1);
+});
+
+test('should enable redo button after undo creates future history', async () => {
+  const testStore = createStore(
+    {
+      ...initialState,
+      ...editableState,
+      dashboardLayout: {
+        present: {
+          [DASHBOARD_HEADER_ID]: {
+            meta: { text: 'Original Title' },
+          },
+        },
+        past: [],
+        future: [],
+      },
+    },
+    reducerIndex,
+  );
+
+  render(
+    <div className="dashboard">
+      <Header />
+    </div>,
+    {
+      useRedux: true,
+      useTheme: true,
+      store: testStore,
+    },
+  );
+
+  testStore.dispatch({
+    type: UPDATE_COMPONENTS,
+    payload: {
+      nextComponents: {
+        [DASHBOARD_HEADER_ID]: {
+          meta: { text: 'Updated Title' },
+        },
+      },
+    },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('undo-action').parentElement).toBeEnabled();
+  });
+
+  testStore.dispatch(UndoActionCreators.undo());
+
+  await waitFor(() => {
+    const redoButton = screen.getByTestId('redo-action').parentElement;
+    expect(redoButton).toBeEnabled();
+  });
+
   expect(onRedo).not.toHaveBeenCalled();
-  userEvent.click(redo);
+
+  userEvent.click(screen.getByTestId('redo-action'));
   expect(onRedo).toHaveBeenCalledTimes(1);
 });
 
-test('should redo with key listener', () => {
-  setup(redoState);
+test('should enable undo button when real actions create past history', async () => {
+  const testStore = createStore(
+    {
+      ...initialState,
+      ...editableState,
+      dashboardLayout: {
+        present: {
+          [DASHBOARD_HEADER_ID]: {
+            meta: { text: 'Original Title' },
+          },
+        },
+        past: [],
+        future: [],
+      },
+    },
+    reducerIndex,
+  );
+
+  render(
+    <div className="dashboard">
+      <Header />
+    </div>,
+    {
+      useRedux: true,
+      useTheme: true,
+      store: testStore,
+    },
+  );
+
+  const undoButton = screen.getByTestId('undo-action').parentElement;
+  expect(undoButton).toBeDisabled();
+
+  testStore.dispatch({
+    type: UPDATE_COMPONENTS,
+    payload: {
+      nextComponents: {
+        [DASHBOARD_HEADER_ID]: {
+          meta: { text: 'Updated Title' },
+        },
+      },
+    },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('undo-action').parentElement).toBeEnabled();
+  });
+
+  expect(onUndo).not.toHaveBeenCalled();
+
+  userEvent.click(screen.getByTestId('undo-action'));
+  expect(onUndo).toHaveBeenCalledTimes(1);
+});
+
+test('should disable both buttons when no actions available', () => {
+  setup(editableState);
+
+  const undoButton = screen.getByTestId('undo-action').parentElement;
+  const redoButton = screen.getByTestId('redo-action').parentElement;
+
+  expect(undoButton).toBeDisabled();
+  expect(redoButton).toBeDisabled();
+  expect(onUndo).not.toHaveBeenCalled();
   expect(onRedo).not.toHaveBeenCalled();
-  fireEvent.keyDown(document.body, { key: 'y', code: 'KeyY', ctrlKey: true });
-  expect(onRedo).toHaveBeenCalledTimes(1);
+
+  userEvent.click(screen.getByTestId('undo-action'));
+  userEvent.click(screen.getByTestId('redo-action'));
+
+  expect(onUndo).not.toHaveBeenCalled();
+  expect(onRedo).not.toHaveBeenCalled();
 });
 
 test('should render the "Discard changes" button', () => {
@@ -475,7 +599,7 @@ test('should hide edit button and navbar, and show Exit fullscreen when in fulls
 test('should show Exit fullscreen when in fullscreen mode', async () => {
   setup();
 
-  fireEvent.click(screen.getByTestId('actions-trigger'));
+  userEvent.click(screen.getByTestId('actions-trigger'));
 
   expect(await screen.findByText('Exit fullscreen')).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -617,7 +617,9 @@ const Header = () => {
                     <StyledUndoRedoButton
                       buttonStyle="link"
                       disabled={undoLength < 1}
-                      onClick={undoLength && boundActionCreators.onUndo}
+                      onClick={
+                        undoLength > 0 ? boundActionCreators.onUndo : undefined
+                      }
                     >
                       <Icons.Undo
                         css={[
@@ -637,7 +639,9 @@ const Header = () => {
                     <StyledUndoRedoButton
                       buttonStyle="link"
                       disabled={redoLength < 1}
-                      onClick={redoLength && boundActionCreators.onRedo}
+                      onClick={
+                        redoLength > 0 ? boundActionCreators.onRedo : undefined
+                      }
                     >
                       <Icons.Redo
                         css={[

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -533,9 +533,13 @@ const Header = () => {
         tags: updates.tags,
       });
       boundActionCreators.setUnsavedChanges(true);
-      boundActionCreators.dashboardTitleChanged(updates.title);
+
+      if (updates.title && dashboardTitle !== updates.title) {
+        boundActionCreators.updateDashboardTitle(updates.title);
+        boundActionCreators.onChange();
+      }
     },
-    [boundActionCreators],
+    [boundActionCreators, dashboardTitle],
   );
 
   const NavExtension = extensionsRegistry.get('dashboard.nav.right');

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.test.jsx
@@ -80,6 +80,11 @@ const defaultState = {
     superset_can_csv: false,
     common: { conf: { SUPERSET_WEBSERVER_TIMEOUT: 0, SQL_MAX_ROW: 666 } },
   },
+  dashboardLayout: {
+    present: {},
+    past: [],
+    future: [],
+  },
 };
 
 function setup(overrideProps, overrideState) {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal.test.ts
@@ -24,7 +24,15 @@ import { useCrossFiltersScopingModal } from './useCrossFiltersScopingModal';
 
 test('Renders modal after calling method open', async () => {
   const { result } = renderHook(() => useCrossFiltersScopingModal(), {
-    wrapper: createWrapper(),
+    wrapper: createWrapper({
+      initialState: {
+        dashboardLayout: {
+          present: {},
+          past: [],
+          future: [],
+        },
+      },
+    }),
   });
 
   const [openModal, Modal] = result.current;
@@ -34,6 +42,13 @@ test('Renders modal after calling method open', async () => {
 
   const { getByText } = render(result.current[1] as ReactElement, {
     useRedux: true,
+    initialState: {
+      dashboardLayout: {
+        present: {},
+        past: [],
+        future: [],
+      },
+    },
   });
 
   expect(getByText('Cross-filtering scoping')).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/HorizontalFilterBar.test.tsx
@@ -41,6 +41,11 @@ const renderWrapper = (overrideProps?: Record<string, any>) =>
         dashboardInfo: {
           dash_edit_perm: true,
         },
+        dashboardLayout: {
+          present: {},
+          past: [],
+          future: [],
+        },
       },
     }),
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -58,6 +58,11 @@ class MainPreset extends Preset {
 const defaultState = () => ({
   datasources: { ...mockDatasource },
   charts: chartQueries,
+  dashboardLayout: {
+    present: {},
+    past: [],
+    future: [],
+  },
 });
 
 const noTemporalColumnsState = () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -59,6 +59,13 @@ function setup(overridesProps?: any) {
   return render(<FiltersConfigModal {...mockedProps} {...overridesProps} />, {
     useDnd: true,
     useRedux: true,
+    initialState: {
+      dashboardLayout: {
+        present: {},
+        past: [],
+        future: [],
+      },
+    },
   });
 }
 

--- a/superset-frontend/src/dashboard/reducers/undoableDashboardLayout.js
+++ b/superset-frontend/src/dashboard/reducers/undoableDashboardLayout.js
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import undoable, { includeAction } from 'redux-undo';
+import undoable from 'redux-undo';
 import { UNDO_LIMIT } from '../util/constants';
 import {
   UPDATE_COMPONENTS,
@@ -33,20 +33,69 @@ import { HYDRATE_DASHBOARD } from '../actions/hydrate';
 
 import dashboardLayout from './dashboardLayout';
 
-export default undoable(dashboardLayout, {
+// List of actions that should trigger undo history
+const TRACKED_ACTIONS = [
+  HYDRATE_DASHBOARD,
+  UPDATE_COMPONENTS,
+  DELETE_COMPONENT,
+  CREATE_COMPONENT,
+  CREATE_TOP_LEVEL_TABS,
+  DELETE_TOP_LEVEL_TABS,
+  RESIZE_COMPONENT,
+  MOVE_COMPONENT,
+  HANDLE_COMPONENT_DROP,
+];
+
+/*
+ * WORKAROUND FOR REDUX-UNDO FILTER BUG
+ *
+ * PROBLEM:
+ * Redux-undo's filter functionality is broken in multiple versions. Users report that
+ * actions are either incorrectly filtered out or incorrectly included in undo history,
+ * making undo/redo buttons not work when they should.
+ *
+ * AFFECTED VERSIONS:
+ * - Beta versions (like 1.0.0-beta9-9-7 currently used by Superset)
+ * - Stable versions up to 1.1.0
+ * Both includeAction/excludeAction helpers AND custom filter functions fail.
+ *
+ * WHY FILTERING MATTERS:
+ * Without filtering, ALL Redux actions (API calls, toasts, theme changes, etc.) would
+ * create undo history entries, making undo/redo confusing and inefficient. We only want
+ * dashboard layout changes to be undoable.
+ *
+ * SOLUTION:
+ * Instead of using redux-undo's broken filter system, we filter at the reducer level
+ * by wrapping the base dashboardLayout reducer. This approach:
+ * 1. Prevents non-layout actions from reaching the reducer (so no state changes)
+ * 2. Allows redux-undo to work without any filtering (which works fine)
+ * 3. Results in only layout actions being tracked in undo history
+ * 4. Provides the same filtering result without hitting the redux-undo bug
+ *
+ * WHEN TO REMOVE:
+ * This can be reverted when redux-undo fixes their filter functionality by:
+ * 1. Removing the layoutOnlyReducer wrapper
+ * 2. Using the base dashboardLayout reducer directly
+ * 3. Adding back: filter: includeAction(TRACKED_ACTIONS)
+ *
+ * BUG REPORT:
+ * - https://github.com/omnidan/redux-undo/issues/306
+ */
+
+// Wrapper reducer that filters actions before they reach the dashboardLayout reducer
+const layoutOnlyReducer = (state, action) => {
+  // Only allow layout-related actions to reach the dashboardLayout reducer
+  if (!TRACKED_ACTIONS.includes(action.type)) return state;
+
+  // For layout actions, proceed with normal dashboardLayout reduction
+  return dashboardLayout(state, action);
+};
+
+const undoableReducer = undoable(layoutOnlyReducer, {
   // +1 because length of history seems max out at limit - 1
   // +1 again so we can detect if we've exceeded the limit
   limit: UNDO_LIMIT + 2,
   ignoreInitialState: true,
-  filter: includeAction([
-    HYDRATE_DASHBOARD,
-    UPDATE_COMPONENTS,
-    DELETE_COMPONENT,
-    CREATE_COMPONENT,
-    CREATE_TOP_LEVEL_TABS,
-    DELETE_TOP_LEVEL_TABS,
-    RESIZE_COMPONENT,
-    MOVE_COMPONENT,
-    HANDLE_COMPONENT_DROP,
-  ]),
 });
+
+export default undoableReducer;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed a bug where undo/redo buttons in dashboard edit mode weren't getting enabled when adding or removing dashboard components. The issue was caused by a known bug in the redux-undo library where the `includeAction` filter incorrectly filters out actions that should be tracked.

**Root Cause**: Redux-undo's filter functionality is broken in multiple versions (including the beta version used by Superset), causing layout actions like `DELETE_COMPONENT` to be incorrectly excluded from undo history.

**Solution**: Implemented reducer-level filtering by wrapping the base `dashboardLayout` reducer before passing it to redux-undo. This approach:
- Prevents non-layout actions from reaching the reducer (no state change = no undo entry)
- Allows redux-undo to work without filtering (which works correctly)
- Maintains proper action filtering while avoiding the redux-undo bug
- Is well-documented with references to upstream bug reports for future removal

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![undo_redo_before](https://github.com/user-attachments/assets/21dc80b3-d992-4025-8dc7-c69f31c765ab)

After:
![undo_redo_after](https://github.com/user-attachments/assets/32fab389-ee26-4abd-ac8e-8f4fbb10611c)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open a dashboard in edit mode
2. Add a new chart component to the dashboard
3. Verify the undo button becomes enabled
4. Delete a chart component from the dashboard
5. Verify the undo button becomes enabled
6. Click undo to verify the action is reversed
7. Verify the redo button becomes enabled after undoing
8. Click redo to verify the action is re-applied

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
