### PR TITLE
docs(typos): correct spelling mistakes

### DIFF
--- a/docs/docs/contributing/development.mdx
+++ b/docs/docs/contributing/development.mdx
@@ -620,10 +620,10 @@ See [how tos](/docs/contributing/howtos#linting)
 
 :::tip
 `act` compatibility of Superset's GHAs is not fully tested. Running `act` locally may or may not
-work for different actions, and may require fine tunning and local secret-handling.
+work for different actions, and may require fine tuning and local secret-handling.
 For those more intricate GHAs that are tricky to run locally, we recommend iterating
 directly on GHA's infrastructure, by pushing directly on a branch and monitoring GHA logs.
-For more targetted iteration, see the `gh workflow run --ref {BRANCH}` subcommand of the GitHub CLI.
+For more targeted iteration, see the `gh workflow run --ref {BRANCH}` subcommand of the GitHub CLI.
 :::
 
 For automation and CI/CD, Superset makes extensive use of GitHub Actions (GHA). You

--- a/docs/docs/contributing/howtos.mdx
+++ b/docs/docs/contributing/howtos.mdx
@@ -232,7 +232,7 @@ CYPRESS_CONFIG=true docker compose up --build
 ```
 `docker compose` will get to work and expose a Cypress-ready Superset app.
 This app uses a different database schema (`superset_cypress`) to keep it isolated from
-your other dev environmen(s)t, a specific set of examples, and a set of configurations that
+your other dev environment(s), a specific set of examples, and a set of configurations that
 aligns with the expectations within the end-to-end tests.  Also note that it's served on a
 different port than the default port for the backend (`8088`).
 
@@ -627,7 +627,7 @@ feature flag to `true`, you can add the following line to the PR body/descriptio
 FEATURE_TAGGING_SYSTEM=true
 ```
 
-Simarly, it's possible to disable feature flags with:
+Similarly, it's possible to disable feature flags with:
 
 ```
 FEATURE_TAGGING_SYSTEM=false

--- a/docs/docs/installation/docker-compose.mdx
+++ b/docs/docs/installation/docker-compose.mdx
@@ -282,5 +282,5 @@ address.
 When running `docker compose up`, docker will build what is required behind the scene, but
 may use the docker cache if assets already exist. Running `docker compose build` prior to
 `docker compose up` or the equivalent shortcut `docker compose up --build` ensures that your
-docker images matche the definition in the repository. This should only apply to the main
+docker images match the definition in the repository. This should only apply to the main
 docker-compose.yml file (default) and not to the alternative methods defined above.

--- a/docs/versioned_docs/version-6.0.0/contributing/development.mdx
+++ b/docs/versioned_docs/version-6.0.0/contributing/development.mdx
@@ -620,10 +620,10 @@ See [how tos](/docs/contributing/howtos#linting)
 
 :::tip
 `act` compatibility of Superset's GHAs is not fully tested. Running `act` locally may or may not
-work for different actions, and may require fine tunning and local secret-handling.
+work for different actions, and may require fine tuning and local secret-handling.
 For those more intricate GHAs that are tricky to run locally, we recommend iterating
 directly on GHA's infrastructure, by pushing directly on a branch and monitoring GHA logs.
-For more targetted iteration, see the `gh workflow run --ref {BRANCH}` subcommand of the GitHub CLI.
+For more targeted iteration, see the `gh workflow run --ref {BRANCH}` subcommand of the GitHub CLI.
 :::
 
 For automation and CI/CD, Superset makes extensive use of GitHub Actions (GHA). You

--- a/docs/versioned_docs/version-6.0.0/contributing/howtos.mdx
+++ b/docs/versioned_docs/version-6.0.0/contributing/howtos.mdx
@@ -232,7 +232,7 @@ CYPRESS_CONFIG=true docker compose up --build
 ```
 `docker compose` will get to work and expose a Cypress-ready Superset app.
 This app uses a different database schema (`superset_cypress`) to keep it isolated from
-your other dev environmen(s)t, a specific set of examples, and a set of configurations that
+your other dev environment(s), a specific set of examples, and a set of configurations that
 aligns with the expectations within the end-to-end tests.  Also note that it's served on a
 different port than the default port for the backend (`8088`).
 
@@ -627,7 +627,7 @@ feature flag to `true`, you can add the following line to the PR body/descriptio
 FEATURE_TAGGING_SYSTEM=true
 ```
 
-Simarly, it's possible to disable feature flags with:
+Similarly, it's possible to disable feature flags with:
 
 ```
 FEATURE_TAGGING_SYSTEM=false

--- a/docs/versioned_docs/version-6.0.0/installation/docker-compose.mdx
+++ b/docs/versioned_docs/version-6.0.0/installation/docker-compose.mdx
@@ -282,5 +282,5 @@ address.
 When running `docker compose up`, docker will build what is required behind the scene, but
 may use the docker cache if assets already exist. Running `docker compose build` prior to
 `docker compose up` or the equivalent shortcut `docker compose up --build` ensures that your
-docker images matche the definition in the repository. This should only apply to the main
+docker images match the definition in the repository. This should only apply to the main
 docker-compose.yml file (default) and not to the alternative methods defined above.


### PR DESCRIPTION
SUMMARY

Correct typos and minor spelling errors in documentation for enhanced readability and consistency.

BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

TESTING INSTRUCTIONS

Open the modified documentation files.
Verify that typos are corrected and no content meaning has changed.