### PR TITLE
fix(dashboard): table charts render correctly after tab switch and refresh

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row.jsx
@@ -171,6 +171,7 @@ const Row = props => {
   useEffect(() => {
     let observerEnabler;
     let observerDisabler;
+
     if (
       isFeatureEnabled(FeatureFlag.DashboardVirtualization) &&
       !isCurrentUserBot()
@@ -179,12 +180,15 @@ const Row = props => {
         ([entry]) => {
           if (entry.isIntersecting && isComponentVisibleRef.current) {
             setIsInView(true);
+          } else if (!isComponentVisibleRef.current) {
+            setIsInView(false);
           }
         },
         {
           rootMargin: '100% 0px',
         },
       );
+
       observerDisabler = new IntersectionObserver(
         ([entry]) => {
           if (!entry.isIntersecting && isComponentVisibleRef.current) {
@@ -198,12 +202,14 @@ const Row = props => {
           rootMargin: '400% 0px',
         },
       );
+
       const element = containerRef.current;
       if (element) {
         observerEnabler.observe(element);
         observerDisabler.observe(element);
       }
     }
+
     return () => {
       observerEnabler?.disconnect();
       observerDisabler?.disconnect();


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Table charts were appearing blank when refreshing a dashboard and then switching to a tab containing table charts. This occurred because intersection observers weren't properly handling component visibility changes during tab switches.

The fix adds a lightweight visibility handler that immediately sets charts as not in view when tabs become hidden. When a tab becomes active, the intersection observers can then properly detect and render the visible charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
![not_working](https://github.com/user-attachments/assets/c658de19-1e43-4d38-968e-4ae5560fe754)

After:
![working](https://github.com/user-attachments/assets/39cb9280-24f3-4e8b-a76b-6ba046bf2d80)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a dashboard with multiple tabs containing table charts
2. Navigate to a tab with table charts and verify they display correctly
3. Refresh the dashboard using the "Refresh dashboard" button
4. Switch to a different tab that contains table charts
5. **Expected**: Table charts should render immediately and display data
6. **Previously**: Table charts would appear blank (requiring another refresh)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
