### PR TITLE
fix(filters): preserve backend metric-based sorting

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -379,4 +379,300 @@ describe('SelectFilterPlugin', () => {
     userEvent.type(screen.getByRole('combobox'), 'new value');
     expect(await screen.findByTitle('new value')).toBeInTheDocument();
   });
+
+  test('preserves backend order when sortMetric is specified', () => {
+    const testData = [
+      { gender: 'zebra' },
+      { gender: 'alpha' },
+      { gender: 'beta' },
+    ];
+
+    const testProps = {
+      ...selectMultipleProps,
+      formData: {
+        ...selectMultipleProps.formData,
+        sortMetric: 'count',
+        sortAscending: true,
+      },
+      queriesData: [
+        {
+          rowcount: 3,
+          colnames: ['gender'],
+          coltypes: [1],
+          data: testData,
+          applied_filters: [{ column: 'gender' }],
+          rejected_filters: [],
+        },
+      ],
+      filterState: {
+        value: [],
+        label: '',
+        excludeFilterValues: true,
+      },
+    };
+
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps(testProps)}
+        setDataMask={jest.fn()}
+        showOverflow={false}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          nativeFilters: {
+            filters: {
+              'test-filter': {
+                name: 'Test Filter',
+              },
+            },
+          },
+          dataMask: {
+            'test-filter': {
+              extraFormData: {},
+              filterState: {
+                value: [],
+                label: '',
+                excludeFilterValues: true,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    // When sortMetric is specified, options should appear in the original data order
+    // (zebra, alpha, beta) not alphabetically sorted
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('zebra');
+    expect(options[1]).toHaveTextContent('alpha');
+    expect(options[2]).toHaveTextContent('beta');
+  });
+
+  test('applies alphabetical sorting when sortMetric is not specified', () => {
+    const testData = [
+      { gender: 'zebra' },
+      { gender: 'alpha' },
+      { gender: 'beta' },
+    ];
+
+    const testProps = {
+      ...selectMultipleProps,
+      formData: {
+        ...selectMultipleProps.formData,
+        sortMetric: undefined,
+        sortAscending: true,
+      },
+      queriesData: [
+        {
+          rowcount: 3,
+          colnames: ['gender'],
+          coltypes: [1],
+          data: testData,
+          applied_filters: [{ column: 'gender' }],
+          rejected_filters: [],
+        },
+      ],
+      filterState: {
+        value: [],
+        label: '',
+        excludeFilterValues: true,
+      },
+    };
+
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps(testProps)}
+        setDataMask={jest.fn()}
+        showOverflow={false}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          nativeFilters: {
+            filters: {
+              'test-filter': {
+                name: 'Test Filter',
+              },
+            },
+          },
+          dataMask: {
+            'test-filter': {
+              extraFormData: {},
+              filterState: {
+                value: [],
+                label: '',
+                excludeFilterValues: true,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    // When sortMetric is not specified, options should be sorted alphabetically
+    // (alpha, beta, zebra)
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('alpha');
+    expect(options[1]).toHaveTextContent('beta');
+    expect(options[2]).toHaveTextContent('zebra');
+  });
+
+  test('applies descending alphabetical sorting when sortAscending is false and no sortMetric', () => {
+    const testData = [
+      { gender: 'zebra' },
+      { gender: 'alpha' },
+      { gender: 'beta' },
+    ];
+
+    const testProps = {
+      ...selectMultipleProps,
+      formData: {
+        ...selectMultipleProps.formData,
+        sortMetric: undefined,
+        sortAscending: false,
+      },
+      queriesData: [
+        {
+          rowcount: 3,
+          colnames: ['gender'],
+          coltypes: [1],
+          data: testData,
+          applied_filters: [{ column: 'gender' }],
+          rejected_filters: [],
+        },
+      ],
+      filterState: {
+        value: [],
+        label: '',
+        excludeFilterValues: true,
+      },
+    };
+
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps(testProps)}
+        setDataMask={jest.fn()}
+        showOverflow={false}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          nativeFilters: {
+            filters: {
+              'test-filter': {
+                name: 'Test Filter',
+              },
+            },
+          },
+          dataMask: {
+            'test-filter': {
+              extraFormData: {},
+              filterState: {
+                value: [],
+                label: '',
+                excludeFilterValues: true,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    // When sortAscending is false and no sortMetric, options should be sorted
+    // in descending alphabetical order (zebra, beta, alpha)
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('zebra');
+    expect(options[1]).toHaveTextContent('beta');
+    expect(options[2]).toHaveTextContent('alpha');
+  });
+
+  test('preserves backend order even when sortAscending is false and sortMetric is specified', () => {
+    const testData = [
+      { gender: 'zebra' },
+      { gender: 'alpha' },
+      { gender: 'beta' },
+    ];
+
+    const testProps = {
+      ...selectMultipleProps,
+      formData: {
+        ...selectMultipleProps.formData,
+        sortMetric: 'count',
+        sortAscending: false,
+      },
+      queriesData: [
+        {
+          rowcount: 3,
+          colnames: ['gender'],
+          coltypes: [1],
+          data: testData,
+          applied_filters: [{ column: 'gender' }],
+          rejected_filters: [],
+        },
+      ],
+      filterState: {
+        value: [],
+        label: '',
+        excludeFilterValues: true,
+      },
+    };
+
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps(testProps)}
+        setDataMask={jest.fn()}
+        showOverflow={false}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          nativeFilters: {
+            filters: {
+              'test-filter': {
+                name: 'Test Filter',
+              },
+            },
+          },
+          dataMask: {
+            'test-filter': {
+              extraFormData: {},
+              filterState: {
+                value: [],
+                label: '',
+                excludeFilterValues: true,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    // When sortMetric is specified, original order should be preserved regardless
+    // of sortAscending value (zebra, alpha, beta)
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('zebra');
+    expect(options[1]).toHaveTextContent('alpha');
+    expect(options[2]).toHaveTextContent('beta');
+  });
 });

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -317,13 +317,20 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   const sortComparator = useCallback(
     (a: LabeledValue, b: LabeledValue) => {
+      // When sortMetric is specified, the backend already sorted the data correctly
+      // Don't override the backend's metric-based sorting with frontend alphabetical sorting
+      if (formData.sortMetric) {
+        return 0; // Preserve the original order from the backend
+      }
+
+      // Only apply alphabetical sorting when no sortMetric is specified
       const labelComparator = propertyComparator('label');
       if (formData.sortAscending) {
         return labelComparator(a, b);
       }
       return labelComparator(b, a);
     },
-    [formData.sortAscending],
+    [formData.sortAscending, formData.sortMetric],
   );
 
   // Use effect for initialisation for filter plugin


### PR DESCRIPTION
## SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes broken metric-based sorting (e.g., sort by MAU) in select filter components by preventing frontend alphabetical sorting from overriding backend sort order. Also adds comprehensive test coverage for this functionality.

**Problem:**
- When `sortMetric` was specified in filter configuration, the backend would correctly sort data by the specified metric (e.g., MAU, revenue, etc.)
- However, the frontend `sortComparator` was then applying alphabetical sorting on the labels, completely overriding the intended metric-based order
- This resulted in filters showing values sorted alphabetically instead of by their actual metric values

**Solution:**
- Check if `formData.sortMetric` is specified before applying sort logic
- When `sortMetric` exists, return 0 to preserve the original backend order
- Only apply alphabetical sorting when no `sortMetric` is configured
- Add `sortMetric` to useCallback dependency array for proper re-rendering
- Add comprehensive test coverage for all sorting scenarios

This ensures that metric-based sorting (like "sort by MAU") works correctly while maintaining alphabetical sorting as a fallback for other cases.

## BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before:** Select filter options sorted alphabetically regardless of sortMetric setting
**After:** Select filter options preserve backend metric-based order when sortMetric is specified

## TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


<p class="p1">You configure a Select filter to sort by a metric like <span class="s1"><b>Monthly Active Users (MAU)</b></span>.</p>
</li><li>
<p class="p1">Superset’s backend correctly sorts the options: <span class="s1">['Google', 'Microsoft', 'Oracle']</span> based on MAU.</p>
</li><li>
<p class="p1">But the frontend says: “Oh, a list of strings! I’ll sort them alphabetically!” 😬</p>
</li><li>
<p class="p1"><span class="s1">So you’d see: </span>['Google', 'Microsoft', 'Oracle']<span class="s1"> — even if MAU was </span>1000<span class="s1">, </span>900<span class="s1">, </span>800<span class="s1">.</span></p>
</li></ul></span></p>
<p class="p3"><br></p>
<p class="p2"><span class="s3"><h3><b>After:</b></h3></span></p>
<p class="p2"><span class="s3"><ul><li>
<p class="p1">If <span class="s1">sortMetric</span> is set, the frontend <span class="s2"><b>does not override</b></span> the order.</p>
</li><li>
<p class="p1">If <span class="s1">sortMetric</span> is <i>not</i> set, it still sorts alphabetically (fallback behavior).</p>
</li></ul></span></p>
<p class="p2"><span class="s3"><hr></span></p>
<p class="p2"><span class="s3"><h2><b>🧪 How to Manually Test This in Superset (Step-by-Step)</b></h2></span></p>
<p class="p3"><br></p>
<blockquote style="margin: 0.0px 0.0px 0.0px 15.0px; font: 14.0px '.AppleSystemUIFont'; color: #0e0e0e">🧠 You’ll need a dataset where each row has a <span class="s1"><b>grouping dimension</b></span> (like company name or user ID) and a <span class="s1"><b>metric</b></span> (like MAU).</blockquote>
<p class="p2"><span class="s3"><hr></span></p>
<p class="p2"><h3><span class="s3"><b>🔧 1.<span class="Apple-converted-space"> </span></b><b>Create a Filter Box or Filter Select on a Dashboard</b></h3></span></p>
<p class="p2"><span class="s3"><ol start="1"><li>
<p class="p1">Open a dashboard.</p>
</li><li>
<p class="p1"><span class="s1">Click </span><b>Edit Dashboard → Add Filter</b><span class="s1">.</span></p>
</li><li>
<p class="p1">Choose the <span class="s1"><b>Select Filter</b></span> plugin.</p>
</li><li>
<p class="p1">In the filter config:</p>
<p class="p2"><span class="s1"><ul><li>
<p class="p1">Set <span class="s1">Column</span> = dimension (e.g., <span class="s1">company_name</span>)</p>
</li><li>
<p class="p1">Set <span class="s1">Sort Metric</span> = metric (e.g., <span class="s1">MAU</span>)</p>
</li></ul></span></p>
</li><li>
<p class="p1">Save and view the dashboard.</p>
</li></ol></span></p>
<p class="p2"><span class="s3"><hr></span></p>
<p class="p2"><span class="s3"><h3><b>👀 2.<span class="Apple-converted-space"> </span></b><b>Verify: Options Appear in Metric Order</b></h3></span></p>
<p class="p3"><br></p>
<p class="p1">Example:</p>



company_name | MAU
-- | --
Google | 5000
Apple | 3000
Oracle | 1000


## ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->

- [x] Has associated issue: Fixes #35331
- [ ] Required feature flags:
- [x] Changes UI (sorting behavior)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API  
- [ ] Removes existing feature or API

**Test Coverage Added:**
- ✅ Backend order preservation when `sortMetric` is specified
- ✅ Alphabetical sorting fallback when no `sortMetric` is specified
- ✅ Ascending and descending alphabetical sorting behavior
- ✅ `sortMetric` precedence over `sortAscending` setting

**Commits:**
1. `fix(filters): preserve backend metric-based sorting in select filters` - The core fix
2. `test(filters): add comprehensive tests for sortMetric functionality` - Test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)