### PR TITLE
fix: Typescript declaration files

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -140,6 +140,11 @@ jobs:
           docker run --rm $TAG bash -c \
           "npm i && npm run eslint -- . --quiet"
 
+      - name: tsc
+        run: |
+          docker run --rm $TAG bash -c \
+          "npm run plugins:build && npm run type"
+
   validate-frontend:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'
@@ -156,12 +161,7 @@ jobs:
       - name: Build Plugins Packages
         run: |
           docker run --rm $TAG bash -c \
-          "npm i && npm run plugins:build"
-
-      - name: tsc
-        run: |
-          docker run --rm $TAG bash -c \
-          "npm run type"
+          "npm run plugins:build"
 
       - name: Build Plugins Storybook
         run: |

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -140,11 +140,6 @@ jobs:
           docker run --rm $TAG bash -c \
           "npm i && npm run eslint -- . --quiet"
 
-      - name: tsc
-        run: |
-          docker run --rm $TAG bash -c \
-          "npm run plugins:build && npm run type"
-
   validate-frontend:
     needs: frontend-build
     if: needs.frontend-build.outputs.should-run == 'true'
@@ -162,6 +157,11 @@ jobs:
         run: |
           docker run --rm $TAG bash -c \
           "npm run plugins:build"
+
+      - name: tsc
+        run: |
+          docker run --rm $TAG bash -c \
+          "npm run type"
 
       - name: Build Plugins Storybook
         run: |

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Build Plugins Packages
         run: |
           docker run --rm $TAG bash -c \
-          "npm run plugins:build"
+          "npm i && npm run plugins:build"
 
       - name: tsc
         run: |

--- a/superset-frontend/packages/superset-core/tsconfig.json
+++ b/superset-frontend/packages/superset-core/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"]

--- a/superset-frontend/packages/superset-ui-chart-controls/tsconfig.json
+++ b/superset-frontend/packages/superset-ui-chart-controls/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"],

--- a/superset-frontend/packages/superset-ui-core/tsconfig.json
+++ b/superset-frontend/packages/superset-ui-core/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"],

--- a/superset-frontend/packages/superset-ui-switchboard/tsconfig.json
+++ b/superset-frontend/packages/superset-ui-switchboard/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"]

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-chord/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-chord/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-horizon/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-horizon/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-paired-t-test/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-parallel-coordinates/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-rose/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-rose/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/tsconfig.json
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/tsconfig.json
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"],

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/tsconfig.json
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/plugin-chart-echarts/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-echarts/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/plugin-chart-handlebars/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-handlebars/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/plugin-chart-pivot-table/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["src/**/*.test.*", "src/**/*.stories.*"],

--- a/superset-frontend/plugins/plugin-chart-table/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-table/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/plugins/plugin-chart-word-cloud/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Path Resolution: Override baseUrl to maintain correct path mappings from parent config
+    // (e.g., "@apache-superset/core" -> "./packages/superset-core/src")
     "baseUrl": "../..",
-    "outDir": "lib"
+
+    // Directory Overrides: Parent config paths are relative to frontend root,
+    // but packages need paths relative to their own directory
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
   "exclude": [

--- a/superset-frontend/scripts/build.js
+++ b/superset-frontend/scripts/build.js
@@ -84,14 +84,22 @@ function getPackages(packagePattern, tsOnly = false) {
 
   const allScopes = [];
   if (supersetUiPackages.length > 0) {
-    allScopes.push(`@superset-ui/${
-      supersetUiPackages.length > 1 ? `{${supersetUiPackages.join(',')}}` : supersetUiPackages[0]
-    }`);
+    allScopes.push(
+      `@superset-ui/${
+        supersetUiPackages.length > 1
+          ? `{${supersetUiPackages.join(',')}}`
+          : supersetUiPackages[0]
+      }`,
+    );
   }
   if (apachePackages.length > 0) {
-    allScopes.push(`@apache-superset/${
-      apachePackages.length > 1 ? `{${apachePackages.join(',')}}` : apachePackages[0]
-    }`);
+    allScopes.push(
+      `@apache-superset/${
+        apachePackages.length > 1
+          ? `{${apachePackages.join(',')}}`
+          : apachePackages[0]
+      }`,
+    );
   }
 
   if (allScopes.length === 0) {

--- a/superset-frontend/scripts/build.js
+++ b/superset-frontend/scripts/build.js
@@ -50,12 +50,14 @@ function run(cmd, options) {
 function getPackages(packagePattern, tsOnly = false) {
   let pattern = packagePattern;
   if (pattern === '*' && !tsOnly) {
-    return `@superset-ui/!(${[...META_PACKAGES].join('|')})`;
+    return `{@superset-ui/!(${[...META_PACKAGES].join('|')}),@apache-superset/*}`;
   }
   if (!pattern.includes('*')) {
     pattern = `*${pattern}`;
   }
-  const packages = [
+
+  // Find packages in both @superset-ui and @apache-superset scopes
+  const supersetUiPackages = [
     ...new Set(
       fastGlob
         .sync([
@@ -67,12 +69,36 @@ function getPackages(packagePattern, tsOnly = false) {
         .filter(x => !META_PACKAGES.has(x)),
     ),
   ];
-  if (packages.length === 0) {
+
+  const apachePackages = [
+    ...new Set(
+      fastGlob
+        .sync([
+          `./node_modules/@apache-superset/${pattern}/src/**/*.${
+            tsOnly ? '{ts,tsx}' : '{ts,tsx,js,jsx}'
+          }`,
+        ])
+        .map(x => x.split('/')[3]),
+    ),
+  ];
+
+  const allScopes = [];
+  if (supersetUiPackages.length > 0) {
+    allScopes.push(`@superset-ui/${
+      supersetUiPackages.length > 1 ? `{${supersetUiPackages.join(',')}}` : supersetUiPackages[0]
+    }`);
+  }
+  if (apachePackages.length > 0) {
+    allScopes.push(`@apache-superset/${
+      apachePackages.length > 1 ? `{${apachePackages.join(',')}}` : apachePackages[0]
+    }`);
+  }
+
+  if (allScopes.length === 0) {
     throw new Error('No matching packages');
   }
-  return `@superset-ui/${
-    packages.length > 1 ? `{${packages.join(',')}}` : packages[0]
-  }`;
+
+  return allScopes.length > 1 ? `{${allScopes.join(',')}}` : allScopes[0];
 }
 
 let scope = getPackages(glob);


### PR DESCRIPTION
### SUMMARY
This change fixes TypeScript declaration file generation across the entire superset-frontend monorepo by adding proper `rootDir`, `declarationDir`, and `baseUrl` overrides to all 23 package and plugin `tsconfig.json` files, along with comprehensive inline documentation explaining why these overrides are necessary. Previously, packages were inheriting incompatible directory paths from the parent configuration designed for the frontend root, causing `npm run build` to generate JavaScript files but no `.d.ts` declaration files needed for proper npm publishing. The fix ensures all packages and plugins now generate proper declaration files, while the added documentation prevents future developers from accidentally removing these critical configuration overrides that resolve path conflicts between the monorepo structure and individual package builds.

Follow-up of https://github.com/apache/superset/pull/35159

### TESTING INSTRUCTIONS
Build packages and plugins and check that their Typescript declaration files are being generated.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
