### PR TITLE
fix(tests): Mock MessageChannel to prevent Jest hanging from rc-overflow

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,7 @@ This file documents any backwards-incompatible changes in Superset and
 assists people when migrating to a new version.
 
 ## Next
+- [34871](https://github.com/apache/superset/pull/34871): Fixed Jest test hanging issue from Ant Design v5 upgrade. MessageChannel is now mocked in test environment to prevent rc-overflow from causing Jest to hang. Test environment only - no production impact.
 - [34782](https://github.com/apache/superset/pull/34782): Dataset exports now include the dataset ID in their file name (similar to charts and dashboards). If managing assets as code, make sure to rename existing dataset YAMLs to include the ID (and avoid duplicated files).
 - [34536](https://github.com/apache/superset/pull/34536): The `ENVIRONMENT_TAG_CONFIG` color values have changed to support only Ant Design semantic colors. Update your `superset_config.py`:
   - Change `"error.base"` to just `"error"` after this PR

--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -765,6 +765,8 @@ If Jest tests hang with "Jest did not exit one second after the test run has com
 - Ant Design switches away from rc-overflow
 - We switch away from Ant Design v5
 
+**See**: [PR #34871](https://github.com/apache/superset/pull/34871) for full technical details.
+
 ### Debugging Server App
 
 #### Local

--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -747,6 +747,24 @@ To run a single test file:
 npm run test -- path/to/file.js
 ```
 
+#### Known Issues and Workarounds
+
+**Jest Test Hanging (MessageChannel Issue)**
+
+If Jest tests hang with "Jest did not exit one second after the test run has completed", this is likely due to the MessageChannel issue from rc-overflow (Ant Design v5 components).
+
+**Root Cause**: `rc-overflow@1.4.1` creates MessageChannel handles for responsive overflow detection that remain open after test completion.
+
+**Current Workaround**: MessageChannel is mocked as undefined in `spec/helpers/jsDomWithFetchAPI.ts`, forcing rc-overflow to use requestAnimationFrame fallback.
+
+**To verify if still needed**: Remove the MessageChannel mocking lines and run `npm test -- --shard=4/8`. If tests hang, the workaround is still required.
+
+**Future removal conditions**: This workaround can be removed when:
+- rc-overflow updates to properly clean up MessagePorts in test environments
+- Jest updates to handle MessageChannel/MessagePort cleanup better
+- Ant Design switches away from rc-overflow
+- We switch away from Ant Design v5
+
 ### Debugging Server App
 
 #### Local

--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -31,5 +31,34 @@ export default class FixJSDOMEnvironment extends JSDOMEnvironment {
     this.global.Response = Response;
     this.global.AbortSignal = AbortSignal;
     this.global.AbortController = AbortController;
+
+    // WORKAROUND: Mock MessageChannel to prevent Jest test hanging
+    // 
+    // Issue: rc-overflow@1.4.1 (used by Ant Design v5 components: Select, Menu, Picker)
+    // creates MessageChannel handles for responsive overflow detection that remain 
+    // open after test completion, causing Jest to hang with:
+    // "Jest did not exit one second after the test run has completed"
+    //
+    // Root Cause: Ant Design v5 upgrade (commit dd129fa40370c93da1d0d536be870a5f363364fb, PR #31590)
+    // introduced rc-overflow library which uses MessageChannel for micro-task scheduling
+    //
+    // Solution: Set MessageChannel to undefined forces rc-overflow to use its built-in
+    // requestAnimationFrame fallback, which Jest handles properly without hanging
+    //
+    // Impact: No functional test coverage loss - JSDOM can't test visual overflow anyway.
+    // All component logic (interactions, state, API calls) still tested normally.
+    //
+    // Future Removal Conditions:
+    // - rc-overflow updates to properly clean up MessagePorts in test environments
+    // - Jest updates to handle MessageChannel/MessagePort cleanup better  
+    // - Ant Design switches away from rc-overflow
+    // - We switch away from Ant Design v5
+    //
+    // To verify if still needed: Remove these lines and run `npm test -- --shard=4/8`
+    // If tests hang, the workaround is still required.
+    //
+    // Related: See PROJECT.md for full investigation details
+    this.global.MessageChannel = undefined as any;
+    this.global.MessagePort = undefined as any;
   }
 }

--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -36,7 +36,7 @@ export default class FixJSDOMEnvironment extends JSDOMEnvironment {
     // Forces rc-overflow to use requestAnimationFrame fallback instead
     // Can be removed when rc-overflow properly cleans up MessagePorts in test environments
     // See: https://github.com/apache/superset/pull/34871
-    this.global.MessageChannel = undefined as any;
-    this.global.MessagePort = undefined as any;
+    delete (this.global as any).MessageChannel;
+    delete (this.global as any).MessagePort;
   }
 }

--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -32,32 +32,10 @@ export default class FixJSDOMEnvironment extends JSDOMEnvironment {
     this.global.AbortSignal = AbortSignal;
     this.global.AbortController = AbortController;
 
-    // WORKAROUND: Mock MessageChannel to prevent Jest test hanging
-    // 
-    // Issue: rc-overflow@1.4.1 (used by Ant Design v5 components: Select, Menu, Picker)
-    // creates MessageChannel handles for responsive overflow detection that remain 
-    // open after test completion, causing Jest to hang with:
-    // "Jest did not exit one second after the test run has completed"
-    //
-    // Root Cause: Ant Design v5 upgrade (commit dd129fa40370c93da1d0d536be870a5f363364fb, PR #31590)
-    // introduced rc-overflow library which uses MessageChannel for micro-task scheduling
-    //
-    // Solution: Set MessageChannel to undefined forces rc-overflow to use its built-in
-    // requestAnimationFrame fallback, which Jest handles properly without hanging
-    //
-    // Impact: No functional test coverage loss - JSDOM can't test visual overflow anyway.
-    // All component logic (interactions, state, API calls) still tested normally.
-    //
-    // Future Removal Conditions:
-    // - rc-overflow updates to properly clean up MessagePorts in test environments
-    // - Jest updates to handle MessageChannel/MessagePort cleanup better  
-    // - Ant Design switches away from rc-overflow
-    // - We switch away from Ant Design v5
-    //
-    // To verify if still needed: Remove these lines and run `npm test -- --shard=4/8`
-    // If tests hang, the workaround is still required.
-    //
-    // Related: See PROJECT.md for full investigation details
+    // Mock MessageChannel to prevent hanging Jest tests with rc-overflow@1.4.1
+    // Forces rc-overflow to use requestAnimationFrame fallback instead
+    // Can be removed when rc-overflow properly cleans up MessagePorts in test environments
+    // See: https://github.com/apache/superset/pull/34871
     this.global.MessageChannel = undefined as any;
     this.global.MessagePort = undefined as any;
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes Jest test hanging issue where tests would hang indefinitely with "Jest did not exit one second after the test run has completed" error.

  **Root Cause**: `rc-overflow@1.4.1` (used by Ant Design v5 components:
   Select, Menu, Picker) creates MessageChannel handles for responsive overflow detection that remain open after test completion, causing Jest to hang.

  **Solution**: Mock MessageChannel as undefined in the Jest test environment (`spec/helpers/jsDomWithFetchAPI.ts`), forcing rc-overflow to use its built-in requestAnimationFrame fallback which Jest handles properly.

  **Why mocking is safe**:
  - MessageChannel is only used by rc-overflow for **visual overflow detection** (deciding when to show "More..." buttons)
  - **JSDOM cannot test visual overflow behavior** - it doesn't provide real layout dimensions or `getBoundingClientRect()` values
  - **We're not testing overflow functionality** - our unit tests focus on component logic, user interactions, and state management
  - **All functional test coverage preserved** - clicking, selecting, state changes, API calls still work normally
  - rc-overflow already has this fallback mechanism built-in for environments without MessageChannel

  **Impact**:
  - ✅ Fixes Jest hanging in shard 4 tests (ChartList, ControlPanelsContainer, SliceHeader, etc.)
  - ✅ Test environment only - no production impact
  - ✅ No loss of meaningful test coverage - visual overflow should be tested in E2E tests anyway

  **Documentation**:
  - Comprehensive code comments explaining root cause and removal conditions
  - Added "Known Issues and Workarounds" section to development documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before: 
When viewing results you'll see this in the comments:
> PASS packages/superset-ui-core/test/ui-overrides/ExtensionsRegistry.test.ts
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
jest-html-reporter >> Report generated (/app/superset-frontend/test-report.html)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
