### PR TITLE
fix: sync config to db, make it optional

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -721,6 +721,10 @@ COMMON_BOOTSTRAP_OVERRIDES_FUNC: Callable[  # noqa: E731
 # This is merely a default
 EXTRA_CATEGORICAL_COLOR_SCHEMES: list[dict[str, Any]] = []
 
+# When SYNC_CONFIG_TO_DB_ON_INIT is True (default), configuration
+# will be synchronized to the database during initialization. Set to False if your setup
+# does not support db operation at the Flask app init stage
+SYNC_CONFIG_TO_DB_ON_INIT = True
 # ---------------------------------------------------
 # Theme Configuration for Superset
 # ---------------------------------------------------

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -577,7 +577,8 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         # Sync configuration to database (themes, etc.)
         # This can be called separately in multi-tenant environments
-        self.superset_app.sync_config_to_db()
+        if self.flask_app.config["SYNC_CONFIG_TO_DB_ON_INIT"]:
+            self.superset_app.sync_config_to_db()
 
         self.init_views()
 

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -577,7 +577,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         # Sync configuration to database (themes, etc.)
         # This can be called separately in multi-tenant environments
-        if self.flask_app.config["SYNC_CONFIG_TO_DB_ON_INIT"]:
+        if self.config["SYNC_CONFIG_TO_DB_ON_INIT"]:
             self.superset_app.sync_config_to_db()
 
         self.init_views()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces a new configuration flag `SYNC_CONFIG_TO_DB_ON_INIT` that controls whether configuration from `superset_config.py` is synchronized to the database during application initialization.

**Key changes:**
- Added `SYNC_CONFIG_TO_DB_ON_INIT` config flag (defaults to `True` for backward compatibility)
- Made the `sync_config_to_db()` call conditional based on this flag
- Useful for specific environments where configuration needs to be managed separately per tenant

**Rationale:**
In some deployments, automatically syncing configuration to the database on initialization can cause issues since we don't expect to have a connection string ready at this stage.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A - Backend configuration change only

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. **Test default behavior (should sync):**
   - Start Superset without setting `SYNC_CONFIG_TO_DB_ON_INIT` in config
   - Verify that configuration is synced to database on startup
   - Check that themes and other config-based settings are available

2. **Test with sync disabled:**
   - Set `SYNC_CONFIG_TO_DB_ON_INIT = False` in `superset_config.py`
   - Start Superset
   - Verify that configuration is NOT automatically synced to database
   - Confirm that manual sync can still be triggered if needed

3. **Test backward compatibility:**
   - Ensure existing deployments continue to work without any config changes
   - Verify that the default `True` value maintains current behavior

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API (new config option)
- [ ] Removes existing feature or API