### PR TITLE
feat: allow create metric and add to folder in single request

### DIFF
--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -178,13 +178,19 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         if folders := self._properties.get("folders"):
             valid_uuids: set[UUID] = set()
             if metrics:
-                valid_uuids.update(UUID(metric["uuid"]) for metric in metrics)
+                valid_uuids.update(
+                    UUID(metric["uuid"]) for metric in metrics if "uuid" in metric
+                )
             else:
                 valid_uuids.update(metric.uuid for metric in self._model.metrics)
+
             if columns:
-                valid_uuids.update(UUID(column["uuid"]) for column in columns)
+                valid_uuids.update(
+                    UUID(column["uuid"]) for column in columns if "uuid" in column
+                )
             else:
                 valid_uuids.update(column.uuid for column in self._model.columns)
+
             try:
                 validate_folders(folders, valid_uuids)
             except ValidationError as ex:
@@ -266,7 +272,7 @@ def validate_folders(  # noqa: C901
     seen_fqns = set()  # fully qualified folder names
     while queue:
         obj, path = queue.pop(0)
-        uuid, name = UUID(obj["uuid"]), obj.get("name")
+        uuid, name = obj["uuid"], obj.get("name")
 
         if uuid in path:
             raise ValidationError(f"Cycle detected: {uuid} appears in its ancestry")

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -711,46 +711,6 @@ def test_validate_folders_partial_override(mocker: MockerFixture) -> None:
 
 
 @with_feature_flags(DATASET_FOLDERS=True)
-def test_validate_folders_invalid_uuid_format(mocker: MockerFixture) -> None:
-    """
-    Test that invalid UUID formats are caught properly.
-    """
-    from uuid import UUID
-
-    # Folder with invalid UUID format
-    folder_uuid = UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-    folders = [
-        {
-            "uuid": str(folder_uuid),
-            "type": "folder",
-            "name": "Test Folder",
-            "children": [
-                {
-                    "uuid": "not-a-valid-uuid-format",  # Invalid UUID
-                    "type": "metric",
-                    "name": "bad_metric",
-                }
-            ],
-        }
-    ]
-
-    # Create mock model
-    mock_model = mocker.MagicMock()
-    mock_model.metrics = []
-    mock_model.columns = []
-
-    command = UpdateDatasetCommand(1, {"folders": folders})
-    command._model = mock_model
-
-    # The invalid UUID should cause a ValueError to be raised during validation
-    with pytest.raises((ValueError, ValidationError)) as exc_info:
-        command._validate_semantics([])
-
-    # Should be a ValueError about badly formed UUID
-    assert "badly formed hexadecimal UUID string" in str(exc_info.value)
-
-
-@with_feature_flags(DATASET_FOLDERS=True)
 def test_validate_folders_uuid_types_enforced(mocker: MockerFixture) -> None:
     """
     Test that the new implementation enforces proper UUID types.


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We recently introduced folders to datasets that can contain columns and/or metrics. Currently, folders can only be managed via the API (there's no UI for it). It's currently not possible to add a new column and/or metric to the dataset and also add this column/metric to a folder in the same API call.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
