### PR TITLE
fix(docs): escape comparison operators in MDX files to resolve build errors

### DIFF
--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -36,11 +36,11 @@ Screenshots will be taken but no messages actually sent as long as `ALERT_REPORT
 #### In your `Dockerfile`
 
 You'll need to extend the Superset image to include a headless browser. Your options include:
-- Use Playwright with Chrome: this is the recommended approach as of version >=4.1.x. A working example of a Dockerfile that installs these tools is provided under “Building your own production Docker image” on the [Docker Builds](/docs/installation/docker-builds#building-your-own-production-docker-image) page. Read the code comments there as you'll also need to change a feature flag in your config.
+- Use Playwright with Chrome: this is the recommended approach as of version `>=4.1.x`. A working example of a Dockerfile that installs these tools is provided under "Building your own production Docker image" on the [Docker Builds](/docs/installation/docker-builds#building-your-own-production-docker-image) page. Read the code comments there as you'll also need to change a feature flag in your config.
 - Use Firefox: you'll need to install geckodriver and Firefox.
 - Use Chrome without Playwright: you'll need to install Chrome and set the value of `WEBDRIVER_TYPE` to `"chrome"` in your `superset_config.py`.
 
-In Superset versions <=4.0x, users installed Firefox or Chrome and that was documented here.
+In Superset versions `<=4.0.x`, users installed Firefox or Chrome and that was documented here.
 
 Only the worker container needs the browser.
 

--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -36,7 +36,7 @@ Screenshots will be taken but no messages actually sent as long as `ALERT_REPORT
 #### In your `Dockerfile`
 
 You'll need to extend the Superset image to include a headless browser. Your options include:
-- Use Playwright with Chrome: this is the recommended approach as of version `>=4.1.x`. A working example of a Dockerfile that installs these tools is provided under "Building your own production Docker image" on the [Docker Builds](/docs/installation/docker-builds#building-your-own-production-docker-image) page. Read the code comments there as you'll also need to change a feature flag in your config.
+- Use Playwright with Chrome: this is the recommended approach as of version 4.1.x or greater. A working example of a Dockerfile that installs these tools is provided under "Building your own production Docker image" on the [Docker Builds](/docs/installation/docker-builds#building-your-own-production-docker-image) page. Read the code comments there as you'll also need to change a feature flag in your config.
 - Use Firefox: you'll need to install geckodriver and Firefox.
 - Use Chrome without Playwright: you'll need to install Chrome and set the value of `WEBDRIVER_TYPE` to `"chrome"` in your `superset_config.py`.
 

--- a/docs/docs/configuration/alerts-reports.mdx
+++ b/docs/docs/configuration/alerts-reports.mdx
@@ -40,7 +40,7 @@ You'll need to extend the Superset image to include a headless browser. Your opt
 - Use Firefox: you'll need to install geckodriver and Firefox.
 - Use Chrome without Playwright: you'll need to install Chrome and set the value of `WEBDRIVER_TYPE` to `"chrome"` in your `superset_config.py`.
 
-In Superset versions `<=4.0.x`, users installed Firefox or Chrome and that was documented here.
+In Superset versions prior to 4.1, users installed Firefox or Chrome and that was documented here.
 
 Only the worker container needs the browser.
 

--- a/docs/docs/configuration/theming.mdx
+++ b/docs/docs/configuration/theming.mdx
@@ -7,7 +7,7 @@ version: 1
 # Theming Superset
 
 :::note
-apache-superset>=6.0
+`apache-superset>=6.0`
 :::
 
 Superset now rides on **Ant Design v5's token-based theming**.

--- a/docs/docs/contributing/guidelines.mdx
+++ b/docs/docs/contributing/guidelines.mdx
@@ -130,7 +130,7 @@ Committers may also update title to reflect the issue/PR content if the author-p
 
 If the PR passes CI tests and does not have any `need:` labels, it is ready for review, add label `review` and/or `design-review`.
 
-If an issue/PR has been inactive for >=30 days, it will be closed. If it does not have any status label, add `inactive`.
+If an issue/PR has been inactive for `>=30` days, it will be closed. If it does not have any status label, add `inactive`.
 
 When creating a PR, if you're aiming to have it included in a specific release, please tag it with the version label. For example, to have a PR considered for inclusion in Superset 1.1 use the label `v1.1`.
 

--- a/docs/docs/contributing/guidelines.mdx
+++ b/docs/docs/contributing/guidelines.mdx
@@ -130,7 +130,7 @@ Committers may also update title to reflect the issue/PR content if the author-p
 
 If the PR passes CI tests and does not have any `need:` labels, it is ready for review, add label `review` and/or `design-review`.
 
-If an issue/PR has been inactive for `>=30` days, it will be closed. If it does not have any status label, add `inactive`.
+If an issue/PR has been inactive for at least 30 days, it will be closed. If it does not have any status label, add `inactive`.
 
 When creating a PR, if you're aiming to have it included in a specific release, please tag it with the version label. For example, to have a PR considered for inclusion in Superset 1.1 use the label `v1.1`.
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed MDX compilation errors in documentation build by escaping comparison operators (`<=`, `>=`) in version strings. The root cause was MDX interpreting these operators as JSX syntax rather than plain text, causing CI build failures.

**Root Cause:** MDX parser was attempting to parse comparison operators as JSX expressions when they appeared outside of code blocks, resulting in syntax errors like "Unexpected character `=` (U+003D) before name".

**Solution:** Wrapped version strings containing comparison operators in backticks to treat them as inline code, preventing MDX from attempting JSX parsing.

  **Files affected:**
  - `docs/docs/configuration/alerts-reports.mdx` - Fixed `<=4.0.x` and `>=4.1.x`
  - `docs/docs/configuration/theming.mdx` - Fixed `apache-superset>=6.0`
  - `docs/docs/contributing/guidelines.mdx` - Fixed `>=30 days`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
  1. Run documentation build: `cd docs && yarn build`
  2. Verify build completes without MDX compilation errors
  3. Check that version strings display correctly as inline code in the rendered documentation


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
