### PR TITLE
fix(theming): Icons in ExecutionLogList and Country map chart tooltip theme consistency

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/src/ReactCountryMap.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/src/ReactCountryMap.jsx
@@ -58,11 +58,13 @@ export default styled(CountryMap)`
     }
 
     .superset-legacy-chart-country-map text.result-text {
+      fill: ${theme.colorText};
       font-weight: ${theme.fontWeightLight};
       font-size: ${theme.fontSizeXL}px;
     }
 
     .superset-legacy-chart-country-map text.big-text {
+      fill: ${theme.colorText};
       font-weight: ${theme.fontWeightStrong};
       font-size: ${theme.fontSizeLG}px;
     }

--- a/superset-frontend/src/features/alerts/components/AlertStatusIcon.tsx
+++ b/superset-frontend/src/features/alerts/components/AlertStatusIcon.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, SupersetTheme, useTheme } from '@superset-ui/core';
+import { t, SupersetTheme, useTheme, css } from '@superset-ui/core';
 import { Tooltip } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { AlertState } from '../types';
@@ -32,7 +32,7 @@ function getStatusColor(
     case AlertState.Error:
       return theme.colorErrorText;
     case AlertState.Success:
-      return isReportEnabled ? theme.colorSuccessText : theme.colorErrorText;
+      return theme.colorSuccessText;
     case AlertState.Noop:
       return theme.colorSuccessText;
     case AlertState.Grace:
@@ -57,9 +57,7 @@ export default function AlertStatusIcon({
   };
   switch (state) {
     case AlertState.Success:
-      lastStateConfig.icon = isReportEnabled
-        ? Icons.CheckOutlined
-        : Icons.WarningOutlined;
+      lastStateConfig.icon = Icons.CheckOutlined;
       lastStateConfig.label = isReportEnabled
         ? t('Report sent')
         : t('Alert triggered, notification sent');
@@ -95,16 +93,30 @@ export default function AlertStatusIcon({
       lastStateConfig.status = AlertState.Noop;
   }
   const Icon = lastStateConfig.icon;
+  const isRunningIcon = state === AlertState.Working;
   return (
     <Tooltip title={lastStateConfig.label} placement="bottomLeft">
-      <Icon
-        iconSize="m"
-        iconColor={getStatusColor(
-          lastStateConfig.status,
-          isReportEnabled,
-          theme,
-        )}
-      />
+      <span
+        css={
+          isRunningIcon
+            ? css`
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                transform: scale(1.8);
+              `
+            : undefined
+        }
+      >
+        <Icon
+          iconSize="m"
+          iconColor={getStatusColor(
+            lastStateConfig.status,
+            isReportEnabled,
+            theme,
+          )}
+        />
+      </span>
     </Tooltip>
   );
 }


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
County Map chart tooltip fixed to match theme
County Map chart tooltip fixed to match theme
This PR fixes two styling issues:

  1. ExecutionLogList Running Icon Size: Fixed size inconsistency of the custom Running icon compared to other Antd status icons
  2. Country Map Tooltip Theme Colors: Fixed tooltip text colors to use theme variables instead of hardcoded values

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Alert and Reports:
<img width="1504" height="265" alt="ReportAndAlerts" src="https://github.com/user-attachments/assets/8393f920-82d7-466c-889a-0ee8313ce636" />

Country Map Chart:
<img width="1046" height="595" alt="CountryMapLight" src="https://github.com/user-attachments/assets/1ef42e05-175d-47b8-8398-9b347a941e1d" />
<img width="920" height="544" alt="CountryMapDark" src="https://github.com/user-attachments/assets/bca2c545-0fec-4bf4-adc2-3f0947268237" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
