### PR TITLE
fix: Athena quoting

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -81,6 +81,9 @@ def monkeypatch_dialect() -> None:
     try:
         from sqlalchemy_databricks._dialect import DatabricksDialect
 
+        # copy because the dictionary is shared with other subclasses if it hasn't been
+        # overwritten
+        DatabricksDialect.colspecs = DatabricksDialect.colspecs.copy()
         DatabricksDialect.colspecs[types.String] = DatabricksStringType
     except ImportError:
         pass


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/34180 fixed how single quotes are escaped in Databricks by monkeypatching the dialect:

```python
DatabricksDialect.colspecs[types.String] = DatabricksStringType
```

Unfortunately, it seems like `colspecs` is an attribute of the base class, and `DatabricksDialect` does not override it. Which means that:

```python
>>> AthenaPandasDialect.colspecs is DatabricksDialect.colspecs
True
```

So as a side-effect, the same escaping was being applied to Athena (and potentially [Pinot](https://github.com/apache/superset/issues/34856) and other dialects).

This PR fixes the problem with:

```python
DatabricksDialect.colspecs = DatabricksDialect.colspecs.copy()
DatabricksDialect.colspecs[types.String] = DatabricksStringType
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Tested with Athena, with the fix it generates the correct SQL.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
