### PR TITLE
fix: Low contrast in viz creator selected tag in dark mode

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -176,11 +176,11 @@ const SelectorLabel = styled.button`
     }
 
     &.selected {
-      background-color: ${theme.colorPrimaryBgHover};
-      color: ${theme.colorPrimaryTextActive};
+      background-color: ${theme.colorPrimary};
+      color: ${theme.colorTextLightSolid};
 
       svg {
-        color: ${theme.colorIcon};
+        color: ${theme.colorTextLightSolid};
       }
 
       &:hover {


### PR DESCRIPTION
### SUMMARY
In Chart creation page, the selected categories and tags had low text contrast in dark mode.
Also changed the icon color to match the text after consultation with @kasiazjc 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="210" height="65" alt="image" src="https://github.com/user-attachments/assets/71d68244-8d43-4612-af81-f66d3ca8714e" />

<img width="268" height="80" alt="image" src="https://github.com/user-attachments/assets/23db50f6-1809-46d6-ab11-7f3b35c19a8c" />

After:

<img width="224" height="90" alt="image" src="https://github.com/user-attachments/assets/2f8df81d-b5b4-4f74-a3c8-be38d4782758" />

<img width="218" height="76" alt="image" src="https://github.com/user-attachments/assets/ae53c327-7d56-4da8-be16-9894199b387f" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API