### PR TITLE
fix: Change database event in core

### DIFF
--- a/superset-frontend/src/core/sqlLab.ts
+++ b/superset-frontend/src/core/sqlLab.ts
@@ -102,8 +102,11 @@ export const onDidChangeEditorDatabase: typeof sqlLabType.onDidChangeEditorDatab
     createActionListener(
       predicate(QUERY_EDITOR_SETDB),
       listener,
-      (action: { type: string; queryEditor: { dbId: number } }) =>
-        action.queryEditor.dbId,
+      (action: {
+        type: string;
+        dbId?: number;
+        queryEditor: { dbId: number };
+      }) => action.dbId || action.queryEditor.dbId,
       thisArgs,
     );
 


### PR DESCRIPTION
### SUMMARY
Fix the `onDidChangeEditorDatabase` event to get the database ID from the action before trying to get it from the editor. 

### TESTING INSTRUCTIONS
CI is sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
