### PR TITLE
docs(reports): add wget dependency

### DIFF
--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -234,7 +234,7 @@ FROM apache/superset:3.1.0
 USER root
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y firefox-esr
+    apt-get install --no-install-recommends -y firefox-esr wget
 
 ENV GECKODRIVER_VERSION=0.29.0
 RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz && \


### PR DESCRIPTION
### SUMMARY

```Dockerfile
FROM apache/superset:3.1.0
USER root
RUN apt-get update && \
    apt-get install --no-install-recommends -y firefox-esr wget
ENV GECKODRIVER_VERSION=0.29.0
RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz && \
    tar -x geckodriver -zf geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz -O > /usr/bin/geckodriver && \
    chmod 755 /usr/bin/geckodriver && \
    rm geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz
RUN pip install --no-cache gevent psycopg2 redis
USER superset
```

This Dockerfile is provided in the documentation, but it is not functional because the image does not contain `wget`.

```
 => ERROR [3/4] RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v0.29.0/geckodriver-v0.29.0-linux64.tar  0.4s
```

If you look at the Dockerfile provided for Chrome, wget is downloaded.

```Dockefile
FROM apache/superset:3.1.0
USER root
RUN apt-get update && \
    apt-get install -y wget zip libaio1
...
```

### TESTING INSTRUCTIONS
docker build -t superset-custom .
