### PR TITLE
fix: add --without-threads flag to Flask dev server for DuckDB compatibility

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -72,7 +72,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --reload --debugger --host=0.0.0.0
+    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0
     ;;
   app-gunicorn)
     echo "Starting web app..."


### PR DESCRIPTION
DuckDB (now used in dev envs) requires single-threaded operation in development environments. Adding --without-threads flag to flask run command in docker-bootstrap.sh to prevent threading conflicts with DuckDB.

Note: the flask docs are really unclear about what the default is, and exposes `--with-threads` and `--without-threads`. Default changed in Flask v1 apparently.

Fixes lock ups in dev envs.