### PR TITLE
chore(react18): Migrate legacy react methods

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -413,13 +413,6 @@ module.exports = {
     'icons/no-fa-icons-usage': 'error',
     'i18n-strings/no-template-vars': ['error', true],
     'i18n-strings/sentence-case-buttons': 'error',
-    camelcase: [
-      'error',
-      {
-        allow: ['^UNSAFE_'],
-        properties: 'never',
-      },
-    ],
     'class-methods-use-this': 0,
     curly: 2,
     'func-names': 0,

--- a/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
@@ -93,6 +93,7 @@ export default class CRUDCollection extends PureComponent<
       collectionArray,
       sortColumn: '',
       sort: 0,
+      prevCollection: props.collection,
     };
     this.onAddItem = this.onAddItem.bind(this);
     this.renderExpandableSection = this.renderExpandableSection.bind(this);
@@ -104,17 +105,24 @@ export default class CRUDCollection extends PureComponent<
     this.toggleExpand = this.toggleExpand.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: CRUDCollectionProps) {
-    if (nextProps.collection !== this.props.collection) {
+  static getDerivedStateFromProps(
+    nextProps: CRUDCollectionProps,
+    prevState: CRUDCollectionState,
+  ) {
+    if (nextProps.collection !== prevState.prevCollection) {
       const { collection, collectionArray } = createKeyedCollection(
         nextProps.collection,
       );
-      this.setState(prevState => ({
+      return {
         collection,
         collectionArray,
         expandedColumns: prevState.expandedColumns,
-      }));
+        prevCollection: nextProps.collection,
+      };
     }
+    return {
+      prevCollection: nextProps.collection,
+    };
   }
 
   onCellChange(id: number, col: string, val: boolean) {

--- a/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/CollectionTable/index.tsx
@@ -93,7 +93,6 @@ export default class CRUDCollection extends PureComponent<
       collectionArray,
       sortColumn: '',
       sort: 0,
-      prevCollection: props.collection,
     };
     this.onAddItem = this.onAddItem.bind(this);
     this.renderExpandableSection = this.renderExpandableSection.bind(this);
@@ -105,24 +104,17 @@ export default class CRUDCollection extends PureComponent<
     this.toggleExpand = this.toggleExpand.bind(this);
   }
 
-  static getDerivedStateFromProps(
-    nextProps: CRUDCollectionProps,
-    prevState: CRUDCollectionState,
-  ) {
-    if (nextProps.collection !== prevState.prevCollection) {
+  componentDidUpdate(prevProps: CRUDCollectionProps) {
+    if (this.props.collection !== prevProps.collection) {
       const { collection, collectionArray } = createKeyedCollection(
-        nextProps.collection,
+        this.props.collection,
       );
-      return {
+      this.setState(prevState => ({
         collection,
         collectionArray,
         expandedColumns: prevState.expandedColumns,
-        prevCollection: nextProps.collection,
-      };
+      }));
     }
-    return {
-      prevCollection: nextProps.collection,
-    };
   }
 
   onCellChange(id: number, col: string, val: boolean) {

--- a/superset-frontend/src/components/Datasource/types.ts
+++ b/superset-frontend/src/components/Datasource/types.ts
@@ -89,4 +89,5 @@ export interface CRUDCollectionState {
   expandedColumns: Record<PropertyKey, any>;
   sortColumn: string;
   sort: SortOrder;
+  prevCollection: Record<PropertyKey, any>[];
 }

--- a/superset-frontend/src/components/Datasource/types.ts
+++ b/superset-frontend/src/components/Datasource/types.ts
@@ -89,5 +89,4 @@ export interface CRUDCollectionState {
   expandedColumns: Record<PropertyKey, any>;
   sortColumn: string;
   sort: SortOrder;
-  prevCollection: Record<PropertyKey, any>[];
 }

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -120,15 +120,12 @@ class Dashboard extends PureComponent {
     this.applyCharts();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     this.applyCharts();
-  }
+    const currentChartIds = getChartIdsFromLayout(prevProps.layout);
+    const nextChartIds = getChartIdsFromLayout(this.props.layout);
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const currentChartIds = getChartIdsFromLayout(this.props.layout);
-    const nextChartIds = getChartIdsFromLayout(nextProps.layout);
-
-    if (this.props.dashboardId !== nextProps.dashboardId) {
+    if (prevProps.dashboardId !== this.props.dashboardId) {
       // single-page-app navigation check
       return;
     }
@@ -140,7 +137,7 @@ class Dashboard extends PureComponent {
       newChartIds.forEach(newChartId =>
         this.props.actions.addSliceToDashboard(
           newChartId,
-          getLayoutComponentFromChartId(nextProps.layout, newChartId),
+          getLayoutComponentFromChartId(this.props.layout, newChartId),
         ),
       );
     } else if (currentChartIds.length > nextChartIds.length) {

--- a/superset-frontend/src/dashboard/components/SliceAdder.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.tsx
@@ -81,8 +81,6 @@ type SliceAdderState = {
   sortBy: keyof Slice;
   selectedSliceIdsSet: Set<number>;
   showOnlyMyCharts: boolean;
-  prevLastUpdated: number;
-  prevSelectedSliceIds?: number[];
 };
 
 const KEYS_TO_FILTERS = ['slice_name', 'viz_type', 'datasource_name'];
@@ -194,8 +192,6 @@ class SliceAdder extends Component<SliceAdderProps, SliceAdderState> {
         LocalStorageKeys.DashboardEditorShowOnlyMyCharts,
         true,
       ),
-      prevLastUpdated: props.lastUpdated,
-      prevSelectedSliceIds: props.selectedSliceIds,
     };
     this.rowRenderer = this.rowRenderer.bind(this);
     this.searchUpdated = this.searchUpdated.bind(this);
@@ -216,28 +212,25 @@ class SliceAdder extends Component<SliceAdderProps, SliceAdderState> {
     );
   }
 
-  static getDerivedStateFromProps(
-    nextProps: SliceAdderProps,
-    prevState: SliceAdderState,
-  ) {
-    const newState: Partial<SliceAdderState> = {};
-    if (prevState.prevLastUpdated !== nextProps.lastUpdated) {
-      newState.filteredSlices = getFilteredSortedSlices(
-        nextProps.slices,
-        prevState.searchTerm,
-        prevState.sortBy,
-        prevState.showOnlyMyCharts,
-        nextProps.userId,
+  componentDidUpdate(prevProps: SliceAdderProps) {
+    const nextState: SliceAdderState = {} as SliceAdderState;
+    if (this.props.lastUpdated !== prevProps.lastUpdated) {
+      nextState.filteredSlices = getFilteredSortedSlices(
+        this.props.slices,
+        this.state.searchTerm,
+        this.state.sortBy,
+        this.state.showOnlyMyCharts,
+        this.props.userId,
       );
     }
-    if (nextProps.selectedSliceIds !== prevState.prevSelectedSliceIds) {
-      newState.selectedSliceIdsSet = new Set(nextProps.selectedSliceIds);
+
+    if (prevProps.selectedSliceIds !== this.props.selectedSliceIds) {
+      nextState.selectedSliceIdsSet = new Set(this.props.selectedSliceIds);
     }
-    return {
-      ...newState,
-      prevLastUpdated: nextProps.lastUpdated,
-      prevSelectedSliceIds: nextProps.selectedSliceIds,
-    };
+
+    if (Object.keys(nextState).length) {
+      this.setState(nextState);
+    }
   }
 
   componentWillUnmount() {

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -40,7 +40,6 @@ interface WithPopoverMenuProps {
 
 interface WithPopoverMenuState {
   isFocused: Boolean;
-  needsClickListner?: boolean;
 }
 
 const WithPopoverMenuStyles = styled.div`
@@ -130,27 +129,15 @@ export default class WithPopoverMenu extends PureComponent<
     this.handleClick = this.handleClick.bind(this);
   }
 
-  static getDerivedStateFromProps(
-    nextProps: WithPopoverMenuProps,
-    prevState: WithPopoverMenuState,
-  ) {
-    if (nextProps.editMode && nextProps.isFocused && !prevState.isFocused) {
-      return { isFocused: true, needsClickListner: true };
-    }
-    if (prevState.isFocused && !nextProps.editMode) {
-      return { isFocused: false, needsClickListner: false };
-    }
-    return { needsClickListner: undefined };
-  }
-
   componentDidUpdate(prevProps: WithPopoverMenuProps) {
-    const { needsClickListner } = this.state;
-    if (needsClickListner === true) {
+    if (this.props.editMode && this.props.isFocused && !this.state.isFocused) {
       document.addEventListener('click', this.handleClick);
       document.addEventListener('drag', this.handleClick);
-    } else if (needsClickListner === false) {
+      this.setState({ isFocused: true });
+    } else if (this.state.isFocused && !this.props.editMode) {
       document.removeEventListener('click', this.handleClick);
       document.removeEventListener('drag', this.handleClick);
+      this.setState({ isFocused: false });
     }
   }
 

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -136,7 +136,8 @@ export default class WithPopoverMenu extends PureComponent<
   ) {
     if (nextProps.editMode && nextProps.isFocused && !prevState.isFocused) {
       return { isFocused: true, needsClickListner: true };
-    } else if (prevState.isFocused && !nextProps.editMode) {
+    }
+    if (prevState.isFocused && !nextProps.editMode) {
       return { isFocused: false, needsClickListner: false };
     }
     return { needsClickListner: undefined };

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -40,6 +40,7 @@ interface WithPopoverMenuProps {
 
 interface WithPopoverMenuState {
   isFocused: Boolean;
+  needsClickListner?: boolean;
 }
 
 const WithPopoverMenuStyles = styled.div`
@@ -129,15 +130,26 @@ export default class WithPopoverMenu extends PureComponent<
     this.handleClick = this.handleClick.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: WithPopoverMenuProps) {
-    if (nextProps.editMode && nextProps.isFocused && !this.state.isFocused) {
+  static getDerivedStateFromProps(
+    nextProps: WithPopoverMenuProps,
+    prevState: WithPopoverMenuState,
+  ) {
+    if (nextProps.editMode && nextProps.isFocused && !prevState.isFocused) {
+      return { isFocused: true, needsClickListner: true };
+    } else if (prevState.isFocused && !nextProps.editMode) {
+      return { isFocused: false, needsClickListner: false };
+    }
+    return { needsClickListner: undefined };
+  }
+
+  componentDidUpdate(prevProps: WithPopoverMenuProps) {
+    const { needsClickListner } = this.state;
+    if (needsClickListner === true) {
       document.addEventListener('click', this.handleClick);
       document.addEventListener('drag', this.handleClick);
-      this.setState({ isFocused: true });
-    } else if (this.state.isFocused && !nextProps.editMode) {
+    } else if (needsClickListner === false) {
       document.removeEventListener('click', this.handleClick);
       document.removeEventListener('drag', this.handleClick);
-      this.setState({ isFocused: false });
     }
   }
 

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
@@ -121,9 +121,7 @@ class AnnotationLayerControl extends PureComponent<Props, PopoverState> {
         this.props.actions.setControlValue(
           name,
           value,
-          Object.keys(annotationError).length
-            ? Object.keys(annotationError)
-            : [],
+          Object.keys(annotationError),
         );
       }
     }

--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
@@ -107,17 +107,25 @@ class AnnotationLayerControl extends PureComponent<Props, PopoverState> {
     AnnotationLayer.preload();
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    const { name, annotationError, validationErrors, value } = nextProps;
-    if (Object.keys(annotationError).length && !validationErrors.length) {
-      this.props.actions.setControlValue(
-        name,
-        value,
-        Object.keys(annotationError),
-      );
-    }
-    if (!Object.keys(annotationError).length && validationErrors.length) {
-      this.props.actions.setControlValue(name, value, []);
+  componentDidUpdate(prevProps: Props) {
+    const { name, annotationError, validationErrors, value } = this.props;
+    if (
+      (Object.keys(annotationError).length && !validationErrors.length) ||
+      (!Object.keys(annotationError).length && validationErrors.length)
+    ) {
+      if (
+        annotationError !== prevProps.annotationError ||
+        validationErrors !== prevProps.validationErrors ||
+        value !== prevProps.value
+      ) {
+        this.props.actions.setControlValue(
+          name,
+          value,
+          Object.keys(annotationError).length
+            ? Object.keys(annotationError)
+            : [],
+        );
+      }
     }
   }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
@@ -166,8 +166,6 @@ class AdhocFilterControl extends Component {
       values: filters,
       options: optionsForSelect(this.props),
       partitionColumn: null,
-      prevColumns: props.columns,
-      prevValue: props.value,
     };
   }
 
@@ -213,21 +211,17 @@ class AdhocFilterControl extends Component {
     }
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const newState = {};
-    if (nextProps.columns !== prevState.prevColumns) {
-      newState.options = optionsForSelect(nextProps);
+  componentDidUpdate(prevProps) {
+    if (this.props.columns !== prevProps.columns) {
+      this.setState({ options: optionsForSelect(this.props) });
     }
-    if (nextProps.value !== prevState.prevValue) {
-      newState.values = (nextProps.value || []).map(filter =>
-        isDictionaryForAdhocFilter(filter) ? new AdhocFilter(filter) : filter,
-      );
+    if (this.props.value !== prevProps.value) {
+      this.setState({
+        values: (this.props.value || []).map(filter =>
+          isDictionaryForAdhocFilter(filter) ? new AdhocFilter(filter) : filter,
+        ),
+      });
     }
-    return {
-      ...newState,
-      prevColumns: nextProps.columns,
-      prevValue: nextProps.value,
-    };
   }
 
   removeFilter(index) {

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -162,29 +162,19 @@ export default class SelectControl extends PureComponent {
     super(props);
     this.state = {
       options: this.getOptions(props),
-      prevChoices: props.choices,
-      prevOptions: props.options,
     };
     this.onChange = this.onChange.bind(this);
     this.handleFilterOptions = this.handleFilterOptions.bind(this);
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (
-      !isEqualArray(nextProps.choices, prevState.prevChoices) ||
-      !isEqualArray(nextProps.options, prevState.prevOptions)
+      !isEqualArray(this.props.choices, prevProps.choices) ||
+      !isEqualArray(this.props.options, prevProps.options)
     ) {
-      const options = innerGetOptions(nextProps);
-      return {
-        options,
-        prevChoices: nextProps.choices,
-        prevOptions: nextProps.options,
-      };
+      const options = this.getOptions(this.props);
+      this.setState({ options });
     }
-    return {
-      prevChoices: nextProps.choices,
-      prevOptions: nextProps.options,
-    };
   }
 
   // Beware: This is acting like an on-click instead of an on-change

--- a/superset-frontend/src/explore/components/controls/SelectControl.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.jsx
@@ -162,19 +162,29 @@ export default class SelectControl extends PureComponent {
     super(props);
     this.state = {
       options: this.getOptions(props),
+      prevChoices: props.choices,
+      prevOptions: props.options,
     };
     this.onChange = this.onChange.bind(this);
     this.handleFilterOptions = this.handleFilterOptions.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  static getDerivedStateFromProps(nextProps, prevState) {
     if (
-      !isEqualArray(nextProps.choices, this.props.choices) ||
-      !isEqualArray(nextProps.options, this.props.options)
+      !isEqualArray(nextProps.choices, prevState.prevChoices) ||
+      !isEqualArray(nextProps.options, prevState.prevOptions)
     ) {
-      const options = this.getOptions(nextProps);
-      this.setState({ options });
+      const options = innerGetOptions(nextProps);
+      return {
+        options,
+        prevChoices: nextProps.choices,
+        prevOptions: nextProps.options,
+      };
     }
+    return {
+      prevChoices: nextProps.choices,
+      prevOptions: nextProps.options,
+    };
   }
 
   // Beware: This is acting like an on-click instead of an on-change


### PR DESCRIPTION
### SUMMARY
This commit migrates legacy lifecycle methods to their newer versions as part of the upgrade process to React 18.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
CI and specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
