### PR TITLE
fix(native-filters): Low contrast of empty state in dark mode

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -74,7 +74,7 @@ const verticalStyle = (theme: SupersetTheme, width: number) => css`
 
   background: linear-gradient(
     ${rgba(theme.colorBgLayout, 0)},
-    ${theme.colorBgElevated} 20%
+    ${theme.colorBgContainer} 20%
   );
 
   & > .filter-apply-button {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -70,7 +70,6 @@ const Bar = styled.div<{ width: number }>`
     display: none;
     &.open {
       display: flex;
-      background-color: ${theme.colorBgBase};
     }
   `}
 `;


### PR DESCRIPTION
### SUMMARY
1. Due to black background, the empty state text color had low contrast in dark mode.
2. Fixes the gradient around buttons at the bottom - it should have the same color as the background to provide smooth transition when scrolling down the list of filters, but it shouldn't stand out

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="261" height="690" alt="image" src="https://github.com/user-attachments/assets/c79002cb-cd5e-4762-a4ab-6d89719010f1" />

<img width="260" height="160" alt="image" src="https://github.com/user-attachments/assets/14e28645-807b-4582-9bb2-b21951218ae0" />

After:

<img width="276" height="345" alt="image" src="https://github.com/user-attachments/assets/6284e4e2-9e18-4138-be71-aba881110849" />

<img width="248" height="166" alt="image" src="https://github.com/user-attachments/assets/9bff5fb6-0abb-458f-8412-e747bb121f2a" />


### TESTING INSTRUCTIONS
1. Go to dashboard
2. Ensure there are no native filters added, open the filters bar in vertical mode
3. Enable dark mode
4. Ensure the empty state text is readable
5. Ensure the gradient around the buttons at the bottom is not visible 
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
