### PR TITLE
fix: Remove emotion-rgba from dependencies and codebase

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -64,7 +64,6 @@
         "dom-to-image-more": "^3.6.0",
         "dom-to-pdf": "^0.3.2",
         "echarts": "^5.6.0",
-        "emotion-rgba": "0.0.12",
         "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.2.0",
@@ -24465,12 +24464,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/emotion-rgba": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/emotion-rgba/-/emotion-rgba-0.0.12.tgz",
-      "integrity": "sha512-lvtZ52BWisYDtis+HctQMkxcHwmFbzTiZhgMJGFfWXLsBYEzthfKE7nlysOiUwmmAdTM/8YBAPfwQ4MEDwiaWw==",
-      "license": "MIT"
     },
     "node_modules/encodable": {
       "version": "0.7.8",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -132,7 +132,6 @@
     "dom-to-image-more": "^3.6.0",
     "dom-to-pdf": "^0.3.2",
     "echarts": "^5.6.0",
-    "emotion-rgba": "0.0.12",
     "eslint-plugin-i18n-strings": "file:eslint-rules/eslint-plugin-i18n-strings",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",

--- a/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
+++ b/superset-frontend/src/dashboard/components/BuilderComponentPane/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 /* eslint-env browser */
-import { rgba } from 'emotion-rgba';
+import tinycolor from 'tinycolor2';
 import Tabs from '@superset-ui/core/components/Tabs';
 import { t, css, SupersetTheme, useTheme } from '@superset-ui/core';
 import { useSelector } from 'react-redux';
@@ -68,7 +68,8 @@ const BuilderComponentPane = ({ topOffset = 0 }) => {
           position: absolute;
           height: 100%;
           width: ${BUILDER_PANE_WIDTH}px;
-          box-shadow: -4px 0 4px 0 ${rgba(theme.colorBorder, 0.1)};
+          box-shadow: -4px 0 4px 0
+            ${tinycolor(theme.colorBorder).setAlpha(0.1).toRgbString()};
           background-color: ${theme.colorBgBase};
         `}
       >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -28,7 +28,7 @@ import {
 } from '@superset-ui/core';
 import { Button } from '@superset-ui/core/components';
 import { OPEN_FILTER_BAR_WIDTH } from 'src/dashboard/constants';
-import { rgba } from 'emotion-rgba';
+import tinycolor from 'tinycolor2';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { getFilterBarTestId } from '../utils';
 
@@ -73,7 +73,7 @@ const verticalStyle = (theme: SupersetTheme, width: number) => css`
   padding-top: ${theme.sizeUnit * 6}px;
 
   background: linear-gradient(
-    ${rgba(theme.colorBgLayout, 0)},
+    ${tinycolor(theme.colorBgLayout).setAlpha(0).toRgbString()},
     ${theme.colorBgContainer} 20%
   );
 


### PR DESCRIPTION
### SUMMARY
Removed emotion-rgba package from dependencies as it is no longer maintained. The package does not support 8-digit hex colors (with alpha channel), which are increasingly used in modern web development for transparency. The package was not being utilized anywhere in the codebase but was still being bundled, unnecessarily increasing bundle size.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
setting up a theme with an 8 digit value: 
<img width="1470" height="824" alt="Screenshot 2025-09-12 at 7 55 52 PM" src="https://github.com/user-attachments/assets/612a5ab9-6f5d-41ea-a141-b2763698b40a" />

Dashboard with filter (no errors)
<img width="1470" height="824" alt="Screenshot 2025-09-12 at 7 56 33 PM" src="https://github.com/user-attachments/assets/8290bef3-07a0-4817-a414-017a2b9a334b" />


### TESTING INSTRUCTIONS
Set up a theme with an 8 digit hex color. 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API