### PR TITLE
fix(dashboard): remove visual gap at top of horizontal filter bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -32,7 +32,7 @@ import crossFiltersSelector from './CrossFilters/selectors';
 
 const HorizontalBar = styled.div`
   ${({ theme }) => `
-    padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px ${
+    padding: 0 ${theme.sizeUnit * 2}px ${
       theme.sizeUnit * 3
     }px ${theme.sizeUnit * 4}px;
     background: ${theme.colorBgBase};


### PR DESCRIPTION
## Summary
- Removes unnecessary visual gap at the top of the horizontal filter bar
- Fixes layout issue where filter bar had excessive top padding

## Problem
The horizontal filter bar was displaying with an unnecessary visual gap at the top due to excessive padding (`theme.sizeUnit * 3px` on the top). This created poor visual alignment between the filter bar and the rest of the dashboard content.

## Solution
- Remove top padding from the `HorizontalBar` styled component
- Change from `padding: ${theme.sizeUnit * 3}px ${theme.sizeUnit * 2}px ...` 
- To `padding: 0 ${theme.sizeUnit * 2}px ...`
- Maintains proper side and bottom padding for appropriate spacing

## Visual Impact
- ✅ Eliminates unwanted gap above horizontal filter bar
- ✅ Improves visual alignment with dashboard content
- ✅ Better overall page layout and spacing
- ✅ No impact on filter functionality

## Files Changed
- `superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)