### PR TITLE
feat: add optional garbage collection after requests

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -626,6 +626,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "DATE_RANGE_TIMESHIFTS_ENABLED": False,
     # Enable Matrixify feature for matrix-style chart layouts
     "MATRIXIFY": False,
+    # Force garbage collection after every request
+    "FORCE_GARBAGE_COLLECTION_AFTER_EVERY_REQUEST": False,
 }
 
 # ------------------------------

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -638,6 +638,17 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
                     response.headers[k] = v
             return response
 
+        @self.superset_app.after_request
+        def cleanup_analytics_memory(response: Response) -> Response:
+            """Force garbage collection after each request if feature flag enabled"""
+            if feature_flag_manager.is_feature_enabled(
+                "FORCE_GARBAGE_COLLECTION_AFTER_EVERY_REQUEST"
+            ):
+                import gc
+
+                gc.collect()
+            return response
+
         @self.superset_app.context_processor
         def get_common_bootstrap_data() -> dict[str, Any]:
             # Import here to avoid circular imports


### PR DESCRIPTION
## Summary
Adds a feature flag FORCE_GARBAGE_COLLECTION_AFTER_EVERY_REQUEST and corresponding Flask after_request hook to force garbage collection after each request when enabled.

This can help with memory accumulation issues in analytics workloads by ensuring Python's garbage collector runs more frequently.

## Test plan
- [ ] Feature flag defaults to False (disabled)
- [ ] When enabled, gc.collect() is called after each request
- [ ] No functional changes when feature flag is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)