### PR TITLE
fix(dashboard): update header border to use colorBorder token

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -100,7 +100,7 @@ import { useHeaderActionsMenu } from './useHeaderActionsDropdownMenu';
 const extensionsRegistry = getExtensionsRegistry();
 
 const headerContainerStyle = theme => css`
-  border-bottom: 1px solid ${theme.colorSplit};
+  border-bottom: 1px solid ${theme.colorBorder};
 `;
 
 const editButtonStyle = theme => css`


### PR DESCRIPTION
### SUMMARY
This PR updates the dashboard header border color to use the correct theming token `colorBorder` instead of `colorSplit`. This change ensures better consistency with the Ant Design theming system and improves visual cohesion across different theme modes.

The `colorBorder` token is the standard token for borders in Ant Design v5, while `colorSplit` is deprecated/less commonly used. This aligns with the ongoing frontend modernization efforts to properly use Ant Design theming tokens.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Dashboard header uses `colorSplit` for border
**After:** Dashboard header uses `colorBorder` for border

This is a subtle visual change that primarily affects theme consistency, particularly noticeable in dark mode where border colors have different values.

### TESTING INSTRUCTIONS
1. Navigate to any dashboard at `/dashboard/list/`
2. Open a dashboard
3. Observe the header border color (the line separating the header from the dashboard content)
4. Toggle between light and dark modes using the theme toggle button (paint roller icon in the header)
5. Verify that the border color properly matches the theme's border color token

### ADDITIONAL INFORMATION
- [x] Changes UI
- This change is part of the ongoing effort to standardize theming token usage across the application
- Follows the guidance in CLAUDE.md to prefer antd tokens over legacy theming tokens

🤖 Generated with [Claude Code](https://claude.ai/code)