### PR TITLE
feat: allow drill-to-details to a specific chart (optionaly) configured at the dataset level

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6781,6 +6781,16 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/source-map/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@jest/test-result": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.0.2.tgz",
@@ -20793,15 +20803,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/camel-case": {
@@ -44941,6 +44942,15 @@
       "dependencies": {
         "callsites": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -6781,16 +6781,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/source-map/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@jest/test-result": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.0.2.tgz",
@@ -20803,6 +20793,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camel-case": {
@@ -44942,15 +44941,6 @@
       "dependencies": {
         "callsites": "^3.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parent-module/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -64,8 +64,7 @@ import {
   SaveDatasetModal,
 } from 'src/SqlLab/components/SaveDatasetModal';
 import { EXPLORE_CHART_DEFAULT, SqlLabRootState } from 'src/SqlLab/types';
-import { mountExploreUrl } from 'src/explore/exploreUtils';
-import { postFormData } from 'src/explore/exploreUtils/formData';
+import { generateExploreUrl } from 'src/explore/exploreUtils/formData';
 import ProgressBar from '@superset-ui/core/components/ProgressBar';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
@@ -78,7 +77,6 @@ import {
   reFetchQueryResults,
   reRunQuery,
 } from 'src/SqlLab/actions/sqlLab';
-import { URL_PARAMS } from 'src/constants';
 import useLogAction from 'src/logger/useLogAction';
 import {
   LOG_ACTIONS_SQLLAB_COPY_RESULT_TO_CLIPBOARD,
@@ -277,15 +275,12 @@ const ResultSet = ({
     const openInNewWindow = clickEvent.metaKey;
     logAction(LOG_ACTIONS_SQLLAB_CREATE_CHART, {});
     if (results?.query_id) {
-      const key = await postFormData(results.query_id, 'query', {
+      const url = await generateExploreUrl(results.query_id, 'query', {
         ...EXPLORE_CHART_DEFAULT,
         datasource: `${results.query_id}__query`,
         ...{
           all_columns: results.columns.map(column => column.column_name),
         },
-      });
-      const url = mountExploreUrl(null, {
-        [URL_PARAMS.formDataKey.name]: key,
       });
       if (openInNewWindow) {
         window.open(url, '_blank', 'noreferrer');

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -275,17 +275,22 @@ const ResultSet = ({
     const openInNewWindow = clickEvent.metaKey;
     logAction(LOG_ACTIONS_SQLLAB_CREATE_CHART, {});
     if (results?.query_id) {
-      const url = await generateExploreUrl(results.query_id, 'query', {
-        ...EXPLORE_CHART_DEFAULT,
-        datasource: `${results.query_id}__query`,
-        ...{
-          all_columns: results.columns.map(column => column.column_name),
-        },
-      });
-      if (openInNewWindow) {
-        window.open(url, '_blank', 'noreferrer');
-      } else {
-        history.push(url);
+      try {
+        const url = await generateExploreUrl(results.query_id, 'query', {
+          ...EXPLORE_CHART_DEFAULT,
+          datasource: `${results.query_id}__query`,
+          ...{
+            all_columns: results.columns.map(column => column.column_name),
+          },
+        });
+        if (openInNewWindow) {
+          window.open(url, '_blank', 'noreferrer');
+        } else {
+          history.push(url);
+        }
+      } catch (error) {
+        console.error('Failed to generate chart explore URL:', error);
+        addDangerToast(t('Failed to generate chart explore URL'));
       }
     } else {
       addDangerToast(t('Unable to create chart without a query id.'));

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.tsx
@@ -43,7 +43,7 @@ import {
 } from '@superset-ui/core/components';
 import { RootState } from 'src/dashboard/types';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
-import { postFormData } from 'src/explore/exploreUtils/formData';
+import { generateExploreUrl } from 'src/explore/exploreUtils/formData';
 import { simpleFilterToAdhoc } from 'src/utils/simpleFilterToAdhoc';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -96,11 +96,12 @@ const ModalFooter = ({ formData, closeModal }: ModalFooterProps) => {
   useEffect(() => {
     // short circuit if the user is embedded as explore is not available
     if (isEmbedded()) return;
-    postFormData(Number(datasource_id), datasource_type, formData, 0)
-      .then(key => {
-        setUrl(
-          `/explore/?form_data_key=${key}&dashboard_page_id=${dashboardPageId}`,
-        );
+    generateExploreUrl(Number(datasource_id), datasource_type, formData, {
+      chartId: 0,
+      dashboardPageId,
+    })
+      .then(url => {
+        setUrl(url);
       })
       .catch(() => {
         addDangerToast(t('Failed to generate chart edit URL'));

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
@@ -92,21 +92,21 @@ test('should render the title', async () => {
   expect(screen.getByText(`Drill to detail: ${chartName}`)).toBeInTheDocument();
 });
 
-test('should not render Edit chart button when no drill-through chart is configured', async () => {
+test('should not render Explore button when no drill-through chart is configured', async () => {
   await renderModal();
   expect(
-    screen.queryByRole('button', { name: 'Edit chart' }),
+    screen.queryByRole('button', { name: 'Explore' }),
   ).not.toBeInTheDocument();
   expect(screen.getAllByRole('button', { name: 'Close' })).toHaveLength(2);
 });
 
-test('should render Edit chart link when drill-through chart is configured', async () => {
+test('should render Explore button when drill-through chart is configured', async () => {
   const datasetWithDrillThrough = {
     drill_through_chart_id: 123,
     id: 456, // Required for URL generation
   };
   await renderModal({}, datasetWithDrillThrough);
-  expect(screen.getByRole('link', { name: 'Edit chart' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Explore' })).toBeInTheDocument();
   expect(screen.getAllByRole('button', { name: 'Close' })).toHaveLength(2);
 });
 
@@ -117,23 +117,7 @@ test('should close the modal', async () => {
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
-test('should have correct href for drill-through chart', async () => {
-  const drillThroughChartId = 123;
-  const datasetId = 456;
-  const datasetWithDrillThrough = {
-    drill_through_chart_id: drillThroughChartId,
-    id: datasetId,
-  };
-  await renderModal({}, datasetWithDrillThrough);
-  const editLink = screen.getByRole('link', { name: 'Edit chart' });
-  expect(editLink).toHaveAttribute(
-    'href',
-    `/explore/?dashboard_page_id=&slice_id=${drillThroughChartId}`,
-  );
-  expect(editLink).not.toHaveAttribute('target'); // We removed target="_blank"
-});
-
-test('should render "Edit chart" as disabled without can_explore permission', async () => {
+test('should render "Explore" as disabled without can_explore permission', async () => {
   const datasetWithDrillThrough = {
     drill_through_chart_id: 123,
     id: 456, // Required for URL generation
@@ -147,5 +131,5 @@ test('should render "Edit chart" as disabled without can_explore permission', as
     },
     datasetWithDrillThrough,
   );
-  expect(screen.getByRole('button', { name: 'Edit chart' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Explore' })).toBeDisabled();
 });

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
@@ -32,6 +32,14 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+jest.mock('src/explore/exploreUtils', () => ({
+  ...jest.requireActual('src/explore/exploreUtils'),
+  getExploreUrl: jest.fn(
+    ({ formData }) =>
+      `/explore/?dashboard_page_id=&slice_id=${formData.slice_id}`,
+  ),
+}));
+
 const { id: chartId, form_data: formData } = chartQueries[sliceId];
 const { slice_name: chartName } = formData;
 const store = getMockStoreWithNativeFilters();

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.test.tsx
@@ -32,12 +32,9 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('src/explore/exploreUtils', () => ({
-  ...jest.requireActual('src/explore/exploreUtils'),
-  getExploreUrl: jest.fn(
-    ({ formData }) =>
-      `/explore/?dashboard_page_id=&slice_id=${formData.slice_id}`,
-  ),
+jest.mock('src/explore/exploreUtils/formData', () => ({
+  ...jest.requireActual('src/explore/exploreUtils/formData'),
+  postFormData: jest.fn().mockResolvedValue('mock-form-data-key'),
 }));
 
 const { id: chartId, form_data: formData } = chartQueries[sliceId];

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -119,33 +119,27 @@ export default function DrillDetailModal({
     findPermission('can_explore', 'Superset', state.user?.roles),
   );
 
-  // Determine if we should show the Explore button
   const showEditButton = Boolean(dataset?.drill_through_chart_id);
-
-  // Get dashboard context for the drill-through chart using the proper hook
   const dashboardContextFormData = useDashboardFormData(
     dataset?.drill_through_chart_id,
   );
 
-  // Generate formData for drill-through chart using proper dashboard context resolution
   const drillThroughFormData = useMemo(() => {
     if (!dataset?.drill_through_chart_id || !dataset?.id) {
       return null;
     }
 
-    // Create base formData for the drill-through chart
     const drillThroughBaseFormData = {
       slice_id: dataset.drill_through_chart_id,
       datasource: `${dataset.id}__table`,
-      viz_type: 'table', // Default viz type
+      viz_type: 'table',
     };
 
-    // Use the enhanced dashboard context function that handles drill-to-detail filters
     return getFormDataWithDashboardContext(
       drillThroughBaseFormData,
       dashboardContextFormData,
-      undefined, // saveAction
-      initialFilters, // drillToDetailFilters - drill-down filters from context menu
+      undefined,
+      initialFilters,
     );
   }, [
     dataset?.drill_through_chart_id,
@@ -153,8 +147,6 @@ export default function DrillDetailModal({
     dashboardContextFormData,
     initialFilters,
   ]);
-
-  // Handle explore button click - generate URL and navigate
   const handleExploreClick = async (event: React.MouseEvent) => {
     event.preventDefault();
 
@@ -170,16 +162,15 @@ export default function DrillDetailModal({
 
     try {
       const url = await generateExploreUrl(
-        dataset.id, // datasourceId
-        'table', // datasourceType
-        drillThroughFormData, // our perfectly crafted formData with dashboard context + drill-down filters
+        dataset.id,
+        'table',
+        drillThroughFormData,
         {
           chartId: dataset.drill_through_chart_id,
           dashboardPageId,
         },
       );
 
-      // Navigate to the explore page
       window.location.href = url;
     } catch (error) {
       console.error('Failed to generate chart explore URL:', error);

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -26,6 +26,7 @@ import {
   t,
   useTheme,
 } from '@superset-ui/core';
+import { getExploreUrl } from 'src/explore/exploreUtils';
 import { Button, Modal } from '@superset-ui/core/components';
 import { useSelector } from 'react-redux';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
@@ -112,7 +113,15 @@ export default function DrillDetailModal({
   const exploreUrl = useMemo(() => {
     // Use drill-through chart ID if configured, otherwise use original chart
     const targetChartId = dataset?.drill_through_chart_id || chartId;
-    return `/explore/?dashboard_page_id=${dashboardPageId}&slice_id=${targetChartId}`;
+    return getExploreUrl({
+      formData: {
+        slice_id: targetChartId,
+      },
+      endpointType: 'base',
+      requestParams: dashboardPageId
+        ? { dashboard_page_id: dashboardPageId }
+        : {},
+    });
   }, [chartId, dashboardPageId, dataset?.drill_through_chart_id]);
 
   const exploreChart = useCallback(() => {

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -109,10 +109,11 @@ export default function DrillDetailModal({
     findPermission('can_explore', 'Superset', state.user?.roles),
   );
 
-  const exploreUrl = useMemo(
-    () => `/explore/?dashboard_page_id=${dashboardPageId}&slice_id=${chartId}`,
-    [chartId, dashboardPageId],
-  );
+  const exploreUrl = useMemo(() => {
+    // Use drill-through chart ID if configured, otherwise use original chart
+    const targetChartId = dataset?.drill_through_chart_id || chartId;
+    return `/explore/?dashboard_page_id=${dashboardPageId}&slice_id=${targetChartId}`;
+  }, [chartId, dashboardPageId, dataset?.drill_through_chart_id]);
 
   const exploreChart = useCallback(() => {
     history.push(exploreUrl);

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -35,9 +35,7 @@ import { findPermission } from 'src/utils/findPermission';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { getFormDataWithDashboardContext } from 'src/explore/controlUtils/getFormDataWithDashboardContext';
 import { useDashboardFormData } from 'src/dashboard/hooks/useDashboardFormData';
-import { postFormData } from 'src/explore/exploreUtils/formData';
-import { mountExploreUrl } from 'src/explore/exploreUtils';
-import { URL_PARAMS } from 'src/constants';
+import { generateExploreUrl } from 'src/explore/exploreUtils/formData';
 import { Dataset } from '../types';
 import DrillDetailPane from './DrillDetailPane';
 
@@ -171,24 +169,18 @@ export default function DrillDetailModal({
     setIsGeneratingUrl(true);
 
     try {
-      const key = await postFormData(
+      const url = await generateExploreUrl(
         dataset.id, // datasourceId
         'table', // datasourceType
         drillThroughFormData, // our perfectly crafted formData with dashboard context + drill-down filters
-        dataset.drill_through_chart_id, // chartId
+        {
+          chartId: dataset.drill_through_chart_id,
+          dashboardPageId,
+        },
       );
 
-      const baseUrl = mountExploreUrl(null, {
-        [URL_PARAMS.formDataKey.name]: key,
-      });
-
-      // Add dashboard_page_id if available
-      const finalUrl = dashboardPageId
-        ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}dashboard_page_id=${dashboardPageId}`
-        : baseUrl;
-
       // Navigate to the explore page
-      window.location.href = finalUrl;
+      window.location.href = url;
     } catch (error) {
       console.error('Failed to generate chart explore URL:', error);
       addDangerToast(t('Failed to generate chart explore URL'));

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -18,6 +18,7 @@
  */
 
 import { useContext, useMemo, useState } from 'react';
+import { sanitizeUrl } from '@braintree/sanitize-url';
 import {
   BinaryQueryObjectFilterClause,
   css,
@@ -171,7 +172,7 @@ export default function DrillDetailModal({
         },
       );
 
-      window.location.href = url;
+      window.location.href = sanitizeUrl(url);
     } catch (error) {
       console.error('Failed to generate chart explore URL:', error);
       addDangerToast(t('Failed to generate chart explore URL'));

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailModal.tsx
@@ -194,6 +194,7 @@ export default function DrillDetailModal({
       footer={
         <ModalFooter
           canExplore={canExplore}
+          closeModal={onHideModal}
           showEditButton={showEditButton}
           onExploreClick={handleExploreClick}
           isGeneratingUrl={isGeneratingUrl}

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -51,6 +51,7 @@ import Table, {
 import { RootState } from 'src/dashboard/types';
 import HeaderWithRadioGroup from '@superset-ui/core/components/Table/header-renderers/HeaderWithRadioGroup';
 import { useDatasetMetadataBar } from 'src/features/datasets/metadataBar/useDatasetMetadataBar';
+import { useDashboardFormData } from 'src/dashboard/hooks/useDashboardFormData';
 import { Dataset } from '../types';
 import TableControls from './DrillDetailTableControls';
 import { getDrillPayload } from './utils';
@@ -119,6 +120,11 @@ export default function DrillDetailPane({
   const { metadataBar: metadataBarComponent } = useDatasetMetadataBar({
     dataset,
   });
+
+  // Get dashboard context for StatefulChart
+  const dashboardContext = useDashboardFormData(
+    dataset?.drill_through_chart_id,
+  );
 
   // Get page of results
   const resultsPage = useMemo(() => {
@@ -311,6 +317,7 @@ export default function DrillDetailPane({
         <StatefulChart
           chartId={dataset.drill_through_chart_id}
           formDataOverrides={{
+            ...dashboardContext,
             adhoc_filters: adhocFilters,
           }}
           height="100%"

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -24,6 +24,7 @@ export enum DrillByType {
 }
 
 export type Dataset = {
+  id?: number;
   changed_by?: {
     first_name: string;
     last_name: string;

--- a/superset-frontend/src/components/Chart/types.ts
+++ b/superset-frontend/src/components/Chart/types.ts
@@ -44,4 +44,5 @@ export type Dataset = {
   drillable_columns?: Column[];
   metrics?: Metric[];
   verbose_map?: Record<string, string>;
+  drill_through_chart_id?: number | null;
 };

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -46,6 +46,7 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import { ErrorMessageWithStackTrace } from 'src/components';
 import type { DatasetObject } from 'src/features/datasets/types';
 import type { DatasourceModalProps } from '../types';
+import { invalidateDatasetDrillCache } from 'src/utils/cachedSupersetGet';
 
 const DatasourceEditor = AsyncEsmComponent(
   () => import('../components/DatasourceEditor'),
@@ -181,6 +182,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       owners: datasource.owners.map(
         (o: Record<string, number>) => o.value || o.id,
       ),
+      drill_through_chart_id: datasource.drill_through_chart_id || null,
     };
     // Handle catalog based on database's allow_multi_catalog setting
     // If multi-catalog is disabled, don't include catalog in payload
@@ -203,6 +205,10 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       const { json } = await SupersetClient.get({
         endpoint: `/api/v1/dataset/${currentDatasource?.id}`,
       });
+
+      // Invalidate drill info cache to pick up any drill-through config changes
+      invalidateDatasetDrillCache(currentDatasource.id);
+
       addSuccessToast(t('The dataset has been saved'));
       // eslint-disable-next-line no-param-reassign
       json.result.type = 'table';

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -202,12 +202,14 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
         jsonPayload: buildPayload(currentDatasource),
       });
 
+      // Invalidate drill info cache to pick up any drill-through config changes.
+      // This must happen right after the mutation succeeds, independently of the
+      // follow-up GET below, so a failed refresh doesn't leave stale drill config cached.
+      invalidateDatasetDrillCache(currentDatasource.id);
+
       const { json } = await SupersetClient.get({
         endpoint: `/api/v1/dataset/${currentDatasource?.id}`,
       });
-
-      // Invalidate drill info cache to pick up any drill-through config changes
-      invalidateDatasetDrillCache(currentDatasource.id);
 
       addSuccessToast(t('The dataset has been saved'));
       // eslint-disable-next-line no-param-reassign

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -182,7 +182,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       owners: datasource.owners.map(
         (o: Record<string, number>) => o.value || o.id,
       ),
-      drill_through_chart_id: datasource.drill_through_chart_id || null,
+      drill_through_chart_id: datasource.drill_through_chart_id ?? null,
     };
     // Handle catalog based on database's allow_multi_catalog setting
     // If multi-catalog is disabled, don't include catalog in payload

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -1068,7 +1068,7 @@ class DatasourceEditor extends PureComponent {
               <ChartSelect
                 datasetId={datasource.id}
                 placeholder={t('Default (show all columns)')}
-                clearable
+                allowClear
                 ariaLabel={t('Select drill-to-details chart')}
               />
             }

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -75,6 +75,7 @@ import Fieldset from '../Fieldset';
 import Field from '../Field';
 import { fetchSyncedColumns, updateColumns } from '../../utils';
 import DatasetUsageTab from './components/DatasetUsageTab';
+import ChartSelect from '../Select/ChartSelect';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -1050,6 +1051,25 @@ class DatasourceEditor extends PureComponent {
                 controlId="fetch_values_predicate"
                 minLines={5}
                 resize="vertical"
+              />
+            }
+          />
+        )}
+        {this.state.isSqla && (
+          <Field
+            fieldKey="drill_through_chart_id"
+            value={datasource.drill_through_chart_id}
+            onChange={this.onDatasourcePropChange}
+            label={t('Drill-to-details table/chart')}
+            description={t(
+              'Select a chart to display when users drill into this dataset. If not configured, shows all columns in a table.',
+            )}
+            control={
+              <ChartSelect
+                datasetId={datasource.id}
+                placeholder={t('Default (show all columns)')}
+                clearable
+                ariaLabel={t('Select drill-to-details chart')}
               />
             }
           />

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -75,7 +75,7 @@ import Fieldset from '../Fieldset';
 import Field from '../Field';
 import { fetchSyncedColumns, updateColumns } from '../../utils';
 import DatasetUsageTab from './components/DatasetUsageTab';
-import ChartSelect from '../Select/ChartSelect';
+import ChartSelect from '../../../Select/ChartSelect';
 
 const extensionsRegistry = getExtensionsRegistry();
 

--- a/superset-frontend/src/components/Select/ChartSelect.test.tsx
+++ b/superset-frontend/src/components/Select/ChartSelect.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from 'spec/helpers/testing-library';
+import ChartSelectUsingAsync from './ChartSelect';
+
+const mockOnChange = jest.fn();
+
+const defaultProps = {
+  value: null,
+  onChange: mockOnChange,
+  datasetId: 123,
+  placeholder: 'Select a chart',
+  allowClear: true,
+  ariaLabel: 'Select drill-to-details chart',
+};
+
+test('renders chart select component with default props', () => {
+  const { container } = render(<ChartSelectUsingAsync {...defaultProps} />, {
+    useRedux: true,
+  });
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders with custom placeholder', () => {
+  const customProps = {
+    ...defaultProps,
+    placeholder: 'Choose your chart',
+  };
+
+  const { container } = render(<ChartSelectUsingAsync {...customProps} />, {
+    useRedux: true,
+  });
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders with selected value', () => {
+  const propsWithValue = {
+    ...defaultProps,
+    value: 456,
+  };
+
+  const { container } = render(<ChartSelectUsingAsync {...propsWithValue} />, {
+    useRedux: true,
+  });
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders without dataset filter when datasetId is undefined', () => {
+  const propsWithoutDataset = {
+    ...defaultProps,
+    datasetId: undefined,
+  };
+
+  const { container } = render(
+    <ChartSelectUsingAsync {...propsWithoutDataset} />,
+    { useRedux: true },
+  );
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders with custom aria label', () => {
+  const propsWithCustomAriaLabel = {
+    ...defaultProps,
+    ariaLabel: 'Custom chart selector',
+  };
+
+  const { container } = render(
+    <ChartSelectUsingAsync {...propsWithCustomAriaLabel} />,
+    { useRedux: true },
+  );
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders as non-clearable when allowClear is false', () => {
+  const nonClearableProps = {
+    ...defaultProps,
+    allowClear: false,
+  };
+
+  const { container } = render(
+    <ChartSelectUsingAsync {...nonClearableProps} />,
+    { useRedux: true },
+  );
+  expect(container.firstChild).toBeInTheDocument();
+});
+
+test('passes through additional props to SelectAsyncControl', () => {
+  const propsWithExtra = {
+    ...defaultProps,
+    description: 'Test description',
+    hovered: true,
+    'data-testid': 'chart-select',
+  };
+
+  const { container } = render(<ChartSelectUsingAsync {...propsWithExtra} />, {
+    useRedux: true,
+  });
+  expect(container.firstChild).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/Select/ChartSelect.tsx
+++ b/superset-frontend/src/components/Select/ChartSelect.tsx
@@ -19,16 +19,21 @@
 import { useMemo } from 'react';
 import { t } from '@superset-ui/core';
 import SelectAsyncControl from 'src/explore/components/controls/SelectAsyncControl';
+import type { ComponentProps } from 'react';
 import rison from 'rison';
 
-export interface ChartSelectProps {
+// Extract the actual props from SelectAsyncControl component
+type SelectAsyncControlProps = ComponentProps<typeof SelectAsyncControl>;
+
+export interface ChartSelectProps
+  extends Omit<
+    SelectAsyncControlProps,
+    'onChange' | 'dataEndpoint' | 'mutator' | 'addDangerToast'
+  > {
+  // ChartSelect-specific props that override base props
   value?: number | null;
   onChange: (value: number | null) => void;
   datasetId?: number;
-  placeholder?: string;
-  clearable?: boolean;
-  ariaLabel?: string;
-  label?: React.ReactNode;
 }
 
 /**
@@ -37,18 +42,16 @@ export interface ChartSelectProps {
  * @param onChange - Callback when selection changes
  * @param datasetId - Optional dataset ID to filter charts
  * @param placeholder - Optional placeholder text
- * @param clearable - Whether the selection can be cleared
  * @param ariaLabel - ARIA label for accessibility
- * @param label - Form label (passed by Field component)
+ * @param rest - All other props are passed through to SelectAsyncControl
  */
 export default function ChartSelectUsingAsync({
   value,
   onChange,
   datasetId,
   placeholder = t('Select a chart'),
-  clearable = true,
   ariaLabel = t('Select drill-to-details chart'),
-  label,
+  ...rest
 }: ChartSelectProps) {
   // Build query parameters for filtering charts by dataset
   const queryParams = useMemo(() => {
@@ -95,9 +98,8 @@ export default function ChartSelectUsingAsync({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      allowClear={clearable}
       multi={false}
-      label={label}
+      {...rest}
     />
   );
 }

--- a/superset-frontend/src/components/Select/ChartSelect.tsx
+++ b/superset-frontend/src/components/Select/ChartSelect.tsx
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useMemo } from 'react';
+import { t } from '@superset-ui/core';
+import SelectAsyncControl from 'src/explore/components/controls/SelectAsyncControl';
+import rison from 'rison';
+
+export interface ChartSelectProps {
+  value?: number | null;
+  onChange: (value: number | null) => void;
+  datasetId?: number;
+  placeholder?: string;
+  clearable?: boolean;
+  ariaLabel?: string;
+  label?: React.ReactNode;
+}
+
+/**
+ * A chart selection component built on SelectAsyncControl
+ * @param value - The selected chart ID
+ * @param onChange - Callback when selection changes
+ * @param datasetId - Optional dataset ID to filter charts
+ * @param placeholder - Optional placeholder text
+ * @param clearable - Whether the selection can be cleared
+ * @param ariaLabel - ARIA label for accessibility
+ * @param label - Form label (passed by Field component)
+ */
+export default function ChartSelectUsingAsync({
+  value,
+  onChange,
+  datasetId,
+  placeholder = t('Select a chart'),
+  clearable = true,
+  ariaLabel = t('Select drill-to-details chart'),
+  label,
+}: ChartSelectProps) {
+  // Build query parameters for filtering charts by dataset
+  const queryParams = useMemo(() => {
+    if (!datasetId) return undefined;
+
+    const filters = [
+      {
+        col: 'datasource_id',
+        opr: 'eq',
+        value: datasetId,
+      },
+      {
+        col: 'datasource_type',
+        opr: 'eq',
+        value: 'table',
+      },
+    ];
+
+    return {
+      q: rison.encode({
+        filters,
+        order_column: 'slice_name',
+        order_direction: 'asc',
+      }),
+    };
+  }, [datasetId]);
+
+  // Transform response to format expected by SelectAsyncControl
+  const mutator = useMemo(
+    () => (response: any) =>
+      response.result.map((chart: any) => ({
+        value: chart.id,
+        label: `${chart.slice_name} (${chart.viz_type})`,
+      })),
+    [],
+  );
+
+  return (
+    <SelectAsyncControl
+      ariaLabel={ariaLabel}
+      dataEndpoint="/api/v1/chart/"
+      queryParams={queryParams}
+      mutator={mutator}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      allowClear={clearable}
+      multi={false}
+      label={label}
+    />
+  );
+}

--- a/superset-frontend/src/components/Select/ChartSelect.tsx
+++ b/superset-frontend/src/components/Select/ChartSelect.tsx
@@ -93,7 +93,7 @@ export default function ChartSelectUsingAsync({
     <SelectAsyncControl
       ariaLabel={ariaLabel}
       dataEndpoint="/api/v1/chart/"
-      queryParams={queryParams}
+      searchParams={queryParams}
       mutator={mutator}
       value={value}
       onChange={onChange}

--- a/superset-frontend/src/components/Select/ChartSelect.tsx
+++ b/superset-frontend/src/components/Select/ChartSelect.tsx
@@ -28,7 +28,7 @@ type SelectAsyncControlProps = ComponentProps<typeof SelectAsyncControl>;
 export interface ChartSelectProps
   extends Omit<
     SelectAsyncControlProps,
-    'onChange' | 'dataEndpoint' | 'mutator' | 'addDangerToast'
+    'onChange' | 'dataEndpoint' | 'mutator' | 'addDangerToast' | 'multi'
   > {
   // ChartSelect-specific props that override base props
   value?: number | null;
@@ -98,8 +98,8 @@ export default function ChartSelectUsingAsync({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      multi={false}
       {...rest}
+      multi={false}
     />
   );
 }

--- a/superset-frontend/src/dashboard/hooks/useDashboardFormData.test.tsx
+++ b/superset-frontend/src/dashboard/hooks/useDashboardFormData.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { useDashboardFormData } from './useDashboardFormData';
+
+const mockStore = configureMockStore([]);
+
+const createMockState = (overrides = {}) => ({
+  dashboardInfo: {
+    id: 123,
+    metadata: {
+      chart_configuration: {},
+    },
+  },
+  dashboardState: {
+    sliceIds: [1, 2, 3],
+  },
+  nativeFilters: {
+    filters: {},
+  },
+  dataMask: {},
+  ...overrides,
+});
+
+const renderUseDashboardFormData = (
+  chartId: number | null | undefined,
+  state = {},
+) => {
+  const store = mockStore(createMockState(state));
+  return renderHook(() => useDashboardFormData(chartId), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+};
+
+test('returns base dashboard context when chartId is null', () => {
+  const { result } = renderUseDashboardFormData(null);
+
+  expect(result.current).toEqual({ dashboardId: 123 });
+});
+
+test('returns base dashboard context when chartId is undefined', () => {
+  const { result } = renderUseDashboardFormData(undefined);
+
+  expect(result.current).toEqual({ dashboardId: 123 });
+});
+
+test('returns base dashboard context when required state is missing', () => {
+  const { result } = renderUseDashboardFormData(1, {
+    nativeFilters: null,
+  });
+
+  expect(result.current).toEqual({ dashboardId: 123 });
+});
+
+test('returns base dashboard context when no filters apply to chart', () => {
+  const { result } = renderUseDashboardFormData(1, {
+    nativeFilters: {
+      filters: {
+        'filter-1': {
+          scope: [2, 3], // Doesn't include chartId 1
+        },
+      },
+    },
+    dashboardInfo: {
+      id: 123,
+      metadata: {
+        chart_configuration: {
+          'filter-1': {
+            id: 'filter-1',
+            scope: [2, 3],
+          },
+        },
+      },
+    },
+  });
+
+  expect(result.current).toEqual({ dashboardId: 123 });
+});
+
+test('returns dashboard context with extra form data when filters apply', () => {
+  const mockState = {
+    nativeFilters: {
+      filters: {
+        'filter-1': {
+          scope: [1, 2, 3], // Includes chartId 1
+        },
+      },
+    },
+    dashboardInfo: {
+      id: 123,
+      metadata: {
+        chart_configuration: {
+          'filter-1': {
+            id: 'filter-1',
+            scope: [1, 2, 3],
+          },
+        },
+      },
+    },
+    dataMask: {
+      'filter-1': {
+        extraFormData: {
+          filters: [
+            {
+              col: 'country',
+              op: 'IN',
+              val: ['USA', 'Canada'],
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  // Mock the external utility functions
+  jest.mock('../util/activeAllDashboardFilters', () => ({
+    getAllActiveFilters: () => ({
+      'filter-1': {
+        scope: [1, 2, 3],
+      },
+    }),
+  }));
+
+  jest.mock('../components/nativeFilters/utils', () => ({
+    getExtraFormData: () => ({
+      filters: [
+        {
+          col: 'country',
+          op: 'IN',
+          val: ['USA', 'Canada'],
+        },
+      ],
+    }),
+  }));
+
+  const { result } = renderUseDashboardFormData(1, mockState);
+
+  expect(result.current.dashboardId).toBe(123);
+  expect(result.current.extra_form_data).toBeDefined();
+});
+
+test('handles different dashboard IDs correctly', () => {
+  const { result } = renderUseDashboardFormData(1, {
+    dashboardInfo: {
+      id: 456,
+      metadata: {
+        chart_configuration: {},
+      },
+    },
+  });
+
+  expect(result.current).toEqual({ dashboardId: 456 });
+});

--- a/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
+++ b/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState, DashboardContextFormData } from '../types';
+import { getExtraFormData } from '../components/nativeFilters/utils';
+import { getAllActiveFilters } from '../util/activeAllDashboardFilters';
+
+/**
+ * Hook that provides dashboard context as formatted formData for charts.
+ * This encapsulates all the complex logic for determining which dashboard
+ * filters, colors, and other context should be applied to a specific chart.
+ *
+ * @param chartId - The ID of the chart to get dashboard context for
+ * @returns Dashboard context formatted as QueryFormData fields
+ */
+export const useDashboardFormData = (
+  chartId: number | null | undefined,
+): DashboardContextFormData => {
+  // Dashboard state selectors
+  const dashboardId = useSelector<RootState, number>(
+    ({ dashboardInfo }) => dashboardInfo.id,
+  );
+
+  const nativeFilters = useSelector(
+    (state: RootState) => state.nativeFilters?.filters,
+  );
+
+  const dataMask = useSelector((state: RootState) => state.dataMask);
+
+  const chartConfiguration = useSelector(
+    (state: RootState) =>
+      state.dashboardInfo.metadata?.chart_configuration || {},
+  );
+
+  const allSliceIds = useSelector(
+    (state: RootState) => state.dashboardState.sliceIds,
+  );
+
+  // Compute dashboard context for the chart
+  return useMemo((): DashboardContextFormData => {
+    const baseContext: DashboardContextFormData = { dashboardId };
+
+    // Early return if we don't have required data or chartId
+    if (
+      !chartId ||
+      !nativeFilters ||
+      !dataMask ||
+      !chartConfiguration ||
+      !allSliceIds
+    ) {
+      return baseContext;
+    }
+
+    // Get active filters using the same logic as normal dashboard charts
+    const activeFilters = getAllActiveFilters({
+      chartConfiguration,
+      nativeFilters,
+      dataMask,
+      allSliceIds,
+    });
+
+    // Find which filters apply to this specific chart
+    const filterIdsAppliedOnChart = Object.entries(activeFilters)
+      .filter(([, activeFilter]) => activeFilter.scope.includes(chartId))
+      .map(([filterId]) => filterId);
+
+    // If no filters apply, return just the base context
+    if (filterIdsAppliedOnChart.length === 0) {
+      return baseContext;
+    }
+
+    // Get the extra form data from dashboard filters
+    const extraFormData = getExtraFormData(dataMask, filterIdsAppliedOnChart);
+
+    return {
+      ...baseContext,
+      extra_form_data: extraFormData,
+      // TODO: Add other dashboard context like color schemes when needed
+    };
+  }, [
+    chartId,
+    dashboardId,
+    nativeFilters,
+    dataMask,
+    chartConfiguration,
+    allSliceIds,
+  ]);
+};

--- a/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
+++ b/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
@@ -22,6 +22,7 @@ import { useSelector } from 'react-redux';
 import { RootState, DashboardContextFormData } from '../types';
 import { getExtraFormData } from '../components/nativeFilters/utils';
 import { getAllActiveFilters } from '../util/activeAllDashboardFilters';
+import { getFilterIdsAppliedOnChart } from '../util/getFilterIdsAppliedOnChart';
 
 /**
  * Hook that provides dashboard context as formatted formData for charts.
@@ -78,9 +79,10 @@ export const useDashboardFormData = (
     });
 
     // Find which filters apply to this specific chart
-    const filterIdsAppliedOnChart = Object.entries(activeFilters)
-      .filter(([, activeFilter]) => activeFilter.scope.includes(chartId))
-      .map(([filterId]) => filterId);
+    const filterIdsAppliedOnChart = getFilterIdsAppliedOnChart(
+      activeFilters,
+      chartId,
+    );
 
     // If no filters apply, return just the base context
     if (filterIdsAppliedOnChart.length === 0) {

--- a/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
+++ b/superset-frontend/src/dashboard/hooks/useDashboardFormData.ts
@@ -61,7 +61,7 @@ export const useDashboardFormData = (
 
     // Early return if we don't have required data or chartId
     if (
-      !chartId ||
+      chartId == null ||
       !nativeFilters ||
       !dataMask ||
       !chartConfiguration ||

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -26,6 +26,7 @@ import {
   NativeFilterScope,
   NativeFiltersState,
   NativeFilterTarget,
+  QueryFormData,
 } from '@superset-ui/core';
 import { Dataset } from '@superset-ui/chart-controls';
 import { chart } from 'src/components/Chart/chartReducer';
@@ -298,4 +299,32 @@ export enum MenuKeys {
   ManageEmbedded = 'manage_embedded',
   ManageEmailReports = 'manage_email_reports',
   ExportPivotXlsx = 'export_pivot_xlsx',
+}
+
+/**
+ * Represents the dashboard context that can be applied to a chart's formData.
+ * This type defines the specific formData fields that dashboard components
+ * can provide to integrate charts with the current dashboard state.
+ */
+export interface DashboardContextFormData extends Partial<QueryFormData> {
+  /** The ID of the current dashboard */
+  dashboardId: number;
+
+  /** Dashboard native filters applied to the chart */
+  extra_form_data?: ExtraFormData;
+
+  /** Dashboard color scheme */
+  color_scheme?: string;
+
+  /** Dashboard color namespace */
+  color_namespace?: string;
+
+  /** Dashboard label colors mapping */
+  label_colors?: Record<string, string>;
+
+  /** Dashboard shared label colors */
+  shared_label_colors?: string[];
+
+  /** Dashboard map label colors */
+  map_label_colors?: Record<string, string>;
 }

--- a/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
+++ b/superset-frontend/src/dashboard/util/charts/getFormDataWithExtraFilters.ts
@@ -34,6 +34,7 @@ import { areObjectsEqual } from 'src/reduxUtils';
 import { isEqual } from 'lodash';
 import getEffectiveExtraFilters from './getEffectiveExtraFilters';
 import { getAllActiveFilters } from '../activeAllDashboardFilters';
+import { getFilterIdsAppliedOnChart } from '../getFilterIdsAppliedOnChart';
 
 interface CachedFormData {
   extra_form_data?: JsonObject;
@@ -157,9 +158,10 @@ export default function getFormDataWithExtraFilters({
     });
 
   let extraData: JsonObject = {};
-  const filterIdsAppliedOnChart = Object.entries(activeFilters)
-    .filter(([, activeFilter]) => activeFilter.scope.includes(chart.id))
-    .map(([filterId]) => filterId);
+  const filterIdsAppliedOnChart = getFilterIdsAppliedOnChart(
+    activeFilters,
+    chart.id,
+  );
 
   if (filterIdsAppliedOnChart.length) {
     const aggregatedFormData = getExtraFormData(

--- a/superset-frontend/src/dashboard/util/getFilterIdsAppliedOnChart.test.ts
+++ b/superset-frontend/src/dashboard/util/getFilterIdsAppliedOnChart.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getFilterIdsAppliedOnChart } from './getFilterIdsAppliedOnChart';
+import { ActiveFilters } from '../types';
+
+describe('getFilterIdsAppliedOnChart', () => {
+  const createMockActiveFilters = (
+    filterConfigs: Array<{ id: string; scope: number[] }>,
+  ): ActiveFilters => {
+    const activeFilters: ActiveFilters = {};
+    filterConfigs.forEach(({ id, scope }) => {
+      activeFilters[id] = {
+        scope,
+        targets: [],
+        values: {},
+      };
+    });
+    return activeFilters;
+  };
+
+  test('returns filters that include chart in their scope', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'filter-1', scope: [1, 2, 3] },
+      { id: 'filter-2', scope: [2, 4, 5] },
+      { id: 'filter-3', scope: [1, 3, 6] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 2);
+    expect(result).toEqual(['filter-1', 'filter-2']);
+  });
+
+  test('returns empty array when no filters apply to chart', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'filter-1', scope: [1, 3, 5] },
+      { id: 'filter-2', scope: [7, 8, 9] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 2);
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when activeFilters is empty', () => {
+    const activeFilters: ActiveFilters = {};
+    const result = getFilterIdsAppliedOnChart(activeFilters, 1);
+    expect(result).toEqual([]);
+  });
+
+  test('handles single filter with single chart scope', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'single-filter', scope: [42] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 42);
+    expect(result).toEqual(['single-filter']);
+  });
+
+  test('handles multiple filters all applying to same chart', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'filter-a', scope: [1, 2] },
+      { id: 'filter-b', scope: [1] },
+      { id: 'filter-c', scope: [1, 3, 4] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 1);
+    expect(result).toEqual(['filter-a', 'filter-b', 'filter-c']);
+  });
+
+  test('preserves filter ID order from Object.entries', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'zebra', scope: [1] },
+      { id: 'alpha', scope: [1] },
+      { id: 'beta', scope: [1] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 1);
+    // Object.entries preserves insertion order in modern JS
+    expect(result).toEqual(['zebra', 'alpha', 'beta']);
+  });
+
+  test('handles edge case with large chart IDs', () => {
+    const activeFilters = createMockActiveFilters([
+      { id: 'filter-large', scope: [999999, 1000000, 1000001] },
+    ]);
+
+    const result = getFilterIdsAppliedOnChart(activeFilters, 1000000);
+    expect(result).toEqual(['filter-large']);
+  });
+});

--- a/superset-frontend/src/dashboard/util/getFilterIdsAppliedOnChart.ts
+++ b/superset-frontend/src/dashboard/util/getFilterIdsAppliedOnChart.ts
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ActiveFilters } from '../types';
+
+/**
+ * Returns the filter IDs that apply to a specific chart based on their scope.
+ * This centralizes the logic for determining which dashboard filters
+ * should be applied to a given chart.
+ *
+ * @param activeFilters - The currently active dashboard filters
+ * @param chartId - The ID of the chart to check filter scope for
+ * @returns Array of filter IDs that apply to the specified chart
+ */
+export const getFilterIdsAppliedOnChart = (
+  activeFilters: ActiveFilters,
+  chartId: number,
+): string[] =>
+  Object.entries(activeFilters)
+    .filter(([, activeFilter]) => activeFilter.scope.includes(chartId))
+    .map(([filterId]) => filterId);

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/SelectAsyncControl.test.tsx
@@ -104,3 +104,15 @@ test('Should send correct props to Select component - function onChange multi:fa
   userEvent.click(await screen.findByText('onChange'));
   expect(props.onChange).toHaveBeenCalledTimes(1);
 });
+
+test('Should handle null value without crashing when clearing selection', () => {
+  const props = createProps();
+  const { rerender } = render(<SelectAsyncControl {...props} />, {
+    useRedux: true,
+  });
+
+  // Simulate clearing the selection by passing null value
+  expect(() => {
+    rerender(<SelectAsyncControl {...props} value={null} />);
+  }).not.toThrow();
+});

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
@@ -50,7 +50,7 @@ interface SelectAsyncControlProps extends SelectAsyncProps {
 }
 
 function isLabeledValue(arg: any): arg is LabeledValue {
-  return arg.value !== undefined;
+  return arg && typeof arg === 'object' && arg.value !== undefined;
 }
 
 const SelectAsyncControl = ({

--- a/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/SelectAsyncControl/index.tsx
@@ -41,8 +41,8 @@ interface SelectAsyncControlProps extends SelectAsyncProps {
   ) => SelectOptionsType;
   multi?: boolean;
   onChange: (val: SelectValue) => void;
-  // Optional query parameters to append to the endpoint
-  queryParams?: Record<string, any>;
+  // Optional search parameters to append to the endpoint
+  searchParams?: Record<string, any>;
   // ControlHeader related props
   description?: string;
   hovered?: boolean;
@@ -62,7 +62,7 @@ const SelectAsyncControl = ({
   mutator,
   onChange,
   placeholder,
-  queryParams,
+  searchParams,
   value,
   ...props
 }: SelectAsyncControlProps) => {
@@ -98,22 +98,10 @@ const SelectAsyncControl = ({
         const { error } = e;
         addDangerToast(t('Error while fetching data: %s', error));
       });
-    const loadOptions = () => {
-      // Build endpoint with query parameters if provided
-      let endpoint = dataEndpoint;
-      if (queryParams && Object.keys(queryParams).length > 0) {
-        const urlParams = new URLSearchParams();
-        Object.entries(queryParams).forEach(([key, value]) => {
-          if (value !== undefined && value !== null) {
-            urlParams.append(key, String(value));
-          }
-        });
-        const separator = dataEndpoint.includes('?') ? '&' : '?';
-        endpoint = `${dataEndpoint}${separator}${urlParams.toString()}`;
-      }
-
-      return SupersetClient.get({
-        endpoint,
+    const loadOptions = () =>
+      SupersetClient.get({
+        endpoint: dataEndpoint,
+        searchParams,
       })
         .then(response => {
           const data = mutator
@@ -125,12 +113,11 @@ const SelectAsyncControl = ({
         .finally(() => {
           setLoaded(true);
         });
-    };
 
     if (!loaded) {
       loadOptions();
     }
-  }, [addDangerToast, dataEndpoint, mutator, value, loaded, queryParams]);
+  }, [addDangerToast, dataEndpoint, mutator, value, loaded, searchParams]);
 
   return (
     <Select

--- a/superset-frontend/src/explore/exploreUtils/formData.ts
+++ b/superset-frontend/src/explore/exploreUtils/formData.ts
@@ -18,6 +18,8 @@
  */
 import { SupersetClient, JsonObject, JsonResponse } from '@superset-ui/core';
 import { sanitizeFormData } from 'src/utils/sanitizeFormData';
+import { URL_PARAMS } from 'src/constants';
+import { mountExploreUrl } from './index';
 
 type Payload = {
   datasource_id: number;
@@ -86,3 +88,48 @@ export const putFormData = (
       chartId,
     ),
   }).then((r: JsonResponse) => r.json.message);
+
+/**
+ * Generate explore URL by posting formData to server and creating URL with key.
+ * This solves URL length limitations by storing complex formData server-side.
+ *
+ * @param datasourceId - The datasource ID
+ * @param datasourceType - The datasource type (typically 'table' or 'query')
+ * @param formData - The form data object to be posted
+ * @param options - Optional parameters
+ * @param options.chartId - Chart ID for the explore URL
+ * @param options.tabId - Tab ID for multi-tab environments
+ * @param options.dashboardPageId - Dashboard page ID to maintain context
+ * @returns Promise that resolves to the complete explore URL
+ */
+export const generateExploreUrl = async (
+  datasourceId: number,
+  datasourceType: string,
+  formData: JsonObject,
+  options?: {
+    chartId?: number;
+    tabId?: string;
+    dashboardPageId?: string;
+  },
+): Promise<string> => {
+  // Post formData to server and get key
+  const key = await postFormData(
+    datasourceId,
+    datasourceType,
+    formData,
+    options?.chartId,
+    options?.tabId,
+  );
+
+  // Generate base explore URL with form_data_key
+  const baseUrl = mountExploreUrl(null, {
+    [URL_PARAMS.formDataKey.name]: key,
+  });
+
+  // Add dashboard_page_id if provided
+  const finalUrl = options?.dashboardPageId
+    ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}dashboard_page_id=${options.dashboardPageId}`
+    : baseUrl;
+
+  return finalUrl;
+};

--- a/superset-frontend/src/explore/exploreUtils/formData.ts
+++ b/superset-frontend/src/explore/exploreUtils/formData.ts
@@ -128,7 +128,7 @@ export const generateExploreUrl = async (
 
   // Add dashboard_page_id if provided
   const finalUrl = options?.dashboardPageId
-    ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}dashboard_page_id=${options.dashboardPageId}`
+    ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}dashboard_page_id=${encodeURIComponent(options.dashboardPageId)}`
     : baseUrl;
 
   return finalUrl;

--- a/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
@@ -119,9 +119,9 @@ describe('Footer', () => {
     const dropdownTrigger = screen.getByRole('button', { name: 'down' });
     userEvent.click(dropdownTrigger);
 
-    // Check that the dropdown menu option is visible
+    // Check that the dropdown menu option is in the document
     await waitFor(() => {
-      expect(screen.getByText('Create dataset')).toBeVisible();
+      expect(screen.getByText('Create dataset')).toBeInTheDocument();
     });
   });
 

--- a/superset-frontend/src/features/datasets/types.ts
+++ b/superset-frontend/src/features/datasets/types.ts
@@ -81,4 +81,5 @@ export type DatasetObject = {
   column_formats: Record<string, string>;
   datasource_name: string | null;
   verbose_map: Record<string, string>;
+  drill_through_chart_id?: number | null;
 };

--- a/superset-frontend/src/utils/cachedSupersetGet.ts
+++ b/superset-frontend/src/utils/cachedSupersetGet.ts
@@ -27,3 +27,20 @@ export const cachedSupersetGet = cacheWrapper(
   supersetGetCache,
   ({ endpoint }) => endpoint || '',
 );
+
+/**
+ * Invalidates cached dataset drill info for all dashboards containing this dataset
+ */
+export const invalidateDatasetDrillCache = (datasetId: string | number) => {
+  const numericDatasetId =
+    typeof datasetId === 'string'
+      ? Number(datasetId.split('__')[0])
+      : Number(datasetId);
+
+  // Find and delete all cache entries for this dataset's drill info
+  const keysToDelete = Array.from(supersetGetCache.keys()).filter(key =>
+    key.includes(`/api/v1/dataset/${numericDatasetId}/drill_info/`),
+  );
+
+  keysToDelete.forEach(key => supersetGetCache.delete(key));
+};

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1148,6 +1148,16 @@ class SqlaTable(
     always_filter_main_dttm = Column(Boolean, default=False)
     folders = Column(JSON, nullable=True)
 
+    # Drill-through configuration
+    drill_through_chart_id = Column(
+        Integer, ForeignKey("slices.id", ondelete="SET NULL"), nullable=True
+    )
+    drill_through_chart: Mapped[Optional[Slice]] = relationship(
+        "Slice",
+        foreign_keys=[drill_through_chart_id],
+        backref=backref("drill_through_datasets", passive_deletes=True),
+    )
+
     baselink = "tablemodelview"
 
     export_fields = [
@@ -1169,6 +1179,7 @@ class SqlaTable(
         "normalize_columns",
         "always_filter_main_dttm",
         "folders",
+        "drill_through_chart_id",
     ]
     update_from_object_fields = [f for f in export_fields if f != "database_id"]
     export_parent = "database"

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1376,6 +1376,7 @@ class SqlaTable(
             data_["owners"] = self.owners_data
             data_["always_filter_main_dttm"] = self.always_filter_main_dttm
             data_["normalize_columns"] = self.normalize_columns
+            data_["drill_through_chart_id"] = self.drill_through_chart_id
         return data_
 
     @property

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -220,6 +220,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "changed_on_humanized",
         "changed_by.first_name",
         "changed_by.last_name",
+        "drill_through_chart_id",
     ]
     show_columns = show_select_columns + [
         "columns.type_generic",

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -236,6 +236,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "time_grain_sqla",
         "order_by_choices",
         "verbose_map",
+        "drill_through_chart_id",
     ]
     add_model_schema = DatasetPostSchema()
     edit_model_schema = DatasetPutSchema()
@@ -261,6 +262,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "columns",
         "metrics",
         "extra",
+        "drill_through_chart_id",
     ]
     openapi_spec_tag = "Datasets"
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1242,6 +1242,7 @@ class DatasetRestApi(BaseSupersetModelRestApi):
             "columns.column_name",
             "columns.verbose_name",
             "columns.groupby",
+            "drill_through_chart_id",
         ]
         dataset_schema = DatasetDrillInfoSchema()
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -237,7 +237,6 @@ class DatasetRestApi(BaseSupersetModelRestApi):
         "time_grain_sqla",
         "order_by_choices",
         "verbose_map",
-        "drill_through_chart_id",
     ]
     add_model_schema = DatasetPostSchema()
     edit_model_schema = DatasetPutSchema()

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -174,6 +174,7 @@ class DatasetPutSchema(Schema):
     columns = fields.List(fields.Nested(DatasetColumnsPutSchema))
     metrics = fields.List(fields.Nested(DatasetMetricsPutSchema))
     folders = fields.List(fields.Nested(FolderSchema), required=False)
+    drill_through_chart_id = fields.Integer(allow_none=True)
     extra = fields.String(allow_none=True)
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True)
@@ -322,6 +323,7 @@ class ImportV1DatasetSchema(Schema):
     fetch_values_predicate = fields.String(allow_none=True)
     extra = fields.Dict(allow_none=True)
     uuid = fields.UUID(required=True)
+    drill_through_chart_id = fields.Integer(allow_none=True)
     columns = fields.List(fields.Nested(ImportV1ColumnSchema))
     metrics = fields.List(fields.Nested(ImportV1MetricSchema))
     version = fields.String(required=True)
@@ -415,6 +417,7 @@ class DatasetDrillInfoSchema(Schema):
     created_on_humanized = fields.String()
     changed_by = fields.Nested(UserSchema)
     changed_on_humanized = fields.String()
+    drill_through_chart_id = fields.Integer(allow_none=True)
 
     # pylint: disable=unused-argument
     @post_dump(pass_original=True)

--- a/superset/migrations/versions/2025-08-11_12-43_f56ac3accfc9_drill_through_chart_fk.py
+++ b/superset/migrations/versions/2025-08-11_12-43_f56ac3accfc9_drill_through_chart_fk.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""drill-through-chart-fk
+
+Revision ID: f56ac3accfc9
+Revises: cd1fb11291f2
+Create Date: 2025-08-11 12:43:59.086693
+
+"""
+
+import sqlalchemy as sa
+
+from superset.migrations.shared.utils import (
+    add_columns,
+    create_fks_for_table,
+    drop_columns,
+    drop_fks_for_table,
+)
+
+# revision identifiers, used by Alembic.
+revision = "f56ac3accfc9"
+down_revision = "cd1fb11291f2"
+
+
+def upgrade():
+    # Add the drill_through_chart_id column to the tables table
+    add_columns(
+        "tables", sa.Column("drill_through_chart_id", sa.Integer(), nullable=True)
+    )
+
+    # Create foreign key constraint to slices table
+    create_fks_for_table(
+        foreign_key_name="fk_tables_drill_through_chart_id_slices",
+        table_name="tables",
+        referenced_table="slices",
+        local_cols=["drill_through_chart_id"],
+        remote_cols=["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade():
+    # Drop the foreign key constraint first
+    drop_fks_for_table(
+        table_name="tables",
+        foreign_key_names=["fk_tables_drill_through_chart_id_slices"],
+    )
+
+    # Drop the column
+    drop_columns("tables", "drill_through_chart_id")

--- a/superset/migrations/versions/2025-08-21_01-54_852e99567fe7_.py
+++ b/superset/migrations/versions/2025-08-21_01-54_852e99567fe7_.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""merge heads: theme system and drill-through chart
+
+Revision ID: 852e99567fe7
+Revises: ('c233f5365c9e', 'f56ac3accfc9')
+Create Date: 2025-08-21 01:54:38.918459
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "852e99567fe7"
+down_revision = ("c233f5365c9e", "f56ac3accfc9")
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/tests/integration_tests/datasets/commands_tests.py
+++ b/tests/integration_tests/datasets/commands_tests.py
@@ -184,6 +184,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
             "template_params": None,
             "uuid": str(example_dataset.uuid),
             "version": "1.0.0",
+            "drill_through_chart_id": None,
         }
 
     @patch("superset.security.manager.g")
@@ -241,6 +242,7 @@ class TestExportDatasetsCommand(SupersetTestCase):
             "normalize_columns",
             "always_filter_main_dttm",
             "folders",
+            "drill_through_chart_id",
             "uuid",
             "metrics",
             "columns",

--- a/tests/unit_tests/datasets/commands/export_test.py
+++ b/tests/unit_tests/datasets/commands/export_test.py
@@ -197,6 +197,7 @@ folders:
     - uuid: 00000000-0000-0000-0000-000000000005
       type: column
       name: profit
+drill_through_chart_id: null
 uuid: {payload["uuid"]}
 metrics:
 - metric_name: cnt


### PR DESCRIPTION
This PR introduces customizable drill-to-details functionality that allows dataset owners to configure which chart should be used when users drill through from any chart using their dataset.

<img width="527" height="301" alt="Screenshot 2025-08-20 at 11 41 36 PM" src="https://github.com/user-attachments/assets/4f591c27-3ecb-4edd-8b3a-c5a679f25439" />

<img width="899" height="742" alt="Screenshot 2025-08-20 at 11 36 27 PM" src="https://github.com/user-attachments/assets/a0091aa4-ad7e-4ecc-bddf-b9a4528bdf14" />

Problem: Current drill-to-details uses a one-size-fits-all approach showing all columns in a generic table with no customization options.

Solution: Dataset-level drill-to-details customization allowing association of any existing chart as the drill-to-details target.

Key Benefits:
- Take advantage of all the features of the Table viz in drill-to-details (column selection, ordering, sorting, aggregation, conditional formatting, link/url support, ...)
- Flexible chart types: Any chart type or visualization supported
- Backwards compatible: No-op unless configured, falls back gracefully
- Cross-dashboard consistency: Same experience across all dashboards

Implementation:
- Backend: Added drill_through_chart_id column with FK relationship
- Frontend: ChartSelect component with Dataset Editor integration
- Enhanced drill modal to render StatefulChart when configured
- Full TypeScript support with proper type definitions

Walkthrough:
- create a chart you'd like to see when drilling-to-details for a given dataset
- edit the dataset properties, settings, pick that chart as your drill-to-details chart
- open a dashboard with that dataset
- drill-to-details