### PR TITLE
chore: standardize DB engine spec queries

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1670,14 +1670,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
     @classmethod
     def estimate_statement_cost(
-        cls, database: Database, statement: str, cursor: Any
+        cls, database: Database, statement: str
     ) -> dict[str, Any]:
         """
         Generate a SQL query that estimates the cost of a given statement.
 
         :param database: A Database object
         :param statement: A single SQL statement
-        :param cursor: Cursor instance
         :return: Dictionary with different costs
         """
         raise Exception(  # pylint: disable=broad-exception-raised
@@ -1738,20 +1737,13 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         parsed_script = SQLScript(sql, engine=cls.engine)
 
-        with database.get_raw_connection(
-            catalog=catalog,
-            schema=schema,
-            source=source,
-        ) as conn:
-            cursor = conn.cursor()
-            return [
-                cls.estimate_statement_cost(
-                    database,
-                    cls.process_statement(statement, database),
-                    cursor,
-                )
-                for statement in parsed_script.statements
-            ]
+        return [
+            cls.estimate_statement_cost(
+                database,
+                cls.process_statement(statement, database),
+            )
+            for statement in parsed_script.statements
+        ]
 
     @classmethod
     def impersonate_user(

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1855,6 +1855,39 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             raise cls.get_dbapi_mapped_exception(ex) from ex
 
     @classmethod
+    def execute_metadata_query(
+        cls,
+        database: Database,
+        query: str,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> list[tuple[Any, ...]]:
+        """
+        Standardized method for executing metadata queries.
+
+        This method provides a unified interface for all metadata query operations
+        across different database engines using SQLAlchemy connections.
+
+        For single-row results, add "LIMIT 1" to your query rather than using
+        separate fetch parameters.
+
+        :param database: Database instance
+        :param query: SQL query to execute for metadata
+        :param catalog: Optional catalog/database name
+        :param schema: Optional schema name
+        :return: Query results as list of tuples
+        """
+        with cls.get_engine(
+            database,
+            catalog=catalog,
+            schema=schema,
+            source=utils.QuerySource.METADATA,
+        ) as engine:
+            with engine.connect() as conn:
+                result = conn.execute(text(query))
+                return result.fetchall()
+
+    @classmethod
     def needs_oauth2(cls, ex: Exception) -> bool:
         """
         Check if the exception is one that indicates OAuth2 is needed.

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -331,9 +331,11 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         )
 
         # Build the query
-        query = select(
-            func.max(partitions_table.c.partition_id).label("max_partition_id")
-        ).where(partitions_table.c.table_name == table.table).limit(1)
+        query = (
+            select(func.max(partitions_table.c.partition_id).label("max_partition_id"))
+            .where(partitions_table.c.table_name == table.table)
+            .limit(1)
+        )
 
         # Compile to BigQuery SQL
         compiled_query = query.compile(

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -344,13 +344,13 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         )
 
         # Run the query and handle result
-        results = cls.execute_metadata_query(
+        result = cls.execute_metadata_query(
             database,
             str(compiled_query),
             catalog=table.catalog,
             schema=table.schema,
         )
-        return results[0][0] if results else None
+        return result.scalar()
 
     @classmethod
     def get_time_partition_column(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -503,12 +503,13 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         if default_catalog := connect_args.get("catalog"):
             return default_catalog
 
-        with database.get_sqla_engine() as engine:
-            catalogs = {catalog for (catalog,) in engine.execute("SHOW CATALOGS")}
-            if len(catalogs) == 1:
-                return catalogs.pop()
+        result = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        catalogs = {catalog for (catalog,) in result}
+        if len(catalogs) == 1:
+            return catalogs.pop()
 
-            return engine.execute("SELECT current_catalog()").scalar()
+        result = cls.execute_metadata_query(database, "SELECT current_catalog()")
+        return result.scalar()
 
     @classmethod
     def get_prequeries(

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -532,7 +532,8 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         database: Database,
         inspector: Inspector,
     ) -> set[str]:
-        return {catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")}
+        results = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        return {catalog for (catalog,) in results}
 
 
 class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
@@ -624,7 +625,8 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
         database: Database,
         inspector: Inspector,
     ) -> set[str]:
-        return {catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")}
+        results = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        return {catalog for (catalog,) in results}
 
     @classmethod
     def adjust_engine_params(

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -297,8 +297,8 @@ class DorisEngineSpec(MySQLEngineSpec):
         CatalogId, CatalogName, Type, IsCurrent, CreateTime, LastUpdateTime, Comment
         We need to extract just the CatalogName column.
         """
-        result = inspector.bind.execute("SHOW CATALOGS")
-        return {row.CatalogName for row in result}
+        results = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        return {row.CatalogName for row in results}
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -298,7 +298,7 @@ class DorisEngineSpec(MySQLEngineSpec):
         We need to extract just the CatalogName column.
         """
         results = cls.execute_metadata_query(database, "SHOW CATALOGS")
-        return {row.CatalogName for row in results}
+        return {row[0] for row in results}
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -298,7 +298,7 @@ class DorisEngineSpec(MySQLEngineSpec):
         We need to extract just the CatalogName column.
         """
         results = cls.execute_metadata_query(database, "SHOW CATALOGS")
-        return {row[0] for row in results}
+        return {row.CatalogName for row in results}
 
     @classmethod
     def get_schema_from_engine_params(

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -388,9 +388,8 @@ class MotherDuckEngineSpec(DuckDBEngineSpec):
         database: Database,
         inspector: Inspector,
     ) -> set[str]:
-        return {
-            catalog
-            for (catalog,) in inspector.bind.execute(
-                "SELECT alias FROM MD_ALL_DATABASES() WHERE is_attached;"
-            )
-        }
+        results = cls.execute_metadata_query(
+            database,
+            "SELECT alias FROM MD_ALL_DATABASES() WHERE is_attached;",
+        )
+        return {catalog for (catalog,) in results}

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -154,12 +154,13 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         database: Database,
         table: Table,
     ) -> dict[str, Any]:
-        results_list = cls.execute_metadata_query(
+        result = cls.execute_metadata_query(
             database,
             f'SELECT GET_METADATA("{table.table}") LIMIT 1',
             catalog=table.catalog,
             schema=table.schema,
         )
+        results_list = result.fetchall()
         results = results_list[0][0] if results_list else None
         try:
             metadata = json.loads(results) if results else {}

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -154,13 +154,13 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         database: Database,
         table: Table,
     ) -> dict[str, Any]:
-        with database.get_raw_connection(
+        results_list = cls.execute_metadata_query(
+            database,
+            f'SELECT GET_METADATA("{table.table}") LIMIT 1',
             catalog=table.catalog,
             schema=table.schema,
-        ) as conn:
-            cursor = conn.cursor()
-            cursor.execute(f'SELECT GET_METADATA("{table.table}")')
-            results = cursor.fetchone()[0]
+        )
+        results = results_list[0][0] if results_list else None
         try:
             metadata = json.loads(results)
         except Exception:  # pylint: disable=broad-except

--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -162,7 +162,7 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         )
         results = results_list[0][0] if results_list else None
         try:
-            metadata = json.loads(results)
+            metadata = json.loads(results) if results else {}
         except Exception:  # pylint: disable=broad-except
             metadata = {}
 

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -614,9 +614,9 @@ class HiveEngineSpec(PrestoEngineSpec):
         if schema:
             sql += f" IN `{schema}`"
 
-        results = cls.execute_metadata_query(
+        result = cls.execute_metadata_query(
             database,
             sql,
             schema=schema,
         )
-        return {row[0] for row in results}
+        return {row[0] for row in result}

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -614,8 +614,9 @@ class HiveEngineSpec(PrestoEngineSpec):
         if schema:
             sql += f" IN `{schema}`"
 
-        with database.get_raw_connection(schema=schema) as conn:
-            cursor = conn.cursor()
-            cursor.execute(sql)
-            results = cursor.fetchall()
-            return {row[0] for row in results}
+        results = cls.execute_metadata_query(
+            database,
+            sql,
+            schema=schema,
+        )
+        return {row[0] for row in results}

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -78,8 +78,6 @@ class ImpalaEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_schema_names(cls, inspector: Inspector) -> set[str]:
-        # Note: This method can't use execute_metadata_query since it doesn't receive database parameter
-        # TODO: Update when base class method signature is changed to include database parameter
         return {
             row[0]
             for row in inspector.engine.execute("SHOW SCHEMAS")

--- a/superset/db_engine_specs/impala.py
+++ b/superset/db_engine_specs/impala.py
@@ -78,6 +78,8 @@ class ImpalaEngineSpec(BaseEngineSpec):
 
     @classmethod
     def get_schema_names(cls, inspector: Inspector) -> set[str]:
+        # Note: This method can't use execute_metadata_query since it doesn't receive database parameter
+        # TODO: Update when base class method signature is changed to include database parameter
         return {
             row[0]
             for row in inspector.engine.execute("SHOW SCHEMAS")

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -393,15 +393,14 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
 
         In Postgres, a catalog is called a "database".
         """
-        return {
-            catalog
-            for (catalog,) in inspector.bind.execute(
-                """
+        results = cls.execute_metadata_query(
+            database,
+            """
 SELECT datname FROM pg_database
 WHERE datistemplate = false;
-            """
-            )
-        }
+            """,
+        )
+        return {catalog for (catalog,) in results}
 
     @classmethod
     def get_table_names(

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -364,7 +364,8 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
         """
         sql = f"EXPLAIN {statement} LIMIT 1"
         results = cls.execute_metadata_query(database, sql)
-        result = results[0][0] if results else ""
+        rows = results.fetchall()
+        result = rows[0][0] if rows else ""
         match = re.search(r"cost=([\d\.]+)\.\.([\d\.]+)", result)
         if match:
             return {

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -354,19 +354,17 @@ class PostgresEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
 
     @classmethod
     def estimate_statement_cost(
-        cls, database: Database, statement: str, cursor: Any
+        cls, database: Database, statement: str
     ) -> dict[str, Any]:
         """
         Run a SQL query that estimates the cost of a given statement.
         :param database: A Database object
         :param statement: A single SQL statement
-        :param cursor: Cursor instance
-        :return: JSON response from Trino
+        :return: Cost estimate dictionary
         """
-        sql = f"EXPLAIN {statement}"
-        cursor.execute(sql)
-
-        result = cursor.fetchone()[0]
+        sql = f"EXPLAIN {statement} LIMIT 1"
+        results = cls.execute_metadata_query(database, sql)
+        result = results[0][0] if results else ""
         match = re.search(r"cost=([\d\.]+)\.\.([\d\.]+)", result)
         if match:
             return {

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -321,7 +321,8 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         """
         Get all catalogs.
         """
-        return {catalog for (catalog,) in inspector.bind.execute("SHOW CATALOGS")}
+        results = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        return {catalog for (catalog,) in results}
 
     @classmethod
     def adjust_engine_params(

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -321,8 +321,8 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
         """
         Get all catalogs.
         """
-        results = cls.execute_metadata_query(database, "SHOW CATALOGS")
-        return {catalog for (catalog,) in results}
+        result = cls.execute_metadata_query(database, "SHOW CATALOGS")
+        return {catalog for (catalog,) in result}
 
     @classmethod
     def adjust_engine_params(

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -209,12 +209,11 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
 
         In Snowflake, a catalog is called a "database".
         """
-        return {
-            catalog
-            for (catalog,) in inspector.bind.execute(
-                "SELECT DATABASE_NAME from information_schema.databases"
-            )
-        }
+        results = cls.execute_metadata_query(
+            database,
+            "SELECT DATABASE_NAME from information_schema.databases",
+        )
+        return {catalog for (catalog,) in results}
 
     @classmethod
     def epoch_to_dttm(cls) -> str:

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -320,6 +320,7 @@ class QuerySource(Enum):
     CHART = 0
     DASHBOARD = 1
     SQL_LAB = 2
+    METADATA = 3
 
 
 class QueryStatus(StrEnum):

--- a/tests/integration_tests/db_engine_specs/postgres_tests.py
+++ b/tests/integration_tests/db_engine_specs/postgres_tests.py
@@ -158,9 +158,12 @@ class TestPostgresDbEngineSpec(SupersetTestCase):
         with mock.patch.object(
             PostgresEngineSpec, "execute_metadata_query"
         ) as mock_execute:
-            mock_execute.return_value = [
+            mock_result = mock.Mock()
+            expected_results = [
                 ("Seq Scan on birth_names (cost=0.00..1537.91 rows=75691 width=46)",)
             ]
+            mock_result.fetchall.return_value = expected_results
+            mock_execute.return_value = mock_result
             results = PostgresEngineSpec.estimate_statement_cost(database, sql)
 
         assert results == {"Start-up cost": 0.0, "Total cost": 1537.91}

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -938,7 +938,9 @@ class TestPrestoDbEngineSpec(SupersetTestCase):
         with mock.patch.object(
             PrestoEngineSpec, "execute_metadata_query"
         ) as mock_execute:
-            mock_execute.return_value = [('{"a": "b"}',)]
+            mock_result = mock.Mock()
+            mock_result.scalar.return_value = '{"a": "b"}'
+            mock_execute.return_value = mock_result
             result = PrestoEngineSpec.estimate_statement_cost(mock_database, sql)
 
         assert result == estimate_json

--- a/tests/integration_tests/db_engine_specs/presto_tests.py
+++ b/tests/integration_tests/db_engine_specs/presto_tests.py
@@ -1215,10 +1215,10 @@ def test_get_catalog_names(app_context: AppContext) -> None:
         return
 
     with database.get_inspector() as inspector:
-        assert PrestoEngineSpec.get_catalog_names(database, inspector) == [
+        assert PrestoEngineSpec.get_catalog_names(database, inspector) == {
             "jmx",
             "memory",
             "system",
             "tpcds",
             "tpch",
-        ]
+        }

--- a/tests/unit_tests/commands/databases/conftest.py
+++ b/tests/unit_tests/commands/databases/conftest.py
@@ -44,10 +44,10 @@ def database_with_catalog(mocker: MockerFixture) -> MagicMock:
     database.database_name = "my_db"
     database.db_engine_spec.__name__ = "test_engine"
     database.db_engine_spec.supports_catalog = True
-    database.get_all_catalog_names.return_value = ["catalog1", "catalog2"]
+    database.get_all_catalog_names.return_value = {"catalog1", "catalog2"}
     database.get_all_schema_names.side_effect = [
-        ["schema1", "schema2"],
-        ["schema3", "schema4"],
+        {"schema1", "schema2"},
+        {"schema3", "schema4"},
     ]
     database.get_default_catalog.return_value = "catalog2"
 
@@ -63,7 +63,7 @@ def database_without_catalog(mocker: MockerFixture) -> MagicMock:
     database.database_name = "my_db"
     database.db_engine_spec.__name__ = "test_engine"
     database.db_engine_spec.supports_catalog = False
-    database.get_all_schema_names.return_value = ["schema1", "schema2"]
+    database.get_all_schema_names.return_value = {"schema1", "schema2"}
     database.is_oauth2_enabled.return_value = False
     database.db_engine_spec.needs_oauth2.return_value = False
 

--- a/tests/unit_tests/commands/databases/sync_permissions_test.py
+++ b/tests/unit_tests/commands/databases/sync_permissions_test.py
@@ -69,23 +69,24 @@ def test_sync_permissions_command_sync_mode(
     add_pvm_mock.assert_has_calls(
         [
             mocker.call(
-                db.session, security_manager, "catalog_access", "[my_db].[catalog2]"
+                db.session, security_manager, "catalog_access", "[my_db].[catalog1]"
             ),
             mocker.call(
                 db.session,
                 security_manager,
                 "schema_access",
-                "[my_db].[catalog2].[schema3]",
+                "[my_db].[catalog1].[schema3]",
             ),
             mocker.call(
                 db.session,
                 security_manager,
                 "schema_access",
-                "[my_db].[catalog2].[schema4]",
+                "[my_db].[catalog1].[schema4]",
             ),
-        ]
+        ],
+        any_order=True,
     )
-    mock_refresh_schemas.assert_called_once_with("catalog1", ["schema1", "schema2"])
+    mock_refresh_schemas.assert_called_once_with("catalog2", {"schema1", "schema2"})
     mock_rename_db_perm.assert_not_called()
 
 
@@ -246,7 +247,7 @@ def test_sync_permissions_command_get_catalogs(database_with_catalog: MagicMock)
     Test the ``_get_catalog_names`` method.
     """
     cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
-    assert cmmd._get_catalog_names() == ["catalog1", "catalog2"]
+    assert cmmd._get_catalog_names() == {"catalog1", "catalog2"}
 
 
 def test_sync_permissions_command_get_default_catalog(database_with_catalog: MagicMock):
@@ -263,7 +264,7 @@ def test_sync_permissions_command_get_default_catalog(database_with_catalog: Mag
 
     database_with_catalog.allow_multi_catalog = True
     cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
-    assert cmmd._get_catalog_names() == ["catalog1", "catalog2"]
+    assert cmmd._get_catalog_names() == {"catalog1", "catalog2"}
 
 
 @pytest.mark.parametrize(
@@ -295,8 +296,8 @@ def test_sync_permissions_command_get_schemas(database_with_catalog: MagicMock):
     Test the ``_get_schema_names`` method.
     """
     cmmd = SyncPermissionsCommand(1, None, db_connection=database_with_catalog)
-    assert cmmd._get_schema_names("catalog1") == ["schema1", "schema2"]
-    assert cmmd._get_schema_names("catalog2") == ["schema3", "schema4"]
+    assert cmmd._get_schema_names("catalog1") == {"schema1", "schema2"}
+    assert cmmd._get_schema_names("catalog2") == {"schema3", "schema4"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/db_engine_specs/test_base_metadata.py
+++ b/tests/unit_tests/db_engine_specs/test_base_metadata.py
@@ -1,0 +1,183 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import mock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from superset.db_engine_specs.base import BaseEngineSpec
+from superset.utils.core import QuerySource
+from tests.integration_tests.base_tests import SupersetTestCase
+
+
+class TestBaseEngineSpecMetadata(SupersetTestCase):
+    @mock.patch.object(BaseEngineSpec, "get_engine")
+    def test_execute_metadata_query_basic(self, mock_get_engine):
+        """Test basic metadata query execution"""
+        database = mock.Mock()
+        mock_engine = mock.Mock()
+        mock_connection = mock.Mock()
+        mock_result = mock.Mock()
+
+        # Setup mock chain
+        mock_get_engine.return_value.__enter__ = mock.Mock(return_value=mock_engine)
+        mock_get_engine.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_connection
+        )
+        mock_engine.connect.return_value.__exit__ = mock.Mock(return_value=None)
+
+        expected_results = [("catalog1",), ("catalog2",)]
+        mock_result.fetchall.return_value = expected_results
+        mock_connection.execute.return_value = mock_result
+
+        # Execute the method
+        query = "SHOW CATALOGS"
+        results = BaseEngineSpec.execute_metadata_query(database, query)
+
+        # Verify results
+        assert results == expected_results
+
+        # Verify call chain
+        mock_get_engine.assert_called_once_with(
+            database, catalog=None, schema=None, source=QuerySource.METADATA
+        )
+        mock_connection.execute.assert_called_once()
+        executed_query = mock_connection.execute.call_args[0][0]
+        assert str(executed_query) == query
+
+    @mock.patch.object(BaseEngineSpec, "get_engine")
+    def test_execute_metadata_query_with_catalog_schema(self, mock_get_engine):
+        """Test metadata query with catalog and schema parameters"""
+        database = mock.Mock()
+        mock_engine = mock.Mock()
+        mock_connection = mock.Mock()
+        mock_result = mock.Mock()
+
+        # Setup mock chain
+        mock_get_engine.return_value.__enter__ = mock.Mock(return_value=mock_engine)
+        mock_get_engine.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_connection
+        )
+        mock_engine.connect.return_value.__exit__ = mock.Mock(return_value=None)
+
+        expected_results = [("table1",), ("table2",)]
+        mock_result.fetchall.return_value = expected_results
+        mock_connection.execute.return_value = mock_result
+
+        # Execute with catalog and schema
+        query = "SHOW TABLES"
+        catalog = "my_catalog"
+        schema = "my_schema"
+        results = BaseEngineSpec.execute_metadata_query(
+            database, query, catalog=catalog, schema=schema
+        )
+
+        # Verify results
+        assert results == expected_results
+
+        # Verify catalog and schema were passed to get_engine
+        mock_get_engine.assert_called_once_with(
+            database, catalog=catalog, schema=schema, source=QuerySource.METADATA
+        )
+
+    @mock.patch.object(BaseEngineSpec, "get_engine")
+    def test_execute_metadata_query_uses_correct_query_source(self, mock_get_engine):
+        """Test that QuerySource.METADATA is used correctly"""
+        database = mock.Mock()
+        mock_engine = mock.Mock()
+        mock_connection = mock.Mock()
+        mock_result = mock.Mock()
+
+        # Setup mock chain
+        mock_get_engine.return_value.__enter__ = mock.Mock(return_value=mock_engine)
+        mock_get_engine.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_connection
+        )
+        mock_engine.connect.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        # Execute the method
+        BaseEngineSpec.execute_metadata_query(database, "SELECT 1")
+
+        # Verify QuerySource.METADATA was used
+        mock_get_engine.assert_called_once_with(
+            database, catalog=None, schema=None, source=QuerySource.METADATA
+        )
+
+    @mock.patch.object(BaseEngineSpec, "get_engine")
+    def test_execute_metadata_query_handles_sql_error(self, mock_get_engine):
+        """Test proper exception handling for SQL errors"""
+        database = mock.Mock()
+        mock_engine = mock.Mock()
+        mock_connection = mock.Mock()
+
+        # Setup mock chain
+        mock_get_engine.return_value.__enter__ = mock.Mock(return_value=mock_engine)
+        mock_get_engine.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_connection
+        )
+        mock_engine.connect.return_value.__exit__ = mock.Mock(return_value=None)
+
+        # Mock connection to raise SQLAlchemyError
+        mock_connection.execute.side_effect = SQLAlchemyError("Database error")
+
+        # Execute and verify exception is propagated
+        with pytest.raises(SQLAlchemyError):
+            BaseEngineSpec.execute_metadata_query(database, "INVALID QUERY")
+
+    @mock.patch.object(BaseEngineSpec, "get_engine")
+    def test_execute_metadata_query_empty_results(self, mock_get_engine):
+        """Test handling of queries that return no results"""
+        database = mock.Mock()
+        mock_engine = mock.Mock()
+        mock_connection = mock.Mock()
+        mock_result = mock.Mock()
+
+        # Setup mock chain
+        mock_get_engine.return_value.__enter__ = mock.Mock(return_value=mock_engine)
+        mock_get_engine.return_value.__exit__ = mock.Mock(return_value=None)
+
+        mock_engine.connect.return_value.__enter__ = mock.Mock(
+            return_value=mock_connection
+        )
+        mock_engine.connect.return_value.__exit__ = mock.Mock(return_value=None)
+
+        # Empty results
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        # Execute the method
+        results = BaseEngineSpec.execute_metadata_query(database, "SELECT 1 WHERE 1=0")
+
+        # Verify empty results are handled correctly
+        assert results == []
+
+    def test_execute_metadata_query_query_source_enum_value(self):
+        """Test QuerySource.METADATA enum has correct value"""
+        # This is a simple enum test that doesn't require complex mocking
+        assert QuerySource.METADATA.value == 3
+        assert QuerySource.METADATA.name == "METADATA"

--- a/tests/unit_tests/utils/test_core.py
+++ b/tests/unit_tests/utils/test_core.py
@@ -1122,3 +1122,21 @@ def test_get_stacktrace():
     except Exception:
         stacktrace = get_stacktrace()
         assert stacktrace is None
+
+
+def test_query_source_metadata_enum():
+    """Test that QuerySource.METADATA enum value exists and has correct value"""
+    assert hasattr(QuerySource, "METADATA")
+    assert QuerySource.METADATA.value == 3
+    assert QuerySource.METADATA.name == "METADATA"
+
+    # Verify all expected QuerySource values
+    expected_sources = {
+        QuerySource.CHART: 0,
+        QuerySource.DASHBOARD: 1,
+        QuerySource.SQL_LAB: 2,
+        QuerySource.METADATA: 3,
+    }
+
+    for source, expected_value in expected_sources.items():
+        assert source.value == expected_value


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds a class method called `execute_metadata_query` to the base DB engine spec, to be used when DB engine specs need to run introspection/metadata queries. It replaces all the different ways this is done in DB engine specs today (some use the engine, some use the inspector bind, some use a raw connection).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
