### PR TITLE
fix(echarts): Series labels hard to read in dark mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -450,6 +450,7 @@ export default function transformProps(
         showValueIndexes: showValueIndexesA,
         thresholdValues,
         timeShiftColor,
+        theme,
       },
     );
     if (transformedSeries) series.push(transformedSeries);
@@ -516,6 +517,7 @@ export default function transformProps(
         showValueIndexes: showValueIndexesB,
         thresholdValues: thresholdValuesB,
         timeShiftColor,
+        theme,
       },
     );
     if (transformedSeries) series.push(transformedSeries);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -331,6 +331,7 @@ export default function transformProps(
         lineStyle,
         timeCompare: array,
         timeShiftColor,
+        theme,
       },
     );
     if (transformedSeries) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -168,6 +168,7 @@ export function transformSeries(
     queryIndex?: number;
     timeCompare?: string[];
     timeShiftColor?: boolean;
+    theme?: SupersetTheme;
   },
 ): SeriesOption | undefined {
   const { name, data } = series;
@@ -197,6 +198,7 @@ export function transformSeries(
     queryIndex = 0,
     timeCompare = [],
     timeShiftColor,
+    theme,
   } = opts;
   const contexts = seriesContexts[name || ''] || [];
   const hasForecast =
@@ -323,6 +325,8 @@ export function transformSeries(
     label: {
       show: !!showValue,
       position: isHorizontal ? 'right' : 'top',
+      color: theme?.colorText,
+      textBorderWidth: 0,
       formatter: (params: any) => {
         // don't show confidence band value labels, as they're already visible on the tooltip
         if (


### PR DESCRIPTION
### SUMMARY
In dark mode, value lables in Echarts Series charts had a white border which was hard to read. This PR changes that to simply white text color.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1028" height="127" alt="image" src="https://github.com/user-attachments/assets/4834aec1-9219-4b2f-8331-e1b40a9ce18a" />

<img width="1050" height="222" alt="image" src="https://github.com/user-attachments/assets/b839395b-892b-4d3e-a6f6-9d21124a2179" />

After:

<img width="1045" height="125" alt="image" src="https://github.com/user-attachments/assets/c054fc97-d90b-4542-95af-9bcc1b9502df" />

<img width="1037" height="129" alt="image" src="https://github.com/user-attachments/assets/2f32463e-e68c-4f22-9192-c4e0de08c947" />



### TESTING INSTRUCTIONS
1. Open bar chart
2. Check show value
3. Verify that it's easy to read in dark and light mode

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
