### PR TITLE
fix(sqllab): Missing executed sql value in the result table

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -194,6 +194,7 @@ const ResultSet = ({
         'dbId',
         'tab',
         'sql',
+        'executedSql',
         'sqlEditorId',
         'templateParams',
         'schema',
@@ -553,6 +554,7 @@ const ResultSet = ({
     sql = (
       <HighlightedSql
         sql={query.sql}
+        rawSql={query.executedSql}
         {...(showSqlInline && { maxLines: 1, maxWidth: 60 })}
       />
     );

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.js
@@ -389,6 +389,7 @@ export default function sqlLabReducer(state = {}, action) {
         results: action.results,
         rows: action?.results?.query?.rows || 0,
         state: QueryState.Success,
+        executedSql: action?.results?.query?.executedSql,
         limitingFactor: action?.results?.query?.limitingFactor,
         tempSchema: action?.results?.query?.tempSchema,
         tempTable: action?.results?.query?.tempTable,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
To address #24787, this commit fixes the issue where the property value corresponding to the executed SQL was missing during implementation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="846" height="326" alt="Screenshot 2025-08-25 at 11 57 18 AM" src="https://github.com/user-attachments/assets/d6b270fc-75ef-4f6f-b2c6-e6153b850c96" />

After:
<img width="610" height="353" alt="Screenshot 2025-08-25 at 11 57 32 AM" src="https://github.com/user-attachments/assets/f48df2f5-02ae-40db-ade5-f4b004443753" />


### TESTING INSTRUCTIONS
Run a query and then click SQL box to check the executed sql

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
