### PR TITLE
fix(theme-crud): add unsaved changes modal

### DIFF
--- a/superset-frontend/src/features/themes/ThemeModal.test.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.test.tsx
@@ -64,14 +64,14 @@ const mockSystemTheme: ThemeObject = {
   is_system: true,
 };
 
-const setupFetchMocks = () => {
+beforeEach(() => {
   fetchMock.reset();
   fetchMock.get('glob:*/api/v1/theme/1', { result: mockTheme });
   fetchMock.get('glob:*/api/v1/theme/2', { result: mockSystemTheme });
   fetchMock.get('glob:*/api/v1/theme/*', { result: mockTheme });
   fetchMock.post('glob:*/api/v1/theme/', { result: { ...mockTheme, id: 3 } });
   fetchMock.put('glob:*/api/v1/theme/*', { result: mockTheme });
-};
+});
 
 afterEach(() => {
   fetchMock.restore();
@@ -79,7 +79,6 @@ afterEach(() => {
 });
 
 test('renders modal with add theme dialog when show is true', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -97,7 +96,6 @@ test('renders modal with add theme dialog when show is true', () => {
 });
 
 test('does not render modal when show is false', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -114,7 +112,6 @@ test('does not render modal when show is false', () => {
 });
 
 test('renders edit mode title when theme is provided', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -134,7 +131,6 @@ test('renders edit mode title when theme is provided', async () => {
 });
 
 test('renders view mode title for system themes', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -156,7 +152,6 @@ test('renders view mode title for system themes', async () => {
 });
 
 test('renders theme name input field', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -173,7 +168,6 @@ test('renders theme name input field', () => {
 });
 
 test('renders JSON configuration field', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -190,7 +184,6 @@ test('renders JSON configuration field', () => {
 });
 
 test('disables inputs for read-only system themes', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -210,7 +203,6 @@ test('disables inputs for read-only system themes', async () => {
 });
 
 test('shows Apply button when canDevelop is true and theme exists', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -230,7 +222,6 @@ test('shows Apply button when canDevelop is true and theme exists', async () => 
 });
 
 test('does not show Apply button when canDevelop is false', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -249,7 +240,6 @@ test('does not show Apply button when canDevelop is false', () => {
 });
 
 test('disables save button when theme name is empty', () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -268,7 +258,6 @@ test('disables save button when theme name is empty', () => {
 });
 
 test('enables save button when theme name is entered', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -290,7 +279,6 @@ test('enables save button when theme name is entered', async () => {
 });
 
 test('validates JSON format and enables save button', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -312,7 +300,6 @@ test('validates JSON format and enables save button', async () => {
 });
 
 test('shows unsaved changes alert when closing modal with modifications', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -345,7 +332,6 @@ test('shows unsaved changes alert when closing modal with modifications', async 
 });
 
 test('does not show unsaved changes alert when closing without modifications', async () => {
-  setupFetchMocks();
   const onHide = jest.fn();
   render(
     <ThemeModal
@@ -369,7 +355,6 @@ test('does not show unsaved changes alert when closing without modifications', a
 });
 
 test('allows user to keep editing after triggering cancel alert', async () => {
-  setupFetchMocks();
   render(
     <ThemeModal
       addDangerToast={jest.fn()}
@@ -406,7 +391,6 @@ test('allows user to keep editing after triggering cancel alert', async () => {
 });
 
 test('saves changes when clicking Save button in unsaved changes alert', async () => {
-  setupFetchMocks();
   const onHide = jest.fn();
   const onThemeAdd = jest.fn();
   render(
@@ -440,7 +424,6 @@ test('saves changes when clicking Save button in unsaved changes alert', async (
 });
 
 test('discards changes when clicking Discard button in unsaved changes alert', async () => {
-  setupFetchMocks();
   const onHide = jest.fn();
   render(
     <ThemeModal
@@ -473,7 +456,6 @@ test('discards changes when clicking Discard button in unsaved changes alert', a
 });
 
 test('creates new theme when saving', async () => {
-  setupFetchMocks();
   const onHide = jest.fn();
   const onThemeAdd = jest.fn();
   render(
@@ -499,7 +481,6 @@ test('creates new theme when saving', async () => {
 });
 
 test('updates existing theme when saving', async () => {
-  setupFetchMocks();
   const onHide = jest.fn();
   const onThemeAdd = jest.fn();
   render(
@@ -555,7 +536,6 @@ test('handles API errors gracefully', async () => {
 });
 
 test('applies theme locally when clicking Apply button', async () => {
-  setupFetchMocks();
   const onThemeApply = jest.fn();
   render(
     <ThemeModal

--- a/superset-frontend/src/features/themes/ThemeModal.test.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.test.tsx
@@ -134,7 +134,9 @@ describe('ThemeModal', () => {
   describe('Form Fields', () => {
     test('should render theme name input', () => {
       setup();
-      expect(screen.getByPlaceholderText('Enter theme name')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('Enter theme name'),
+      ).toBeInTheDocument();
     });
 
     test('should render JSON editor', () => {
@@ -180,7 +182,7 @@ describe('ThemeModal', () => {
 
       await waitFor(() => {
         const saveButton = screen.getByRole('button', { name: 'Add' });
-        expect(saveButton).not.toBeDisabled();
+        expect(saveButton).toBeEnabled();
       });
     });
 
@@ -192,13 +194,13 @@ describe('ThemeModal', () => {
 
       await waitFor(() => {
         const saveButton = screen.getByRole('button', { name: 'Add' });
-        expect(saveButton).not.toBeDisabled();
+        expect(saveButton).toBeEnabled();
       });
     });
   });
 
-  describe('Unsaved Changes Modal', () => {
-    test('should show unsaved changes modal when closing with changes', async () => {
+  describe('Unsaved Changes Alert', () => {
+    test('should show unsaved changes alert when closing with changes', async () => {
       setup();
       const nameInput = screen.getByPlaceholderText('Enter theme name');
       const cancelButton = screen.getByRole('button', { name: 'Cancel' });
@@ -208,50 +210,89 @@ describe('ThemeModal', () => {
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
-        expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
-        expect(screen.getByText("If you don't save, your changes will be lost.")).toBeInTheDocument();
+        expect(
+          screen.getByText('You have unsaved changes'),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            'Your changes will be lost if you leave without saving.',
+          ),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: 'Keep editing' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: 'Discard' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: 'Save' }),
+        ).toBeInTheDocument();
       });
     });
 
-    test('should not show unsaved changes modal when no changes made', async () => {
+    test('should not show unsaved changes alert when no changes made', async () => {
       const { mockProps } = setup();
       const cancelButton = screen.getByRole('button', { name: 'Cancel' });
 
       await userEvent.click(cancelButton);
 
       expect(mockProps.onHide).toHaveBeenCalled();
-      expect(screen.queryByText('Unsaved Changes')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('You have unsaved changes'),
+      ).not.toBeInTheDocument();
     });
 
-    test('should show unsaved changes modal when canceling with changes', async () => {
+    test('should allow keeping editing when canceling with changes', async () => {
       setup();
       const nameInput = screen.getByPlaceholderText('Enter theme name');
 
       await userEvent.type(nameInput, 'Modified Theme');
 
-      const cancelButton = await screen.findByRole('button', { name: /cancel/i });
+      const cancelButton = await screen.findByRole('button', {
+        name: /cancel/i,
+      });
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
-        expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
-        expect(screen.getByText("If you don't save, your changes will be lost.")).toBeInTheDocument();
+        expect(
+          screen.getByText('You have unsaved changes'),
+        ).toBeInTheDocument();
+      });
+
+      const keepEditingButton = screen.getByRole('button', {
+        name: 'Keep editing',
+      });
+      await userEvent.click(keepEditingButton);
+
+      // Alert should disappear but modal remains with data
+      await waitFor(() => {
+        expect(
+          screen.queryByText('You have unsaved changes'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Enter theme name')).toHaveValue(
+          'Modified Theme',
+        );
       });
     });
 
-    test('should call save handler when choosing save option', async () => {
+    test('should save changes when clicking Save in alert', async () => {
       setup();
       const nameInput = screen.getByPlaceholderText('Enter theme name');
 
       await userEvent.type(nameInput, 'Modified Theme');
 
-      const cancelButton = await screen.findByRole('button', { name: /cancel/i });
+      const cancelButton = await screen.findByRole('button', {
+        name: /cancel/i,
+      });
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
-        expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
+        expect(
+          screen.getByText('You have unsaved changes'),
+        ).toBeInTheDocument();
       });
 
-      const saveButton = await screen.findByRole('button', { name: /^save$/i });
+      const saveButton = screen.getByRole('button', { name: 'Save' });
       await userEvent.click(saveButton);
 
       await waitFor(() => {
@@ -259,20 +300,24 @@ describe('ThemeModal', () => {
       });
     });
 
-    test('should discard changes when choosing to discard', async () => {
+    test('should discard changes when choosing to confirm cancel', async () => {
       const { mockProps } = setup();
       const nameInput = screen.getByPlaceholderText('Enter theme name');
 
       await userEvent.type(nameInput, 'Modified Theme');
 
-      const cancelButton = await screen.findByRole('button', { name: /cancel/i });
+      const cancelButton = await screen.findByRole('button', {
+        name: /cancel/i,
+      });
       await userEvent.click(cancelButton);
 
       await waitFor(() => {
-        expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
+        expect(
+          screen.getByText('You have unsaved changes'),
+        ).toBeInTheDocument();
       });
 
-      const discardButton = await screen.findByRole('button', { name: /discard/i });
+      const discardButton = screen.getByRole('button', { name: 'Discard' });
       await userEvent.click(discardButton);
 
       await waitFor(() => {
@@ -292,7 +337,7 @@ describe('ThemeModal', () => {
       await userEvent.type(nameInput, 'New Theme');
 
       const saveButton = await screen.findByRole('button', { name: 'Add' });
-      expect(saveButton).not.toBeDisabled();
+      expect(saveButton).toBeEnabled();
 
       await userEvent.click(saveButton);
 
@@ -335,7 +380,7 @@ describe('ThemeModal', () => {
       await userEvent.type(nameInput, 'New Theme');
 
       const saveButton = await screen.findByRole('button', { name: 'Add' });
-      expect(saveButton).not.toBeDisabled();
+      expect(saveButton).toBeEnabled();
 
       await userEvent.click(saveButton);
 
@@ -365,7 +410,7 @@ describe('ThemeModal', () => {
       );
 
       const applyButton = screen.getByRole('button', { name: /apply/i });
-      expect(applyButton).not.toBeDisabled();
+      expect(applyButton).toBeEnabled();
 
       await userEvent.click(applyButton);
 
@@ -394,5 +439,4 @@ describe('ThemeModal', () => {
       expect(applyButton).toBeDisabled();
     });
   });
-
 });

--- a/superset-frontend/src/features/themes/ThemeModal.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.tsx
@@ -41,6 +41,7 @@ import {
   Input,
   JsonEditor,
   Modal,
+  Space,
   Tooltip,
 } from '@superset-ui/core/components';
 import { useJsonValidation } from '@superset-ui/core/components/AsyncAceEditor';
@@ -371,7 +372,7 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
               textAlign: 'left',
             }}
             action={
-              <div css={{ display: 'flex', gap: '8px' }}>
+              <Space>
                 <Button
                   key="keep-editing"
                   buttonStyle="tertiary"
@@ -397,7 +398,7 @@ const ThemeModal: FunctionComponent<ThemeModalProps> = ({
                 >
                   {t('Save')}
                 </Button>
-              </div>
+              </Space>
             }
           />
         ) : (

--- a/superset-frontend/src/hooks/useBeforeUnload/index.ts
+++ b/superset-frontend/src/hooks/useBeforeUnload/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect } from 'react';
+
+/**
+ * Custom hook to handle browser navigation/reload with unsaved changes
+ * @param shouldWarn - Boolean indicating if there are unsaved changes
+ * @param message - Optional custom message (most browsers ignore this and show their own)
+ */
+export const useBeforeUnload = (
+  shouldWarn: boolean,
+  message?: string,
+): void => {
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!shouldWarn) return;
+
+      event.preventDefault();
+      // Most browsers require returnValue to be set, even though they ignore custom messages
+      // eslint-disable-next-line no-param-reassign
+      event.returnValue = message || '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [shouldWarn, message]);
+};

--- a/superset-frontend/src/hooks/useBeforeUnload/useBeforeUnload.test.ts
+++ b/superset-frontend/src/hooks/useBeforeUnload/useBeforeUnload.test.ts
@@ -19,6 +19,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useBeforeUnload } from './index';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useBeforeUnload', () => {
   let addEventListenerSpy: jest.SpyInstance;
   let removeEventListenerSpy: jest.SpyInstance;

--- a/superset-frontend/src/hooks/useBeforeUnload/useBeforeUnload.test.ts
+++ b/superset-frontend/src/hooks/useBeforeUnload/useBeforeUnload.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useBeforeUnload } from './index';
+
+describe('useBeforeUnload', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+  let mockHandler: (e: BeforeUnloadEvent) => void;
+
+  beforeEach(() => {
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+
+    addEventListenerSpy = jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type, handler) => {
+        if (type === 'beforeunload') {
+          mockHandler = handler as (e: BeforeUnloadEvent) => void;
+        }
+      });
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should add event listener when shouldWarn is true', () => {
+    renderHook(() => useBeforeUnload(true));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    );
+  });
+
+  test('should not prevent default when shouldWarn is false', () => {
+    renderHook(() => useBeforeUnload(false));
+
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: undefined as string | undefined,
+    } as unknown as BeforeUnloadEvent;
+
+    mockHandler(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.returnValue).toBeUndefined();
+  });
+
+  test('should prevent default and set returnValue when shouldWarn is true', () => {
+    renderHook(() => useBeforeUnload(true));
+
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: undefined as string | undefined,
+    } as unknown as BeforeUnloadEvent;
+
+    mockHandler(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  test('should use custom message when provided', () => {
+    const customMessage = 'You have unsaved changes!';
+    renderHook(() => useBeforeUnload(true, customMessage));
+
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: undefined as string | undefined,
+    } as unknown as BeforeUnloadEvent;
+
+    mockHandler(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe(customMessage);
+  });
+
+  test('should remove event listener on unmount', () => {
+    const { unmount } = renderHook(() => useBeforeUnload(true));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'beforeunload',
+      expect.any(Function),
+    );
+  });
+
+  test('should update handler when shouldWarn changes', () => {
+    const { rerender } = renderHook(
+      ({ shouldWarn }) => useBeforeUnload(shouldWarn),
+      {
+        initialProps: { shouldWarn: false },
+      },
+    );
+
+    // Initially, shouldWarn is false
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: undefined as string | undefined,
+    } as unknown as BeforeUnloadEvent;
+
+    mockHandler(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+
+    // Clear previous calls
+    (event.preventDefault as jest.Mock).mockClear();
+    event.returnValue = undefined;
+
+    // Clear spy counts before rerender to test properly
+    const initialAddCalls = addEventListenerSpy.mock.calls.length;
+
+    // Update to shouldWarn = true
+    rerender({ shouldWarn: true });
+
+    // Should remove old listener and add new one
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+    // Should have added at least one more listener after rerender
+    expect(addEventListenerSpy.mock.calls.length).toBeGreaterThan(
+      initialAddCalls,
+    );
+
+    // Test with new value
+    mockHandler(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  test('should handle multiple instances independently', () => {
+    const { unmount: unmount1 } = renderHook(() => useBeforeUnload(true));
+    const { unmount: unmount2 } = renderHook(() => useBeforeUnload(false));
+
+    // Check that each hook instance registered a listener
+    const beforeunloadCalls = addEventListenerSpy.mock.calls.filter(
+      call => call[0] === 'beforeunload',
+    );
+    expect(beforeunloadCalls.length).toBeGreaterThanOrEqual(2);
+
+    unmount1();
+    // Should have at least one removal call
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+
+    const removalCount = removeEventListenerSpy.mock.calls.length;
+    unmount2();
+    // Should have more removal calls after second unmount
+    expect(removeEventListenerSpy.mock.calls.length).toBeGreaterThan(
+      removalCount,
+    );
+  });
+});

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -19,6 +19,7 @@
 import { getClientErrorObject, t } from '@superset-ui/core';
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useBeforeUnload } from 'src/hooks/useBeforeUnload';
 
 type UseUnsavedChangesPromptProps = {
   hasUnsavedChanges: boolean;
@@ -95,25 +96,13 @@ export const useUnsavedChangesPrompt = ({
   }, [blockCallback, hasUnsavedChanges, history]);
 
   useEffect(() => {
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!hasUnsavedChanges) return;
-      event.preventDefault();
-
-      // Most browsers require a "returnValue" set to empty string
-      const evt = event as any;
-      evt.returnValue = '';
-    };
-
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [hasUnsavedChanges]);
-
-  useEffect(() => {
     if (!isSaveModalVisible && manualSaveRef.current) {
       setShowModal(false);
       manualSaveRef.current = false;
     }
   }, [isSaveModalVisible]);
+
+  useBeforeUnload(hasUnsavedChanges);
 
   return {
     showModal,

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -57,7 +57,6 @@ test('should block navigation and show modal if there are unsaved changes', () =
     { wrapper },
   );
 
-  // Simulate blocked navigation
   act(() => {
     const unblock = history.block((tx: any) => tx);
     unblock();
@@ -119,7 +118,6 @@ test('should close modal when handleConfirmNavigation is called', () => {
     { wrapper },
   );
 
-  // First, trigger navigation to show the modal
   act(() => {
     const unblock = history.block((tx: any) => tx);
     unblock();
@@ -128,7 +126,6 @@ test('should close modal when handleConfirmNavigation is called', () => {
 
   expect(result.current.showModal).toBe(true);
 
-  // Then call handleConfirmNavigation to discard changes
   act(() => {
     result.current.handleConfirmNavigation();
   });

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -57,6 +57,7 @@ test('should block navigation and show modal if there are unsaved changes', () =
     { wrapper },
   );
 
+  // Simulate blocked navigation
   act(() => {
     const unblock = history.block((tx: any) => tx);
     unblock();
@@ -118,6 +119,7 @@ test('should close modal when handleConfirmNavigation is called', () => {
     { wrapper },
   );
 
+  // First, trigger navigation to show the modal
   act(() => {
     const unblock = history.block((tx: any) => tx);
     unblock();
@@ -126,6 +128,7 @@ test('should close modal when handleConfirmNavigation is called', () => {
 
   expect(result.current.showModal).toBe(true);
 
+  // Then call handleConfirmNavigation to discard changes
   act(() => {
     result.current.handleConfirmNavigation();
   });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds an `unsaved changes alert` to prevent accidental data loss when users have modifications but haven't saved them. The alert appears in the modal footer with options to save, discard, or continue editing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![after-theme-unsaved-changes](https://github.com/user-attachments/assets/580114d3-638f-4e07-8462-a53360b8e417)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Navigate to Settings > Themes
2. Click "Add Theme" or edit an existing theme
3. Make changes to the theme name or JSON configuration
4. Click Cancel or the X button to close the modal
5. Verify that the unsaved changes modal appears with three options:
   - "Keep editing" - returns to the editor
   - "Save and close" - saves changes and closes
   - "Discard changes" - closes without saving
6. Test that the modal does NOT appear when:
   - No changes have been made
   - Viewing a read-only system theme
   - After successfully saving changes

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
