### PR TITLE
fix(tests): Improve MessageChannel mocking to prevent worker force exits

### DIFF
--- a/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
+++ b/superset-frontend/spec/helpers/jsDomWithFetchAPI.ts
@@ -36,7 +36,7 @@ export default class FixJSDOMEnvironment extends JSDOMEnvironment {
     // Forces rc-overflow to use requestAnimationFrame fallback instead
     // Can be removed when rc-overflow properly cleans up MessagePorts in test environments
     // See: https://github.com/apache/superset/pull/34871
-    delete (this.global as any).MessageChannel;
-    delete (this.global as any).MessagePort;
+    this.global.MessageChannel = undefined as any;
+    this.global.MessagePort = undefined as any;
   }
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes Jest worker process force exits in test shard 4/8 by improving MessageChannel mocking approach.

**Problem**
After the initial MessageChannel fix in #34871, tests were still experiencing "A worker process has failed to exit gracefully and has been force exited" errors, specifically in test shard 4/8. The issue was that while the `delete` approach prevented infinite hanging, it didn't fully prevent MessagePort handle leaks.

**Root Cause Analysis**
The original `delete (this.global as any).MessageChannel` approach had a timing issue:
  1. **Module caching**: Some modules imported/cached MessageChannel references before our mock took effect
  2. **Property restoration**: Components could still restore or access MessageChannel through cached references
  3. **Handle leaks**: MessagePort handles created before the delete remained active after test completion
  4. **Incomplete cleanup**: `delete` only removed the property at setup time, not throughout the test lifecycle

Investigation showed that `ControlPanelsContainer.test.tsx` was detecting open MESSAGEPORT handles from `rc-overflow/lib/hooks/channelUpdate.js`, indicating the fallback wasn't being consistently triggered.

**Solution**
Replace `delete` with `undefined` assignment:

  ```typescript
  // Before (caused handle leaks)
  delete (this.global as any).MessageChannel;
  delete (this.global as any).MessagePort;

  // After (prevents handle leaks)
  this.global.MessageChannel = undefined as any;
  this.global.MessagePort = undefined as any;
```

Why undefined works better:
- Property exists but unusable: Prevents any code from successfully creating MessageChannel instances
  - Consistent throughout lifecycle: Works even if modules cached early references
  - Proper fallback triggering: Ensures typeof MessageChannel === 'undefined' is true consistently
  - Complete handle prevention: No MessagePort handles can be created at any point

🤖 Generated with [Claude Code](https://claude.ai/code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Check that shard 4/8 tests do not have any errors or closed due to timeout

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
