### PR TITLE
ci: Add Python 3.12 images to Docker Hub 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - id: set_matrix
         run: |
-          MATRIX_CONFIG=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo '["dev", "lean"]'; else echo '["dev", "lean", "py310", "websocket", "dockerize", "py311"]'; fi)
+          MATRIX_CONFIG=$(if [ "${{ github.event_name }}" == "pull_request" ]; then echo '["dev", "lean"]'; else echo '["dev", "lean", "py310", "websocket", "dockerize", "py311", "py312"]'; fi)
           echo "matrix_config=${MATRIX_CONFIG}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        build_preset: ["dev", "lean", "py310", "websocket", "dockerize", "py311"]
+        build_preset: ["dev", "lean", "py310", "websocket", "dockerize", "py311", "py312"]
       fail-fast: false
     steps:
 


### PR DESCRIPTION
SUMMARY

The aim of this PR is to add python 3.12 images to Docker Hub. Replicates https://github.com/apache/superset/pull/30733

Please merge https://github.com/apache-superset/supersetbot/pull/6 before merging this