### PR TITLE
fix(dataset): sort by database in Dataset and Saved queries Issue

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -214,59 +214,30 @@ test('handleTableChange should convert array field to dot notation for nested fi
     setSortBy,
   };
 
-  const component = render(<TableCollection {...sortingProps} />);
+  render(<TableCollection {...sortingProps} />);
 
-  // Get the Table component instance
-  const table = component.container.querySelector('.ant-table');
-  expect(table).toBeInTheDocument();
-
-  // Simulate the handleTableChange function behavior directly
-  // This tests the logic without requiring actual table interaction
-  const mockSorter = {
-    field: ['database', 'database_name'], // Array format from AntD
-    order: 'descend',
+  // Test the array-to-dot-notation conversion logic directly
+  const mockArraySorter = {
+    field: ['database', 'database_name'],
+    order: 'descend' as const,
   };
 
-  // Get the component instance to test the callback logic
-  const handleTableChange = (_pagination: any, _filters: any, sorter: any) => {
-    if (sorter && sorter.field) {
-      // This is the logic we implemented in the fix
-      const fieldId = Array.isArray(sorter.field)
-        ? sorter.field.join('.')
-        : sorter.field;
-
-      setSortBy([
-        {
-          id: fieldId,
-          desc: sorter.order === 'descend',
-        },
-      ]);
-    }
-  };
-
-  // Test the callback logic with array field
-  handleTableChange(null, null, mockSorter);
-
-  expect(setSortBy).toHaveBeenCalledWith([
-    {
-      id: 'database.database_name', // Should be converted to dot notation
-      desc: true,
-    },
-  ]);
-
-  // Test with string field (should pass through unchanged)
-  setSortBy.mockClear();
   const mockStringSorter = {
-    field: 'table_name', // String format
-    order: 'ascend',
+    field: 'table_name',
+    order: 'ascend' as const,
   };
 
-  handleTableChange(null, null, mockStringSorter);
+  // Test array field conversion
+  const fieldIdArray = Array.isArray(mockArraySorter.field)
+    ? mockArraySorter.field.join('.')
+    : mockArraySorter.field;
 
-  expect(setSortBy).toHaveBeenCalledWith([
-    {
-      id: 'table_name', // Should remain as string
-      desc: false,
-    },
-  ]);
+  expect(fieldIdArray).toBe('database.database_name');
+
+  // Test string field passthrough
+  const fieldIdString = Array.isArray(mockStringSorter.field)
+    ? mockStringSorter.field.join('.')
+    : mockStringSorter.field;
+
+  expect(fieldIdString).toBe('table_name');
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -36,19 +36,28 @@ beforeEach(() => {
       accessor: 'col2',
       id: 'col2',
     },
+    {
+      Header: 'Nested Field',
+      accessor: 'parent.child',
+      id: 'parent.child',
+      dataIndex: ['parent', 'child'],
+    },
   ];
   const data = [
     {
       col1: 'Line 01 - Col 01',
       col2: 'Line 01 - Col 02',
+      parent: { child: 'Nested Value 1' },
     },
     {
       col1: 'Line 02 - Col 01',
       col2: 'Line 02 - Col 02',
+      parent: { child: 'Nested Value 2' },
     },
     {
       col1: 'Line 03 - Col 01',
       col2: 'Line 03 - Col 02',
+      parent: { child: 'Nested Value 3' },
     },
   ];
   // @ts-ignore
@@ -216,14 +225,12 @@ test('should call setSortBy when clicking sortable column header', () => {
 
   render(<TableCollection {...sortingProps} />);
 
-  const columnHeaders = screen.getAllByRole('columnheader');
-  expect(columnHeaders.length).toBeGreaterThan(0);
+  // Target the nested field column (the column that needs the array-to-dot conversion)
+  const nestedFieldHeader = screen.getByText('Nested Field');
+  expect(nestedFieldHeader).toBeInTheDocument();
 
-  const firstColumnHeader = columnHeaders[0];
-  expect(firstColumnHeader).toBeInTheDocument();
-
-  // Click on the column header to trigger sorting
-  fireEvent.click(firstColumnHeader);
+  // Click on the nested field column header to trigger sorting
+  fireEvent.click(nestedFieldHeader);
 
   // Verify setSortBy was called immediately
   expect(setSortBy).toHaveBeenCalled();
@@ -233,8 +240,7 @@ test('should call setSortBy when clicking sortable column header', () => {
   expect(sortCallArgs[0]).toHaveProperty('id');
   expect(sortCallArgs[0]).toHaveProperty('desc');
 
-  // Verify it was called with a valid column ID (any string) and boolean desc
-  expect(typeof sortCallArgs[0].id).toBe('string');
-  expect(sortCallArgs[0].id.length).toBeGreaterThan(0);
+  // Verify the nested field array was converted to dot notation
+  expect(sortCallArgs[0].id).toBe('parent.child');
   expect(typeof sortCallArgs[0].desc).toBe('boolean');
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -232,15 +232,11 @@ test('should call setSortBy when clicking sortable column header', () => {
   // Click on the nested field column header to trigger sorting
   fireEvent.click(nestedFieldHeader);
 
-  // Verify setSortBy was called immediately
-  expect(setSortBy).toHaveBeenCalled();
-
-  const sortCallArgs = setSortBy.mock.calls[0][0];
-  expect(Array.isArray(sortCallArgs)).toBe(true);
-  expect(sortCallArgs[0]).toHaveProperty('id');
-  expect(sortCallArgs[0]).toHaveProperty('desc');
-
-  // Verify the nested field array was converted to dot notation
-  expect(sortCallArgs[0].id).toBe('parent.child');
-  expect(typeof sortCallArgs[0].desc).toBe('boolean');
+  // Verify setSortBy was called with the correct arguments and dot notation conversion
+  expect(setSortBy).toHaveBeenCalledWith([
+    {
+      id: 'parent.child',
+      desc: expect.any(Boolean),
+    },
+  ]);
 });

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -215,9 +215,14 @@ function TableCollection<T extends object>({
   const handleTableChange = useCallback(
     (_pagination: any, _filters: any, sorter: SorterResult) => {
       if (sorter && sorter.field) {
+        // Convert array field back to dot notation for nested fields
+        const fieldId = Array.isArray(sorter.field)
+          ? sorter.field.join('.')
+          : sorter.field;
+
         setSortBy?.([
           {
-            id: sorter.field,
+            id: fieldId,
             desc: sorter.order === 'descend',
           },
         ] as SortingRule<T>[]);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes database column sorting in Dataset and SavedQuery list views. After the Ant Design v5 migration, nested columns (like database.database_name) were split into arrays for dataIndex, but when sorting occurs, AntD returns the array format instead of the original dot-notation string, causing backend validation errors.

  The fix converts array fields back to dot notation in the handleTableChange callback while preserving existing string fields unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
  1. Navigate to Datasets page (/dataset/list/)
  2. Click on the "Database" column header to sort
  3. Verify sorting works without API errors
  4. Repeat for Saved Queries page (/savedqueryview/list/)
  5. Test sorting other columns to ensure no regressions
  
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
