### PR TITLE
feat: use default catalog/schema on DB selector

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -73,11 +73,14 @@ beforeEach(() => {
           dbId: expectDbId,
           forceRefresh: false,
         },
-        fakeSchemaApiResult.map(value => ({
-          value,
-          label: value,
-          title: value,
-        })),
+        {
+          result: fakeSchemaApiResult.map(value => ({
+            value,
+            label: value,
+            title: value,
+          })),
+          default: null,
+        },
       ),
     );
     store.dispatch(
@@ -307,11 +310,14 @@ test('returns long keywords with docText', async () => {
           dbId: expectLongKeywordDbId,
           forceRefresh: false,
         },
-        ['short', longKeyword].map(value => ({
-          value,
-          label: value,
-          title: value,
-        })),
+        {
+          result: ['short', longKeyword].map(value => ({
+            value,
+            label: value,
+            title: value,
+          })),
+          default: null,
+        },
       ),
     );
   });

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -164,7 +164,7 @@ export function useKeywords(
 
   const schemaKeywords = useMemo(
     () =>
-      (schemaOptions ?? []).map(s => ({
+      (schemaOptions?.result ?? []).map(s => ({
         name: s.label,
         value: s.value,
         score: SCHEMA_AUTOCOMPLETE_SCORE,

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -397,7 +397,7 @@ test('Should auto-select default schema on load', async () => {
 
   // Wait for the default schema to be auto-selected
   await waitFor(() => {
-    expect(props.onSchemaChange).toHaveBeenCalledWith('public');
+    expect(propsWithoutSchema.onSchemaChange).toHaveBeenCalledWith('public');
   });
 });
 

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -355,19 +355,6 @@ export function DatabaseSelector({
     }
   }, [currentDb?.id, showCatalogSelector]);
 
-  // Auto-select when data becomes available (handles both fresh data and cached data)
-  useEffect(() => {
-    if (catalogData?.result) {
-      autoSelectCatalog(catalogData.result, catalogData.default);
-    }
-  }, [catalogData?.result, catalogData?.default, autoSelectCatalog]);
-
-  useEffect(() => {
-    if (schemaData?.result) {
-      autoSelectSchema(schemaData.result, schemaData.default);
-    }
-  }, [schemaData?.result, schemaData?.default, autoSelectSchema]);
-
   function changeDatabase(
     value: { label: string; value: number },
     database: DatabaseValue,

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -325,7 +325,7 @@ export function DatabaseSelector({
         changeCatalog(undefined);
       }
     },
-    [showCatalogSelector, catalogRef],
+    [showCatalogSelector, changeCatalog, catalogRef],
   );
 
   const autoSelectSchema = useCallback(

--- a/superset-frontend/src/hooks/apiResources/schemas.test.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.test.ts
@@ -28,29 +28,41 @@ import { useSchemas } from './schemas';
 
 const fakeApiResult = {
   result: ['test schema 1', 'test schema b'],
+  default: 'test schema 1',
 };
 const fakeApiResult2 = {
   result: ['test schema 2', 'test schema a'],
+  default: null,
 };
 const fakeApiResult3 = {
   result: ['test schema 3', 'test schema c'],
+  default: 'test schema 3',
 };
 
-const expectedResult = fakeApiResult.result.map((value: string) => ({
-  value,
-  label: value,
-  title: value,
-}));
-const expectedResult2 = fakeApiResult2.result.map((value: string) => ({
-  value,
-  label: value,
-  title: value,
-}));
-const expectedResult3 = fakeApiResult3.result.map((value: string) => ({
-  value,
-  label: value,
-  title: value,
-}));
+const expectedResult = {
+  result: fakeApiResult.result.map((value: string) => ({
+    value,
+    label: value,
+    title: value,
+  })),
+  default: fakeApiResult.default,
+};
+const expectedResult2 = {
+  result: fakeApiResult2.result.map((value: string) => ({
+    value,
+    label: value,
+    title: value,
+  })),
+  default: fakeApiResult2.default,
+};
+const expectedResult3 = {
+  result: fakeApiResult3.result.map((value: string) => ({
+    value,
+    label: value,
+    title: value,
+  })),
+  default: fakeApiResult3.default,
+};
 
 describe('useSchemas hook', () => {
   beforeEach(() => {

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -172,7 +172,7 @@ export function useTables(options: Params) {
     catalog: catalog || undefined,
   });
   const schemaOptionsMap = useMemo(
-    () => new Set(schemaOptions?.map(({ value }) => value)),
+    () => new Set(schemaOptions?.result?.map(({ value }) => value)),
     [schemaOptions],
   );
 

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -728,6 +728,11 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 catalogs,
             )
             default_catalog = database.get_default_catalog()
+            # TODO: Consider refactoring API response structure during
+            # next breaking change window to return catalogs as objects
+            # with a 'default' flag instead of separate fields
+            # e.g., result=[{"name": "catalog1", "default": true},
+            #                {"name": "catalog2", "default": false}]
             return self.response(200, result=list(catalogs), default=default_catalog)
         except OperationalError:
             return self.response(
@@ -815,6 +820,11 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                         ],
                         default=default_schema,
                     )
+            # TODO: Consider refactoring API response structure during
+            # next breaking change window to return schemas as objects
+            # with a 'default' flag instead of separate fields
+            # e.g., result=[{"name": "schema1", "default": true},
+            #                {"name": "schema2", "default": false}]
             return self.response(200, result=list(schemas), default=default_schema)
         except OperationalError:
             return self.response(

--- a/superset/databases/api.py
+++ b/superset/databases/api.py
@@ -727,7 +727,8 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 database,
                 catalogs,
             )
-            return self.response(200, result=list(catalogs))
+            default_catalog = database.get_default_catalog()
+            return self.response(200, result=list(catalogs), default=default_catalog)
         except OperationalError:
             return self.response(
                 500,
@@ -796,9 +797,10 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                 catalog,
                 schemas,
             )
+            default_schema = database.get_default_schema(catalog)
             if params.get("upload_allowed"):
                 if not database.allow_file_upload:
-                    return self.response(200, result=[])
+                    return self.response(200, result=[], default=default_schema)
                 if allowed_schemas := database.get_schema_access_for_file_upload():
                     # some databases might return the list of schemas in uppercase,
                     # while the list of allowed schemas is manually inputted so
@@ -811,8 +813,9 @@ class DatabaseRestApi(BaseSupersetModelRestApi):
                             for schema in schemas
                             if schema.lower() in allowed_schemas
                         ],
+                        default=default_schema,
                     )
-            return self.response(200, result=list(schemas))
+            return self.response(200, result=list(schemas), default=default_schema)
         except OperationalError:
             return self.response(
                 500, message="There was an error connecting to the database"

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -724,11 +724,19 @@ class SchemasResponseSchema(Schema):
     result = fields.List(
         fields.String(metadata={"description": "A database schema name"})
     )
+    default = fields.String(
+        allow_none=True,
+        metadata={"description": "The default schema for this database"},
+    )
 
 
 class CatalogsResponseSchema(Schema):
     result = fields.List(
         fields.String(metadata={"description": "A database catalog name"})
+    )
+    default = fields.String(
+        allow_none=True,
+        metadata={"description": "The default catalog for this database"},
     )
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We have information on the default catalog and schema, so why not use it to select a catalog and a schema after reading the possible values?

This PR adds the default catalog/schema to the catalogs/schemas response, respectively, and pre-selects them in the `DatabaseSelector` component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

https://github.com/user-attachments/assets/627213cf-4a5d-4784-881a-a4c1939e0b6d

Note that for duckdb the default schema is `main` (as returned by the SQLAlchemy dialect), but it doesn't match any of the schemas returned by `get_schema_names`, so nothing gets selected. This is a bug in the duckdb dialect and I've talked with them about it.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
