### PR TITLE
fix: Bump pandas to 2.1.4 for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <2.1",
+    "pandas[excel]>=2.0.3, <2.2",
     "bottleneck", # recommended performance dependency for pandas, see https://pandas.pydata.org/docs/getting_started/install.html#performance-dependencies-recommended
     # --------------------------
     "parsedatetime",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,6 +158,7 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
+    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0
@@ -264,7 +265,7 @@ packaging==25.0
     #   limits
     #   marshmallow
     #   shillelagh
-pandas==2.0.3
+pandas==2.1.4
     # via apache-superset (pyproject.toml)
 paramiko==3.5.1
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -327,6 +327,7 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
+    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -532,7 +533,7 @@ packaging==25.0
     #   pytest
     #   shillelagh
     #   sqlalchemy-bigquery
-pandas==2.0.3
+pandas==2.1.4
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset/commands/database/uploaders/excel_reader.py
+++ b/superset/commands/database/uploaders/excel_reader.py
@@ -72,7 +72,7 @@ class ExcelReader(BaseDataReader):
             "na_values": self._options.get("null_values")
             if self._options.get("null_values")  # None if an empty list
             else None,
-            "parse_dates": self._options.get("column_dates"),
+            "parse_dates": self._options.get("column_dates") or False,
             "skiprows": self._options.get("skip_rows", 0),
             "sheet_name": self._options.get("sheet_name", 0),
             "nrows": self._options.get("rows_to_read"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,8 @@ def data_loader(
     pandas_loader_configuration: PandasLoaderConfigurations,
     table_to_df_convertor: TableToDfConvertor,
 ) -> DataLoader:
+    if example_db_engine.dialect.name == PRESTO:
+        example_db_engine.dialect.get_view_names = Mock(return_value=[])
     return PandasDataLoader(
         example_db_engine, pandas_loader_configuration, table_to_df_convertor
     )


### PR DESCRIPTION
### SUMMARY
Pandas at 2.0.3 does not support Python 3.12 and it is currently building pandas from source in that case. Bumps to a supported version that has been tested and does not include breaking changes.
N.B. Cannot go >=2.2.* until on SQLAlchemy 2.0

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #34910
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
