### PR TITLE
fix(pie): fixes pie chart other click error

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -54,7 +54,9 @@ const getCrossFilterDataMask =
       values = [value];
     }
 
-    const groupbyValues = values.map(value => labelMap[value]);
+    const groupbyValues = values
+      .map(value => labelMap[value])
+      .filter(Boolean) as string[][];
 
     return {
       dataMask: {
@@ -122,6 +124,9 @@ export const contextMenuEventHandler =
       const drillFilters: BinaryQueryObjectFilterClause[] = [];
       if (groupby.length > 0) {
         const values = labelMap[e.name];
+        if (!values) {
+          return;
+        }
         groupby.forEach((dimension, i) => {
           drillFilters.push({
             col: dimension,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
Fixes pie chart run time error on clicking the "other" group.
Fixes #35028 

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The issue was caused by the event handler in eventHandlers.ts which did not account for the "Other" group not having a corresponding entry in the labelMap. This led to an attempt to access a property on an undefined value, resulting in a TypeError.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:-
<img width="1248" height="760" alt="Screenshot 2025-09-10 at 16 20 58" src="https://github.com/user-attachments/assets/bc570c71-5865-4b80-9033-02d411f1a046" />
After:-
<img width="1248" height="760" alt="Screenshot 2025-09-10 at 16 21 27" src="https://github.com/user-attachments/assets/35d55804-46ee-4334-9e01-7417b709235a" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Create or open a dashboard with a Pie Chart, ensure an "Other" slice is generated (e.g., by lowering the Series Limit), then click both a regular slice and the "Other" slice.
Verify that regular slices support cross-filtering as expected, while clicking "Other" does not crash the app and shows no drill-down options.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
