### PR TITLE
fix: only block showtime for unauthorized users on push

### DIFF
--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -61,17 +61,8 @@ jobs:
             console.log(`📊 Permission level for ${actor}: ${permission.permission}`);
             const authorized = ['write', 'admin'].includes(permission.permission);
 
-            if (!authorized) {
-              console.log(`🚨 Unauthorized user ${actor} - skipping all operations`);
-              core.setOutput('authorized', 'false');
-              return;
-            }
-
-            console.log(`✅ Authorized maintainer: ${actor}`);
-            core.setOutput('authorized', 'true');
-
-            // If this is a synchronize event, check if Showtime is active and set blocked label
-            if (context.eventName === 'pull_request_target' && context.payload.action === 'synchronize') {
+            // If this is a synchronize event from unauthorized user, check if Showtime is active and set blocked label
+            if (!authorized && context.eventName === 'pull_request_target' && context.payload.action === 'synchronize') {
               console.log(`🔒 Synchronize event detected - checking if Showtime is active`);
 
               // Check if PR has any circus tent labels (Showtime is in use)
@@ -98,6 +89,15 @@ jobs:
                 console.log(`ℹ️ No circus labels found - Showtime not in use, skipping block`);
               }
             }
+
+            if (!authorized) {
+              console.log(`🚨 Unauthorized user ${actor} - skipping all operations`);
+              core.setOutput('authorized', 'false');
+              return;
+            }
+
+            console.log(`✅ Authorized maintainer: ${actor}`);
+            core.setOutput('authorized', 'true');
 
       - name: Install Superset Showtime
         if: steps.auth.outputs.authorized == 'true'


### PR DESCRIPTION
The workflow was incorrectly blocking authorized maintainers from auto-deploying on push events. Now it only sets the blocked label when:
- User is unauthorized (non-maintainer)
- It's a synchronize (push) event
- PR has active showtime labels

This allows maintainers to push and auto-deploy while preventing unauthorized users from triggering deployments through pushes.
