### PR TITLE
fix(table): conditionally render search dropdown only when search input is enabled

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -452,7 +452,7 @@ export default typedMemo(function DataTable<D extends object>({
               />
             ) : null}
             <Flex wrap align="center" gap="middle">
-              {serverPagination && (
+              {serverPagination && searchInput && (
                 <Space size="small" className="search-select-container">
                   <span className="search-by-label">Search by:</span>
                   <SearchSelectDropdown


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add searchInput condition to SearchSelectDropdown rendering in DataTable
- Prevents search dropdown from appearing when search functionality is disabled
- Fixes UI inconsistency where search controls were shown without search input capability

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before

[before.mp4](https://github.com/user-attachments/assets/34f1747e-4be5-4f3c-962a-3c74069ba036)

After

[after.mp4](https://github.com/user-attachments/assets/af6b3fe5-b83c-4b0d-b353-f5bc9fcf55f4)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes #35300
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
