### PR TITLE
fix: Add DuckDB examples URI to ECS task definition for showtime environments

### DIFF
--- a/.github/workflows/ecs-task-definition.json
+++ b/.github/workflows/ecs-task-definition.json
@@ -31,6 +31,10 @@
                 {
                     "name": "TALISMAN_ENABLED",
                     "value": "False"
+                },
+                {
+                    "name": "SUPERSET__SQLALCHEMY_EXAMPLES_URI",
+                    "value": "duckdb:////app/data/examples.duckdb?access_mode=read_only"
                 }
             ],
             "mountPoints": [],


### PR DESCRIPTION
## Summary

This PR fixes example loading in showtime ephemeral environments by adding the missing `SUPERSET__SQLALCHEMY_EXAMPLES_URI` environment variable to the ECS task definition.

**Problem**: After the August 2025 Docker changes that added DuckDB examples support (#34831), showtime ephemeral environments stopped loading examples. The Docker build process correctly downloads the DuckDB examples file to `/app/data/examples.duckdb`, but the ECS task definition was missing the environment variable that tells Superset where to find this file.

**Root Cause**: The main repo's ECS task definition (used by showtime) wasn't updated when DuckDB examples support was added to the Docker build process. This created a disconnect between:
- ✅ Docker build: Downloads examples.duckdb file via `LOAD_EXAMPLES_DUCKDB=true`
- ❌ Runtime config: Missing `SUPERSET__SQLALCHEMY_EXAMPLES_URI` to locate the file

**Solution**: Added the DuckDB examples database URI to match the configuration used in docker-compose.yml files and the working showtime repo configuration.

## Before/After

**Before**: Showtime ephemeral environments failed to load examples - containers had the DuckDB file but didn't know where to find it
**After**: Showtime environments can properly access the pre-built DuckDB examples file and load dashboards/charts

## Testing Instructions

1. Create a showtime ephemeral environment by adding the `🎪 ⚡ showtime-trigger-start` label to a PR
2. Wait for environment to deploy (look for `🎪 {sha} 🚦 running` label)
3. Access the showtime URL from the `🎪 {sha} 🌐 {ip}:8080` label
4. Verify examples are loaded correctly in the UI
5. Check that dashboards and charts are available in the examples section

## Context: Showtime Ephemeral Environments

This change is specifically needed for the showtime system that creates ephemeral Apache Superset environments for PR testing. The showtime repo already has this configuration working, but the main Apache Superset repo's ECS task definition was missing this critical environment variable.

Without this fix, showtime environments appear to start successfully but fail to load any example data, making them less useful for testing and demonstration purposes.

## Additional Information

- [x] Fixes examples loading in showtime ephemeral environments
- [ ] Has associated issue: 
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No  
- [ ] Removes existing feature or API: No

🤖 Generated with [Claude Code](https://claude.ai/code)