### PR TITLE
chore(sqllab): remove unused json param

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -338,7 +338,6 @@ export function runQuery(query, runPreviewOnly) {
     const postPayload = {
       client_id: query.id,
       database_id: query.dbId,
-      json: true,
       runAsync: query.runAsync,
       catalog: query.catalog,
       schema: query.schema,

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -740,7 +740,6 @@ class DatasourceEditor extends PureComponent {
     this.props.runQuery({
       client_id: this.props.clientId,
       database_id: this.state.datasource.database.id,
-      json: true,
       runAsync: false,
       catalog: this.state.datasource.catalog,
       schema: this.state.datasource.schema,

--- a/superset-frontend/src/database/types.ts
+++ b/superset-frontend/src/database/types.ts
@@ -20,7 +20,6 @@
 export interface QueryExecutePayload {
   client_id: string;
   database_id: number;
-  json: boolean;
   runAsync: boolean;
   catalog: string | null;
   schema: string;

--- a/superset/sqllab/schemas.py
+++ b/superset/sqllab/schemas.py
@@ -63,7 +63,6 @@ class ExecutePayloadSchema(Schema):
     templateParams = fields.String(allow_none=True)  # noqa: N815
     tmp_table_name = fields.String(allow_none=True)
     select_as_cta = fields.Boolean(allow_none=True)
-    json = fields.Boolean(allow_none=True)
     runAsync = fields.Boolean(allow_none=True)  # noqa: N815
     expand_data = fields.Boolean(allow_none=True)
 

--- a/superset/views/sql_lab/schemas.py
+++ b/superset/views/sql_lab/schemas.py
@@ -30,6 +30,5 @@ class SqlJsonPayloadSchema(Schema):
     templateParams = fields.String(allow_none=True)  # noqa: N815
     tmp_table_name = fields.String(allow_none=True)
     select_as_cta = fields.Boolean(allow_none=True)
-    json = fields.Boolean(allow_none=True)
     runAsync = fields.Boolean(allow_none=True)  # noqa: N815
     expand_data = fields.Boolean(allow_none=True)


### PR DESCRIPTION
### SUMMARY
Regarding the `json` field in the sqllab execute request, this value was defined [a long time ago](https://github.com/apache/superset/pull/514/files) and is always sent as a fixed value from the frontend. Additionally, after reviewing [the code](https://github.com/apache/superset/blob/da7f6efea897efeb54208a8bdb0dd80d72aa4bef/superset/sqllab/sqllab_execution_context.py#L74-L94), I could not find any place where this value is actually used.
Therefore, I have determined that it is unnecessary and will be removing it.


### TESTING INSTRUCTIONS
CI and specs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
