### PR TITLE
fix: playwright feature flag evaluation

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -38,7 +38,6 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support import expected_conditions as EC  # noqa: N812
 from selenium.webdriver.support.ui import WebDriverWait
 
-from superset import feature_flag_manager
 from superset.extensions import machine_auth_provider_factory
 from superset.utils.retries import retry_call
 from superset.utils.screenshot_utils import take_tiled_screenshot
@@ -47,9 +46,11 @@ WindowSize = tuple[int, int]
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from flask_appbuilder.security.sqla.models import User
 
-if feature_flag_manager.is_feature_enabled("PLAYWRIGHT_REPORTS_AND_THUMBNAILS"):
+try:
     from playwright.sync_api import (
         BrowserContext,
         Error as PlaywrightError,
@@ -58,6 +59,16 @@ if feature_flag_manager.is_feature_enabled("PLAYWRIGHT_REPORTS_AND_THUMBNAILS"):
         sync_playwright,
         TimeoutError as PlaywrightTimeout,
     )
+except ImportError:
+    from typing import Any
+
+    # Define dummy classes when playwright is not available
+    BrowserContext = Any
+    PlaywrightError = Exception
+    PlaywrightTimeout = Exception
+    Locator = Any
+    Page = Any
+    sync_playwright = None
 
 
 class DashboardStandaloneMode(Enum):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes an issue where the `PLAYWRIGHT_REPORTS_AND_THUMBNAILS` feature flag was being evaluated at the module level in `superset/utils/webdriver.py`. 

**Problem:**
Feature flag evaluations should not occur at the module level because:
1. **Dynamic Nature**: Feature flags are designed to be dynamically turned on and off at runtime. Module-level evaluation happens once at import time, preventing dynamic changes from taking effect.
2. **App Context Requirements**: Custom implementations of feature flag evaluation may require a full application context to be created. This context provides essential information about the app state, current user, and request details needed for proper evaluation.
3. **Import-time Issues**: Evaluating feature flags during module import can cause initialization problems when the app context isn't fully set up yet.

**Solution:**
Replace the feature flag check with a try-except block for importing Playwright dependencies. This approach:
- Attempts to import Playwright modules if they're available
- Gracefully handles ImportError by defining fallback types when Playwright isn't installed
- Removes the dependency on feature flag evaluation at module level
- Allows the feature to be controlled dynamically at runtime where appropriate

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags: `PLAYWRIGHT_REPORTS_AND_THUMBNAILS` (but no longer evaluated at module level)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API