### PR TITLE
feat(themes): Adding SupersetText support to Themes Modal

### DIFF
--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -21,6 +21,7 @@ import { FunctionComponent, useState, useEffect, ChangeEvent } from 'react';
 import { css, styled, t, useTheme } from '@superset-ui/core';
 import { useSingleViewResource } from 'src/views/CRUD/hooks';
 import { useThemeContext } from 'src/theme/ThemeProvider';
+import SupersetText from 'src/utils/textUtils';
 
 import { Icons } from '@superset-ui/core/components/Icons';
 import withToasts from 'src/components/MessageToasts/withToasts';
@@ -105,6 +106,14 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
   const isReadOnly = isSystemTheme;
 
   const canDevelopThemes = canDevelop;
+
+  // SupersetText URL configurations
+  const themeEditorUrl =
+    SupersetText?.THEME_MODAL?.THEME_EDITOR_URL ||
+    'https://ant.design/theme-editor';
+  const documentationUrl =
+    SupersetText?.THEME_MODAL?.DOCUMENTATION_URL ||
+    'https://superset.apache.org/docs/configuration/theming/';
 
   // JSON validation annotations using reusable hook
   const jsonAnnotations = useJsonValidation(currentTheme?.json_data, {
@@ -350,7 +359,7 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
                 <span>
                   {t('Design with')}{' '}
                   <a
-                    href="https://ant.design/theme-editor"
+                    href={themeEditorUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -358,7 +367,7 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
                   </a>
                   {t(', then paste the JSON below. See our')}{' '}
                   <a
-                    href="https://superset.apache.org/docs/configuration/theming/"
+                    href={documentationUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In order to be able to easily customize URL's in Theme Modal, `SupersetText` is added with propper fallback 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
