### PR TITLE
fix: Bump pandas to 2.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <2.1",
+    "pandas[excel]>=2.0.3, <2.2",
     "bottleneck", # recommended performance dependency for pandas, see https://pandas.pydata.org/docs/getting_started/install.html#performance-dependencies-recommended
     # --------------------------
     "parsedatetime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <2.2",
+    "pandas[excel]>=2.3, <3",
     "bottleneck", # recommended performance dependency for pandas, see https://pandas.pydata.org/docs/getting_started/install.html#performance-dependencies-recommended
     # --------------------------
     "parsedatetime",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -265,7 +265,7 @@ packaging==25.0
     #   limits
     #   marshmallow
     #   shillelagh
-pandas==2.1.4
+pandas==2.3.2
     # via apache-superset (pyproject.toml)
 paramiko==3.5.1
     # via
@@ -312,6 +312,8 @@ pyparsing==3.2.3
     # via apache-superset (pyproject.toml)
 pysocks==1.7.1
     # via urllib3
+python-calamine==0.5.3
+    # via pandas
 python-dateutil==2.9.0.post0
     # via
     #   apache-superset (pyproject.toml)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,6 +158,7 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
+    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0
@@ -264,7 +265,7 @@ packaging==25.0
     #   limits
     #   marshmallow
     #   shillelagh
-pandas==2.0.3
+pandas==2.1.4
     # via apache-superset (pyproject.toml)
 paramiko==3.5.1
     # via

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -327,6 +327,7 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
+    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -532,7 +533,7 @@ packaging==25.0
     #   pytest
     #   shillelagh
     #   sqlalchemy-bigquery
-pandas==2.0.3
+pandas==2.1.4
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -533,7 +533,7 @@ packaging==25.0
     #   pytest
     #   shillelagh
     #   sqlalchemy-bigquery
-pandas==2.1.4
+pandas==2.3.2
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
@@ -686,6 +686,10 @@ pytest-mock==3.10.0
     # via
     #   apache-superset
     #   apache-superset-extensions-cli
+python-calamine==0.5.3
+    # via
+    #   -c requirements/base-constraint.txt
+    #   pandas
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/base-constraint.txt

--- a/superset/commands/database/uploaders/excel_reader.py
+++ b/superset/commands/database/uploaders/excel_reader.py
@@ -72,7 +72,7 @@ class ExcelReader(BaseDataReader):
             "na_values": self._options.get("null_values")
             if self._options.get("null_values")  # None if an empty list
             else None,
-            "parse_dates": self._options.get("column_dates"),
+            "parse_dates": self._options.get("column_dates") or False,
             "skiprows": self._options.get("skip_rows", 0),
             "sheet_name": self._options.get("sheet_name", 0),
             "nrows": self._options.get("rows_to_read"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,8 @@ def data_loader(
     pandas_loader_configuration: PandasLoaderConfigurations,
     table_to_df_convertor: TableToDfConvertor,
 ) -> DataLoader:
+    if example_db_engine.dialect.name == PRESTO:
+        example_db_engine.dialect.get_view_names = Mock(return_value=[])
     return PandasDataLoader(
         example_db_engine, pandas_loader_configuration, table_to_df_convertor
     )


### PR DESCRIPTION
### SUMMARY
I opened PR to bump pandas to 2.1.4, but couldn't remember the reason why we could not go further, so this is just to test out which tests fail.
