### PR TITLE
feat(TimeTable): add other sparkline type options

### DIFF
--- a/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   bounds: PropTypes.array,
   d3format: PropTypes.string,
   dateFormat: PropTypes.string,
+  sparkType: PropTypes.string,
   onChange: PropTypes.func,
 };
 
@@ -64,6 +65,7 @@ const defaultProps = {
   bounds: [null, null],
   d3format: '',
   dateFormat: '',
+  sparkType: 'line',
 };
 
 const comparisonTypeOptions = [
@@ -78,6 +80,12 @@ const colTypeOptions = [
   { value: 'contrib', label: t('Contribution'), key: 'contrib' },
   { value: 'spark', label: t('Sparkline'), key: 'spark' },
   { value: 'avg', label: t('Period average'), key: 'avg' },
+];
+
+const sparkTypeOptions = [
+  { value: 'line', label: t('Line Chart'), key: 'line' },
+  { value: 'bar', label: t('Bar Chart'), key: 'bar' },
+  { value: 'area', label: t('Area Chart'), key: 'area' },
 ];
 
 const StyledRow = styled(Row)`
@@ -130,6 +138,7 @@ export default class TimeSeriesColumnControl extends Component {
       bounds: this.props.bounds,
       d3format: this.props.d3format,
       dateFormat: this.props.dateFormat,
+      sparkType: this.props.sparkType,
       popoverVisible: false,
     };
   }
@@ -229,6 +238,18 @@ export default class TimeSeriesColumnControl extends Component {
           />,
         )}
         <Divider />
+        {this.state.colType === 'spark' &&
+          this.formRow(
+            t('Chart Type'),
+            t('Type of chart to display in sparkline'),
+            'spark-type',
+            <Select
+              ariaLabel={t('Chart Type')}
+              value={this.state.sparkType || undefined}
+              onChange={this.onSelectChange.bind(this, 'sparkType')}
+              options={sparkTypeOptions}
+            />,
+          )}
         {this.state.colType === 'spark' &&
           this.formRow(
             t('Width'),

--- a/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/TimeSeriesColumnControl/index.jsx
@@ -240,7 +240,7 @@ export default class TimeSeriesColumnControl extends Component {
         <Divider />
         {this.state.colType === 'spark' &&
           this.formRow(
-            t('Chart Type'),
+            t('Chart type'),
             t('Type of chart to display in sparkline'),
             'spark-type',
             <Select

--- a/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.tsx
@@ -55,6 +55,7 @@ const Sparkline = ({
       yAxisBounds={yAxisBounds}
       showYAxis={column.showYAxis || false}
       entries={entries}
+      sparkType={column.sparkType || 'line'}
     />
   );
 };

--- a/superset-frontend/src/visualizations/TimeTable/components/SparklineCell/SparklineCell.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/SparklineCell/SparklineCell.tsx
@@ -23,9 +23,13 @@ import { scaleLinear } from '@visx/scale';
 import {
   Axis,
   LineSeries,
+  BarSeries,
+  AreaSeries,
   Tooltip,
   XYChart,
   buildChartTheme,
+  type SeriesProps,
+  AxisScale,
 } from '@visx/xychart';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import {
@@ -33,6 +37,7 @@ import {
   createYScaleConfig,
   transformChartData,
 } from '../../utils';
+import { SparkType } from '../../types';
 
 interface Entry {
   time: string;
@@ -51,6 +56,7 @@ interface SparklineCellProps {
   showYAxis?: boolean;
   width?: number;
   yAxisBounds?: [number | undefined, number | undefined];
+  sparkType?: SparkType;
 }
 
 const MARGIN = {
@@ -71,6 +77,7 @@ const SparklineCell = ({
   yAxisBounds = [undefined, undefined],
   showYAxis = false,
   entries = [],
+  sparkType = 'line',
 }: SparklineCellProps): ReactElement => {
   const theme = useTheme();
 
@@ -127,6 +134,17 @@ const SparklineCell = ({
   const xAccessor = (d: { x: number; y: number }) => d.x;
   const yAccessor = (d: { x: number; y: number }) => d.y;
 
+  const chartSeriesMap: Record<
+    SparkType,
+    (props: SeriesProps<AxisScale, AxisScale, object>) => JSX.Element
+  > = {
+    line: LineSeries,
+    bar: BarSeries,
+    area: AreaSeries,
+  };
+
+  const SeriesComponent = chartSeriesMap[sparkType] || LineSeries;
+
   if (validData.length === 0) return <div style={{ width, height }} />;
 
   return (
@@ -165,7 +183,7 @@ const SparklineCell = ({
             />
           </>
         )}
-        <LineSeries
+        <SeriesComponent
           data={chartData}
           dataKey={dataKey}
           xAccessor={xAccessor}

--- a/superset-frontend/src/visualizations/TimeTable/types.ts
+++ b/superset-frontend/src/visualizations/TimeTable/types.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+export type SparkType = 'line' | 'bar' | 'area';
+
 export interface ColumnConfig {
   key: string;
   label?: string;
@@ -32,6 +34,7 @@ export interface ColumnConfig {
   dateFormat?: string;
   yAxisBounds?: [number | undefined, number | undefined] | null[];
   showYAxis?: boolean;
+  sparkType?: SparkType;
 }
 
 export interface ColumnRow {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`xychart` from `visx` supports area and bar charts in addition to line charts. This pr aims to add that option to TimeSeries table visualization.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

<img width="1079" height="805" alt="image" src="https://github.com/user-attachments/assets/30fdb066-785a-4119-8dde-7354e28be80d" />

<img width="1308" height="750" alt="image" src="https://github.com/user-attachments/assets/3a924c76-e498-431e-969d-766e07191cf0" />

<img width="1258" height="692" alt="image" src="https://github.com/user-attachments/assets/6b3376c1-40f1-455e-b24b-33a9742c5942" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a Time-series table chart and add a time series column.
2. Change column type to sparkline and select chart type.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
