### PR TITLE
fix(security-manager): switch from deprecated get_session to session attribute

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -623,7 +623,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             and form_data.get("slice_id") == 0
             and (chart_id := form_data.get("chart_id"))
             and (
-                slc := self.get_session.query(Slice)
+                slc := self.session.query(Slice)
                 .filter(Slice.id == chart_id)
                 .one_or_none()
             )
@@ -633,7 +633,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             and (
                 drillable_columns := {
                     row[0]
-                    for row in self.get_session.query(TableColumn.column_name)
+                    for row in self.session.query(TableColumn.column_name)
                     .filter(TableColumn.table_id == datasource.id)
                     .filter(TableColumn.groupby)
                     .all()


### PR DESCRIPTION
### SUMMARY

Updates SupersetSecurityManager to use the modern session property instead of the deprecated get_session method when querying the database.

After Flask-AppBuilder version v5.x, the method to access the security manager’s database session has changed.

**Before (v4.x):**

```python
# Old session access method
session = appbuilder.sm.get_session
```

**After (v5.x):**

```python
# New session access method
session = appbuilder.sm.session
```

Link: https://flask-appbuilder.readthedocs.io/en/latest/versionmigration.html
