### PR TITLE
fix: defensive code to avoid accesing attribute of a NoneType object

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1342,6 +1342,8 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         self.incr_stats("from_cache", self.thumbnail.__name__)
         try:
             image = cache_payload.get_image()
+            if not image or not hasattr(image, "read"):
+                return self.response_404()
         except ScreenshotImageNotAvailableException:
             return self.response_404()
         return Response(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed a bug in the dashboard thumbnail API (`/api/v1/dashboard/{id}/thumbnail/{digest}/`) that was causing `AttributeError: 'NoneType' object has no attribute 'read'` errors. The issue occurred when the thumbnail cache contained corrupted or invalid image data that resulted in a None object being passed to `FileWrapper`.

Added defensive validation to check if the image object exists and has the required `read` attribute before passing it to `FileWrapper`. If the image is invalid, the API now returns a proper `404` response instead of crashing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes thumbnail API crashes with corrupted cache
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
