### PR TITLE
chore(matrixify): Remove leftover option

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.test.ts
@@ -204,7 +204,8 @@ test('getMatrixifyConfig should handle topn selection mode', () => {
 test('getMatrixifyValidationErrors should return empty array when matrixify is not enabled', () => {
   const formData = {
     viz_type: 'table',
-    matrixify_enabled: false,
+    matrixify_enable_vertical_layout: false,
+    matrixify_enable_horizontal_layout: false,
   } as MatrixifyFormData;
 
   expect(getMatrixifyValidationErrors(formData)).toEqual([]);

--- a/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/types/matrixify.ts
@@ -96,9 +96,6 @@ export interface MatrixifyAxisConfig {
  * Complete Matrixify configuration in form data
  */
 export interface MatrixifyFormData {
-  // Enable/disable matrixify functionality
-  matrixify_enabled?: boolean;
-
   // Layout enable controls
   matrixify_enable_vertical_layout?: boolean;
   matrixify_enable_horizontal_layout?: boolean;

--- a/superset-frontend/src/components/Chart/ChartRenderer.test.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.test.jsx
@@ -182,7 +182,6 @@ test('should handle matrixify-related form data changes', () => {
   const initialProps = {
     ...requiredProps,
     formData: {
-      matrixify_enabled: false,
       regular_control: 'value1',
     },
     queriesResponse: [{ data: 'current' }],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

After the [recent improvements pr](https://github.com/apache/superset/pull/35067) there was a matrixify enabled type and option leftover which were replaced by row and column toggles. It's removed in this pr.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Matrixify should work as before.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
