### PR TITLE
fix(tests): make SingleStore test_adjust_engine_params version-agnostic

### DIFF
--- a/tests/unit_tests/db_engine_specs/test_singlestore.py
+++ b/tests/unit_tests/db_engine_specs/test_singlestore.py
@@ -95,18 +95,22 @@ def test_get_schema_from_engine_params() -> None:
 
 
 def test_adjust_engine_params() -> None:
+    from flask import current_app as app
+
     adjusted = SingleStoreSpec.adjust_engine_params(
         make_url("singlestoredb://user:password@host:5432/dev"),
         {},
         schema="pro d",
     )
+
+    expected_version = app.config.get("VERSION_STRING", "dev")
     assert adjusted == (
         make_url("singlestoredb://user:password@host:5432/pro%20d"),
         {
             "conn_attrs": {
                 "_connector_name": "SingleStore Superset Database Engine",
-                "_connector_version": "0.0.0-dev",
-                "_product_version": "0.0.0-dev",
+                "_connector_version": expected_version,
+                "_product_version": expected_version,
             }
         },
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The test was expecting hardcoded version strings "0.0.0-dev" but the actual code reads VERSION_STRING from app.config, which comes from package.json.

Changed the test to dynamically read the actual VERSION_STRING value instead of hardcoding expectations, making it resilient to version changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
