### PR TITLE
fix(sqllab): autocomplete and delete tabs

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -284,8 +284,6 @@ const SqlEditor: FC<Props> = ({
 
   const SqlFormExtension = extensionsRegistry.get('sqleditor.extension.form');
 
-  const isTempId = (value: unknown): boolean => Number.isNaN(Number(value));
-
   const startQuery = useCallback(
     (ctasArg = false, ctas_method = CtasEnum.Table) => {
       if (!database) {
@@ -934,9 +932,7 @@ const SqlEditor: FC<Props> = ({
               {({ height }) =>
                 isActive && (
                   <AceEditorWrapper
-                    autocomplete={
-                      autocompleteEnabled && !isTempId(queryEditor.id)
-                    }
+                    autocomplete={autocompleteEnabled}
                     onBlur={onSqlChanged}
                     onChange={onSqlChanged}
                     queryEditorId={queryEditor.id}

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.ts
@@ -163,7 +163,10 @@ export default function getInitialState({
     if (localStorageData && sqlLabCacheData?.sqlLab) {
       const { sqlLab } = sqlLabCacheData;
 
-      if (sqlLab.queryEditors.length === 0) {
+      if (
+        sqlLab.queryEditors.length === 0 &&
+        Object.keys(sqlLab.destroyedQueryEditors ?? {}).length === 0
+      ) {
         // migration was successful
         localStorage.removeItem('redux');
       } else {
@@ -221,18 +224,21 @@ export default function getInitialState({
           });
         }
         if (sqlLab.tabHistory) {
-          tabHistory.push(...sqlLab.tabHistory);
+          tabHistory.push(
+            ...sqlLab.tabHistory.filter(
+              tabId => !sqlLab.destroyedQueryEditors?.[tabId],
+            ),
+          );
         }
-        lastUpdatedActiveTab = tabHistory.slice(tabHistory.length - 1)[0] || '';
-
         if (sqlLab.destroyedQueryEditors) {
           Object.entries(sqlLab.destroyedQueryEditors).forEach(([id, ts]) => {
+            destroyedQueryEditors[id] = ts;
             if (queryEditors[id]) {
-              destroyedQueryEditors[id] = ts;
               delete queryEditors[id];
             }
           });
         }
+        lastUpdatedActiveTab = tabHistory.slice(tabHistory.length - 1)[0] || '';
       }
     }
   } catch (error) {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -135,7 +135,7 @@ export default function sqlLabReducer(state = {}, action) {
       };
       let newState = removeFromArr(state, 'queryEditors', queryEditor);
       // List of remaining queryEditor ids
-      const qeIds = newState.queryEditors.map(qe => qe.id);
+      const qeIds = newState.queryEditors.map(qe => qe.tabViewId ?? qe.id);
 
       const queries = {};
       Object.keys(state.queries).forEach(k => {
@@ -150,7 +150,8 @@ export default function sqlLabReducer(state = {}, action) {
 
       // Remove associated table schemas
       const tables = state.tables.filter(
-        table => table.queryEditorId !== queryEditor.id,
+        table =>
+          table.queryEditorId !== (queryEditor.tabViewId ?? queryEditor.id),
       );
 
       newState = {
@@ -167,7 +168,9 @@ export default function sqlLabReducer(state = {}, action) {
         },
         destroyedQueryEditors: {
           ...newState.destroyedQueryEditors,
-          ...(!queryEditor.inLocalStorage && { [queryEditor.id]: Date.now() }),
+          ...(!queryEditor.inLocalStorage && {
+            [queryEditor.tabViewId ?? queryEditor.id]: Date.now(),
+          }),
         },
       };
       return newState;

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -261,8 +261,8 @@ describe('sqlLabReducer', () => {
         type: actions.REMOVE_QUERY_EDITOR,
         queryEditor: newQueryEditor,
       };
-      expect(newState.queryEditors).toHaveLength(length - 1);
       newState = sqlLabReducer(newState, removeAction);
+      expect(newState.queryEditors).toHaveLength(length - 1);
       expect(Object.keys(newState.destroyedQueryEditors)).toContain(
         newQueryEditor.tabViewId,
       );

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -240,7 +240,7 @@ describe('sqlLabReducer', () => {
       );
     });
     it('should migrate query editor by new query editor id', () => {
-      const length = newState.queryEditors.length;
+      const { length } = newState.queryEditors;
       const index = newState.queryEditors.findIndex(({ id }) => id === qe.id);
       const newQueryEditor = {
         ...qe,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -240,11 +240,13 @@ describe('sqlLabReducer', () => {
       );
     });
     it('should migrate query editor by new query editor id', () => {
+      const length = newState.queryEditors.length;
       const index = newState.queryEditors.findIndex(({ id }) => id === qe.id);
       const newQueryEditor = {
         ...qe,
-        id: 'updatedNewId',
+        tabViewId: 'updatedNewId',
         schema: 'updatedSchema',
+        inLocalStorage: false,
       };
       const action = {
         type: actions.MIGRATE_QUERY_EDITOR,
@@ -252,8 +254,18 @@ describe('sqlLabReducer', () => {
         newQueryEditor,
       };
       newState = sqlLabReducer(newState, action);
-      expect(newState.queryEditors[index].id).toEqual('updatedNewId');
+      expect(newState.queryEditors[index].id).toEqual(qe.id);
+      expect(newState.queryEditors[index].tabViewId).toEqual('updatedNewId');
       expect(newState.queryEditors[index]).toEqual(newQueryEditor);
+      const removeAction = {
+        type: actions.REMOVE_QUERY_EDITOR,
+        queryEditor: newQueryEditor,
+      };
+      expect(newState.queryEditors).toHaveLength(length - 1);
+      newState = sqlLabReducer(newState, removeAction);
+      expect(Object.keys(newState.destroyedQueryEditors)).toContain(
+        newQueryEditor.tabViewId,
+      );
     });
     it('should clear the destroyed query editors', () => {
       const expectedQEId = '1233289';


### PR DESCRIPTION
### SUMMARY
In the previous #33522, the autocomplete function was set to be skipped before it was synced. In this commit, following the fix for the SQL editor flushing issue in #34720, this behavior has been reverted so that the autocomplete function works correctly. Additionally, an issue where deleted tabs were not removed upon refresh before they were synced to the server has been fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

- autocomplete

before:

https://github.com/user-attachments/assets/d45df600-6507-46a1-a201-04873e47a204

after:

https://github.com/user-attachments/assets/e9ad5f39-4bf7-43db-93a5-2d478f42c712

- close tabs

before:

https://github.com/user-attachments/assets/13f189ef-2886-47c1-8383-eb4a385d0762

after:

https://github.com/user-attachments/assets/cf2d5a32-399b-441e-a27c-09fbe6891396


### TESTING INSTRUCTIONS
Open a new tab and type some keyword to check autocomplete and then close the tab and then refresh the page for deletion

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
