### PR TITLE
fix(DateFilterControl): remove modal overlay style to fix z-index issues

### DIFF
--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -31,7 +31,6 @@ import {
   Button,
   Constants,
   Divider,
-  Modal,
   Tooltip,
   Select,
 } from '@superset-ui/core/components';
@@ -39,7 +38,6 @@ import ControlHeader from 'src/explore/components/ControlHeader';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { useDebouncedEffect } from 'src/explore/exploreUtils';
 import { noOp } from 'src/utils/common';
-import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
 import ControlPopover from '../ControlPopover/ControlPopover';
 
 import { DateFilterControlProps, FrameType } from './types';
@@ -146,7 +144,6 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
     onChange,
     onOpenPopover = noOp,
     onClosePopover = noOp,
-    overlayStyle = 'Popover',
     isOverflowingFilterBar = false,
   } = props;
   const defaultTimeFilter = useDefaultTimeFilter();
@@ -384,46 +381,10 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
     </ControlPopover>
   );
 
-  const modalContent = (
-    <>
-      <Tooltip placement="top" title={tooltipTitle}>
-        <DateLabel
-          name={name}
-          aria-labelledby={`filter-name-${props.name}`}
-          aria-describedby={`date-label-${props.name}`}
-          onClick={toggleOverlay}
-          label={actualTimeRange}
-          isActive={show}
-          isPlaceholder={actualTimeRange === NO_TIME_RANGE}
-          data-test={DateFilterTestKey.ModalOverlay}
-          ref={labelRef}
-        />
-      </Tooltip>
-      {/* the zIndex value is from trying so that the Modal doesn't overlay the AdhocFilter */}
-      <Modal
-        title={
-          <ModalTitleWithIcon
-            className="text"
-            isEditMode
-            title={t('Edit time range')}
-          />
-        }
-        name={t('Edit time range')}
-        show={show}
-        onHide={toggleOverlay}
-        width="600px"
-        hideFooter
-        zIndex={1030}
-      >
-        {overlayContent}
-      </Modal>
-    </>
-  );
-
   return (
     <>
       <ControlHeader {...props} />
-      {overlayStyle === 'Modal' ? modalContent : popoverContent}
+      {popoverContent}
     </>
   );
 }

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
@@ -58,15 +58,6 @@ test('DateFilter with default props', () => {
   ).toBeInTheDocument();
 });
 
-test('DateFilter should be applied the overlayStyle props', () => {
-  render(setup({ onChange: () => {}, overlayStyle: 'Modal' }));
-  // should be Modal as overlay
-  userEvent.click(screen.getByText(NO_TIME_RANGE));
-  expect(
-    screen.getByTestId(DateFilterTestKey.ModalOverlay),
-  ).toBeInTheDocument();
-});
-
 test('DateFilter should be applied the global config time_filter from the store', () => {
   render(
     setup(

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/types.ts
@@ -112,6 +112,5 @@ export interface DateFilterControlProps {
   value?: string;
   onOpenPopover?: () => void;
   onClosePopover?: () => void;
-  overlayStyle?: 'Modal' | 'Popover';
   isOverflowingFilterBar?: boolean;
 }

--- a/superset-frontend/src/explore/components/controls/FilterControl/utils/useDatePickerInAdhocFilter.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/utils/useDatePickerInAdhocFilter.tsx
@@ -52,7 +52,6 @@ export const useDatePickerInAdhocFilter = ({
         value={timeRange}
         name="time_range"
         onChange={onTimeRangeChange}
-        overlayStyle="Modal"
       />
     </>
   ) : undefined;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
DateFilterControl had an option to set overlayStyle to Modal which was used in adhoc filters and explore and caused z-index issues in the former. This pr removes that option entirely.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

<img width="1252" height="651" alt="image" src="https://github.com/user-attachments/assets/69de47e0-8047-4e71-ba57-075f78a1e69d" />

<img width="1707" height="1040" alt="image" src="https://github.com/user-attachments/assets/12af7241-40c0-4880-9c42-a04db6a5bf05" />

After:
<img width="1360" height="678" alt="image" src="https://github.com/user-attachments/assets/a3d4515f-ab37-4345-b47f-1b782dfdc754" />

<img width="1707" height="1040" alt="image" src="https://github.com/user-attachments/assets/6041cd18-dd55-4505-9407-5e7ba2aef3b7" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Visual testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35280
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
