### PR TITLE
fix: Add TypeScript declaration file generation to @apache-superset/core package

### DIFF
--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@apache-superset/core",
-  "version": "0.0.1-rc2",
+  "version": "0.0.1-rc3",
   "description": "This package contains UI elements, APIs, and utility functions used by Superset.",
   "sideEffects": false,
   "main": "lib/index.js",
-  "module": "esm/index.js",
+  "types": "lib/index.d.ts",
   "files": [
-    "esm",
     "lib"
   ],
   "author": "",
@@ -19,14 +18,15 @@
     "@babel/preset-typescript": "^7.26.0",
     "@types/react": "^17.0.83",
     "install": "^0.13.0",
-    "npm": "^11.1.0"
+    "npm": "^11.1.0",
+    "typescript": "^5.0.0"
   },
   "peerDependencies": {
     "antd": "^5.24.6",
     "react": "^17.0.2"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --extensions \".ts,.tsx\"",
+    "build": "babel src --out-dir lib --extensions \".ts,.tsx\" && tsc --emitDeclarationOnly",
     "type": "tsc --noEmit"
   },
   "publishConfig": {

--- a/superset-frontend/packages/superset-core/tsconfig.json
+++ b/superset-frontend/packages/superset-core/tsconfig.json
@@ -10,7 +10,9 @@
     "baseUrl": ".",
     "module": "esnext",
     "moduleResolution": "node",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "target": "es2015",
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts*"],
   "exclude": ["lib"]

--- a/superset-frontend/packages/superset-core/tsconfig.json
+++ b/superset-frontend/packages/superset-core/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "target": "es2015",
+    "target": "es2020",
     "esModuleInterop": true
   },
   "include": ["src/**/*.ts*"],


### PR DESCRIPTION
### SUMMARY
This change adds the missing types field to `package.json`, includes TypeScript as a dev dependency, and updates the build script to generate `.d.ts` declaration files alongside JavaScript output, resolving the issue where extensions could not import TypeScript definitions from the package.

### TESTING INSTRUCTIONS
Check that Typescript definitions are included in the build.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
