### PR TITLE
fix: Add dataset ID to file name on exports

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,7 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
+- [34782](https://github.com/apache/superset/pull/34782): Dataset exports now include the dataset ID in their file name (similar to charts and dashboards). If managing assets as code, make sure to rename existing dataset YAMLs to include the ID (and avoid duplicated files).
 - [34536](https://github.com/apache/superset/pull/34536): The `ENVIRONMENT_TAG_CONFIG` color values have changed to support only Ant Design semantic colors. Update your `superset_config.py`:
   - Change `"error.base"` to just `"error"` after this PR
   - Change any hex color values to one of: `"success"`, `"processing"`, `"error"`, `"warning"`, `"default"`

--- a/superset/commands/dataset/export.py
+++ b/superset/commands/dataset/export.py
@@ -46,7 +46,7 @@ class ExportDatasetsCommand(ExportModelsCommand):
         db_file_name = get_filename(
             model.database.database_name, model.database.id, skip_id=True
         )
-        ds_file_name = get_filename(model.table_name, model.id, skip_id=True)
+        ds_file_name = get_filename(model.table_name, model.id)
         return f"datasets/{db_file_name}/{ds_file_name}.yaml"
 
     @staticmethod

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -74,7 +74,7 @@ class TestExportChartsCommand(SupersetTestCase):
         expected = [
             "metadata.yaml",
             f"charts/Energy_Sankey_{example_chart.id}.yaml",
-            "datasets/examples/energy_usage.yaml",
+            f"datasets/examples/energy_usage_{example_chart.table.id}.yaml",
             "databases/examples.yaml",
         ]
         assert expected == list(contents.keys())

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -87,7 +87,9 @@ class TestExportDashboardsCommand(SupersetTestCase):
             chart_slug = secure_filename(chart.slice_name)
             expected_paths.add(f"charts/{chart_slug}_{chart.id}.yaml")
             dataset_slug = secure_filename(chart.table.table_name)
-            expected_paths.add(f"datasets/{dataset_slug}_{chart.table.id}.yaml")
+            expected_paths.add(
+                f"datasets/examples/{dataset_slug}_{chart.table.id}.yaml"
+            )
         assert expected_paths == set(contents.keys())
 
         metadata = yaml.safe_load(

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -81,12 +81,13 @@ class TestExportDashboardsCommand(SupersetTestCase):
         expected_paths = {
             "metadata.yaml",
             f"dashboards/World_Banks_Data_{example_dashboard.id}.yaml",
-            "datasets/examples/wb_health_population.yaml",
             "databases/examples.yaml",
         }
         for chart in example_dashboard.slices:
             chart_slug = secure_filename(chart.slice_name)
             expected_paths.add(f"charts/{chart_slug}_{chart.id}.yaml")
+            dataset_slug = secure_filename(chart.table.table_name)
+            expected_paths.add(f"datasets/{dataset_slug}_{chart.table.id}.yaml")
         assert expected_paths == set(contents.keys())
 
         metadata = yaml.safe_load(

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2395,27 +2395,17 @@ class TestDatasetApi(SupersetTestCase):
         Dataset API: Test that exported dataset filenames include the dataset ID
         to prevent filename collisions when datasets have identical names.
         """
-        example_db = get_example_database()
-        db1 = Database(
-            database_name="test_db_connection_1",
-            sqlalchemy_uri=example_db.sqlalchemy_uri,
-        )
-        db.session.add(db1)
-        db2 = Database(
-            database_name="test_db_connection_2",
-            sqlalchemy_uri=example_db.sqlalchemy_uri,
-        )
-        db.session.add(db2)
-        db.session.commit()
+        first_connection = self.insert_database("test_db_connection_1")
+        second_connection = self.insert_database("test_db_connection_2")
         dataset1 = self.insert_dataset(
             table_name="test_dataset",
             owners=[],
-            database=db1,
+            database=first_connection,
         )
         dataset2 = self.insert_dataset(
             table_name="test_dataset",
             owners=[],
-            database=db2,
+            database=second_connection,
         )
 
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2401,11 +2401,13 @@ class TestDatasetApi(SupersetTestCase):
             table_name="test_dataset",
             owners=[],
             database=first_connection,
+            fetch_metadata=False,
         )
         dataset2 = self.insert_dataset(
             table_name="test_dataset",
             owners=[],
             database=second_connection,
+            fetch_metadata=False,
         )
 
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2434,12 +2434,18 @@ class TestDatasetApi(SupersetTestCase):
         with ZipFile(buf, "r") as zip_file:
             filenames = zip_file.namelist()
 
-            assert (
-                f"datasets/test_db_connection_1/test_dataset_{first_dataset.id}.yaml"
-            ) in filenames
-            assert (
-                f"datasets/test_db_connection_2/test_dataset_{second_dataset.id}.yaml"
-            ) in filenames
+            assert any(
+                filename.endswith(
+                    f"datasets/test_db_connection_1/test_dataset_{first_dataset.id}.yaml"
+                )
+                for filename in filenames
+            )
+            assert any(
+                filename.endswith(
+                    f"datasets/test_db_connection_2/test_dataset_{second_dataset.id}.yaml"
+                )
+                for filename in filenames
+            )
 
     @unittest.skip("Number of related objects depend on DB")
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -78,11 +78,13 @@ class TestExportDatasetsCommand(SupersetTestCase):
 
         assert list(contents.keys()) == [
             "metadata.yaml",
-            "datasets/examples/energy_usage.yaml",
+            f"datasets/examples/energy_usage_{example_dataset.id}.yaml",
             "databases/examples.yaml",
         ]
 
-        metadata = yaml.safe_load(contents["datasets/examples/energy_usage.yaml"]())
+        metadata = yaml.safe_load(
+            contents[f"datasets/examples/energy_usage_{example_dataset.id}.yaml"]()
+        )
 
         # sort columns for deterministic comparison
         metadata["columns"] = sorted(metadata["columns"], key=itemgetter("column_name"))
@@ -218,7 +220,9 @@ class TestExportDatasetsCommand(SupersetTestCase):
         command = ExportDatasetsCommand([example_dataset.id])
         contents = dict(command.run())
 
-        metadata = yaml.safe_load(contents["datasets/examples/energy_usage.yaml"]())
+        metadata = yaml.safe_load(
+            contents[f"datasets/examples/energy_usage_{example_dataset.id}.yaml"]()
+        )
         assert list(metadata.keys()) == [
             "table_name",
             "main_dttm_col",
@@ -261,7 +265,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
 
         assert list(contents.keys()) == [
             "metadata.yaml",
-            "datasets/examples/energy_usage.yaml",
+            f"datasets/examples/energy_usage_{example_dataset.id}.yaml",
         ]
 
 

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -132,6 +132,10 @@ def test_export(session: Session) -> None:
         extra=json.dumps({"warning_markdown": "*WARNING*"}),
     )
 
+    # Add the table to the session and flush to get an ID
+    db.session.add(sqla_table)
+    db.session.flush()
+
     export = [
         (file[0], file[1]())
         for file in list(
@@ -148,7 +152,7 @@ def test_export(session: Session) -> None:
 
     assert export == [
         (
-            "datasets/my_database/my_table.yaml",
+            f"datasets/my_database/my_table_{sqla_table.id}.yaml",
             f"""table_name: my_table
 main_dttm_col: ds
 description: This is the description


### PR DESCRIPTION
### SUMMARY
When generating an export, Superset would add the asset ID to the chart and dashboard file names, however for datasets it would use only the dataset name. This is problematic because it's possible to have multiple datasets with the same name as long as they have a different schema, catalog, or are from a different DB connection.

As a result, if two datasets with the same name are exported, only one (likely the last one to be generated) is included in the ZIP file. 

This PR fixes this issue by adding the dataset ID to the file name (which is already the case for dashboards and charts).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Make sure you have 2 DB connections.
2. Access SQL lab and create two virtual datasets using `select 1 as one` with the same name (one from each DB connection).
3. Access the **Datasets** menu and export both datasets via the bulk export. 
4. Confirm both datasets are present in the ZIP file.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
