### PR TITLE
fix(dashboard): Anchor link positions

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/index.tsx
@@ -34,8 +34,10 @@ const StyledEditableTitle = styled.span<{
   canEdit: boolean;
 }>`
   &.editable-title {
-    display: inline-block;
-    width: 100%;
+    display: inline;
+    &.editable-title--editing {
+      width: 100%;
+    }
 
     input,
     textarea {

--- a/superset-frontend/src/components/CopyToClipboard/index.tsx
+++ b/superset-frontend/src/components/CopyToClipboard/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Component, cloneElement, ReactElement } from 'react';
-import { t } from '@superset-ui/core';
+import { t, css, SupersetTheme } from '@superset-ui/core';
 import copyTextToClipboard from 'src/utils/copy';
 import { Tooltip } from '@superset-ui/core/components';
 import withToasts from '../MessageToasts/withToasts';
@@ -104,7 +104,14 @@ class CopyToClip extends Component<CopyToClipboardProps> {
     return (
       <span css={{ display: 'inline-flex', alignItems: 'center' }}>
         {this.props.shouldShowText && this.props.text && (
-          <span data-test="short-url">{this.props.text}</span>
+          <span
+            data-test="short-url"
+            css={(theme: SupersetTheme) => css`
+              margin-right: ${theme.sizeUnit}px;
+            `}
+          >
+            {this.props.text}
+          </span>
         )}
         {this.renderTooltip('pointer')}
       </span>

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
@@ -75,6 +75,18 @@ const HeaderStyles = styled.div`
       font-size: ${theme.fontSizeXXL}px;
     }
 
+    .anchor-link-container {
+      display: inline;
+      line-height: 0;
+      vertical-align: bottom; /* trick to align the anchor with text */
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+    }
+
+    &:hover .anchor-link-container {
+      opacity: 1;
+    }
+
     .dashboard--editing .dashboard-grid & {
       &:after {
         border: 1px dashed transparent;

--- a/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header.jsx
@@ -80,7 +80,7 @@ const HeaderStyles = styled.div`
       line-height: 0;
       vertical-align: bottom; /* trick to align the anchor with text */
       opacity: 0;
-      transition: opacity 0.2s ease-in-out;
+      transition: opacity ${theme.motionDurationMid} ease-in-out;
     }
 
     &:hover .anchor-link-container {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -79,10 +79,23 @@ const defaultProps = {
 
 const TabTitleContainer = styled.div`
   ${({ isHighlighted, theme: { sizeUnit, colorPrimaryBg } }) => `
-    padding: ${sizeUnit}px ${sizeUnit * 8}px ${sizeUnit}px ${sizeUnit * 2}px;
-    margin: ${-sizeUnit}px ${sizeUnit * -2}px;
+    display: inline-flex;
+    position: relative;
+    align-items: center;
+    margin: 0 ${sizeUnit * 2}px;
     transition: box-shadow 0.2s ease-in-out;
-    ${isHighlighted && `box-shadow: 0 0 ${sizeUnit}px ${colorPrimaryBg};`}
+    ${isHighlighted ? `box-shadow: 0 0 ${sizeUnit}px ${colorPrimaryBg};` : ''}
+
+    .anchor-link-container {
+      position: absolute;
+      right: -${sizeUnit * 7}px;
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+    }
+
+    &:hover .anchor-link-container {
+      opacity: 1;
+    }
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab.jsx
@@ -88,7 +88,7 @@ const TabTitleContainer = styled.div`
 
     .anchor-link-container {
       position: absolute;
-      right: -${sizeUnit * 7}px;
+      left: 100%;
       opacity: 0;
       transition: opacity 0.2s ease-in-out;
     }


### PR DESCRIPTION
### SUMMARY
1. Fixes anchor link in tabs always visible - it should only display on hover
2. Fixes anchor link in headers always visible - it should only display on hover
3. Fixes incorrect position of anchor link in headers - it was displayed in a separate line, now it's displayed next to text
4. Adds a small spacing between the url text and copy icon (visible when anchor popover is open)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

https://github.com/user-attachments/assets/ff600f73-c7e3-4c4c-933c-584b7040bdaa

After:

https://github.com/user-attachments/assets/e363fde0-c603-41f4-ba77-9431b70ee6fe

### TESTING INSTRUCTIONS
1. Open a dashboard
2. Add some tabs and headers components
3. Verify that anchor links appear only on hover

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
