### PR TITLE
fix: apache-superset-core exported packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    # no bounds for apache-superset-core until a stable version
+    # no bounds for apache-superset-core until we have a stable version
     "apache-superset-core",
     "backoff>=1.8.0",
     "celery>=5.3.6, <6.0.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,7 +158,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -327,7 +327,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -452,7 +451,7 @@ marshmallow-sqlalchemy==1.4.0
     #   flask-appbuilder
 marshmallow-union==0.1.15
     # via
-    #   -c requirements/base.txt
+    #   -c requirements/base-constraint.txt
     #   apache-superset
 matplotlib==3.9.0
     # via prophet

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -18,7 +18,7 @@
 
 [project]
 name = "apache-superset-core"
-version = "0.0.1rc1"
+version = "0.0.1rc2"
 description = "Core Python package for building Apache Superset backend extensions and integrations"
 readme = "README.md"
 authors = [
@@ -57,5 +57,7 @@ requires = ["setuptools>=76.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["superset_core"]
 package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/superset-extensions-cli/pyproject.toml
+++ b/superset-extensions-cli/pyproject.toml
@@ -43,7 +43,8 @@ classifiers = [
     "Topic :: System :: Software Distribution",
 ]
 dependencies = [
-    "apache-superset-core>=0.0.1rc1, <0.2",
+    # no bounds for apache-superset-core until we have a stable version
+    "apache-superset-core",
     "click>=8.0.3",
     "jinja2>=3.1.6",
     "semver>=3.0.4",


### PR DESCRIPTION
### SUMMARY
Fixed the `superset-core` package build configuration by replacing the explicit `packages = ["superset_core"]` declaration with automatic package discovery using `[tool.setuptools.packages.find]`, ensuring that all subpackages (`api`, `extensions`) are now included in the PyPI distribution instead of just the top-level `__init__.py` file.

### TESTING INSTRUCTIONS
Run `python -m build` and check that the packages exist in the distribution.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
