### PR TITLE
fix(cli): inconsistent options for set-database-uri

### DIFF
--- a/superset/cli/update.py
+++ b/superset/cli/update.py
@@ -39,14 +39,14 @@ logger = logging.getLogger(__name__)
 @click.command()
 @with_appcontext
 @transaction()
-@click.option("--database_name", "-d", help="Database name to change")
-@click.option("--uri", "-u", help="Database URI to change")
+@click.option("--database_name", "-d", required=True, help="Database name to change")
+@click.option("--uri", "-u", required=True, help="Database URI to change")
 @click.option(
     "--skip_create",
     "-s",
     is_flag=True,
     default=False,
-    help="Create the DB if it doesn't exist",
+    help="Don't create the DB if it doesn't exist",
 )
 def set_database_uri(database_name: str, uri: str, skip_create: bool) -> None:
     """Updates a database connection URI"""


### PR DESCRIPTION
### SUMMARY
This is a very simple fix implemented directly in the decorators for this command.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Before the fix
```
# superset set-database-uri --help
<removed irrelevant logs>
Usage: superset set-database-uri [OPTIONS]

  Updates a database connection URI

Options:
  -d, --database_name TEXT  Database name to change
  -u, --uri TEXT            Database URI to change
  -s, --skip_create         Create the DB if it doesn't exist
  --help                    Show this message and exit.

# superset set-database-uri
<removed irrelevant logs>
2025-08-28 19:57:30,942:INFO:superset.utils.database:Creating database reference for None
Traceback (most recent call last):
  File "/app/.venv/bin/superset", line 10, in <module>
    sys.exit(superset())
             ^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/flask/cli.py", line 358, in decorator
    return __ctx.invoke(f, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/superset/utils/decorators.py", line 267, in wrapped
    return on_error(ex)
           ^^^^^^^^^^^^
  File "/app/superset/utils/decorators.py", line 232, in on_error
    raise ex
  File "/app/superset/utils/decorators.py", line 260, in wrapped
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/app/superset/cli/update.py", line 53, in set_database_uri
    database_utils.get_or_create_db(database_name, uri, not skip_create)
  File "/app/superset/utils/database.py", line 56, in get_or_create_db
    database.set_sqlalchemy_uri(sqlalchemy_uri)
  File "/app/superset/models/core.py", line 398, in set_sqlalchemy_uri
    conn = make_url_safe(uri.strip())
                         ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```


#### After the fix
```
# superset set-database-uri --help     
Loaded your LOCAL configuration at [/app/docker/pythonpath_dev/superset_config.py]
<removed irrelevant logs>
Usage: superset set-database-uri [OPTIONS]

  Updates a database connection URI

Options:
  -d, --database_name TEXT  Database name to change  [required]
  -u, --uri TEXT            Database URI to change  [required]
  -s, --skip_create         Don't create the DB if it doesn't exist
  --help                    Show this message and exit.

# superset set-database-uri
<removed irrelevant logs>
Usage: superset set-database-uri [OPTIONS]
Try 'superset set-database-uri --help' for help.

Error: Missing option '--database_name' / '-d'.
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
- [X] Has associated issue: Fixes #34891
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
