### PR TITLE
fix: Remove the underline from the right section of main menu

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -683,6 +683,12 @@ const RightMenu = ({
           flex-direction: row;
           align-items: center;
 
+          /* Remove the underline from menu items */
+          .ant-menu-item:after,
+          .ant-menu-submenu:after {
+            content: none !important;
+          }
+
           .submenu-with-caret {
             padding: 0 ${theme.sizeUnit}px;
             .ant-menu-submenu-title {


### PR DESCRIPTION
### SUMMARY
Remove the underline from the right section of main menu - there shouldn't be an underline under menu items like the theme setter or the "+" icon.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="319" height="88" alt="image" src="https://github.com/user-attachments/assets/95da6796-3ebd-45da-98f3-5d298c97032b" />

After:

<img width="317" height="79" alt="image" src="https://github.com/user-attachments/assets/99009e01-3190-4722-b832-44fd0b5a58db" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
