### PR TITLE
fix(ui-core): Invalid postTransform process

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
@@ -1,0 +1,75 @@
+import { render, waitFor } from '@testing-library/react';
+
+import {
+  ChartPlugin,
+  ChartMetadata,
+  ChartProps,
+  DatasourceType,
+  getChartComponentRegistry,
+} from '@superset-ui/core';
+
+import SuperChartCore from './SuperChartCore';
+
+describe('processChartProps', () => {
+  const props = {
+    chartType: 'line',
+  };
+  const FakeChart = () => <span>test</span>;
+
+  beforeEach(() => {
+    const metadata = new ChartMetadata({
+      name: 'test-chart',
+      thumbnail: '',
+    });
+    const buildQuery = () => ({
+      datasource: { id: 1, type: DatasourceType.Table },
+      queries: [{ granularity: 'day' }],
+      force: false,
+      result_format: 'json',
+      result_type: 'full',
+    });
+    const controlPanel = { abc: 1 };
+    const plugin = new ChartPlugin({
+      metadata,
+      Chart: FakeChart,
+      buildQuery,
+      controlPanel,
+    });
+    plugin.configure({ key: props.chartType }).register();
+  });
+
+  test('should return the same result for identical inputs (cache hit)', async () => {
+    const pre = jest.fn(x => x);
+    const transform = jest.fn(x => x);
+    const post = jest.fn(x => x);
+    expect(getChartComponentRegistry().get(props.chartType)).toBe(FakeChart);
+
+    expect(pre).toHaveBeenCalledTimes(0);
+    const { rerender } = render(
+      <SuperChartCore
+        {...props}
+        preTransformProps={pre}
+        overrideTransformProps={transform}
+        postTransformProps={post}
+      />,
+    );
+
+    await waitFor(() => expect(pre).toHaveBeenCalledTimes(1));
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledTimes(1);
+
+    const updatedPost = jest.fn(x => x);
+
+    rerender(
+      <SuperChartCore
+        {...props}
+        preTransformProps={pre}
+        overrideTransformProps={transform}
+        postTransformProps={updatedPost}
+      />,
+    );
+    await waitFor(() => expect(updatedPost).toHaveBeenCalledTimes(1));
+    expect(transform).toHaveBeenCalledTimes(1);
+    expect(pre).toHaveBeenCalledTimes(1);
+  });
+});

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
@@ -55,7 +55,7 @@ describe('processChartProps', () => {
     plugin.configure({ key: props.chartType }).register();
   });
 
-  test('should return the result from cache unless transformProps has changed', async () => {
+  it('should return the result from cache unless transformProps has changed', async () => {
     const pre = jest.fn(x => x);
     const transform = jest.fn(x => x);
     const post = jest.fn(x => x);

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
@@ -1,9 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { render, waitFor } from '@testing-library/react';
 
 import {
   ChartPlugin,
   ChartMetadata,
-  ChartProps,
   DatasourceType,
   getChartComponentRegistry,
 } from '@superset-ui/core';
@@ -38,7 +55,7 @@ describe('processChartProps', () => {
     plugin.configure({ key: props.chartType }).register();
   });
 
-  test('should return the same result for identical inputs (cache hit)', async () => {
+  test('should return the result from cache unless transformProps has changed', async () => {
     const pre = jest.fn(x => x);
     const transform = jest.fn(x => x);
     const post = jest.fn(x => x);

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.test.tsx
@@ -27,66 +27,64 @@ import {
 
 import SuperChartCore from './SuperChartCore';
 
-describe('processChartProps', () => {
-  const props = {
-    chartType: 'line',
-  };
-  const FakeChart = () => <span>test</span>;
+const props = {
+  chartType: 'line',
+};
+const FakeChart = () => <span>test</span>;
 
-  beforeEach(() => {
-    const metadata = new ChartMetadata({
-      name: 'test-chart',
-      thumbnail: '',
-    });
-    const buildQuery = () => ({
-      datasource: { id: 1, type: DatasourceType.Table },
-      queries: [{ granularity: 'day' }],
-      force: false,
-      result_format: 'json',
-      result_type: 'full',
-    });
-    const controlPanel = { abc: 1 };
-    const plugin = new ChartPlugin({
-      metadata,
-      Chart: FakeChart,
-      buildQuery,
-      controlPanel,
-    });
-    plugin.configure({ key: props.chartType }).register();
+beforeEach(() => {
+  const metadata = new ChartMetadata({
+    name: 'test-chart',
+    thumbnail: '',
   });
-
-  it('should return the result from cache unless transformProps has changed', async () => {
-    const pre = jest.fn(x => x);
-    const transform = jest.fn(x => x);
-    const post = jest.fn(x => x);
-    expect(getChartComponentRegistry().get(props.chartType)).toBe(FakeChart);
-
-    expect(pre).toHaveBeenCalledTimes(0);
-    const { rerender } = render(
-      <SuperChartCore
-        {...props}
-        preTransformProps={pre}
-        overrideTransformProps={transform}
-        postTransformProps={post}
-      />,
-    );
-
-    await waitFor(() => expect(pre).toHaveBeenCalledTimes(1));
-    expect(transform).toHaveBeenCalledTimes(1);
-    expect(post).toHaveBeenCalledTimes(1);
-
-    const updatedPost = jest.fn(x => x);
-
-    rerender(
-      <SuperChartCore
-        {...props}
-        preTransformProps={pre}
-        overrideTransformProps={transform}
-        postTransformProps={updatedPost}
-      />,
-    );
-    await waitFor(() => expect(updatedPost).toHaveBeenCalledTimes(1));
-    expect(transform).toHaveBeenCalledTimes(1);
-    expect(pre).toHaveBeenCalledTimes(1);
+  const buildQuery = () => ({
+    datasource: { id: 1, type: DatasourceType.Table },
+    queries: [{ granularity: 'day' }],
+    force: false,
+    result_format: 'json',
+    result_type: 'full',
   });
+  const controlPanel = { abc: 1 };
+  const plugin = new ChartPlugin({
+    metadata,
+    Chart: FakeChart,
+    buildQuery,
+    controlPanel,
+  });
+  plugin.configure({ key: props.chartType }).register();
+});
+
+test('should return the result from cache unless transformProps has changed', async () => {
+  const pre = jest.fn(x => x);
+  const transform = jest.fn(x => x);
+  const post = jest.fn(x => x);
+  expect(getChartComponentRegistry().get(props.chartType)).toBe(FakeChart);
+
+  expect(pre).toHaveBeenCalledTimes(0);
+  const { rerender } = render(
+    <SuperChartCore
+      {...props}
+      preTransformProps={pre}
+      overrideTransformProps={transform}
+      postTransformProps={post}
+    />,
+  );
+
+  await waitFor(() => expect(pre).toHaveBeenCalledTimes(1));
+  expect(transform).toHaveBeenCalledTimes(1);
+  expect(post).toHaveBeenCalledTimes(1);
+
+  const updatedPost = jest.fn(x => x);
+
+  rerender(
+    <SuperChartCore
+      {...props}
+      preTransformProps={pre}
+      overrideTransformProps={transform}
+      postTransformProps={updatedPost}
+    />,
+  );
+  await waitFor(() => expect(updatedPost).toHaveBeenCalledTimes(1));
+  expect(transform).toHaveBeenCalledTimes(1);
+  expect(pre).toHaveBeenCalledTimes(1);
 });

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
@@ -140,6 +140,25 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
     (transformedChartProps, post = IDENTITY) => post(transformedChartProps),
   );
 
+  processChartProps = ({
+    chartProps,
+    preTransformProps,
+    transformProps,
+    postTransformProps,
+  }: {
+    chartProps: ChartProps;
+    preTransformProps?: PreTransformProps;
+    transformProps?: TransformProps;
+    postTransformProps?: PostTransformProps;
+  }) =>
+    this.postSelector({
+      chartProps: this.transformSelector({
+        chartProps: this.preSelector({ chartProps, preTransformProps }),
+        transformProps,
+      }),
+      postTransformProps,
+    });
+
   /**
    * memoized function so it will not recompute
    * and return previous value
@@ -186,11 +205,10 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
 
     return (
       <Chart
-        {...this.postSelector({
-          chartProps: this.transformSelector({
-            chartProps: this.preSelector({ chartProps, preTransformProps }),
-            transformProps,
-          }),
+        {...this.processChartProps({
+          chartProps,
+          preTransformProps,
+          transformProps,
           postTransformProps,
         })}
       />

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChartCore.tsx
@@ -85,8 +85,7 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
   container?: HTMLElement | null;
 
   /**
-   * memoized function so it will not recompute
-   * and return previous value
+   * memoized function so it will not recompute and return previous value
    * unless one of
    * - preTransformProps
    * - chartProps
@@ -104,12 +103,8 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
   );
 
   /**
-   * memoized function so it will not recompute
-   * and return previous value
-   * unless one of
-   * - transformProps
-   * - preprocessed result
-   * is changed.
+   * memoized function so it will not recompute and return previous value
+   * unless one of the input arguments have changed.
    */
   transformSelector = createSelector(
     [
@@ -122,12 +117,8 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
   );
 
   /**
-   * memoized function so it will not recompute
-   * and return previous value
-   * unless one of
-   * - postTransformProps
-   * - transformed result
-   * is changed.
+   * memoized function so it will not recompute and return previous value
+   * unless one of the input arguments have changed.
    */
   postSelector = createSelector(
     [
@@ -140,6 +131,9 @@ export default class SuperChartCore extends PureComponent<Props, {}> {
     (transformedChartProps, post = IDENTITY) => post(transformedChartProps),
   );
 
+  /**
+   * Using each memoized function to retrieve the computed chartProps
+   */
   processChartProps = ({
     chartProps,
     preTransformProps,

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -182,6 +182,7 @@ class ChartRenderer extends Component {
           this.props.formData.subcategories ||
         nextProps.cacheBusterProp !== this.props.cacheBusterProp ||
         nextProps.emitCrossFilters !== this.props.emitCrossFilters ||
+        nextProps.postTransformProps !== this.props.postTransformProps ||
         hasMatrixifyChanges()
       );
     }

--- a/superset-frontend/src/components/Chart/ChartRenderer.test.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.test.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, waitFor } from 'spec/helpers/testing-library';
+import { render } from 'spec/helpers/testing-library';
 import {
   ChartMetadata,
   getChartMetadataRegistry,


### PR DESCRIPTION
### SUMMARY
Previously, the processChartProps selector had an inefficient cache logic: it always repeated the entire process of `post(transform(pre(props)))` even if only one of pre, transform, or post was changed.
For example, if only `postChartProps` was updated, it still redundantly repeated the unchanged `pre` and `transform` steps, resulting in performance degradation.

To address this, this commit refactors the process by separating each step and implementing cache selectors. This change allows unnecessary transformation steps to be handled by the cache, improving performance by avoiding redundant computations.
Additionally, we added a missing equality check for `postTransformProps` in ChartRenderer for the correct re-rendering logic.

### TESTING INSTRUCTIONS

specs are added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
