### PR TITLE
fix(embedded): resolve theme context error in Loading component

### DIFF
--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -91,14 +91,14 @@ const EmbededLazyDashboardPage = () => {
 };
 
 const EmbeddedRoute = () => (
-  <Suspense fallback={<Loading />}>
-    <EmbeddedContextProviders>
+  <EmbeddedContextProviders>
+    <Suspense fallback={<Loading />}>
       <ErrorBoundary>
         <EmbededLazyDashboardPage />
       </ErrorBoundary>
       <ToastContainer position="top" />
-    </EmbeddedContextProviders>
-  </Suspense>
+    </Suspense>
+  </EmbeddedContextProviders>
 );
 
 const EmbeddedApp = () => (


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move Suspense fallback inside EmbeddedContextProviders to ensure Loading component has access to ThemeProvider context. This fixes the "useTheme() could not find a ThemeContext" error that occurred when Loading component was rendered outside the theme provider scope.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:

![](https://github.com/user-attachments/assets/57cac66a-dc26-4cce-8af4-0b0d3d597bc2)
After:
![](https://github.com/user-attachments/assets/597b7e1c-e1d5-450e-a912-e6a8860b34e1)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/35167
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
