### PR TITLE
fix(docker): bind webpack dev server to all interfaces

### DIFF
--- a/docker-compose-light.yml
+++ b/docker-compose-light.yml
@@ -163,7 +163,7 @@ services:
       # configuring the dev-server to use the host.docker.internal to connect to the backend
       superset: "http://superset-light:8088"
       # Webpack dev server configuration
-      WEBPACK_DEVSERVER_HOST: "${WEBPACK_DEVSERVER_HOST:-127.0.0.1}"
+      WEBPACK_DEVSERVER_HOST: "${WEBPACK_DEVSERVER_HOST:-0.0.0.0}"
       WEBPACK_DEVSERVER_PORT: "${WEBPACK_DEVSERVER_PORT:-9000}"
     ports:
       - "${NODE_PORT:-9001}:9000"  # Parameterized port, accessible on all interfaces


### PR DESCRIPTION
## Summary

Fixes an issue where the frontend development server is inaccessible from the host machine when using Docker Compose for local development.

**Problem**: When running `docker-compose -f docker-compose-light.yml up`, the frontend dev server starts successfully inside the container but cannot be accessed from the host machine at `http://localhost:9001`. This breaks the local development workflow for contributors using Docker.

**Root Cause**: The webpack dev server was configured to bind only to `127.0.0.1` (localhost within the container), while the Docker port mapping expects the service to be accessible on all network interfaces.

**Solution**: Changes the default `WEBPACK_DEVSERVER_HOST` from `127.0.0.1` to `0.0.0.0` in `docker-compose-light.yml`, allowing the dev server to accept connections from outside the container while still allowing override via environment variable.

## Before/After

**Before**: 
- `docker-compose -f docker-compose-light.yml up` starts successfully
- Frontend dev server runs inside container but is unreachable from host
- Developers cannot access `http://localhost:9001` for frontend development

**After**:
- Frontend dev server is accessible from host machine at `http://localhost:9001`
- Normal Docker-based development workflow is restored
- Environment variable override still works: `WEBPACK_DEVSERVER_HOST=127.0.0.1` forces localhost-only

## Test Plan

- [ ] Run `docker-compose -f docker-compose-light.yml up`
- [ ] Verify frontend is accessible at `http://localhost:9001`
- [ ] Confirm hot reloading works when making frontend changes
- [ ] Test that `WEBPACK_DEVSERVER_HOST=127.0.0.1 docker-compose -f docker-compose-light.yml up` still works for localhost-only access

## Impact

This change restores normal Docker-based frontend development functionality for contributors who rely on containerized development environments.

🤖 Generated with [Claude Code](https://claude.ai/code)