### PR TITLE
fix(tests): one of integration test in TestSqlaTableModel  does not support MySQL "concat" 

### DIFF
--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -450,12 +450,11 @@ class TestSqlaTableModel(SupersetTestCase):
         spec.allows_joins = inner_join
 
         # Use database-specific string concatenation syntax
-        database = self.get_database_by_id(tbl.database_id)
-        if database.backend == "mysql":
-            arbitrary_gby = "CONCAT(state, gender, '_test')"
-        else:
-            # Use PostgreSQL/SQLite style for other databases
-            arbitrary_gby = "state || gender || '_test'"
+        arbitrary_gby = (
+            "CONCAT(state, gender, '_test')"
+            if get_example_database().backend == "mysql"
+            else "state || gender || '_test'"
+        )
 
         arbitrary_metric = dict(  # noqa: C408
             label="arbitrary", expressionType="SQL", sqlExpression="SUM(num_boys)"

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -448,11 +448,15 @@ class TestSqlaTableModel(SupersetTestCase):
             return None
         old_inner_join = spec.allows_joins
         spec.allows_joins = inner_join
-        arbitrary_gby = (
-            "state OR gender OR '_test'"
-            if get_example_database().backend == "mysql"
-            else "state || gender || '_test'"
-        )
+
+        # Use database-specific string concatenation syntax
+        database = self.get_database_by_id(tbl.database_id)
+        if database.backend == "mysql":
+            arbitrary_gby = "CONCAT(state, gender, '_test')"
+        else:
+            # Use PostgreSQL/SQLite style for other databases
+            arbitrary_gby = "state || gender || '_test'"
+
         arbitrary_metric = dict(  # noqa: C408
             label="arbitrary", expressionType="SQL", sqlExpression="SUM(num_boys)"
         )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The test: tests/integration_tests/model_tests.py::TestSqlaTableModel::test_query_with_expr_groupby_timeseries uses MySQL as the database backend (SQLALCHEMY_EXAMPLES_URI). However, I noticed that the SQL sent to MySQL does not conform to expectations. It contains the PG syntax "select state || gender || '_test'" (or "or" in MySQL). This behavior is intended to implement string concatenation, but it is not logically valid for MySQL. Although this case passes, its logic is flawed.

The mysql || (or "or") operation on multiple strings evaluates to 0. This 0 is used as the result of a subquery in the join SQL statement, resulting in a query result. However, this test only checks whether a result was obtained, not whether the result is correct, so it passes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
