### PR TITLE
chore: Add instruction for LLMs to use antd theme tokens

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -10,6 +10,7 @@ Apache Superset is a data visualization platform with Flask/Python backend and R
 - **NO `any` types** - Use proper TypeScript types
 - **NO JavaScript files** - Convert to TypeScript (.ts/.tsx)
 - **Use @superset-ui/core** - Don't import Ant Design directly
+- **Use antd theming tokens** - Prefer antd tokens over legacy theming tokens
 
 ### Testing Strategy Migration
 - **Prefer unit tests** over integration tests

--- a/LLMS.md
+++ b/LLMS.md
@@ -9,8 +9,9 @@ Apache Superset is a data visualization platform with Flask/Python backend and R
 ### Frontend Modernization
 - **NO `any` types** - Use proper TypeScript types
 - **NO JavaScript files** - Convert to TypeScript (.ts/.tsx)
-- **Use @superset-ui/core** - Don't import Ant Design directly
+- **Use @superset-ui/core** - Don't import Ant Design directly, prefer Ant Design component wrappers from @superset-ui/core/components
 - **Use antd theming tokens** - Prefer antd tokens over legacy theming tokens
+- **Avoid custom css and styles** - Follow antd best practices and avoid styling and custom CSS whenever possible
 
 ### Testing Strategy Migration
 - **Prefer unit tests** over integration tests


### PR DESCRIPTION
### SUMMARY
Add instruction for LLMs to use antd theme tokens instead of legacy tokens like `theme.colors.grayscale...`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
