### PR TITLE
fix(filters): preserve backend metric-based sorting in select filters

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -317,13 +317,20 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   const sortComparator = useCallback(
     (a: LabeledValue, b: LabeledValue) => {
+      // When sortMetric is specified, the backend already sorted the data correctly
+      // Don't override the backend's metric-based sorting with frontend alphabetical sorting
+      if (formData.sortMetric) {
+        return 0; // Preserve the original order from the backend
+      }
+
+      // Only apply alphabetical sorting when no sortMetric is specified
       const labelComparator = propertyComparator('label');
       if (formData.sortAscending) {
         return labelComparator(a, b);
       }
       return labelComparator(b, a);
     },
-    [formData.sortAscending],
+    [formData.sortAscending, formData.sortMetric],
   );
 
   // Use effect for initialisation for filter plugin


### PR DESCRIPTION
## Summary
- Fixes broken metric-based sorting in select filter components  
- Preserves backend sort order when sortMetric is specified (e.g., sort by MAU)
- Maintains alphabetical sorting as fallback when no metric is configured

## Problem
Select filters with metric-based sorting were not working correctly:

**Expected behavior:**
- Configure filter with "Sort by MAU" 
- Backend returns data sorted by MAU values: [high MAU, medium MAU, low MAU]
- Filter options should display in that metric-based order

**Actual behavior:**  
- ❌ Backend correctly sorted by MAU and returned proper order
- ❌ Frontend `sortComparator` was applying alphabetical sorting on labels
- ❌ This completely overrode the intended metric-based sort order
- ❌ Users saw alphabetically sorted options instead of metric-sorted ones

## Root Cause
The `sortComparator` in `SelectFilterPlugin.tsx` was always applying alphabetical sorting based on `formData.sortAscending`, without considering whether `formData.sortMetric` was specified. This meant metric-based backend sorting was being ignored.

## Solution
**1. Check for metric-based sorting:**
```typescript
if (formData.sortMetric) {
  return 0; // Preserve the original order from the backend
}
```

**2. Preserve backend order when sortMetric exists:**
- When `sortMetric` is specified, return 0 from comparator
- This maintains the exact order returned by the backend
- Backend has already done the complex metric-based sorting

**3. Fallback to alphabetical sorting:**
- Only apply alphabetical sorting when no `sortMetric` is configured
- Maintains existing behavior for non-metric sorts

**4. Update dependencies:**
- Added `formData.sortMetric` to `useCallback` dependency array
- Ensures proper re-rendering when sortMetric configuration changes

## Impact
- ✅ Metric-based sorting now works correctly (e.g., sort by MAU, revenue, etc.)
- ✅ Alphabetical sorting still works when no metric is specified  
- ✅ No breaking changes to existing functionality
- ✅ Backend sort order is properly respected

## Files Changed
- `superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx`

## Testing
- Create filter with "Sort by MAU" configuration
- Verify filter options appear in MAU order (not alphabetical)
- Test filters without sortMetric still sort alphabetically
- Confirm sortAscending toggle still works for both cases

🤖 Generated with [Claude Code](https://claude.ai/code)