### PR TITLE
fix: Remove border around textarea in dashboard edit mode

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/index.tsx
@@ -52,7 +52,6 @@ const StyledEditableTitle = styled.span<{
 
     input[type='text'],
     textarea {
-      border: 1px solid ${({ theme }) => theme.colorSplit};
       color: ${({ theme }) => theme.colorTextTertiary};
       border-radius: ${({ theme }) => theme.sizeUnit}px;
       font-size: ${({ theme }) => theme.fontSizeLG}px;


### PR DESCRIPTION
### SUMMARY
In dashboard edit mode, text areas (chart titles, tab titles) had a weird border around them. This PR removes that

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="815" height="522" alt="image" src="https://github.com/user-attachments/assets/9c9cf116-7843-4125-80ca-04d4ad89c6fd" />

After:

<img width="815" height="514" alt="image" src="https://github.com/user-attachments/assets/c99ddad9-d842-41a9-8155-fec1c6241ef8" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
