### PR TITLE
fix(embedded-sdk): clear fetchGuestToken timers on unmount

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -254,7 +254,7 @@ export async function embedDashboard({
       log("error refreshing guest token:", error);
       // Still schedule retry if not unmounted
       if (!isUnmounted) {
-        refreshTimerId = setTimeout(refreshGuestToken, 30000); // retry in 30 seconds
+        refreshTimerId = setTimeout(refreshGuestToken, getGuestTokenRefreshTiming(newGuestToken));
       }
     }
   }

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -252,7 +252,7 @@ export async function embedDashboard({
       }
     } catch (error) {
       log("error refreshing guest token:", error);
-      // Still schedule retry if not unmounted (you might want to add exponential backoff here)
+      // Still schedule retry if not unmounted
       if (!isUnmounted) {
         refreshTimerId = setTimeout(refreshGuestToken, 30000); // retry in 30 seconds
       }

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -109,7 +109,7 @@ export async function embedDashboard({
 }: EmbedDashboardParams): Promise<EmbeddedDashboard> {
   let refreshTimerId: NodeJS.Timeout | null = null;
   let isUnmounted = false;
-  
+
   function log(...info: unknown[]) {
     if (debug) {
       console.debug(`[superset-embedded-sdk][dashboard ${id}]`, ...info);
@@ -237,7 +237,7 @@ export async function embedDashboard({
 
     try {
       const newGuestToken = await fetchGuestToken();
-      
+
       // Check again after async operation
       if (isUnmounted) {
         log("skipping token emission - component unmounted during fetch");
@@ -245,7 +245,7 @@ export async function embedDashboard({
       }
 
       ourPort.emit("guestToken", { guestToken: newGuestToken });
-      
+
       // Schedule next refresh only if not unmounted
       if (!isUnmounted) {
         refreshTimerId = setTimeout(refreshGuestToken, getGuestTokenRefreshTiming(newGuestToken));
@@ -265,14 +265,14 @@ export async function embedDashboard({
     log("unmounting");
     // Set unmount flag to prevent further operations
     isUnmounted = true;
-    
+
     // Clear any pending refresh timer
     if (refreshTimerId) {
       clearTimeout(refreshTimerId);
       refreshTimerId = null;
       log("cleared refresh timer");
     }
-    
+
     // Clear the DOM
     //@ts-ignore
     mountPoint.replaceChildren();


### PR DESCRIPTION
### SUMMARY
Fixes memory leak in @superset-ui/embedded-sdk where fetchGuestToken refresh timers continue running after unmount().

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
1. Create a test application that uses embedDashboard()
2. Call unmount() after embedding
3. Verify no setTimeout timers continue running
4. Check browser dev tools for continued network requests (should be none)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #34529 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
