### PR TITLE
fix(docker): configure gunicorn for DuckDB thread safety in docker-compose-light

### DIFF
--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -116,14 +116,13 @@ services:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
       POSTGRES_DB: superset_light
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
-      # DuckDB thread-safety configuration: DuckDB is not fully thread-safe in all contexts,
-      # so we use multiple sync workers (8) with single threading (1 thread per worker)
-      # instead of the default gthread worker class to avoid database locking issues
-      SERVER_WORKER_AMOUNT: 8
-      SERVER_THREADS_AMOUNT: 1
-      SERVER_WORKER_CLASS: sync
+      # DuckDB concurrency configuration: DuckDB examples database uses read-only mode
+      # to allow concurrent access from multiple workers/threads without file locking issues
+      # SERVER_WORKER_AMOUNT: 8
+      # SERVER_THREADS_AMOUNT: 1
+      # SERVER_WORKER_CLASS: sync
 
   superset-init-light:
     build:
@@ -143,7 +142,7 @@ services:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
       POSTGRES_DB: superset_light
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
     healthcheck:
       disable: true
@@ -197,7 +196,7 @@ services:
       DATABASE_DB: test
       POSTGRES_DB: test
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@db-light:5432/test
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
       SUPERSET_CONFIG: superset_test_config_light
       PYTHONPATH: /app/pythonpath:/app/docker/pythonpath_dev:/app
 

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -118,6 +118,12 @@ services:
       POSTGRES_DB: superset_light
       SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
+      # DuckDB thread-safety configuration: DuckDB is not fully thread-safe in all contexts,
+      # so we use multiple sync workers (8) with single threading (1 thread per worker)
+      # instead of the default gthread worker class to avoid database locking issues
+      SERVER_WORKER_AMOUNT: 8
+      SERVER_THREADS_AMOUNT: 1
+      SERVER_WORKER_CLASS: sync
 
   superset-init-light:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
         condition: service_completed_successfully
     volumes: *superset-volumes
     environment:
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
 
   superset-websocket:
     container_name: superset_websocket
@@ -162,7 +162,7 @@ services:
     user: *superset-user
     volumes: *superset-volumes
     environment:
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
     healthcheck:
       disable: true
 


### PR DESCRIPTION
DuckDB is not fully thread-safe in all contexts, causing database locking issues when used with Gunicorn's default gthread worker class. This change configures docker-compose-light.yml to use multiple sync workers (8) with single threading (1 thread per worker) instead of the default threaded configuration to prevent database conflicts.

