### PR TITLE
fix(PropertiesModal): do not show validation errors while loading

### DIFF
--- a/superset-frontend/src/components/Modal/StandardModal.tsx
+++ b/superset-frontend/src/components/Modal/StandardModal.tsx
@@ -18,7 +18,7 @@
  */
 import { ReactNode } from 'react';
 import { styled, t } from '@superset-ui/core';
-import { Modal } from '@superset-ui/core/components';
+import { Modal, Loading, Flex } from '@superset-ui/core/components';
 import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
 
 interface StandardModalProps {
@@ -39,6 +39,7 @@ interface StandardModalProps {
   destroyOnClose?: boolean;
   maskClosable?: boolean;
   wrapProps?: object;
+  contentLoading?: boolean;
 }
 
 // Standard modal widths
@@ -113,12 +114,13 @@ export function StandardModal({
   destroyOnClose = true,
   maskClosable = false,
   wrapProps,
+  contentLoading = false,
 }: StandardModalProps) {
   const primaryButtonName = saveText || (isEditMode ? t('Save') : t('Add'));
 
   return (
     <StyledModal
-      disablePrimaryButton={saveDisabled || saveLoading}
+      disablePrimaryButton={saveDisabled || saveLoading || contentLoading}
       primaryButtonLoading={saveLoading}
       primaryTooltipMessage={errorTooltip}
       onHandledPrimaryAction={onSave}
@@ -139,7 +141,13 @@ export function StandardModal({
         )
       }
     >
-      {children}
+      {contentLoading ? (
+        <Flex justify="center" align="center" style={{ minHeight: 200 }}>
+          <Loading />
+        </Flex>
+      ) : (
+        children
+      )}
     </StyledModal>
   );
 }

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -365,7 +365,7 @@ describe('PropertiesModal', () => {
     render(<PropertiesModal {...propsWithDashboardInfo} />, {
       useRedux: true,
     });
-    
+
     // Wait for the form to be visible
     expect(
       await screen.findByTestId('dashboard-edit-properties-form'),
@@ -400,7 +400,7 @@ describe('PropertiesModal', () => {
     render(<PropertiesModal {...propsWithDashboardInfo} />, {
       useRedux: true,
     });
-    
+
     // Wait for the form to be visible
     expect(
       await screen.findByTestId('dashboard-edit-properties-form'),

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -354,9 +354,19 @@ describe('PropertiesModal', () => {
     mockedIsFeatureEnabled.mockReturnValue(false);
     const props = createProps();
     props.onlyApply = false;
-    render(<PropertiesModal {...props} />, {
+    // Pass dashboardInfo to avoid loading state
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
       useRedux: true,
     });
+    
+    // Wait for the form to be visible
     expect(
       await screen.findByTestId('dashboard-edit-properties-form'),
     ).toBeInTheDocument();
@@ -379,9 +389,19 @@ describe('PropertiesModal', () => {
     mockedIsFeatureEnabled.mockReturnValue(false);
     const props = createProps();
     props.onlyApply = true;
-    render(<PropertiesModal {...props} />, {
+    // Pass dashboardInfo to avoid loading state
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
       useRedux: true,
     });
+    
+    // Wait for the form to be visible
     expect(
       await screen.findByTestId('dashboard-edit-properties-form'),
     ).toBeInTheDocument();

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -522,11 +522,6 @@ const PropertiesModal = ({
         key: 'basic',
         name: t('General information'),
         validator: () => {
-          // Don't validate while loading
-          if (isLoading) {
-            return [];
-          }
-
           const errors = [];
           const values = form.getFieldsValue();
 
@@ -552,11 +547,6 @@ const PropertiesModal = ({
         key: 'refresh',
         name: t('Refresh settings'),
         validator: () => {
-          // Don't validate while loading
-          if (isLoading) {
-            return [];
-          }
-
           const errors = [];
           const refreshLimit =
             dashboardInfo?.common?.conf
@@ -585,11 +575,6 @@ const PropertiesModal = ({
         key: 'advanced',
         name: t('Advanced settings'),
         validator: () => {
-          // Don't validate while loading
-          if (isLoading) {
-            return [];
-          }
-
           if (jsonAnnotations.length > 0) {
             return [t('Invalid JSON metadata')];
           }
@@ -597,7 +582,7 @@ const PropertiesModal = ({
         },
       },
     ],
-    [form, jsonAnnotations, refreshFrequency, dashboardInfo, isLoading],
+    [form, jsonAnnotations, refreshFrequency, dashboardInfo],
   );
 
   const {
@@ -610,26 +595,20 @@ const PropertiesModal = ({
     sections: modalSections,
   });
 
-  // Validate basic section when title changes (but not while loading)
+  // Validate basic section when title changes
   useEffect(() => {
-    if (!isLoading) {
-      validateSection('basic');
-    }
-  }, [dashboardTitle, isLoading, validateSection]);
+    validateSection('basic');
+  }, [dashboardTitle, validateSection]);
 
-  // Validate advanced section when JSON changes (but not while loading)
+  // Validate advanced section when JSON changes
   useEffect(() => {
-    if (!isLoading) {
-      validateSection('advanced');
-    }
-  }, [jsonMetadata, isLoading, validateSection]);
+    validateSection('advanced');
+  }, [jsonMetadata, validateSection]);
 
-  // Validate refresh section when refresh frequency changes (but not while loading)
+  // Validate refresh section when refresh frequency changes
   useEffect(() => {
-    if (!isLoading) {
-      validateSection('refresh');
-    }
-  }, [refreshFrequency, isLoading, validateSection]);
+    validateSection('refresh');
+  }, [refreshFrequency, validateSection]);
 
   return (
     <StandardModal
@@ -643,9 +622,10 @@ const PropertiesModal = ({
       title={t('Dashboard properties')}
       isEditMode
       saveDisabled={
-        isLoading || dashboardInfo?.isManagedExternally || hasErrors
+        dashboardInfo?.isManagedExternally || hasErrors
       }
       saveLoading={isApplying}
+      contentLoading={isLoading}
       errorTooltip={
         dashboardInfo?.isManagedExternally
           ? t(
@@ -660,10 +640,8 @@ const PropertiesModal = ({
         form={form}
         onFinish={onFinish}
         onFieldsChange={() => {
-          // Re-validate sections when form fields change (but not while loading)
-          if (!isLoading) {
-            setTimeout(() => validateSection('basic'), 100);
-          }
+          // Re-validate sections when form fields change
+          setTimeout(() => validateSection('basic'), 100);
         }}
         data-test="dashboard-edit-properties-form"
         layout="vertical"
@@ -688,7 +666,6 @@ const PropertiesModal = ({
               children: (
                 <BasicInfoSection
                   form={form}
-                  isLoading={isLoading}
                   validationStatus={validationStatus}
                 />
               ),

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -621,9 +621,7 @@ const PropertiesModal = ({
       }}
       title={t('Dashboard properties')}
       isEditMode
-      saveDisabled={
-        dashboardInfo?.isManagedExternally || hasErrors
-      }
+      saveDisabled={dashboardInfo?.isManagedExternally || hasErrors}
       saveLoading={isApplying}
       contentLoading={isLoading}
       errorTooltip={

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
@@ -51,16 +51,6 @@ test('shows required asterisk for name field', () => {
   expect(screen.getByText('*')).toBeInTheDocument();
 });
 
-test('disables inputs when loading', () => {
-  render(
-    <Form>
-      <BasicInfoSection {...defaultProps} />
-    </Form>,
-  );
-
-  expect(screen.getByTestId('dashboard-title-input')).toBeDisabled();
-});
-
 test('shows error message when name is empty and has validation errors', () => {
   const mockForm = {
     getFieldValue: jest.fn(field => (field === 'title' ? '' : 'test')),

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
@@ -21,7 +21,9 @@ import { Form } from '@superset-ui/core/components';
 import BasicInfoSection from './BasicInfoSection';
 
 const defaultProps = {
-  form: {} as any,
+  form: {
+    getFieldValue: jest.fn(() => 'Test Dashboard'),
+  } as any,
   isLoading: false,
   validationStatus: {
     basic: { hasErrors: false, errors: [], name: 'Basic' },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
@@ -24,7 +24,6 @@ const defaultProps = {
   form: {
     getFieldValue: jest.fn(() => 'Test Dashboard'),
   } as any,
-  isLoading: false,
   validationStatus: {
     basic: { hasErrors: false, errors: [], name: 'Basic' },
   },
@@ -55,7 +54,7 @@ test('shows required asterisk for name field', () => {
 test('disables inputs when loading', () => {
   render(
     <Form>
-      <BasicInfoSection {...defaultProps} isLoading />
+      <BasicInfoSection {...defaultProps} />
     </Form>,
   );
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
@@ -23,18 +23,15 @@ import { ValidationObject } from 'src/components/Modal/useModalValidation';
 
 interface BasicInfoSectionProps {
   form: FormInstance;
-  isLoading: boolean;
   validationStatus: ValidationObject;
 }
 
 const BasicInfoSection = ({
   form,
-  isLoading,
   validationStatus,
 }: BasicInfoSectionProps) => {
   const titleValue = form.getFieldValue('title');
   const hasError =
-    !isLoading &&
     validationStatus.basic?.hasErrors &&
     (!titleValue || titleValue.trim().length === 0);
 
@@ -61,7 +58,6 @@ const BasicInfoSection = ({
             placeholder={t('The display name of your dashboard')}
             data-test="dashboard-title-input"
             type="text"
-            disabled={isLoading}
           />
         </FormItem>
       </ModalFormField>
@@ -75,7 +71,6 @@ const BasicInfoSection = ({
             placeholder={t('A readable URL for your dashboard')}
             data-test="dashboard-slug-input"
             type="text"
-            disabled={isLoading}
           />
         </FormItem>
       </ModalFormField>

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
@@ -31,54 +31,56 @@ const BasicInfoSection = ({
   form,
   isLoading,
   validationStatus,
-}: BasicInfoSectionProps) => (
-  <>
-    <ModalFormField
-      label={t('Name')}
-      required
-      testId="dashboard-name-field"
-      error={
-        validationStatus.basic?.hasErrors &&
-        (!form.getFieldValue('title') ||
-          form.getFieldValue('title').trim().length === 0)
-          ? t('Dashboard name is required')
-          : undefined
-      }
-    >
-      <FormItem
-        name="title"
-        noStyle
-        rules={[
-          {
-            required: true,
-            message: t('Dashboard name is required'),
-            whitespace: true,
-          },
-        ]}
+}: BasicInfoSectionProps) => {
+  const titleValue = form.getFieldValue('title');
+  const hasError =
+    !isLoading &&
+    validationStatus.basic?.hasErrors &&
+    (!titleValue || titleValue.trim().length === 0);
+
+  return (
+    <>
+      <ModalFormField
+        label={t('Name')}
+        required
+        testId="dashboard-name-field"
+        error={hasError ? t('Dashboard name is required') : undefined}
       >
-        <Input
-          placeholder={t('The display name of your dashboard')}
-          data-test="dashboard-title-input"
-          type="text"
-          disabled={isLoading}
-        />
-      </FormItem>
-    </ModalFormField>
-    <ModalFormField
-      label={t('URL Slug')}
-      testId="dashboard-slug-field"
-      bottomSpacing={false}
-    >
-      <FormItem name="slug" noStyle>
-        <Input
-          placeholder={t('A readable URL for your dashboard')}
-          data-test="dashboard-slug-input"
-          type="text"
-          disabled={isLoading}
-        />
-      </FormItem>
-    </ModalFormField>
-  </>
-);
+        <FormItem
+          name="title"
+          noStyle
+          rules={[
+            {
+              required: true,
+              message: t('Dashboard name is required'),
+              whitespace: true,
+            },
+          ]}
+        >
+          <Input
+            placeholder={t('The display name of your dashboard')}
+            data-test="dashboard-title-input"
+            type="text"
+            disabled={isLoading}
+          />
+        </FormItem>
+      </ModalFormField>
+      <ModalFormField
+        label={t('URL Slug')}
+        testId="dashboard-slug-field"
+        bottomSpacing={false}
+      >
+        <FormItem name="slug" noStyle>
+          <Input
+            placeholder={t('A readable URL for your dashboard')}
+            data-test="dashboard-slug-input"
+            type="text"
+            disabled={isLoading}
+          />
+        </FormItem>
+      </ModalFormField>
+    </>
+  );
+};
 
 export default BasicInfoSection;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Dashboard properties modal was showing validation errors when in a loading state. This pr fixes that.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://github.com/user-attachments/assets/95fec6a6-cb7f-483d-a4b9-4c6565947ec7

After:

https://github.com/user-attachments/assets/6ea06a81-42f3-43d1-afba-267071e82794



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Visual testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
