### PR TITLE
fix(echarts): rename time series shifted for isTimeComparisonValue

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/renameOperator.ts
@@ -43,15 +43,17 @@ export const renameOperator: PostProcessingFactory<PostProcessingRename> = (
 
   // remove or rename top level of column name(metric name) in the MultiIndex when
   // 1) at least 1 metric
-  // 2) dimension exist or multiple time shift metrics exist
-  // 3) xAxis exist
-  // 4) truncate_metric in form_data and truncate_metric is true
+  // 2) xAxis exist
+  // 3a) isTimeComparisonValue
+  // 3b-1) dimension exist or multiple time shift metrics exist
+  // 3b-2) truncate_metric in form_data and truncate_metric is true
   if (
     metrics.length > 0 &&
-    (columns.length > 0 || timeOffsets.length > 1) &&
     xAxisLabel &&
-    truncate_metric !== undefined &&
-    !!truncate_metric
+    (isTimeComparisonValue ||
+      ((columns.length > 0 || timeOffsets.length > 1) &&
+        truncate_metric !== undefined &&
+        !!truncate_metric))
   ) {
     const renamePairs: [string, string | null][] = [];
     if (

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/renameOperator.test.ts
@@ -160,6 +160,44 @@ test('should add renameOperator if exists derived metrics', () => {
   });
 });
 
+test('should add renameOperator if isTimeComparisonValue without columns', () => {
+  [
+    ComparisonType.Difference,
+    ComparisonType.Ratio,
+    ComparisonType.Percentage,
+  ].forEach(type => {
+    expect(
+      renameOperator(
+        {
+          ...formData,
+          ...{
+            comparison_type: type,
+            time_compare: ['1 year ago'],
+          },
+        },
+        {
+          ...queryObject,
+          ...{
+            columns: [],
+            metrics: ['sum(val)', 'avg(val2)'],
+          },
+        },
+      ),
+    ).toEqual({
+      operation: 'rename',
+      options: {
+        columns: {
+          [`${type}__avg(val2)__avg(val2)__1 year ago`]:
+            'avg(val2), 1 year ago',
+          [`${type}__sum(val)__sum(val)__1 year ago`]: 'sum(val), 1 year ago',
+        },
+        inplace: true,
+        level: 0,
+      },
+    });
+  });
+});
+
 test('should add renameOperator if x_axis does not exist', () => {
   expect(
     renameOperator(


### PR DESCRIPTION
### SUMMARY
Following up https://github.com/apache/superset/pull/34541, this commit adds an additional rename rule for non-actual value types containing a time comparison value.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:

<img width="1313" height="974" alt="Screenshot_2025-09-04_at_2_33_44 PM" src="https://github.com/user-attachments/assets/8aef565f-20d3-431d-9cec-9e2eee47917f" />

after:

<img width="1310" height="1011" alt="Screenshot_2025-09-04_at_2_34_35 PM" src="https://github.com/user-attachments/assets/f0be7012-40fb-4a43-a5ac-4147f6683ebd" />

### TESTING INSTRUCTIONS
specs are added


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
