### PR TITLE
fix(ConditionalFormattingControl): icon color in dark mode

### DIFF
--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
@@ -53,7 +53,6 @@ export const FormatterContainer = styled(OptionControlContainer)`
 
 export const CloseButton = styled.button`
   ${({ theme }) => css`
-    color: ${theme.colorIcon};
     height: 100%;
     width: ${theme.sizeUnit * 6}px;
     border: none;

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/ConditionalFormattingControl.tsx
@@ -53,6 +53,8 @@ export const FormatterContainer = styled(OptionControlContainer)`
 
 export const CloseButton = styled.button`
   ${({ theme }) => css`
+    background: ${theme.colorBgLayout};
+    color: ${theme.colorIcon};
     height: 100%;
     width: ${theme.sizeUnit * 6}px;
     border: none;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

CloseOutlined icon was not visible in dark themes in ConditionalFormattingControl.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before can be observed in linked issue
<img width="325" height="168" alt="image" src="https://github.com/user-attachments/assets/2e796e6c-c808-4b5f-babb-12d9274ca5aa" />

After:
<img width="349" height="134" alt="image" src="https://github.com/user-attachments/assets/538f26d9-6982-4f1c-a15b-bd5eb907dec8" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Visual testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35236 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
