### PR TITLE
fix: Update @apache-superset/core reference in package-lock.json

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -53602,10 +53602,6 @@
         "kdbush": "^4.0.2"
       }
     },
-    "node_modules/superset-core": {
-      "resolved": "packages/superset-core",
-      "link": true
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -60600,7 +60596,8 @@
       }
     },
     "packages/superset-core": {
-      "version": "0.0.1",
+      "name": "@apache-superset/core",
+      "version": "0.0.1-rc2",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",


### PR DESCRIPTION
### SUMMARY
Updates the referenced version of `@apache-superset/core` in `package-lock.json`.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
