### PR TITLE
fix: Undefined error when viewing query in Explore + visual fixes

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
@@ -76,6 +76,7 @@ const ViewQueryModalFooter: FC<ViewQueryModalFooterProps> = (props: {
   return (
     <div>
       <Button
+        buttonStyle="secondary"
         onClick={() => {
           props?.closeModal?.();
           props?.changeDatasource?.();
@@ -83,11 +84,13 @@ const ViewQueryModalFooter: FC<ViewQueryModalFooterProps> = (props: {
       >
         {SAVE_AS_DATASET}
       </Button>
-      <Button onClick={({ metaKey }) => openSQL(Boolean(metaKey))}>
+      <Button
+        buttonStyle="secondary"
+        onClick={({ metaKey }) => openSQL(Boolean(metaKey))}
+      >
         {OPEN_IN_SQL_LAB}
       </Button>
       <Button
-        buttonStyle="primary"
         onClick={() => {
           props?.closeModal?.();
         }}

--- a/superset-frontend/src/features/queries/QueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/QueryPreviewModal.tsx
@@ -40,11 +40,10 @@ const QueryLabel = styled.div`
 `;
 
 const QueryViewToggle = styled.div`
-  margin: 0 0 ${({ theme }) => theme.sizeUnit * 6}px 0;
+  display: flex;
 `;
 
 const TabButton = styled.div`
-  display: inline;
   font-size: ${({ theme }) => theme.fontSizeSM}px;
   padding: ${({ theme }) => theme.sizeUnit * 2}px
     ${({ theme }) => theme.sizeUnit * 4}px;
@@ -55,9 +54,7 @@ const TabButton = styled.div`
   &:focus,
   &:hover {
     background: ${({ theme }) => theme.colorPrimaryBg};
-    border-bottom: none;
     border-radius: ${({ theme }) => theme.borderRadius}px;
-    margin-bottom: ${({ theme }) => theme.sizeUnit * 2}px;
   }
 
   &:hover:not(.active) {
@@ -110,6 +107,7 @@ function QueryPreviewModal({
             <Button
               data-test="previous-query"
               key="previous-query"
+              buttonStyle="secondary"
               disabled={disablePrevious}
               onClick={() => handleDataChange(true)}
             >
@@ -118,6 +116,7 @@ function QueryPreviewModal({
             <Button
               data-test="next-query"
               key="next-query"
+              buttonStyle="secondary"
               disabled={disableNext}
               onClick={() => handleDataChange(false)}
             >
@@ -126,7 +125,6 @@ function QueryPreviewModal({
             <Button
               data-test="open-in-sql-lab"
               key="open-in-sql-lab"
-              buttonStyle="primary"
               onClick={() => openInSqlLab(id)}
             >
               {t('Open in SQL Lab')}

--- a/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
+++ b/superset-frontend/src/features/queries/SavedQueryPreviewModal.tsx
@@ -34,7 +34,7 @@ const QueryTitle = styled.div`
 const QueryLabel = styled.div`
   color: ${({ theme }) => theme.colorTextLabel};
   font-size: ${({ theme }) => theme.fontSize}px;
-  padding: 4px 0 16px 0;
+  padding-top: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const StyledModal = styled(Modal)`
@@ -89,6 +89,7 @@ const SavedQueryPreviewModal: FunctionComponent<
             <Button
               data-test="previous-saved-query"
               key="previous-saved-query"
+              buttonStyle="secondary"
               disabled={disablePrevious}
               onClick={() => handleDataChange(true)}
             >
@@ -97,6 +98,7 @@ const SavedQueryPreviewModal: FunctionComponent<
             <Button
               data-test="next-saved-query"
               key="next-saved-query"
+              buttonStyle="secondary"
               disabled={disableNext}
               onClick={() => handleDataChange(false)}
             >
@@ -105,7 +107,6 @@ const SavedQueryPreviewModal: FunctionComponent<
             <Button
               data-test="open-in-sql-lab"
               key="open-in-sql-lab"
-              buttonStyle="primary"
               onClick={({ metaKey }) =>
                 openInSqlLab(savedQuery.id, Boolean(metaKey))
               }

--- a/superset-frontend/src/features/queries/SyntaxHighlighterCopy.tsx
+++ b/superset-frontend/src/features/queries/SyntaxHighlighterCopy.tsx
@@ -29,7 +29,6 @@ import copyTextToClipboard from 'src/utils/copy';
 
 const SyntaxHighlighterWrapper = styled.div`
   position: relative;
-  margin-top: -24px;
 
   &:hover {
     .copy-button {

--- a/superset-frontend/src/pages/QueryHistoryList/index.tsx
+++ b/superset-frontend/src/pages/QueryHistoryList/index.tsx
@@ -190,7 +190,7 @@ function QueryList({ addDangerToast }: QueryListProps) {
           ) {
             statusConfig.name = (
               <Icons.CloseOutlined
-                iconSize="xs"
+                iconSize="m"
                 iconColor={
                   status === QueryState.Failed
                     ? theme.colorError
@@ -201,19 +201,22 @@ function QueryList({ addDangerToast }: QueryListProps) {
             statusConfig.label = t('Failed');
           } else if (status === QueryState.Running) {
             statusConfig.name = (
-              <Icons.Running iconColor={theme.colorPrimary} />
+              <Icons.LoadingOutlined
+                iconSize="m"
+                iconColor={theme.colorPrimary}
+              />
             );
             statusConfig.label = t('Running');
           } else if (status === QueryState.TimedOut) {
             statusConfig.name = (
-              <Icons.CircleSolid iconColor={theme.colorIcon} />
+              <Icons.CircleSolid iconSize="m" iconColor={theme.colorIcon} />
             );
             statusConfig.label = t('Offline');
           } else if (
             status === QueryState.Scheduled ||
             status === QueryState.Pending
           ) {
-            statusConfig.name = <Icons.Queued />;
+            statusConfig.name = <Icons.Queued iconSize="m" />;
             statusConfig.label = t('Scheduled');
           }
           return (


### PR DESCRIPTION

### SUMMARY
1. Undefined error when creating a chart from a query
When you run a query in SQL Lab and click "Create chart", the query is used as a datasource in Explore. Then when you click on "Query preview" in datasource control menu (on the left side), the control crashes with undefined error. Even if it didn't crash, we'd see an infinite load for the formatted query, because we were trying to call the /dataset endpoint, passing the query's id as dataset's id, which of course might not exist. 
This PR refactors the logic of `ViewQuery` component by using the data already available in Redux and only calling /dataset when it's not available.

2. Visual fixes
- 3 primary buttons next to each others in query preview modals: in Explore, Saved Queries and Query History viewes
- Query Running/Failed icons in Query History view were very small
- Query Preview modal in Query History view had weird spacings and tabs were cut off at the bottom

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="376" height="734" alt="image" src="https://github.com/user-attachments/assets/9337c6a9-87ee-4746-ab0a-efc2197e8a67" />

<img width="83" height="776" alt="image" src="https://github.com/user-attachments/assets/ea8a1048-a902-4af7-b4d7-b2b601e1e764" />

<img width="758" height="484" alt="image" src="https://github.com/user-attachments/assets/f5a56ede-8c0e-421c-8fd1-5062a06b494e" />


After:

<img width="1719" height="853" alt="image" src="https://github.com/user-attachments/assets/93b5178a-050b-4fcb-9bc4-80b2da2d7480" />

<img width="114" height="725" alt="image" src="https://github.com/user-attachments/assets/773f9764-dc5f-46fb-956b-7899fd3f7223" />

<img width="702" height="500" alt="image" src="https://github.com/user-attachments/assets/bf97763f-7a28-4e6b-bf3c-799bc416fd4e" />


### TESTING INSTRUCTIONS
1. Run a valid query in SQL Lab
2. Click "Create chart"
3. In Explore, click on 3 dots next to datasource's name and click "Query Preview"
4. Verify that the modal opens, the query is displayed, the formatting works, and the formatting toggle works
5. Go to Query History page
6. Verify that the status icons on the left side have consistent sizes
7. Verify that Query preview modal has 2 secondary buttons and 1 primary button and the "User query"/"Executed query" buttons are not cut off

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
