### PR TITLE
fix: doris genericDataType modify

### DIFF
--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -193,12 +193,12 @@ class DorisEngineSpec(MySQLEngineSpec):
         (
             re.compile(r"^datetime.*", re.IGNORECASE),
             types.DATETIME(),
-            GenericDataType.STRING,
+            GenericDataType.TEMPORAL,
         ),
         (
             re.compile(r"^date.*", re.IGNORECASE),
             types.DATE(),
-            GenericDataType.STRING,
+            GenericDataType.TEMPORAL,
         ),
         (
             re.compile(r"^text.*", re.IGNORECASE),

--- a/tests/unit_tests/db_engine_specs/test_doris.py
+++ b/tests/unit_tests/db_engine_specs/test_doris.py
@@ -55,8 +55,8 @@ from tests.unit_tests.db_engine_specs.utils import assert_column_spec
         ("text", types.TEXT, None, GenericDataType.STRING, False),
         ("string", types.String, None, GenericDataType.STRING, False),
         # Date
-        ("datetimev2", types.DateTime, None, GenericDataType.STRING, False),
-        ("datev2", types.Date, None, GenericDataType.STRING, False),
+        ("datetimev2", types.DateTime, None, GenericDataType.TEMPORAL, False),
+        ("datev2", types.Date, None, GenericDataType.TEMPORAL, False),
         # Complex type
         ("array<varchar(65533)>", ARRAY, None, GenericDataType.STRING, False),
         ("map<string,int>", MAP, None, GenericDataType.STRING, False),

--- a/tests/unit_tests/db_engine_specs/test_doris.py
+++ b/tests/unit_tests/db_engine_specs/test_doris.py
@@ -55,8 +55,8 @@ from tests.unit_tests.db_engine_specs.utils import assert_column_spec
         ("text", types.TEXT, None, GenericDataType.STRING, False),
         ("string", types.String, None, GenericDataType.STRING, False),
         # Date
-        ("datetimev2", types.DateTime, None, GenericDataType.TEMPORAL, False),
-        ("datev2", types.Date, None, GenericDataType.TEMPORAL, False),
+        ("datetimev2", types.DateTime, None, GenericDataType.TEMPORAL, True),
+        ("datev2", types.Date, None, GenericDataType.TEMPORAL, True),
         # Complex type
         ("array<varchar(65533)>", ARRAY, None, GenericDataType.STRING, False),
         ("map<string,int>", MAP, None, GenericDataType.STRING, False),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
test case :tests/integration_tests/sqla_models_tests.py::TestDatabaseModel::test_db_column_types  fails when running with doris as the data backend because we mapped the date data type to string in doris's column_type_mappings.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
