### PR TITLE
fix: Misaligned global controls in Table chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -451,9 +451,7 @@ export default typedMemo(function DataTable<D extends object>({
       {hasGlobalControl ? (
         <div ref={globalControlRef} className="form-inline dt-controls">
           <StyledRow className="row">
-            <div
-              className={renderTimeComparisonDropdown ? 'col-sm-4' : 'col-sm-5'}
-            >
+            <StyledSpace size="middle">
               {hasPagination ? (
                 <SelectPageSize
                   total={resultsSize}
@@ -467,23 +465,17 @@ export default typedMemo(function DataTable<D extends object>({
                   onChange={setPageSize}
                 />
               ) : null}
-            </div>
-            {searchInput ? (
-              <StyledSpace
-                className={
-                  renderTimeComparisonDropdown ? 'col-sm-7' : 'col-sm-8'
-                }
-              >
-                {serverPagination && (
-                  <div className="search-select-container">
-                    <span className="search-by-label">Search by: </span>
-                    <SearchSelectDropdown
-                      searchOptions={searchOptions}
-                      value={serverPaginationData?.searchColumn || ''}
-                      onChange={onSearchColChange}
-                    />
-                  </div>
-                )}
+              {serverPagination && (
+                <div className="search-select-container">
+                  <span className="search-by-label">Search by: </span>
+                  <SearchSelectDropdown
+                    searchOptions={searchOptions}
+                    value={serverPaginationData?.searchColumn || ''}
+                    onChange={onSearchColChange}
+                  />
+                </div>
+              )}
+              {searchInput && (
                 <GlobalFilter<D>
                   searchInput={
                     typeof searchInput === 'boolean' ? undefined : searchInput
@@ -497,16 +489,11 @@ export default typedMemo(function DataTable<D extends object>({
                   serverPagination={!!serverPagination}
                   rowCount={rowCount}
                 />
-              </StyledSpace>
-            ) : null}
-            {renderTimeComparisonDropdown ? (
-              <div
-                className="col-sm-1"
-                style={{ float: 'right', marginTop: '6px' }}
-              >
-                {renderTimeComparisonDropdown()}
-              </div>
-            ) : null}
+              )}
+              {renderTimeComparisonDropdown
+                ? renderTimeComparisonDropdown()
+                : null}
+            </StyledSpace>
           </StyledRow>
         </div>
       ) : null}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -197,7 +197,6 @@ function SearchInput({
     <Space direction="horizontal" size={4} className="dt-global-filter">
       {t('Search')}
       <Input
-        size="small"
         aria-label={t('Search %s records', count)}
         placeholder={tn('search.num_records', count)}
         value={value}


### PR DESCRIPTION

### SUMMARY
Pagination, search and time comparison controls in Table chart were misaligned and had weird spacings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="783" height="110" alt="image" src="https://github.com/user-attachments/assets/5f675afb-e066-4769-82c0-7d3a8e63dac3" />


After:

<img width="851" height="124" alt="image" src="https://github.com/user-attachments/assets/7646aac6-81f5-4c1f-b52d-d1e5db1d617d" />

### TESTING INSTRUCTIONS
1. Open a table chart in Explore
2. Enable server pagination, search and time comparison
3. Verify that the controls in the chart are well aligned

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
