### PR TITLE
docs: Add instruction to avoid time-specific language in code comments

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -70,6 +70,10 @@ superset/
 - **New files require ASF license headers** - When creating new code files, include the standard Apache Software Foundation license header
 - **LLM instruction files are excluded** - Files like LLMS.md, CLAUDE.md, etc. are in `.rat-excludes` to avoid header token overhead
 
+### Code Comments
+- **Avoid time-specific language** - Don't use words like "now", "currently", "today" in code comments as they become outdated
+- **Write timeless comments** - Comments should remain accurate regardless of when they're read
+
 ## Documentation Requirements
 
 - **docs/**: Update for any user-facing changes


### PR DESCRIPTION
### SUMMARY
Added guidance to LLM documentation (LLMS.md) instructing AI assistants to avoid using time-specific words like "now", "currently", and "today" in code comments, as these become outdated over time. Comments should be written to remain accurate regardless of when they're read.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Documentation change only

### TESTING INSTRUCTIONS
1. Review the updated LLMS.md file
2. Verify the new "Code Comments" section appears under "Code Standards"
3. Confirm the guidance is clear and actionable for LLM tools

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: N/A
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

This is a documentation improvement to help maintain code quality when using LLM assistants for development.

🤖 Generated with [Claude Code](https://claude.ai/code)