### PR TITLE
fix(playwright): allow screenshotting empty dashboards (#33107)

### DIFF
--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -188,7 +188,6 @@ class WebDriverPlaywright(WebDriverProxy):
                     # chart containers didn't render
                     logger.debug("Wait for chart containers to draw at url: %s", url)
                     slice_container_locator = page.locator(".chart-container")
-                    slice_container_locator.first.wait_for()
                     for slice_container_elem in slice_container_locator.all():
                         slice_container_elem.wait_for()
                 except PlaywrightTimeout:


### PR DESCRIPTION
(cherry picked from commit 2233c02720f30e01198e2e8a1367902d29c59729)

### SUMMARY
This small PR just back ports the change described in https://github.com/apache/superset/pull/33107 to `4.1` branch

### TESTING INSTRUCTIONS
When `4.1.x` worker with playwright enable screenshots an empty dashboard or a slice without a graph:

```
[2025-09-05 06:27:29,501: ERROR/ForkPoolWorker-6] Timed out requesting url https://<redacted>/superset/slice/3129/?standalone=true
Traceback (most recent call last):
  File "/app/superset/utils/webdriver.py", line 182, in get_screenshot
    element.wait_for()
  File "/usr/local/lib/python3.10/site-packages/playwright/sync_api/_generated.py", line 17975, in wait_for
    self._sync(self._impl_obj.wait_for(timeout=timeout, state=state))
  File "/usr/local/lib/python3.10/site-packages/playwright/_impl/_sync_base.py", line 115, in _sync
    return task.result()
  File "/usr/local/lib/python3.10/site-packages/playwright/_impl/_locator.py", line 692, in wait_for
    await self._frame.wait_for_selector(
  File "/usr/local/lib/python3.10/site-packages/playwright/_impl/_frame.py", line 369, in wait_for_selector
    await self._channel.send(
  File "/usr/local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 69, in send
    return await self._connection.wrap_api_call(
  File "/usr/local/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 558, in wrap_api_call
    raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 120000ms exceeded.
Call log:
  - waiting for locator(".chart-container") to be visible
```

### ADDITIONAL INFORMATION
- [X] Has associated issue: https://github.com/apache/superset/issues/33132
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
