### PR TITLE
fix(theming): replace error color with bolt icon for local themes

### DIFF
--- a/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
@@ -188,7 +188,7 @@ describe('useThemeMenuItems', () => {
 
   it('displays override icon when hasLocalOverride is true', () => {
     renderThemeMenu({ ...defaultProps, hasLocalOverride: true });
-    expect(screen.getByTestId('format-painter')).toBeInTheDocument();
+    expect(screen.getByTestId('thunderbolt')).toBeInTheDocument();
   });
 
   it('renders Theme group header', async () => {

--- a/superset-frontend/src/hooks/useThemeMenuItems.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 import { useMemo } from 'react';
-import { Icons } from '@superset-ui/core/components';
+import { Icons, Tooltip } from '@superset-ui/core/components';
 import type { MenuItem } from '@superset-ui/core/components/Menu';
-import { t, ThemeMode, useTheme, ThemeAlgorithm } from '@superset-ui/core';
+import { t, ThemeMode, ThemeAlgorithm } from '@superset-ui/core';
 
 export interface ThemeSubMenuOption {
   key: ThemeMode;
@@ -43,8 +43,6 @@ export const useThemeMenuItems = ({
   onClearLocalSettings,
   allowOSPreference = true,
 }: ThemeSubMenuProps): MenuItem => {
-  const theme = useTheme();
-
   const handleSelect = (mode: ThemeMode) => {
     setThemeMode(mode);
   };
@@ -63,11 +61,13 @@ export const useThemeMenuItems = ({
   const selectedThemeModeIcon = useMemo(
     () =>
       hasLocalOverride ? (
-        <Icons.FormatPainterOutlined style={{ color: theme.colorError }} />
+        <Tooltip title={t('This theme is set locally')} placement="bottom">
+          <Icons.ThunderboltOutlined />
+        </Tooltip>
       ) : (
         themeIconMap[themeMode]
       ),
-    [hasLocalOverride, theme.colorError, themeIconMap, themeMode],
+    [hasLocalOverride, themeIconMap, themeMode],
   );
 
   const themeOptions: MenuItem[] = [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improved the visual clarity of the `theme` dropdown in the `navbar` by removing the confusing use of error color for local theme indicators. Instead, implemented a consistent icon color scheme with a bolt icon `(ThunderboltOutlined)` to indicate when a theme is set locally, matching the existing convention used in the `theme CRUD interface`.

Also added a helpful `tooltip` that displays `"This theme is set locally"` on hover for better user understanding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="347" height="208" alt="image (3)" src="https://github.com/user-attachments/assets/896c88d1-f5db-44c2-aa6d-b2aa993a3fc6" />

After:
<img width="233" height="64" alt="image" src="https://github.com/user-attachments/assets/185abd2b-a7a4-4c26-9669-90f04efa4e4f" />
<img width="285" height="286" alt="image" src="https://github.com/user-attachments/assets/89cd0a56-aeb5-412d-845b-40c75d8427ce" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Navigate to the theme settings and set a local theme
2. Check the navbar theme dropdown - you should see a bolt icon instead of a colored icon
3. Hover over the bolt icon - you should see the tooltip "This theme is set locally"
4. Verify that all theme icons now use consistent colors (no error color)
5. Clear the local theme settings and verify the bolt icon disappears

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
