### PR TITLE
fix(deck.gl): ensure min/max values are included in polygon map legend breakpoints

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
@@ -280,7 +280,7 @@ describe('getBreakPoints', () => {
       expect(3.14).toBeGreaterThanOrEqual(firstBp);
       
       // The first breakpoint should be a clean floor value
-      expect(breakPoints[0]).toMatch(/^3(\.0+)?$/);
+      expect(breakPoints[0]).toMatch(/^3(\.0*)?$/);
     });
 
     it('prevents maximum value exclusion edge case', () => {
@@ -308,7 +308,7 @@ describe('getBreakPoints', () => {
       expect(38.7).toBeLessThanOrEqual(lastBp);
       
       // The last breakpoint should be a clean ceil value
-      expect(breakPoints[breakPoints.length - 1]).toMatch(/^39(\.0+)?$/);
+      expect(breakPoints[breakPoints.length - 1]).toMatch(/^39(\.0*)?$/);
     });
   });
 
@@ -447,8 +447,8 @@ describe('getBreakPoints', () => {
         accessor,
       );
 
-      // Should handle gracefully, even if results are unusual
-      expect(Array.isArray(breakPoints)).toBe(true);
+      // Should return empty array when Infinity values are present
+      expect(breakPoints).toEqual([]);
     });
   });
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
@@ -50,11 +50,7 @@ describe('getBreakPoints', () => {
 
   describe('automatic breakpoint generation', () => {
     it('generates correct number of breakpoints for given buckets', () => {
-      const features = [
-        { value: 0 },
-        { value: 50 },
-        { value: 100 },
-      ];
+      const features = [{ value: 0 }, { value: 50 }, { value: 100 }];
 
       const breakPoints = getBreakPoints(
         { break_points: [], num_buckets: '5' },
@@ -117,7 +113,7 @@ describe('getBreakPoints', () => {
       // Check that breakpoints are evenly spaced
       const numericBreakPoints = breakPoints.map(parseFloat);
       const deltas = [];
-      for (let i = 1; i < numericBreakPoints.length; i++) {
+      for (let i = 1; i < numericBreakPoints.length; i += 1) {
         deltas.push(numericBreakPoints[i] - numericBreakPoints[i - 1]);
       }
 
@@ -129,11 +125,7 @@ describe('getBreakPoints', () => {
     });
 
     it('handles single value datasets', () => {
-      const features = [
-        { value: 42 },
-        { value: 42 },
-        { value: 42 },
-      ];
+      const features = [{ value: 42 }, { value: 42 }, { value: 42 }];
 
       const breakPoints = getBreakPoints(
         { break_points: [], num_buckets: '5' },
@@ -190,11 +182,15 @@ describe('getBreakPoints', () => {
 
       const numericBreakPoints = breakPoints.map(parseFloat);
       expect(numericBreakPoints[0]).toBeLessThanOrEqual(-100);
-      expect(numericBreakPoints[numericBreakPoints.length - 1]).toBeGreaterThanOrEqual(100);
+      expect(
+        numericBreakPoints[numericBreakPoints.length - 1],
+      ).toBeGreaterThanOrEqual(100);
 
       // Verify ascending order
-      for (let i = 1; i < numericBreakPoints.length; i++) {
-        expect(numericBreakPoints[i]).toBeGreaterThan(numericBreakPoints[i - 1]);
+      for (let i = 1; i < numericBreakPoints.length; i += 1) {
+        expect(numericBreakPoints[i]).toBeGreaterThan(
+          numericBreakPoints[i - 1],
+        );
       }
     });
 
@@ -223,7 +219,7 @@ describe('getBreakPoints', () => {
     it('uses floor/ceil for boundary breakpoints to ensure inclusion', () => {
       // Test that Math.floor and Math.ceil are used for boundaries
       // This ensures all data points fall within the breakpoint range
-      
+
       const testCases = [
         { minValue: 3.14, maxValue: 100, buckets: 5 },
         { minValue: 2.345, maxValue: 10.678, buckets: 4 },
@@ -233,7 +229,7 @@ describe('getBreakPoints', () => {
 
       testCases.forEach(({ minValue, maxValue, buckets }) => {
         const features = [{ value: minValue }, { value: maxValue }];
-        
+
         const breakPoints = getBreakPoints(
           { break_points: [], num_buckets: String(buckets) },
           features,
@@ -242,13 +238,13 @@ describe('getBreakPoints', () => {
 
         const firstBp = parseFloat(breakPoints[0]);
         const lastBp = parseFloat(breakPoints[breakPoints.length - 1]);
-        
+
         // First breakpoint should be floored (always <= minValue)
         expect(firstBp).toBeLessThanOrEqual(minValue);
-        
+
         // Last breakpoint should be ceiled (always >= maxValue)
         expect(lastBp).toBeGreaterThanOrEqual(maxValue);
-        
+
         // All values should be within range
         expect(minValue).toBeGreaterThanOrEqual(firstBp);
         expect(maxValue).toBeLessThanOrEqual(lastBp);
@@ -258,13 +254,13 @@ describe('getBreakPoints', () => {
     it('prevents minimum value exclusion edge case', () => {
       // Specific edge case test for minimum value exclusion
       // Tests the exact scenario where rounding would exclude the min value
-      
+
       const features = [
         { value: 3.14 }, // This would round to 3 at precision 0
         { value: 50 },
         { value: 100 },
       ];
-      
+
       const breakPoints = getBreakPoints(
         { break_points: [], num_buckets: '5' },
         features,
@@ -272,13 +268,13 @@ describe('getBreakPoints', () => {
       );
 
       const firstBp = parseFloat(breakPoints[0]);
-      
+
       // The first breakpoint must be <= 3.14 (floor behavior)
       expect(firstBp).toBeLessThanOrEqual(3.14);
-      
+
       // Verify that 3.14 is not excluded
       expect(3.14).toBeGreaterThanOrEqual(firstBp);
-      
+
       // The first breakpoint should be a clean floor value
       expect(breakPoints[0]).toMatch(/^3(\.0*)?$/);
     });
@@ -286,13 +282,13 @@ describe('getBreakPoints', () => {
     it('prevents maximum value exclusion edge case', () => {
       // Specific edge case test for maximum value exclusion
       // Tests the exact scenario where rounding would exclude the max value
-      
+
       const features = [
         { value: 0 },
         { value: 20 },
         { value: 38.7 }, // Original bug case
       ];
-      
+
       const breakPoints = getBreakPoints(
         { break_points: [], num_buckets: '5' },
         features,
@@ -300,13 +296,13 @@ describe('getBreakPoints', () => {
       );
 
       const lastBp = parseFloat(breakPoints[breakPoints.length - 1]);
-      
+
       // The last breakpoint must be >= 38.7 (ceil behavior)
       expect(lastBp).toBeGreaterThanOrEqual(38.7);
-      
+
       // Verify that 38.7 is not excluded
       expect(38.7).toBeLessThanOrEqual(lastBp);
-      
+
       // The last breakpoint should be a clean ceil value
       expect(breakPoints[breakPoints.length - 1]).toMatch(/^39(\.0*)?$/);
     });
@@ -411,7 +407,8 @@ describe('getBreakPoints', () => {
       const breakPoints = getBreakPoints(
         { break_points: [], num_buckets: '3' },
         features,
-        (d: any) => (typeof d.value === 'string' ? parseFloat(d.value) : d.value),
+        (d: any) =>
+          typeof d.value === 'string' ? parseFloat(d.value) : d.value,
       );
 
       const firstBp = parseFloat(breakPoints[0]);
@@ -457,14 +454,14 @@ describe('getBreakPoints', () => {
       // Generate random test data
       const generateRandomData = (count: number, min: number, max: number) => {
         const data = [];
-        for (let i = 0; i < count; i++) {
+        for (let i = 0; i < count; i += 1) {
           data.push({ value: Math.random() * (max - min) + min });
         }
         return data;
       };
 
       // Test with various random datasets
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 10; i += 1) {
         const features = generateRandomData(20, -1000, 1000);
         const minValue = Math.min(...features.map(f => f.value));
         const maxValue = Math.max(...features.map(f => f.value));

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -86,6 +86,11 @@ export function getBreakPoints(
         const value = minValue + i * delta;
         // For the first breakpoint, use the actual min value
         if (i === 0) {
+          const rounded = parseFloat(minValue.toFixed(precision));
+          // Ensure first breakpoint is <= minValue to include all data points
+          return rounded > minValue
+            ? (minValue - Math.pow(10, -precision)).toFixed(precision)
+            : minValue.toFixed(precision);
           return minValue.toFixed(precision);
         }
         // For the last breakpoint, ensure it includes the max value

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -91,7 +91,6 @@ export function getBreakPoints(
           return rounded > minValue
             ? (minValue - Math.pow(10, -precision)).toFixed(precision)
             : minValue.toFixed(precision);
-          return minValue.toFixed(precision);
         }
         // For the last breakpoint, ensure it includes the max value
         if (i === numBuckets) {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -84,34 +84,20 @@ export function getBreakPoints(
       .fill(0)
       .map((_, i) => {
         const value = minValue + i * delta;
-        // For the first breakpoint, use the actual min value
+        
+        // For the first breakpoint, floor to ensure minimum is included
         if (i === 0) {
-          const rounded = parseFloat(minValue.toFixed(precision));
-          // Ensure first breakpoint is <= minValue to include all data points
-          return rounded > minValue
-            ? (minValue - Math.pow(10, -precision)).toFixed(precision)
-            : minValue.toFixed(precision);
+          const scale = Math.pow(10, precision);
+          return (Math.floor(minValue * scale) / scale).toFixed(precision);
         }
-        // For the last breakpoint, ensure it includes the max value
+        
+        // For the last breakpoint, ceil to ensure maximum is included
         if (i === numBuckets) {
-          // Use the actual max value or slightly higher if needed for rounding
-          const calculatedValue = parseFloat(value.toFixed(precision));
-          const roundedMaxValue = parseFloat(maxValue.toFixed(precision));
-          
-          // If the calculated value from the delta is >= maxValue, use it
-          if (calculatedValue >= maxValue) {
-            return calculatedValue.toFixed(precision);
-          }
-          
-          // If maxValue.toFixed(precision) rounds down and excludes maxValue,
-          // we need to adjust it upward
-          if (roundedMaxValue < maxValue) {
-            return (maxValue + Math.pow(10, -precision)).toFixed(precision);
-          }
-          
-          // Otherwise, use the rounded max value
-          return maxValue.toFixed(precision);
+          const scale = Math.pow(10, precision);
+          return (Math.ceil(maxValue * scale) / scale).toFixed(precision);
         }
+        
+        // For middle breakpoints, use standard rounding
         return value.toFixed(precision);
       });
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -95,10 +95,22 @@ export function getBreakPoints(
         // For the last breakpoint, ensure it includes the max value
         if (i === numBuckets) {
           // Use the actual max value or slightly higher if needed for rounding
-          const rounded = parseFloat(value.toFixed(precision));
-          return rounded >= maxValue
-            ? rounded.toFixed(precision)
-            : maxValue.toFixed(precision);
+          const calculatedValue = parseFloat(value.toFixed(precision));
+          const roundedMaxValue = parseFloat(maxValue.toFixed(precision));
+          
+          // If the calculated value from the delta is >= maxValue, use it
+          if (calculatedValue >= maxValue) {
+            return calculatedValue.toFixed(precision);
+          }
+          
+          // If maxValue.toFixed(precision) rounds down and excludes maxValue,
+          // we need to adjust it upward
+          if (roundedMaxValue < maxValue) {
+            return (maxValue + Math.pow(10, -precision)).toFixed(precision);
+          }
+          
+          // Otherwise, use the rounded max value
+          return maxValue.toFixed(precision);
         }
         return value.toFixed(precision);
       });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -78,16 +78,28 @@ export function getBreakPoints(
     const delta = (maxValue - minValue) / numBuckets;
     const precision =
       delta === 0 ? 0 : Math.max(0, Math.ceil(Math.log10(1 / delta)));
-    const extraBucket =
-      maxValue > parseFloat(maxValue.toFixed(precision)) ? 1 : 0;
-    const startValue =
-      minValue < parseFloat(minValue.toFixed(precision))
-        ? minValue - 1
-        : minValue;
 
-    return new Array(numBuckets + 1 + extraBucket)
+    // Generate breakpoints
+    const breakPoints = new Array(numBuckets + 1)
       .fill(0)
-      .map((_, i) => (startValue + i * delta).toFixed(precision));
+      .map((_, i) => {
+        const value = minValue + i * delta;
+        // For the first breakpoint, use the actual min value
+        if (i === 0) {
+          return minValue.toFixed(precision);
+        }
+        // For the last breakpoint, ensure it includes the max value
+        if (i === numBuckets) {
+          // Use the actual max value or slightly higher if needed for rounding
+          const rounded = parseFloat(value.toFixed(precision));
+          return rounded >= maxValue
+            ? rounded.toFixed(precision)
+            : maxValue.toFixed(precision);
+        }
+        return value.toFixed(precision);
+      });
+
+    return breakPoints;
   }
 
   return formDataBreakPoints.sort(
@@ -146,7 +158,9 @@ export function getBreakPointColorScaler(
     scaler = scaleThreshold<number, string>()
       .domain(points)
       .range(bucketedColors);
-    maskPoint = value => !!value && (value > points[n] || value < points[0]);
+    // Only mask values that are strictly outside the min/max bounds
+    // Include values equal to the max breakpoint
+    maskPoint = value => !!value && (value > points[points.length - 1] || value < points[0]);
   } else {
     // interpolate colors linearly
     const linearScaleDomain = extent(features, accessor);

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -75,6 +75,10 @@ export function getBreakPoints(
     if (minValue === undefined || maxValue === undefined) {
       return [];
     }
+    // Handle Infinity values
+    if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
+      return [];
+    }
     const delta = (maxValue - minValue) / numBuckets;
     const precision =
       delta === 0 ? 0 : Math.max(0, Math.ceil(Math.log10(1 / delta)));

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.ts
@@ -84,26 +84,24 @@ export function getBreakPoints(
       delta === 0 ? 0 : Math.max(0, Math.ceil(Math.log10(1 / delta)));
 
     // Generate breakpoints
-    const breakPoints = new Array(numBuckets + 1)
-      .fill(0)
-      .map((_, i) => {
-        const value = minValue + i * delta;
-        
-        // For the first breakpoint, floor to ensure minimum is included
-        if (i === 0) {
-          const scale = Math.pow(10, precision);
-          return (Math.floor(minValue * scale) / scale).toFixed(precision);
-        }
-        
-        // For the last breakpoint, ceil to ensure maximum is included
-        if (i === numBuckets) {
-          const scale = Math.pow(10, precision);
-          return (Math.ceil(maxValue * scale) / scale).toFixed(precision);
-        }
-        
-        // For middle breakpoints, use standard rounding
-        return value.toFixed(precision);
-      });
+    const breakPoints = new Array(numBuckets + 1).fill(0).map((_, i) => {
+      const value = minValue + i * delta;
+
+      // For the first breakpoint, floor to ensure minimum is included
+      if (i === 0) {
+        const scale = Math.pow(10, precision);
+        return (Math.floor(minValue * scale) / scale).toFixed(precision);
+      }
+
+      // For the last breakpoint, ceil to ensure maximum is included
+      if (i === numBuckets) {
+        const scale = Math.pow(10, precision);
+        return (Math.ceil(maxValue * scale) / scale).toFixed(precision);
+      }
+
+      // For middle breakpoints, use standard rounding
+      return value.toFixed(precision);
+    });
 
     return breakPoints;
   }
@@ -166,7 +164,8 @@ export function getBreakPointColorScaler(
       .range(bucketedColors);
     // Only mask values that are strictly outside the min/max bounds
     // Include values equal to the max breakpoint
-    maskPoint = value => !!value && (value > points[points.length - 1] || value < points[0]);
+    maskPoint = value =>
+      !!value && (value > points[points.length - 1] || value < points[0]);
   } else {
     // interpolate colors linearly
     const linearScaleDomain = extent(features, accessor);


### PR DESCRIPTION
### Summary
This PR fixes #34747 in the polygon map visualization where the legend color scale incorrectly calculates breakpoints, causing max values (like 38.7) to fall outside the legend bounds and display with incorrect colors.

The issue was in the `getBreakPoints` function which didn't guarantee that min and max values were included in the generated breakpoints. When a value like 38.7 was rounded to create legend intervals (e.g., "31-38"), the actual max value would exceed the last breakpoint, causing it to be masked/transparent instead of showing the correct color.

**Changes made:**
- Fixed `getBreakPoints` function to ensure the first breakpoint always includes the minimum value
- Ensured the last breakpoint always includes or exceeds the maximum value
- Updated `maskPoint` logic to use the actual last breakpoint index for clarity
- Added comprehensive test coverage for edge cases including decimal values

### TESTING INSTRUCTIONS
1. Create a polygon map visualization with decimal max values (e.g., data ranging from 3.2 to 38.7)
2. Set the number of buckets to 5
3. Verify that:
   - The legend includes all data values within its ranges
   - The maximum value (38.7) displays with the correct color (darkest in the scale)
   - No values appear transparent/white due to being outside bounds

4. Run the new unit tests:
   ```bash
   cd superset-frontend
   npm test -- plugins/legacy-preset-chart-deckgl/src/utils.test.ts
   ```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes the polygon legend scale calculation issue reported where max values fall outside bounds
- [ ] Required feature flags:
- [x] Changes UI - Fixes visual display of polygon maps with decimal values
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API