### PR TITLE
chore: Reference GenericDataType from @apache-superset/core

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnTypeLabel/ColumnTypeLabel.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/ColumnTypeLabel/ColumnTypeLabel.tsx
@@ -18,7 +18,8 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { css, GenericDataType, styled, t } from '@superset-ui/core';
+import { css, styled, t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ClockCircleOutlined,
   QuestionOutlined,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/constants.ts
@@ -16,13 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  DTTM_ALIAS,
-  GenericDataType,
-  QueryColumn,
-  QueryMode,
-  t,
-} from '@superset-ui/core';
+import { DTTM_ALIAS, QueryColumn, QueryMode, t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnMeta, SortSeriesData, SortSeriesType } from './types';
 
 export const DEFAULT_MAX_ROW = 100000;

--- a/superset-frontend/packages/superset-ui-chart-controls/src/fixtures.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/fixtures.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DatasourceType, GenericDataType } from '@superset-ui/core';
+import { DatasourceType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { Dataset } from './types';
 
 export const TestDataset: Dataset = {

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -20,13 +20,13 @@
 import {
   ContributionType,
   ensureIsArray,
-  GenericDataType,
   getColumnLabel,
   getMetricLabel,
   QueryFormColumn,
   QueryFormMetric,
   t,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlPanelState,
   ControlState,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/dndControls.tsx
@@ -17,12 +17,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  GenericDataType,
-  QueryColumn,
-  t,
-  validateNonEmpty,
-} from '@superset-ui/core';
+import { QueryColumn, t, validateNonEmpty } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ExtraControlProps,
   SharedControlConfig,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/checkColumnType.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/checkColumnType.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ensureIsArray, GenericDataType, ValueOf } from '@superset-ui/core';
+import { ensureIsArray, ValueOf } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ControlPanelState, isDataset, isQueryResponse } from '../types';
 
 export function checkColumnType(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/columnChoices.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType, QueryColumn, QueryResponse } from '@superset-ui/core';
+import { QueryColumn, QueryResponse } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnMeta, Dataset, isDataset, isQueryResponse } from '../types';
 
 export function columnsByType(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/isSortable.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/isSortable.ts
@@ -17,11 +17,11 @@
  * under the License.
  */
 import {
-  GenericDataType,
   getColumnLabel,
   isPhysicalColumn,
   QueryFormColumn,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { checkColumnType, ControlStateMapping } from '..';
 
 export function isSortable(controls: ControlStateMapping): boolean {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnOption.test.tsx
@@ -18,8 +18,7 @@
  */
 import '@testing-library/jest-dom';
 import { render } from '@superset-ui/core/spec';
-import { GenericDataType } from '@superset-ui/core';
-
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnOption, ColumnOptionProps } from '../../src';
 
 jest.mock('@superset-ui/chart-controls/components/SQLPopover', () => ({

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnTypeLabel.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnTypeLabel.test.tsx
@@ -19,8 +19,7 @@
 import { isValidElement } from 'react';
 import { render, screen } from '@superset-ui/core/spec';
 import '@testing-library/jest-dom';
-import { GenericDataType } from '@superset-ui/core';
-
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnTypeLabel, ColumnTypeLabelProps } from '../../src';
 
 describe('ColumnOption', () => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/checkColumnType.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/checkColumnType.test.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType, testQueryResponse } from '@superset-ui/core';
+import { testQueryResponse } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { checkColumnType, TestDataset } from '../../src';
 
 test('checkColumnType columns from a Dataset', () => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  DatasourceType,
-  GenericDataType,
-  testQueryResponse,
-} from '@superset-ui/core';
+import { DatasourceType, testQueryResponse } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { columnChoices } from '../../src';
 
 describe('columnChoices()', () => {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getTemporalColumns.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getTemporalColumns.test.ts
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  GenericDataType,
-  testQueryResponse,
-  testQueryResults,
-} from '@superset-ui/core';
+import { testQueryResponse, testQueryResults } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   Dataset,
   getTemporalColumns,

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/isSortable.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/isSortable.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ControlStateMapping } from '@superset-ui/chart-controls';
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { isSortable } from '../../src/utils/isSortable';
 
 const controls: ControlStateMapping = {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Column.ts
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import { GenericDataType } from './QueryResponse';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { QueryFormColumn } from './QueryFormData';
 
 export interface AdhocColumn {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -17,6 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { DatasourceType } from './Datasource';
 import { BinaryOperator, SetOperator, UnaryOperator } from './Operator';
 import { AppliedTimeExtras, TimeRange } from './Time';
@@ -31,7 +32,7 @@ import { Maybe } from '../../types';
 import { PostProcessingRule } from './PostProcessing';
 import { JsonObject } from '../../connection';
 import { TimeGranularity } from '../../time-format';
-import { GenericDataType, DataRecordValue } from './QueryResponse';
+import { DataRecordValue } from './QueryResponse';
 
 export type BaseQueryObjectFilterClause = {
   col: QueryFormColumn;

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -17,18 +17,9 @@
  * under the License.
  */
 
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { TimeseriesDataRecord } from '../../chart';
 import { AnnotationData } from './AnnotationLayer';
-
-/**
- * Generic data types, see enum of the same name in superset/utils/core.py.
- */
-export enum GenericDataType {
-  Numeric = 0,
-  String = 1,
-  Temporal = 2,
-  Boolean = 3,
-}
 
 /**
  * Primitive types for data field values.

--- a/superset-frontend/packages/superset-ui-core/test/fixtures.ts
+++ b/superset-frontend/packages/superset-ui-core/test/fixtures.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AdhocMetric, GenericDataType } from '@superset-ui/core';
+import { AdhocMetric } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 export const NUM_METRIC: AdhocMetric = {
   expressionType: 'SIMPLE',

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -19,10 +19,10 @@
 import {
   DataRecord,
   DataRecordValue,
-  GenericDataType,
   getTimeFormatterForGranularity,
   t,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import { isEqual } from 'lodash';
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -43,7 +43,6 @@ import {
 import {
   ensureIsArray,
   FeatureFlag,
-  GenericDataType,
   isAdhocColumn,
   isFeatureEnabled,
   isPhysicalColumn,
@@ -55,7 +54,7 @@ import {
   validateMaxValue,
   validateServerPagination,
 } from '@superset-ui/core';
-
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { isEmpty, last } from 'lodash';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { ColorSchemeEnum } from './types';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -25,7 +25,6 @@ import {
   ensureIsArray,
   extractTimegrain,
   FeatureFlag,
-  GenericDataType,
   getMetricLabel,
   getNumberFormatter,
   getTimeFormatter,
@@ -38,7 +37,7 @@ import {
   TimeFormats,
   TimeFormatter,
 } from '@superset-ui/core';
-
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { isEmpty, isEqual } from 'lodash';
 import {
   ConditionalFormattingConfig,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
@@ -26,7 +26,6 @@ import {
   DataRecord,
   DataRecordValue,
   DataRecordFilters,
-  GenericDataType,
   QueryMode,
   ChartDataResponseResult,
   QueryFormData,
@@ -36,6 +35,7 @@ import {
   JsonObject,
   Metric,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ColDef,
   Column,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/formatValue.ts
@@ -19,12 +19,12 @@
 import {
   CurrencyFormatter,
   DataRecordValue,
-  GenericDataType,
   getNumberFormatter,
   isDefined,
   isProbablyHTML,
   sanitizeHtml,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ValueFormatterParams,
   ValueGetterParams,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -19,7 +19,8 @@
  */
 import { ColDef } from '@superset-ui/core/components/ThemedAgGridReact';
 import { useCallback, useMemo } from 'react';
-import { DataRecord, GenericDataType } from '@superset-ui/core';
+import { DataRecord } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 import { extent as d3Extent, max as d3Max } from 'd3-array';
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberPeriodOverPeriod/controlPanel.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, GenericDataType } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlPanelConfig,
   getStandardizedControls,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType, SMART_DATE_ID, t } from '@superset-ui/core';
+import { SMART_DATE_ID, t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlPanelConfig,
   D3_FORMAT_DOCS,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { getColorFormatters } from '@superset-ui/chart-controls';
 import { BigNumberTotalChartProps } from '../types';
 import transformProps from './transformProps';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.ts
@@ -22,12 +22,12 @@ import {
   Metric,
 } from '@superset-ui/chart-controls';
 import {
-  GenericDataType,
   getMetricLabel,
   extractTimegrain,
   QueryFormData,
   getValueFormatter,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { BigNumberTotalChartProps, BigNumberVizProps } from '../types';
 import { getDateFormatter, getOriginalLabel, parseMetricValue } from '../utils';
 import { Refs } from '../../types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import transformProps from './transformProps';
 import { BigNumberWithTrendlineChartProps, BigNumberDatum } from '../types';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.ts
@@ -20,7 +20,6 @@ import {
   extractTimegrain,
   getNumberFormatter,
   NumberFormats,
-  GenericDataType,
   getMetricLabel,
   getXAxisLabel,
   Metric,
@@ -28,6 +27,7 @@ import {
   t,
   tooltipHtml,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { EChartsCoreOption, graphic } from 'echarts/core';
 import { aggregationChoices } from '@superset-ui/chart-controls';
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/controlPanel.tsx
@@ -22,7 +22,8 @@ import {
   sections,
   sharedControls,
 } from '@superset-ui/chart-controls';
-import { GenericDataType, t } from '@superset-ui/core';
+import { t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   legendSection,
   showExtraControls,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/transformProps.ts
@@ -27,13 +27,13 @@ import {
   CategoricalColorNamespace,
   DataRecord,
   DataRecordValue,
-  GenericDataType,
   getColumnLabel,
   getNumberFormatter,
   t,
   tooltipHtml,
 } from '@superset-ui/core';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { CallbackDataParams } from 'echarts/types/src/util/types';
 import {
   Cartesian2dCoordSys,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/transformProps.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import {
-  GenericDataType,
   NumberFormats,
   QueryFormColumn,
   getColumnLabel,
@@ -29,6 +28,7 @@ import {
   addAlpha,
   tooltipHtml,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import memoizeOne from 'memoize-one';
 import { maxBy, minBy } from 'lodash';
 import type { ComposeOption } from 'echarts/core';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/controlPanel.tsx
@@ -16,12 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  GenericDataType,
-  t,
-  validateInteger,
-  validateNonEmpty,
-} from '@superset-ui/core';
+import { t, validateInteger, validateNonEmpty } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlPanelConfig,
   formatSelectOptionsForRange,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -25,7 +25,6 @@ import {
   CategoricalColorNamespace,
   CurrencyFormatter,
   ensureIsArray,
-  GenericDataType,
   getCustomFormatter,
   getNumberFormatter,
   getXAxisLabel,
@@ -42,6 +41,7 @@ import {
   tooltipHtml,
   ValueFormatter,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { getOriginalSeries } from '@superset-ui/chart-controls';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { SeriesOption } from 'echarts';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -18,11 +18,11 @@
  */
 import {
   ChartDataResponseResult,
-  GenericDataType,
   QueryFormMetric,
   t,
   validateNumber,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlPanelConfig,
   ControlSubSectionHeader,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -26,7 +26,6 @@ import {
   CurrencyFormatter,
   ensureIsArray,
   tooltipHtml,
-  GenericDataType,
   getCustomFormatter,
   getMetricLabel,
   getNumberFormatter,
@@ -41,6 +40,7 @@ import {
   TimeseriesChartDataResponseResult,
   NumberFormats,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   extractExtraMetrics,
   getOriginalSeries,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/transformProps.ts
@@ -20,7 +20,6 @@ import {
   CurrencyFormatter,
   DataRecord,
   ensureIsArray,
-  GenericDataType,
   getMetricLabel,
   getNumberFormatter,
   getTimeFormatter,
@@ -29,6 +28,7 @@ import {
   rgbToHex,
   tooltipHtml,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import type { ComposeOption } from 'echarts/core';
 import type { BarSeriesOption } from 'echarts/charts';
 import {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -24,7 +24,6 @@ import {
   DataRecordValue,
   DTTM_ALIAS,
   ensureIsArray,
-  GenericDataType,
   LegendState,
   normalizeTimestamp,
   NumberFormats,
@@ -33,6 +32,7 @@ import {
   TimeFormatter,
   ValueFormatter,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
 import type { LegendComponentOption } from 'echarts/components';

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -20,11 +20,11 @@ import { SortSeriesType } from '@superset-ui/chart-controls';
 import {
   AxisType,
   DataRecord,
-  GenericDataType,
   getNumberFormatter,
   getTimeFormatter,
   supersetTheme as theme,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   calculateLowerLogTick,
   dedupSeries,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -20,13 +20,13 @@ import {
   ChartProps,
   DataRecord,
   extractTimegrain,
-  GenericDataType,
   getTimeFormatter,
   getTimeFormatterForGranularity,
   QueryFormData,
   SMART_DATE_ID,
   TimeFormats,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { getColorFormatters } from '@superset-ui/chart-controls';
 import { DateFormatter } from '../types';
 

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -43,7 +43,6 @@ import {
   DataRecordValue,
   DTTM_ALIAS,
   ensureIsArray,
-  GenericDataType,
   getSelectedText,
   getTimeFormatterForGranularity,
   BinaryQueryObjectFilterClause,
@@ -54,6 +53,7 @@ import {
   useTheme,
   SupersetTheme,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   Input,
   Space,
@@ -83,7 +83,6 @@ import DataTable, {
   SelectPageSizeRendererProps,
   SizeOption,
 } from './DataTable';
-
 import Styles from './Styles';
 import { formatColumnValue } from './utils/formatValue';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -42,7 +42,6 @@ import {
 } from '@superset-ui/chart-controls';
 import {
   ensureIsArray,
-  GenericDataType,
   isAdhocColumn,
   isPhysicalColumn,
   legacyValidateInteger,
@@ -53,7 +52,7 @@ import {
   validateMaxValue,
   validateServerPagination,
 } from '@superset-ui/core';
-
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { isEmpty, last } from 'lodash';
 import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { ColorSchemeEnum } from './types';

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -24,7 +24,6 @@ import {
   DataRecord,
   ensureIsArray,
   extractTimegrain,
-  GenericDataType,
   getMetricLabel,
   getNumberFormatter,
   getTimeFormatter,
@@ -36,6 +35,7 @@ import {
   TimeFormats,
   TimeFormatter,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ColorFormatters,
   ConditionalFormattingConfig,

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -25,7 +25,6 @@ import {
   DataRecord,
   DataRecordValue,
   DataRecordFilters,
-  GenericDataType,
   QueryMode,
   ChartDataResponseResult,
   QueryFormData,
@@ -34,6 +33,7 @@ import {
   CurrencyFormatter,
   Currency,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColorFormatters } from '@superset-ui/chart-controls';
 
 export type CustomFormatter = (value: DataRecordValue) => string;

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -19,11 +19,11 @@
 import {
   CurrencyFormatter,
   DataRecordValue,
-  GenericDataType,
   getNumberFormatter,
   isProbablyHTML,
   sanitizeHtml,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { DataColumnMeta } from '../types';
 import DateWithFormatter from './DateWithFormatter';
 

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -20,12 +20,12 @@ import {
   ChartDataResponseResult,
   ChartProps,
   DatasourceType,
-  GenericDataType,
   QueryMode,
   supersetTheme,
   ComparisonType,
   VizType,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { TableChartProps, TableChartFormData } from '../src/types';
 
 const basicFormData: TableChartFormData = {

--- a/superset-frontend/src/SqlLab/fixtures.ts
+++ b/superset-frontend/src/SqlLab/fixtures.ts
@@ -23,10 +23,10 @@ import {
   DatasourceType,
   denormalizeTimestamp,
   ErrorTypeEnum,
-  GenericDataType,
   QueryResponse,
   QueryState,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { LatestQueryEditorVersion } from 'src/SqlLab/types';
 import { ISaveableDatasource } from 'src/SqlLab/components/SaveDatasetModal';
 

--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -30,12 +30,12 @@ import {
   BinaryQueryObjectFilterClause,
   css,
   ensureIsArray,
-  GenericDataType,
   JsonObject,
   QueryFormData,
   t,
   useTheme,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { useResizeDetector } from 'react-resize-detector';
 import BooleanCell from '@superset-ui/core/components/Table/cell-renderers/BooleanCell';
 import NullCell from '@superset-ui/core/components/Table/cell-renderers/NullCell';

--- a/superset-frontend/src/components/Chart/DrillDetail/types.ts
+++ b/superset-frontend/src/components/Chart/DrillDetail/types.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 export type ResultsPage = {
   total: number;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -26,7 +26,6 @@ import {
   isFeatureEnabled,
   FeatureFlag,
   Filter,
-  GenericDataType,
   getChartMetadataRegistry,
   JsonResponse,
   NativeFilterType,
@@ -39,6 +38,7 @@ import {
   css,
   getExtensionsRegistry,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { debounce, isEqual } from 'lodash';
 import {
   forwardRef,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/constants.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/constants.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 export const INPUT_HEIGHT = 32;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/utils.ts
@@ -20,7 +20,8 @@ import { flatMapDeep } from 'lodash';
 import type { FormInstance } from '@superset-ui/core/components';
 import { useState, useCallback } from 'react';
 import { CustomControlItem, Dataset } from '@superset-ui/chart-controls';
-import { Column, ensureIsArray, GenericDataType } from '@superset-ui/core';
+import { Column, ensureIsArray } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { DatasourcesState, ChartsState } from 'src/dashboard/types';
 import { FILTER_SUPPORTED_TYPES } from './constants';
 

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -21,18 +21,17 @@ import {
   DataMaskStateWithId,
   DatasourceType,
   ExtraFormData,
-  GenericDataType,
   JsonObject,
   NativeFilterScope,
   NativeFiltersState,
   NativeFilterTarget,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { Dataset } from '@superset-ui/chart-controls';
 import { chart } from 'src/components/Chart/chartReducer';
 import componentTypes from 'src/dashboard/util/componentTypes';
 import Database from 'src/types/Database';
 import { UrlParamEntries } from 'src/utils/urlUtils';
-
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import Owner from 'src/types/Owner';
 import { ChartState } from '../explore/types';

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -19,7 +19,6 @@
 import { useMemo, useState, useEffect, useRef, RefObject } from 'react';
 import {
   css,
-  GenericDataType,
   getTimeFormatter,
   safeHtmlSpan,
   styled,
@@ -27,6 +26,7 @@ import {
   TimeFormats,
   useTheme,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { Column } from 'react-table';
 import { debounce } from 'lodash';
 import {

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { renderHook } from '@testing-library/react-hooks';
 import { Constants } from '@superset-ui/core/components';
 import { useTableColumns } from '.';

--- a/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/DataTableControls.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled, css, GenericDataType } from '@superset-ui/core';
+import { styled, css } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { useMemo } from 'react';
 import { zip } from 'lodash';
 import {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { ensureIsArray, GenericDataType, styled, t } from '@superset-ui/core';
+import { ensureIsArray, styled, t } from '@superset-ui/core';
 import {
   TableView,
   TableSize,
@@ -25,6 +25,7 @@ import {
   Loading,
   EmptyWrapperType,
 } from '@superset-ui/core/components';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   useFilteredTableData,
   useTableColumns,

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  GenericDataType,
-  JsonObject,
-  LatestQueryFormData,
-} from '@superset-ui/core';
+import { JsonObject, LatestQueryFormData } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import type { ChartStatus, Datasource } from 'src/explore/types';
 
 export enum ResultTypes {

--- a/superset-frontend/src/explore/components/DatasourcePanel/fixtures.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/fixtures.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 export const columns = [
   {

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigControl.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import { useMemo, useState } from 'react';
-import { useTheme, t, GenericDataType } from '@superset-ui/core';
-
+import { useTheme, t } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   COLUMN_NAME_ALIASES,
   ControlComponentProps,

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/ColumnConfigPopover.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import Tabs from '@superset-ui/core/components/Tabs';
 import {
   SHARED_COLUMN_CONFIG_PROPS,

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/constants.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType, t, validateNumber } from '@superset-ui/core';
+import { t, validateNumber } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   ControlFormItemSpec,
   D3_FORMAT_DOCS,

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  GenericDataType,
-  JsonObject,
-  StrictJsonValue,
-} from '@superset-ui/core';
+import { JsonObject, StrictJsonValue } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ControlFormItemSpec } from '@superset-ui/chart-controls';
 import {
   SHARED_COLUMN_CONFIG_PROPS,

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
@@ -24,7 +24,7 @@ import {
 } from 'spec/helpers/testing-library';
 import { Comparator } from '@superset-ui/chart-controls';
 import { ColorSchemeEnum } from '@superset-ui/plugin-chart-table';
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { FormattingPopoverContent } from './FormattingPopoverContent';
 
 const mockOnChange = jest.fn();

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -17,13 +17,8 @@
  * under the License.
  */
 import { useMemo, useState, useEffect } from 'react';
-import {
-  GenericDataType,
-  styled,
-  SupersetTheme,
-  t,
-  useTheme,
-} from '@superset-ui/core';
+import { styled, SupersetTheme, t, useTheme } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   Comparator,
   MultipleValueComparators,

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/types.ts
@@ -20,7 +20,7 @@
 import { ReactNode } from 'react';
 import { PopoverProps } from '@superset-ui/core/components/Popover';
 import { Comparator, ControlComponentProps } from '@superset-ui/chart-controls';
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 export type ConditionalFormattingConfig = {
   operator?: Comparator;

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -19,13 +19,9 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
-import {
-  ensureIsArray,
-  GenericDataType,
-  QueryFormData,
-} from '@superset-ui/core';
+import { ensureIsArray, QueryFormData } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
-
 import {
   fireEvent,
   render,

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -21,7 +21,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { nanoid } from 'nanoid';
 import {
   ensureIsArray,
-  GenericDataType,
   isAdhocMetricSimple,
   isSavedMetric,
   Metric,
@@ -29,6 +28,7 @@ import {
   t,
   tn,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { ColumnMeta } from '@superset-ui/chart-controls';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 import AdhocMetricPopoverTrigger from 'src/explore/components/controls/MetricControl/AdhocMetricPopoverTrigger';

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.stories.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.stories.tsx
@@ -17,11 +17,8 @@
  * under the License.
  */
 import { action } from '@storybook/addon-actions';
-import {
-  SuperChart,
-  getChartTransformPropsRegistry,
-  GenericDataType,
-} from '@superset-ui/core';
+import { SuperChart, getChartTransformPropsRegistry } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import RangeFilterPlugin from './index';
 import transformProps from './transformProps';
 

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AppSection, GenericDataType } from '@superset-ui/core';
+import { AppSection } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'spec/helpers/testing-library';
 import RangeFilterPlugin from './RangeFilterPlugin';

--- a/superset-frontend/src/filters/components/Range/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Range/buildQuery.ts
@@ -16,11 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  buildQueryContext,
-  GenericDataType,
-  QueryFormData,
-} from '@superset-ui/core';
+import { buildQueryContext, QueryFormData } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 
 /**
  * The buildQuery function is used to create an instance of QueryContext that's

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -23,7 +23,6 @@ import {
   DataMask,
   ensureIsArray,
   ExtraFormData,
-  GenericDataType,
   getColumnLabel,
   JsonObject,
   finestTemporalGrainFormatter,
@@ -31,6 +30,7 @@ import {
   tn,
   styled,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { debounce, isUndefined } from 'lodash';
 import { useImmerReducer } from 'use-immer';
 import {

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import buildQuery from './buildQuery';
 import { PluginFilterSelectQueryFormData } from './types';
 

--- a/superset-frontend/src/filters/components/Select/buildQuery.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.ts
@@ -18,13 +18,13 @@
  */
 import {
   buildQueryContext,
-  GenericDataType,
   getColumnLabel,
   isPhysicalColumn,
   QueryObject,
   QueryObjectFilterClause,
   BuildQuery,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { DEFAULT_FORM_DATA, PluginFilterSelectQueryFormData } from './types';
 
 const buildQuery: BuildQuery<PluginFilterSelectQueryFormData> = (

--- a/superset-frontend/src/filters/components/Select/transformProps.ts
+++ b/superset-frontend/src/filters/components/Select/transformProps.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { GenericDataType } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { noOp } from 'src/utils/common';
 import { DEFAULT_FORM_DATA, PluginFilterSelectChartProps } from './types';
 

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -22,10 +22,10 @@ import {
   ChartProps,
   DataRecord,
   FilterState,
-  GenericDataType,
   QueryFormData,
   ChartDataResponseResult,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { RefObject } from 'react';
 import { FilterBarOrientation } from 'src/dashboard/types';
 import { PluginFilterHooks, PluginFilterStylesProps } from '../types';

--- a/superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeColumn/TimeColumnFilterPlugin.tsx
@@ -16,13 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  ensureIsArray,
-  ExtraFormData,
-  GenericDataType,
-  t,
-  tn,
-} from '@superset-ui/core';
+import { ensureIsArray, ExtraFormData, t, tn } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { useEffect, useState } from 'react';
 import {
   FormItem,

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -18,12 +18,12 @@
  */
 
 import {
-  GenericDataType,
   getNumberFormatter,
   getTimeFormatter,
   NumberFormats,
   TimeFormats,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   getDataRecordFormatter,
   getRangeExtraFormData,

--- a/superset-frontend/src/filters/utils.ts
+++ b/superset-frontend/src/filters/utils.ts
@@ -18,12 +18,12 @@
  */
 import {
   DataRecordValue,
-  GenericDataType,
   NumberFormatter,
   QueryObjectFilterClause,
   TimeFormatter,
   ExtraFormData,
 } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
 import { FALSE_STRING, NULL_STRING, TRUE_STRING } from 'src/utils/common';
 import {
   Clauses,


### PR DESCRIPTION
### SUMMARY
This PR migrates `GenericDataType` imports from `@superset-ui/core` to `@apache-superset/core` across the frontend codebase, updating numerous chart plugins, controls, and components to use the new package location.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
