### PR TITLE
refactor: remove unnecessary themedConfirm wrapper function

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -368,13 +368,9 @@ const CustomModal = ({
 };
 CustomModal.displayName = 'Modal';
 
-// Theme-aware confirmation modal - now inherits theme through App wrapper in SupersetThemeProvider
-const themedConfirm = (props: Parameters<typeof AntdModal.confirm>[0]) =>
-  AntdModal.confirm(props);
-
 export const Modal = Object.assign(CustomModal, {
   error: AntdModal.error,
   warning: AntdModal.warning,
-  confirm: themedConfirm,
+  confirm: AntdModal.confirm,
   useModal: AntdModal.useModal,
 });


### PR DESCRIPTION
## Summary
- Removed unnecessary `themedConfirm` wrapper function in Modal component
- Replaced with direct reference to `AntdModal.confirm` for clarity
- Eliminates pointless abstraction layer that provided no value

## Problem
The `themedConfirm` function was a pass-through wrapper that added no functionality:
```typescript
const themedConfirm = (props: Parameters<typeof AntdModal.confirm>[0]) =>
  AntdModal.confirm(props);
```

Issues with this approach:
- ❌ Claims to be "theme-aware" but provides no theming logic
- ❌ Simply calls `AntdModal.confirm(props)` with identical props  
- ❌ Adds unnecessary abstraction without benefits
- ❌ Misleading comment suggests functionality that doesn't exist

## Solution
Replaced the wrapper with direct reference:
```typescript
// Before
confirm: themedConfirm,

// After  
confirm: AntdModal.confirm,
```

## Why This Is Safe
- **Theming is automatic**: Ant Design modals inherit theming through the App wrapper in SupersetThemeProvider
- **No behavior change**: The function was a pure pass-through
- **Same API**: All existing `Modal.confirm()` calls continue to work identically
- **Better clarity**: More honest about what's actually happening

## Analysis
This appears to be:
- **Legacy code** from an older theming implementation, or
- **Prepared infrastructure** that was never actually utilized, or  
- **Future-proofing** that turned out to be unnecessary

## Testing
✅ No functional changes - pure refactor
✅ All existing Modal.confirm() usage continues to work
✅ Theming still works through SupersetThemeProvider's App wrapper

🤖 Generated with [Claude Code](https://claude.ai/code)