### PR TITLE
fix(docker): remove --with-threads from remaining dev workflows for DuckDB compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ js-format:
 	cd superset-frontend; npm run prettier
 
 flask-app:
-	flask run -p 8088 --with-threads --reload --debugger
+	flask run -p 8088 --reload --debugger
 
 node-app:
 	cd superset-frontend; npm run dev-server

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -116,7 +116,7 @@ services:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
       POSTGRES_DB: superset_light
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
 
   superset-init-light:
@@ -137,7 +137,7 @@ services:
       DATABASE_HOST: db-light
       DATABASE_DB: superset_light
       POSTGRES_DB: superset_light
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
     healthcheck:
       disable: true
@@ -191,7 +191,7 @@ services:
       DATABASE_DB: test
       POSTGRES_DB: test
       SUPERSET__SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@db-light:5432/test
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
       SUPERSET_CONFIG: superset_test_config_light
       PYTHONPATH: /app/pythonpath:/app/docker/pythonpath_dev:/app
 

--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -118,11 +118,6 @@ services:
       POSTGRES_DB: superset_light
       SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
       SUPERSET_CONFIG_PATH: /app/docker/pythonpath_dev/superset_config_docker_light.py
-      # DuckDB concurrency configuration: DuckDB examples database uses read-only mode
-      # to allow concurrent access from multiple workers/threads without file locking issues
-      # SERVER_WORKER_AMOUNT: 8
-      # SERVER_THREADS_AMOUNT: 1
-      # SERVER_WORKER_CLASS: sync
 
   superset-init-light:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
         condition: service_completed_successfully
     volumes: *superset-volumes
     environment:
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
 
   superset-websocket:
     container_name: superset_websocket
@@ -162,7 +162,7 @@ services:
     user: *superset-user
     volumes: *superset-volumes
     environment:
-      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb?access_mode=read_only"
+      SUPERSET__SQLALCHEMY_EXAMPLES_URI: "duckdb:////app/data/examples.duckdb"
     healthcheck:
       disable: true
 

--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -72,7 +72,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --with-threads --reload --debugger --host=0.0.0.0
+    flask run -p $PORT --reload --debugger --host=0.0.0.0
     ;;
   app-gunicorn)
     echo "Starting web app..."


### PR DESCRIPTION
Follow-up to #34831 and #34848 - completing the threading removal for DuckDB compatibility. Removes --with-threads from Makefile flask-app target and docker-bootstrap.sh, and cleans up unused gunicorn env vars in docker-compose-light.yml since it uses flask dev server, not gunicorn.

