### PR TITLE
chore: standardize webpack dev server host configuration and enable LAN access

### DIFF
--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -162,8 +162,11 @@ services:
       SCARF_ANALYTICS: "${SCARF_ANALYTICS:-}"
       # configuring the dev-server to use the host.docker.internal to connect to the backend
       superset: "http://superset-light:8088"
+      # Webpack dev server configuration
+      WEBPACK_DEVSERVER_HOST: "${WEBPACK_DEVSERVER_HOST:-127.0.0.1}"
+      WEBPACK_DEVSERVER_PORT: "${WEBPACK_DEVSERVER_PORT:-9000}"
     ports:
-      - "127.0.0.1:${NODE_PORT:-9001}:9000"  # Parameterized port
+      - "${NODE_PORT:-9001}:9000"  # Parameterized port, accessible on all interfaces
     command: ["/app/docker/docker-frontend.sh"]
     env_file:
       - path: docker/.env # default

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -51,10 +51,16 @@ const MINI_CSS_EXTRACT_PUBLICPATH = './';
 
 const {
   mode = 'development',
-  devserverPort = 9000,
+  devserverPort: cliPort,
+  devserverHost: cliHost,
   measure = false,
   nameChunks = false,
 } = parsedArgs;
+
+// Precedence: CLI args > env vars > defaults
+const devserverPort = cliPort || process.env.WEBPACK_DEVSERVER_PORT || 9000;
+const devserverHost =
+  cliHost || process.env.WEBPACK_DEVSERVER_HOST || '127.0.0.1';
 
 const isDevMode = mode !== 'production';
 const isDevServer = process.argv[1].includes('webpack-dev-server');
@@ -568,7 +574,9 @@ if (isDevMode) {
     },
     historyApiFallback: true,
     hot: true,
+    host: devserverHost,
     port: devserverPort,
+    allowedHosts: ['localhost', '.localhost', '127.0.0.1', '::1', '.local'],
     proxy: [() => proxyConfig],
     client: {
       overlay: {


### PR DESCRIPTION
Standardize webpack dev server host configuration and enable LAN access

    - Adds configurable devserverHost parameter with CLI and env var support
    - Supports WEBPACK_DEVSERVER_HOST and WEBPACK_DEVSERVER_PORT environment variables
    - Maintains CLI argument precedence: --devserverHost > WEBPACK_DEVSERVER_HOST > 127.0.0.1
    - Updates allowedHosts to support .local domains for LAN development
    - Removes docker-compose localhost binding restriction for external access
    - Follows 2025 framework standards: secure by default, easy opt-in for network access