### PR TITLE
fix: apache-superset-extensions-cli exported files

### DIFF
--- a/superset-extensions-cli/pyproject.toml
+++ b/superset-extensions-cli/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-superset-extensions-cli"
-version = "0.0.1rc1"
+version = "0.0.1rc2"
 description = "Official command-line interface for building, bundling, and managing Apache Superset extensions"
 readme = "README.md"
 authors = [
@@ -71,8 +71,14 @@ requires = ["setuptools>=76.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["superset_extensions_cli"]
 package-dir = { "" = "src" }
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+superset_extensions_cli = ["templates/**/*"]
 
 [project.scripts]
 superset-extensions = "superset_extensions_cli.cli:app"


### PR DESCRIPTION
### SUMMARY
Fixed the `superset-extensions-cli` package configuration to properly include template files by switching from explicit package listing to automatic package discovery using `[tool.setuptools.packages.find]` and adding `[tool.setuptools.package-data]` to ensure the Jinja2 templates in the `templates/` subdirectories are included in the published package distribution.

### TESTING INSTRUCTIONS
Run `python -m build` and check that the files exist in the distribution.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
