### PR TITLE
fix: Oauth2 connection failures with postional arguments

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -2027,9 +2027,9 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         """
         return None
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         Some databases require adding elements to connection parameters,

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -261,9 +261,9 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "port": "port",
     }
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         Add a user agent to be used in the requests.

--- a/superset/db_engine_specs/druid.py
+++ b/superset/db_engine_specs/druid.py
@@ -78,9 +78,9 @@ class DruidEngineSpec(BaseEngineSpec):
         if orm_col.column_name == "__time":
             orm_col.is_dttm = True
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         For Druid, the path to a SSL certificate is placed in `connect_args`.

--- a/superset/db_engine_specs/duckdb.py
+++ b/superset/db_engine_specs/duckdb.py
@@ -300,9 +300,9 @@ class DuckDBEngineSpec(DuckDBParametersMixin, BaseEngineSpec):
     ) -> set[str]:
         return set(inspector.get_table_names(schema))
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         Add a user agent to be used in the requests.

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -412,9 +412,9 @@ WHERE datistemplate = false;
             inspector.get_foreign_table_names(schema)
         )
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         For Postgres, the path to a SSL certificate is placed in `connect_args`.

--- a/superset/db_engine_specs/snowflake.py
+++ b/superset/db_engine_specs/snowflake.py
@@ -135,9 +135,9 @@ class SnowflakeEngineSpec(PostgresBaseEngineSpec):
         ),
     }
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         Add a user agent to be used in the requests.

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -301,9 +301,9 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
         return True
 
-    @staticmethod
+    @classmethod
     def get_extra_params(
-        database: Database, source: QuerySource | None = None
+        cls, database: Database, source: QuerySource | None = None
     ) -> dict[str, Any]:
         """
         Some databases require adding elements to connection parameters,

--- a/tests/unit_tests/models/test_core_database_methods.py
+++ b/tests/unit_tests/models/test_core_database_methods.py
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for Database model methods that interact with DB engine specs.
+
+These tests verify the contract between the Database model and engine specs,
+particularly around method calling patterns and signatures.
+"""
+
+import pytest
+
+from superset.models.core import Database
+from superset.utils.core import QuerySource
+
+
+@pytest.mark.parametrize(
+    "sqlalchemy_uri",
+    [
+        "snowflake://user:pass@account/db?role=role&warehouse=warehouse",
+        "postgresql://localhost/test",
+        "trino://localhost:8080/hive/default",
+        "databricks://token@workspace/http_path",
+        "duckdb:///path/to/db",
+    ],
+)
+def test_database_get_extra_with_multiple_engines(sqlalchemy_uri):
+    """
+    Test that Database.get_extra() works correctly with all database engine specs.
+
+    This test verifies the actual production call pattern:
+    Database.get_extra() -> self.db_engine_spec.get_extra_params(self, source)
+
+    The bug: get_extra_params methods are declared as @staticmethod but called
+    as if they were @classmethod, causing argument count mismatch errors
+    """
+    database = Database(database_name="test_db", sqlalchemy_uri=sqlalchemy_uri)
+
+    # This is the actual production call pattern that was broken
+    # It should work regardless of which engine spec is used
+    extra = database.get_extra(source=QuerySource.SQL_LAB)
+    assert isinstance(extra, dict)
+
+    # Also test without source parameter (original behavior)
+    extra = database.get_extra()
+    assert isinstance(extra, dict)
+
+
+def test_database_engine_spec_contract():
+    """
+    Verify the contract between Database model and all engine specs.
+
+    This test ensures that all Database methods that call engine spec methods
+    work correctly with the actual method signatures and decorators.
+
+    Tests the integration between layers, not just isolated unit tests.
+    """
+    # Test engines that override get_extra_params
+    test_engines = [
+        ("snowflake://user:pass@account/db", "SnowflakeEngineSpec"),
+        ("postgresql://localhost/test", "PostgresEngineSpec"),
+        ("trino://localhost:8080/hive", "TrinoEngineSpec"),
+        ("databricks://token@workspace", "DatabricksNativeEngineSpec"),
+        ("duckdb:///test.db", "DuckDBEngineSpec"),
+    ]
+
+    for sqlalchemy_uri, engine_name in test_engines:
+        database = Database(
+            database_name=f"test_{engine_name.lower()}", sqlalchemy_uri=sqlalchemy_uri
+        )
+
+        # Test that the calling pattern matches the method signature
+        try:
+            # This calls: self.db_engine_spec.get_extra_params(self, source)
+            # If get_extra_params is @staticmethod, this will fail with:
+            # "takes 2 positional arguments but 3 were given"
+            result = database.get_extra(source=QuerySource.SQL_LAB)
+            assert isinstance(result, dict), (
+                f"{engine_name} should return dict from get_extra_params"
+            )
+
+        except TypeError as e:
+            if "positional arguments" in str(e):
+                pytest.fail(
+                    f"{engine_name}.get_extra_params has incompatible signature. "
+                    f"Error: {e}. "
+                    "This suggests @staticmethod should be @classmethod."
+                )
+            else:
+                raise
+
+
+def test_regression_snowflake_oauth2_get_extra_params():
+    """
+    Regression test for the specific issue reported.
+
+    Bug: SnowflakeOAuth2Override.get_extra_params() takes 2 positional
+    arguments but 3 were given
+
+    This test reproduces the exact scenario that caused the error.
+    """
+    database = Database(
+        database_name="snowflake_oauth_test",
+        sqlalchemy_uri="snowflake://user:pass@account/db?role=role&warehouse=warehouse",
+    )
+
+    # This specific call pattern caused the original error
+    # The error occurred when OAuth2 was enabled, creating a dynamic override class
+    try:
+        extra = database.get_extra(source=QuerySource.SQL_LAB)
+        assert isinstance(extra, dict)
+        assert "engine_params" in extra
+        assert "connect_args" in extra["engine_params"]
+
+    except TypeError as e:
+        if "takes 2 positional arguments but 3 were given" in str(e):
+            pytest.fail(
+                f"Snowflake OAuth2 method signature issue not fixed: {e}. "
+                "get_extra_params should use @classmethod, not @staticmethod."
+            )
+        else:
+            raise


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**🐛 Problem**

Snowflake OAuth2 connections were failing with the error:
```
SnowflakeOAuth2Override.get_extra_params() takes 2 positional arguments but 3 were given
```
This error occurred when attempting to connect to Snowflake databases with OAuth2 authentication enabled, preventing users from establishing database connections.

**🔍 Root Cause**

The issue was a method signature mismatch when user agent customization was added:

- Problem: `get_extra_params` methods were declared as `@staticmethod` but called as if they were instance methods
- Call Pattern: `Database.get_extra()` calls `self.db_engine_spec.get_extra_params(self, source)`
- Mismatch: Static methods expect (database, source) but receive (class_reference, database, source)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Added comprehensive test suite in `tests/unit_tests/models/test_core_database_methods.py`:
  - Integration tests: Verify Database.get_extra() works with all 5 database engine types
  - Contract tests: Ensure Database ↔ EngineSpec interface compatibility
  - Regression test: Specific test for the reported Snowflake OAuth2 scenario
  - Coverage: Tests the actual production call pattern that was broken



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
