### PR TITLE
fix: Filter bar orientation submenu should not be highlighted

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
@@ -190,6 +190,7 @@ const FilterBarSettings = () => {
       items.push({
         key: 'placement',
         label: t('Orientation of filter bar'),
+        className: 'filter-bar-orientation-submenu',
         children: [
           {
             key: FilterBarOrientation.Vertical,
@@ -200,9 +201,6 @@ const FilterBarSettings = () => {
                   FilterBarOrientation.Vertical && (
                   <Icons.CheckOutlined
                     iconColor={theme.colorPrimary}
-                    css={css`
-                      vertical-align: -${theme.sizeUnit * 0.03125}em;
-                    `}
                     iconSize="m"
                   />
                 )}
@@ -252,6 +250,18 @@ const FilterBarSettings = () => {
           selectedKeys: [selectedFilterBarOrientation],
         }}
         trigger={['click']}
+        popupRender={menu => (
+          <div
+            css={css`
+              .filter-bar-orientation-submenu.ant-dropdown-menu-submenu-selected
+                > .ant-dropdown-menu-submenu-title {
+                color: inherit;
+              }
+            `}
+          >
+            {menu}
+          </div>
+        )}
       >
         <Button
           buttonStyle="link"


### PR DESCRIPTION
### SUMMARY
In dashboard filters config menu, the "Orientation of filter bar" submenu items was always highlighted. That's the default antd behavior when any of the submenu's children are selected.
This PR adds some styles to set the text color to the same color as other menu items

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="250" height="181" alt="image" src="https://github.com/user-attachments/assets/371738cb-740e-41cb-9771-958e8d53b60a" />

After:

<img width="303" height="201" alt="image" src="https://github.com/user-attachments/assets/82a72262-3874-4c45-a0b6-658a815b8ede" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
