### PR TITLE
fix: DB icon sizes in database add modal

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/IconButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/IconButton/index.tsx
@@ -50,17 +50,7 @@ const IconButton: React.FC<IconButtonProps> = ({
   };
 
   const renderIcon = () => {
-    const iconContent = icon ? (
-      <img
-        src={icon as string}
-        alt={altText || buttonText}
-        css={css`
-          width: 100%;
-          object-fit: contain;
-          height: 100px;
-        `}
-      />
-    ) : (
+    const iconContent = (
       <div
         css={css`
           display: flex;
@@ -69,12 +59,19 @@ const IconButton: React.FC<IconButtonProps> = ({
           height: 100px;
         `}
       >
-        <Icons.DatabaseOutlined
-          css={css`
-            font-size: 48px;
-          `}
-          aria-label="default-icon"
-        />
+        {icon ? (
+          <img
+            src={icon as string}
+            alt={altText || buttonText}
+            css={css`
+              width: 100%;
+              object-fit: contain;
+              height: 48px;
+            `}
+          />
+        ) : (
+          <Icons.DatabaseOutlined iconSize="xxl" aria-label="default-icon" />
+        )}
       </div>
     );
 


### PR DESCRIPTION
### SUMMARY
In database add modal, the database add images are very big, while the placeholder icons are small. This PR adjusts the sizes so that it looks more consistent

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1728" height="880" alt="image" src="https://github.com/user-attachments/assets/fdfd3b16-f141-4abb-83e0-194d7315e9b2" />

After:

<img width="1726" height="874" alt="image" src="https://github.com/user-attachments/assets/158524a3-5eeb-49ab-a29c-bc28729eca98" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
