### PR TITLE
fix: Unexpected overflow ellipsis dots after status icon in Dashboard list

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
@@ -180,6 +180,10 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
       text-overflow: ellipsis;
     }
 
+    td.ant-table-cell.no-ellipsis {
+      text-overflow: unset;
+    }
+
     .ant-table-tbody > tr > td {
       white-space: nowrap;
       overflow: hidden;

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/utils.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/utils.tsx
@@ -56,6 +56,7 @@ type EnhancedColumnInstance<T extends object = any> = RTColumnInstance<T> &
   Partial<UseResizeColumnsColumnProps<T>> & {
     hidden?: boolean;
     size?: keyof typeof COLUMN_SIZE_MAP;
+    className?: string;
   };
 
 type EnhancedHeaderGroup<T extends object = any> = RTHeaderGroup<T> & {
@@ -122,6 +123,7 @@ export function mapColumns<T extends object>(
         }
         return val;
       },
+      className: column.className,
     };
   });
 }

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -361,6 +361,7 @@ function DashboardList(props: DashboardListProps) {
         accessor: 'published',
         size: 'sm',
         id: 'published',
+        className: 'no-ellipsis',
       },
       {
         Cell: ({


### PR DESCRIPTION
### SUMMARY
Remove `text-overflow: ellipsis` style for Status column in Dashboard list view

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="271" height="318" alt="image" src="https://github.com/user-attachments/assets/ae2285e8-096c-4da1-aa81-9ced5532904e" />

After:

<img width="251" height="344" alt="image" src="https://github.com/user-attachments/assets/ebdc6c5d-a072-492f-9f0c-8d0313081410" />


### TESTING INSTRUCTIONS
Open dashboard list, resize the window a bit, verify that there are no dots next to status pills

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
