### PR TITLE
test(frontend): Migrate from describe/it to flat test() pattern

### DIFF
--- a/superset-frontend/src/.eslintrc.json
+++ b/superset-frontend/src/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "overrides": [
+    {
+      "files": ["*.test.ts", "*.test.tsx", "*.test.js", "*.test.jsx"],
+      "rules": {
+        "jest/consistent-test-it": ["error", {"fn": "test"}],
+        "no-restricted-globals": ["warn", "describe", "it"]
+      }
+    }
+  ]
+}

--- a/superset-frontend/src/.eslintrc.json
+++ b/superset-frontend/src/.eslintrc.json
@@ -4,7 +4,7 @@
       "files": ["*.test.ts", "*.test.tsx", "*.test.js", "*.test.jsx"],
       "rules": {
         "jest/consistent-test-it": ["error", {"fn": "test"}],
-        "no-restricted-globals": ["warn", "describe", "it"]
+        "no-restricted-globals": ["error", "describe", "it"]
       }
     }
   ]

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -109,7 +109,7 @@ describe('async actions', () => {
       return request(dispatch, () => initialState);
     };
 
-    it('posts to the correct url', () => {
+    test('posts to the correct url', () => {
       expect.assertions(1);
 
       const store = mockStore(initialState);
@@ -118,7 +118,7 @@ describe('async actions', () => {
       });
     });
 
-    it('posts the correct query object', () => {
+    test('posts the correct query object', () => {
       const store = mockStore(initialState);
       return store.dispatch(actions.saveQuery(query, queryId)).then(() => {
         const call = fetchMock.calls(saveQueryEndpoint)[0];
@@ -131,7 +131,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls 3 dispatch actions', () => {
+    test('calls 3 dispatch actions', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -139,7 +139,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls QUERY_EDITOR_SAVED after making a request', () => {
+    test('calls QUERY_EDITOR_SAVED after making a request', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -147,7 +147,7 @@ describe('async actions', () => {
       });
     });
 
-    it('onSave calls QUERY_EDITOR_SAVED and QUERY_EDITOR_SET_TITLE', () => {
+    test('onSave calls QUERY_EDITOR_SAVED and QUERY_EDITOR_SET_TITLE', () => {
       expect.assertions(1);
 
       const store = mockStore(initialState);
@@ -186,7 +186,7 @@ describe('async actions', () => {
       return request(dispatch, store.getState);
     };
 
-    it('makes the fetch request', () => {
+    test('makes the fetch request', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -194,7 +194,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls requestQueryResults', () => {
+    test('calls requestQueryResults', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -202,7 +202,7 @@ describe('async actions', () => {
       });
     });
 
-    it.skip('parses large number result without losing precision', () =>
+    test.skip('parses large number result without losing precision', () =>
       makeRequest().then(() => {
         expect(fetchMock.calls(fetchQueryEndpoint)).toHaveLength(1);
         expect(dispatch.callCount).toBe(2);
@@ -211,7 +211,7 @@ describe('async actions', () => {
         );
       }));
 
-    it('calls querySuccess on fetch success', () => {
+    test('calls querySuccess on fetch success', () => {
       expect.assertions(1);
 
       const store = mockStore({});
@@ -226,7 +226,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls queryFailed on fetch error', () => {
+    test('calls queryFailed on fetch error', () => {
       expect.assertions(1);
 
       fetchMock.get(
@@ -254,7 +254,7 @@ describe('async actions', () => {
       return request(dispatch, () => initialState);
     };
 
-    it('makes the fetch request', () => {
+    test('makes the fetch request', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -262,7 +262,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls startQuery', () => {
+    test('calls startQuery', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -270,7 +270,7 @@ describe('async actions', () => {
       });
     });
 
-    it.skip('parses large number result without losing precision', () =>
+    test.skip('parses large number result without losing precision', () =>
       makeRequest().then(() => {
         expect(fetchMock.calls(runQueryEndpoint)).toHaveLength(1);
         expect(dispatch.callCount).toBe(2);
@@ -279,7 +279,7 @@ describe('async actions', () => {
         );
       }));
 
-    it('calls querySuccess on fetch success', () => {
+    test('calls querySuccess on fetch success', () => {
       expect.assertions(1);
 
       const store = mockStore({});
@@ -293,7 +293,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls queryFailed on fetch error and logs the error details', () => {
+    test('calls queryFailed on fetch error and logs the error details', () => {
       expect.assertions(2);
 
       fetchMock.post(
@@ -342,7 +342,7 @@ describe('async actions', () => {
       return request(dispatch, () => initialState);
     };
 
-    it('makes the fetch request', async () => {
+    test('makes the fetch request', async () => {
       const runQueryEndpointWithParams =
         'glob:*/api/v1/sqllab/execute/?foo=bar';
       fetchMock.post(
@@ -356,7 +356,7 @@ describe('async actions', () => {
   });
 
   describe('reRunQuery', () => {
-    it('creates new query with a new id', () => {
+    test('creates new query with a new id', () => {
       const id = 'id';
       const state = {
         sqlLab: {
@@ -385,7 +385,7 @@ describe('async actions', () => {
       return request(dispatch);
     };
 
-    it('makes the fetch request', () => {
+    test('makes the fetch request', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -393,7 +393,7 @@ describe('async actions', () => {
       });
     });
 
-    it('calls stopQuery', () => {
+    test('calls stopQuery', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -401,7 +401,7 @@ describe('async actions', () => {
       });
     });
 
-    it('sends the correct data', () => {
+    test('sends the correct data', () => {
       expect.assertions(1);
 
       return makeRequest().then(() => {
@@ -413,7 +413,7 @@ describe('async actions', () => {
   });
 
   describe('cloneQueryToNewTab', () => {
-    it('creates new query editor', () => {
+    test('creates new query editor', () => {
       expect.assertions(1);
 
       const id = 'id';
@@ -508,7 +508,7 @@ describe('async actions', () => {
       supersetClientGetSpy.mockRestore();
     });
 
-    it('calls API endpint with correct params', async () => {
+    test('calls API endpint with correct params', async () => {
       supersetClientGetSpy.mockResolvedValue({
         json: { result: mockSavedQueryApiResponse },
       });
@@ -520,7 +520,7 @@ describe('async actions', () => {
       });
     });
 
-    it('dispatches addQueryEditor with correct params on successful API call', async () => {
+    test('dispatches addQueryEditor with correct params on successful API call', async () => {
       supersetClientGetSpy.mockResolvedValue({
         json: { result: mockSavedQueryApiResponse },
       });
@@ -547,7 +547,7 @@ describe('async actions', () => {
       );
     });
 
-    it('should dispatch addDangerToast on API error', async () => {
+    test('should dispatch addDangerToast on API error', async () => {
       supersetClientGetSpy.mockResolvedValue(new Error());
 
       await makeRequest(1);
@@ -562,7 +562,7 @@ describe('async actions', () => {
   });
 
   describe('addQueryEditor', () => {
-    it('creates new query editor', () => {
+    test('creates new query editor', () => {
       expect.assertions(1);
 
       const store = mockStore(initialState);
@@ -583,7 +583,7 @@ describe('async actions', () => {
     });
 
     describe('addNewQueryEditor', () => {
-      it('creates new query editor with new tab name', () => {
+      test('creates new query editor with new tab name', () => {
         const store = mockStore({
           ...initialState,
           sqlLab: {
@@ -621,7 +621,7 @@ describe('async actions', () => {
     });
   });
 
-  it('set current query editor', () => {
+  test('set current query editor', () => {
     expect.assertions(1);
 
     const store = mockStore(initialState);
@@ -637,7 +637,7 @@ describe('async actions', () => {
   });
 
   describe('swithQueryEditor', () => {
-    it('switch to the next tab editor', () => {
+    test('switch to the next tab editor', () => {
       const store = mockStore(initialState);
       const expectedActions = [
         {
@@ -650,7 +650,7 @@ describe('async actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
-    it('switch to the first tab editor once it reaches the rightmost tab', () => {
+    test('switch to the first tab editor once it reaches the rightmost tab', () => {
       const store = mockStore({
         ...initialState,
         sqlLab: {
@@ -673,7 +673,7 @@ describe('async actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
-    it('switch to the previous tab editor', () => {
+    test('switch to the previous tab editor', () => {
       const store = mockStore({
         ...initialState,
         sqlLab: {
@@ -692,7 +692,7 @@ describe('async actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
-    it('switch to the last tab editor once it reaches the leftmost tab', () => {
+    test('switch to the last tab editor once it reaches the leftmost tab', () => {
       const store = mockStore({
         ...initialState,
         sqlLab: {
@@ -746,7 +746,7 @@ describe('async actions', () => {
     afterEach(() => fetchMock.resetHistory());
 
     describe('addQueryEditor', () => {
-      it('creates the tab state in the local storage', () => {
+      test('creates the tab state in the local storage', () => {
         expect.assertions(2);
 
         const store = mockStore({});
@@ -770,7 +770,7 @@ describe('async actions', () => {
     });
 
     describe('removeQueryEditor', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const store = mockStore({});
@@ -786,7 +786,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetDb', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const dbId = 42;
@@ -804,7 +804,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetCatalog', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const catalog = 'public';
@@ -822,7 +822,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetSchema', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const schema = 'schema';
@@ -840,7 +840,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetAutorun', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const autorun = true;
@@ -858,7 +858,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetTitle', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const name = 'name';
@@ -887,7 +887,7 @@ describe('async actions', () => {
         },
       ];
       describe('with backend persistence flag on', () => {
-        it('updates the tab state in the backend', () => {
+        test('updates the tab state in the backend', () => {
           expect.assertions(2);
 
           const store = mockStore({
@@ -905,7 +905,7 @@ describe('async actions', () => {
         });
       });
       describe('with backend persistence flag off', () => {
-        it('does not update the tab state in the backend', () => {
+        test('does not update the tab state in the backend', () => {
           isFeatureEnabled.mockImplementation(
             feature => !(feature === 'SQLLAB_BACKEND_PERSISTENCE'),
           );
@@ -928,7 +928,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetQueryLimit', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const queryLimit = 10;
@@ -948,7 +948,7 @@ describe('async actions', () => {
     });
 
     describe('queryEditorSetTemplateParams', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(1);
 
         const templateParams = '{"foo": "bar"}';
@@ -969,7 +969,7 @@ describe('async actions', () => {
     });
 
     describe('addTable', () => {
-      it('dispatches table state from unsaved change', () => {
+      test('dispatches table state from unsaved change', () => {
         const tableName = 'table';
         const catalogName = null;
         const schemaName = 'schema';
@@ -1003,7 +1003,7 @@ describe('async actions', () => {
         );
       });
 
-      it('uses tabViewId when available', () => {
+      test('uses tabViewId when available', () => {
         const tableName = 'table';
         const catalogName = null;
         const schemaName = 'schema';
@@ -1043,7 +1043,7 @@ describe('async actions', () => {
         );
       });
 
-      it('falls back to id when tabViewId is not available', () => {
+      test('falls back to id when tabViewId is not available', () => {
         const tableName = 'table';
         const catalogName = null;
         const schemaName = 'schema';
@@ -1084,7 +1084,7 @@ describe('async actions', () => {
     });
 
     describe('syncTable', () => {
-      it('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend', () => {
         expect.assertions(4);
 
         const tableName = 'table';
@@ -1137,7 +1137,7 @@ describe('async actions', () => {
         fetchMock.resetHistory();
       });
 
-      it('updates and runs data preview query when configured', () => {
+      test('updates and runs data preview query when configured', () => {
         expect.assertions(3);
 
         const expectedActionTypes = [
@@ -1161,7 +1161,7 @@ describe('async actions', () => {
         });
       });
 
-      it('runs data preview query only', () => {
+      test('runs data preview query only', () => {
         const expectedActionTypes = [
           actions.START_QUERY, // runQuery (data preview)
           actions.QUERY_SUCCESS, // querySuccess
@@ -1187,7 +1187,7 @@ describe('async actions', () => {
     });
 
     describe('expandTable', () => {
-      it('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend', () => {
         expect.assertions(2);
 
         const table = { id: 1 };
@@ -1206,7 +1206,7 @@ describe('async actions', () => {
     });
 
     describe('collapseTable', () => {
-      it('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend', () => {
         expect.assertions(2);
 
         const table = { id: 1 };
@@ -1225,7 +1225,7 @@ describe('async actions', () => {
     });
 
     describe('removeTables', () => {
-      it('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend', () => {
         expect.assertions(2);
 
         const table = { id: 1, initialized: true };
@@ -1242,7 +1242,7 @@ describe('async actions', () => {
         });
       });
 
-      it('deletes multiple tables and updates the table schema state in the backend', () => {
+      test('deletes multiple tables and updates the table schema state in the backend', () => {
         expect.assertions(2);
 
         const tables = [
@@ -1262,7 +1262,7 @@ describe('async actions', () => {
         });
       });
 
-      it('only updates the initialized table schema state in the backend', () => {
+      test('only updates the initialized table schema state in the backend', () => {
         expect.assertions(2);
 
         const tables = [{ id: 1 }, { id: 2, initialized: true }];
@@ -1281,7 +1281,7 @@ describe('async actions', () => {
     });
 
     describe('syncQueryEditor', () => {
-      it('updates the tab state in the backend', () => {
+      test('updates the tab state in the backend', () => {
         expect.assertions(3);
 
         const results = {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -49,6 +49,7 @@ jest.mock('@superset-ui/core', () => ({
   isFeatureEnabled: jest.fn(),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getUpToDateQuery', () => {
   test('should return the up to date query editor state', () => {
     const outOfUpdatedQueryEditor = {
@@ -72,6 +73,7 @@ describe('getUpToDateQuery', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('async actions', () => {
   const mockBigNumber = '9223372036854775807';
   const queryEditor = {
@@ -100,6 +102,7 @@ describe('async actions', () => {
   const runQueryEndpoint = 'glob:*/api/v1/sqllab/execute/';
   fetchMock.post(runQueryEndpoint, `{ "data": ${mockBigNumber} }`);
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('saveQuery', () => {
     const saveQueryEndpoint = 'glob:*/api/v1/saved_query/';
     fetchMock.post(saveQueryEndpoint, { results: { json: {} } });
@@ -163,6 +166,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('formatQuery', () => {
     const formatQueryEndpoint = 'glob:*/api/v1/sqllab/format_sql/';
     const expectedSql = 'SELECT 1';
@@ -179,6 +183,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('fetchQueryResults', () => {
     const makeRequest = () => {
       const store = mockStore(initialState);
@@ -248,6 +253,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('runQuery without query params', () => {
     const makeRequest = () => {
       const request = actions.runQuery(query);
@@ -324,6 +330,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('runQuery with query params', () => {
     const { location } = window;
 
@@ -355,6 +362,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('reRunQuery', () => {
     test('creates new query with a new id', () => {
       const id = 'id';
@@ -372,6 +380,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('postStopQuery', () => {
     const stopQueryEndpoint = 'glob:*/api/v1/query/stop';
     fetchMock.post(stopQueryEndpoint, {});
@@ -412,6 +421,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('cloneQueryToNewTab', () => {
     test('creates new query editor', () => {
       expect.assertions(1);
@@ -455,6 +465,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('popSavedQuery', () => {
     const supersetClientGetSpy = jest.spyOn(SupersetClient, 'get');
     const store = mockStore({});
@@ -561,6 +572,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('addQueryEditor', () => {
     test('creates new query editor', () => {
       expect.assertions(1);
@@ -582,6 +594,7 @@ describe('async actions', () => {
       expect(store.getActions()).toEqual(expectedActions);
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('addNewQueryEditor', () => {
       test('creates new query editor with new tab name', () => {
         const store = mockStore({
@@ -636,6 +649,7 @@ describe('async actions', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('swithQueryEditor', () => {
     test('switch to the next tab editor', () => {
       const store = mockStore(initialState);
@@ -715,6 +729,7 @@ describe('async actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('backend sync', () => {
     const updateTabStateEndpoint = 'glob:*/tabstateview/*';
     fetchMock.put(updateTabStateEndpoint, {});
@@ -745,6 +760,7 @@ describe('async actions', () => {
 
     afterEach(() => fetchMock.resetHistory());
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('addQueryEditor', () => {
       test('creates the tab state in the local storage', () => {
         expect.assertions(2);
@@ -769,6 +785,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('removeQueryEditor', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -785,6 +802,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetDb', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -803,6 +821,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetCatalog', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -821,6 +840,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetSchema', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -839,6 +859,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetAutorun', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -857,6 +878,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetTitle', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -877,6 +899,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetAndSaveSql', () => {
       const sql = 'SELECT * ';
       const expectedActions = [
@@ -886,6 +909,7 @@ describe('async actions', () => {
           sql,
         },
       ];
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('with backend persistence flag on', () => {
         test('updates the tab state in the backend', () => {
           expect.assertions(2);
@@ -904,6 +928,7 @@ describe('async actions', () => {
           });
         });
       });
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('with backend persistence flag off', () => {
         test('does not update the tab state in the backend', () => {
           isFeatureEnabled.mockImplementation(
@@ -927,6 +952,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetQueryLimit', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -947,6 +973,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('queryEditorSetTemplateParams', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(1);
@@ -968,6 +995,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('addTable', () => {
       test('dispatches table state from unsaved change', () => {
         const tableName = 'table';
@@ -1083,6 +1111,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('syncTable', () => {
       test('updates the table schema state in the backend', () => {
         expect.assertions(4);
@@ -1107,6 +1136,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('runTablePreviewQuery', () => {
       const results = {
         data: mockBigNumber,
@@ -1186,6 +1216,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('expandTable', () => {
       test('updates the table schema state in the backend', () => {
         expect.assertions(2);
@@ -1205,6 +1236,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('collapseTable', () => {
       test('updates the table schema state in the backend', () => {
         expect.assertions(2);
@@ -1224,6 +1256,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('removeTables', () => {
       test('updates the table schema state in the backend', () => {
         expect.assertions(2);
@@ -1280,6 +1313,7 @@ describe('async actions', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('syncQueryEditor', () => {
       test('updates the tab state in the backend', () => {
         expect.assertions(3);

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -68,6 +68,7 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AceEditorWrapper', () => {
   beforeEach(() => {
     (FullSQLEditor as any as jest.Mock).mockClear();

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -73,7 +73,7 @@ describe('AceEditorWrapper', () => {
     (FullSQLEditor as any as jest.Mock).mockClear();
   });
 
-  it('renders ace editor including sql value', async () => {
+  test('renders ace editor including sql value', async () => {
     const store = createStore(initialState, reducerIndex);
     const { getByTestId } = setup(defaultQueryEditor, store);
     await waitFor(() => expect(getByTestId('react-ace')).toBeInTheDocument());
@@ -83,7 +83,7 @@ describe('AceEditorWrapper', () => {
     );
   });
 
-  it('renders current sql for unrelated unsaved changes', () => {
+  test('renders current sql for unrelated unsaved changes', () => {
     const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
     const store = createStore(
       {
@@ -108,7 +108,7 @@ describe('AceEditorWrapper', () => {
     );
   });
 
-  it('skips rerendering for updating cursor position', () => {
+  test('skips rerendering for updating cursor position', () => {
     const store = createStore(initialState, reducerIndex);
     setup(defaultQueryEditor, store);
 

--- a/superset-frontend/src/SqlLab/components/App/App.test.tsx
+++ b/superset-frontend/src/SqlLab/components/App/App.test.tsx
@@ -60,23 +60,23 @@ describe('SqlLab App', () => {
     jest.useRealTimers();
   });
 
-  it('is valid', () => {
+  test('is valid', () => {
     expect(isValidElement(<App />)).toBe(true);
   });
 
-  it('should render', () => {
+  test('should render', () => {
     const { getByTestId } = render(<App />, { useRedux: true, store });
     expect(getByTestId('SqlLabApp')).toBeInTheDocument();
     expect(getByTestId('mock-tabbed-sql-editors')).toBeInTheDocument();
   });
 
-  it('reset hotkey events on unmount', () => {
+  test('reset hotkey events on unmount', () => {
     const { unmount } = render(<App />, { useRedux: true, store });
     unmount();
     expect(Mousetrap.reset).toHaveBeenCalled();
   });
 
-  it('logs current usage warning', () => {
+  test('logs current usage warning', () => {
     const localStorageUsageInKilobytes = LOCALSTORAGE_MAX_USAGE_KB + 10;
     const initialState = {
       localStorageUsageInKilobytes,
@@ -100,7 +100,7 @@ describe('SqlLab App', () => {
     );
   });
 
-  it('logs current local storage usage', async () => {
+  test('logs current local storage usage', async () => {
     const localStorageUsageInKilobytes = LOCALSTORAGE_MAX_USAGE_KB - 10;
     const storeExceedLocalStorage = mockStore(
       sqlLabReducer(

--- a/superset-frontend/src/SqlLab/components/App/App.test.tsx
+++ b/superset-frontend/src/SqlLab/components/App/App.test.tsx
@@ -47,6 +47,7 @@ const sqlLabReducer = combineReducers({
 });
 const mockAction = {} as AnyAction;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SqlLab App', () => {
   const middlewares = [thunk];
   const mockStore = configureStore(middlewares);

--- a/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
@@ -26,17 +26,17 @@ describe('ColumnElement', () => {
     actions: mockedActions,
     column: table.columns[0],
   };
-  it('is valid with props', () => {
+  test('is valid with props', () => {
     expect(isValidElement(<ColumnElement {...mockedProps} />)).toBe(true);
   });
-  it('renders a proper primary key', () => {
+  test('renders a proper primary key', () => {
     const { container } = render(<ColumnElement column={table.columns[0]} />);
     expect(container.querySelector('i.fa-key')).toBeInTheDocument();
     expect(
       container.querySelector('[data-test="col-name"]')?.firstChild,
     ).toHaveTextContent('id');
   });
-  it('renders a multi-key column', () => {
+  test('renders a multi-key column', () => {
     const { container } = render(<ColumnElement column={table.columns[1]} />);
     expect(container.querySelector('i.fa-link')).toBeInTheDocument();
     expect(container.querySelector('i.fa-bookmark')).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe('ColumnElement', () => {
       container.querySelector('[data-test="col-name"]')?.firstChild,
     ).toHaveTextContent('first_name');
   });
-  it('renders a column with no keys', () => {
+  test('renders a column with no keys', () => {
     const { container } = render(<ColumnElement column={table.columns[2]} />);
     expect(container.querySelector('i')).not.toBeInTheDocument();
     expect(

--- a/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
@@ -21,6 +21,7 @@ import { render } from 'spec/helpers/testing-library';
 import ColumnElement from 'src/SqlLab/components/ColumnElement';
 import { mockedActions, table } from 'src/SqlLab/fixtures';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColumnElement', () => {
   const mockedProps = {
     actions: mockedActions,

--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
@@ -54,13 +54,13 @@ const setup = (props: Partial<EstimateQueryCostButtonProps>, store?: Store) =>
   );
 
 describe('EstimateQueryCostButton', () => {
-  it('renders EstimateQueryCostButton', async () => {
+  test('renders EstimateQueryCostButton', async () => {
     const { queryByText } = setup({}, mockStore(initialState));
 
     expect(queryByText('Estimate cost')).toBeInTheDocument();
   });
 
-  it('renders label for selected query', async () => {
+  test('renders label for selected query', async () => {
     const { queryByText } = setup(
       { queryEditorId: extraQueryEditor1.id },
       mockStore(initialState),
@@ -69,7 +69,7 @@ describe('EstimateQueryCostButton', () => {
     expect(queryByText('Estimate selected query cost')).toBeInTheDocument();
   });
 
-  it('renders label for selected query from unsaved', async () => {
+  test('renders label for selected query from unsaved', async () => {
     const { queryByText } = setup(
       {},
       mockStore({
@@ -87,7 +87,7 @@ describe('EstimateQueryCostButton', () => {
     expect(queryByText('Estimate selected query cost')).toBeInTheDocument();
   });
 
-  it('renders estimation error result', async () => {
+  test('renders estimation error result', async () => {
     const { queryByText, getByText } = setup(
       {},
       mockStore({
@@ -109,7 +109,7 @@ describe('EstimateQueryCostButton', () => {
     expect(queryByText('Estimate error')).toBeInTheDocument();
   });
 
-  it('renders estimation success result', async () => {
+  test('renders estimation success result', async () => {
     const { queryByText, getByText } = setup(
       {},
       mockStore({

--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
@@ -53,6 +53,7 @@ const setup = (props: Partial<EstimateQueryCostButtonProps>, store?: Store) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('EstimateQueryCostButton', () => {
   test('renders EstimateQueryCostButton', async () => {
     const { queryByText } = setup({}, mockStore(initialState));

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -47,6 +47,7 @@ const setup = (props: Partial<ExploreCtasResultsButtonProps>, store?: Store) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ExploreCtasResultsButton', () => {
   const postFormSpy = jest.spyOn(SupersetClientClass.prototype, 'postForm');
   postFormSpy.mockImplementation(jest.fn());

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -51,13 +51,13 @@ describe('ExploreCtasResultsButton', () => {
   const postFormSpy = jest.spyOn(SupersetClientClass.prototype, 'postForm');
   postFormSpy.mockImplementation(jest.fn());
 
-  it('renders', async () => {
+  test('renders', async () => {
     const { queryByText } = setup({}, mockStore(initialState));
 
     expect(queryByText('Explore')).toBeInTheDocument();
   });
 
-  it('visualize results', async () => {
+  test('visualize results', async () => {
     const { getByText } = setup({}, mockStore(initialState));
 
     postFormSpy.mockClear();
@@ -75,7 +75,7 @@ describe('ExploreCtasResultsButton', () => {
     });
   });
 
-  it('visualize results fails', async () => {
+  test('visualize results fails', async () => {
     const { getByText } = setup({}, mockStore(initialState));
 
     postFormSpy.mockClear();

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
@@ -31,6 +31,7 @@ const setup = (
     useRedux: true,
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ExploreResultsButton', () => {
   test('renders', async () => {
     const { queryByText } = setup(jest.fn(), {

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
@@ -32,7 +32,7 @@ const setup = (
   });
 
 describe('ExploreResultsButton', () => {
-  it('renders', async () => {
+  test('renders', async () => {
     const { queryByText } = setup(jest.fn(), {
       database: { allows_subquery: true },
     });
@@ -41,7 +41,7 @@ describe('ExploreResultsButton', () => {
     expect(screen.getByRole('button', { name: /Create chart/i })).toBeEnabled();
   });
 
-  it('renders disabled if subquery not allowed', async () => {
+  test('renders disabled if subquery not allowed', async () => {
     const { queryByText } = setup(jest.fn());
     expect(queryByText('Create chart')).toBeInTheDocument();
     // Updated line to match the actual button name that includes the icon

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
@@ -43,6 +43,7 @@ const mockState = {
   databases: mockDatabases,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('QueryAutoRefresh', () => {
   const runningQueries: QueryDictionary = { [runningQuery.id]: runningQuery };
   const successfulQueries: QueryDictionary = {

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
@@ -62,15 +62,15 @@ describe('QueryAutoRefresh', () => {
     jest.useRealTimers();
   });
 
-  it('isQueryRunning returns true for valid running query', () => {
+  test('isQueryRunning returns true for valid running query', () => {
     expect(isQueryRunning(runningQuery)).toBe(true);
   });
 
-  it('isQueryRunning returns false for valid not-running query', () => {
+  test('isQueryRunning returns false for valid not-running query', () => {
     expect(isQueryRunning(successfulQuery)).toBe(false);
   });
 
-  it('isQueryRunning returns false for invalid query', () => {
+  test('isQueryRunning returns false for invalid query', () => {
     // @ts-ignore
     expect(isQueryRunning(null)).toBe(false);
     // @ts-ignore
@@ -81,15 +81,15 @@ describe('QueryAutoRefresh', () => {
     expect(isQueryRunning({ state: { badFormat: true } })).toBe(false);
   });
 
-  it('shouldCheckForQueries is true for valid running query', () => {
+  test('shouldCheckForQueries is true for valid running query', () => {
     expect(shouldCheckForQueries(runningQueries)).toBe(true);
   });
 
-  it('shouldCheckForQueries is false for valid completed query', () => {
+  test('shouldCheckForQueries is false for valid completed query', () => {
     expect(shouldCheckForQueries(successfulQueries)).toBe(false);
   });
 
-  it('shouldCheckForQueries is false for invalid inputs', () => {
+  test('shouldCheckForQueries is false for invalid inputs', () => {
     // @ts-ignore
     expect(shouldCheckForQueries(null)).toBe(false);
     // @ts-ignore
@@ -109,7 +109,7 @@ describe('QueryAutoRefresh', () => {
     ).toBe(false);
   });
 
-  it('Attempts to refresh when given pending query', async () => {
+  test('Attempts to refresh when given pending query', async () => {
     const store = mockStore({ sqlLab: { ...mockState } });
 
     fetchMock.get(refreshApi, {
@@ -135,7 +135,7 @@ describe('QueryAutoRefresh', () => {
     );
   });
 
-  it('Attempts to clear inactive queries when updated queries are empty', async () => {
+  test('Attempts to clear inactive queries when updated queries are empty', async () => {
     const store = mockStore({ sqlLab: { ...mockState } });
 
     fetchMock.get(refreshApi, { result: [] });
@@ -164,7 +164,7 @@ describe('QueryAutoRefresh', () => {
     expect(fetchMock.calls(refreshApi)).toHaveLength(1);
   });
 
-  it('Does not fail and attempts to refresh with mixed valid/invalid queries', async () => {
+  test('Does not fail and attempts to refresh with mixed valid/invalid queries', async () => {
     const store = mockStore({ sqlLab: { ...mockState } });
 
     fetchMock.get(refreshApi, {
@@ -191,7 +191,7 @@ describe('QueryAutoRefresh', () => {
     );
   });
 
-  it('Does NOT Attempt to refresh when given only completed queries', async () => {
+  test('Does NOT Attempt to refresh when given only completed queries', async () => {
     const store = mockStore({ sqlLab: { ...mockState } });
 
     fetchMock.get(refreshApi, {
@@ -219,7 +219,7 @@ describe('QueryAutoRefresh', () => {
     expect(fetchMock.calls(refreshApi)).toHaveLength(0);
   });
 
-  it('logs the failed error for async queries', async () => {
+  test('logs the failed error for async queries', async () => {
     const store = mockStore({ sqlLab: { ...mockState } });
 
     fetchMock.get(refreshApi, {

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
@@ -59,7 +59,7 @@ const setup = (props?: Partial<QueryLimitSelectProps>, store?: Store) =>
   );
 
 describe('QueryLimitSelect', () => {
-  it('renders current query limit size', () => {
+  test('renders current query limit size', () => {
     const queryLimit = 10;
     const { getByText } = setup(
       {
@@ -81,12 +81,12 @@ describe('QueryLimitSelect', () => {
     expect(getByText(queryLimit)).toBeInTheDocument();
   });
 
-  it('renders default query limit for initial queryEditor', () => {
+  test('renders default query limit for initial queryEditor', () => {
     const { getByText } = setup({}, mockStore(initialState));
     expect(getByText(defaultQueryLimit)).toBeInTheDocument();
   });
 
-  it('renders queryLimit from unsavedQueryEditor', () => {
+  test('renders queryLimit from unsavedQueryEditor', () => {
     const queryLimit = 10000;
     const { getByText } = setup(
       {},
@@ -104,7 +104,7 @@ describe('QueryLimitSelect', () => {
     expect(getByText(convertToNumWithSpaces(queryLimit))).toBeInTheDocument();
   });
 
-  it('renders dropdown select', async () => {
+  test('renders dropdown select', async () => {
     const { baseElement, getAllByRole, getByRole } = setup(
       { maxRow: 50000 },
       mockStore(initialState),
@@ -126,7 +126,7 @@ describe('QueryLimitSelect', () => {
     expect(actualLabels).toEqual(expectedLabels);
   });
 
-  it('renders dropdown select correctly when maxRow is less than 10', async () => {
+  test('renders dropdown select correctly when maxRow is less than 10', async () => {
     const { baseElement, getAllByRole, getByRole } = setup(
       { maxRow: 5 },
       mockStore(initialState),
@@ -146,7 +146,7 @@ describe('QueryLimitSelect', () => {
     expect(actualLabels).toEqual(expectedLabels);
   });
 
-  it('renders dropdown select correctly when maxRow is a multiple of 10', async () => {
+  test('renders dropdown select correctly when maxRow is a multiple of 10', async () => {
     const { baseElement, getAllByRole, getByRole } = setup(
       { maxRow: 10000 },
       mockStore(initialState),
@@ -168,7 +168,7 @@ describe('QueryLimitSelect', () => {
     expect(actualLabels).toEqual(expectedLabels);
   });
 
-  it('dispatches QUERY_EDITOR_SET_QUERY_LIMIT action on dropdown menu click', async () => {
+  test('dispatches QUERY_EDITOR_SET_QUERY_LIMIT action on dropdown menu click', async () => {
     const store = mockStore(initialState);
     const expectedIndex = 1;
     const { baseElement, getAllByRole, getByRole } = setup({}, store);

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
@@ -58,6 +58,7 @@ const setup = (props?: Partial<QueryLimitSelectProps>, store?: Store) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('QueryLimitSelect', () => {
   test('renders current query limit size', () => {
     const queryLimit = 10;

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
@@ -29,6 +29,7 @@ const mockedProps = {
   latestQueryId: 'ryhMUZCGb',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('QueryTable', () => {
   test('is valid', () => {
     expect(isValidElement(<QueryTable displayLimit={100} />)).toBe(true);

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -150,6 +150,7 @@ const setup = (props?: any, store?: Store) =>
     ...(store && { store }),
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ResultSet', () => {
   beforeAll(() => {
     setupAGGridModules();

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/RunQueryActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/RunQueryActionButton.test.tsx
@@ -53,17 +53,17 @@ const setup = (props?: Partial<RunQueryActionButtonProps>, store?: Store) =>
     ...(store && { store }),
   });
 
-it('renders a single Button', () => {
+test('renders a single Button', () => {
   const { getByRole } = setup({}, mockStore(initialState));
   expect(getByRole('button')).toBeInTheDocument();
 });
 
-it('renders a label for Run Query', () => {
+test('renders a label for Run Query', () => {
   const { getByText } = setup({}, mockStore(initialState));
   expect(getByText('Run')).toBeInTheDocument();
 });
 
-it('renders a label for Selected Query', () => {
+test('renders a label for Selected Query', () => {
   const { getByText } = setup(
     {},
     mockStore({
@@ -80,7 +80,7 @@ it('renders a label for Selected Query', () => {
   expect(getByText('Run selection')).toBeInTheDocument();
 });
 
-it('disable button when sql from unsaved changes is empty', () => {
+test('disable button when sql from unsaved changes is empty', () => {
   const { getByRole } = setup(
     {},
     mockStore({
@@ -98,7 +98,7 @@ it('disable button when sql from unsaved changes is empty', () => {
   expect(button).toBeDisabled();
 });
 
-it('disable button when selectedText only contains blank contents', () => {
+test('disable button when selectedText only contains blank contents', () => {
   const { getByRole } = setup(
     {},
     mockStore({
@@ -116,7 +116,7 @@ it('disable button when selectedText only contains blank contents', () => {
   expect(button).toBeDisabled();
 });
 
-it('enable default button for unrelated unsaved changes', () => {
+test('enable default button for unrelated unsaved changes', () => {
   const { getByRole } = setup(
     {},
     mockStore({
@@ -134,7 +134,7 @@ it('enable default button for unrelated unsaved changes', () => {
   expect(button).toBeEnabled();
 });
 
-it('dispatch runQuery on click', async () => {
+test('dispatch runQuery on click', async () => {
   const runQuery = jest.fn();
   const { getByRole } = setup({ runQuery }, mockStore(initialState));
   const button = getByRole('button');
@@ -143,7 +143,7 @@ it('dispatch runQuery on click', async () => {
   await waitFor(() => expect(runQuery).toHaveBeenCalledTimes(1));
 });
 
-it('dispatch stopQuery on click while running state', async () => {
+test('dispatch stopQuery on click while running state', async () => {
   const stopQuery = jest.fn();
   const { getByRole } = setup(
     { queryState: 'running', stopQuery },

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -24,6 +24,7 @@ const overlayMenu = (
   <Menu items={[{ label: 'Save dataset', key: 'save-dataset' }]} />
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SaveDatasetActionButton', () => {
   test('renders a split save button', async () => {
     render(

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -62,6 +62,7 @@ jest.mock('src/explore/exploreUtils/formData', () => ({
   postFormData: jest.fn(),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SaveDatasetModal', () => {
   test('renders a "Save as new" field', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -63,7 +63,7 @@ jest.mock('src/explore/exploreUtils/formData', () => ({
 }));
 
 describe('SaveDatasetModal', () => {
-  it('renders a "Save as new" field', () => {
+  test('renders a "Save as new" field', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const saveRadioBtn = screen.getByRole('radio', {
@@ -80,7 +80,7 @@ describe('SaveDatasetModal', () => {
     expect(inputFieldText).toBeInTheDocument();
   });
 
-  it('renders an "Overwrite existing" field', () => {
+  test('renders an "Overwrite existing" field', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     const overwriteRadioBtn = screen.getByRole('radio', {
@@ -96,20 +96,20 @@ describe('SaveDatasetModal', () => {
     expect(placeholderText).toBeInTheDocument();
   });
 
-  it('renders a close button', () => {
+  test('renders a close button', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
   });
 
-  it('renders a save button when "Save as new" is selected', () => {
+  test('renders a save button when "Save as new" is selected', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // "Save as new" is selected when the modal opens by default
     expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
   });
 
-  it('renders an overwrite button when "Overwrite existing" is selected', () => {
+  test('renders an overwrite button when "Overwrite existing" is selected', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
     // Click the overwrite radio button to reveal the overwrite confirmation and back buttons
@@ -123,7 +123,7 @@ describe('SaveDatasetModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the overwrite button as disabled until an existing dataset is selected', async () => {
+  test('renders the overwrite button as disabled until an existing dataset is selected', async () => {
     useSelectorMock.mockReturnValue({ ...user });
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
@@ -155,7 +155,7 @@ describe('SaveDatasetModal', () => {
     expect(overwriteConfirmationBtn).toBeEnabled();
   });
 
-  it('renders a confirm overwrite screen when overwrite is clicked', async () => {
+  test('renders a confirm overwrite screen when overwrite is clicked', async () => {
     useSelectorMock.mockReturnValue({ ...user });
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
 
@@ -196,7 +196,7 @@ describe('SaveDatasetModal', () => {
     ).toBeInTheDocument();
   });
 
-  it('sends the schema when creating the dataset', async () => {
+  test('sends the schema when creating the dataset', async () => {
     const dummyDispatch = jest.fn().mockResolvedValue({});
     useDispatchMock.mockReturnValue(dummyDispatch);
     useSelectorMock.mockReturnValue({ ...user });
@@ -221,7 +221,7 @@ describe('SaveDatasetModal', () => {
     });
   });
 
-  it('sends the catalog when creating the dataset', async () => {
+  test('sends the catalog when creating the dataset', async () => {
     const dummyDispatch = jest.fn().mockResolvedValue({});
     useDispatchMock.mockReturnValue(dummyDispatch);
     useSelectorMock.mockReturnValue({ ...user });
@@ -252,12 +252,12 @@ describe('SaveDatasetModal', () => {
     });
   });
 
-  it('does not renders a checkbox button when template processing is disabled', () => {
+  test('does not renders a checkbox button when template processing is disabled', () => {
     render(<SaveDatasetModal {...mockedProps} />, { useRedux: true });
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 
-  it('renders a checkbox button when template processing is enabled', () => {
+  test('renders a checkbox button when template processing is enabled', () => {
     // @ts-ignore
     global.featureFlags = {
       [FeatureFlag.EnableTemplateProcessing]: true,
@@ -266,7 +266,7 @@ describe('SaveDatasetModal', () => {
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
   });
 
-  it('correctly includes template parameters when template processing is enabled', () => {
+  test('correctly includes template parameters when template processing is enabled', () => {
     // @ts-ignore
     global.featureFlags = {
       [FeatureFlag.EnableTemplateProcessing]: true,
@@ -301,7 +301,7 @@ describe('SaveDatasetModal', () => {
     });
   });
 
-  it('correctly excludes template parameters when template processing is enabled', () => {
+  test('correctly excludes template parameters when template processing is enabled', () => {
     // @ts-ignore
     global.featureFlags = {
       [FeatureFlag.EnableTemplateProcessing]: true,

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -65,7 +65,7 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
 describe('SavedQuery', () => {
-  it('doesnt render save button when allows_virtual_table_explore is undefined', async () => {
+  test('doesnt render save button when allows_virtual_table_explore is undefined', async () => {
     const noRenderProps = {
       ...mockedProps,
       database: {
@@ -84,7 +84,7 @@ describe('SavedQuery', () => {
     );
   });
 
-  it('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
+  test('renders a non-split save button when allows_virtual_table_explore is not enabled', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -95,7 +95,7 @@ describe('SavedQuery', () => {
     expect(saveBtn).toBeVisible();
   });
 
-  it('renders a save query modal when user clicks save button', () => {
+  test('renders a save query modal when user clicks save button', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -111,7 +111,7 @@ describe('SavedQuery', () => {
     expect(saveQueryModalHeader).toBeInTheDocument();
   });
 
-  it('renders the save query modal UI', () => {
+  test('renders the save query modal UI', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -146,7 +146,7 @@ describe('SavedQuery', () => {
     expect(cancelBtn).toBeInTheDocument();
   });
 
-  it('renders a "save as new" and "update" button if query already exists', () => {
+  test('renders a "save as new" and "update" button if query already exists', () => {
     render(<SaveQuery {...mockedProps} />, {
       useRedux: true,
       store: mockStore({
@@ -171,7 +171,7 @@ describe('SavedQuery', () => {
     expect(updateBtn).toBeInTheDocument();
   });
 
-  it('renders a split save button when allows_virtual_table_explore is enabled', async () => {
+  test('renders a split save button when allows_virtual_table_explore is enabled', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -186,7 +186,7 @@ describe('SavedQuery', () => {
     });
   });
 
-  it('renders a save dataset modal when user clicks "save dataset" menu item', async () => {
+  test('renders a save dataset modal when user clicks "save dataset" menu item', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -205,7 +205,7 @@ describe('SavedQuery', () => {
     expect(saveDatasetHeader).toBeInTheDocument();
   });
 
-  it('renders the save dataset modal UI', async () => {
+  test('renders the save dataset modal UI', async () => {
     render(<SaveQuery {...splitSaveBtnProps} />, {
       useRedux: true,
       store: mockStore(mockState),
@@ -246,7 +246,7 @@ describe('SavedQuery', () => {
     expect(overwritePlaceholderText).toBeInTheDocument();
   });
 
-  it('modal stays open while save is in progress and closes after completion', async () => {
+  test('modal stays open while save is in progress and closes after completion', async () => {
     let resolveSave: () => void;
     const savePromise = new Promise<void>(resolve => {
       resolveSave = resolve;
@@ -290,7 +290,7 @@ describe('SavedQuery', () => {
     expect(mockOnSave).toHaveBeenCalledTimes(1);
   });
 
-  it('handles save with a new tab that has no changes', async () => {
+  test('handles save with a new tab that has no changes', async () => {
     const mockOnSave = jest.fn().mockResolvedValue(undefined);
 
     // Mock state for a new tab with default SQL

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -64,6 +64,7 @@ const splitSaveBtnProps = {
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SavedQuery', () => {
   test('doesnt render save button when allows_virtual_table_explore is undefined', async () => {
     const noRenderProps = {

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -76,6 +76,7 @@ const unsavedQueryEditor = {
   templateParams: '{ "my_value": "foo" }',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ShareSqlLabQuery', () => {
   const storeQueryUrl = 'glob:*/api/v1/sqllab/permalink';
   const storeQueryMockId = 'ci39c3';
@@ -94,6 +95,7 @@ describe('ShareSqlLabQuery', () => {
 
   afterAll(() => fetchMock.reset());
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('via permalink api', () => {
     beforeAll(() => {
       mockedIsFeatureEnabled.mockImplementation(() => true);

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -103,7 +103,7 @@ describe('ShareSqlLabQuery', () => {
       mockedIsFeatureEnabled.mockReset();
     });
 
-    it('calls storeQuery() with the query when getCopyUrl() is called', async () => {
+    test('calls storeQuery() with the query when getCopyUrl() is called', async () => {
       await act(async () => {
         render(<ShareSqlLabQuery {...defaultProps} />, {
           useRedux: true,
@@ -121,7 +121,7 @@ describe('ShareSqlLabQuery', () => {
       ).toEqual(expected);
     });
 
-    it('calls storeQuery() with unsaved changes', async () => {
+    test('calls storeQuery() with unsaved changes', async () => {
       await act(async () => {
         render(<ShareSqlLabQuery {...defaultProps} />, {
           useRedux: true,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -149,6 +149,7 @@ const createStore = (initState: object) =>
       getDefaultMiddleware().concat(api.middleware, logAction),
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SqlEditor', () => {
   beforeAll(() => {
     jest.setTimeout(30000);
@@ -360,6 +361,7 @@ describe('SqlEditor', () => {
     ).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('with EstimateQueryCost enabled', () => {
     beforeEach(() => {
       mockIsFeatureEnabled.mockImplementation(
@@ -436,6 +438,7 @@ describe('SqlEditor', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('with SqllabBackendPersistence enabled', () => {
     beforeEach(() => {
       mockIsFeatureEnabled.mockImplementation(

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -192,7 +192,7 @@ describe('SqlEditor', () => {
     });
   });
 
-  it('does not render SqlEditor if no db selected', async () => {
+  test('does not render SqlEditor if no db selected', async () => {
     const queryEditor = initialState.sqlLab.queryEditors[2];
     const { findByText } = setup({ ...mockedProps, queryEditor }, store);
     expect(
@@ -200,7 +200,7 @@ describe('SqlEditor', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders db unavailable message', async () => {
+  test('renders db unavailable message', async () => {
     const queryEditor = initialState.sqlLab.queryEditors[1];
     const { findByText } = setup({ ...mockedProps, queryEditor }, store);
     expect(
@@ -210,7 +210,7 @@ describe('SqlEditor', () => {
     ).toBeInTheDocument();
   });
 
-  it('render a SqlEditorLeftBar', async () => {
+  test('render a SqlEditorLeftBar', async () => {
     const { getByTestId, unmount } = setup(mockedProps, store);
 
     await waitFor(
@@ -222,7 +222,7 @@ describe('SqlEditor', () => {
   }, 15000);
 
   // Update other similar tests with timeouts
-  it('render an AceEditorWrapper', async () => {
+  test('render an AceEditorWrapper', async () => {
     const { findByTestId, unmount } = setup(mockedProps, store);
 
     await waitFor(
@@ -233,7 +233,7 @@ describe('SqlEditor', () => {
     unmount();
   }, 15000);
 
-  it('skip rendering an AceEditorWrapper when the current tab is inactive', async () => {
+  test('skip rendering an AceEditorWrapper when the current tab is inactive', async () => {
     const { findByTestId, queryByTestId } = setup(
       {
         ...mockedProps,
@@ -245,7 +245,7 @@ describe('SqlEditor', () => {
     expect(queryByTestId('react-ace')).not.toBeInTheDocument();
   });
 
-  it('avoids rerendering EditorLeftBar and ResultSet while typing', async () => {
+  test('avoids rerendering EditorLeftBar and ResultSet while typing', async () => {
     const { findByTestId } = setup(mockedProps, store);
     const editor = await findByTestId('react-ace');
     const sql = 'select *';
@@ -260,7 +260,7 @@ describe('SqlEditor', () => {
     expect(ResultSet).toHaveBeenCalledTimes(renderCountForSouthPane);
   });
 
-  it('renders sql from unsaved change', async () => {
+  test('renders sql from unsaved change', async () => {
     const expectedSql = 'SELECT updated_column\nFROM updated_table\nWHERE';
     store = createStore({
       ...initialState,
@@ -293,12 +293,12 @@ describe('SqlEditor', () => {
     expect(editor).toHaveValue(expectedSql);
   });
 
-  it('render a SouthPane', async () => {
+  test('render a SouthPane', async () => {
     const { findByTestId } = setup(mockedProps, store);
     expect(await findByTestId('mock-result-set')).toBeInTheDocument();
   });
 
-  it('runs query action with ctas false', async () => {
+  test('runs query action with ctas false', async () => {
     store = createStore({
       ...initialState,
       sqlLab: {
@@ -338,7 +338,7 @@ describe('SqlEditor', () => {
     );
   });
 
-  it('render a Limit Dropdown', async () => {
+  test('render a Limit Dropdown', async () => {
     const defaultQueryLimit = 101;
     const updatedProps = { ...mockedProps, defaultQueryLimit };
     const { findByText } = setup(updatedProps, store);
@@ -346,7 +346,7 @@ describe('SqlEditor', () => {
     expect(await findByText('10 000')).toBeInTheDocument();
   });
 
-  it('renders an Extension if provided', async () => {
+  test('renders an Extension if provided', async () => {
     const extensionsRegistry = getExtensionsRegistry();
 
     extensionsRegistry.set('sqleditor.extension.form', () => (
@@ -370,7 +370,7 @@ describe('SqlEditor', () => {
       mockIsFeatureEnabled.mockClear();
     });
 
-    it('sends the catalog and schema to the endpoint', async () => {
+    test('sends the catalog and schema to the endpoint', async () => {
       const estimateApi = 'http://localhost/api/v1/sqllab/estimate/';
       fetchMock.post(estimateApi, {});
 
@@ -446,7 +446,7 @@ describe('SqlEditor', () => {
       mockIsFeatureEnabled.mockClear();
     });
 
-    it('should render loading state when its Editor is not loaded', async () => {
+    test('should render loading state when its Editor is not loaded', async () => {
       const switchTabApi = `glob:*/tabstateview/${defaultQueryEditor.id}/activate`;
       fetchMock.post(switchTabApi, {});
       const { getByTestId } = setup(

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -56,6 +56,7 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
     ...(store && { store }),
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SqlEditorTabHeader', () => {
   test('renders name', () => {
     const { queryByText } = setup(defaultQueryEditor, mockStore(initialState));
@@ -106,6 +107,7 @@ describe('SqlEditorTabHeader', () => {
     expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('with dropdown menus', () => {
     let store = mockStore();
     beforeEach(async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -57,14 +57,14 @@ const setup = (queryEditor: QueryEditor, store?: Store) =>
   });
 
 describe('SqlEditorTabHeader', () => {
-  it('renders name', () => {
+  test('renders name', () => {
     const { queryByText } = setup(defaultQueryEditor, mockStore(initialState));
     expect(queryByText(defaultQueryEditor.name)).toBeInTheDocument();
     expect(queryByText(extraQueryEditor1.name)).not.toBeInTheDocument();
     expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
   });
 
-  it('renders name from unsaved changes', () => {
+  test('renders name from unsaved changes', () => {
     const expectedTitle = 'updated title';
     const { queryByText } = setup(
       defaultQueryEditor,
@@ -85,7 +85,7 @@ describe('SqlEditorTabHeader', () => {
     expect(queryByText(extraQueryEditor2.name)).not.toBeInTheDocument();
   });
 
-  it('renders current name for unrelated unsaved changes', () => {
+  test('renders current name for unrelated unsaved changes', () => {
     const unrelatedTitle = 'updated title';
     const { queryByText } = setup(
       defaultQueryEditor,
@@ -116,7 +116,7 @@ describe('SqlEditorTabHeader', () => {
       userEvent.click(dropdown);
     });
 
-    it('should dispatch removeQueryEditor action', async () => {
+    test('should dispatch removeQueryEditor action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
       );
@@ -132,7 +132,7 @@ describe('SqlEditorTabHeader', () => {
       );
     });
 
-    it('should dispatch queryEditorSetTitle action', async () => {
+    test('should dispatch queryEditorSetTitle action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
       );
@@ -155,7 +155,7 @@ describe('SqlEditorTabHeader', () => {
       mockPrompt.mockClear();
     });
 
-    it('should dispatch toggleLeftBar action', async () => {
+    test('should dispatch toggleLeftBar action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
       );
@@ -173,7 +173,7 @@ describe('SqlEditorTabHeader', () => {
       );
     });
 
-    it('should dispatch removeAllOtherQueryEditors action', async () => {
+    test('should dispatch removeAllOtherQueryEditors action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
       );
@@ -194,7 +194,7 @@ describe('SqlEditorTabHeader', () => {
       );
     });
 
-    it('should dispatch cloneQueryToNewTab action', async () => {
+    test('should dispatch cloneQueryToNewTab action', async () => {
       await waitFor(() =>
         expect(screen.getByTestId('close-tab-menu-option')).toBeInTheDocument(),
       );

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.tsx
@@ -56,6 +56,7 @@ afterEach(() => {
   pathStub.mockReset();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('componentDidMount', () => {
   let uriStub = jest.spyOn(URI.prototype, 'search');
   let replaceState = jest.spyOn(window.history, 'replaceState');

--- a/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
@@ -135,6 +135,7 @@ test('renders preview', async () => {
   );
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('table actions', () => {
   test('refreshes table metadata when triggered', async () => {
     const { getByRole, getByText } = render(<TablePreview {...mockedProps} />, {

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -64,6 +64,7 @@ const setup = (
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TemplateParamsEditor', () => {
   test('should render with a title', () => {
     const { container } = setup();

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -65,12 +65,12 @@ const setup = (
   );
 
 describe('TemplateParamsEditor', () => {
-  it('should render with a title', () => {
+  test('should render with a title', () => {
     const { container } = setup();
     expect(container.querySelector('div[role="button"]')).toBeInTheDocument();
   });
 
-  it('should open a modal with the ace editor', async () => {
+  test('should open a modal with the ace editor', async () => {
     const { container, getByTestId } = setup();
     fireEvent.click(getByText(container, 'Parameters'));
     await waitFor(() => {
@@ -78,7 +78,7 @@ describe('TemplateParamsEditor', () => {
     });
   });
 
-  it('renders templateParams', async () => {
+  test('renders templateParams', async () => {
     const { container, getByTestId } = setup();
     fireEvent.click(getByText(container, 'Parameters'));
     await waitFor(() => {
@@ -89,7 +89,7 @@ describe('TemplateParamsEditor', () => {
     );
   });
 
-  it('renders code from unsaved changes', async () => {
+  test('renders code from unsaved changes', async () => {
     const expectedCode = 'custom code value';
     const { container, getByTestId } = setup(
       {},

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -52,6 +52,7 @@ const apiDataWithTabState = {
     latest_query: null,
   },
 };
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getInitialState', () => {
   afterEach(() => {
     localStorage.clear();
@@ -67,6 +68,7 @@ describe('getInitialState', () => {
     ).toBeUndefined();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('dedupeTabHistory', () => {
     test('should dedupe the tab history', () => {
       [
@@ -136,6 +138,7 @@ describe('getInitialState', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('dedupe tables schema', () => {
     test('should dedupe the table schema', () => {
       localStorage.setItem(
@@ -249,6 +252,7 @@ describe('getInitialState', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('restore unsaved changes for PERSISTENCE mode', () => {
     const lastUpdatedTime = Date.now();
     const expectedValue = 'updated editor value';

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -57,10 +57,10 @@ describe('getInitialState', () => {
     localStorage.clear();
   });
 
-  it('should output the user that is passed in', () => {
+  test('should output the user that is passed in', () => {
     expect(getInitialState(apiData).user?.userId).toEqual(1);
   });
-  it('should return undefined instead of null for templateParams', () => {
+  test('should return undefined instead of null for templateParams', () => {
     expect(
       getInitialState(apiDataWithTabState).sqlLab?.queryEditors?.[0]
         ?.templateParams,
@@ -68,7 +68,7 @@ describe('getInitialState', () => {
   });
 
   describe('dedupeTabHistory', () => {
-    it('should dedupe the tab history', () => {
+    test('should dedupe the tab history', () => {
       [
         { value: [], expected: [] },
         {
@@ -137,7 +137,7 @@ describe('getInitialState', () => {
   });
 
   describe('dedupe tables schema', () => {
-    it('should dedupe the table schema', () => {
+    test('should dedupe the table schema', () => {
       localStorage.setItem(
         'redux',
         JSON.stringify({
@@ -195,7 +195,7 @@ describe('getInitialState', () => {
       expect(initializedTables.map(({ id }) => id)).toEqual([1, 2, 6]);
     });
 
-    it('should parse the float dttm value', () => {
+    test('should parse the float dttm value', () => {
       const startDttmInStr = '1693433503447.166992';
       const endDttmInStr = '1693433503500.23132';
 
@@ -284,7 +284,7 @@ describe('getInitialState', () => {
       );
     });
 
-    it('restore unsaved changes for PERSISTENCE mode', () => {
+    test('restore unsaved changes for PERSISTENCE mode', () => {
       const apiDataWithLocalStorage = {
         ...apiData,
         active_tab: {
@@ -321,7 +321,7 @@ describe('getInitialState', () => {
       ).toEqual(apiDataWithTabState.active_tab.id.toString());
     });
 
-    it('skip unsaved changes for expired data', () => {
+    test('skip unsaved changes for expired data', () => {
       const apiDataWithLocalStorage = {
         ...apiData,
         active_tab: {
@@ -345,7 +345,7 @@ describe('getInitialState', () => {
       );
     });
 
-    it('skip unsaved changes for legacy cache data', () => {
+    test('skip unsaved changes for legacy cache data', () => {
       const apiDataWithLocalStorage = {
         ...apiData,
         active_tab: {

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -38,12 +38,12 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, action);
       qe = newState.queryEditors.find(e => e.id === 'abcd');
     });
-    it('should add a query editor', () => {
+    test('should add a query editor', () => {
       expect(newState.queryEditors).toHaveLength(
         initialState.queryEditors.length + 1,
       );
     });
-    it('should merge the current unsaved changes when adding a query editor', () => {
+    test('should merge the current unsaved changes when adding a query editor', () => {
       const expectedTitle = 'new updated title';
       const updateAction = {
         type: actions.QUERY_EDITOR_SET_TITLE,
@@ -62,7 +62,7 @@ describe('sqlLabReducer', () => {
         newState.queryEditors[newState.queryEditors.length - 1].id,
       ).toEqual('efgh');
     });
-    it('should remove a query editor', () => {
+    test('should remove a query editor', () => {
       expect(newState.queryEditors).toHaveLength(
         initialState.queryEditors.length + 1,
       );
@@ -75,7 +75,7 @@ describe('sqlLabReducer', () => {
         initialState.queryEditors.length,
       );
     });
-    it('should select the latest query editor when tabHistory is empty', () => {
+    test('should select the latest query editor when tabHistory is empty', () => {
       const currentQE = newState.queryEditors[0];
       newState = {
         ...initialState,
@@ -94,7 +94,7 @@ describe('sqlLabReducer', () => {
       );
       expect(newState.tabHistory).toEqual([initialState.queryEditors[2].id]);
     });
-    it('should remove a query editor including unsaved changes', () => {
+    test('should remove a query editor including unsaved changes', () => {
       expect(newState.queryEditors).toHaveLength(
         initialState.queryEditors.length + 1,
       );
@@ -116,7 +116,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.dbId).toBeUndefined();
       expect(newState.unsavedQueryEditor.id).toBeUndefined();
     });
-    it('should set q query editor active', () => {
+    test('should set q query editor active', () => {
       const expectedTitle = 'new updated title';
       const addQueryEditorAction = {
         type: actions.ADD_QUERY_EDITOR,
@@ -139,7 +139,7 @@ describe('sqlLabReducer', () => {
       );
       expect(newState.queryEditors[1].name).toEqual(expectedTitle);
     });
-    it('should not fail while setting DB', () => {
+    test('should not fail while setting DB', () => {
       const dbId = 9;
       const action = {
         type: actions.QUERY_EDITOR_SETDB,
@@ -150,7 +150,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.dbId).toBe(dbId);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not fail while setting schema', () => {
+    test('should not fail while setting schema', () => {
       const schema = 'foo';
       const action = {
         type: actions.QUERY_EDITOR_SET_SCHEMA,
@@ -161,7 +161,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.schema).toBe(schema);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not fail while setting autorun', () => {
+    test('should not fail while setting autorun', () => {
       const action = {
         type: actions.QUERY_EDITOR_SET_AUTORUN,
         queryEditor: qe,
@@ -173,7 +173,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.autorun).toBe(true);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not fail while setting title', () => {
+    test('should not fail while setting title', () => {
       const title = 'Untitled Query 1';
       const action = {
         type: actions.QUERY_EDITOR_SET_TITLE,
@@ -184,7 +184,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.name).toBe(title);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not fail while setting Sql', () => {
+    test('should not fail while setting Sql', () => {
       const sql = 'SELECT nothing from dev_null';
       const action = {
         type: actions.QUERY_EDITOR_SET_SQL,
@@ -195,7 +195,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.sql).toBe(sql);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not fail while setting queryLimit', () => {
+    test('should not fail while setting queryLimit', () => {
       const queryLimit = 101;
       const action = {
         type: actions.QUERY_EDITOR_SET_QUERY_LIMIT,
@@ -206,7 +206,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.queryLimit).toBe(queryLimit);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should set selectedText', () => {
+    test('should set selectedText', () => {
       const selectedText = 'TEST';
       const action = {
         type: actions.QUERY_EDITOR_SET_SELECTED_TEXT,
@@ -218,7 +218,7 @@ describe('sqlLabReducer', () => {
       expect(newState.unsavedQueryEditor.selectedText).toBe(selectedText);
       expect(newState.unsavedQueryEditor.id).toBe(qe.id);
     });
-    it('should not wiped out unsaved changes while delayed async call intercepted', () => {
+    test('should not wiped out unsaved changes while delayed async call intercepted', () => {
       const expectedSql = 'Updated SQL WORKING IN PROGRESS--';
       const action = {
         type: actions.QUERY_EDITOR_SET_SQL,
@@ -239,7 +239,7 @@ describe('sqlLabReducer', () => {
         interceptedAction.northPercent,
       );
     });
-    it('should migrate query editor by new query editor id', () => {
+    test('should migrate query editor by new query editor id', () => {
       const { length } = newState.queryEditors;
       const index = newState.queryEditors.findIndex(({ id }) => id === qe.id);
       const newQueryEditor = {
@@ -267,7 +267,7 @@ describe('sqlLabReducer', () => {
         newQueryEditor.tabViewId,
       );
     });
-    it('should clear the destroyed query editors', () => {
+    test('should clear the destroyed query editors', () => {
       const expectedQEId = '1233289';
       const action = {
         type: actions.CLEAR_DESTROYED_QUERY_EDITOR,
@@ -297,12 +297,12 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(initialState, action);
       newTable = newState.tables[0];
     });
-    it('should add a table', () => {
+    test('should add a table', () => {
       // Testing that beforeEach actually added the table
       expect(newState.tables).toHaveLength(1);
       expect(newState.tables[0].expanded).toBe(true);
     });
-    it('should merge the table attributes', () => {
+    test('should merge the table attributes', () => {
       // Merging the extra attribute
       newTable.extra = true;
       const action = {
@@ -313,7 +313,7 @@ describe('sqlLabReducer', () => {
       expect(newState.tables).toHaveLength(1);
       expect(newState.tables[0].extra).toBe(true);
     });
-    it('should overwrite table ID be ignored when the existing table is already initialized', () => {
+    test('should overwrite table ID be ignored when the existing table is already initialized', () => {
       const action = {
         type: actions.MERGE_TABLE,
         table: newTable,
@@ -345,7 +345,7 @@ describe('sqlLabReducer', () => {
       expect(newState.tables).toHaveLength(1);
       expect(newState.tables[0].id).toBe(remoteId);
     });
-    it('should expand and collapse a table', () => {
+    test('should expand and collapse a table', () => {
       const collapseTableAction = {
         type: actions.COLLAPSE_TABLE,
         table: newTable,
@@ -359,7 +359,7 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, expandTableAction);
       expect(newState.tables[0].expanded).toBe(true);
     });
-    it('should remove a table', () => {
+    test('should remove a table', () => {
       const action = {
         type: actions.REMOVE_TABLES,
         tables: [newTable],
@@ -385,7 +385,7 @@ describe('sqlLabReducer', () => {
         sqlEditorId: 'dfsadfs',
       };
     });
-    it('should start a query', () => {
+    test('should start a query', () => {
       const action = {
         type: actions.START_QUERY,
         query: {
@@ -401,7 +401,7 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, action);
       expect(Object.keys(newState.queries)).toHaveLength(1);
     });
-    it('should stop the query', () => {
+    test('should stop the query', () => {
       const startQueryAction = {
         type: actions.START_QUERY,
         query,
@@ -415,7 +415,7 @@ describe('sqlLabReducer', () => {
       const q = newState.queries[Object.keys(newState.queries)[0]];
       expect(q.state).toBe('stopped');
     });
-    it('should remove a query', () => {
+    test('should remove a query', () => {
       const startQueryAction = {
         type: actions.START_QUERY,
         query,
@@ -428,7 +428,7 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, removeQueryAction);
       expect(Object.keys(newState.queries)).toHaveLength(0);
     });
-    it('should refresh queries when polling returns new results', () => {
+    test('should refresh queries when polling returns new results', () => {
       const startDttmInStr = '1693433503447.166992';
       const endDttmInStr = '1693433503500.23132';
       newState = sqlLabReducer(
@@ -449,7 +449,7 @@ describe('sqlLabReducer', () => {
       expect(newState.queries.abcd.endDttm).toBe(Number(endDttmInStr));
       expect(newState.queriesLastUpdate).toBe(CHANGED_ON_TIMESTAMP);
     });
-    it('should skip refreshing queries when polling contains existing results', () => {
+    test('should skip refreshing queries when polling contains existing results', () => {
       const completedQuery = {
         ...query,
         extra: {
@@ -478,7 +478,7 @@ describe('sqlLabReducer', () => {
       expect(newState.queries.abcd).toBe(query);
       expect(newState.queries.def).toBe(completedQuery);
     });
-    it('should refresh queries when polling returns empty', () => {
+    test('should refresh queries when polling returns empty', () => {
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
     });
   });
@@ -496,7 +496,7 @@ describe('sqlLabReducer', () => {
         cached: false,
       };
     });
-    it('updates queries that have already been completed', () => {
+    test('updates queries that have already been completed', () => {
       newState = sqlLabReducer(
         {
           ...newState,

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -23,7 +23,9 @@ import { table, initialState as mockState } from '../fixtures';
 
 const initialState = mockState.sqlLab;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('sqlLabReducer', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Query editors actions', () => {
     let newState;
     let defaultQueryEditor;
@@ -285,6 +287,7 @@ describe('sqlLabReducer', () => {
       expect(newState.destroyedQueryEditors).toEqual({});
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Tables', () => {
     let newState;
     let newTable;
@@ -368,6 +371,7 @@ describe('sqlLabReducer', () => {
       expect(newState.tables).toHaveLength(0);
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Run Query', () => {
     const DENORMALIZED_CHANGED_ON = '2023-06-26T07:53:05.439';
     const CHANGED_ON_TIMESTAMP = 1687765985439;
@@ -482,6 +486,7 @@ describe('sqlLabReducer', () => {
       newState = sqlLabReducer(newState, actions.refreshQueries({}));
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('CLEAR_INACTIVE_QUERIES', () => {
     let newState;
     let query;

--- a/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
+++ b/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
@@ -37,7 +37,7 @@ describe('reduxStateToLocalStorageHelper', () => {
     });
   });
 
-  it('should empty query.results if query.startDttm is > LOCALSTORAGE_MAX_QUERY_AGE_MS', () => {
+  test('should empty query.results if query.startDttm is > LOCALSTORAGE_MAX_QUERY_AGE_MS', () => {
     // make sure sample data contains old query
     const oldQuery = queries[0];
     const { id, startDttm } = oldQuery;
@@ -51,7 +51,7 @@ describe('reduxStateToLocalStorageHelper', () => {
     expect(emptiedQuery[id].results).toEqual({});
   });
 
-  it('should empty query.results if query,.results size is greater than LOCALSTORAGE_MAX_QUERY_RESULTS_KB', () => {
+  test('should empty query.results if query,.results size is greater than LOCALSTORAGE_MAX_QUERY_RESULTS_KB', () => {
     const reasonableSizeQuery = {
       ...queries[0],
       startDttm: Date.now(),
@@ -83,7 +83,7 @@ describe('reduxStateToLocalStorageHelper', () => {
     );
   });
 
-  it('should only return selected keys for query editor', () => {
+  test('should only return selected keys for query editor', () => {
     const queryEditors = [{ ...defaultQueryEditor, dummy: 'value' }];
     expect(Object.keys(queryEditors[0])).toContain('dummy');
 

--- a/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
+++ b/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
@@ -29,6 +29,7 @@ import {
 } from 'src/SqlLab/constants';
 import { queries, defaultQueryEditor } from '../fixtures';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('reduxStateToLocalStorageHelper', () => {
   const queriesObj: Record<string, any> = {};
   beforeEach(() => {

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -30,12 +30,12 @@ const emptyEditor = {
 };
 
 describe('newQueryTabName', () => {
-  it("should return default title if queryEditor's length is 0", () => {
+  test("should return default title if queryEditor's length is 0", () => {
     const defaultTitle = 'default title';
     const title = newQueryTabName([], defaultTitle);
     expect(title).toEqual(defaultTitle);
   });
-  it('should return next available number if there are unsaved editors', () => {
+  test('should return next available number if there are unsaved editors', () => {
     const untitledQueryText = 'Untitled Query';
     const unsavedEditors = [
       { ...emptyEditor, name: `${untitledQueryText} 1` },

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -29,6 +29,7 @@ const emptyEditor = {
   remoteId: null,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('newQueryTabName', () => {
   test("should return default title if queryEditor's length is 0", () => {
     const defaultTitle = 'default title';

--- a/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
@@ -21,32 +21,32 @@ import { alterForComparison, formatValueHandler, getRowsFromDiffs } from '.';
 import { RowType } from '../types';
 
 describe('alterForComparison', () => {
-  it('returns null for undefined value', () => {
+  test('returns null for undefined value', () => {
     expect(alterForComparison(undefined)).toBeNull();
   });
 
-  it('returns null for null value', () => {
+  test('returns null for null value', () => {
     expect(alterForComparison(null)).toBeNull();
   });
 
-  it('returns null for empty string value', () => {
+  test('returns null for empty string value', () => {
     expect(alterForComparison('')).toBeNull();
   });
 
-  it('returns null for empty array value', () => {
+  test('returns null for empty array value', () => {
     expect(alterForComparison([])).toBeNull();
   });
 
-  it('returns null for empty object value', () => {
+  test('returns null for empty object value', () => {
     expect(alterForComparison({})).toBeNull();
   });
 
-  it('returns value for non-empty array', () => {
+  test('returns value for non-empty array', () => {
     const value = [1, 2, 3];
     expect(alterForComparison(value)).toEqual(value);
   });
 
-  it('returns value for non-empty object', () => {
+  test('returns value for non-empty object', () => {
     const value = { key: 'value' };
     expect(alterForComparison(value)).toEqual(value);
   });
@@ -61,7 +61,7 @@ describe('formatValueHandler', () => {
     other_control: { type: 'OtherControl', label: 'Other' },
   };
 
-  it('handles undefined value', () => {
+  test('handles undefined value', () => {
     const value = undefined;
     const key = 'b';
 
@@ -74,7 +74,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue).toBe('N/A');
   });
 
-  it('handles null value', () => {
+  test('handles null value', () => {
     const value = null;
     const key = 'b';
 
@@ -87,7 +87,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue).toBe('null');
   });
 
-  it('returns "[]" for empty filters', () => {
+  test('returns "[]" for empty filters', () => {
     const value: unknown[] = [];
     const key = 'adhoc_filters';
 
@@ -100,7 +100,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue).toBe('[]');
   });
 
-  it('formats filters with array values', () => {
+  test('formats filters with array values', () => {
     const filters = [
       {
         clause: 'WHERE',
@@ -129,7 +129,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue).toBe(expected);
   });
 
-  it('formats filters with string values', () => {
+  test('formats filters with string values', () => {
     const filters = [
       {
         clause: 'WHERE',
@@ -158,7 +158,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue).toBe(expected);
   });
 
-  it('formats "Min" and "Max" for BoundsControl', () => {
+  test('formats "Min" and "Max" for BoundsControl', () => {
     const value: number[] = [1, 2];
     const key = 'b';
 
@@ -167,7 +167,7 @@ describe('formatValueHandler', () => {
     expect(result).toEqual('Min: 1, Max: 2');
   });
 
-  it('formats stringified objects for CollectionControl', () => {
+  test('formats stringified objects for CollectionControl', () => {
     const value = [{ a: 1 }, { b: 2 }];
     const key = 'column_collection';
 
@@ -178,7 +178,7 @@ describe('formatValueHandler', () => {
     );
   });
 
-  it('formats MetricsControl values correctly', () => {
+  test('formats MetricsControl values correctly', () => {
     const value = [{ label: 'SUM(Sales)' }, { label: 'Metric2' }];
     const key = 'metrics';
 
@@ -187,7 +187,7 @@ describe('formatValueHandler', () => {
     expect(result).toEqual('SUM(Sales), Metric2');
   });
 
-  it('formats boolean values as string', () => {
+  test('formats boolean values as string', () => {
     const value1 = true;
     const value2 = false;
     const key = 'b';
@@ -207,7 +207,7 @@ describe('formatValueHandler', () => {
     expect(formattedValue2).toBe('false');
   });
 
-  it('formats array values correctly', () => {
+  test('formats array values correctly', () => {
     const value = [
       { label: 'Label1' },
       { label: 'Label2' },
@@ -229,7 +229,7 @@ describe('formatValueHandler', () => {
     expect(result).toEqual(expected);
   });
 
-  it('formats string values correctly', () => {
+  test('formats string values correctly', () => {
     const value = 'test';
     const key = 'other_control';
 
@@ -238,7 +238,7 @@ describe('formatValueHandler', () => {
     expect(result).toEqual('test');
   });
 
-  it('formats number values correctly', () => {
+  test('formats number values correctly', () => {
     const value = 123;
     const key = 'other_control';
 
@@ -247,7 +247,7 @@ describe('formatValueHandler', () => {
     expect(result).toEqual(123);
   });
 
-  it('formats object values correctly', () => {
+  test('formats object values correctly', () => {
     const value = { 1: 2, alpha: 'bravo' };
     const key = 'other_control';
     const expected = '{"1":2,"alpha":"bravo"}';
@@ -259,7 +259,7 @@ describe('formatValueHandler', () => {
 });
 
 describe('getRowsFromDiffs', () => {
-  it('returns formatted rows for diffs', () => {
+  test('returns formatted rows for diffs', () => {
     const diffs = {
       metric: { before: [{ label: 'old' }], after: [{ label: 'new' }] },
       limit: { before: 10, after: 20 },
@@ -278,7 +278,7 @@ describe('getRowsFromDiffs', () => {
     ]);
   });
 
-  it('falls back to key if label is missing', () => {
+  test('falls back to key if label is missing', () => {
     const diffs = {
       unknown: { before: 'a', after: 'b' },
     };

--- a/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
@@ -20,6 +20,7 @@
 import { alterForComparison, formatValueHandler, getRowsFromDiffs } from '.';
 import { RowType } from '../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('alterForComparison', () => {
   test('returns null for undefined value', () => {
     expect(alterForComparison(undefined)).toBeNull();
@@ -52,6 +53,7 @@ describe('alterForComparison', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('formatValueHandler', () => {
   const controlsMap = {
     b: { type: 'BoundsControl', label: 'Bounds' },
@@ -258,6 +260,7 @@ describe('formatValueHandler', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getRowsFromDiffs', () => {
   test('returns formatted rows for diffs', () => {
     const diffs = {

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -42,6 +42,7 @@ const ERROR_MESSAGE_COMPONENT = (props: ErrorMessageComponentProps) => (
   </>
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartErrorMessage', () => {
   const defaultProps = {
     chartId: 1,

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -49,7 +49,7 @@ describe('ChartErrorMessage', () => {
     source: 'test_source' as ChartSource,
   };
 
-  it('renders the default error message when error is null', () => {
+  test('renders the default error message when error is null', () => {
     mockUseChartOwnerNames.mockReturnValue({
       result: null,
       status: ResourceStatus.Loading,
@@ -61,7 +61,7 @@ describe('ChartErrorMessage', () => {
     expect(screen.getByText('Test subtitle')).toBeInTheDocument();
   });
 
-  it('renders the error message that is passed in from the error', () => {
+  test('renders the error message that is passed in from the error', () => {
     getErrorMessageComponentRegistry().registerValue(
       'VALID_KEY',
       ERROR_MESSAGE_COMPONENT,

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -281,6 +281,7 @@ test('should render "Edit chart" enabled with can_explore permission', async () 
   expect(screen.getByRole('button', { name: 'Edit chart' })).toBeEnabled();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Embedded mode behavior', () => {
   // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
   const { isEmbedded } = require('src/dashboard/util/isEmbedded');
@@ -357,6 +358,7 @@ describe('Embedded mode behavior', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Table view with pagination', () => {
   beforeEach(() => {
     // Mock a large dataset response for pagination testing

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -126,7 +126,7 @@ describe('chart actions', () => {
       fakeMetadata = { viz_type: 'my_viz', useLegacyApi: false };
     });
 
-    it('should query with the built query', async () => {
+    test('should query with the built query', async () => {
       const actionThunk = actions.postChartFormData({}, null);
       await actionThunk(dispatch, mockGetState);
 
@@ -141,7 +141,7 @@ describe('chart actions', () => {
       expect(dispatch.args[0][0].type).toBe(actions.CHART_UPDATE_STARTED);
     });
 
-    it('should handle the bigint without regression', async () => {
+    test('should handle the bigint without regression', async () => {
       getChartDataUriStub.restore();
       const mockBigIntUrl = '/mock/chart/data/bigint';
       const expectedBigNumber = '9223372036854775807';
@@ -160,7 +160,7 @@ describe('chart actions', () => {
       expect(json.value.toString()).toEqual(expectedBigNumber);
     });
 
-    it('handleChartDataResponse should return result if GlobalAsyncQueries flag is disabled', async () => {
+    test('handleChartDataResponse should return result if GlobalAsyncQueries flag is disabled', async () => {
       const result = await handleChartDataResponse(
         { status: 200 },
         { result: [1, 2, 3] },
@@ -168,7 +168,7 @@ describe('chart actions', () => {
       expect(result).toEqual([1, 2, 3]);
     });
 
-    it('handleChartDataResponse should handle responses when GlobalAsyncQueries flag is enabled and results are returned synchronously', async () => {
+    test('handleChartDataResponse should handle responses when GlobalAsyncQueries flag is enabled and results are returned synchronously', async () => {
       global.featureFlags = {
         [FeatureFlag.GlobalAsyncQueries]: true,
       };
@@ -179,7 +179,7 @@ describe('chart actions', () => {
       expect(result).toEqual([1, 2, 3]);
     });
 
-    it('handleChartDataResponse should handle responses when GlobalAsyncQueries flag is enabled and query is running asynchronously', async () => {
+    test('handleChartDataResponse should handle responses when GlobalAsyncQueries flag is enabled and query is running asynchronously', async () => {
       global.featureFlags = {
         [FeatureFlag.GlobalAsyncQueries]: true,
       };
@@ -196,7 +196,7 @@ describe('chart actions', () => {
       fakeMetadata = { useLegacyApi: true };
     });
 
-    it('should dispatch CHART_UPDATE_STARTED action before the query', () => {
+    test('should dispatch CHART_UPDATE_STARTED action before the query', () => {
       const actionThunk = actions.postChartFormData({});
 
       return actionThunk(dispatch, mockGetState).then(() => {
@@ -207,7 +207,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch TRIGGER_QUERY action with the query', () => {
+    test('should dispatch TRIGGER_QUERY action with the query', () => {
       const actionThunk = actions.postChartFormData({});
       return actionThunk(dispatch, mockGetState).then(() => {
         // chart update, trigger query, update form data, success
@@ -217,7 +217,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch UPDATE_QUERY_FORM_DATA action with the query', () => {
+    test('should dispatch UPDATE_QUERY_FORM_DATA action with the query', () => {
       const actionThunk = actions.postChartFormData({});
       return actionThunk(dispatch, mockGetState).then(() => {
         // chart update, trigger query, update form data, success
@@ -227,7 +227,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch logEvent async action', () => {
+    test('should dispatch logEvent async action', () => {
       const actionThunk = actions.postChartFormData({});
       return actionThunk(dispatch, mockGetState).then(() => {
         // chart update, trigger query, update form data, success
@@ -241,7 +241,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch CHART_UPDATE_SUCCEEDED action upon success', () => {
+    test('should dispatch CHART_UPDATE_SUCCEEDED action upon success', () => {
       const actionThunk = actions.postChartFormData({});
       return actionThunk(dispatch, mockGetState).then(() => {
         // chart update, trigger query, update form data, success
@@ -251,7 +251,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch CHART_UPDATE_FAILED action upon query timeout', () => {
+    test('should dispatch CHART_UPDATE_FAILED action upon query timeout', () => {
       const unresolvingPromise = new Promise(() => {});
       fetchMock.post(MOCK_URL, () => unresolvingPromise, {
         overwriteRoutes: true,
@@ -269,7 +269,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should dispatch CHART_UPDATE_FAILED action upon non-timeout non-abort failure', () => {
+    test('should dispatch CHART_UPDATE_FAILED action upon non-timeout non-abort failure', () => {
       fetchMock.post(
         MOCK_URL,
         { throws: { statusText: 'misc error' } },
@@ -290,7 +290,7 @@ describe('chart actions', () => {
       });
     });
 
-    it('should handle the bigint without regression', async () => {
+    test('should handle the bigint without regression', async () => {
       getExploreUrlStub.restore();
       const mockBigIntUrl = '/mock/chart/data/bigint';
       const expectedBigNumber = '9223372036854775807';
@@ -316,7 +316,7 @@ describe('chart actions', () => {
       jest.clearAllMocks();
     });
 
-    it('should dispatch annotationQueryStarted and annotationQuerySuccess on successful query', async () => {
+    test('should dispatch annotationQueryStarted and annotationQuerySuccess on successful query', async () => {
       const annotation = {
         name: 'Holidays',
         annotationType: 'EVENT',
@@ -371,7 +371,7 @@ describe('chart actions timeout', () => {
     jest.clearAllMocks();
   });
 
-  it('should use the timeout from arguments when given', async () => {
+  test('should use the timeout from arguments when given', async () => {
     const postSpy = jest.spyOn(SupersetClient, 'post');
     postSpy.mockImplementation(() => Promise.resolve({ json: { result: [] } }));
     const timeout = 10; // Set the timeout value here
@@ -403,7 +403,7 @@ describe('chart actions timeout', () => {
     expect(postSpy).toHaveBeenCalledWith(expectedPayload);
   });
 
-  it('should use the timeout from common.conf when not passed as an argument', async () => {
+  test('should use the timeout from common.conf when not passed as an argument', async () => {
     const postSpy = jest.spyOn(SupersetClient, 'post');
     postSpy.mockImplementation(() => Promise.resolve({ json: { result: [] } }));
     const formData = { datasource: 'table__1' }; // Set the formData here

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -59,6 +59,7 @@ jest.mock('@superset-ui/core', () => ({
   getChartBuildQueryRegistry: jest.fn(),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('chart actions', () => {
   const MOCK_URL = '/mockURL';
   let dispatch;
@@ -121,6 +122,7 @@ describe('chart actions', () => {
     };
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('v1 API', () => {
     beforeEach(() => {
       fakeMetadata = { viz_type: 'my_viz', useLegacyApi: false };
@@ -191,6 +193,7 @@ describe('chart actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('legacy API', () => {
     beforeEach(() => {
       fakeMetadata = { useLegacyApi: true };
@@ -310,6 +313,7 @@ describe('chart actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('runAnnotationQuery', () => {
     const mockDispatch = jest.fn();
     beforeEach(() => {
@@ -366,6 +370,7 @@ describe('chart actions', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('chart actions timeout', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/components/Chart/chartReducers.test.js
+++ b/superset-frontend/src/components/Chart/chartReducers.test.js
@@ -19,6 +19,7 @@
 import chartReducer, { chart } from 'src/components/Chart/chartReducer';
 import * as actions from 'src/components/Chart/chartAction';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('chart reducers', () => {
   const chartKey = 1;
   let testChart;

--- a/superset-frontend/src/components/Chart/chartReducers.test.js
+++ b/superset-frontend/src/components/Chart/chartReducers.test.js
@@ -31,13 +31,13 @@ describe('chart reducers', () => {
     charts = { [chartKey]: testChart };
   });
 
-  it('should update endtime on fail', () => {
+  test('should update endtime on fail', () => {
     const newState = chartReducer(charts, actions.chartUpdateStopped(chartKey));
     expect(newState[chartKey].chartUpdateEndTime).toBeGreaterThan(0);
     expect(newState[chartKey].chartStatus).toEqual('stopped');
   });
 
-  it('should update endtime on timeout', () => {
+  test('should update endtime on timeout', () => {
     const newState = chartReducer(
       charts,
       actions.chartUpdateFailed(

--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
@@ -74,23 +74,23 @@ beforeEach(() => {
 });
 
 describe('DatasourceModal', () => {
-  it('renders', async () => {
+  test('renders', async () => {
     expect(container).toBeDefined();
   });
 
-  it('renders the component', () => {
+  test('renders the component', () => {
     expect(screen.getByText('Edit Dataset')).toBeInTheDocument();
   });
 
-  it('renders a Modal', async () => {
+  test('renders a Modal', async () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('renders a DatasourceEditor', async () => {
+  test('renders a DatasourceEditor', async () => {
     expect(screen.getByTestId('datasource-editor')).toBeInTheDocument();
   });
 
-  it('disables the save button when the datasource is managed externally', () => {
+  test('disables the save button when the datasource is managed externally', () => {
     // the render is currently in a before operation, so it needs to be cleaned up
     // we could alternatively move all the renders back into the tests or find a better
     // way to automatically render but still allow to pass in props with the tests
@@ -104,7 +104,7 @@ describe('DatasourceModal', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('calls the onDatasourceSave function when the save button is clicked', async () => {
+  test('calls the onDatasourceSave function when the save button is clicked', async () => {
     cleanup();
     const onDatasourceSave = jest.fn();
 
@@ -120,7 +120,7 @@ describe('DatasourceModal', () => {
     });
   });
 
-  it('should render error dialog', async () => {
+  test('should render error dialog', async () => {
     jest
       .spyOn(SupersetClient, 'put')
       .mockRejectedValue(new Error('Something went wrong'));

--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
@@ -73,6 +73,7 @@ beforeEach(() => {
   fetchMock.get(GET_DATABASE_ENDPOINT, { result: [] });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceModal', () => {
   test('renders', async () => {
     expect(container).toBeDefined();

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DashboardLinksExternal/DashboardLinksExternal.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DashboardLinksExternal/DashboardLinksExternal.test.tsx
@@ -46,6 +46,7 @@ const setupTest = (dashboards = mockDashboards) =>
     }),
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardLinksExternal', () => {
   test('renders empty state when no dashboards provided', () => {
     setupTest([]);

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
@@ -80,11 +80,11 @@ describe('DatasourceEditor', () => {
     // jest.clearAllMocks();
   });
 
-  it('renders Tabs', () => {
+  test('renders Tabs', () => {
     expect(screen.getByTestId('edit-dataset-tabs')).toBeInTheDocument();
   });
 
-  it('can sync columns from source', async () => {
+  test('can sync columns from source', async () => {
     const columnsTab = screen.getByTestId('collection-tab-Columns');
     userEvent.click(columnsTab);
 
@@ -111,7 +111,7 @@ describe('DatasourceEditor', () => {
   });
 
   // to add, remove and modify columns accordingly
-  it('can modify columns', async () => {
+  test('can modify columns', async () => {
     const columnsTab = screen.getByTestId('collection-tab-Columns');
     userEvent.click(columnsTab);
 
@@ -138,7 +138,7 @@ describe('DatasourceEditor', () => {
     userEvent.type(inputCertDetails, 'test');
   }, 40000);
 
-  it('can delete columns', async () => {
+  test('can delete columns', async () => {
     const columnsTab = screen.getByTestId('collection-tab-Columns');
     userEvent.click(columnsTab);
 
@@ -162,7 +162,7 @@ describe('DatasourceEditor', () => {
     });
   }, 60000); // 60 seconds timeout to avoid timeouts
 
-  it('can add new columns', async () => {
+  test('can add new columns', async () => {
     const calcColsTab = screen.getByTestId('collection-tab-Calculated columns');
     userEvent.click(calcColsTab);
 
@@ -180,7 +180,7 @@ describe('DatasourceEditor', () => {
     });
   }, 60000);
 
-  it('renders isSqla fields', async () => {
+  test('renders isSqla fields', async () => {
     const columnsTab = screen.getByRole('tab', {
       name: /settings/i,
     });
@@ -216,7 +216,7 @@ describe('DatasourceEditor Source Tab', () => {
     isFeatureEnabled.mockRestore();
   });
 
-  it('Source Tab: edit mode', async () => {
+  test('Source Tab: edit mode', async () => {
     const getLockBtn = screen.getByRole('img', { name: /lock/i });
     userEvent.click(getLockBtn);
 
@@ -231,7 +231,7 @@ describe('DatasourceEditor Source Tab', () => {
     expect(virtualRadioBtn).toBeEnabled();
   });
 
-  it('Source Tab: readOnly mode', () => {
+  test('Source Tab: readOnly mode', () => {
     const getLockBtn = screen.getByRole('img', { name: /lock/i });
     expect(getLockBtn).toBeInTheDocument();
 
@@ -246,7 +246,7 @@ describe('DatasourceEditor Source Tab', () => {
     expect(virtualRadioBtn).toBeDisabled();
   });
 
-  it('calls onChange with empty SQL when switching to physical dataset', async () => {
+  test('calls onChange with empty SQL when switching to physical dataset', async () => {
     // Clean previous render
     cleanup();
 

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
@@ -63,6 +63,7 @@ export const asyncRender = props =>
     }),
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceEditor', () => {
   beforeAll(() => {
     jest.clearAllMocks();
@@ -195,6 +196,7 @@ describe('DatasourceEditor', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceEditor Source Tab', () => {
   beforeAll(() => {
     isFeatureEnabled.mockImplementation(() => false);

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
@@ -30,6 +30,7 @@ const fastRender = props =>
     initialState: { common: { currencies: ['USD', 'GBP', 'EUR'] } },
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceEditor Currency Tests', () => {
   beforeEach(() => {
     fetchMock.get(DATASOURCE_ENDPOINT, [], { overwriteRoutes: true });

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
@@ -40,7 +40,7 @@ describe('DatasourceEditor Currency Tests', () => {
   });
 
   // The problematic test, now optimized
-  it('renders currency controls', async () => {
+  test('renders currency controls', async () => {
     // Setup a metric with currency data
     const propsWithCurrency = {
       ...props,

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
@@ -24,6 +24,7 @@ import {
   DATASOURCE_ENDPOINT,
 } from './DatasourceEditor.test';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceEditor RTL Metrics Tests', () => {
   beforeEach(() => {
     fetchMock.get(DATASOURCE_ENDPOINT, [], { overwriteRoutes: true });
@@ -82,6 +83,7 @@ describe('DatasourceEditor RTL Metrics Tests', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceEditor RTL Columns Tests', () => {
   beforeEach(() => {
     fetchMock.get(DATASOURCE_ENDPOINT, [], { overwriteRoutes: true });

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
@@ -34,7 +34,7 @@ describe('DatasourceEditor RTL Metrics Tests', () => {
     fetchMock.restore();
   });
 
-  it('properly renders the metric information', async () => {
+  test('properly renders the metric information', async () => {
     await asyncRender(props);
 
     const metricButton = screen.getByTestId('collection-tab-Metrics');
@@ -52,7 +52,7 @@ describe('DatasourceEditor RTL Metrics Tests', () => {
     expect(warningMarkdown.value).toEqual('someone');
   });
 
-  it('properly updates the metric information', async () => {
+  test('properly updates the metric information', async () => {
     await asyncRender(props);
 
     const metricButton = screen.getByTestId('collection-tab-Metrics');
@@ -92,7 +92,7 @@ describe('DatasourceEditor RTL Columns Tests', () => {
     fetchMock.restore();
   });
 
-  it('shows the default datetime column', async () => {
+  test('shows the default datetime column', async () => {
     await asyncRender(props);
 
     const columnsButton = screen.getByTestId('collection-tab-Columns');
@@ -107,7 +107,7 @@ describe('DatasourceEditor RTL Columns Tests', () => {
     expect(genderDefaultDatetimeRadio).not.toBeChecked();
   });
 
-  it('allows choosing only temporal columns as the default datetime', async () => {
+  test('allows choosing only temporal columns as the default datetime', async () => {
     await asyncRender(props);
 
     const columnsButton = screen.getByTestId('collection-tab-Columns');

--- a/superset-frontend/src/components/Datasource/utils/utils.test.tsx
+++ b/superset-frontend/src/components/Datasource/utils/utils.test.tsx
@@ -27,7 +27,7 @@ describe('updateColumns', () => {
     addSuccessToast = jest.fn();
   });
 
-  it('adds new columns when prevCols is empty', () => {
+  test('adds new columns when prevCols is empty', () => {
     interface Column {
       column_name: string;
       type: string;
@@ -56,7 +56,7 @@ describe('updateColumns', () => {
     );
   });
 
-  it('modifies columns when type or is_dttm changes', () => {
+  test('modifies columns when type or is_dttm changes', () => {
     const prevCols = [
       { column_name: 'col1', type: 'string', is_dttm: false },
       { column_name: 'col2', type: 'number', is_dttm: false },
@@ -94,7 +94,7 @@ describe('updateColumns', () => {
     );
   });
 
-  it('removes columns not present in newCols', () => {
+  test('removes columns not present in newCols', () => {
     const prevCols = [
       { column_name: 'col1', type: 'string', is_dttm: false },
       { column_name: 'col2', type: 'number', is_dttm: true },
@@ -121,7 +121,7 @@ describe('updateColumns', () => {
     );
   });
 
-  it('handles combined additions, modifications, and removals', () => {
+  test('handles combined additions, modifications, and removals', () => {
     const prevCols = [
       { column_name: 'col1', type: 'string', is_dttm: false },
       { column_name: 'col2', type: 'number', is_dttm: false },
@@ -170,7 +170,7 @@ describe('updateColumns', () => {
       ],
     ]);
   });
-  it('should not remove columns with expressions', () => {
+  test('should not remove columns with expressions', () => {
     const prevCols = [
       { column_name: 'col1', type: 'string', is_dttm: false },
       { column_name: 'col2', type: 'number', is_dttm: false },

--- a/superset-frontend/src/components/Datasource/utils/utils.test.tsx
+++ b/superset-frontend/src/components/Datasource/utils/utils.test.tsx
@@ -20,6 +20,7 @@
 import { tn } from '@superset-ui/core';
 import { updateColumns } from '.';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('updateColumns', () => {
   let addSuccessToast: jest.Mock;
 

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
@@ -21,7 +21,7 @@ import { screen, fireEvent, render } from 'spec/helpers/testing-library';
 import { ErrorAlert } from './ErrorAlert';
 
 describe('ErrorAlert', () => {
-  it('renders the error message correctly', () => {
+  test('renders the error message correctly', () => {
     render(
       <ErrorAlert
         errorType="Error"
@@ -34,7 +34,7 @@ describe('ErrorAlert', () => {
     expect(screen.getByText('Something went wrong')).toBeInTheDocument();
   });
 
-  it('renders the description when provided', () => {
+  test('renders the description when provided', () => {
     const description = 'This is a detailed description';
     render(
       <ErrorAlert
@@ -48,7 +48,7 @@ describe('ErrorAlert', () => {
     expect(screen.getByText(description)).toBeInTheDocument();
   });
 
-  it('toggles description details visibility when show more/less is clicked', () => {
+  test('toggles description details visibility when show more/less is clicked', () => {
     const descriptionDetails = 'Additional details about the error.';
     render(
       <ErrorAlert
@@ -71,7 +71,7 @@ describe('ErrorAlert', () => {
     expect(screen.queryByText(descriptionDetails)).not.toBeInTheDocument();
   });
 
-  it('renders compact mode with a tooltip and modal', () => {
+  test('renders compact mode with a tooltip and modal', () => {
     render(
       <ErrorAlert
         errorType="Error"

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
@@ -20,72 +20,71 @@
 import { screen, fireEvent, render } from 'spec/helpers/testing-library';
 import { ErrorAlert } from './ErrorAlert';
 
-describe('ErrorAlert', () => {
-  test('renders the error message correctly', () => {
-    render(
-      <ErrorAlert
-        errorType="Error"
-        message="Something went wrong"
-        type="error"
-      />,
-    );
+// ErrorAlert
+test('ErrorAlert renders the error message correctly', () => {
+  render(
+    <ErrorAlert
+      errorType="Error"
+      message="Something went wrong"
+      type="error"
+    />,
+  );
 
-    expect(screen.getByText('Error')).toBeInTheDocument();
-    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
-  });
+  expect(screen.getByText('Error')).toBeInTheDocument();
+  expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+});
 
-  test('renders the description when provided', () => {
-    const description = 'This is a detailed description';
-    render(
-      <ErrorAlert
-        errorType="Error"
-        message="Something went wrong"
-        type="error"
-        description={description}
-      />,
-    );
+test('ErrorAlert renders the description when provided', () => {
+  const description = 'This is a detailed description';
+  render(
+    <ErrorAlert
+      errorType="Error"
+      message="Something went wrong"
+      type="error"
+      description={description}
+    />,
+  );
 
-    expect(screen.getByText(description)).toBeInTheDocument();
-  });
+  expect(screen.getByText(description)).toBeInTheDocument();
+});
 
-  test('toggles description details visibility when show more/less is clicked', () => {
-    const descriptionDetails = 'Additional details about the error.';
-    render(
-      <ErrorAlert
-        errorType="Error"
-        message="Something went wrong"
-        type="error"
-        descriptionDetails={descriptionDetails}
-        descriptionDetailsCollapsed
-      />,
-    );
+test('ErrorAlert toggles description details visibility when show more/less is clicked', () => {
+  const descriptionDetails = 'Additional details about the error.';
+  render(
+    <ErrorAlert
+      errorType="Error"
+      message="Something went wrong"
+      type="error"
+      descriptionDetails={descriptionDetails}
+      descriptionDetailsCollapsed
+    />,
+  );
 
-    const showMoreButton = screen.getByText('See more');
-    expect(showMoreButton).toBeInTheDocument();
+  const showMoreButton = screen.getByText('See more');
+  expect(showMoreButton).toBeInTheDocument();
 
-    fireEvent.click(showMoreButton);
-    expect(screen.getByText(descriptionDetails)).toBeInTheDocument();
+  fireEvent.click(showMoreButton);
+  expect(screen.getByText(descriptionDetails)).toBeInTheDocument();
 
-    const showLessButton = screen.getByText('See less');
-    fireEvent.click(showLessButton);
-    expect(screen.queryByText(descriptionDetails)).not.toBeInTheDocument();
-  });
+  const showLessButton = screen.getByText('See less');
+  fireEvent.click(showLessButton);
+  expect(screen.queryByText(descriptionDetails)).not.toBeInTheDocument();
+});
 
-  test('renders compact mode with a tooltip and modal', () => {
-    render(
-      <ErrorAlert
-        errorType="Error"
-        message="Compact mode example"
-        type="error"
-        compact
-        descriptionDetails="Detailed description in compact mode."
-      />,
-    );
+test('ErrorAlert renders compact mode with a tooltip and modal', () => {
+  render(
+    <ErrorAlert
+      errorType="Error"
+      message="Compact mode example"
+      type="error"
+      compact
+      descriptionDetails="Detailed description in compact mode."
+    />,
+  );
 
-    const iconTrigger = screen.getByText('Error');
-    expect(iconTrigger).toBeInTheDocument();
+  const iconTrigger = screen.getByText('Error');
+  expect(iconTrigger).toBeInTheDocument();
 
-    fireEvent.click(iconTrigger);
-    expect(screen.getByText('Compact mode example')).toBeInTheDocument();
-  });
+  fireEvent.click(iconTrigger);
+  expect(screen.getByText('Compact mode example')).toBeInTheDocument();
 });

--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
@@ -54,6 +54,7 @@ const missingExtraProps = {
 const renderComponent = (overrides = {}) =>
   render(<InvalidSQLErrorMessage {...defaultProps} {...overrides} />);
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('InvalidSQLErrorMessage', () => {
   beforeAll(() => {
     jest.setTimeout(30000);

--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
@@ -64,7 +64,7 @@ describe('InvalidSQLErrorMessage', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
   });
 
-  it('renders the error message with correct properties', async () => {
+  test('renders the error message with correct properties', async () => {
     const { getByText, unmount } = renderComponent();
 
     // Validate main properties
@@ -75,13 +75,13 @@ describe('InvalidSQLErrorMessage', () => {
     unmount();
   });
 
-  it('renders the error message with the empty extra properties', () => {
+  test('renders the error message with the empty extra properties', () => {
     const { getByText } = renderComponent(missingExtraProps);
     expect(getByText('Unable to parse SQL')).toBeInTheDocument();
     expect(getByText(missingExtraProps.error.message)).toBeInTheDocument();
   });
 
-  it('displays the SQL error line and column indicator', async () => {
+  test('displays the SQL error line and column indicator', async () => {
     const { getByText, container, unmount } = renderComponent();
 
     // Validate SQL and caret indicator
@@ -95,7 +95,7 @@ describe('InvalidSQLErrorMessage', () => {
     unmount();
   });
 
-  it('handles missing line number gracefully', async () => {
+  test('handles missing line number gracefully', async () => {
     const overrides = {
       error: {
         ...defaultProps.error,
@@ -114,7 +114,7 @@ describe('InvalidSQLErrorMessage', () => {
     unmount();
   });
 
-  it('handles missing column number gracefully', async () => {
+  test('handles missing column number gracefully', async () => {
     const overrides = {
       error: {
         ...defaultProps.error,

--- a/superset-frontend/src/components/ErrorMessage/MarshmallowErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/MarshmallowErrorMessage.test.tsx
@@ -21,6 +21,7 @@ import { render, screen, fireEvent } from 'spec/helpers/testing-library';
 import { ErrorLevel, ErrorTypeEnum } from '@superset-ui/core';
 import { MarshmallowErrorMessage } from './MarshmallowErrorMessage';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('MarshmallowErrorMessage', () => {
   const mockError = {
     extra: {

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -100,14 +100,14 @@ const setup = (overrides = {}) => (
 );
 
 describe('OAuth2RedirectMessage Component', () => {
-  it('renders without crashing and displays the correct initial UI elements', () => {
+  test('renders without crashing and displays the correct initial UI elements', () => {
     const { getByText } = render(setup());
 
     expect(getByText(/Authorization needed/i)).toBeInTheDocument();
     expect(getByText(/provide authorization/i)).toBeInTheDocument();
   });
 
-  it('opens a new window with the correct URL when the link is clicked', () => {
+  test('opens a new window with the correct URL when the link is clicked', () => {
     const { getByText } = render(setup());
 
     const linkElement = getByText(/provide authorization/i);
@@ -116,7 +116,7 @@ describe('OAuth2RedirectMessage Component', () => {
     expect(mockOpen).toHaveBeenCalledWith('https://example.com', '_blank');
   });
 
-  it('cleans up the message event listener on unmount', () => {
+  test('cleans up the message event listener on unmount', () => {
     const { unmount } = render(setup());
 
     expect(mockAddEventListener).toHaveBeenCalled();
@@ -124,7 +124,7 @@ describe('OAuth2RedirectMessage Component', () => {
     expect(mockRemoveEventListener).toHaveBeenCalled();
   });
 
-  it('dispatches reRunQuery action when a message with correct tab ID is received for SQL Lab', async () => {
+  test('dispatches reRunQuery action when a message with correct tab ID is received for SQL Lab', async () => {
     render(setup());
 
     simulateMessageEvent({ tabId: 'tabId' }, 'https://redirect.example.com');
@@ -134,7 +134,7 @@ describe('OAuth2RedirectMessage Component', () => {
     });
   });
 
-  it('dispatches triggerQuery action for explore source upon receiving a correct message', async () => {
+  test('dispatches triggerQuery action for explore source upon receiving a correct message', async () => {
     render(setup({ source: 'explore' }));
 
     simulateMessageEvent({ tabId: 'tabId' }, 'https://redirect.example.com');
@@ -144,7 +144,7 @@ describe('OAuth2RedirectMessage Component', () => {
     });
   });
 
-  it('dispatches onRefresh action for dashboard source upon receiving a correct message', async () => {
+  test('dispatches onRefresh action for dashboard source upon receiving a correct message', async () => {
     render(setup({ source: 'dashboard' }));
 
     simulateMessageEvent({ tabId: 'tabId' }, 'https://redirect.example.com');

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -99,6 +99,7 @@ const setup = (overrides = {}) => (
   </Provider>
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('OAuth2RedirectMessage Component', () => {
   test('renders without crashing and displays the correct initial UI elements', () => {
     const { getByText } = render(setup());

--- a/superset-frontend/src/components/FacePile/FacePile.test.tsx
+++ b/superset-frontend/src/components/FacePile/FacePile.test.tsx
@@ -58,14 +58,14 @@ afterEach(() => {
 });
 
 describe('FacePile', () => {
-  it('renders empty state with no users', () => {
+  test('renders empty state with no users', () => {
     const { container } = render(<FacePile users={[]} />, { store });
 
     expect(container.querySelector('.ant-avatar-group')).toBeInTheDocument();
     expect(container.querySelectorAll('.ant-avatar')).toHaveLength(0);
   });
 
-  it('renders single user without truncation', () => {
+  test('renders single user without truncation', () => {
     const { container } = render(<FacePile users={users.slice(0, 1)} />, {
       store,
     });
@@ -76,7 +76,7 @@ describe('FacePile', () => {
     expect(within(container).queryByText(/\+/)).not.toBeInTheDocument();
   });
 
-  it('renders multiple users no truncation', () => {
+  test('renders multiple users no truncation', () => {
     const { container } = render(<FacePile users={users.slice(0, 4)} />, {
       store,
     });
@@ -90,7 +90,7 @@ describe('FacePile', () => {
     expect(within(container).queryByText(/\+/)).not.toBeInTheDocument();
   });
 
-  it('renders multiple users with truncation', () => {
+  test('renders multiple users with truncation', () => {
     const { container } = render(<FacePile users={users} />, { store });
 
     // Should show 4 avatars + 1 overflow indicator = 5 total elements
@@ -107,7 +107,7 @@ describe('FacePile', () => {
     expect(within(container).getByText('+6')).toBeInTheDocument();
   });
 
-  it('displays user tooltip on hover', () => {
+  test('displays user tooltip on hover', () => {
     const { container } = render(<FacePile users={users.slice(0, 2)} />, {
       store,
     });
@@ -119,7 +119,7 @@ describe('FacePile', () => {
     expect(screen.getByRole('tooltip')).toHaveTextContent('user 0');
   });
 
-  it('displays avatar images when Slack avatars are enabled', () => {
+  test('displays avatar images when Slack avatars are enabled', () => {
     // Enable Slack avatars feature flag
     mockIsFeatureEnabled.mockImplementation(
       feature => feature === 'SLACK_ENABLE_AVATARS',
@@ -147,20 +147,20 @@ describe('utils', () => {
   describe('getRandomColor', () => {
     const colors = ['color1', 'color2', 'color3'];
 
-    it('produces the same color for the same input values', () => {
+    test('produces the same color for the same input values', () => {
       const name = 'foo';
       expect(getRandomColor(name, colors)).toEqual(
         getRandomColor(name, colors),
       );
     });
 
-    it('produces a different color for different input values', () => {
+    test('produces a different color for different input values', () => {
       expect(getRandomColor('foo', colors)).not.toEqual(
         getRandomColor('bar', colors),
       );
     });
 
-    it('handles non-ascii input values', () => {
+    test('handles non-ascii input values', () => {
       expect(getRandomColor('泰', colors)).toMatchInlineSnapshot(`"color1"`);
       expect(getRandomColor('مُحَمَّد‎', colors)).toMatchInlineSnapshot(
         `"color2"`,

--- a/superset-frontend/src/components/FacePile/FacePile.test.tsx
+++ b/superset-frontend/src/components/FacePile/FacePile.test.tsx
@@ -57,6 +57,7 @@ afterEach(() => {
   cleanup();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FacePile', () => {
   test('renders empty state with no users', () => {
     const { container } = render(<FacePile users={[]} />, { store });
@@ -143,7 +144,9 @@ describe('FacePile', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('utils', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getRandomColor', () => {
     const colors = ['color1', 'color2', 'color3'];
 

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -26,6 +26,7 @@ import {
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
 import { FilterableTable } from '.';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterableTable', () => {
   beforeAll(() => {
     setupAGGridModules();
@@ -74,6 +75,7 @@ describe('FilterableTable', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterableTable sorting - RTL', () => {
   beforeAll(() => {
     setupAGGridModules();

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -40,10 +40,10 @@ describe('FilterableTable', () => {
     ],
     height: 500,
   };
-  it('is valid element', () => {
+  test('is valid element', () => {
     expect(isValidElement(<FilterableTable {...mockedProps} />)).toBe(true);
   });
-  it('renders a grid with 3 Table rows', () => {
+  test('renders a grid with 3 Table rows', () => {
     const { getByRole, getByText } = render(
       <FilterableTable {...mockedProps} />,
     );
@@ -52,7 +52,7 @@ describe('FilterableTable', () => {
       expect(getByText(columnBContent)).toBeInTheDocument();
     });
   });
-  it('filters on a string', () => {
+  test('filters on a string', () => {
     const props = {
       ...mockedProps,
       filterText: 'b1',
@@ -62,7 +62,7 @@ describe('FilterableTable', () => {
     expect(queryByText('b2')).not.toBeInTheDocument();
     expect(queryByText('b3')).not.toBeInTheDocument();
   });
-  it('filters on a number', () => {
+  test('filters on a number', () => {
     const props = {
       ...mockedProps,
       filterText: '100',
@@ -79,7 +79,7 @@ describe('FilterableTable sorting - RTL', () => {
     setupAGGridModules();
   });
 
-  it('sorts strings correctly', () => {
+  test('sorts strings correctly', () => {
     const stringProps = {
       orderedColumnKeys: ['columnA'],
       data: [
@@ -128,7 +128,7 @@ describe('FilterableTable sorting - RTL', () => {
     );
   });
 
-  it('sorts integers correctly', () => {
+  test('sorts integers correctly', () => {
     const integerProps = {
       orderedColumnKeys: ['columnB'],
       data: [{ columnB: 21 }, { columnB: 0 }, { columnB: 623 }],
@@ -163,7 +163,7 @@ describe('FilterableTable sorting - RTL', () => {
     expect(gridCells?.textContent).toEqual(['21', '0', '623'].join(''));
   });
 
-  it('sorts floating numbers correctly', () => {
+  test('sorts floating numbers correctly', () => {
     const floatProps = {
       orderedColumnKeys: ['columnC'],
       data: [{ columnC: 45.67 }, { columnC: 1.23 }, { columnC: 89.0000001 }],
@@ -206,7 +206,7 @@ describe('FilterableTable sorting - RTL', () => {
     );
   });
 
-  it('sorts rows properly when floating numbers have mixed types', () => {
+  test('sorts rows properly when floating numbers have mixed types', () => {
     const mixedFloatProps = {
       orderedColumnKeys: ['columnD'],
       data: [
@@ -308,7 +308,7 @@ describe('FilterableTable sorting - RTL', () => {
     );
   });
 
-  it('sorts YYYY-MM-DD properly', () => {
+  test('sorts YYYY-MM-DD properly', () => {
     const dsProps = {
       orderedColumnKeys: ['columnDS'],
       data: [

--- a/superset-frontend/src/components/GridTable/HeaderMenu.test.tsx
+++ b/superset-frontend/src/components/GridTable/HeaderMenu.test.tsx
@@ -152,6 +152,7 @@ test('renders unhide when invisible column exists', async () => {
   expect(mockGridApi.setColumnsVisible).toHaveBeenCalledWith(['column2'], true);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('for main menu', () => {
   test('renders Copy to Clipboard', async () => {
     const { getByText } = setup({ ...mockedProps, isMain: true });

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -146,7 +146,7 @@ describe('ListView', () => {
   });
 
   // Example of converted test:
-  it('calls fetchData on mount', () => {
+  test('calls fetchData on mount', () => {
     expect(mockedProps.fetchData).toHaveBeenCalledWith({
       filters: [],
       pageIndex: 0,
@@ -155,7 +155,7 @@ describe('ListView', () => {
     });
   });
 
-  it('calls fetchData on sort', async () => {
+  test('calls fetchData on sort', async () => {
     const sortHeader = screen.getAllByTestId('sort-header')[1];
     await userEvent.click(sortHeader);
 
@@ -173,7 +173,7 @@ describe('ListView', () => {
   });
 
   // Update pagination control tests for Ant Design pagination
-  it('renders pagination controls', () => {
+  test('renders pagination controls', () => {
     const paginationList = screen.getByRole('list');
     expect(paginationList).toBeInTheDocument();
 
@@ -181,7 +181,7 @@ describe('ListView', () => {
     expect(pageOneItem).toBeInTheDocument();
   });
 
-  it('calls fetchData on page change', async () => {
+  test('calls fetchData on page change', async () => {
     const pageTwoItem = screen.getByRole('listitem', { name: '2' });
     await userEvent.click(pageTwoItem);
 
@@ -197,7 +197,7 @@ describe('ListView', () => {
     });
   });
 
-  it('handles bulk actions on 1 row', async () => {
+  test('handles bulk actions on 1 row', async () => {
     const checkboxes = screen.getAllByRole('checkbox');
     await userEvent.click(checkboxes[1]); // Index 1 is the first row checkbox
 
@@ -217,12 +217,12 @@ describe('ListView', () => {
   });
 
   // Update UI filters test to use more specific selector
-  it('renders UI filters', () => {
+  test('renders UI filters', () => {
     const filterControls = screen.getAllByRole('combobox');
     expect(filterControls).toHaveLength(2);
   });
 
-  it('calls fetchData on filter', async () => {
+  test('calls fetchData on filter', async () => {
     // Handle select filter
     const selectFilter = screen.getAllByRole('combobox')[0];
     await userEvent.click(selectFilter);
@@ -252,7 +252,7 @@ describe('ListView', () => {
     );
   });
 
-  it('calls fetchData on card view sort', async () => {
+  test('calls fetchData on card view sort', async () => {
     factory({
       ...mockedProps,
       renderCard: jest.fn(),

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -130,6 +130,7 @@ const factory = (props = mockedProps) =>
     { store: mockStore() },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ListView', () => {
   beforeEach(() => {
     fetchMock.reset();

--- a/superset-frontend/src/components/MessageToasts/reducers.test.js
+++ b/superset-frontend/src/components/MessageToasts/reducers.test.js
@@ -20,11 +20,11 @@ import { ADD_TOAST, REMOVE_TOAST } from 'src/components/MessageToasts/actions';
 import messageToastsReducer from 'src/components/MessageToasts/reducers';
 
 describe('messageToasts reducer', () => {
-  it('should return initial state', () => {
+  test('should return initial state', () => {
     expect(messageToastsReducer(undefined, {})).toEqual([]);
   });
 
-  it('should add a toast', () => {
+  test('should add a toast', () => {
     expect(
       messageToastsReducer([], {
         type: ADD_TOAST,
@@ -33,7 +33,7 @@ describe('messageToasts reducer', () => {
     ).toEqual([{ text: 'test', id: 'id', type: 'test_type' }]);
   });
 
-  it('should remove a toast', () => {
+  test('should remove a toast', () => {
     expect(
       messageToastsReducer([{ id: 'id' }, { id: 'id2' }], {
         type: REMOVE_TOAST,

--- a/superset-frontend/src/components/MessageToasts/reducers.test.js
+++ b/superset-frontend/src/components/MessageToasts/reducers.test.js
@@ -19,26 +19,25 @@
 import { ADD_TOAST, REMOVE_TOAST } from 'src/components/MessageToasts/actions';
 import messageToastsReducer from 'src/components/MessageToasts/reducers';
 
-describe('messageToasts reducer', () => {
-  test('should return initial state', () => {
-    expect(messageToastsReducer(undefined, {})).toEqual([]);
-  });
+// messageToasts reducer
+test('messageToasts reducer should return initial state', () => {
+  expect(messageToastsReducer(undefined, {})).toEqual([]);
+});
 
-  test('should add a toast', () => {
-    expect(
-      messageToastsReducer([], {
-        type: ADD_TOAST,
-        payload: { text: 'test', id: 'id', type: 'test_type' },
-      }),
-    ).toEqual([{ text: 'test', id: 'id', type: 'test_type' }]);
-  });
+test('messageToasts reducer should add a toast', () => {
+  expect(
+    messageToastsReducer([], {
+      type: ADD_TOAST,
+      payload: { text: 'test', id: 'id', type: 'test_type' },
+    }),
+  ).toEqual([{ text: 'test', id: 'id', type: 'test_type' }]);
+});
 
-  test('should remove a toast', () => {
-    expect(
-      messageToastsReducer([{ id: 'id' }, { id: 'id2' }], {
-        type: REMOVE_TOAST,
-        payload: { id: 'id' },
-      }),
-    ).toEqual([{ id: 'id2' }]);
-  });
+test('messageToasts reducer should remove a toast', () => {
+  expect(
+    messageToastsReducer([{ id: 'id' }, { id: 'id2' }], {
+      type: REMOVE_TOAST,
+      payload: { id: 'id' },
+    }),
+  ).toEqual([{ id: 'id2' }]);
 });

--- a/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
+++ b/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
@@ -21,26 +21,26 @@ import { Icons } from '@superset-ui/core/components';
 import { ModalTitleWithIcon } from '.';
 
 describe('ModalTitleWithIcon', () => {
-  it('renders the title without icon if none is passed and isEditMode is undefined', () => {
+  test('renders the title without icon if none is passed and isEditMode is undefined', () => {
     render(<ModalTitleWithIcon title="My Title" />);
     expect(screen.getByText('My Title')).toBeInTheDocument();
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
-  it('renders Edit icon if isEditMode is true', () => {
+  test('renders Edit icon if isEditMode is true', () => {
     render(<ModalTitleWithIcon title="Edit Mode" isEditMode />);
     expect(screen.getByText('Edit Mode')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /edit/i })).toBeInTheDocument();
   });
 
-  it('renders Plus icon if isEditMode is false', () => {
+  test('renders Plus icon if isEditMode is false', () => {
     render(<ModalTitleWithIcon title="Add Mode" isEditMode={false} />);
     expect(screen.getByText('Add Mode')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: /plus/i })).toBeInTheDocument();
   });
 
-  it('renders custom icon when passed explicitly', () => {
+  test('renders custom icon when passed explicitly', () => {
     render(
       <ModalTitleWithIcon
         title="Custom Icon"
@@ -51,7 +51,7 @@ describe('ModalTitleWithIcon', () => {
     expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
   });
 
-  it('respects the level prop (e.g., renders h3 for level=3)', () => {
+  test('respects the level prop (e.g., renders h3 for level=3)', () => {
     const { container } = render(
       <ModalTitleWithIcon title="Header Level 3" level={3} />,
     );

--- a/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
+++ b/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
@@ -20,41 +20,40 @@ import { render, screen } from 'spec/helpers/testing-library';
 import { Icons } from '@superset-ui/core/components';
 import { ModalTitleWithIcon } from '.';
 
-describe('ModalTitleWithIcon', () => {
-  test('renders the title without icon if none is passed and isEditMode is undefined', () => {
-    render(<ModalTitleWithIcon title="My Title" />);
-    expect(screen.getByText('My Title')).toBeInTheDocument();
+// ModalTitleWithIcon
+test('ModalTitleWithIcon renders the title without icon if none is passed and isEditMode is undefined', () => {
+  render(<ModalTitleWithIcon title="My Title" />);
+  expect(screen.getByText('My Title')).toBeInTheDocument();
 
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-  });
+  expect(screen.queryByRole('img')).not.toBeInTheDocument();
+});
 
-  test('renders Edit icon if isEditMode is true', () => {
-    render(<ModalTitleWithIcon title="Edit Mode" isEditMode />);
-    expect(screen.getByText('Edit Mode')).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /edit/i })).toBeInTheDocument();
-  });
+test('ModalTitleWithIcon renders Edit icon if isEditMode is true', () => {
+  render(<ModalTitleWithIcon title="Edit Mode" isEditMode />);
+  expect(screen.getByText('Edit Mode')).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: /edit/i })).toBeInTheDocument();
+});
 
-  test('renders Plus icon if isEditMode is false', () => {
-    render(<ModalTitleWithIcon title="Add Mode" isEditMode={false} />);
-    expect(screen.getByText('Add Mode')).toBeInTheDocument();
-    expect(screen.getByRole('img', { name: /plus/i })).toBeInTheDocument();
-  });
+test('ModalTitleWithIcon renders Plus icon if isEditMode is false', () => {
+  render(<ModalTitleWithIcon title="Add Mode" isEditMode={false} />);
+  expect(screen.getByText('Add Mode')).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: /plus/i })).toBeInTheDocument();
+});
 
-  test('renders custom icon when passed explicitly', () => {
-    render(
-      <ModalTitleWithIcon
-        title="Custom Icon"
-        icon={<Icons.DownOutlined data-test="custom-icon" />}
-      />,
-    );
-    expect(screen.getByText('Custom Icon')).toBeInTheDocument();
-    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
-  });
+test('ModalTitleWithIcon renders custom icon when passed explicitly', () => {
+  render(
+    <ModalTitleWithIcon
+      title="Custom Icon"
+      icon={<Icons.DownOutlined data-test="custom-icon" />}
+    />,
+  );
+  expect(screen.getByText('Custom Icon')).toBeInTheDocument();
+  expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+});
 
-  test('respects the level prop (e.g., renders h3 for level=3)', () => {
-    const { container } = render(
-      <ModalTitleWithIcon title="Header Level 3" level={3} />,
-    );
-    expect(container.querySelector('h3')).toHaveTextContent('Header Level 3');
-  });
+test('ModalTitleWithIcon respects the level prop (e.g., renders h3 for level=3)', () => {
+  const { container } = render(
+    <ModalTitleWithIcon title="Header Level 3" level={3} />,
+  );
+  expect(container.querySelector('h3')).toHaveTextContent('Header Level 3');
 });

--- a/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
+++ b/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
@@ -26,6 +26,7 @@ import useStoredSidebarWidth from './useStoredSidebarWidth';
 
 const INITIAL_WIDTH = 300;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useStoredSidebarWidth', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
+++ b/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
@@ -35,7 +35,7 @@ describe('useStoredSidebarWidth', () => {
     localStorage.clear();
   });
 
-  it('returns a default filterBar width by initialWidth', () => {
+  test('returns a default filterBar width by initialWidth', () => {
     const id = '123';
     const { result } = renderHook(() =>
       useStoredSidebarWidth(id, INITIAL_WIDTH),
@@ -45,7 +45,7 @@ describe('useStoredSidebarWidth', () => {
     expect(actualWidth).toEqual(INITIAL_WIDTH);
   });
 
-  it('returns a stored filterBar width from localStorage', () => {
+  test('returns a stored filterBar width from localStorage', () => {
     const id = '123';
     const expectedWidth = 378;
     setItem(LocalStorageKeys.CommonResizableSidebarWidths, {
@@ -61,7 +61,7 @@ describe('useStoredSidebarWidth', () => {
     expect(actualWidth).not.toEqual(250);
   });
 
-  it('returns a setter for filterBar width that stores the state in localStorage together', () => {
+  test('returns a setter for filterBar width that stores the state in localStorage together', () => {
     const id = '123';
     const expectedWidth = 378;
     const otherDashboardId = '456';

--- a/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
+++ b/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
@@ -46,7 +46,7 @@ describe('SQLEditorWithValidation', () => {
     jest.clearAllMocks();
   });
 
-  it('renders SQLEditor with validation bar when showValidation is true', () => {
+  test('renders SQLEditor with validation bar when showValidation is true', () => {
     render(<SQLEditorWithValidation {...defaultProps} />);
 
     expect(screen.getByText('Unverified')).toBeInTheDocument();
@@ -55,7 +55,7 @@ describe('SQLEditorWithValidation', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not render validation bar when showValidation is false', () => {
+  test('does not render validation bar when showValidation is false', () => {
     render(
       <SQLEditorWithValidation {...defaultProps} showValidation={false} />,
     );
@@ -66,7 +66,7 @@ describe('SQLEditorWithValidation', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows primary button style when unverified', () => {
+  test('shows primary button style when unverified', () => {
     render(<SQLEditorWithValidation {...defaultProps} />);
 
     const validateButton = screen.getByRole('button', {
@@ -76,7 +76,7 @@ describe('SQLEditorWithValidation', () => {
     // Button should have primary styling (this would need to check actual class or style)
   });
 
-  it('disables validate button when no value or datasourceId', () => {
+  test('disables validate button when no value or datasourceId', () => {
     render(
       <SQLEditorWithValidation
         {...defaultProps}
@@ -91,7 +91,7 @@ describe('SQLEditorWithValidation', () => {
     expect(validateButton).toBeDisabled();
   });
 
-  it('shows validating state when validation is in progress', async () => {
+  test('shows validating state when validation is in progress', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -117,7 +117,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('shows success state when validation passes', async () => {
+  test('shows success state when validation passes', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -138,7 +138,7 @@ describe('SQLEditorWithValidation', () => {
     expect(validateButton).toBeInTheDocument();
   });
 
-  it('shows error state when validation fails', async () => {
+  test('shows error state when validation fails', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -169,7 +169,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('handles API errors gracefully', async () => {
+  test('handles API errors gracefully', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -189,7 +189,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('sends correct payload for column expression', async () => {
+  test('sends correct payload for column expression', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -221,7 +221,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('sends correct payload for WHERE expression', async () => {
+  test('sends correct payload for WHERE expression', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -252,7 +252,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('sends correct payload for HAVING expression', async () => {
+  test('sends correct payload for HAVING expression', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;
@@ -283,7 +283,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('resets validation state when value changes', () => {
+  test('resets validation state when value changes', () => {
     const { rerender } = render(<SQLEditorWithValidation {...defaultProps} />);
 
     // Simulate having a validation result
@@ -304,7 +304,7 @@ describe('SQLEditorWithValidation', () => {
     expect(screen.getByText('Unverified')).toBeInTheDocument();
   });
 
-  it('calls onChange when editor value changes', () => {
+  test('calls onChange when editor value changes', () => {
     const onChange = jest.fn();
     render(<SQLEditorWithValidation {...defaultProps} onChange={onChange} />);
 
@@ -313,7 +313,7 @@ describe('SQLEditorWithValidation', () => {
     expect(onChange).toBeDefined();
   });
 
-  it('calls onValidationComplete callback when provided', async () => {
+  test('calls onValidationComplete callback when provided', async () => {
     const onValidationComplete = jest.fn();
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
@@ -337,7 +337,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('calls onValidationComplete with errors when validation fails', async () => {
+  test('calls onValidationComplete with errors when validation fails', async () => {
     const onValidationComplete = jest.fn();
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
@@ -371,7 +371,7 @@ describe('SQLEditorWithValidation', () => {
     });
   });
 
-  it('shows tooltip with full error message when error is truncated', async () => {
+  test('shows tooltip with full error message when error is truncated', async () => {
     const longErrorMessage =
       'This is a very long error message that should be truncated in the display but shown in full in the tooltip when user hovers over it';
 
@@ -410,7 +410,7 @@ describe('SQLEditorWithValidation', () => {
     expect(errorElement.parentElement).toBeTruthy();
   });
 
-  it('handles empty response gracefully', async () => {
+  test('handles empty response gracefully', async () => {
     const mockPost = SupersetClient.post as jest.MockedFunction<
       typeof SupersetClient.post
     >;

--- a/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
+++ b/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
@@ -41,6 +41,7 @@ const defaultProps = {
   datasourceType: 'table',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SQLEditorWithValidation', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/components/Tag/utils.test.tsx
+++ b/superset-frontend/src/components/Tag/utils.test.tsx
@@ -20,6 +20,7 @@ import fetchMock from 'fetch-mock';
 import rison from 'rison';
 import { tagToSelectOption, loadTags } from 'src/components/Tag/utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('tagToSelectOption', () => {
   test('converts a Tag object with table_name to a SelectTagsValue', () => {
     const tag = {
@@ -38,6 +39,7 @@ describe('tagToSelectOption', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('loadTags', () => {
   beforeEach(() => {
     fetchMock.reset();

--- a/superset-frontend/src/components/TagsList/TagsList.test.tsx
+++ b/superset-frontend/src/components/TagsList/TagsList.test.tsx
@@ -79,6 +79,7 @@ test('should render 3 elements when maxTags is set to 3', async () => {
   expect(tagsListItems[2]).toHaveTextContent('+3...');
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Tag type filtering', () => {
   test('should render only custom type tags (type: 1)', async () => {
     const mixedTypeTags = [

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
@@ -86,7 +86,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('updateComponents', () => {
-    it('should dispatch an updateLayout action', () => {
+    test('should dispatch an updateLayout action', () => {
       const { getState, dispatch } = setup();
       const nextComponents = { 1: {} };
       const thunk = updateComponents(nextComponents);
@@ -101,7 +101,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(0);
     });
 
-    it('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -116,7 +116,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('deleteComponents', () => {
-    it('should dispatch an deleteComponent action', () => {
+    test('should dispatch an deleteComponent action', () => {
       const { getState, dispatch } = setup();
       const thunk = deleteComponent('id', 'parentId');
       thunk(dispatch, getState);
@@ -129,7 +129,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -143,7 +143,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('updateDashboardTitle', () => {
-    it('should dispatch an updateComponent action for the header component', () => {
+    test('should dispatch an updateComponent action for the header component', () => {
       const { getState, dispatch } = setup();
       const thunk1 = updateDashboardTitle('new text');
       thunk1(dispatch, getState);
@@ -168,7 +168,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('createTopLevelTabs', () => {
-    it('should dispatch a createTopLevelTabs action', () => {
+    test('should dispatch a createTopLevelTabs action', () => {
       const { getState, dispatch } = setup();
       const dropResult = {};
       const thunk = createTopLevelTabs(dropResult);
@@ -182,7 +182,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -197,7 +197,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('deleteTopLevelTabs', () => {
-    it('should dispatch a deleteTopLevelTabs action', () => {
+    test('should dispatch a deleteTopLevelTabs action', () => {
       const { getState, dispatch } = setup();
       const dropResult = {};
       const thunk = deleteTopLevelTabs(dropResult);
@@ -211,7 +211,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -240,7 +240,7 @@ describe('dashboardLayout actions', () => {
       },
     };
 
-    it('should update the size of the component', () => {
+    test('should update the size of the component', () => {
       const { getState, dispatch } = setup({
         dashboardLayout,
       });
@@ -271,7 +271,7 @@ describe('dashboardLayout actions', () => {
       expect(dispatch.callCount).toBe(2);
     });
 
-    it('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
         dashboardLayout,
@@ -290,7 +290,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('handleComponentDrop', () => {
-    it('should create a component if it is new', () => {
+    test('should create a component if it is new', () => {
       const { getState, dispatch } = setup();
       const dropResult = {
         source: { id: NEW_COMPONENTS_SOURCE_ID },
@@ -315,7 +315,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should move a component if the component is not new', () => {
+    test('should move a component if the component is not new', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: {
           // if 'dragging' is not only child will dispatch deleteComponent thunk
@@ -345,7 +345,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should dispatch a toast if the drop overflows the destination', () => {
+    test('should dispatch a toast if the drop overflows the destination', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: {
           present: {
@@ -374,7 +374,7 @@ describe('dashboardLayout actions', () => {
       expect(dispatch.callCount).toBe(1);
     });
 
-    it('should delete a parent Row or Tabs if the moved child was the only child', () => {
+    test('should delete a parent Row or Tabs if the moved child was the only child', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: {
           present: {
@@ -411,7 +411,7 @@ describe('dashboardLayout actions', () => {
       });
     });
 
-    it('should create top-level tabs if dropped on root', () => {
+    test('should create top-level tabs if dropped on root', () => {
       const { getState, dispatch } = setup();
       const dropResult = {
         source: { id: NEW_COMPONENTS_SOURCE_ID },
@@ -433,7 +433,7 @@ describe('dashboardLayout actions', () => {
       });
     });
 
-    it('should dispatch a toast if drop top-level tab into nested tab', () => {
+    test('should dispatch a toast if drop top-level tab into nested tab', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: {
           present: {
@@ -489,7 +489,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('undoLayoutAction', () => {
-    it('should dispatch a redux-undo .undo() action', () => {
+    test('should dispatch a redux-undo .undo() action', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: { past: ['non-empty'] },
       });
@@ -500,7 +500,7 @@ describe('dashboardLayout actions', () => {
       expect(dispatch.getCall(0).args[0]).toEqual(UndoActionCreators.undo());
     });
 
-    it('should dispatch a setUnsavedChanges(false) action history length is zero', () => {
+    test('should dispatch a setUnsavedChanges(false) action history length is zero', () => {
       const { getState, dispatch } = setup({
         dashboardLayout: { past: [] },
       });
@@ -513,7 +513,7 @@ describe('dashboardLayout actions', () => {
   });
 
   describe('redoLayoutAction', () => {
-    it('should dispatch a redux-undo .redo() action', () => {
+    test('should dispatch a redux-undo .redo() action', () => {
       const { getState, dispatch } = setup();
       const thunk = redoLayoutAction();
       thunk(dispatch, getState);
@@ -524,7 +524,7 @@ describe('dashboardLayout actions', () => {
       expect(dashboardFilters.updateLayoutComponents.callCount).toEqual(1);
     });
 
-    it('should dispatch a setUnsavedChanges(true) action if hasUnsavedChanges=false', () => {
+    test('should dispatch a setUnsavedChanges(true) action if hasUnsavedChanges=false', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
@@ -58,6 +58,7 @@ import {
   NEW_ROW_ID,
 } from 'src/dashboard/util/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dashboardLayout actions', () => {
   const mockState = {
     dashboardState: {
@@ -85,6 +86,7 @@ describe('dashboardLayout actions', () => {
     dashboardFilters.updateLayoutComponents.restore();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('updateComponents', () => {
     test('should dispatch an updateLayout action', () => {
       const { getState, dispatch } = setup();
@@ -115,6 +117,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('deleteComponents', () => {
     test('should dispatch an deleteComponent action', () => {
       const { getState, dispatch } = setup();
@@ -142,6 +145,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('updateDashboardTitle', () => {
     test('should dispatch an updateComponent action for the header component', () => {
       const { getState, dispatch } = setup();
@@ -167,6 +171,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('createTopLevelTabs', () => {
     test('should dispatch a createTopLevelTabs action', () => {
       const { getState, dispatch } = setup();
@@ -196,6 +201,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('deleteTopLevelTabs', () => {
     test('should dispatch a deleteTopLevelTabs action', () => {
       const { getState, dispatch } = setup();
@@ -225,6 +231,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('resizeComponent', () => {
     const dashboardLayout = {
       ...mockState.dashboardLayout,
@@ -289,6 +296,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('handleComponentDrop', () => {
     test('should create a component if it is new', () => {
       const { getState, dispatch } = setup();
@@ -488,6 +496,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('undoLayoutAction', () => {
     test('should dispatch a redux-undo .undo() action', () => {
       const { getState, dispatch } = setup({
@@ -512,6 +521,7 @@ describe('dashboardLayout actions', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('redoLayoutAction', () => {
     test('should dispatch a redux-undo .redo() action', () => {
       const { getState, dispatch } = setup();

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -102,7 +102,7 @@ describe('dashboardState actions', () => {
   }
 
   describe('saveDashboardRequest', () => {
-    it('should dispatch UPDATE_COMPONENTS_PARENTS_LIST action', () => {
+    test('should dispatch UPDATE_COMPONENTS_PARENTS_LIST action', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -115,7 +115,7 @@ describe('dashboardState actions', () => {
       expect(dispatch.getCall(1).args[0].type).toBe(SAVE_DASHBOARD_STARTED);
     });
 
-    it('should post dashboard data with updated redux state', () => {
+    test('should post dashboard data with updated redux state', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
       });
@@ -155,7 +155,7 @@ describe('dashboardState actions', () => {
         isFeatureEnabled.mockRestore();
       });
 
-      it('dispatches SET_OVERRIDE_CONFIRM when an inspect value has diff', async () => {
+      test('dispatches SET_OVERRIDE_CONFIRM when an inspect value has diff', async () => {
         const id = 192;
         const { getState, dispatch } = setup();
         const thunk = saveDashboardRequest(
@@ -174,7 +174,7 @@ describe('dashboardState actions', () => {
         ).toBe(id);
       });
 
-      it('should post dashboard data with after confirm the overwrite values', async () => {
+      test('should post dashboard data with after confirm the overwrite values', async () => {
         const id = 192;
         const { getState, dispatch } = setup();
         const confirmedDashboardData = {

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -43,6 +43,7 @@ jest.mock('@superset-ui/core', () => ({
   isFeatureEnabled: jest.fn(),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dashboardState actions', () => {
   const mockState = {
     dashboardState: {
@@ -101,6 +102,7 @@ describe('dashboardState actions', () => {
     return { getState, dispatch, state };
   }
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('saveDashboardRequest', () => {
     test('should dispatch UPDATE_COMPONENTS_PARENTS_LIST action', () => {
       const { getState, dispatch } = setup({
@@ -144,6 +146,7 @@ describe('dashboardState actions', () => {
       ).toStrictEqual(mockParentsList);
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('FeatureFlag.CONFIRM_DASHBOARD_DIFF', () => {
       beforeEach(() => {
         isFeatureEnabled.mockImplementation(

--- a/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
+++ b/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
@@ -30,7 +30,7 @@ describe('AnchorLink', () => {
     window.location = globalLocation;
   });
 
-  it('should scroll the AnchorLink into view upon mount if id matches hash', async () => {
+  test('should scroll the AnchorLink into view upon mount if id matches hash', async () => {
     const callback = jest.fn();
     jest.spyOn(document, 'getElementById').mockReturnValue({
       scrollIntoView: callback,
@@ -49,7 +49,7 @@ describe('AnchorLink', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it('should render anchor link without short link button', () => {
+  test('should render anchor link without short link button', () => {
     const { container, queryByRole } = render(
       <AnchorLink showShortLinkButton={false} {...props} />,
       { useRedux: true },
@@ -58,7 +58,7 @@ describe('AnchorLink', () => {
     expect(queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('should render short link button', () => {
+  test('should render short link button', () => {
     const { getByRole } = render(
       <AnchorLink {...props} showShortLinkButton />,
       { useRedux: true },

--- a/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
+++ b/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
@@ -19,6 +19,7 @@
 import { render, act } from 'spec/helpers/testing-library';
 import AnchorLink from 'src/dashboard/components/AnchorLink';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AnchorLink', () => {
   const props = {
     id: 'CHART-123',

--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -91,7 +91,7 @@ describe('Dashboard', () => {
     jest.clearAllMocks();
   });
 
-  it('should render the children component', () => {
+  test('should render the children component', () => {
     renderDashboard();
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
@@ -102,7 +102,7 @@ describe('Dashboard', () => {
       1001: newComponentFactory(CHART_TYPE, { chartId: 1001 }),
     };
 
-    it('should call addSliceToDashboard if a new slice is added to the layout', () => {
+    test('should call addSliceToDashboard if a new slice is added to the layout', () => {
       const { rerender } = renderDashboard();
 
       rerender(
@@ -116,7 +116,7 @@ describe('Dashboard', () => {
       expect(mockAddSlice).toHaveBeenCalled();
     });
 
-    it('should call removeSliceFromDashboard if a slice is removed from the layout', () => {
+    test('should call removeSliceFromDashboard if a slice is removed from the layout', () => {
       const { rerender } = renderDashboard({ layout: layoutWithExtraChart });
 
       const nextLayout = { ...layoutWithExtraChart };
@@ -135,7 +135,7 @@ describe('Dashboard', () => {
   });
 
   describe('filter updates', () => {
-    it('should not call refresh when in editMode', () => {
+    test('should not call refresh when in editMode', () => {
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
       rerender(
@@ -156,7 +156,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).not.toHaveBeenCalled();
     });
 
-    it('should not call refresh when there is no change', () => {
+    test('should not call refresh when there is no change', () => {
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
       rerender(
@@ -170,7 +170,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).not.toHaveBeenCalled();
     });
 
-    it('should call refresh when native filters changed', () => {
+    test('should call refresh when native filters changed', () => {
       getRelatedCharts.mockReturnValue([230]);
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -195,7 +195,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalled();
     });
 
-    it('should call refresh if a filter is added', () => {
+    test('should call refresh if a filter is added', () => {
       getRelatedCharts.mockReturnValue([1]);
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -214,7 +214,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalled();
     });
 
-    it('should call refresh if a filter is removed', () => {
+    test('should call refresh if a filter is removed', () => {
       getRelatedCharts.mockReturnValue([1]); // Ensure we return some charts to refresh
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -233,7 +233,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalledWith(true, 1);
     });
 
-    it('should call refresh if a filter is changed', () => {
+    test('should call refresh if a filter is changed', () => {
       getRelatedCharts.mockReturnValue([1]);
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -253,7 +253,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalled();
     });
 
-    it('should call refresh with multiple chart ids', () => {
+    test('should call refresh with multiple chart ids', () => {
       getRelatedCharts.mockReturnValue([1, 2]);
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -273,7 +273,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalled();
     });
 
-    it('should call refresh if a filter scope is changed', () => {
+    test('should call refresh if a filter scope is changed', () => {
       getRelatedCharts.mockReturnValue([2]);
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });
 
@@ -293,7 +293,7 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).toHaveBeenCalled();
     });
 
-    it('should call refresh with empty [] if a filter is changed but scope is not applicable', () => {
+    test('should call refresh with empty [] if a filter is changed but scope is not applicable', () => {
       getRelatedCharts.mockReturnValue([]);
       const { rerender } = renderDashboard({
         activeFilters: OVERRIDE_FILTERS,

--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -39,6 +39,7 @@ import { getRelatedCharts } from 'src/dashboard/util/getRelatedCharts';
 
 jest.mock('src/dashboard/util/getRelatedCharts');
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Dashboard', () => {
   const mockAddSlice = jest.fn();
   const mockRemoveSlice = jest.fn();
@@ -96,6 +97,7 @@ describe('Dashboard', () => {
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('layout changes', () => {
     const layoutWithExtraChart = {
       ...props.layout,
@@ -134,6 +136,7 @@ describe('Dashboard', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('filter updates', () => {
     test('should not call refresh when in editMode', () => {
       const { rerender } = renderDashboard({ activeFilters: OVERRIDE_FILTERS });

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -83,6 +83,7 @@ jest.mock('src/dashboard/containers/DashboardGrid', () => () => (
   <div data-test="mock-dashboard-grid" />
 ));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardBuilder', () => {
   let favStarStub: jest.Mock;
   let activeTabsStub: jest.Mock;

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -120,13 +120,13 @@ describe('DashboardBuilder', () => {
     });
   }
 
-  it('should render a StickyContainer with class "dashboard"', () => {
+  test('should render a StickyContainer with class "dashboard"', () => {
     const { getByTestId } = setup();
     const stickyContainer = getByTestId('dashboard-content-wrapper');
     expect(stickyContainer).toHaveClass('dashboard');
   });
 
-  it('should add the "dashboard--editing" class if editMode=true', () => {
+  test('should add the "dashboard--editing" class if editMode=true', () => {
     const { getByTestId } = setup({
       dashboardState: { ...mockState.dashboardState, editMode: true },
     });
@@ -134,13 +134,13 @@ describe('DashboardBuilder', () => {
     expect(stickyContainer).toHaveClass('dashboard dashboard--editing');
   });
 
-  it('should render a DragDroppable DashboardHeader', () => {
+  test('should render a DragDroppable DashboardHeader', () => {
     const { queryByTestId } = setup();
     const header = queryByTestId('dashboard-header-container');
     expect(header).toBeInTheDocument();
   });
 
-  it('should render a Sticky top-level Tabs if the dashboard has tabs', async () => {
+  test('should render a Sticky top-level Tabs if the dashboard has tabs', async () => {
     const { findAllByTestId } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,
     });
@@ -162,7 +162,7 @@ describe('DashboardBuilder', () => {
     });
   });
 
-  it('should render one Tabs and two TabPane', async () => {
+  test('should render one Tabs and two TabPane', async () => {
     const { findAllByRole } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,
     });
@@ -172,7 +172,7 @@ describe('DashboardBuilder', () => {
     expect(tabPanels.length).toBe(2);
   });
 
-  it('should render a TabPane and DashboardGrid for first Tab', async () => {
+  test('should render a TabPane and DashboardGrid for first Tab', async () => {
     const { findByTestId } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,
     });
@@ -188,7 +188,7 @@ describe('DashboardBuilder', () => {
     ).toBe(1);
   });
 
-  it('should render a TabPane and DashboardGrid for second Tab', async () => {
+  test('should render a TabPane and DashboardGrid for second Tab', async () => {
     const { findByTestId } = setup({
       dashboardLayout: undoableDashboardLayoutWithTabs,
       dashboardState: {
@@ -209,13 +209,13 @@ describe('DashboardBuilder', () => {
     ).toBe(1);
   });
 
-  it('should render a BuilderComponentPane if editMode=false and user selects "Insert Components" pane', () => {
+  test('should render a BuilderComponentPane if editMode=false and user selects "Insert Components" pane', () => {
     const { queryAllByTestId } = setup();
     const builderComponents = queryAllByTestId('mock-builder-component-pane');
     expect(builderComponents.length).toBe(0);
   });
 
-  it('should render a BuilderComponentPane if editMode=true and user selects "Insert Components" pane', () => {
+  test('should render a BuilderComponentPane if editMode=true and user selects "Insert Components" pane', () => {
     const { queryAllByTestId } = setup({
       dashboardState: { ...mockState.dashboardState, editMode: true },
     });
@@ -223,7 +223,7 @@ describe('DashboardBuilder', () => {
     expect(builderComponents.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('should change redux state if a top-level Tab is clicked', async () => {
+  test('should change redux state if a top-level Tab is clicked', async () => {
     (setDirectPathToChild as jest.Mock).mockImplementation(arg0 => ({
       type: 'type',
       arg0,
@@ -243,13 +243,13 @@ describe('DashboardBuilder', () => {
     (setDirectPathToChild as jest.Mock).mockReset();
   });
 
-  it('should not display a loading spinner when saving is not in progress', () => {
+  test('should not display a loading spinner when saving is not in progress', () => {
     const { queryByTestId } = setup();
 
     expect(queryByTestId('loading-indicator')).not.toBeInTheDocument();
   });
 
-  it('should display a loading spinner when saving is in progress', async () => {
+  test('should display a loading spinner when saving is in progress', async () => {
     const { findByTestId } = setup({
       dashboardState: { ...mockState.dashboardState, dashboardIsSaving: true },
     });
@@ -257,7 +257,7 @@ describe('DashboardBuilder', () => {
     expect(await findByTestId('loading-indicator')).toBeVisible();
   });
 
-  it('should set FilterBar width by useStoredSidebarWidth', () => {
+  test('should set FilterBar width by useStoredSidebarWidth', () => {
     const expectedValue = 200;
     const setter = jest.fn();
     (useStoredSidebarWidth as jest.Mock).mockImplementation(() => [
@@ -274,7 +274,7 @@ describe('DashboardBuilder', () => {
     expect(filterbar).toHaveStyleRule('width', `${expectedValue}px`);
   });
 
-  it('filter panel state when featureflag is true', () => {
+  test('filter panel state when featureflag is true', () => {
     window.featureFlags = {
       [FeatureFlag.FilterBarClosedByDefault]: true,
     };
@@ -294,7 +294,7 @@ describe('DashboardBuilder', () => {
     expect(filterbar).toHaveStyleRule('width', `${CLOSED_FILTER_BAR_WIDTH}px`);
   });
 
-  it('filter panel state when featureflag is false', () => {
+  test('filter panel state when featureflag is false', () => {
     window.featureFlags = {
       [FeatureFlag.FilterBarClosedByDefault]: false,
     };
@@ -314,7 +314,7 @@ describe('DashboardBuilder', () => {
     expect(filterbar).toHaveStyleRule('width', `${OPEN_FILTER_BAR_WIDTH}px`);
   });
 
-  it('should not render the filter bar when nativeFiltersEnabled is false', () => {
+  test('should not render the filter bar when nativeFiltersEnabled is false', () => {
     jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
       showDashboard: true,
       missingInitialFilters: [],
@@ -327,7 +327,7 @@ describe('DashboardBuilder', () => {
     expect(queryByTestId('dashboard-filters-panel')).not.toBeInTheDocument();
   });
 
-  it('should render the filter bar when nativeFiltersEnabled is true and not in edit mode', () => {
+  test('should render the filter bar when nativeFiltersEnabled is true and not in edit mode', () => {
     jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
       showDashboard: true,
       missingInitialFilters: [],
@@ -340,7 +340,7 @@ describe('DashboardBuilder', () => {
     expect(queryByTestId('dashboard-filters-panel')).toBeInTheDocument();
   });
 
-  it('should not render the filter bar when in edit mode even if nativeFiltersEnabled is true', () => {
+  test('should not render the filter bar when in edit mode even if nativeFiltersEnabled is true', () => {
     jest.spyOn(useNativeFiltersModule, 'useNativeFilters').mockReturnValue({
       showDashboard: true,
       missingInitialFilters: [],

--- a/superset-frontend/src/dashboard/components/FiltersBadge/FiltersBadge.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/FiltersBadge.test.tsx
@@ -54,6 +54,7 @@ buildActiveFilters({
   components: dashboardWithFilter,
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('for dashboard filters', () => {
   test('does not show number when there are no active filters', () => {
     const store = getMockStoreWithFilters();
@@ -96,6 +97,7 @@ describe('for dashboard filters', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('for native filters', () => {
   test('does not show number when there are no active filters', () => {
     const store = getMockStoreWithNativeFilters();

--- a/superset-frontend/src/dashboard/components/MissingChart.test.tsx
+++ b/superset-frontend/src/dashboard/components/MissingChart.test.tsx
@@ -28,6 +28,7 @@ const setup = (overrides?: MissingChartProps) => (
   <MissingChart height={100} {...overrides} />
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('MissingChart', () => {
   test('renders a .missing-chart-container', () => {
     const rendered = render(setup());

--- a/superset-frontend/src/dashboard/components/MissingChart.test.tsx
+++ b/superset-frontend/src/dashboard/components/MissingChart.test.tsx
@@ -29,7 +29,7 @@ const setup = (overrides?: MissingChartProps) => (
 );
 
 describe('MissingChart', () => {
-  it('renders a .missing-chart-container', () => {
+  test('renders a .missing-chart-container', () => {
     const rendered = render(setup());
 
     const missingChartContainer = rendered.container.querySelector(
@@ -38,7 +38,7 @@ describe('MissingChart', () => {
     expect(missingChartContainer).toBeVisible();
   });
 
-  it('renders a .missing-chart-body', () => {
+  test('renders a .missing-chart-body', () => {
     const rendered = render(setup());
 
     const missingChartBody = rendered.container.querySelector(

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -180,6 +180,7 @@ afterAll(() => {
   fetchMock.restore();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('PropertiesModal', () => {
   jest.setTimeout(60000); // Increased timeout for complex modal rendering
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/StylingSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/StylingSection.test.tsx
@@ -157,6 +157,7 @@ test('displays current color scheme value', () => {
 });
 
 // CSS Template Tests
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('CSS Template functionality', () => {
   test('does not show CSS template select when feature flag is disabled', () => {
     mockIsFeatureEnabled.mockReturnValue(false);

--- a/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
@@ -82,28 +82,28 @@ describe('SliceAdder', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the create new chart button', () => {
+  test('renders the create new chart button', () => {
     renderSliceAdder();
     expect(screen.getByText('Create new chart')).toBeInTheDocument();
   });
 
-  it('renders loading state', () => {
+  test('renders loading state', () => {
     renderSliceAdder({ ...defaultProps, isLoading: true });
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('renders error message', () => {
+  test('renders error message', () => {
     const errorMessage = 'Error loading charts';
     renderSliceAdder({ ...defaultProps, errorMessage });
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
   });
 
-  it('fetches slices on mount', () => {
+  test('fetches slices on mount', () => {
     renderSliceAdder();
     expect(defaultProps.fetchSlices).toHaveBeenCalledWith(1, '', 'changed_on');
   });
 
-  it('handles search input changes', async () => {
+  test('handles search input changes', async () => {
     renderSliceAdder();
     const searchInput = screen.getByPlaceholderText('Filter your charts');
     await userEvent.type(searchInput, 'test search');
@@ -114,7 +114,7 @@ describe('SliceAdder', () => {
     );
   });
 
-  it('handles sort selection changes', async () => {
+  test('handles sort selection changes', async () => {
     renderSliceAdder();
     // Update selector to match the actual rendered element
     const sortSelect = screen.getByText('Sort by recent');
@@ -124,7 +124,7 @@ describe('SliceAdder', () => {
     expect(defaultProps.fetchSlices).toHaveBeenCalledWith(1, '', 'viz_type');
   });
 
-  it('handles show only my charts toggle', async () => {
+  test('handles show only my charts toggle', async () => {
     renderSliceAdder();
     const checkbox = screen.getByRole('checkbox');
     await userEvent.click(checkbox);
@@ -135,7 +135,7 @@ describe('SliceAdder', () => {
     );
   });
 
-  it('opens new chart in new tab when create new chart is clicked', () => {
+  test('opens new chart in new tab when create new chart is clicked', () => {
     const windowSpy = jest.spyOn(window, 'open').mockImplementation();
     renderSliceAdder();
     const createButton = screen.getByText('Create new chart');
@@ -170,7 +170,7 @@ describe('SliceAdder', () => {
       query_context: null,
     };
 
-    it('should sort by changed_on in descending order', () => {
+    test('should sort by changed_on in descending order', () => {
       const input = [
         {
           ...baseSlice,
@@ -198,7 +198,7 @@ describe('SliceAdder', () => {
       expect(sorted[2].changed_on).toBe(1577836800000);
     });
 
-    it('should sort by other fields in ascending order', () => {
+    test('should sort by other fields in ascending order', () => {
       const input = [
         {
           ...baseSlice,
@@ -228,7 +228,7 @@ describe('SliceAdder', () => {
     });
   });
 
-  it('should update selectedSliceIdsSet when props change', () => {
+  test('should update selectedSliceIdsSet when props change', () => {
     const { rerender } = renderSliceAdder();
     rerender(<SliceAdder {...defaultProps} selectedSliceIds={[129]} />);
     // Verify the internal state was updated by checking if new charts are available

--- a/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
@@ -77,6 +77,7 @@ const defaultProps: Omit<SliceAdderProps, 'theme'> = {
 const renderSliceAdder = (props = defaultProps) =>
   render(<SliceAdder {...props} />, { store: mockStore });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SliceAdder', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -148,6 +149,7 @@ describe('SliceAdder', () => {
     windowSpy.mockRestore();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('sortByComparator', () => {
     const baseSlice = {
       slice_url: '/superset/explore/',

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
@@ -60,7 +60,7 @@ describe('DragDroppable', () => {
     };
   }
 
-  it('should call its child function', () => {
+  test('should call its child function', () => {
     const renderChild = jest.fn(provided => (
       <div data-test="child-content" {...provided}>
         Test Content
@@ -76,7 +76,7 @@ describe('DragDroppable', () => {
     );
   });
 
-  it('should call its child function with "dragSourceRef" if editMode=true', () => {
+  test('should call its child function with "dragSourceRef" if editMode=true', () => {
     const renderChild = jest.fn().mockImplementation(provided => (
       <div data-test="child-content" {...provided}>
         Test Content
@@ -100,7 +100,7 @@ describe('DragDroppable', () => {
     );
   });
 
-  it('should call its child function with "dropIndicatorProps" dependent on editMode and isDraggingOver', () => {
+  test('should call its child function with "dropIndicatorProps" dependent on editMode and isDraggingOver', () => {
     const renderChild = jest.fn(provided => (
       <div data-test="child-content" {...provided}>
         Test Content
@@ -135,7 +135,7 @@ describe('DragDroppable', () => {
     });
   });
 
-  it('should call props.dragPreviewRef and props.droppableRef on mount', () => {
+  test('should call props.dragPreviewRef and props.droppableRef on mount', () => {
     const dragPreviewRef = jest.fn();
     const droppableRef = jest.fn();
 
@@ -144,7 +144,7 @@ describe('DragDroppable', () => {
     expect(droppableRef).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle forbidden drops correctly', () => {
+  test('should handle forbidden drops correctly', () => {
     const renderChild = jest.fn(provided => (
       <div data-test="child-content" {...provided}>
         Test Content
@@ -178,7 +178,7 @@ describe('DragDroppable', () => {
     });
   });
 
-  it('should handle orientation prop correctly', () => {
+  test('should handle orientation prop correctly', () => {
     const { container } = setup({ orientation: 'column' });
     expect(container.firstChild).toHaveClass('dragdroppable-column');
 
@@ -186,7 +186,7 @@ describe('DragDroppable', () => {
     expect(container2.firstChild).toHaveClass('dragdroppable-row');
   });
 
-  it('should handle disabled drag and drop', () => {
+  test('should handle disabled drag and drop', () => {
     const renderChild = jest.fn(provided => (
       <div data-test="child-content" {...provided}>
         Test Content
@@ -221,7 +221,7 @@ describe('DragDroppable', () => {
   });
 
   // Later in the file, remove the require and use the imported getEmptyImage
-  it('should handle empty drag preview correctly', () => {
+  test('should handle empty drag preview correctly', () => {
     const dragPreviewRef = jest.fn();
 
     setup({
@@ -237,7 +237,7 @@ describe('DragDroppable', () => {
     );
   });
 
-  it('should call onDropIndicatorChange when appropriate', () => {
+  test('should call onDropIndicatorChange when appropriate', () => {
     const onDropIndicatorChange = jest.fn();
     const { rerender } = setup({
       component: newComponentFactory(TAB_TYPE),

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
@@ -27,6 +27,7 @@ import {
 } from 'src/dashboard/util/componentTypes';
 import { UnwrappedDragDroppable as DragDroppable } from 'src/dashboard/components/dnd/DragDroppable';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DragDroppable', () => {
   const props = {
     component: newComponentFactory(CHART_TYPE),

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -110,7 +110,7 @@ describe('ChartHolder', () => {
       store,
     });
 
-  it('should render empty state', async () => {
+  test('should render empty state', async () => {
     renderWrapper();
 
     expect(
@@ -124,7 +124,7 @@ describe('ChartHolder', () => {
     expect(screen.getByRole('img', { name: 'empty' })).toBeVisible();
   });
 
-  it('should render anchor link when not editing', async () => {
+  test('should render anchor link when not editing', async () => {
     const store = createMockStore();
     const { rerender } = renderWrapper(store, { editMode: false });
 
@@ -155,7 +155,7 @@ describe('ChartHolder', () => {
     ).toEqual(0);
   });
 
-  it('should highlight when path matches', async () => {
+  test('should highlight when path matches', async () => {
     const store = createMockStore({
       dashboardState: {
         ...mockState.dashboardState,
@@ -202,7 +202,7 @@ describe('ChartHolder', () => {
     );
   });
 
-  it('should calculate the default widthMultiple', async () => {
+  test('should calculate the default widthMultiple', async () => {
     const widthMultiple = 5;
     renderWrapper(createMockStore(), {
       editMode: true,
@@ -231,7 +231,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(`${expectedWidth}px`);
   });
 
-  it('should set the resizable width to auto when parent component type is column', async () => {
+  test('should set the resizable width to auto when parent component type is column', async () => {
     renderWrapper(createMockStore(), {
       editMode: true,
       parentComponent: {
@@ -255,7 +255,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual('auto');
   });
 
-  it("should override the widthMultiple if there's a column in the parent chain whose width is less than the chart", async () => {
+  test("should override the widthMultiple if there's a column in the parent chain whose width is less than the chart", async () => {
     const widthMultiple = 10;
     const parentColumnWidth = 6;
     renderWrapper(createMockStore(), {
@@ -288,7 +288,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(`${expectedWidth}px`);
   });
 
-  it('should calculate the chartWidth', async () => {
+  test('should calculate the chartWidth', async () => {
     const widthMultiple = 7;
     const columnWidth = 250;
     renderWrapper(createMockStore(), {
@@ -319,7 +319,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(expectedWidth);
   });
 
-  it('should calculate the chartWidth on full screen mode', async () => {
+  test('should calculate the chartWidth on full screen mode', async () => {
     const widthMultiple = 7;
     const columnWidth = 250;
     renderWrapper(createMockStore(), {
@@ -345,7 +345,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(expectedWidth);
   });
 
-  it('should calculate the chartHeight', async () => {
+  test('should calculate the chartHeight', async () => {
     const heightMultiple = 12;
     renderWrapper(createMockStore(), {
       fullSizeChartId: null,
@@ -372,7 +372,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(expectedWidth);
   });
 
-  it('should calculate the chartHeight on full screen mode', async () => {
+  test('should calculate the chartHeight on full screen mode', async () => {
     const heightMultiple = 12;
     renderWrapper(createMockStore(), {
       component: {
@@ -397,7 +397,7 @@ describe('ChartHolder', () => {
     expect(computedWidth).toEqual(expectedWidth);
   });
 
-  it('should call deleteComponent when deleted', async () => {
+  test('should call deleteComponent when deleted', async () => {
     const deleteComponent = sinon.spy();
     const store = createMockStore();
     const { rerender } = renderWrapper(store, {

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -45,6 +45,7 @@ import { GRID_BASE_UNIT, GRID_GUTTER_SIZE } from '../../../util/constants';
 
 const DEFAULT_HEADER_HEIGHT = 22;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartHolder', () => {
   let scrollViewBase: any;
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
@@ -46,19 +46,19 @@ describe('Divider', () => {
       useDnd: true,
     });
 
-  it('should render a Draggable', () => {
+  test('should render a Draggable', () => {
     setup();
     expect(screen.getByTestId('dragdroppable-object')).toBeInTheDocument();
   });
 
-  it('should render a div with class "dashboard-component-divider"', () => {
+  test('should render a div with class "dashboard-component-divider"', () => {
     const { container } = setup();
     expect(
       container.querySelector('.dashboard-component-divider'),
     ).toBeInTheDocument();
   });
 
-  it('should render a HoverMenu with DeleteComponentButton in editMode', () => {
+  test('should render a HoverMenu with DeleteComponentButton in editMode', () => {
     setup();
     expect(screen.queryByTestId('hover-menu')).not.toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('Divider', () => {
     );
   });
 
-  it('should call deleteComponent when deleted', () => {
+  test('should call deleteComponent when deleted', () => {
     const deleteComponent = sinon.spy();
     setup({ editMode: true, deleteComponent });
     userEvent.click(screen.getByRole('button'));

--- a/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
@@ -26,6 +26,7 @@ import {
 import { screen, render, userEvent } from 'spec/helpers/testing-library';
 import Divider from './Divider';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Divider', () => {
   const props = {
     id: 'id',

--- a/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
@@ -132,6 +132,7 @@ const renderWithRedux = (component: React.ReactElement) =>
     },
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DynamicComponent', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
@@ -31,6 +31,7 @@ import {
 import { mockStoreWithTabs } from 'spec/fixtures/mockStore';
 import Header from './Header';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Header', () => {
   const props = {
     id: 'id',

--- a/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
@@ -57,17 +57,17 @@ describe('Header', () => {
     );
   }
 
-  it('should render a Draggable', () => {
+  test('should render a Draggable', () => {
     setup();
     expect(screen.getByTestId('dragdroppable-object')).toBeInTheDocument();
   });
 
-  it('should render a WithPopoverMenu', () => {
+  test('should render a WithPopoverMenu', () => {
     setup();
     expect(screen.getByRole('none')).toBeInTheDocument();
   });
 
-  it('should render a HoverMenu in editMode', () => {
+  test('should render a HoverMenu in editMode', () => {
     setup();
     expect(screen.queryByTestId('hover-menu')).not.toBeInTheDocument();
 
@@ -76,14 +76,14 @@ describe('Header', () => {
     expect(hoverMenus[0]).toBeInTheDocument();
   });
 
-  it('should render an EditableTitle with meta.text', () => {
+  test('should render an EditableTitle with meta.text', () => {
     setup();
     const titleElement = screen.getByTestId('editable-title');
     expect(titleElement).toBeInTheDocument();
     expect(titleElement).toHaveTextContent(props.component.meta.text);
   });
 
-  it('should call updateComponents when EditableTitle changes', () => {
+  test('should call updateComponents when EditableTitle changes', () => {
     const updateComponents = sinon.spy();
     setup({ editMode: true, updateComponents });
 
@@ -103,13 +103,13 @@ describe('Header', () => {
     );
   });
 
-  it('should render a DeleteComponentButton when focused in editMode', () => {
+  test('should render a DeleteComponentButton when focused in editMode', () => {
     setup({ editMode: true });
     const trashButton = screen.getByRole('img', { name: 'delete' });
     expect(trashButton).toBeInTheDocument();
   });
 
-  it('should call deleteComponent when deleted', () => {
+  test('should call deleteComponent when deleted', () => {
     const deleteComponent = sinon.spy();
     setup({ editMode: true, deleteComponent });
 
@@ -119,17 +119,17 @@ describe('Header', () => {
     expect(deleteComponent.callCount).toBe(1);
   });
 
-  it('should render the AnchorLink in view mode', () => {
+  test('should render the AnchorLink in view mode', () => {
     setup();
     expect(screen.getByTestId('anchor-link')).toBeInTheDocument();
   });
 
-  it('should not render the AnchorLink in edit mode', () => {
+  test('should not render the AnchorLink in edit mode', () => {
     setup({ editMode: true });
     expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
   });
 
-  it('should not render the AnchorLink in embedded mode', () => {
+  test('should not render the AnchorLink in embedded mode', () => {
     setup({ embeddedMode: true });
     expect(screen.queryByTestId('anchor-link')).not.toBeInTheDocument();
   });

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -81,12 +81,12 @@ describe('Markdown', () => {
     jest.clearAllMocks();
   });
 
-  it('should render the markdown component', async () => {
+  test('should render the markdown component', async () => {
     await setup();
     expect(screen.getByTestId('dashboard-markdown-editor')).toBeInTheDocument();
   });
 
-  it('should render the markdown content in preview mode by default', async () => {
+  test('should render the markdown content in preview mode by default', async () => {
     await setup();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(
@@ -94,7 +94,7 @@ describe('Markdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render editor when in edit mode and clicked', async () => {
+  test('should render editor when in edit mode and clicked', async () => {
     await setup({ editMode: true });
     const container = screen.getByTestId('dashboard-component-chart-holder');
     await act(async () => {
@@ -104,7 +104,7 @@ describe('Markdown', () => {
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
   });
 
-  it('should switch between edit and preview modes', async () => {
+  test('should switch between edit and preview modes', async () => {
     await setup({ editMode: true });
     const container = screen.getByTestId('dashboard-component-chart-holder');
 
@@ -129,7 +129,7 @@ describe('Markdown', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
-  it('should call updateComponents when switching from edit to preview with changes', async () => {
+  test('should call updateComponents when switching from edit to preview with changes', async () => {
     const updateComponents = jest.fn();
     const mockCode = 'new markdown!';
 
@@ -201,7 +201,7 @@ describe('Markdown', () => {
     });
   });
 
-  it('should show placeholder text when markdown is empty', async () => {
+  test('should show placeholder text when markdown is empty', async () => {
     await setup({
       component: {
         ...mockLayout.present.MARKDOWN_ID,
@@ -214,7 +214,7 @@ describe('Markdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('should handle markdown errors gracefully', async () => {
+  test('should handle markdown errors gracefully', async () => {
     const addDangerToast = jest.fn();
     const { container } = await setup({
       addDangerToast,
@@ -250,7 +250,7 @@ describe('Markdown', () => {
     });
   });
 
-  it('should resize editor when width changes', async () => {
+  test('should resize editor when width changes', async () => {
     const { rerender } = await setup({ editMode: true });
 
     await act(async () => {
@@ -278,7 +278,7 @@ describe('Markdown', () => {
     });
   });
 
-  it('should update content when undo/redo changes occur', async () => {
+  test('should update content when undo/redo changes occur', async () => {
     const { rerender } = await setup({
       editMode: true,
       component: {
@@ -305,7 +305,7 @@ describe('Markdown', () => {
     expect(screen.getByText('updated')).toBeInTheDocument();
   });
 
-  it('should adjust width based on parent type', async () => {
+  test('should adjust width based on parent type', async () => {
     const { rerender } = await setup();
 
     // Check ROW_TYPE width

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -22,6 +22,7 @@ import { mockStore } from 'spec/fixtures/mockStore';
 import { dashboardLayout as mockLayout } from 'spec/fixtures/mockDashboardLayout';
 import MarkdownConnected from './Markdown';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Markdown', () => {
   const props = {
     id: 'id',

--- a/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.jsx
@@ -202,6 +202,7 @@ test('should increment the depth of its children', () => {
   );
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('visibility handling for intersection observers', () => {
   const mockIntersectionObserver = jest.fn();
   const mockObserve = jest.fn();

--- a/superset-frontend/src/dashboard/components/gridComponents/TabsRenderer/TabsRenderer.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/TabsRenderer/TabsRenderer.test.tsx
@@ -48,6 +48,7 @@ const mockProps: TabsRendererProps = {
   tabBarPaddingLeft: 16,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TabsRenderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
@@ -25,6 +25,7 @@ import DraggableNewComponent from 'src/dashboard/components/gridComponents/new/D
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 
 // TODO: rewrite to rtl
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DraggableNewComponent', () => {
   const props = {
     id: 'id',

--- a/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
@@ -45,27 +45,27 @@ describe('DraggableNewComponent', () => {
     setup();
   });
 
-  it('should render a DragDroppable', () => {
+  test('should render a DragDroppable', () => {
     expect(screen.getByTestId('dragdroppable-object')).toBeInTheDocument();
   });
 
-  it('should pass component={ type, id } to DragDroppable', () => {
+  test('should pass component={ type, id } to DragDroppable', () => {
     const dragComponent = screen.getByTestId('dragdroppable-object');
     expect(dragComponent).toHaveClass(
       'dragdroppable dragdroppable--edit-mode dragdroppable-row',
     );
   });
 
-  it('should pass appropriate parent source and id to DragDroppable', () => {
+  test('should pass appropriate parent source and id to DragDroppable', () => {
     const dragComponent = screen.getByTestId('new-component');
     expect(dragComponent).toHaveAttribute('draggable', 'true');
   });
 
-  it('should render the passed label', () => {
+  test('should render the passed label', () => {
     expect(screen.getByText(props.label)).toBeInTheDocument();
   });
 
-  it('should add the passed className', () => {
+  test('should add the passed className', () => {
     const component = screen
       .getByTestId('new-component')
       .querySelector('.new-component-placeholder');

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -78,7 +78,7 @@ test('should apply', () => {
 });
 
 describe('custom width', () => {
-  it('sets its default width with OPEN_FILTER_BAR_WIDTH', () => {
+  test('sets its default width with OPEN_FILTER_BAR_WIDTH', () => {
     const mockedProps = createProps();
     render(<ActionButtons {...mockedProps} />, { useRedux: true });
     const container = screen.getByTestId('filterbar-action-buttons');
@@ -87,7 +87,7 @@ describe('custom width', () => {
     });
   });
 
-  it('sets custom width', () => {
+  test('sets custom width', () => {
     const mockedProps = createProps();
     const expectedWidth = 423;
     const { getByTestId } = render(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -77,6 +77,7 @@ test('should apply', () => {
   expect(mockedProps.onApply).toHaveBeenCalled();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('custom width', () => {
   test('sets its default width with OPEN_FILTER_BAR_WIDTH', () => {
     const mockedProps = createProps();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ChartsScopingListPanel.test.tsx
@@ -119,7 +119,7 @@ const setup = (props = DEFAULT_PROPS) =>
     initialState: INITIAL_STATE,
   });
 
-it('Renders charts scoping list panel', () => {
+test('Renders charts scoping list panel', () => {
   setup();
   expect(screen.getByText('Add custom scoping')).toBeVisible();
   expect(screen.getByText('All charts/global scoping')).toBeVisible();
@@ -131,7 +131,7 @@ it('Renders charts scoping list panel', () => {
   expect(screen.queryByText('[new custom scoping]')).not.toBeInTheDocument();
 });
 
-it('Renders custom scoping item', () => {
+test('Renders custom scoping item', () => {
   setup({
     ...DEFAULT_PROPS,
     activeChartId: -1,
@@ -158,7 +158,7 @@ it('Renders custom scoping item', () => {
   expect(screen.getByText('[new custom scoping]')).toHaveClass('active');
 });
 
-it('Uses callbacks on click', () => {
+test('Uses callbacks on click', () => {
   setup();
 
   userEvent.click(screen.getByText('Add custom scoping'));
@@ -177,7 +177,7 @@ it('Uses callbacks on click', () => {
   expect(DEFAULT_PROPS.removeCustomScope).toHaveBeenCalledWith(4);
 });
 
-it('Renders charts scoping list panel with FilterTitle rendered with role="button"', () => {
+test('Renders charts scoping list panel with FilterTitle rendered with role="button"', () => {
   setup();
   expect(screen.getByText('All charts/global scoping')).toBeVisible();
   expect(screen.getByText('All charts/global scoping')).toHaveAttribute(

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingModal.test.tsx
@@ -158,14 +158,14 @@ afterEach(() => {
   fetchMock.restore();
 });
 
-it('renders modal', () => {
+test('renders modal', () => {
   setup();
   expect(screen.getByRole('dialog')).toBeInTheDocument();
   expect(screen.getByTestId('scoping-tree-panel')).toBeInTheDocument();
   expect(screen.getByTestId('scoping-list-panel')).toBeInTheDocument();
 });
 
-it('switch currently edited chart scoping', async () => {
+test('switch currently edited chart scoping', async () => {
   setup();
   const withinScopingList = within(screen.getByTestId('scoping-list-panel'));
   expect(withinScopingList.getByText('All charts/global scoping')).toHaveClass(
@@ -180,7 +180,7 @@ it('switch currently edited chart scoping', async () => {
   });
 });
 
-it('scoping tree global and custom checks', () => {
+test('scoping tree global and custom checks', () => {
   setup();
 
   expect(
@@ -200,7 +200,7 @@ it('scoping tree global and custom checks', () => {
   ).toHaveLength(2);
 });
 
-it('add new custom scoping', async () => {
+test('add new custom scoping', async () => {
   setup();
 
   userEvent.click(screen.getByText('Add custom scoping'));
@@ -226,7 +226,7 @@ it('add new custom scoping', async () => {
   ).toHaveLength(2);
 });
 
-it('edit scope and save', async () => {
+test('edit scope and save', async () => {
   setup();
 
   // unselect chart 2 in global scoping

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -178,39 +178,39 @@ describe('FilterBar', () => {
       },
     );
 
-  it('should render', () => {
+  test('should render', () => {
     const { container } = renderWrapper();
     expect(container).toBeInTheDocument();
   });
 
-  it('should render the "Filters" heading', () => {
+  test('should render the "Filters" heading', () => {
     renderWrapper();
     expect(screen.getByText('Filters')).toBeInTheDocument();
   });
 
-  it('should render the "Clear all" option', () => {
+  test('should render the "Clear all" option', () => {
     renderWrapper();
     expect(screen.getByText('Clear all')).toBeInTheDocument();
   });
 
-  it('should render the "Apply filters" option', () => {
+  test('should render the "Apply filters" option', () => {
     renderWrapper();
     expect(screen.getByText('Apply filters')).toBeInTheDocument();
   });
 
-  it('should render the collapse icon', () => {
+  test('should render the collapse icon', () => {
     renderWrapper();
     expect(
       screen.getByRole('img', { name: 'vertical-align' }),
     ).toBeInTheDocument();
   });
 
-  it('should render the filter icon', () => {
+  test('should render the filter icon', () => {
     renderWrapper();
     expect(screen.getByRole('img', { name: 'filter' })).toBeInTheDocument();
   });
 
-  it('should toggle', () => {
+  test('should toggle', () => {
     renderWrapper();
     const collapse = screen.getByRole('img', {
       name: 'vertical-align',
@@ -220,7 +220,7 @@ describe('FilterBar', () => {
     expect(toggleFiltersBar).toHaveBeenCalled();
   });
 
-  it('open filter bar', () => {
+  test('open filter bar', () => {
     renderWrapper();
     expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
     expect(screen.getByTestId(getTestId('expand-button'))).toBeInTheDocument();
@@ -229,7 +229,7 @@ describe('FilterBar', () => {
     expect(toggleFiltersBar).toHaveBeenCalledWith(true);
   });
 
-  it('no edit filter button by disabled permissions', () => {
+  test('no edit filter button by disabled permissions', () => {
     renderWrapper(openedBarProps, {
       ...stateWithoutNativeFilters,
       dashboardInfo: { metadata: {} },
@@ -240,7 +240,7 @@ describe('FilterBar', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('close filter bar', () => {
+  test('close filter bar', () => {
     renderWrapper(openedBarProps);
     const collapseButton = screen.getByTestId(getTestId('collapse-button'));
 
@@ -250,14 +250,14 @@ describe('FilterBar', () => {
     expect(toggleFiltersBar).toHaveBeenCalledWith(false);
   });
 
-  it('no filters', () => {
+  test('no filters', () => {
     renderWrapper(openedBarProps, stateWithoutNativeFilters);
 
     expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
     expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   });
 
-  it('renders dividers', async () => {
+  test('renders dividers', async () => {
     const divider = {
       id: 'NATIVE_FILTER_DIVIDER-1',
       type: 'DIVIDER',
@@ -295,7 +295,7 @@ describe('FilterBar', () => {
     expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   });
 
-  it('create filter and apply it flow', async () => {
+  test('create filter and apply it flow', async () => {
     renderWrapper(openedBarProps, stateWithoutNativeFilters);
     expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 
@@ -304,7 +304,7 @@ describe('FilterBar', () => {
     expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   });
 
-  it('should render without errors with proper state setup', () => {
+  test('should render without errors with proper state setup', () => {
     const stateWithFilter = {
       ...stateWithoutNativeFilters,
       dashboardInfo: {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -89,6 +89,7 @@ const addFilterFlow = async () => {
   // await screen.findByText('All filters (1)');
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterBar', () => {
   new MainPreset().register();
   const toggleFiltersBar = jest.fn();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -24,7 +24,9 @@ import {
   checkIsMissingRequiredValue,
 } from './utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterBar Utils - Validation and Apply Logic', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('checkIsValidateError', () => {
     test('should return true when no filters have validation errors', () => {
       const dataMask: DataMaskStateWithId = {
@@ -89,6 +91,7 @@ describe('FilterBar Utils - Validation and Apply Logic', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('checkIsMissingRequiredValue', () => {
     test('should return true for required filter with undefined value', () => {
       const filter = {
@@ -165,6 +168,7 @@ describe('FilterBar Utils - Validation and Apply Logic', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('checkIsApplyDisabled', () => {
     test('should return true when filters have validation errors', () => {
       const dataMaskSelected: DataMaskStateWithId = {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
 const renderCollapsibleControl = (props = {}) =>
   render(<CollapsibleControl {...defaultProps} {...props} />);
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('CollapsibleControl', () => {
   test('renders title correctly', () => {
     const { getByRole } = renderCollapsibleControl();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
@@ -30,14 +30,14 @@ const renderCollapsibleControl = (props = {}) =>
   render(<CollapsibleControl {...defaultProps} {...props} />);
 
 describe('CollapsibleControl', () => {
-  it('renders title correctly', () => {
+  test('renders title correctly', () => {
     const { getByRole } = renderCollapsibleControl();
     expect(
       getByRole('checkbox', { name: /test control/i }),
     ).toBeInTheDocument();
   });
 
-  it('renders tooltip when provided', () => {
+  test('renders tooltip when provided', () => {
     const tooltipText = 'Test tooltip';
     renderCollapsibleControl({ tooltip: tooltipText });
 
@@ -45,18 +45,18 @@ describe('CollapsibleControl', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  it('starts collapsed when initialValue is false', () => {
+  test('starts collapsed when initialValue is false', () => {
     renderCollapsibleControl({ initialValue: false });
     expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
   });
 
-  it('starts expanded when initialValue is true', () => {
+  test('starts expanded when initialValue is true', () => {
     renderCollapsibleControl({ initialValue: true });
 
     expect(screen.getByTestId('child-content')).toBeInTheDocument();
   });
 
-  it('toggles content when clicked', async () => {
+  test('toggles content when clicked', async () => {
     renderCollapsibleControl();
     const checkbox = screen.getByRole('checkbox', { name: /Test Control/i });
 
@@ -69,7 +69,7 @@ describe('CollapsibleControl', () => {
     expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
   });
 
-  it('calls onChange handler when toggled', async () => {
+  test('calls onChange handler when toggled', async () => {
     const onChangeMock = jest.fn();
     renderCollapsibleControl({ onChange: onChangeMock });
     const checkbox = screen.getByRole('checkbox', { name: /Test Control/i });
@@ -81,7 +81,7 @@ describe('CollapsibleControl', () => {
     expect(onChangeMock).toHaveBeenCalledWith(false);
   });
 
-  it('respects disabled prop', async () => {
+  test('respects disabled prop', async () => {
     const onChangeMock = jest.fn();
     renderCollapsibleControl({
       disabled: true,
@@ -95,7 +95,7 @@ describe('CollapsibleControl', () => {
     expect(onChangeMock).not.toHaveBeenCalled();
   });
 
-  it('updates when controlled checked prop changes', () => {
+  test('updates when controlled checked prop changes', () => {
     const { rerender } = renderCollapsibleControl({ checked: false });
     expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
 
@@ -103,7 +103,7 @@ describe('CollapsibleControl', () => {
     expect(screen.getByTestId('child-content')).toBeInTheDocument();
   });
 
-  it('maintains local state when in uncontrolled mode', async () => {
+  test('maintains local state when in uncontrolled mode', async () => {
     renderCollapsibleControl({ initialValue: false });
     const checkbox = screen.getByRole('checkbox', { name: /Test Control/i });
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
@@ -26,6 +26,7 @@ import {
 import type { FormInstance } from '@superset-ui/core/components';
 import { createMockModal } from './utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterScope TreeInitialization', () => {
   let formRef: { current: FormInstance | null };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
@@ -40,7 +40,7 @@ describe('FilterScope TreeInitialization', () => {
     jest.useRealTimers();
   });
 
-  it('correct init tree with values', async () => {
+  test('correct init tree with values', async () => {
     const { MockModalComponent } = createMockModal({
       scope: {
         rootPath: ['TAB_ID'],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
@@ -40,7 +40,7 @@ describe('FilterScope TreeSelection', () => {
     jest.useRealTimers();
   });
 
-  it('select tree values with 1 excluded', async () => {
+  test('select tree values with 1 excluded', async () => {
     const { MockModalComponent } = createMockModal({ formRef });
     const modal = render(<MockModalComponent />);
 
@@ -81,7 +81,7 @@ describe('FilterScope TreeSelection', () => {
     modal.unmount();
   });
 
-  it('select 1 value only', async () => {
+  test('select 1 value only', async () => {
     const { MockModalComponent } = createMockModal({ formRef });
     const modal = render(<MockModalComponent />);
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
@@ -26,6 +26,7 @@ import {
 import type { FormInstance } from '@superset-ui/core/components';
 import { createMockModal, getTreeSwitcher } from './utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterScope TreeSelection', () => {
   let formRef: { current: FormInstance | null };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
@@ -18047,7 +18047,7 @@ describe('Ensure buildTree does not throw runtime errors when encountering an in
   ];
 
   const initiallyExcludedCharts: number[] = [];
-  it('Succeeds with valid', () => {
+  test('Succeeds with valid', () => {
     expect(() => {
       buildTree(
         // @ts-ignore
@@ -18062,7 +18062,7 @@ describe('Ensure buildTree does not throw runtime errors when encountering an in
     }).not.toThrow();
   });
 
-  it('Avoids runtime error with invalid inputs', () => {
+  test('Avoids runtime error with invalid inputs', () => {
     expect(() => {
       buildTree(
         // @ts-expect-error

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
@@ -24,6 +24,7 @@ import { buildTree } from './utils';
 // This test file is using data from a real example dashboard to test real world data sets.  ts-ignore is set for this entire file
 // until we can reconcile adjusting types to match the actual data structures used
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Ensure buildTree does not throw runtime errors when encountering an invalid node', () => {
   const node = {
     children: ['TABS-97PVJa11D_'],

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -209,6 +209,7 @@ test('Clicking on checkbox when resetConfig:false', () => {
   expect(setNativeFilterFieldValues).not.toHaveBeenCalled();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColumnSelect filterValues behavior', () => {
   beforeEach(() => {
     (getControlItems as jest.Mock).mockReturnValue([

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -85,6 +85,7 @@ test('the form validates required fields', async () => {
   expect(onSave).toHaveBeenCalledTimes(0);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('createNewOnOpen', () => {
   test('does not show alert when there is no unsaved filters', async () => {
     const onCancel = jest.fn();

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
@@ -19,6 +19,7 @@
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import { getCrossFilterIndicator } from './selectors';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getCrossFilterIndicator', () => {
   const chartId = 123;
   const chartLayoutItems = [

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
@@ -37,7 +37,7 @@ describe('getCrossFilterIndicator', () => {
     },
   ];
 
-  it('returns correct indicator with label from filterState.label', () => {
+  test('returns correct indicator with label from filterState.label', () => {
     const dataMask = {
       filterState: { label: 'foo', value: 'bar' },
       extraFormData: {},
@@ -51,7 +51,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns correct indicator with label from filterState.value', () => {
+  test('returns correct indicator with label from filterState.value', () => {
     const dataMask = {
       filterState: { value: ['bar', 'baz'] },
       extraFormData: {},
@@ -65,7 +65,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns correct indicator with column and customColumnLabel', () => {
+  test('returns correct indicator with column and customColumnLabel', () => {
     const dataMask = {
       filterState: {
         value: 'valA',
@@ -84,7 +84,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns correct indicator with column from extraFormData.filters', () => {
+  test('returns correct indicator with column from extraFormData.filters', () => {
     const filterClause = { col: 'colB', op: 'IS NOT NULL' as const };
     const dataMask = {
       filterState: { value: 'valB' },
@@ -99,7 +99,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns correct indicator with column from filterState.filters', () => {
+  test('returns correct indicator with column from filterState.filters', () => {
     const dataMask = {
       filterState: { value: 'valC', filters: { colC: 'something' } },
       extraFormData: {},
@@ -113,7 +113,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns empty name and path if chartLayoutItem is not found', () => {
+  test('returns empty name and path if chartLayoutItem is not found', () => {
     const dataMask = {
       filterState: { value: 'valD' },
       extraFormData: {},
@@ -127,7 +127,7 @@ describe('getCrossFilterIndicator', () => {
     });
   });
 
-  it('returns null value if no label or value in filterState', () => {
+  test('returns null value if no label or value in filterState', () => {
     const dataMask = {
       filterState: {},
       extraFormData: {},

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useIsFilterInScope', () => {
   test('should return true for dividers (always in scope)', () => {
     const divider: Divider = {
@@ -90,6 +91,7 @@ describe('useIsFilterInScope', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useSelectFiltersInScope', () => {
   test('should return all filters in scope when no tabs exist', () => {
     const filters: Filter[] = [

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 });
 
 describe('useIsFilterInScope', () => {
-  it('should return true for dividers (always in scope)', () => {
+  test('should return true for dividers (always in scope)', () => {
     const divider: Divider = {
       id: 'divider_1',
       type: NativeFilterType.Divider,
@@ -52,7 +52,7 @@ describe('useIsFilterInScope', () => {
     expect(result.current(divider)).toBe(true);
   });
 
-  it('should return true for filters with charts in active tabs', () => {
+  test('should return true for filters with charts in active tabs', () => {
     const filter: Filter = {
       id: 'filter_1',
       name: 'Test Filter',
@@ -71,7 +71,7 @@ describe('useIsFilterInScope', () => {
     expect(result.current(filter)).toBe(true);
   });
 
-  it('should return false for filters with inactive rootPath', () => {
+  test('should return false for filters with inactive rootPath', () => {
     const filter: Filter = {
       id: 'filter_3',
       name: 'Test Filter 3',
@@ -91,7 +91,7 @@ describe('useIsFilterInScope', () => {
 });
 
 describe('useSelectFiltersInScope', () => {
-  it('should return all filters in scope when no tabs exist', () => {
+  test('should return all filters in scope when no tabs exist', () => {
     const filters: Filter[] = [
       {
         id: 'filter_1',

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
@@ -21,6 +21,7 @@ import { DashboardLayout } from 'src/dashboard/types';
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import { nativeFilterGate, findTabsWithChartsInScope } from './utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('nativeFilterGate', () => {
   test('should return true for regular chart', () => {
     expect(nativeFilterGate([])).toEqual(true);

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
@@ -22,21 +22,21 @@ import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import { nativeFilterGate, findTabsWithChartsInScope } from './utils';
 
 describe('nativeFilterGate', () => {
-  it('should return true for regular chart', () => {
+  test('should return true for regular chart', () => {
     expect(nativeFilterGate([])).toEqual(true);
   });
 
-  it('should return true for cross filter chart', () => {
+  test('should return true for cross filter chart', () => {
     expect(nativeFilterGate([Behavior.InteractiveChart])).toEqual(true);
   });
 
-  it('should return true for native filter chart with cross filter support', () => {
+  test('should return true for native filter chart with cross filter support', () => {
     expect(
       nativeFilterGate([Behavior.NativeFilter, Behavior.InteractiveChart]),
     ).toEqual(true);
   });
 
-  it('should return false for native filter behavior', () => {
+  test('should return false for native filter behavior', () => {
     expect(nativeFilterGate([Behavior.NativeFilter])).toEqual(false);
   });
 });

--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
@@ -34,7 +34,7 @@ describe('ResizableContainer', () => {
     <ResizableContainer {...props} {...overrides} />
   );
 
-  it('should render a Resizable container', () => {
+  test('should render a Resizable container', () => {
     const rendered = render(setup());
     const resizableContainer = rendered.container.querySelector(
       '.resizable-container',

--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
@@ -22,6 +22,7 @@ import ResizableContainer, {
   ResizableContainerProps,
 } from 'src/dashboard/components/resizable/ResizableContainer';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ResizableContainer', () => {
   const props = {
     editMode: false,

--- a/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
@@ -22,21 +22,21 @@ import ResizableHandle from 'src/dashboard/components/resizable/ResizableHandle'
 
 /* eslint-disable react/jsx-pascal-case */
 describe('ResizableHandle', () => {
-  it('should render a right resize handle', () => {
+  test('should render a right resize handle', () => {
     const rendered = render(<ResizableHandle.right />);
     expect(
       rendered.container.querySelector('.resize-handle.resize-handle--right'),
     ).toBeVisible();
   });
 
-  it('should render a bottom resize handle', () => {
+  test('should render a bottom resize handle', () => {
     const rendered = render(<ResizableHandle.bottom />);
     expect(
       rendered.container.querySelector('.resize-handle.resize-handle--bottom'),
     ).toBeVisible();
   });
 
-  it('should render a bottomRight resize handle', () => {
+  test('should render a bottomRight resize handle', () => {
     const rendered = render(<ResizableHandle.bottomRight />);
     expect(
       rendered.container.querySelector(

--- a/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
@@ -21,6 +21,7 @@ import { render } from 'spec/helpers/testing-library';
 import ResizableHandle from 'src/dashboard/components/resizable/ResizableHandle';
 
 /* eslint-disable react/jsx-pascal-case */
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ResizableHandle', () => {
   test('should render a right resize handle', () => {
     const rendered = render(<ResizableHandle.right />);

--- a/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
@@ -39,7 +39,7 @@ describe('dashboardFilters reducer', () => {
   const directPathToFilter = (component.parents || []).slice();
   directPathToFilter.push(component.id);
 
-  it('should overwrite a filter if merge is false', () => {
+  test('should overwrite a filter if merge is false', () => {
     expect(
       dashboardFiltersReducer(dashboardFilters, {
         type: CHANGE_FILTER,
@@ -72,7 +72,7 @@ describe('dashboardFilters reducer', () => {
     });
   });
 
-  it('should merge a filter if merge is true', () => {
+  test('should merge a filter if merge is true', () => {
     expect(
       dashboardFiltersReducer(dashboardFilters, {
         type: CHANGE_FILTER,
@@ -105,7 +105,7 @@ describe('dashboardFilters reducer', () => {
     });
   });
 
-  it('should buildActiveFilters on UPDATE_DASHBOARD_FILTERS_SCOPE', () => {
+  test('should buildActiveFilters on UPDATE_DASHBOARD_FILTERS_SCOPE', () => {
     const regionScope = {
       scope: ['TAB-1'],
       immune: [],

--- a/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
@@ -33,6 +33,7 @@ import {
 } from 'spec/fixtures/mockSliceEntities';
 import { filterComponent } from 'spec/fixtures/mockDashboardLayout';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dashboardFilters reducer', () => {
   const { form_data } = sliceEntitiesForDashboard.slices[filterId];
   const component = filterComponent;

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
@@ -47,11 +47,11 @@ import {
 } from 'src/dashboard/util/constants';
 
 describe('dashboardLayout reducer', () => {
-  it('should return initial state for unrecognized actions', () => {
+  test('should return initial state for unrecognized actions', () => {
     expect(layoutReducer(undefined, {})).toEqual({});
   });
 
-  it('should delete a component, remove its reference in its parent, and recursively all of its children', () => {
+  test('should delete a component, remove its reference in its parent, and recursively all of its children', () => {
     expect(
       layoutReducer(
         {
@@ -87,7 +87,7 @@ describe('dashboardLayout reducer', () => {
     });
   });
 
-  it('should delete a parent if the parent was a row and no longer has children', () => {
+  test('should delete a parent if the parent was a row and no longer has children', () => {
     expect(
       layoutReducer(
         {
@@ -122,7 +122,7 @@ describe('dashboardLayout reducer', () => {
     });
   });
 
-  it('should update components', () => {
+  test('should update components', () => {
     expect(
       layoutReducer(
         {
@@ -173,7 +173,7 @@ describe('dashboardLayout reducer', () => {
     });
   });
 
-  it('should move a component', () => {
+  test('should move a component', () => {
     const layout = {
       source: {
         id: 'source',
@@ -222,7 +222,7 @@ describe('dashboardLayout reducer', () => {
     });
   });
 
-  it('should wrap a moved component in a row if need be', () => {
+  test('should wrap a moved component in a row if need be', () => {
     const layout = {
       source: {
         id: 'source',
@@ -262,7 +262,7 @@ describe('dashboardLayout reducer', () => {
     expect(Object.keys(result)).toHaveLength(4);
   });
 
-  it('should add top-level tabs from a new tabs component, moving grid children to new tab', () => {
+  test('should add top-level tabs from a new tabs component, moving grid children to new tab', () => {
     const layout = {
       [DASHBOARD_ROOT_ID]: {
         id: DASHBOARD_ROOT_ID,
@@ -308,7 +308,7 @@ describe('dashboardLayout reducer', () => {
     expect(result[DASHBOARD_GRID_ID].children).toHaveLength(0);
   });
 
-  it('should add top-level tabs from an existing tabs component, moving grid children to new tab', () => {
+  test('should add top-level tabs from an existing tabs component, moving grid children to new tab', () => {
     const layout = {
       [DASHBOARD_ROOT_ID]: {
         id: DASHBOARD_ROOT_ID,
@@ -360,7 +360,7 @@ describe('dashboardLayout reducer', () => {
     expect(result[DASHBOARD_GRID_ID].children).toHaveLength(0);
   });
 
-  it('should remove top-level tabs, moving children to the grid', () => {
+  test('should remove top-level tabs, moving children to the grid', () => {
     const layout = {
       [DASHBOARD_ROOT_ID]: {
         id: DASHBOARD_ROOT_ID,
@@ -425,7 +425,7 @@ describe('dashboardLayout reducer', () => {
     });
   });
 
-  it('should create a component', () => {
+  test('should create a component', () => {
     const layout = {
       [DASHBOARD_ROOT_ID]: {
         id: DASHBOARD_ROOT_ID,
@@ -458,7 +458,7 @@ describe('dashboardLayout reducer', () => {
     expect(result[newId].type).toBe(ROW_TYPE);
   });
 
-  it('recursivelyDeleteChildren should be error proof with bad inputs', () => {
+  test('recursivelyDeleteChildren should be error proof with bad inputs', () => {
     /*
      ** The recursivelyDeleteChildren function was missing runtime safety checks before operating
      ** on sub properties of object causing runtime errors when a componentId lookup returned and unexpected value

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
@@ -46,6 +46,7 @@ import {
   NEW_ROW_ID,
 } from 'src/dashboard/util/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dashboardLayout reducer', () => {
   test('should return initial state for unrecognized actions', () => {
     expect(layoutReducer(undefined, {})).toEqual({});

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.js
@@ -34,11 +34,11 @@ import {
 import dashboardStateReducer from 'src/dashboard/reducers/dashboardState';
 
 describe('dashboardState reducer', () => {
-  it('should return initial state', () => {
+  test('should return initial state', () => {
     expect(dashboardStateReducer(undefined, {})).toEqual({});
   });
 
-  it('should add a slice', () => {
+  test('should add a slice', () => {
     expect(
       dashboardStateReducer(
         { sliceIds: [1] },
@@ -47,7 +47,7 @@ describe('dashboardState reducer', () => {
     ).toEqual({ sliceIds: [1, 2] });
   });
 
-  it('should remove a slice', () => {
+  test('should remove a slice', () => {
     expect(
       dashboardStateReducer(
         { sliceIds: [1, 2], filters: {} },
@@ -56,7 +56,7 @@ describe('dashboardState reducer', () => {
     ).toEqual({ sliceIds: [1], filters: {} });
   });
 
-  it('should toggle fav star', () => {
+  test('should toggle fav star', () => {
     expect(
       dashboardStateReducer(
         { isStarred: false },
@@ -65,7 +65,7 @@ describe('dashboardState reducer', () => {
     ).toEqual({ isStarred: true });
   });
 
-  it('should toggle edit mode', () => {
+  test('should toggle edit mode', () => {
     expect(
       dashboardStateReducer(
         { editMode: false },
@@ -76,7 +76,7 @@ describe('dashboardState reducer', () => {
     });
   });
 
-  it('should toggle expanded slices', () => {
+  test('should toggle expanded slices', () => {
     expect(
       dashboardStateReducer(
         { expandedSlices: { 1: true, 2: false } },
@@ -92,7 +92,7 @@ describe('dashboardState reducer', () => {
     ).toEqual({ expandedSlices: { 1: true, 2: true } });
   });
 
-  it('should set hasUnsavedChanges', () => {
+  test('should set hasUnsavedChanges', () => {
     expect(dashboardStateReducer({}, { type: ON_CHANGE })).toEqual({
       hasUnsavedChanges: true,
     });
@@ -107,7 +107,7 @@ describe('dashboardState reducer', () => {
     });
   });
 
-  it('should set maxUndoHistoryExceeded', () => {
+  test('should set maxUndoHistoryExceeded', () => {
     expect(
       dashboardStateReducer(
         {},
@@ -121,7 +121,7 @@ describe('dashboardState reducer', () => {
     });
   });
 
-  it('should set unsaved changes, max undo history, and editMode to false on save', () => {
+  test('should set unsaved changes, max undo history, and editMode to false on save', () => {
     const result = dashboardStateReducer(
       { hasUnsavedChanges: true },
       { type: ON_SAVE },
@@ -132,7 +132,7 @@ describe('dashboardState reducer', () => {
     expect(result.updatedColorScheme).toBe(false);
   });
 
-  it('should reset lastModifiedTime on save', () => {
+  test('should reset lastModifiedTime on save', () => {
     const initTime = new Date().getTime() / 1000;
     dashboardStateReducer(
       {
@@ -150,7 +150,7 @@ describe('dashboardState reducer', () => {
     ).toBeGreaterThanOrEqual(initTime);
   });
 
-  it('should clear the focused filter field', () => {
+  test('should clear the focused filter field', () => {
     const initState = {
       focusedFilterField: {
         chartId: 1,
@@ -167,7 +167,7 @@ describe('dashboardState reducer', () => {
     expect(cleared.focusedFilterField).toBeNull();
   });
 
-  it('should only clear focused filter when the fields match', () => {
+  test('should only clear focused filter when the fields match', () => {
     // dashboard only has 1 focused filter field at a time,
     // but when user switch different filter boxes,
     // browser didn't always fire onBlur and onFocus events in order.
@@ -199,7 +199,7 @@ describe('dashboardState reducer', () => {
     });
   });
 
-  it('should toggle native filters bar', () => {
+  test('should toggle native filters bar', () => {
     expect(
       dashboardStateReducer(
         { nativeFiltersBarOpen: false },

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.js
@@ -33,6 +33,7 @@ import {
 
 import dashboardStateReducer from 'src/dashboard/reducers/dashboardState';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dashboardState reducer', () => {
   test('should return initial state', () => {
     expect(dashboardStateReducer(undefined, {})).toEqual({});

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -53,7 +53,9 @@ const createMockDashboardState = (
   ...overrides,
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardState reducer', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('SET_ACTIVE_TAB', () => {
     test('switches a single tab', () => {
       const store = mockStore({

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -55,7 +55,7 @@ const createMockDashboardState = (
 
 describe('DashboardState reducer', () => {
   describe('SET_ACTIVE_TAB', () => {
-    it('switches a single tab', () => {
+    test('switches a single tab', () => {
       const store = mockStore({
         dashboardState: { activeTabs: [] },
         dashboardLayout: { present: { tab1: { parents: [] } } },
@@ -87,7 +87,7 @@ describe('DashboardState reducer', () => {
       );
     });
 
-    it('switches a multi-depth tab', () => {
+    test('switches a multi-depth tab', () => {
       const initState = { activeTabs: ['TAB-1', 'TAB-A', 'TAB-__a'] };
       const store = mockStore({
         dashboardState: initState,
@@ -176,7 +176,7 @@ describe('DashboardState reducer', () => {
       );
     });
   });
-  it('SET_ACTIVE_TABS', () => {
+  test('SET_ACTIVE_TABS', () => {
     expect(
       typedDashboardStateReducer(
         createMockDashboardState({ activeTabs: [] }),

--- a/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
+++ b/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
@@ -25,11 +25,11 @@ import {
 import sliceEntitiesReducer from 'src/dashboard/reducers/sliceEntities';
 
 describe('sliceEntities reducer', () => {
-  it('should return initial state', () => {
+  test('should return initial state', () => {
     expect(sliceEntitiesReducer({}, {})).toEqual({});
   });
 
-  it('should set loading when fetching slices', () => {
+  test('should set loading when fetching slices', () => {
     expect(
       sliceEntitiesReducer(
         { isLoading: false },
@@ -38,7 +38,7 @@ describe('sliceEntities reducer', () => {
     ).toBe(true);
   });
 
-  it('should set slices', () => {
+  test('should set slices', () => {
     const result = sliceEntitiesReducer(
       { slices: { a: {} } },
       { type: ADD_SLICES, payload: { slices: { 1: {}, 2: {} } } },
@@ -52,7 +52,7 @@ describe('sliceEntities reducer', () => {
     expect(result.isLoading).toBe(false);
   });
 
-  it('should set an error on error', () => {
+  test('should set an error on error', () => {
     const result = sliceEntitiesReducer(
       {},
       {

--- a/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
+++ b/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
@@ -24,6 +24,7 @@ import {
 
 import sliceEntitiesReducer from 'src/dashboard/reducers/sliceEntities';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('sliceEntities reducer', () => {
   test('should return initial state', () => {
     expect(sliceEntitiesReducer({}, {})).toEqual({});

--- a/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
+++ b/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
@@ -44,13 +44,13 @@ const resizable = [COLUMN_TYPE, CHART_TYPE, MARKDOWN_TYPE];
 
 describe('componentIsResizable', () => {
   resizable.forEach(type => {
-    it(`should return true for ${type}`, () => {
+    test(`should return true for ${type}`, () => {
       expect(componentIsResizable({ type })).toBe(true);
     });
   });
 
   notResizable.forEach(type => {
-    it(`should return false for ${type}`, () => {
+    test(`should return false for ${type}`, () => {
       expect(componentIsResizable({ type })).toBe(false);
     });
   });

--- a/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
+++ b/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
@@ -42,6 +42,7 @@ const notResizable = [
 
 const resizable = [COLUMN_TYPE, CHART_TYPE, MARKDOWN_TYPE];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('componentIsResizable', () => {
   resizable.forEach(type => {
     test(`should return true for ${type}`, () => {

--- a/superset-frontend/src/dashboard/util/dnd-reorder.test.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.test.js
@@ -20,6 +20,7 @@ import reorderItem from 'src/dashboard/util/dnd-reorder';
 import { TABS_TYPE } from './componentTypes';
 import { DROP_LEFT, DROP_RIGHT } from './getDropPosition';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dnd-reorderItem', () => {
   test('should remove the item from its source entity and add it to its destination entity', () => {
     const result = reorderItem({

--- a/superset-frontend/src/dashboard/util/dnd-reorder.test.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.test.js
@@ -21,7 +21,7 @@ import { TABS_TYPE } from './componentTypes';
 import { DROP_LEFT, DROP_RIGHT } from './getDropPosition';
 
 describe('dnd-reorderItem', () => {
-  it('should remove the item from its source entity and add it to its destination entity', () => {
+  test('should remove the item from its source entity and add it to its destination entity', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -41,7 +41,7 @@ describe('dnd-reorderItem', () => {
     expect(result.b.children).toEqual(['banana', 'z']);
   });
 
-  it('should correctly move elements within the same list', () => {
+  test('should correctly move elements within the same list', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -56,7 +56,7 @@ describe('dnd-reorderItem', () => {
     expect(result.a.children).toEqual(['z', 'x', 'y']);
   });
 
-  it('should copy items that do not move into the result', () => {
+  test('should copy items that do not move into the result', () => {
     const extraEntity = {};
     const result = reorderItem({
       entitiesMap: {
@@ -77,7 +77,7 @@ describe('dnd-reorderItem', () => {
     expect(result.iAmExtra).toBe(extraEntity);
   });
 
-  it('should handle out of bounds destination index gracefully', () => {
+  test('should handle out of bounds destination index gracefully', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -97,7 +97,7 @@ describe('dnd-reorderItem', () => {
     expect(result.b.children).toEqual(['banana', 'y']);
   });
 
-  it('should do nothing if source and destination are the same and indices are the same', () => {
+  test('should do nothing if source and destination are the same and indices are the same', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -112,7 +112,7 @@ describe('dnd-reorderItem', () => {
     expect(result.a.children).toEqual(['x', 'y', 'z']);
   });
 
-  it('should handle DROP_LEFT in the same TABS_TYPE list correctly', () => {
+  test('should handle DROP_LEFT in the same TABS_TYPE list correctly', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -129,7 +129,7 @@ describe('dnd-reorderItem', () => {
     expect(result.a.children).toEqual(['x', 'z', 'y']);
   });
 
-  it('should handle DROP_RIGHT in the same TABS_TYPE list correctly', () => {
+  test('should handle DROP_RIGHT in the same TABS_TYPE list correctly', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -146,7 +146,7 @@ describe('dnd-reorderItem', () => {
     expect(result.a.children).toEqual(['y', 'x', 'z']);
   });
 
-  it('should handle DROP_LEFT when moving between different TABS_TYPE lists', () => {
+  test('should handle DROP_LEFT when moving between different TABS_TYPE lists', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {
@@ -169,7 +169,7 @@ describe('dnd-reorderItem', () => {
     expect(result.b.children).toEqual(['y', 'banana']);
   });
 
-  it('should handle DROP_RIGHT when moving between different TABS_TYPE lists', () => {
+  test('should handle DROP_RIGHT when moving between different TABS_TYPE lists', () => {
     const result = reorderItem({
       entitiesMap: {
         a: {

--- a/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
+++ b/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
@@ -30,7 +30,7 @@ import {
 } from 'src/dashboard/util/componentTypes';
 
 describe('dropOverflowsParent', () => {
-  it('returns true if a parent does NOT have adequate width for child', () => {
+  test('returns true if a parent does NOT have adequate width for child', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'a' },
@@ -62,7 +62,7 @@ describe('dropOverflowsParent', () => {
     expect(dropOverflowsParent(dropResult, layout as any)).toBe(true);
   });
 
-  it('returns false if a parent DOES have adequate width for child', () => {
+  test('returns false if a parent DOES have adequate width for child', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'a' },
@@ -94,7 +94,7 @@ describe('dropOverflowsParent', () => {
     expect(dropOverflowsParent(dropResult, layout as any)).toBe(false);
   });
 
-  it('returns false if a child CAN shrink to available parent space', () => {
+  test('returns false if a child CAN shrink to available parent space', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'a' },
@@ -126,7 +126,7 @@ describe('dropOverflowsParent', () => {
     expect(dropOverflowsParent(dropResult, layout as any)).toBe(false);
   });
 
-  it('returns true if a child CANNOT shrink to available parent space', () => {
+  test('returns true if a child CANNOT shrink to available parent space', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'a' },
@@ -159,7 +159,7 @@ describe('dropOverflowsParent', () => {
     expect(dropOverflowsParent(dropResult, layout as any)).toBe(true);
   });
 
-  it('returns true if a column has children that CANNOT shrink to available parent space', () => {
+  test('returns true if a column has children that CANNOT shrink to available parent space', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'destination' },
@@ -204,7 +204,7 @@ describe('dropOverflowsParent', () => {
     ).toBe(false);
   });
 
-  it('should work with new components that are not in the layout', () => {
+  test('should work with new components that are not in the layout', () => {
     const dropResult: DropResult = {
       source: { id: NEW_COMPONENTS_SOURCE_ID },
       destination: { id: 'a' },
@@ -222,7 +222,7 @@ describe('dropOverflowsParent', () => {
     expect(dropOverflowsParent(dropResult, layout as any)).toBe(false);
   });
 
-  it('source/destination without widths should not overflow parent', () => {
+  test('source/destination without widths should not overflow parent', () => {
     const dropResult: DropResult = {
       source: { id: '_' },
       destination: { id: 'tab' },

--- a/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
+++ b/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
@@ -29,6 +29,7 @@ import {
   TAB_TYPE,
 } from 'src/dashboard/util/componentTypes';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dropOverflowsParent', () => {
   test('returns true if a parent does NOT have adequate width for child', () => {
     const dropResult: DropResult = {

--- a/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
+++ b/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
@@ -20,6 +20,7 @@ import extractUrlParams from './extractUrlParams';
 
 const originalWindowLocation = window.location;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('extractUrlParams', () => {
   beforeAll(() => {
     // @ts-ignore

--- a/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
+++ b/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
@@ -32,20 +32,20 @@ describe('extractUrlParams', () => {
     window.location = originalWindowLocation;
   });
 
-  it('returns all urlParams', () => {
+  test('returns all urlParams', () => {
     expect(extractUrlParams('all')).toEqual({
       edit: 'true',
       abc: '123',
     });
   });
 
-  it('returns reserved urlParams', () => {
+  test('returns reserved urlParams', () => {
     expect(extractUrlParams('reserved')).toEqual({
       edit: 'true',
     });
   });
 
-  it('returns regular urlParams', () => {
+  test('returns regular urlParams', () => {
     expect(extractUrlParams('regular')).toEqual({
       abc: '123',
     });

--- a/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
+++ b/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
@@ -114,11 +114,11 @@ describe('findFirstParentContainer', () => {
     DASHBOARD_VERSION_KEY: 'v2',
   };
 
-  it('should return grid root', () => {
+  test('should return grid root', () => {
     expect(findFirstParentContainerId(mockGridLayout)).toBe(DASHBOARD_GRID_ID);
   });
 
-  it('should return first tab', () => {
+  test('should return first tab', () => {
     const tabsId = mockTabsLayout[DASHBOARD_ROOT_ID].children[0];
     const firstTabId = mockTabsLayout[tabsId].children[0];
     expect(findFirstParentContainerId(mockTabsLayout)).toBe(firstTabId);

--- a/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
+++ b/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
@@ -22,6 +22,7 @@ import {
   DASHBOARD_ROOT_ID,
 } from 'src/dashboard/util/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('findFirstParentContainer', () => {
   const mockGridLayout = {
     DASHBOARD_VERSION_KEY: 'v2',

--- a/superset-frontend/src/dashboard/util/findParentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findParentId.test.ts
@@ -33,16 +33,16 @@ describe('findParentId', () => {
       children: [],
     },
   };
-  it('should return the correct parentId', () => {
+  test('should return the correct parentId', () => {
     expect(findParentId({ childId: 'b', layout })).toBe('a');
     expect(findParentId({ childId: 'z', layout })).toBe('b');
   });
 
-  it('should return null if the parent cannot be found', () => {
+  test('should return null if the parent cannot be found', () => {
     expect(findParentId({ childId: 'a', layout })).toBeNull();
   });
 
-  it('should not throw error and return null with bad / missing inputs', () => {
+  test('should not throw error and return null with bad / missing inputs', () => {
     // @ts-ignore
     expect(findParentId(null)).toBeNull();
     // @ts-ignore

--- a/superset-frontend/src/dashboard/util/findParentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findParentId.test.ts
@@ -18,6 +18,7 @@
  */
 import findParentId from 'src/dashboard/util/findParentId';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('findParentId', () => {
   const layout = {
     a: {

--- a/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
@@ -50,7 +50,7 @@ describe('findTabIndexByComponentId', () => {
   ];
   const badPath = ['ROOT_ID', 'TABS-MNQQSW-kyd', 'TAB-ABC', 'TABS-Oduxop1L7I'];
 
-  it('should return -1 if no directPathToChild', () => {
+  test('should return -1 if no directPathToChild', () => {
     expect(
       findTabIndexByComponentId({
         currentComponent: topLevelTabsComponent,
@@ -59,7 +59,7 @@ describe('findTabIndexByComponentId', () => {
     ).toBe(-1);
   });
 
-  it('should return -1 if not found tab id', () => {
+  test('should return -1 if not found tab id', () => {
     expect(
       findTabIndexByComponentId({
         currentComponent: topLevelTabsComponent,
@@ -68,7 +68,7 @@ describe('findTabIndexByComponentId', () => {
     ).toBe(-1);
   });
 
-  it('should return children index if matched an id in the path', () => {
+  test('should return children index if matched an id in the path', () => {
     expect(
       findTabIndexByComponentId({
         currentComponent: topLevelTabsComponent,

--- a/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
@@ -19,6 +19,7 @@
 import findTabIndexByComponentId from 'src/dashboard/util/findTabIndexByComponentId';
 import { LayoutItem, LayoutItemMeta } from '../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('findTabIndexByComponentId', () => {
   const topLevelTabsComponent: LayoutItem = {
     children: ['TAB-0g-5l347I2', 'TAB-qrwN_9VB5'],

--- a/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
@@ -19,7 +19,7 @@
 import getChartAndLabelComponentIdFromPath from 'src/dashboard/util/getChartAndLabelComponentIdFromPath';
 
 describe('getChartAndLabelComponentIdFromPath', () => {
-  it('should return label and component id', () => {
+  test('should return label and component id', () => {
     const directPathToChild = [
       'ROOT_ID',
       'TABS-aX1uNK-ryo',

--- a/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
@@ -18,6 +18,7 @@
  */
 import getChartAndLabelComponentIdFromPath from 'src/dashboard/util/getChartAndLabelComponentIdFromPath';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getChartAndLabelComponentIdFromPath', () => {
   test('should return label and component id', () => {
     const directPathToChild = [

--- a/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
@@ -57,14 +57,14 @@ describe('getChartIdsFromLayout', () => {
     },
   };
 
-  it('should return an array of chartIds', () => {
+  test('should return an array of chartIds', () => {
     const result = getChartIdsFromLayout(mockLayout);
     expect(Array.isArray(result)).toBe(true);
     expect(result.includes(123)).toBe(true);
     expect(result.includes(456)).toBe(true);
   });
 
-  it('should return ids only from CHART_TYPE components', () => {
+  test('should return ids only from CHART_TYPE components', () => {
     const result = getChartIdsFromLayout(mockLayout);
     expect(result).toHaveLength(2);
     expect(result.includes(789)).toBe(false);

--- a/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
@@ -20,6 +20,7 @@ import getChartIdsFromLayout from 'src/dashboard/util/getChartIdsFromLayout';
 import { ROW_TYPE, CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import type { DashboardLayout } from '../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getChartIdsFromLayout', () => {
   const mockLayout: DashboardLayout = {
     a: {

--- a/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
@@ -20,6 +20,7 @@ import getDashboardUrl from 'src/dashboard/util/getDashboardUrl';
 import { DASHBOARD_FILTER_SCOPE_GLOBAL } from 'src/dashboard/reducers/dashboardFilters';
 import { DashboardStandaloneMode } from 'src/dashboard/util/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getChartIdsFromLayout', () => {
   const filters = {
     '35_key': {

--- a/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
@@ -33,14 +33,14 @@ describe('getChartIdsFromLayout', () => {
     window.location = globalLocation;
   });
 
-  it('should encode filters', () => {
+  test('should encode filters', () => {
     const url = getDashboardUrl({ pathname: 'path', filters });
     expect(url).toBe(
       'path?preselect_filters=%7B%2235%22%3A%7B%22key%22%3A%5B%22value%22%5D%7D%7D',
     );
   });
 
-  it('should encode filters with hash', () => {
+  test('should encode filters with hash', () => {
     const urlWithHash = getDashboardUrl({
       pathname: 'path',
       filters,
@@ -51,7 +51,7 @@ describe('getChartIdsFromLayout', () => {
     );
   });
 
-  it('should encode filters with standalone', () => {
+  test('should encode filters with standalone', () => {
     const urlWithStandalone = getDashboardUrl({
       pathname: 'path',
       filters,
@@ -62,7 +62,7 @@ describe('getChartIdsFromLayout', () => {
     );
   });
 
-  it('should encode filters with missing standalone', () => {
+  test('should encode filters with missing standalone', () => {
     const urlWithStandalone = getDashboardUrl({
       pathname: 'path',
       filters,
@@ -73,7 +73,7 @@ describe('getChartIdsFromLayout', () => {
     );
   });
 
-  it('should encode filters with missing filters', () => {
+  test('should encode filters with missing filters', () => {
     const urlWithStandalone = getDashboardUrl({
       pathname: 'path',
       filters: undefined,
@@ -84,7 +84,7 @@ describe('getChartIdsFromLayout', () => {
     );
   });
 
-  it('should preserve unknown filters', () => {
+  test('should preserve unknown filters', () => {
     const windowSpy = jest.spyOn(window, 'window', 'get');
     windowSpy.mockImplementation(() => ({
       location: {
@@ -102,7 +102,7 @@ describe('getChartIdsFromLayout', () => {
     windowSpy.mockRestore();
   });
 
-  it('should process native filters key', () => {
+  test('should process native filters key', () => {
     const windowSpy = jest.spyOn(window, 'window', 'get');
     windowSpy.mockImplementation(() => ({
       location: {

--- a/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
+++ b/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
@@ -23,6 +23,7 @@ import {
   GRID_MIN_COLUMN_COUNT,
 } from 'src/dashboard/util/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getDetailedComponentWidth', () => {
   test('should return an object with width, minimumWidth, and occupiedWidth', () => {
     expect(
@@ -32,6 +33,7 @@ describe('getDetailedComponentWidth', () => {
     );
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('width', () => {
     test('should be undefined if the component is not resizable and has no defined width', () => {
       const empty = {
@@ -132,6 +134,7 @@ describe('getDetailedComponentWidth', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('occupiedWidth', () => {
     test('should reflect the sum of child widths for row components', () => {
       expect(
@@ -158,6 +161,7 @@ describe('getDetailedComponentWidth', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('minimumWidth', () => {
     test('should equal GRID_MIN_COLUMN_COUNT for resizable components', () => {
       expect(

--- a/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
+++ b/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
@@ -24,7 +24,7 @@ import {
 } from 'src/dashboard/util/constants';
 
 describe('getDetailedComponentWidth', () => {
-  it('should return an object with width, minimumWidth, and occupiedWidth', () => {
+  test('should return an object with width, minimumWidth, and occupiedWidth', () => {
     expect(
       Object.keys(getDetailedComponentWidth({ id: '_', components: {} })),
     ).toEqual(
@@ -33,7 +33,7 @@ describe('getDetailedComponentWidth', () => {
   });
 
   describe('width', () => {
-    it('should be undefined if the component is not resizable and has no defined width', () => {
+    test('should be undefined if the component is not resizable and has no defined width', () => {
       const empty = {
         width: undefined,
         occupiedWidth: undefined,
@@ -59,7 +59,7 @@ describe('getDetailedComponentWidth', () => {
       ).toEqual(empty);
     });
 
-    it('should match component meta width for resizable components', () => {
+    test('should match component meta width for resizable components', () => {
       expect(
         getDetailedComponentWidth({
           component: { id: '', type: types.CHART_TYPE, meta: { width: 1 } },
@@ -80,7 +80,7 @@ describe('getDetailedComponentWidth', () => {
       ).toEqual({ width: 3, occupiedWidth: 0, minimumWidth: 1 });
     });
 
-    it('should be GRID_COLUMN_COUNT for row components WITHOUT parents', () => {
+    test('should be GRID_COLUMN_COUNT for row components WITHOUT parents', () => {
       expect(
         getDetailedComponentWidth({
           id: 'row',
@@ -93,7 +93,7 @@ describe('getDetailedComponentWidth', () => {
       });
     });
 
-    it('should match parent width for row components WITH parents', () => {
+    test('should match parent width for row components WITH parents', () => {
       expect(
         getDetailedComponentWidth({
           id: 'row',
@@ -114,7 +114,7 @@ describe('getDetailedComponentWidth', () => {
       });
     });
 
-    it('should use either id or component (to support new components)', () => {
+    test('should use either id or component (to support new components)', () => {
       expect(
         getDetailedComponentWidth({
           id: 'id',
@@ -133,7 +133,7 @@ describe('getDetailedComponentWidth', () => {
   });
 
   describe('occupiedWidth', () => {
-    it('should reflect the sum of child widths for row components', () => {
+    test('should reflect the sum of child widths for row components', () => {
       expect(
         getDetailedComponentWidth({
           id: 'row',
@@ -149,7 +149,7 @@ describe('getDetailedComponentWidth', () => {
       ).toEqual({ width: 12, occupiedWidth: 7, minimumWidth: 7 });
     });
 
-    it('should always be zero for column components', () => {
+    test('should always be zero for column components', () => {
       expect(
         getDetailedComponentWidth({
           component: { id: '', type: types.COLUMN_TYPE, meta: { width: 2 } },
@@ -159,7 +159,7 @@ describe('getDetailedComponentWidth', () => {
   });
 
   describe('minimumWidth', () => {
-    it('should equal GRID_MIN_COLUMN_COUNT for resizable components', () => {
+    test('should equal GRID_MIN_COLUMN_COUNT for resizable components', () => {
       expect(
         getDetailedComponentWidth({
           component: { id: '', type: types.CHART_TYPE, meta: { width: 1 } },
@@ -191,7 +191,7 @@ describe('getDetailedComponentWidth', () => {
       });
     });
 
-    it('should equal the width of row children for column components with row children', () => {
+    test('should equal the width of row children for column components with row children', () => {
       expect(
         getDetailedComponentWidth({
           id: 'column',
@@ -221,7 +221,7 @@ describe('getDetailedComponentWidth', () => {
       ).toEqual({ width: 12, occupiedWidth: 0, minimumWidth: 7 });
     });
 
-    it('should equal occupiedWidth for row components', () => {
+    test('should equal occupiedWidth for row components', () => {
       expect(
         getDetailedComponentWidth({
           id: 'row',

--- a/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
+++ b/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
@@ -19,7 +19,7 @@
 import getDirectPathToTabIndex from './getDirectPathToTabIndex';
 
 describe('getDirectPathToTabIndex', () => {
-  it('builds path using parents, id, and child at index', () => {
+  test('builds path using parents, id, and child at index', () => {
     const tabs = {
       id: 'TABS_ID',
       parents: ['ROOT', 'ROW_1'],
@@ -33,7 +33,7 @@ describe('getDirectPathToTabIndex', () => {
     ]);
   });
 
-  it('handles missing parents', () => {
+  test('handles missing parents', () => {
     const tabs = {
       id: 'TABS_ID',
       children: ['TAB_A'],

--- a/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
+++ b/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
@@ -18,6 +18,7 @@
  */
 import getDirectPathToTabIndex from './getDirectPathToTabIndex';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getDirectPathToTabIndex', () => {
   test('builds path using parents, id, and child at index', () => {
     const tabs = {

--- a/superset-frontend/src/dashboard/util/getDropPosition.test.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.test.js
@@ -81,7 +81,7 @@ describe('getDropPosition', () => {
   }
 
   describe('invalid child + invalid sibling', () => {
-    it('should return DROP_FORBIDDEN', () => {
+    test('should return DROP_FORBIDDEN', () => {
       const result = getDropPosition(
         // TAB is an invalid child + sibling of GRID > ROW
         ...getMocks({
@@ -95,7 +95,7 @@ describe('getDropPosition', () => {
   });
 
   describe('valid child + invalid sibling', () => {
-    it('should return DROP_LEFT if component has NO children, and orientation is "row"', () => {
+    test('should return DROP_LEFT if component has NO children, and orientation is "row"', () => {
       // HEADER is a valid child + invalid sibling of ROOT > GRID
       const result = getDropPosition(
         ...getMocks({
@@ -107,7 +107,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_LEFT);
     });
 
-    it('should return DROP_RIGHT if component HAS children, and orientation is "row"', () => {
+    test('should return DROP_RIGHT if component HAS children, and orientation is "row"', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_ROOT_TYPE,
@@ -119,7 +119,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_RIGHT);
     });
 
-    it('should return DROP_TOP if component has NO children, and orientation is "column"', () => {
+    test('should return DROP_TOP if component has NO children, and orientation is "column"', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_ROOT_TYPE,
@@ -131,7 +131,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_TOP);
     });
 
-    it('should return DROP_BOTTOM if component HAS children, and orientation is "column"', () => {
+    test('should return DROP_BOTTOM if component HAS children, and orientation is "column"', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_ROOT_TYPE,
@@ -146,7 +146,7 @@ describe('getDropPosition', () => {
   });
 
   describe('invalid child + valid sibling', () => {
-    it('should return DROP_TOP if orientation="row" and clientOffset is closer to component top than bottom', () => {
+    test('should return DROP_TOP if orientation="row" and clientOffset is closer to component top than bottom', () => {
       const result = getDropPosition(
         // HEADER is an invalid child but valid sibling of GRID > ROW
         ...getMocks({
@@ -163,7 +163,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_TOP);
     });
 
-    it('should return DROP_BOTTOM if orientation="row" and clientOffset is closer to component bottom than top', () => {
+    test('should return DROP_BOTTOM if orientation="row" and clientOffset is closer to component bottom than top', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -179,7 +179,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_BOTTOM);
     });
 
-    it('should return DROP_LEFT if orientation="column" and clientOffset is closer to component left than right', () => {
+    test('should return DROP_LEFT if orientation="column" and clientOffset is closer to component left than right', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -196,7 +196,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_LEFT);
     });
 
-    it('should return DROP_RIGHT if orientation="column" and clientOffset is closer to component right than left', () => {
+    test('should return DROP_RIGHT if orientation="column" and clientOffset is closer to component right than left', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -215,7 +215,7 @@ describe('getDropPosition', () => {
   });
 
   describe('child + valid sibling (row orientation)', () => {
-    it('should return DROP_LEFT if component has NO children, and clientOffset is NOT near top/bottom sibling boundary', () => {
+    test('should return DROP_LEFT if component has NO children, and clientOffset is NOT near top/bottom sibling boundary', () => {
       const result = getDropPosition(
         // CHART is a valid child + sibling of GRID > ROW
         ...getMocks({
@@ -234,7 +234,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_LEFT);
     });
 
-    it('should return DROP_RIGHT if component HAS children, and clientOffset is NOT near top/bottom sibling boundary', () => {
+    test('should return DROP_RIGHT if component HAS children, and clientOffset is NOT near top/bottom sibling boundary', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -253,7 +253,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_RIGHT);
     });
 
-    it('should return DROP_TOP regardless of component children if clientOffset IS near top sibling boundary', () => {
+    test('should return DROP_TOP regardless of component children if clientOffset IS near top sibling boundary', () => {
       const noChildren = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -287,7 +287,7 @@ describe('getDropPosition', () => {
       expect(withChildren).toBe(DROP_TOP);
     });
 
-    it('should return DROP_BOTTOM regardless of component children if clientOffset IS near bottom sibling boundary', () => {
+    test('should return DROP_BOTTOM regardless of component children if clientOffset IS near bottom sibling boundary', () => {
       const noChildren = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -323,7 +323,7 @@ describe('getDropPosition', () => {
   });
 
   describe('child + valid sibling (column orientation)', () => {
-    it('should return DROP_TOP if component has NO children, and clientOffset is NOT near left/right sibling boundary', () => {
+    test('should return DROP_TOP if component has NO children, and clientOffset is NOT near left/right sibling boundary', () => {
       const result = getDropPosition(
         // CHART is a valid child + sibling of GRID > ROW
         ...getMocks({
@@ -343,7 +343,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_TOP);
     });
 
-    it('should return DROP_BOTTOM if component HAS children, and clientOffset is NOT near left/right sibling boundary', () => {
+    test('should return DROP_BOTTOM if component HAS children, and clientOffset is NOT near left/right sibling boundary', () => {
       const result = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -363,7 +363,7 @@ describe('getDropPosition', () => {
       expect(result).toBe(DROP_BOTTOM);
     });
 
-    it('should return DROP_LEFT regardless of component children if clientOffset IS near left sibling boundary', () => {
+    test('should return DROP_LEFT regardless of component children if clientOffset IS near left sibling boundary', () => {
       const noChildren = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,
@@ -399,7 +399,7 @@ describe('getDropPosition', () => {
       expect(withChildren).toBe(DROP_LEFT);
     });
 
-    it('should return DROP_RIGHT regardless of component children if clientOffset IS near right sibling boundary', () => {
+    test('should return DROP_RIGHT regardless of component children if clientOffset IS near right sibling boundary', () => {
       const noChildren = getDropPosition(
         ...getMocks({
           parentType: DASHBOARD_GRID_TYPE,

--- a/superset-frontend/src/dashboard/util/getDropPosition.test.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.test.js
@@ -33,6 +33,7 @@ import {
   TAB_TYPE,
 } from 'src/dashboard/util/componentTypes';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getDropPosition', () => {
   // helper to easily configure test
   function getMocks({
@@ -80,6 +81,7 @@ describe('getDropPosition', () => {
     return [monitorMock, ComponentMock];
   }
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('invalid child + invalid sibling', () => {
     test('should return DROP_FORBIDDEN', () => {
       const result = getDropPosition(
@@ -94,6 +96,7 @@ describe('getDropPosition', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('valid child + invalid sibling', () => {
     test('should return DROP_LEFT if component has NO children, and orientation is "row"', () => {
       // HEADER is a valid child + invalid sibling of ROOT > GRID
@@ -145,6 +148,7 @@ describe('getDropPosition', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('invalid child + valid sibling', () => {
     test('should return DROP_TOP if orientation="row" and clientOffset is closer to component top than bottom', () => {
       const result = getDropPosition(
@@ -214,6 +218,7 @@ describe('getDropPosition', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('child + valid sibling (row orientation)', () => {
     test('should return DROP_LEFT if component has NO children, and clientOffset is NOT near top/bottom sibling boundary', () => {
       const result = getDropPosition(
@@ -322,6 +327,7 @@ describe('getDropPosition', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('child + valid sibling (column orientation)', () => {
     test('should return DROP_TOP if component has NO children, and clientOffset is NOT near left/right sibling boundary', () => {
       const result = getDropPosition(

--- a/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
+++ b/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
@@ -19,7 +19,7 @@
 import getEffectiveExtraFilters from 'src/dashboard/util/charts/getEffectiveExtraFilters';
 
 describe('getEffectiveExtraFilters', () => {
-  it('should create valid filters', () => {
+  test('should create valid filters', () => {
     const result = getEffectiveExtraFilters({
       gender: ['girl'],
       name: null,

--- a/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
+++ b/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
@@ -18,6 +18,7 @@
  */
 import getEffectiveExtraFilters from 'src/dashboard/util/charts/getEffectiveExtraFilters';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getEffectiveExtraFilters', () => {
   test('should create valid filters', () => {
     const result = getEffectiveExtraFilters({

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
@@ -18,6 +18,7 @@
  */
 import getFilterConfigsFromFormdata from 'src/dashboard/util/getFilterConfigsFromFormdata';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getFilterConfigsFromFormdata', () => {
   const testFormdata = {
     filter_configs: [

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
@@ -36,7 +36,7 @@ describe('getFilterConfigsFromFormdata', () => {
     time_range: '2018-12-30T00:00:00+:+last+saturday',
   };
 
-  it('should add time grain', () => {
+  test('should add time grain', () => {
     const result = getFilterConfigsFromFormdata({
       ...testFormdata,
       show_sqla_time_granularity: true,
@@ -46,7 +46,7 @@ describe('getFilterConfigsFromFormdata', () => {
     });
   });
 
-  it('should add time column', () => {
+  test('should add time column', () => {
     const result = getFilterConfigsFromFormdata({
       ...testFormdata,
       show_sqla_time_column: true,
@@ -56,7 +56,7 @@ describe('getFilterConfigsFromFormdata', () => {
     });
   });
 
-  it('should use default value and treat empty defaults as null', () => {
+  test('should use default value and treat empty defaults as null', () => {
     const result = getFilterConfigsFromFormdata({
       ...testFormdata,
       show_sqla_time_column: true,
@@ -78,7 +78,7 @@ describe('getFilterConfigsFromFormdata', () => {
     });
   });
 
-  it('should read multi values from form_data', () => {
+  test('should read multi values from form_data', () => {
     const result = getFilterConfigsFromFormdata({
       ...testFormdata,
       filter_configs: [

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
@@ -19,7 +19,7 @@
 import getFilterScopeFromNodesTree from 'src/dashboard/util/getFilterScopeFromNodesTree';
 
 describe('getFilterScopeFromNodesTree', () => {
-  it('should return empty scope', () => {
+  test('should return empty scope', () => {
     const nodes = [];
     expect(
       getFilterScopeFromNodesTree({
@@ -30,7 +30,7 @@ describe('getFilterScopeFromNodesTree', () => {
     ).toEqual({});
   });
 
-  it('should return scope for simple grid', () => {
+  test('should return scope for simple grid', () => {
     const nodes = [
       {
         label: 'All dashboard',
@@ -284,7 +284,7 @@ describe('getFilterScopeFromNodesTree', () => {
       },
     ];
 
-    it('root level tab scope', () => {
+    test('root level tab scope', () => {
       const checkedChartIds = [106];
       expect(
         getFilterScopeFromNodesTree({
@@ -298,7 +298,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('global scope', () => {
+    test('global scope', () => {
       const checkedChartIds = [106, 104, 101, 102, 103, 105];
       expect(
         getFilterScopeFromNodesTree({
@@ -312,7 +312,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('row level tab scope', () => {
+    test('row level tab scope', () => {
       const checkedChartIds = [103, 105];
       expect(
         getFilterScopeFromNodesTree({
@@ -326,7 +326,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('mixed row level and root level scope', () => {
+    test('mixed row level and root level scope', () => {
       const checkedChartIds = [103, 105, 106];
       expect(
         getFilterScopeFromNodesTree({
@@ -340,7 +340,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('mixed row level tab and chart scope', () => {
+    test('mixed row level tab and chart scope', () => {
       const checkedChartIds = [103, 105, 102];
       expect(
         getFilterScopeFromNodesTree({
@@ -354,7 +354,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('exclude sub-tab', () => {
+    test('exclude sub-tab', () => {
       const checkedChartIds = [103, 104, 105];
       expect(
         getFilterScopeFromNodesTree({
@@ -368,7 +368,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('exclude top-tab', () => {
+    test('exclude top-tab', () => {
       const checkedChartIds = [106, 109];
       expect(
         getFilterScopeFromNodesTree({
@@ -382,7 +382,7 @@ describe('getFilterScopeFromNodesTree', () => {
       });
     });
 
-    it('exclude nested sub-tab', () => {
+    test('exclude nested sub-tab', () => {
       // another layout for test:
       // - filter_109
       // - chart_106

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
@@ -18,6 +18,7 @@
  */
 import getFilterScopeFromNodesTree from 'src/dashboard/util/getFilterScopeFromNodesTree';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getFilterScopeFromNodesTree', () => {
   test('should return empty scope', () => {
     const nodes = [];
@@ -70,6 +71,7 @@ describe('getFilterScopeFromNodesTree', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('should return scope for tabbed dashboard', () => {
     // this is a commonly used layout for dashboard:
     // - Tab 1

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -22,6 +22,7 @@ import getFormDataWithExtraFilters, {
 } from 'src/dashboard/util/charts/getFormDataWithExtraFilters';
 import { sliceId as chartId } from 'spec/fixtures/mockChartQueries';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getFormDataWithExtraFilters', () => {
   const filterId = 'native-filter-1';
   const mockChart = {

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -72,7 +72,7 @@ describe('getFormDataWithExtraFilters', () => {
     allSliceIds: [chartId],
   };
 
-  it('should include filters from the passed filters', () => {
+  test('should include filters from the passed filters', () => {
     const result = getFormDataWithExtraFilters(mockArgs);
     expect(result.extra_filters).toHaveLength(2);
     expect(result.extra_filters[0]).toEqual({
@@ -87,7 +87,7 @@ describe('getFormDataWithExtraFilters', () => {
     });
   });
 
-  it('should compose extra control', () => {
+  test('should compose extra control', () => {
     const result: CachedFormDataWithExtraControls =
       getFormDataWithExtraFilters(mockArgs);
     expect(result.stack).toEqual('Stacked');

--- a/superset-frontend/src/dashboard/util/getKeyForFilterScopeTree.test.ts
+++ b/superset-frontend/src/dashboard/util/getKeyForFilterScopeTree.test.ts
@@ -18,6 +18,7 @@
  */
 import getKeyForFilterScopeTree from './getKeyForFilterScopeTree';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getKeyForFilterScopeTree', () => {
   test('should return stringified activeFilterField array when activeFilterField is provided', () => {
     const props = {

--- a/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
@@ -20,6 +20,7 @@ import getLeafComponentIdFromPath from 'src/dashboard/util/getLeafComponentIdFro
 import { filterId } from 'spec/fixtures/mockSliceEntities';
 import { dashboardFilters } from 'spec/fixtures/mockDashboardFilters';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getLeafComponentIdFromPath', () => {
   const path = dashboardFilters[filterId].directPathToFilter;
   const leaf = path.slice().pop();

--- a/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
@@ -24,11 +24,11 @@ describe('getLeafComponentIdFromPath', () => {
   const path = dashboardFilters[filterId].directPathToFilter;
   const leaf = path.slice().pop();
 
-  it('should return component id', () => {
+  test('should return component id', () => {
     expect(getLeafComponentIdFromPath(path)).toBe(leaf);
   });
 
-  it('should not return label component', () => {
+  test('should not return label component', () => {
     const updatedPath =
       dashboardFilters[filterId].directPathToFilter.concat('LABEL-test123');
     expect(getLeafComponentIdFromPath(updatedPath)).toBe(leaf);

--- a/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
@@ -19,6 +19,7 @@
 import isDashboardEmpty from 'src/dashboard/util/isDashboardEmpty';
 import getEmptyLayout from 'src/dashboard/util/getEmptyLayout';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('isDashboardEmpty', () => {
   const emptyLayout = getEmptyLayout();
   const testLayout: object = {

--- a/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
@@ -32,11 +32,11 @@ describe('isDashboardEmpty', () => {
     },
   };
 
-  it('should return true for empty dashboard', () => {
+  test('should return true for empty dashboard', () => {
     expect(isDashboardEmpty(emptyLayout)).toBe(true);
   });
 
-  it('should return false for non-empty dashboard', () => {
+  test('should return false for non-empty dashboard', () => {
     expect(isDashboardEmpty(testLayout)).toBe(false);
   });
 });

--- a/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
@@ -18,6 +18,7 @@
  */
 import isDashboardLoading, { ChartLoadTimestamps } from './isDashboardLoading';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('isDashboardLoading', () => {
   test('returns false when no charts are loading', () => {
     const charts: Record<string, ChartLoadTimestamps> = {

--- a/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
@@ -19,7 +19,7 @@
 import isDashboardLoading, { ChartLoadTimestamps } from './isDashboardLoading';
 
 describe('isDashboardLoading', () => {
-  it('returns false when no charts are loading', () => {
+  test('returns false when no charts are loading', () => {
     const charts: Record<string, ChartLoadTimestamps> = {
       a: { chartUpdateStartTime: 1, chartUpdateEndTime: 2 },
       b: { chartUpdateStartTime: 5, chartUpdateEndTime: 5 },
@@ -27,7 +27,7 @@ describe('isDashboardLoading', () => {
     expect(isDashboardLoading(charts)).toBe(false);
   });
 
-  it('returns true when any chart has start > end', () => {
+  test('returns true when any chart has start > end', () => {
     const charts: Record<string, ChartLoadTimestamps> = {
       a: { chartUpdateStartTime: 10, chartUpdateEndTime: 5 },
       b: { chartUpdateStartTime: 1, chartUpdateEndTime: 2 },
@@ -35,14 +35,14 @@ describe('isDashboardLoading', () => {
     expect(isDashboardLoading(charts)).toBe(true);
   });
 
-  it('treats missing end as 0', () => {
+  test('treats missing end as 0', () => {
     const charts: Record<string, ChartLoadTimestamps> = {
       a: { chartUpdateStartTime: 1 },
     };
     expect(isDashboardLoading(charts)).toBe(true);
   });
 
-  it('handles empty charts object', () => {
+  test('handles empty charts object', () => {
     expect(isDashboardLoading({})).toBe(false);
   });
 });

--- a/superset-frontend/src/dashboard/util/isValidChild.test.ts
+++ b/superset-frontend/src/dashboard/util/isValidChild.test.ts
@@ -96,7 +96,7 @@ describe('isValidChild', () => {
         if (i > 0 && !didTest[testKey]) {
           didTest[testKey] = true;
 
-          it(`(${exampleIdx})${getIndentation(
+          test(`(${exampleIdx})${getIndentation(
             childDepth,
           )}${parentType} (depth ${parentDepth}) > ${childType} ✅`, () => {
             expect(
@@ -144,7 +144,7 @@ describe('isValidChild', () => {
           if (typeof parentType !== 'string')
             throw TypeError('parent must be string');
 
-          it(`(${exampleIdx})${getIndentation(
+          test(`(${exampleIdx})${getIndentation(
             childDepth,
           )}${parentType} (depth ${parentDepth}) > ${childType} ❌`, () => {
             expect(

--- a/superset-frontend/src/dashboard/util/isValidChild.test.ts
+++ b/superset-frontend/src/dashboard/util/isValidChild.test.ts
@@ -36,7 +36,9 @@ const getIndentation = (depth: number) =>
     .fill('')
     .join('-');
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('isValidChild', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('valid calls', () => {
     // these are representations of nested structures for easy testing
     //  [ROOT (depth 0) > GRID (depth 1) > HEADER (depth 2)]
@@ -114,6 +116,7 @@ describe('isValidChild', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('invalid calls', () => {
     // In order to assert that a parent > child hierarchy at a given depth is invalid
     // we also define some valid hierarchies in doing so. we indicate which

--- a/superset-frontend/src/dashboard/util/logging/childChartsDidLoad.test.ts
+++ b/superset-frontend/src/dashboard/util/logging/childChartsDidLoad.test.ts
@@ -33,6 +33,7 @@ const mockFindNonTabChildChartIds =
     typeof mockFindNonTabChildChartIdsImport
   >;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('childChartsDidLoad', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/dashboard/util/newComponentFactory.test.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.test.js
@@ -46,6 +46,7 @@ const types = [
   TAB_TYPE,
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('newEntityFactory', () => {
   types.forEach(type => {
     test(`returns a new ${type}`, () => {

--- a/superset-frontend/src/dashboard/util/newComponentFactory.test.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.test.js
@@ -48,7 +48,7 @@ const types = [
 
 describe('newEntityFactory', () => {
   types.forEach(type => {
-    it(`returns a new ${type}`, () => {
+    test(`returns a new ${type}`, () => {
       const result = newComponentFactory(type);
 
       expect(result.type).toBe(type);
@@ -58,7 +58,7 @@ describe('newEntityFactory', () => {
     });
   });
 
-  it('adds passed meta data to the entity', () => {
+  test('adds passed meta data to the entity', () => {
     const banana = 'banana';
     const result = newComponentFactory(CHART_TYPE, { banana });
     expect(result.meta.banana).toBe(banana);

--- a/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
+++ b/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
@@ -26,7 +26,7 @@ import {
 } from 'src/dashboard/util/componentTypes';
 
 describe('newEntitiesFromDrop', () => {
-  it('should return a new Entity of appropriate type, and add it to the drop target children', () => {
+  test('should return a new Entity of appropriate type, and add it to the drop target children', () => {
     const result = newEntitiesFromDrop({
       dropResult: {
         destination: { id: 'a', index: 0 },
@@ -48,7 +48,7 @@ describe('newEntitiesFromDrop', () => {
     expect(result[newId].type).toBe(CHART_TYPE);
   });
 
-  it('should create Tab AND Tabs components if the drag entity is Tabs', () => {
+  test('should create Tab AND Tabs components if the drag entity is Tabs', () => {
     const result = newEntitiesFromDrop({
       dropResult: {
         destination: { id: 'a', index: 0 },
@@ -73,7 +73,7 @@ describe('newEntitiesFromDrop', () => {
     expect(result[newTabId].type).toBe(TAB_TYPE);
   });
 
-  it('should create a Row if the drag entity should be wrapped in a row', () => {
+  test('should create a Row if the drag entity should be wrapped in a row', () => {
     const result = newEntitiesFromDrop({
       dropResult: {
         destination: { id: 'a', index: 0 },

--- a/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
+++ b/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
@@ -25,6 +25,7 @@ import {
   TAB_TYPE,
 } from 'src/dashboard/util/componentTypes';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('newEntitiesFromDrop', () => {
   test('should return a new Entity of appropriate type, and add it to the drop target children', () => {
     const result = newEntitiesFromDrop({

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -104,6 +104,7 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('canUserEditDashboard', () => {
   test('allows owners to edit', () => {
     expect(canUserEditDashboard(dashboard, ownerUser)).toEqual(true);
@@ -184,6 +185,7 @@ test('userHasPermission returns true if user has permission', () => {
   ).toEqual(true);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('canUserSaveAsDashboard with RBAC feature flag disabled', () => {
   beforeAll(() => {
     mockedIsFeatureEnabled.mockImplementation(
@@ -208,6 +210,7 @@ describe('canUserSaveAsDashboard with RBAC feature flag disabled', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('canUserSaveAsDashboard with RBAC feature flag enabled', () => {
   beforeAll(() => {
     mockedIsFeatureEnabled.mockImplementation(

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -105,24 +105,24 @@ jest.mock('@superset-ui/core', () => ({
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 describe('canUserEditDashboard', () => {
-  it('allows owners to edit', () => {
+  test('allows owners to edit', () => {
     expect(canUserEditDashboard(dashboard, ownerUser)).toEqual(true);
   });
-  it('allows admin users to edit regardless of ownership', () => {
+  test('allows admin users to edit regardless of ownership', () => {
     expect(canUserEditDashboard(dashboard, adminUser)).toEqual(true);
   });
-  it('rejects non-owners', () => {
+  test('rejects non-owners', () => {
     expect(canUserEditDashboard(dashboard, outsiderUser)).toEqual(false);
   });
-  it('rejects nonexistent users', () => {
+  test('rejects nonexistent users', () => {
     expect(canUserEditDashboard(dashboard, null)).toEqual(false);
   });
-  it('rejects missing roles', () => {
+  test('rejects missing roles', () => {
     // in redux, when there is no user, the user is actually set to an empty object,
     // so we need to handle missing roles as well as a missing user.s
     expect(canUserEditDashboard(dashboard, {})).toEqual(false);
   });
-  it('rejects "admins" if the admin role does not have edit rights for some reason', () => {
+  test('rejects "admins" if the admin role does not have edit rights for some reason', () => {
     expect(
       canUserEditDashboard(dashboard, {
         ...adminUser,
@@ -195,15 +195,15 @@ describe('canUserSaveAsDashboard with RBAC feature flag disabled', () => {
     mockedIsFeatureEnabled.mockRestore();
   });
 
-  it('allows owners', () => {
+  test('allows owners', () => {
     expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
   });
 
-  it('allows admin users', () => {
+  test('allows admin users', () => {
     expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
   });
 
-  it('allows non-owners', () => {
+  test('allows non-owners', () => {
     expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(true);
   });
 });
@@ -219,15 +219,15 @@ describe('canUserSaveAsDashboard with RBAC feature flag enabled', () => {
     mockedIsFeatureEnabled.mockRestore();
   });
 
-  it('allows owners', () => {
+  test('allows owners', () => {
     expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
   });
 
-  it('allows admin users', () => {
+  test('allows admin users', () => {
     expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
   });
 
-  it('reject non-owners', () => {
+  test('reject non-owners', () => {
     expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(false);
   });
 });

--- a/superset-frontend/src/dashboard/util/serializeFilterScopes.test.ts
+++ b/superset-frontend/src/dashboard/util/serializeFilterScopes.test.ts
@@ -44,6 +44,7 @@ const mockDashboardFilters = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('serializeFilterScopes', () => {
   test('should serialize dashboard filter scopes correctly', () => {
     const result = serializeFilterScopes(mockDashboardFilters);

--- a/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
+++ b/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
@@ -44,7 +44,7 @@ describe('updateComponentParentsList', () => {
     ...dashboardLayoutWithTabs.present,
   };
 
-  it('should handle empty layout', () => {
+  test('should handle empty layout', () => {
     const nextState = {
       ...emptyLayout,
     };
@@ -57,7 +57,7 @@ describe('updateComponentParentsList', () => {
     expect(nextState.GRID_ID.parents).toEqual(['ROOT_ID']);
   });
 
-  it('should handle grid layout', () => {
+  test('should handle grid layout', () => {
     const nextState = {
       ...gridLayout,
     };
@@ -76,7 +76,7 @@ describe('updateComponentParentsList', () => {
     ]);
   });
 
-  it('should handle root level tabs', () => {
+  test('should handle root level tabs', () => {
     const nextState = {
       ...tabsLayout,
     };
@@ -97,7 +97,7 @@ describe('updateComponentParentsList', () => {
 });
 
 describe('updateComponentParentsList with bad inputs', () => {
-  it('should handle invalid parameters and not throw error', () => {
+  test('should handle invalid parameters and not throw error', () => {
     updateComponentParentsList({
       currentComponent: undefined,
       layout: undefined,

--- a/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
+++ b/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
@@ -23,6 +23,7 @@ import {
   dashboardLayoutWithTabs,
 } from 'spec/fixtures/mockDashboardLayout';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('updateComponentParentsList', () => {
   const emptyLayout = {
     DASHBOARD_VERSION_KEY: 'v2',
@@ -96,6 +97,7 @@ describe('updateComponentParentsList', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('updateComponentParentsList with bad inputs', () => {
   test('should handle invalid parameters and not throw error', () => {
     updateComponentParentsList({

--- a/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
+++ b/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
@@ -51,7 +51,7 @@ describe('useFilterFocusHighlightStyles', () => {
       store,
     });
 
-  it('should return no style if filter not in scope', async () => {
+  test('should return no style if filter not in scope', async () => {
     renderWrapper(10);
 
     const container = screen.getByTestId('test-component');
@@ -60,7 +60,7 @@ describe('useFilterFocusHighlightStyles', () => {
     expect(styles.opacity).toBeFalsy();
   });
 
-  it('should return unfocused styles if chart is not in scope of focused native filter', async () => {
+  test('should return unfocused styles if chart is not in scope of focused native filter', async () => {
     mockGetRelatedCharts.mockReturnValue([]);
     const store = createMockStore({
       nativeFilters: {
@@ -80,7 +80,7 @@ describe('useFilterFocusHighlightStyles', () => {
     expect(parseFloat(styles.opacity)).toBe(0.3);
   });
 
-  it('should return unfocused styles if chart is not in scope of hovered native filter', async () => {
+  test('should return unfocused styles if chart is not in scope of hovered native filter', async () => {
     mockGetRelatedCharts.mockReturnValue([]);
     const store = createMockStore({
       nativeFilters: {
@@ -100,7 +100,7 @@ describe('useFilterFocusHighlightStyles', () => {
     expect(parseFloat(styles.opacity)).toBe(0.3);
   });
 
-  it('should return focused styles if chart is in scope of focused native filter', async () => {
+  test('should return focused styles if chart is in scope of focused native filter', async () => {
     const chartId = 18;
     mockGetRelatedCharts.mockReturnValue([chartId]);
     const store = createMockStore({
@@ -121,7 +121,7 @@ describe('useFilterFocusHighlightStyles', () => {
     expect(parseFloat(styles.opacity)).toBe(1);
   });
 
-  it('should return focused styles if chart is in scope of hovered native filter', async () => {
+  test('should return focused styles if chart is in scope of hovered native filter', async () => {
     const chartId = 18;
     mockGetRelatedCharts.mockReturnValue([chartId]);
     const store = createMockStore({

--- a/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
+++ b/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
@@ -34,6 +34,7 @@ const TestComponent = ({ chartId }: { chartId: number }) => {
   return <div data-test="test-component" style={styles} />;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useFilterFocusHighlightStyles', () => {
   const createMockStore = (customState: any = {}) =>
     createStore(

--- a/superset-frontend/src/embedded/utils.test.ts
+++ b/superset-frontend/src/embedded/utils.test.ts
@@ -49,7 +49,7 @@ const dataMask: DataMaskStateWithId = {
   },
 };
 
-it('datamask didnt change - both triggers set to false', () => {
+test('datamask didnt change - both triggers set to false', () => {
   const previousDataMask = cloneDeep(dataMask);
   expect(getDataMaskChangeTrigger(dataMask, previousDataMask)).toEqual({
     crossFiltersChanged: false,
@@ -57,7 +57,7 @@ it('datamask didnt change - both triggers set to false', () => {
   });
 });
 
-it('a native filter changed - nativeFiltersChanged set to true', () => {
+test('a native filter changed - nativeFiltersChanged set to true', () => {
   const previousDataMask = cloneDeep(dataMask);
   previousDataMask['NATIVE_FILTER-1'].filterState!.value = 'test';
   expect(getDataMaskChangeTrigger(dataMask, previousDataMask)).toEqual({
@@ -66,7 +66,7 @@ it('a native filter changed - nativeFiltersChanged set to true', () => {
   });
 });
 
-it('a cross filter changed - crossFiltersChanged set to true', () => {
+test('a cross filter changed - crossFiltersChanged set to true', () => {
   const previousDataMask = cloneDeep(dataMask);
   previousDataMask['1'].filterState!.value = 'test';
   expect(getDataMaskChangeTrigger(dataMask, previousDataMask)).toEqual({

--- a/superset-frontend/src/explore/actions/exploreActions.test.js
+++ b/superset-frontend/src/explore/actions/exploreActions.test.js
@@ -78,14 +78,14 @@ const METRICS = [
 ];
 
 describe('reducers', () => {
-  it('Does not set a control value if control does not exist', () => {
+  test('Does not set a control value if control does not exist', () => {
     const newState = exploreReducer(
       defaultState,
       actions.setControlValue('NEW_FIELD', 'x', []),
     );
     expect(newState.controls.NEW_FIELD).toBeUndefined();
   });
-  it('setControlValue works as expected with a Select control', () => {
+  test('setControlValue works as expected with a Select control', () => {
     const newState = exploreReducer(
       defaultState,
       actions.setControlValue('y_axis_format', '$,.2f', []),
@@ -93,7 +93,7 @@ describe('reducers', () => {
     expect(newState.controls.y_axis_format.value).toBe('$,.2f');
     expect(newState.form_data.y_axis_format).toBe('$,.2f');
   });
-  it('Keeps the column config when metric column positions are swapped', () => {
+  test('Keeps the column config when metric column positions are swapped', () => {
     const mockedState = {
       ...defaultState,
       controls: {
@@ -153,7 +153,7 @@ describe('reducers', () => {
     );
   });
 
-  it('Keeps the column config when metric column name is updated', () => {
+  test('Keeps the column config when metric column name is updated', () => {
     const mockedState = {
       ...defaultState,
       controls: {

--- a/superset-frontend/src/explore/actions/exploreActions.test.js
+++ b/superset-frontend/src/explore/actions/exploreActions.test.js
@@ -77,6 +77,7 @@ const METRICS = [
   },
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('reducers', () => {
   test('Does not set a control value if control does not exist', () => {
     const newState = exploreReducer(

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -467,6 +467,7 @@ test('getSliceDashboards with slice handles failure', async () => {
   expect(dispatch.getCall(0).args[0].type).toBe(SAVE_SLICE_FAILED);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getSlicePayload', () => {
   const sliceName = 'Test Slice';
   const formDataWithNativeFilters = {

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -44,6 +44,7 @@ const FormDataMock = () => {
   return <div data-test="mock-formdata">{Object.keys(formData).join(':')}</div>;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ControlPanelsContainer', () => {
   const defaultTableConfig = {
     controlPanelSections: [

--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -29,6 +29,7 @@ import { setItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';
 import { DataTablesPane } from '..';
 import { createDataTablesPaneProps } from './fixture';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DataTablesPane', () => {
   // Collapsed/expanded state depends on local storage
   // We need to clear it manually - otherwise initial state would depend on the order of tests

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -28,6 +28,7 @@ import { ChartMetadata, ChartPlugin, VizType } from '@superset-ui/core';
 import { ResultsPaneOnDashboard } from '../components';
 import { createResultsPaneOnDashboardProps } from './fixture';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ResultsPaneOnDashboard', () => {
   // render and render errorMessage
   fetchMock.post(

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -26,6 +26,7 @@ import {
 import { SamplesPane } from '../components';
 import { createSamplesPaneProps } from './fixture';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SamplesPane', () => {
   fetchMock.post(
     'end:/datasource/samples?force=false&datasource_type=table&datasource_id=34',

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
@@ -197,6 +197,7 @@ test('should render the columns', async () => {
   );
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourcePanel', () => {
   beforeAll(() => {
     jest.setTimeout(30000);

--- a/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
@@ -25,11 +25,11 @@ const url = 'http://localhost/explore/p/100';
 fetchMock.post('glob:*/api/v1/explore/permalink', { url });
 
 describe('EmbedCodeButton', () => {
-  it('renders', () => {
+  test('renders', () => {
     expect(isValidElement(<EmbedCodeContent />)).toBe(true);
   });
 
-  it('returns correct embed code', async () => {
+  test('returns correct embed code', async () => {
     render(<EmbedCodeContent />, { useRedux: true });
     expect(await screen.findByText('iframe', { exact: false })).toBeVisible();
     expect(await screen.findByText('/iframe', { exact: false })).toBeVisible();

--- a/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
@@ -24,6 +24,7 @@ import EmbedCodeContent from 'src/explore/components/EmbedCodeContent';
 const url = 'http://localhost/explore/p/100';
 fetchMock.post('glob:*/api/v1/explore/permalink', { url });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('EmbedCodeButton', () => {
   test('renders', () => {
     expect(isValidElement(<EmbedCodeContent />)).toBe(true);

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -137,6 +137,7 @@ fetchMock.post(
     sendAsJson: false,
   },
 );
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ExploreChartHeader', () => {
   jest.setTimeout(15000); // ✅ Applies to all tests in this suite
 
@@ -373,6 +374,7 @@ describe('ExploreChartHeader', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Additional actions tests', () => {
   jest.setTimeout(15000); // ✅ Applies to all tests in this suite
 
@@ -505,6 +507,7 @@ describe('Additional actions tests', () => {
     expect(props.actions.redirectSQLLab).toHaveBeenCalledTimes(1);
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Download', () => {
     let spyDownloadAsImage = sinon.spy();
     let spyExportChart = sinon.spy();

--- a/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
@@ -66,6 +66,7 @@ const createProps = (overrides = {}) => ({
   ...overrides,
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartContainer', () => {
   jest.setTimeout(10000);
 

--- a/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
@@ -162,7 +162,7 @@ describe('ChartContainer', () => {
     expect(screen.queryByText(/cached/i)).not.toBeInTheDocument();
   });
 
-  it('hides gutter when collapsing data panel', async () => {
+  test('hides gutter when collapsing data panel', async () => {
     const props = createProps();
     setItem(LocalStorageKeys.IsDatapanelOpen, true);
     const { container } = render(<ChartContainer {...props} />, {

--- a/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
@@ -31,7 +31,7 @@ const setup = (overrides = {}) => (
 );
 
 describe('CheckboxControl', () => {
-  it('renders a Checkbox', () => {
+  test('renders a Checkbox', () => {
     render(setup());
 
     const checkbox = screen.getByRole('checkbox');
@@ -39,7 +39,7 @@ describe('CheckboxControl', () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  it('Checks the box when the label is clicked', () => {
+  test('Checks the box when the label is clicked', () => {
     render(setup());
     const label = screen.getByRole('button', {
       name: /checkbox label/i,

--- a/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
@@ -30,6 +30,7 @@ const setup = (overrides = {}) => (
   <CheckboxControl {...defaultProps} {...overrides} />
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('CheckboxControl', () => {
   test('renders a Checkbox', () => {
     render(setup());

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointOption.test.tsx
@@ -48,6 +48,7 @@ const renderComponent = (props: Partial<ColorBreakpointOptionProps> = {}) =>
     useDnd: true,
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColorBreakpointOption', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.test.tsx
@@ -50,6 +50,7 @@ const renderComponent = (
   props: Partial<ColorBreakpointsPopoverControlProps> = {},
 ) => render(<ColorBreakpointPopoverControl {...createProps()} {...props} />);
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColorBreakpointPopoverControl', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverTrigger.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverTrigger.test.tsx
@@ -53,6 +53,7 @@ const renderComponent = (
     </ColorBreakpointPopoverTrigger>,
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColorBreakpointPopoverTrigger', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
@@ -51,7 +51,7 @@ describe('ColorBreakpointsControl', () => {
     jest.clearAllMocks();
   });
 
-  it('should render with default props', () => {
+  test('should render with default props', () => {
     renderComponent();
     expect(screen.getByText('Click to add new breakpoint')).toBeInTheDocument();
   });

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
@@ -46,6 +46,7 @@ const renderComponent = (props: Partial<Props> = {}) =>
     useDnd: true,
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColorBreakpointsControl', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
@@ -28,6 +28,7 @@ const defaultProps = {
   onChange: jest.fn(),
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ColorPickerControl', () => {
   beforeAll(() => {
     getCategoricalSchemeRegistry()

--- a/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
@@ -45,7 +45,7 @@ describe('ColorPickerControl', () => {
     jest.clearAllMocks();
   });
 
-  it('renders a ColorPicker component', () => {
+  test('renders a ColorPicker component', () => {
     render(<ColorPickerControl {...defaultProps} />);
 
     // AntD ColorPicker renders a trigger element with class
@@ -55,14 +55,14 @@ describe('ColorPickerControl', () => {
     expect(colorPickerTrigger).toBeInTheDocument();
   });
 
-  it('displays the correct color value', () => {
+  test('displays the correct color value', () => {
     render(<ColorPickerControl {...defaultProps} />);
 
     // The color should be displayed as hex #007A87 (uppercase in AntD)
     expect(screen.getByText('#007A87')).toBeInTheDocument();
   });
 
-  it('calls onChange with RGB values when color changes', async () => {
+  test('calls onChange with RGB values when color changes', async () => {
     const onChange = jest.fn();
     render(<ColorPickerControl {...defaultProps} onChange={onChange} />);
 
@@ -80,7 +80,7 @@ describe('ColorPickerControl', () => {
     // as it uses complex internal components. The main functionality is covered by the component itself.
   });
 
-  it('includes preset colors from the categorical scheme', () => {
+  test('includes preset colors from the categorical scheme', () => {
     render(<ColorPickerControl {...defaultProps} />);
 
     // The component should have access to the preset colors from the registry

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -83,17 +83,17 @@ describe('DatasourceControl', () => {
     };
   };
 
-  it('should not render Modal', () => {
+  test('should not render Modal', () => {
     setup();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('should not render ChangeDatasourceModal', () => {
+  test('should not render ChangeDatasourceModal', () => {
     setup();
     expect(screen.queryByTestId('Swap dataset-modal')).not.toBeInTheDocument();
   });
 
-  it('show or hide Edit Datasource option', async () => {
+  test('show or hide Edit Datasource option', async () => {
     const {
       rendered: { container, rerender },
       store,
@@ -127,7 +127,7 @@ describe('DatasourceControl', () => {
     });
   });
 
-  it('should render health check message', async () => {
+  test('should render health check message', async () => {
     setup();
     const modalTrigger = screen.getByLabelText('warning');
     expect(modalTrigger).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('DatasourceControl', () => {
     });
   });
 
-  it('Gets Datasource Title', () => {
+  test('Gets Datasource Title', () => {
     const sql = 'This is the sql';
     const name = 'this is a name';
     const emptyResult = '';

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -64,6 +64,7 @@ const defaultProps = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasourceControl', () => {
   const setup = (overrideProps = {}) => {
     const mockStore = configureStore([]);

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
@@ -23,21 +23,21 @@ import { PreviousCalendarWeek, PreviousCalendarQuarter } from '../types';
 import { CALENDAR_RANGE_OPTIONS } from '../utils/constants';
 
 describe('CalendarFrame', () => {
-  it('calls onChange with PreviousCalendarWeek if value is not in CALENDAR_RANGE_SET', () => {
+  test('calls onChange with PreviousCalendarWeek if value is not in CALENDAR_RANGE_SET', () => {
     const mockOnChange = jest.fn();
     render(<CalendarFrame onChange={mockOnChange} value="invalid-value" />);
 
     expect(mockOnChange).toHaveBeenCalledWith(PreviousCalendarWeek);
   });
 
-  it('renders null if value is not in CALENDAR_RANGE_SET', () => {
+  test('renders null if value is not in CALENDAR_RANGE_SET', () => {
     render(<CalendarFrame onChange={jest.fn()} value="invalid-value" />);
     expect(
       screen.queryByText('Configure Time Range: Previous...'),
     ).not.toBeInTheDocument();
   });
 
-  it('renders the correct number of radio options', () => {
+  test('renders the correct number of radio options', () => {
     render(<CalendarFrame onChange={jest.fn()} value={PreviousCalendarWeek} />);
     const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(CALENDAR_RANGE_OPTIONS.length);
@@ -46,7 +46,7 @@ describe('CalendarFrame', () => {
     });
   });
 
-  it('calls onChange with the correct value when a radio button is selected', () => {
+  test('calls onChange with the correct value when a radio button is selected', () => {
     const mockOnChange = jest.fn();
     render(
       <CalendarFrame
@@ -62,7 +62,7 @@ describe('CalendarFrame', () => {
     expect(mockOnChange).toHaveBeenCalledWith(secondOption.value);
   });
 
-  it('renders the section title correctly', () => {
+  test('renders the section title correctly', () => {
     render(
       <CalendarFrame
         onChange={jest.fn()}
@@ -74,7 +74,7 @@ describe('CalendarFrame', () => {
     ).toBeInTheDocument();
   });
 
-  it('ensures the third option is PreviousCalendarQuarter', () => {
+  test('ensures the third option is PreviousCalendarQuarter', () => {
     render(
       <CalendarFrame
         onChange={jest.fn()}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
@@ -22,6 +22,7 @@ import { CalendarFrame } from '../components/CalendarFrame';
 import { PreviousCalendarWeek, PreviousCalendarQuarter } from '../types';
 import { CALENDAR_RANGE_OPTIONS } from '../utils/constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('CalendarFrame', () => {
   test('calls onChange with PreviousCalendarWeek if value is not in CALENDAR_RANGE_SET', () => {
     const mockOnChange = jest.fn();

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
@@ -19,7 +19,9 @@
 
 import { customTimeRangeEncode } from 'src/explore/components/controls/DateFilterControl/utils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Custom TimeRange', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('customTimeRangeEncode', () => {
     test('1) specific : specific', () => {
       expect(

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
@@ -21,7 +21,7 @@ import { customTimeRangeEncode } from 'src/explore/components/controls/DateFilte
 
 describe('Custom TimeRange', () => {
   describe('customTimeRangeEncode', () => {
-    it('1) specific : specific', () => {
+    test('1) specific : specific', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: '2021-01-20T00:00:00',
@@ -38,7 +38,7 @@ describe('Custom TimeRange', () => {
       ).toEqual('2021-01-20T00:00:00 : 2021-01-27T00:00:00');
     });
 
-    it('2) specific : relative', () => {
+    test('2) specific : relative', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: '2021-01-20T00:00:00',
@@ -57,7 +57,7 @@ describe('Custom TimeRange', () => {
       );
     });
 
-    it('3) now : relative', () => {
+    test('3) now : relative', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: 'now',
@@ -74,7 +74,7 @@ describe('Custom TimeRange', () => {
       ).toEqual('now : DATEADD(DATETIME("now"), 7, day)');
     });
 
-    it('4) today : relative', () => {
+    test('4) today : relative', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: 'today',
@@ -91,7 +91,7 @@ describe('Custom TimeRange', () => {
       ).toEqual('today : DATEADD(DATETIME("today"), 7, day)');
     });
 
-    it('5) relative : specific', () => {
+    test('5) relative : specific', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: '2021-01-27T00:00:00',
@@ -110,7 +110,7 @@ describe('Custom TimeRange', () => {
       );
     });
 
-    it('6) relative : now', () => {
+    test('6) relative : now', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: 'now',
@@ -127,7 +127,7 @@ describe('Custom TimeRange', () => {
       ).toEqual('DATEADD(DATETIME("now"), -7, day) : now');
     });
 
-    it('7) relative : today', () => {
+    test('7) relative : today', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: 'today',
@@ -144,7 +144,7 @@ describe('Custom TimeRange', () => {
       ).toEqual('DATEADD(DATETIME("today"), -7, day) : today');
     });
 
-    it('8) relative : relative (now)', () => {
+    test('8) relative : relative (now)', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: 'now',
@@ -163,7 +163,7 @@ describe('Custom TimeRange', () => {
       );
     });
 
-    it('9) relative : relative (date/time)', () => {
+    test('9) relative : relative (date/time)', () => {
       expect(
         customTimeRangeEncode({
           sinceDatetime: '2021-01-27T00:00:00',

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -319,6 +319,7 @@ test('onChange is not called when close is clicked and canDelete is string, warn
   expect(await screen.findByText('Test warning')).toBeInTheDocument();
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('when disallow_adhoc_metrics is set', () => {
   test('can drop a column type from the simple column selection', () => {
     const adhocMetric = new AdhocMetric({

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
@@ -24,6 +24,7 @@ import {
 } from 'spec/helpers/testing-library';
 import Option from 'src/explore/components/controls/DndColumnSelectControl/Option';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Option', () => {
   beforeAll(() => {
     jest.setTimeout(30000);

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -21,7 +21,7 @@ import { Operators } from 'src/explore/constants';
 import { ExpressionTypes, Clauses } from '../types';
 
 describe('AdhocFilter', () => {
-  it('sets filterOptionName in constructor', () => {
+  test('sets filterOptionName in constructor', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'value',
@@ -44,7 +44,7 @@ describe('AdhocFilter', () => {
     });
   });
 
-  it('can create altered duplicates', () => {
+  test('can create altered duplicates', () => {
     const adhocFilter1 = new AdhocFilter({
       isNew: true,
       expressionType: ExpressionTypes.Simple,
@@ -68,7 +68,7 @@ describe('AdhocFilter', () => {
     expect(adhocFilter2.isNew).toStrictEqual(false);
   });
 
-  it('can verify equality', () => {
+  test('can verify equality', () => {
     const adhocFilter1 = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'value',
@@ -84,7 +84,7 @@ describe('AdhocFilter', () => {
     expect(adhocFilter1 === adhocFilter2).toBe(false);
   });
 
-  it('can verify inequality', () => {
+  test('can verify inequality', () => {
     const adhocFilter1 = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'value',
@@ -110,7 +110,7 @@ describe('AdhocFilter', () => {
     expect(adhocFilter3.equals(adhocFilter4)).toBe(false);
   });
 
-  it('can determine if it is valid', () => {
+  test('can determine if it is valid', () => {
     const adhocFilter1 = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'value',
@@ -206,7 +206,7 @@ describe('AdhocFilter', () => {
     expect(adhocFilter10.isValid()).toBe(true);
   });
 
-  it('can translate from simple expressions to sql expressions', () => {
+  test('can translate from simple expressions to sql expressions', () => {
     const adhocFilter1 = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'value',
@@ -225,7 +225,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter2.translateToSql()).toBe('SUM(value) <> 5');
   });
-  it('sets comparator to undefined when operator is IS_NULL', () => {
+  test('sets comparator to undefined when operator is IS_NULL', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'SUM(value)',
@@ -236,7 +236,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.comparator).toBe(undefined);
   });
-  it('sets comparator to undefined when operator is IS_NOT_NULL', () => {
+  test('sets comparator to undefined when operator is IS_NOT_NULL', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'SUM(value)',
@@ -247,7 +247,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.comparator).toBe(undefined);
   });
-  it('sets comparator to undefined when operator is IS_TRUE', () => {
+  test('sets comparator to undefined when operator is IS_TRUE', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'col',
@@ -258,7 +258,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.comparator).toBe(undefined);
   });
-  it('sets comparator to undefined when operator is IS_FALSE', () => {
+  test('sets comparator to undefined when operator is IS_FALSE', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'col',
@@ -269,14 +269,14 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.comparator).toBe(undefined);
   });
-  it('sets the label properly if subject is a string', () => {
+  test('sets the label properly if subject is a string', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'order_date',
     });
     expect(adhocFilter.getDefaultLabel()).toBe('order_date');
   });
-  it('sets the label properly if subject is an object with the column_date property', () => {
+  test('sets the label properly if subject is an object with the column_date property', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: {
@@ -285,7 +285,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.getDefaultLabel()).toBe('year');
   });
-  it('sets the label to empty is there is no column_name in the object', () => {
+  test('sets the label to empty is there is no column_name in the object', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: {
@@ -294,7 +294,7 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.getDefaultLabel()).toBe('');
   });
-  it('sets the label to empty is there is no subject', () => {
+  test('sets the label to empty is there is no subject', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: undefined,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -20,6 +20,7 @@ import AdhocFilter from 'src/explore/components/controls/FilterControl/AdhocFilt
 import { Operators } from 'src/explore/constants';
 import { ExpressionTypes, Clauses } from '../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocFilter', () => {
   test('sets filterOptionName in constructor', () => {
     const adhocFilter = new AdhocFilter({

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
@@ -73,6 +73,7 @@ const renderComponent = (props: Partial<Props> = {}) =>
     useDnd: true,
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocFilterControl', () => {
   test('should render with default props', () => {
     renderComponent();

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
@@ -74,7 +74,7 @@ const renderComponent = (props: Partial<Props> = {}) =>
   });
 
 describe('AdhocFilterControl', () => {
-  it('should render with default props', () => {
+  test('should render with default props', () => {
     renderComponent();
     expect(screen.getByText('Add filter')).toBeInTheDocument();
     expect(screen.getByTestId('adhoc-filter-control')).toBeInTheDocument();
@@ -111,13 +111,13 @@ describe('AdhocFilterControl', () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
-  it('should show add filter button when no filters exist', () => {
+  test('should show add filter button when no filters exist', () => {
     renderComponent();
     const addButton = screen.getByTestId('add-filter-button');
     expect(addButton).toBeInTheDocument();
   });
 
-  it('should handle partition column data', async () => {
+  test('should handle partition column data', async () => {
     const mockPartitionColumn = 'date_column';
     const mockResponse = {
       partitions: {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -74,6 +74,7 @@ const renderPopover = (props = {}) =>
     useRedux: true, // Add Redux provider for context
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocFilterEditPopover', () => {
   test('renders simple tab content by default', () => {
     renderPopover();

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -75,7 +75,7 @@ const renderPopover = (props = {}) =>
   });
 
 describe('AdhocFilterEditPopover', () => {
-  it('renders simple tab content by default', () => {
+  test('renders simple tab content by default', () => {
     renderPopover();
 
     expect(screen.getByRole('tablist')).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('AdhocFilterEditPopover', () => {
     expect(screen.getByText('Simple')).toBeInTheDocument();
   });
 
-  it('renders sql tab content when the adhoc filter expressionType is sql', () => {
+  test('renders sql tab content when the adhoc filter expressionType is sql', () => {
     renderPopover({ adhocFilter: sqlAdhocFilter });
 
     expect(screen.getByRole('tablist')).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe('AdhocFilterEditPopover', () => {
     );
   });
 
-  it('renders error message when filter is faulty', () => {
+  test('renders error message when filter is faulty', () => {
     renderPopover({ adhocFilter: faultyAdhocFilter });
 
     expect(screen.getByRole('tablist')).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe('AdhocFilterEditPopover', () => {
     ).toBeDisabled();
   });
 
-  it.skip('updates the filter when changes are made', async () => {
+  test.skip('updates the filter when changes are made', async () => {
     const onChange = jest.fn();
     renderPopover({
       onChange,
@@ -137,7 +137,7 @@ describe('AdhocFilterEditPopover', () => {
     );
   });
 
-  it('enables save button when valid changes are made', async () => {
+  test('enables save button when valid changes are made', async () => {
     renderPopover({ adhocFilter: simpleAdhocFilter });
 
     // Find the subject select by its test id
@@ -157,7 +157,7 @@ describe('AdhocFilterEditPopover', () => {
     expect(saveButton).toBeEnabled();
   });
 
-  it('disables save button when filter is invalid', () => {
+  test('disables save button when filter is invalid', () => {
     renderPopover({ adhocFilter: faultyAdhocFilter });
 
     const saveButton = screen.getByTestId(
@@ -166,7 +166,7 @@ describe('AdhocFilterEditPopover', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('initiates resize when resize handle is dragged', async () => {
+  test('initiates resize when resize handle is dragged', async () => {
     const onResize = jest.fn();
     renderPopover({ onResize });
 
@@ -178,7 +178,7 @@ describe('AdhocFilterEditPopover', () => {
     expect(onResize).toHaveBeenCalled();
   });
 
-  it('closes popover when close button is clicked', async () => {
+  test('closes popover when close button is clicked', async () => {
     const onClose = jest.fn();
     renderPopover({ onClose });
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -147,11 +147,11 @@ jest.mock('@superset-ui/core', () => ({
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 describe('AdhocFilterEditPopoverSimpleTabContent', () => {
-  it('can render the simple tab form', () => {
+  test('can render the simple tab form', () => {
     expect(() => setup()).not.toThrow();
   });
 
-  it('shows boolean only operators when subject is boolean', () => {
+  test('shows boolean only operators when subject is boolean', () => {
     const props = setup({
       adhocFilter: new AdhocFilter({
         expressionType: ExpressionTypes.Simple,
@@ -179,7 +179,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       Operators.IsFalse,
     ].map(operator => expect(isOperatorRelevant(operator, 'value')).toBe(true));
   });
-  it('shows boolean only operators when subject is number', () => {
+  test('shows boolean only operators when subject is number', () => {
     const props = setup({
       adhocFilter: new AdhocFilter({
         expressionType: ExpressionTypes.Simple,
@@ -208,7 +208,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     ].map(operator => expect(isOperatorRelevant(operator, 'value')).toBe(true));
   });
 
-  it('will convert from individual comparator to array if the operator changes to multi', () => {
+  test('will convert from individual comparator to array if the operator changes to multi', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     onOperatorChange(Operators.In);
@@ -217,7 +217,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     expect(props.onChange.lastCall.args[0].operatorId).toEqual(Operators.In);
   });
 
-  it('will convert from array to individual comparators if the operator changes from multi', () => {
+  test('will convert from array to individual comparators if the operator changes from multi', () => {
     const props = setup({
       adhocFilter: simpleMultiAdhocFilter,
     });
@@ -233,7 +233,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     );
   });
 
-  it('passes the new adhocFilter to onChange after onComparatorChange', () => {
+  test('passes the new adhocFilter to onChange after onComparatorChange', () => {
     const props = setup();
     const { onComparatorChange } = useSimpleTabFilterProps(props);
     onComparatorChange('20');
@@ -243,13 +243,13 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     );
   });
 
-  it('will filter operators for table datasources', () => {
+  test('will filter operators for table datasources', () => {
     const props = setup({ datasource: { type: 'table' } });
     const { isOperatorRelevant } = useSimpleTabFilterProps(props);
     expect(isOperatorRelevant(Operators.Like, 'value')).toBe(true);
   });
 
-  it('will show LATEST PARTITION operator', () => {
+  test('will show LATEST PARTITION operator', () => {
     const props = setup({
       datasource: {
         type: 'table',
@@ -264,7 +264,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     expect(isOperatorRelevant(Operators.LatestPartition, 'value')).toBe(false);
   });
 
-  it('will generate custom sqlExpression for LATEST PARTITION operator', () => {
+  test('will generate custom sqlExpression for LATEST PARTITION operator', () => {
     const testAdhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,
       subject: 'ds',
@@ -293,7 +293,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       }),
     );
   });
-  it('will not display boolean operators when column type is string', () => {
+  test('will not display boolean operators when column type is string', () => {
     const props = setup({
       datasource: {
         type: 'table',
@@ -309,7 +309,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       expect(isOperatorRelevant(operator, 'value')).toBe(false);
     });
   });
-  it('will display boolean operators when column is an expression', () => {
+  test('will display boolean operators when column is an expression', () => {
     const props = setup({
       datasource: {
         type: 'table',
@@ -330,7 +330,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
       expect(isOperatorRelevant(operator, 'value')).toBe(true);
     });
   });
-  it('sets comparator to undefined when operator is IS_TRUE', () => {
+  test('sets comparator to undefined when operator is IS_TRUE', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     onOperatorChange(Operators.IsTrue);
@@ -339,7 +339,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     expect(props.onChange.lastCall.args[0].operator).toBe('IS TRUE');
     expect(props.onChange.lastCall.args[0].comparator).toBe(undefined);
   });
-  it('sets comparator to undefined when operator is IS_FALSE', () => {
+  test('sets comparator to undefined when operator is IS_FALSE', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     onOperatorChange(Operators.IsFalse);
@@ -348,7 +348,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent', () => {
     expect(props.onChange.lastCall.args[0].operator).toBe('IS FALSE');
     expect(props.onChange.lastCall.args[0].comparator).toBe(undefined);
   });
-  it('sets comparator to undefined when operator is IS_NULL or IS_NOT_NULL', () => {
+  test('sets comparator to undefined when operator is IS_NULL or IS_NOT_NULL', () => {
     const props = setup();
     const { onOperatorChange } = useSimpleTabFilterProps(props);
     [Operators.IsNull, Operators.IsNotNull].forEach(op => {
@@ -407,7 +407,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent Advanced data Type Test', () =>
     isFeatureEnabledMock.mockRestore();
   });
 
-  it('should not call API when column has no advanced data type', async () => {
+  test('should not call API when column has no advanced data type', async () => {
     fetchMock.resetHistory();
 
     const props = getAdvancedDataTypeTestProps();
@@ -434,7 +434,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent Advanced data Type Test', () =>
     );
   });
 
-  it('should call API when column has advanced data type', async () => {
+  test('should call API when column has advanced data type', async () => {
     fetchMock.resetHistory();
 
     const props = getAdvancedDataTypeTestProps({
@@ -471,7 +471,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent Advanced data Type Test', () =>
     expect(props.validHandler.lastCall.args[0]).toBe(true);
   });
 
-  it('save button should be disabled if error message from API is returned', async () => {
+  test('save button should be disabled if error message from API is returned', async () => {
     fetchMock.resetHistory();
 
     const props = getAdvancedDataTypeTestProps({
@@ -508,7 +508,7 @@ describe('AdhocFilterEditPopoverSimpleTabContent Advanced data Type Test', () =>
     expect(props.validHandler.lastCall.args[0]).toBe(false);
   });
 
-  it('advanced data type operator list should update after API response', async () => {
+  test('advanced data type operator list should update after API response', async () => {
     fetchMock.resetHistory();
 
     const props = getAdvancedDataTypeTestProps({

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -146,6 +146,7 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocFilterEditPopoverSimpleTabContent', () => {
   test('can render the simple tab form', () => {
     expect(() => setup()).not.toThrow();
@@ -386,6 +387,7 @@ fetchMock.get(ADVANCED_DATA_TYPE_ENDPOINT_INVALID, {
 const mockStore = configureStore([thunk]);
 const store = mockStore({});
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocFilterEditPopoverSimpleTabContent Advanced data Type Test', () => {
   const setupFilter = async (props: Props) => {
     await act(async () => {

--- a/superset-frontend/src/explore/components/controls/FilterControl/adhocFilterType.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/adhocFilterType.test.ts
@@ -23,6 +23,7 @@ import {
 } from './adhocFilterType';
 import { Clauses, ExpressionTypes } from './types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('adhocFilterType', () => {
   test('should accept simple adhoc filter type', () => {
     const simpleFilter: AdhocFilterSimple = {

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
@@ -24,7 +24,7 @@ import AdhocMetric, {
 const valueColumn = { type: 'DOUBLE', column_name: 'value' };
 
 describe('AdhocMetric', () => {
-  it('sets label, hasCustomLabel and optionName in constructor', () => {
+  test('sets label, hasCustomLabel and optionName in constructor', () => {
     const adhocMetric = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -42,7 +42,7 @@ describe('AdhocMetric', () => {
     });
   });
 
-  it('can create altered duplicates', () => {
+  test('can create altered duplicates', () => {
     const adhocMetric1 = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -58,7 +58,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric2.aggregate).toBe(AGGREGATES.AVG);
   });
 
-  it('can verify equality', () => {
+  test('can verify equality', () => {
     const adhocMetric1 = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -69,7 +69,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric1.equals(adhocMetric2)).toBe(true);
   });
 
-  it('can verify inequality', () => {
+  test('can verify inequality', () => {
     const adhocMetric1 = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -95,7 +95,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric3.equals(adhocMetric4)).toBe(false);
   });
 
-  it('updates label if hasCustomLabel is false', () => {
+  test('updates label if hasCustomLabel is false', () => {
     const adhocMetric1 = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -107,7 +107,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric2.label).toBe('AVG(value)');
   });
 
-  it('keeps label if hasCustomLabel is true', () => {
+  test('keeps label if hasCustomLabel is true', () => {
     const adhocMetric1 = new AdhocMetric({
       column: valueColumn,
       aggregate: AGGREGATES.SUM,
@@ -121,7 +121,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric2.label).toBe('label1');
   });
 
-  it('can determine if it is valid', () => {
+  test('can determine if it is valid', () => {
     const adhocMetric1 = new AdhocMetric({
       expressionType: EXPRESSION_TYPES.SIMPLE,
       column: valueColumn,
@@ -170,7 +170,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric5.isValid()).toBe(false);
   });
 
-  it('can translate back from sql expressions to simple expressions when possible', () => {
+  test('can translate back from sql expressions to simple expressions when possible', () => {
     const adhocMetric = new AdhocMetric({
       expressionType: EXPRESSION_TYPES.SQL,
       sqlExpression: 'AVG(my_column)',
@@ -190,7 +190,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric2.inferSqlExpressionAggregate()).toBeNull();
   });
 
-  it('will infer columns and aggregates when converting to a simple expression', () => {
+  test('will infer columns and aggregates when converting to a simple expression', () => {
     const adhocMetric = new AdhocMetric({
       expressionType: EXPRESSION_TYPES.SQL,
       sqlExpression: 'AVG(my_column)',
@@ -212,7 +212,7 @@ describe('AdhocMetric', () => {
     expect(adhocMetric3.column.column_name).toBe('value');
   });
 
-  it('should transform count_distinct SQL and do not change label if does not set metric label', () => {
+  test('should transform count_distinct SQL and do not change label if does not set metric label', () => {
     const withBrackets = new AdhocMetric({
       column: { type: 'TEXT', column_name: '(column-with-barckets)' },
       aggregate: AGGREGATES.COUNT_DISTINCT,

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
@@ -23,6 +23,7 @@ import AdhocMetric, {
 
 const valueColumn = { type: 'DOUBLE', column_name: 'value' };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AdhocMetric', () => {
   test('sets label, hasCustomLabel and optionName in constructor', () => {
     const adhocMetric = new AdhocMetric({

--- a/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
@@ -21,7 +21,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import AggregateOption from 'src/explore/components/controls/MetricControl/AggregateOption';
 
 describe('AggregateOption', () => {
-  it('renders the aggregate', () => {
+  test('renders the aggregate', () => {
     render(<AggregateOption aggregate={{ aggregate_name: 'SUM' }} />);
 
     const aggregateOption = screen.getByText(/sum/i);

--- a/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
@@ -20,6 +20,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 
 import AggregateOption from 'src/explore/components/controls/MetricControl/AggregateOption';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AggregateOption', () => {
   test('renders the aggregate', () => {
     render(<AggregateOption aggregate={{ aggregate_name: 'SUM' }} />);

--- a/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
@@ -36,6 +36,7 @@ const sumValueAdhocMetric = new AdhocMetric({
   aggregate: AGGREGATES.SUM,
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('FilterDefinitionOption', () => {
   test('renders a StyledColumnOption given a column', async () => {
     render(<FilterDefinitionOption option={{ column_name: 'a_column' }} />);

--- a/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
@@ -37,17 +37,17 @@ const sumValueAdhocMetric = new AdhocMetric({
 });
 
 describe('FilterDefinitionOption', () => {
-  it('renders a StyledColumnOption given a column', async () => {
+  test('renders a StyledColumnOption given a column', async () => {
     render(<FilterDefinitionOption option={{ column_name: 'a_column' }} />);
     await expect(screen.getByText('a_column')).toBeVisible();
   });
 
-  it('renders a StyledColumnOption given an adhoc metric', async () => {
+  test('renders a StyledColumnOption given an adhoc metric', async () => {
     render(<FilterDefinitionOption option={sumValueAdhocMetric} />);
     await expect(screen.getByText('SUM(source)')).toBeVisible();
   });
 
-  it('renders the metric name given a saved metric', async () => {
+  test('renders the metric name given a saved metric', async () => {
     render(
       <FilterDefinitionOption
         option={{ saved_metric_name: 'my_custom_metric' }}

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
@@ -67,14 +67,14 @@ const renderSelectControl = (props = {}) => {
 };
 
 describe('SelectControl', () => {
-  it('calls props.onChange when select', async () => {
+  test('calls props.onChange when select', async () => {
     renderSelectControl();
     defaultProps.onChange(50);
     expect(defaultProps.onChange).toHaveBeenCalledWith(50);
   });
 
   describe('render', () => {
-    it('renders with Select by default', () => {
+    test('renders with Select by default', () => {
       renderSelectControl();
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -87,7 +87,7 @@ describe('SelectControl', () => {
       expect(selectorInput).toBeInTheDocument();
     });
 
-    it('renders as mode multiple', () => {
+    test('renders as mode multiple', () => {
       renderSelectControl({ multi: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -102,7 +102,7 @@ describe('SelectControl', () => {
       expect(screen.getByText('Select all (3)')).toBeInTheDocument();
     });
 
-    it('renders with allowNewOptions when freeForm', () => {
+    test('renders with allowNewOptions when freeForm', () => {
       renderSelectControl({ freeForm: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -123,7 +123,7 @@ describe('SelectControl', () => {
       );
     });
 
-    it('renders with allowNewOptions=false when freeForm=false', () => {
+    test('renders with allowNewOptions=false when freeForm=false', () => {
       const container = renderSelectControl({ freeForm: false });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -148,7 +148,7 @@ describe('SelectControl', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders with tokenSeparators', () => {
+    test('renders with tokenSeparators', () => {
       renderSelectControl({ tokenSeparators: ['\n', '\t', ';'], multi: true });
       const selectorWrapper = screen.getByLabelText('Row Limit', {
         selector: 'div',
@@ -176,7 +176,7 @@ describe('SelectControl', () => {
 
     describe('empty placeholder', () => {
       describe('withMulti', () => {
-        it('does not show a placeholder if there are no choices', () => {
+        test('does not show a placeholder if there are no choices', () => {
           renderSelectControl({
             choices: [],
             multi: true,
@@ -186,7 +186,7 @@ describe('SelectControl', () => {
         });
       });
       describe('withSingleChoice', () => {
-        it('does not show a placeholder if there are no choices', async () => {
+        test('does not show a placeholder if there are no choices', async () => {
           const container = renderSelectControl({
             choices: [],
             multi: false,
@@ -198,7 +198,7 @@ describe('SelectControl', () => {
         });
       });
       describe('all choices selected', () => {
-        it('does not show a placeholder', () => {
+        test('does not show a placeholder', () => {
           const container = renderSelectControl({
             multi: true,
             value: ['today', '1 year ago'],
@@ -211,7 +211,7 @@ describe('SelectControl', () => {
       });
     });
     describe('when select is multi', () => {
-      it('does not render the placeholder when a selection has been made', () => {
+      test('does not render the placeholder when a selection has been made', () => {
         renderSelectControl({
           multi: true,
           value: ['today'],
@@ -221,7 +221,7 @@ describe('SelectControl', () => {
       });
     });
     describe('when select is single', () => {
-      it('does not render the placeholder when a selection has been made', () => {
+      test('does not render the placeholder when a selection has been made', () => {
         renderSelectControl({
           multi: true,
           value: 50,
@@ -233,13 +233,13 @@ describe('SelectControl', () => {
   });
 
   describe('getOptions', () => {
-    it('returns the correct options', () => {
+    test('returns the correct options', () => {
       expect(innerGetOptions(defaultProps)).toEqual(options);
     });
   });
 
   describe('areAllValuesNumbers', () => {
-    it('returns true when all values are numbers (array format)', () => {
+    test('returns true when all values are numbers (array format)', () => {
       const items = [
         [1, 'One'],
         [2, 'Two'],
@@ -248,7 +248,7 @@ describe('SelectControl', () => {
       expect(areAllValuesNumbers(items)).toBe(true);
     });
 
-    it('returns false when some values are not numbers (array format)', () => {
+    test('returns false when some values are not numbers (array format)', () => {
       const items = [
         [1, 'One'],
         ['two', 'Two'],
@@ -257,7 +257,7 @@ describe('SelectControl', () => {
       expect(areAllValuesNumbers(items)).toBe(false);
     });
 
-    it('returns true when all values are numbers (object format)', () => {
+    test('returns true when all values are numbers (object format)', () => {
       const items = [
         { value: 1, label: 'One' },
         { value: 2, label: 'Two' },
@@ -266,7 +266,7 @@ describe('SelectControl', () => {
       expect(areAllValuesNumbers(items)).toBe(true);
     });
 
-    it('returns false when some values are not numbers (object format)', () => {
+    test('returns false when some values are not numbers (object format)', () => {
       const items = [
         { value: 1, label: 'One' },
         { value: 'two', label: 'Two' },
@@ -275,17 +275,17 @@ describe('SelectControl', () => {
       expect(areAllValuesNumbers(items)).toBe(false);
     });
 
-    it('returns true when all values are numbers (primitive format)', () => {
+    test('returns true when all values are numbers (primitive format)', () => {
       const items = [1, 2, 3];
       expect(areAllValuesNumbers(items)).toBe(true);
     });
 
-    it('returns false when some values are not numbers (primitive format)', () => {
+    test('returns false when some values are not numbers (primitive format)', () => {
       const items = [1, 'two', 3];
       expect(areAllValuesNumbers(items)).toBe(false);
     });
 
-    it('works with custom valueKey', () => {
+    test('works with custom valueKey', () => {
       const items = [
         { id: 1, label: 'One' },
         { id: 2, label: 'Two' },
@@ -294,7 +294,7 @@ describe('SelectControl', () => {
       expect(areAllValuesNumbers(items, 'id')).toBe(true);
     });
 
-    it('returns false for empty items', () => {
+    test('returns false for empty items', () => {
       expect(areAllValuesNumbers([])).toBe(false);
       expect(areAllValuesNumbers(null)).toBe(false);
       expect(areAllValuesNumbers(undefined)).toBe(false);
@@ -304,7 +304,7 @@ describe('SelectControl', () => {
   describe('getSortComparator', () => {
     const mockExplicitComparator = (a, b) => a.label.localeCompare(b.label);
 
-    it('returns explicit comparator when provided', () => {
+    test('returns explicit comparator when provided', () => {
       const choices = [
         [1, 'One'],
         [2, 'Two'],
@@ -318,7 +318,7 @@ describe('SelectControl', () => {
       expect(result).toBe(mockExplicitComparator);
     });
 
-    it('returns number comparator for numeric choices', () => {
+    test('returns number comparator for numeric choices', () => {
       const choices = [
         [1, 'One'],
         [2, 'Two'],
@@ -328,7 +328,7 @@ describe('SelectControl', () => {
       expect(result).not.toBe(mockExplicitComparator);
     });
 
-    it('returns number comparator for numeric options', () => {
+    test('returns number comparator for numeric options', () => {
       const options = [
         { value: 1, label: 'One' },
         { value: 2, label: 'Two' },
@@ -338,7 +338,7 @@ describe('SelectControl', () => {
       expect(result).not.toBe(mockExplicitComparator);
     });
 
-    it('prioritizes options over choices when both are numeric', () => {
+    test('prioritizes options over choices when both are numeric', () => {
       const choices = [
         [1, 'One'],
         [2, 'Two'],
@@ -351,7 +351,7 @@ describe('SelectControl', () => {
       expect(typeof result).toBe('function');
     });
 
-    it('returns undefined for non-numeric choices', () => {
+    test('returns undefined for non-numeric choices', () => {
       const choices = [
         ['one', 'One'],
         ['two', 'Two'],
@@ -360,7 +360,7 @@ describe('SelectControl', () => {
       expect(result).toBeUndefined();
     });
 
-    it('returns undefined for non-numeric options', () => {
+    test('returns undefined for non-numeric options', () => {
       const options = [
         { value: 'one', label: 'One' },
         { value: 'two', label: 'Two' },
@@ -369,14 +369,14 @@ describe('SelectControl', () => {
       expect(result).toBeUndefined();
     });
 
-    it('returns undefined when no choices or options provided', () => {
+    test('returns undefined when no choices or options provided', () => {
       const result = getSortComparator(null, null, 'value', null);
       expect(result).toBeUndefined();
     });
   });
 
   describe('numeric sorting integration', () => {
-    it('applies numeric sorting to choices automatically', () => {
+    test('applies numeric sorting to choices automatically', () => {
       const numericChoices = [
         [3, 'Three'],
         [1, 'One'],
@@ -392,7 +392,7 @@ describe('SelectControl', () => {
       expect(selectorWrapper).toBeInTheDocument();
     });
 
-    it('applies numeric sorting to options automatically', () => {
+    test('applies numeric sorting to options automatically', () => {
       const numericOptions = [
         { value: 3, label: 'Three' },
         { value: 1, label: 'One' },
@@ -407,7 +407,7 @@ describe('SelectControl', () => {
       expect(selectorWrapper).toBeInTheDocument();
     });
 
-    it('does not apply numeric sorting to mixed-type choices', () => {
+    test('does not apply numeric sorting to mixed-type choices', () => {
       const mixedChoices = [
         [1, 'One'],
         ['two', 'Two'],
@@ -422,7 +422,7 @@ describe('SelectControl', () => {
       expect(selectorWrapper).toBeInTheDocument();
     });
 
-    it('respects explicit sortComparator over automatic numeric sorting', () => {
+    test('respects explicit sortComparator over automatic numeric sorting', () => {
       const numericChoices = [
         [3, 'Three'],
         [1, 'One'],

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
@@ -66,6 +66,7 @@ const renderSelectControl = (props = {}) => {
   return container;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SelectControl', () => {
   test('calls props.onChange when select', async () => {
     renderSelectControl();
@@ -73,6 +74,7 @@ describe('SelectControl', () => {
     expect(defaultProps.onChange).toHaveBeenCalledWith(50);
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('render', () => {
     test('renders with Select by default', () => {
       renderSelectControl();
@@ -174,7 +176,9 @@ describe('SelectControl', () => {
       expect(weekOption?.getAttribute('aria-selected')).toEqual('true');
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('empty placeholder', () => {
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('withMulti', () => {
         test('does not show a placeholder if there are no choices', () => {
           renderSelectControl({
@@ -185,6 +189,7 @@ describe('SelectControl', () => {
           expect(screen.queryByRole('option')).not.toBeInTheDocument();
         });
       });
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('withSingleChoice', () => {
         test('does not show a placeholder if there are no choices', async () => {
           const container = renderSelectControl({
@@ -197,6 +202,7 @@ describe('SelectControl', () => {
           ).not.toBeInTheDocument();
         });
       });
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('all choices selected', () => {
         test('does not show a placeholder', () => {
           const container = renderSelectControl({
@@ -210,6 +216,7 @@ describe('SelectControl', () => {
         });
       });
     });
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('when select is multi', () => {
       test('does not render the placeholder when a selection has been made', () => {
         renderSelectControl({
@@ -220,6 +227,7 @@ describe('SelectControl', () => {
         expect(screen.queryByText('add something')).not.toBeInTheDocument();
       });
     });
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('when select is single', () => {
       test('does not render the placeholder when a selection has been made', () => {
         renderSelectControl({
@@ -232,12 +240,14 @@ describe('SelectControl', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getOptions', () => {
     test('returns the correct options', () => {
       expect(innerGetOptions(defaultProps)).toEqual(options);
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('areAllValuesNumbers', () => {
     test('returns true when all values are numbers (array format)', () => {
       const items = [
@@ -301,6 +311,7 @@ describe('SelectControl', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getSortComparator', () => {
     const mockExplicitComparator = (a, b) => a.label.localeCompare(b.label);
 
@@ -375,6 +386,7 @@ describe('SelectControl', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('numeric sorting integration', () => {
     test('applies numeric sorting to choices automatically', () => {
       const numericChoices = [

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
@@ -31,6 +31,7 @@ const defaultProps = {
   onChange: jest.fn(),
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TextArea', () => {
   test('renders a FormControl', () => {
     render(<TextAreaControl {...defaultProps} />);

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
@@ -32,19 +32,19 @@ const defaultProps = {
 };
 
 describe('TextArea', () => {
-  it('renders a FormControl', () => {
+  test('renders a FormControl', () => {
     render(<TextAreaControl {...defaultProps} />);
     expect(screen.getByRole('textbox')).toBeVisible();
   });
 
-  it('calls onChange when toggled', () => {
+  test('calls onChange when toggled', () => {
     render(<TextAreaControl {...defaultProps} />);
     const textArea = screen.getByRole('textbox');
     fireEvent.change(textArea, { target: { value: 'x' } });
     expect(defaultProps.onChange).toHaveBeenCalledWith('x');
   });
 
-  it('renders a AceEditor when language is specified', async () => {
+  test('renders a AceEditor when language is specified', async () => {
     const props = { ...defaultProps, language: 'markdown' };
     const { container } = render(<TextAreaControl {...props} />);
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('TextArea', () => {
     });
   });
 
-  it('calls onAreaEditorChange when entering in the AceEditor', () => {
+  test('calls onAreaEditorChange when entering in the AceEditor', () => {
     const props = { ...defaultProps, language: 'markdown' };
     render(<TextAreaControl {...props} />);
     const textArea = screen.getByRole('textbox');

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
@@ -55,7 +55,7 @@ describe('TimeOffsetControls', () => {
     return { store, props };
   };
 
-  it('TimeOffsetControl renders DatePicker when startDate is set', () => {
+  test('TimeOffsetControl renders DatePicker when startDate is set', () => {
     setup();
     const datePickerInput = screen.getByRole('textbox');
     expect(datePickerInput).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe('TimeOffsetControls', () => {
 
   // Our Time comparison control depends on this string for supporting date deletion on date picker
   // That's why this test is linked to the TimeOffsetControl component
-  it('Dayjs should return "Invalid date" when parsing an invalid date string', () => {
+  test('Dayjs should return "Invalid date" when parsing an invalid date string', () => {
     const invalidDate = extendedDayjs('not-a-date');
     expect(invalidDate.format()).toBe(INVALID_DATE);
   });

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
@@ -30,6 +30,7 @@ const defaultProps: TimeOffsetControlsProps = {
   onChange: jest.fn(),
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TimeOffsetControls', () => {
   const setup = (initialState = {}) => {
     const store = mockStore({

--- a/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
@@ -32,6 +32,7 @@ const defaultProps = {
 };
 const renderedCoordinate = '6° 51\' 8.50" | 31° 13\' 21.56"';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ViewportControl', () => {
   beforeEach(() => {
     render(<ViewportControl {...defaultProps} />);

--- a/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
@@ -37,18 +37,18 @@ describe('ViewportControl', () => {
     render(<ViewportControl {...defaultProps} />);
   });
 
-  it('renders a OverlayTrigger if clicked', () => {
+  test('renders a OverlayTrigger if clicked', () => {
     expect(screen.getByTestId('foo-header')).toBeInTheDocument(); // Presence of ControlHeader
     userEvent.click(screen.getByText(renderedCoordinate));
     expect(screen.getByText('Viewport')).toBeInTheDocument(); // Presence of Popover
   });
 
-  it('renders a Popover with 5 TextControl if clicked', () => {
+  test('renders a Popover with 5 TextControl if clicked', () => {
     userEvent.click(screen.getByText(renderedCoordinate));
     expect(screen.queryAllByTestId('inline-name')).toHaveLength(5);
   });
 
-  it('renders a summary in the label', () => {
+  test('renders a summary in the label', () => {
     expect(screen.getByText(renderedCoordinate)).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
@@ -55,6 +55,7 @@ afterEach(async () => {
   await new Promise(resolve => setTimeout(resolve, 0));
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('VizTypeControl', () => {
   const registry = getChartMetadataRegistry();
   registry

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
@@ -85,7 +85,7 @@ describe('VizTypeControl', () => {
     await waitForEffects();
   }, 30000); // Increase beforeEach timeout
 
-  it('calls onChange when submitted', async () => {
+  test('calls onChange when submitted', async () => {
     const thumbnail = await screen.findByTestId('viztype-selector-container', {
       timeout: 15000,
     });
@@ -106,7 +106,7 @@ describe('VizTypeControl', () => {
     expect(defaultProps.onChange.called).toBe(true);
   }, 30000);
 
-  it('filters images based on text input', async () => {
+  test('filters images based on text input', async () => {
     const thumbnails = await screen.findByTestId('viztype-selector-container', {
       timeout: 15000,
     });

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -116,7 +116,7 @@ describe('VizTypeControl', () => {
     jest.clearAllMocks();
   });
 
-  it('Fast viz switcher tiles render', async () => {
+  test('Fast viz switcher tiles render', async () => {
     const props = {
       ...defaultProps,
       value: VizType.Line,
@@ -151,7 +151,7 @@ describe('VizTypeControl', () => {
     ).toBeInTheDocument();
   });
 
-  it('Render viz tiles when non-featured chart is selected', async () => {
+  test('Render viz tiles when non-featured chart is selected', async () => {
     const props = {
       ...defaultProps,
       value: 'line',
@@ -165,7 +165,7 @@ describe('VizTypeControl', () => {
     ).toBeVisible();
   });
 
-  it('Render viz tiles when non-featured is rendered', async () => {
+  test('Render viz tiles when non-featured is rendered', async () => {
     const props = {
       ...defaultProps,
       value: VizType.Sankey,
@@ -192,7 +192,7 @@ describe('VizTypeControl', () => {
     ).toBeVisible();
   });
 
-  it('Change viz type on click', async () => {
+  test('Change viz type on click', async () => {
     const props = {
       ...defaultProps,
       value: VizType.Line,
@@ -209,7 +209,7 @@ describe('VizTypeControl', () => {
     expect(props.onChange).toHaveBeenCalledWith('table');
   });
 
-  it('Open viz gallery modal on "View all charts" click', async () => {
+  test('Open viz gallery modal on "View all charts" click', async () => {
     await waitForRenderWrapper({ ...defaultProps, isModalOpenInit: false });
     expect(
       screen.queryByText('Select a visualization type'),
@@ -220,7 +220,7 @@ describe('VizTypeControl', () => {
     ).toBeInTheDocument();
   });
 
-  it('Search visualization type', async () => {
+  test('Search visualization type', async () => {
     await waitForRenderWrapper();
 
     const visualizations = screen.getByTestId(getTestId('viz-row'));
@@ -248,7 +248,7 @@ describe('VizTypeControl', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('Submit on viz type double-click', async () => {
+  test('Submit on viz type double-click', async () => {
     await waitForRenderWrapper();
     userEvent.click(screen.getByRole('tab', { name: 'All charts' }));
     const visualizations = screen.getByTestId(getTestId('viz-row'));
@@ -260,7 +260,7 @@ describe('VizTypeControl', () => {
     expect(defaultProps.onChange).toHaveBeenCalledWith(VizType.Line);
   });
 
-  it('Search input is focused when modal opens', async () => {
+  test('Search input is focused when modal opens', async () => {
     // Mock the focus method to track if it was called
     const focusSpy = jest.fn();
     const originalFocus = HTMLInputElement.prototype.focus;
@@ -278,7 +278,7 @@ describe('VizTypeControl', () => {
     HTMLInputElement.prototype.focus = originalFocus;
   });
 
-  it('Navigate categories and select visualization type', async () => {
+  test('Navigate categories and select visualization type', async () => {
     await waitForRenderWrapper();
 
     const visualizations = screen.getByTestId(getTestId('viz-row'));
@@ -308,7 +308,7 @@ describe('VizTypeControl', () => {
     expect(defaultProps.onChange).toHaveBeenCalledWith(VizType.BigNumberTotal);
   });
 
-  it('Handle category switching between different chart types', async () => {
+  test('Handle category switching between different chart types', async () => {
     await waitForRenderWrapper();
 
     const visualizations = screen.getByTestId(getTestId('viz-row'));

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -86,6 +86,7 @@ const getTestId = testWithId<string>(VIZ_TYPE_CONTROL_TEST_ID, true);
  * on and prevents those warnings.
  */
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('VizTypeControl', () => {
   new MainPreset().register();
   const defaultProps = {

--- a/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
+++ b/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
@@ -37,7 +37,7 @@ const zoomConfigValues = {
 
 describe('zoomUtil', () => {
   describe('computeConfigValues', () => {
-    it('computes fixed values', () => {
+    test('computes fixed values', () => {
       const height = 100;
       const width = 100;
 
@@ -60,7 +60,7 @@ describe('zoomUtil', () => {
       });
     });
 
-    it('computes linear values', () => {
+    test('computes linear values', () => {
       const height = 100;
       const width = 100;
 
@@ -85,7 +85,7 @@ describe('zoomUtil', () => {
       });
     });
 
-    it('computes exponential values', () => {
+    test('computes exponential values', () => {
       const height = 100;
       const width = 100;
 
@@ -113,7 +113,7 @@ describe('zoomUtil', () => {
   });
 
   describe('zoomConfigsToData', () => {
-    it('returns correct output', () => {
+    test('returns correct output', () => {
       const result = zoomConfigsToData(zoomConfigValues);
 
       expect(result.length).toEqual(Object.keys(zoomConfigValues).length);
@@ -129,11 +129,11 @@ describe('zoomUtil', () => {
     };
     const result = toFixedConfig(configs);
 
-    it('has correct type', () => {
+    test('has correct type', () => {
       expect(result.type).toEqual('FIXED');
     });
 
-    it('returns correct result', () => {
+    test('returns correct result', () => {
       expect(result.values[4]).toEqual({
         width: 100,
         height: 100,
@@ -155,11 +155,11 @@ describe('zoomUtil', () => {
     };
     const result = toLinearConfig(configs);
 
-    it('has correct type', () => {
+    test('has correct type', () => {
       expect(result.type).toEqual('LINEAR');
     });
 
-    it('returns correct result', () => {
+    test('returns correct result', () => {
       expect(result.values[4]).toEqual({
         width: 98,
         height: 98,
@@ -181,10 +181,10 @@ describe('zoomUtil', () => {
     };
     // @ts-ignore
     const result = toExpConfig(configs);
-    it('has correct type', () => {
+    test('has correct type', () => {
       expect(result.type).toEqual('EXP');
     });
-    it('returns correct result', () => {
+    test('returns correct result', () => {
       expect(result.values[4]).toEqual({
         width: 93,
         height: 93,

--- a/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
+++ b/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
@@ -35,7 +35,9 @@ const zoomConfigValues = {
   })),
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('zoomUtil', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('computeConfigValues', () => {
     test('computes fixed values', () => {
       const height = 100;
@@ -112,6 +114,7 @@ describe('zoomUtil', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('zoomConfigsToData', () => {
     test('returns correct output', () => {
       const result = zoomConfigsToData(zoomConfigValues);
@@ -121,6 +124,7 @@ describe('zoomUtil', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('toFixedConfig', () => {
     const configs: ZoomConfigs['configs'] = {
       width: 100,
@@ -146,6 +150,7 @@ describe('zoomUtil', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('toLinearConfig', () => {
     const configs: ZoomConfigs['configs'] = {
       width: 100,
@@ -172,6 +177,7 @@ describe('zoomUtil', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('toExpConfig', () => {
     const configs: ZoomConfigs['configs'] = {
       width: 100,

--- a/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
+++ b/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
@@ -83,7 +83,7 @@ async function setup({
 }
 
 describe('VerifiedMetricsControl', () => {
-  it('should call verify correctly', async () => {
+  test('should call verify correctly', async () => {
     expect.assertions(3);
     const { verifier, props, rerender, VerifiedControl } = await setup();
 
@@ -100,7 +100,7 @@ describe('VerifiedMetricsControl', () => {
     );
   });
 
-  it('should trigger onChange event', async () => {
+  test('should trigger onChange event', async () => {
     expect.assertions(2);
     const mockOnChange = jest.fn();
     const { verifier, props } = await setup({

--- a/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
+++ b/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
@@ -82,6 +82,7 @@ async function setup({
   return { props, ...utils, verifier, VerifiedControl };
 }
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('VerifiedMetricsControl', () => {
   test('should call verify correctly', async () => {
     expect.assertions(3);

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
@@ -55,6 +55,7 @@ const createDashboards = (numberOfItems: number) => {
   return dashboards;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardsSubMenu', () => {
   test('exports SEARCH_THRESHOLD constant', () => {
     expect(SEARCH_THRESHOLD).toBe(10);

--- a/superset-frontend/src/explore/controlPanels/Separator.test.ts
+++ b/superset-frontend/src/explore/controlPanels/Separator.test.ts
@@ -52,25 +52,24 @@ function getCodeControlMapStateToProps() {
   return codeControl.config.mapStateToProps;
 }
 
-describe('Separator control panel config', () => {
-  test('defaults language to markdown when markup_type is missing', () => {
-    const mapStateToProps = getCodeControlMapStateToProps();
-    const state: Partial<ControlPanelState> = {};
-    const result = mapStateToProps(state);
-    expect(result.language).toBe('markdown');
-  });
+// Separator control panel config
+test('Separator control panel config defaults language to markdown when markup_type is missing', () => {
+  const mapStateToProps = getCodeControlMapStateToProps();
+  const state: Partial<ControlPanelState> = {};
+  const result = mapStateToProps(state);
+  expect(result.language).toBe('markdown');
+});
 
-  test('uses markup_type value when provided', () => {
-    const mapStateToProps = getCodeControlMapStateToProps();
-    const state: Partial<ControlPanelState> = {
-      controls: {
-        // minimal mock for the control used in mapStateToProps
-        markup_type: { value: 'html' } as Partial<
-          ControlState<'SelectControl'>
-        > as ControlState<'SelectControl'>,
-      },
-    };
-    const result = mapStateToProps(state);
-    expect(result.language).toBe('html');
-  });
+test('Separator control panel config uses markup_type value when provided', () => {
+  const mapStateToProps = getCodeControlMapStateToProps();
+  const state: Partial<ControlPanelState> = {
+    controls: {
+      // minimal mock for the control used in mapStateToProps
+      markup_type: { value: 'html' } as Partial<
+        ControlState<'SelectControl'>
+      > as ControlState<'SelectControl'>,
+    },
+  };
+  const result = mapStateToProps(state);
+  expect(result.language).toBe('html');
 });

--- a/superset-frontend/src/explore/controlPanels/Separator.test.ts
+++ b/superset-frontend/src/explore/controlPanels/Separator.test.ts
@@ -53,14 +53,14 @@ function getCodeControlMapStateToProps() {
 }
 
 describe('Separator control panel config', () => {
-  it('defaults language to markdown when markup_type is missing', () => {
+  test('defaults language to markdown when markup_type is missing', () => {
     const mapStateToProps = getCodeControlMapStateToProps();
     const state: Partial<ControlPanelState> = {};
     const result = mapStateToProps(state);
     expect(result.language).toBe('markdown');
   });
 
-  it('uses markup_type value when provided', () => {
+  test('uses markup_type value when provided', () => {
     const mapStateToProps = getCodeControlMapStateToProps();
     const state: Partial<ControlPanelState> = {
       controls: {

--- a/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
@@ -45,6 +45,7 @@ const getKnownControlConfig = (controlKey: string, vizType: string) =>
 const getKnownControlState = (...args: Parameters<typeof getControlState>) =>
   getControlState(...args) as Exclude<ReturnType<typeof getControlState>, null>;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('controlUtils', () => {
   const state: ControlPanelState = {
     datasource: {
@@ -93,6 +94,7 @@ describe('controlUtils', () => {
       .remove('test-chart-override');
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getControlConfig', () => {
     test('returns a valid spatial controlConfig', () => {
       const spatialControl = getControlConfig('color_scheme', 'test-chart');
@@ -129,6 +131,7 @@ describe('controlUtils', () => {
     );
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('applyMapStateToPropsToControl,', () => {
     test('applies state to props as expected', () => {
       let control = getKnownControlConfig('all_columns', 'table');
@@ -137,6 +140,7 @@ describe('controlUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getControlState', () => {
     test('to still have the functions', () => {
       const control = getKnownControlState('metrics', 'table', state, 'a');
@@ -186,6 +190,7 @@ describe('controlUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('validateControl', () => {
     test('validates the control, returns an error if empty', () => {
       const control = getControlState('metric', 'table', state, null);
@@ -202,6 +207,7 @@ describe('controlUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('findControlItem', () => {
     test('find control as a string', () => {
       const controlItem = findControlItem(

--- a/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
@@ -94,12 +94,12 @@ describe('controlUtils', () => {
   });
 
   describe('getControlConfig', () => {
-    it('returns a valid spatial controlConfig', () => {
+    test('returns a valid spatial controlConfig', () => {
       const spatialControl = getControlConfig('color_scheme', 'test-chart');
       expect(spatialControl?.type).toEqual('ColorSchemeControl');
     });
 
-    it('overrides according to vizType', () => {
+    test('overrides according to vizType', () => {
       let control = getKnownControlConfig('color_scheme', 'test-chart');
       expect(control.label).toEqual('Color Scheme');
 
@@ -107,7 +107,7 @@ describe('controlUtils', () => {
       expect(control.label).toEqual('My beautiful colors');
     });
 
-    it(
+    test(
       'returns correct control config when control config is defined ' +
         'in the control panel definition',
       () => {
@@ -130,7 +130,7 @@ describe('controlUtils', () => {
   });
 
   describe('applyMapStateToPropsToControl,', () => {
-    it('applies state to props as expected', () => {
+    test('applies state to props as expected', () => {
       let control = getKnownControlConfig('all_columns', 'table');
       control = applyMapStateToPropsToControl(control, state);
       expect(control.options).toEqual([{ column_name: 'a' }]);
@@ -138,18 +138,18 @@ describe('controlUtils', () => {
   });
 
   describe('getControlState', () => {
-    it('to still have the functions', () => {
+    test('to still have the functions', () => {
       const control = getKnownControlState('metrics', 'table', state, 'a');
       expect(typeof control.mapStateToProps).toBe('function');
       expect(typeof control.validators?.[0]).toBe('function');
     });
 
-    it('to make sure value is array', () => {
+    test('to make sure value is array', () => {
       const control = getKnownControlState('all_columns', 'table', state, 'a');
       expect(control.value).toEqual(['a']);
     });
 
-    it('removes missing/invalid choice', () => {
+    test('removes missing/invalid choice', () => {
       let control = getControlState(
         'stacked_style',
         'test-chart',
@@ -162,22 +162,22 @@ describe('controlUtils', () => {
       expect(control?.value).toBeNull();
     });
 
-    it('returns null for nonexistent field', () => {
+    test('returns null for nonexistent field', () => {
       const control = getControlState('NON_EXISTENT', 'table', state);
       expect(control).toBeNull();
     });
 
-    it('metrics control should be empty by default', () => {
+    test('metrics control should be empty by default', () => {
       const control = getControlState('metrics', 'table', state);
       expect(control?.default).toBeUndefined();
     });
 
-    it('metric control should be empty by default', () => {
+    test('metric control should be empty by default', () => {
       const control = getControlState('metric', 'table', state);
       expect(control?.default).toBeUndefined();
     });
 
-    it('should not apply mapStateToProps when initializing', () => {
+    test('should not apply mapStateToProps when initializing', () => {
       const control = getControlState('metrics', 'table', {
         ...state,
         controls: undefined,
@@ -187,11 +187,11 @@ describe('controlUtils', () => {
   });
 
   describe('validateControl', () => {
-    it('validates the control, returns an error if empty', () => {
+    test('validates the control, returns an error if empty', () => {
       const control = getControlState('metric', 'table', state, null);
       expect(control?.validationErrors).toEqual(['cannot be empty']);
     });
-    it('should not validate if control panel is initializing', () => {
+    test('should not validate if control panel is initializing', () => {
       const control = getControlState(
         'metric',
         'table',
@@ -203,7 +203,7 @@ describe('controlUtils', () => {
   });
 
   describe('findControlItem', () => {
-    it('find control as a string', () => {
+    test('find control as a string', () => {
       const controlItem = findControlItem(
         controlPanelSectionsChartOptions,
         'color_scheme',
@@ -211,7 +211,7 @@ describe('controlUtils', () => {
       expect(controlItem).toEqual('color_scheme');
     });
 
-    it('find control as a control object', () => {
+    test('find control as a control object', () => {
       let controlItem = findControlItem(
         controlPanelSectionsChartOptions,
         'rose_area_proportion',
@@ -227,7 +227,7 @@ describe('controlUtils', () => {
       expect(controlItem).toHaveProperty('config');
     });
 
-    it('returns null when key is not found', () => {
+    test('returns null when key is not found', () => {
       const controlItem = findControlItem(
         controlPanelSectionsChartOptions,
         'non_existing_key',

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -168,6 +168,7 @@ const tableVizStore = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('should collect control values and create SFD', () => {
   const sharedKey = [...sharedMetricsKey, ...sharedColumnsKey];
   const sharedControlsFormData = {
@@ -379,6 +380,7 @@ describe('should collect control values and create SFD', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('should transform form_data between table and bigNumberTotal', () => {
   beforeAll(() => {
     getChartControlPanelRegistry().registerValue(
@@ -447,6 +449,7 @@ describe('should transform form_data between table and bigNumberTotal', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('initial SFD between different datasource', () => {
   beforeAll(() => {
     getChartControlPanelRegistry().registerValue(

--- a/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
+++ b/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
@@ -40,7 +40,7 @@ describe('exploreUtils', () => {
   }
 
   describe('getExploreUrl', () => {
-    it('generates proper base url', () => {
+    test('generates proper base url', () => {
       // This assertion is to show clearly the value of location.href
       // in the context of unit tests.
       expect(location.href).toBe('http://localhost/');
@@ -53,7 +53,7 @@ describe('exploreUtils', () => {
       });
       compareURI(URI(url), URI('/explore/'));
     });
-    it('generates proper json url', () => {
+    test('generates proper json url', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'json',
@@ -62,7 +62,7 @@ describe('exploreUtils', () => {
       });
       compareURI(URI(url), URI('/superset/explore_json/'));
     });
-    it('generates proper json forced url', () => {
+    test('generates proper json forced url', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'json',
@@ -74,7 +74,7 @@ describe('exploreUtils', () => {
         URI('/superset/explore_json/').search({ force: 'true' }),
       );
     });
-    it('generates proper csv URL', () => {
+    test('generates proper csv URL', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'csv',
@@ -86,7 +86,7 @@ describe('exploreUtils', () => {
         URI('/superset/explore_json/').search({ csv: 'true' }),
       );
     });
-    it('generates proper standalone URL', () => {
+    test('generates proper standalone URL', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'standalone',
@@ -100,7 +100,7 @@ describe('exploreUtils', () => {
         }),
       );
     });
-    it('preserves main URLs params', () => {
+    test('preserves main URLs params', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'json',
@@ -112,7 +112,7 @@ describe('exploreUtils', () => {
         URI('/superset/explore_json/').search({ foo: 'bar' }),
       );
     });
-    it('generate proper save slice url', () => {
+    test('generate proper save slice url', () => {
       const url = getExploreUrl({
         formData,
         endpointType: 'json',
@@ -143,7 +143,7 @@ describe('exploreUtils', () => {
       stub.restore();
     });
 
-    it('generate url to different domains', () => {
+    test('generate url to different domains', () => {
       let url = getExploreUrl({
         formData,
         endpointType: 'json',
@@ -175,7 +175,7 @@ describe('exploreUtils', () => {
       });
       expect(url).toMatch(availableDomains[1]);
     });
-    it('not generate url to different domains without flag', () => {
+    test('not generate url to different domains without flag', () => {
       let csvURL = getExploreUrl({
         formData,
         endpointType: 'csv',
@@ -191,7 +191,7 @@ describe('exploreUtils', () => {
   });
 
   describe('buildV1ChartDataPayload', () => {
-    it('generate valid request payload despite no registered buildQuery', async () => {
+    test('generate valid request payload despite no registered buildQuery', async () => {
       const v1RequestPayload = await buildV1ChartDataPayload({
         formData: { ...formData, viz_type: 'my_custom_viz' },
       });
@@ -210,7 +210,7 @@ describe('exploreUtils', () => {
       getChartMetadataRegistry().remove('my_legacy_viz').remove('my_v1_viz');
     });
 
-    it('returns true for legacy viz', () => {
+    test('returns true for legacy viz', () => {
       const [useLegacyApi, parseMethod] = getQuerySettings({
         ...formData,
         viz_type: 'my_legacy_viz',
@@ -219,7 +219,7 @@ describe('exploreUtils', () => {
       expect(parseMethod).toBe('json-bigint');
     });
 
-    it('returns false for v1 viz', () => {
+    test('returns false for v1 viz', () => {
       const [useLegacyApi, parseMethod] = getQuerySettings({
         ...formData,
         viz_type: 'my_v1_viz',
@@ -228,7 +228,7 @@ describe('exploreUtils', () => {
       expect(parseMethod).toBe('json-bigint');
     });
 
-    it('returns false for formData with unregistered viz_type', () => {
+    test('returns false for formData with unregistered viz_type', () => {
       const [useLegacyApi, parseMethod] = getQuerySettings({
         ...formData,
         viz_type: 'undefined_viz',
@@ -237,7 +237,7 @@ describe('exploreUtils', () => {
       expect(parseMethod).toBe('json-bigint');
     });
 
-    it('returns false for formData without viz_type', () => {
+    test('returns false for formData without viz_type', () => {
       const [useLegacyApi, parseMethod] = getQuerySettings(formData);
       expect(useLegacyApi).toBe(false);
       expect(parseMethod).toBe('json-bigint');
@@ -245,20 +245,20 @@ describe('exploreUtils', () => {
   });
 
   describe('getSimpleSQLExpression', () => {
-    it('returns empty string when subject is undefined', () => {
+    test('returns empty string when subject is undefined', () => {
       expect(getSimpleSQLExpression(undefined, '=', 10)).toBe('');
       expect(getSimpleSQLExpression()).toBe('');
     });
-    it("returns subject when it's provided and operator is undefined", () => {
+    test("returns subject when it's provided and operator is undefined", () => {
       expect(getSimpleSQLExpression('col', undefined, 10)).toBe('col');
       expect(getSimpleSQLExpression('col')).toBe('col');
     });
-    it("returns subject and operator when they're provided and comparator is undefined", () => {
+    test("returns subject and operator when they're provided and comparator is undefined", () => {
       expect(getSimpleSQLExpression('col', '=')).toBe('col =');
       expect(getSimpleSQLExpression('col', 'IN')).toBe('col IN');
       expect(getSimpleSQLExpression('col', 'IN', [])).toBe('col IN');
     });
-    it('returns full expression when subject, operator and comparator are provided', () => {
+    test('returns full expression when subject, operator and comparator are provided', () => {
       expect(getSimpleSQLExpression('col', '=', 'comp')).toBe("col = 'comp'");
       expect(getSimpleSQLExpression('col', '=', "it's an apostrophe")).toBe(
         "col = 'it''s an apostrophe'",
@@ -282,7 +282,7 @@ describe('exploreUtils', () => {
   });
 
   describe('.exploreChart()', () => {
-    it('postForm', () => {
+    test('postForm', () => {
       const postFormSpy = jest.spyOn(SupersetClient, 'postForm');
       postFormSpy.mockImplementation(jest.fn());
 

--- a/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
+++ b/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
@@ -30,6 +30,7 @@ import { DashboardStandaloneMode } from 'src/dashboard/util/constants';
 import * as hostNamesConfig from 'src/utils/hostNamesConfig';
 import { getChartMetadataRegistry, SupersetClient } from '@superset-ui/core';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('exploreUtils', () => {
   const { location } = window;
   const formData = {
@@ -39,6 +40,7 @@ describe('exploreUtils', () => {
     expect(uri1.toString()).toBe(uri2.toString());
   }
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getExploreUrl', () => {
     test('generates proper base url', () => {
       // This assertion is to show clearly the value of location.href
@@ -126,6 +128,7 @@ describe('exploreUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('domain sharding', () => {
     let stub;
     const availableDomains = [
@@ -190,6 +193,7 @@ describe('exploreUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('buildV1ChartDataPayload', () => {
     test('generate valid request payload despite no registered buildQuery', async () => {
       const v1RequestPayload = await buildV1ChartDataPayload({
@@ -199,6 +203,7 @@ describe('exploreUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getQuerySettings', () => {
     beforeAll(() => {
       getChartMetadataRegistry()
@@ -244,6 +249,7 @@ describe('exploreUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getSimpleSQLExpression', () => {
     test('returns empty string when subject is undefined', () => {
       expect(getSimpleSQLExpression(undefined, '=', 10)).toBe('');
@@ -281,6 +287,7 @@ describe('exploreUtils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('.exploreChart()', () => {
     test('postForm', () => {
       const postFormSpy = jest.spyOn(SupersetClient, 'postForm');

--- a/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
@@ -21,6 +21,7 @@ import { getChartDataUri } from '.';
 
 jest.mock('src/utils/pathUtils');
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Get ChartUri', () => {
   (ensureAppRoot as jest.Mock).mockImplementation(
     (path: string) => `/prefix${path}`,

--- a/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
@@ -26,7 +26,7 @@ describe('Get ChartUri', () => {
     (path: string) => `/prefix${path}`,
   );
 
-  it('Get ChartUri when allowDomainSharding:false', () => {
+  test('Get ChartUri when allowDomainSharding:false', () => {
     expect(
       getChartDataUri({
         path: '/path',
@@ -53,7 +53,7 @@ describe('Get ChartUri', () => {
     });
   });
 
-  it('Get ChartUri when allowDomainSharding:true', () => {
+  test('Get ChartUri when allowDomainSharding:true', () => {
     expect(
       getChartDataUri({
         path: '/path-allowDomainSharding-true',

--- a/superset-frontend/src/explore/store.test.jsx
+++ b/superset-frontend/src/explore/store.test.jsx
@@ -41,7 +41,7 @@ describe('store', () => {
       SCOPED_FILTER: false,
     };
 
-    it('applies default to formData if the key is missing', () => {
+    test('applies default to formData if the key is missing', () => {
       const inputFormData = {
         datasource: '11_table',
         viz_type: 'test-chart',
@@ -57,7 +57,7 @@ describe('store', () => {
       expect(outputFormData.row_limit).toEqual(888);
     });
 
-    it('keeps null if key is defined with null', () => {
+    test('keeps null if key is defined with null', () => {
       const inputFormData = {
         datasource: '11_table',
         viz_type: 'test-chart',

--- a/superset-frontend/src/explore/store.test.jsx
+++ b/superset-frontend/src/explore/store.test.jsx
@@ -19,6 +19,7 @@
 import { getChartControlPanelRegistry } from '@superset-ui/core';
 import { applyDefaultFormData } from 'src/explore/store';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('store', () => {
   beforeAll(() => {
     getChartControlPanelRegistry().registerValue('test-chart', {
@@ -36,6 +37,7 @@ describe('store', () => {
     getChartControlPanelRegistry().remove('test-chart');
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('applyDefaultFormData', () => {
     window.featureFlags = {
       SCOPED_FILTER: false,

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -68,7 +68,7 @@ describe('NotificationMethod', () => {
     cleanup();
   });
 
-  it('should render the component', () => {
+  test('should render the component', () => {
     render(
       <NotificationMethod
         setting={mockSetting}
@@ -89,7 +89,7 @@ describe('NotificationMethod', () => {
     expect(screen.getByText('Email recipients')).toBeInTheDocument();
   });
 
-  it('should call onRemove when the delete button is clicked', () => {
+  test('should call onRemove when the delete button is clicked', () => {
     render(
       <NotificationMethod
         setting={mockSetting}
@@ -109,7 +109,7 @@ describe('NotificationMethod', () => {
     expect(mockOnRemove).toHaveBeenCalledWith(1);
   });
 
-  it('should update recipient value when input changes', () => {
+  test('should update recipient value when input changes', () => {
     render(
       <NotificationMethod
         setting={mockSetting}
@@ -134,7 +134,7 @@ describe('NotificationMethod', () => {
     });
   });
 
-  it('should call onRecipientsChange when the recipients value is changed', () => {
+  test('should call onRecipientsChange when the recipients value is changed', () => {
     render(
       <NotificationMethod
         setting={mockSetting}
@@ -159,7 +159,7 @@ describe('NotificationMethod', () => {
     });
   });
 
-  it('should correctly map recipients when method is SlackV2', () => {
+  test('should correctly map recipients when method is SlackV2', () => {
     const method = 'SlackV2';
     const recipientValue = 'user1,user2';
     const slackOptions: { label: string; value: string }[] = [
@@ -175,7 +175,7 @@ describe('NotificationMethod', () => {
     ]);
   });
 
-  it('should return an empty array when recipientValue is an empty string', () => {
+  test('should return an empty array when recipientValue is an empty string', () => {
     const method = 'SlackV2';
     const recipientValue = '';
     const slackOptions: { label: string; value: string }[] = [
@@ -188,7 +188,7 @@ describe('NotificationMethod', () => {
     expect(result).toEqual([]);
   });
 
-  it('should correctly map recipients when method is Slack with updated recipient values', () => {
+  test('should correctly map recipients when method is Slack with updated recipient values', () => {
     const method = 'Slack';
     const recipientValue = 'User One,User Two';
     const slackOptions: { label: string; value: string }[] = [
@@ -203,7 +203,7 @@ describe('NotificationMethod', () => {
       { label: 'User Two', value: 'user2' },
     ]);
   });
-  it('should render CC and BCC fields when method is Email and visibility flags are true', () => {
+  test('should render CC and BCC fields when method is Email and visibility flags are true', () => {
     const defaultProps = {
       setting: {
         method: NotificationMethodOption.Email,
@@ -230,7 +230,7 @@ describe('NotificationMethod', () => {
     expect(getByTestId('cc')).toBeInTheDocument();
     expect(getByTestId('bcc')).toBeInTheDocument();
   });
-  it('should render CC and BCC fields with correct values when method is Email', () => {
+  test('should render CC and BCC fields with correct values when method is Email', () => {
     const defaultProps = {
       setting: {
         method: NotificationMethodOption.Email,
@@ -257,7 +257,7 @@ describe('NotificationMethod', () => {
     expect(getByTestId('cc')).toHaveValue('cc1@example.com');
     expect(getByTestId('bcc')).toHaveValue('bcc1@example.com');
   });
-  it('should not render CC and BCC fields when method is not Email', () => {
+  test('should not render CC and BCC fields when method is not Email', () => {
     const defaultProps = {
       setting: {
         method: NotificationMethodOption.Slack,
@@ -285,7 +285,7 @@ describe('NotificationMethod', () => {
     expect(queryByTestId('bcc')).not.toBeInTheDocument();
   });
   // Handle empty recipients list gracefully
-  it('should handle empty recipients list gracefully', () => {
+  test('should handle empty recipients list gracefully', () => {
     const defaultProps = {
       setting: {
         method: NotificationMethodOption.Email,
@@ -312,7 +312,7 @@ describe('NotificationMethod', () => {
     expect(queryByTestId('cc')).not.toBeInTheDocument();
     expect(queryByTestId('bcc')).not.toBeInTheDocument();
   });
-  it('shows the right combo when ff is false', async () => {
+  test('shows the right combo when ff is false', async () => {
     /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is false and fetchSlackChannels errors
     */
@@ -347,7 +347,7 @@ describe('NotificationMethod', () => {
       ).toBeInTheDocument();
     });
   });
-  it('shows the textbox when the fetch fails', async () => {
+  test('shows the textbox when the fetch fails', async () => {
     /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels errors
     */
@@ -383,7 +383,7 @@ describe('NotificationMethod', () => {
       ).toBeInTheDocument();
     });
   });
-  it('shows the dropdown when ff is true and slackChannels succeed', async () => {
+  test('shows the dropdown when ff is true and slackChannels succeed', async () => {
     /* should show the Select channels dropdown
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
     */
@@ -422,7 +422,7 @@ describe('NotificationMethod', () => {
       expect(screen.getByTitle('Slack')).toBeInTheDocument();
     });
   });
-  it('shows the textarea when ff is true and slackChannels fail', async () => {
+  test('shows the textarea when ff is true and slackChannels fail', async () => {
     /* should show the Select channels dropdown
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
     */
@@ -456,7 +456,7 @@ describe('NotificationMethod', () => {
       screen.getByText('Recipients are separated by "," or ";"'),
     ).toBeInTheDocument();
   });
-  it('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
+  test('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
     /* should show the Select channels dropdown
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
     */
@@ -491,7 +491,7 @@ describe('NotificationMethod', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
+  test('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
     window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
     jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
       throw new Error('Error fetching Slack channels');
@@ -519,7 +519,7 @@ describe('NotificationMethod', () => {
   });
 
   describe('RefreshLabel functionality', () => {
-    it('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {
+    test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {
       // Set feature flag so that SlackV2 branch renders RefreshLabel
       window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
       // Spy on SupersetClient.get which is called by updateSlackOptions

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -62,6 +62,7 @@ const mockSettingSlackV2: NotificationSetting = {
   ],
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('NotificationMethod', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -518,6 +519,7 @@ describe('NotificationMethod', () => {
     ).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('RefreshLabel functionality', () => {
     test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {
       // Set feature flag so that SlackV2 branch renders RefreshLabel

--- a/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
+++ b/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
@@ -21,7 +21,7 @@ import RecipientIcon from './RecipientIcon';
 import { NotificationMethodOption } from '../types';
 
 describe('RecipientIcon', () => {
-  it('should render the email icon when type is Email', () => {
+  test('should render the email icon when type is Email', () => {
     const { container } = render(
       <RecipientIcon type={NotificationMethodOption.Email} />,
     );
@@ -29,27 +29,27 @@ describe('RecipientIcon', () => {
     expect(emailIcon).toBeInTheDocument();
   });
 
-  it('should render the Slack icon when type is Slack', () => {
+  test('should render the Slack icon when type is Slack', () => {
     render(<RecipientIcon type={NotificationMethodOption.Slack} />);
     const regexPattern = new RegExp(NotificationMethodOption.Slack, 'i');
     const slackIcon = screen.getByLabelText(regexPattern);
     expect(slackIcon).toBeInTheDocument();
   });
 
-  it('should render the Slack icon when type is SlackV2', () => {
+  test('should render the Slack icon when type is SlackV2', () => {
     render(<RecipientIcon type={NotificationMethodOption.SlackV2} />);
     const regexPattern = new RegExp(NotificationMethodOption.Slack, 'i');
     const slackIcon = screen.getByLabelText(regexPattern);
     expect(slackIcon).toBeInTheDocument();
   });
 
-  it('should not render any icon when type is not recognized', () => {
+  test('should not render any icon when type is not recognized', () => {
     render(<RecipientIcon type="unknown" />);
     const icons = screen.queryByLabelText(/.*/);
     expect(icons).not.toBeInTheDocument();
   });
 
-  it('All recipient types should have consistent accessibility attributes', () => {
+  test('All recipient types should have consistent accessibility attributes', () => {
     const types = [
       NotificationMethodOption.Email,
       NotificationMethodOption.Slack,

--- a/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
+++ b/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
@@ -20,6 +20,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import RecipientIcon from './RecipientIcon';
 import { NotificationMethodOption } from '../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RecipientIcon', () => {
   test('should render the email icon when type is Email', () => {
     const { container } = render(

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -21,6 +21,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import * as useQueryParamsModule from 'use-query-params';
 import AllEntitiesTable from './AllEntitiesTable';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AllEntitiesTable', () => {
   const mockSetShowTagModal = jest.fn();
 

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -91,7 +91,7 @@ describe('AllEntitiesTable', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders when empty with button to tag if user has perm', () => {
+  test('renders when empty with button to tag if user has perm', () => {
     render(
       <AllEntitiesTable
         search=""
@@ -109,7 +109,7 @@ describe('AllEntitiesTable', () => {
     expect(screen.getByText('Add tag to entities')).toBeInTheDocument();
   });
 
-  it('renders when empty without button to tag if user does not have perm', () => {
+  test('renders when empty without button to tag if user does not have perm', () => {
     render(
       <AllEntitiesTable
         search=""
@@ -127,7 +127,7 @@ describe('AllEntitiesTable', () => {
     expect(screen.queryByText('Add tag to entities')).not.toBeInTheDocument();
   });
 
-  it('renders the correct tags for each object type', () => {
+  test('renders the correct tags for each object type', () => {
     render(
       <AllEntitiesTable
         search=""
@@ -151,7 +151,7 @@ describe('AllEntitiesTable', () => {
     expect(screen.getByText('Engagement')).toBeInTheDocument();
   });
 
-  it('Only list asset types that have entities', () => {
+  test('Only list asset types that have entities', () => {
     const mockObjects = {
       dashboard: [],
       chart: [mockObjectsWithTags.chart[0]],

--- a/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.test.tsx
@@ -84,27 +84,27 @@ beforeEach(() => {
   );
 });
 
-it('Renders the dashboard title', () => {
+test('Renders the dashboard title', () => {
   const titleElement = screen.getByText('Sample Dashboard');
   expect(titleElement).toBeInTheDocument();
 });
 
-it('Renders the certification details', () => {
+test('Renders the certification details', () => {
   const certificationDetailsElement = screen.getByLabelText(/certified/i);
   expect(certificationDetailsElement).toBeInTheDocument();
 });
 
-it('Renders the published status', () => {
+test('Renders the published status', () => {
   const publishedElement = screen.getByText(/published/i);
   expect(publishedElement).toBeInTheDocument();
 });
 
-it('Renders the modified date', () => {
+test('Renders the modified date', () => {
   const modifiedDateElement = screen.getByText('Modified 2 days ago');
   expect(modifiedDateElement).toBeInTheDocument();
 });
 
-it('should fetch thumbnail when dashboard has no thumbnail URL and feature flag is enabled', async () => {
+test('should fetch thumbnail when dashboard has no thumbnail URL and feature flag is enabled', async () => {
   const mockGet = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
     json: { result: { thumbnail_url: '/new-thumbnail.png' } },
   } as unknown as JsonResponse);

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
@@ -102,7 +102,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Engine-to-Field Mapping', () => {
-    it.each(supportedEngines)(
+    test.each(supportedEngines)(
       'resolves field name for %s engine → %s field',
       (engine, expectedField) => {
         const mockDb = createMockDb(engine);
@@ -115,7 +115,7 @@ describe('EncryptedField', () => {
       },
     );
 
-    it('handles unmapped engines gracefully', () => {
+    test('handles unmapped engines gracefully', () => {
       const unmappedEngine = 'unknown-engine-xyz';
       const mockDb = createMockDb(unmappedEngine);
       const props = { ...defaultProps, db: mockDb };
@@ -126,7 +126,7 @@ describe('EncryptedField', () => {
       expect(props.changeMethods.onParametersChange).toHaveBeenCalledTimes(1);
     });
 
-    it.each([
+    test.each([
       ['null engine', null, null],
       ['undefined engine', undefined, undefined],
       ['empty string engine', '', ''],
@@ -170,7 +170,7 @@ describe('EncryptedField', () => {
       },
     ];
 
-    it.each(testCases)(
+    test.each(testCases)(
       'processes $description correctly',
       ({ input, expected }) => {
         const mockDb = createMockDb('gsheets', {
@@ -185,7 +185,7 @@ describe('EncryptedField', () => {
       },
     );
 
-    it('handles null/undefined parameters', () => {
+    test('handles null/undefined parameters', () => {
       const mockDb = createMockDb('gsheets', {});
       const props = { ...defaultProps, db: mockDb, isEditMode: true };
 
@@ -197,7 +197,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Conditional Rendering Logic', () => {
-    it('shows upload selector in create mode', () => {
+    test('shows upload selector in create mode', () => {
       const props = { ...defaultProps, isEditMode: false, editNewDb: false };
 
       render(<EncryptedField {...props} />);
@@ -211,7 +211,7 @@ describe('EncryptedField', () => {
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     });
 
-    it('shows textarea in edit mode', () => {
+    test('shows textarea in edit mode', () => {
       const props = { ...defaultProps, isEditMode: true, editNewDb: false };
 
       render(<EncryptedField {...props} />);
@@ -225,7 +225,7 @@ describe('EncryptedField', () => {
       expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
 
-    it('shows textarea when editNewDb is true', () => {
+    test('shows textarea when editNewDb is true', () => {
       const props = { ...defaultProps, isEditMode: false, editNewDb: true };
 
       render(<EncryptedField {...props} />);
@@ -242,7 +242,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Upload Option State Management', () => {
-    it('defaults to upload option', () => {
+    test('defaults to upload option', () => {
       const props = { ...defaultProps, isEditMode: false };
 
       render(<EncryptedField {...props} />);
@@ -251,7 +251,7 @@ describe('EncryptedField', () => {
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     });
 
-    it('switches to copy-paste option', () => {
+    test('switches to copy-paste option', () => {
       const props = { ...defaultProps, isEditMode: false };
 
       render(<EncryptedField {...props} />);
@@ -270,7 +270,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Form Integration Contract', () => {
-    it.each(supportedEngines)(
+    test.each(supportedEngines)(
       'calls onParametersChange with correct field name for %s engine',
       (engine, fieldName) => {
         const mockDb = createMockDb(engine);
@@ -287,7 +287,7 @@ describe('EncryptedField', () => {
       },
     );
 
-    it('initializes with empty value on mount', () => {
+    test('initializes with empty value on mount', () => {
       const props = { ...defaultProps };
 
       render(<EncryptedField {...props} />);
@@ -299,7 +299,7 @@ describe('EncryptedField', () => {
       );
     });
 
-    it('renders correctly with default props', () => {
+    test('renders correctly with default props', () => {
       const props = { ...defaultProps };
 
       expect(() => render(<EncryptedField {...props} />)).not.toThrow();
@@ -316,7 +316,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Error Boundaries', () => {
-    it('renders gracefully when database prop is missing', () => {
+    test('renders gracefully when database prop is missing', () => {
       const props = { ...defaultProps, db: undefined };
 
       expect(() => render(<EncryptedField {...props} />)).not.toThrow();
@@ -325,7 +325,7 @@ describe('EncryptedField', () => {
       expectParametersChange(props.changeMethods, undefined, '');
     });
 
-    it('renders gracefully with malformed database parameters', () => {
+    test('renders gracefully with malformed database parameters', () => {
       const mockDb = createMockDb('gsheets', {
         service_account_info: Symbol('test-symbol'),
       });
@@ -341,7 +341,7 @@ describe('EncryptedField', () => {
   });
 
   describe('Accessibility', () => {
-    it('provides proper form labels and attributes', () => {
+    test('provides proper form labels and attributes', () => {
       const props = { ...defaultProps, isEditMode: true };
 
       render(<EncryptedField {...props} />);
@@ -356,7 +356,7 @@ describe('EncryptedField', () => {
       );
     });
 
-    it('provides proper labels for upload method selection', () => {
+    test('provides proper labels for upload method selection', () => {
       const props = { ...defaultProps, isEditMode: false };
 
       render(<EncryptedField {...props} />);

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
@@ -33,6 +33,7 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
   }),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('EncryptedField', () => {
   // Test utilities
   const createMockDb = (
@@ -101,6 +102,7 @@ describe('EncryptedField', () => {
     jest.clearAllMocks();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Engine-to-Field Mapping', () => {
     test.each(supportedEngines)(
       'resolves field name for %s engine → %s field',
@@ -141,6 +143,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Parameter Value Processing', () => {
     const testCases = [
       {
@@ -196,6 +199,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Conditional Rendering Logic', () => {
     test('shows upload selector in create mode', () => {
       const props = { ...defaultProps, isEditMode: false, editNewDb: false };
@@ -241,6 +245,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Upload Option State Management', () => {
     test('defaults to upload option', () => {
       const props = { ...defaultProps, isEditMode: false };
@@ -269,6 +274,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Form Integration Contract', () => {
     test.each(supportedEngines)(
       'calls onParametersChange with correct field name for %s engine',
@@ -315,6 +321,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Error Boundaries', () => {
     test('renders gracefully when database prop is missing', () => {
       const props = { ...defaultProps, db: undefined };
@@ -340,6 +347,7 @@ describe('EncryptedField', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Accessibility', () => {
     test('provides proper form labels and attributes', () => {
       const props = { ...defaultProps, isEditMode: true };

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
@@ -21,6 +21,7 @@ import { render, fireEvent } from 'spec/helpers/testing-library';
 import { DatabaseObject } from 'src/features/databases/types';
 import { OAuth2ClientField } from './OAuth2ClientField';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('OAuth2ClientField', () => {
   const mockChangeMethods = {
     onEncryptedExtraInputChange: jest.fn(),

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
@@ -70,7 +70,7 @@ describe('OAuth2ClientField', () => {
     jest.clearAllMocks();
   });
 
-  it('does not show input fields until the collapse trigger is clicked', () => {
+  test('does not show input fields until the collapse trigger is clicked', () => {
     const { getByText, getByTestId, queryByTestId } = render(
       <OAuth2ClientField {...defaultProps} />,
     );
@@ -93,7 +93,7 @@ describe('OAuth2ClientField', () => {
     expect(getByTestId('client-scope')).toBeInTheDocument();
   });
 
-  it('renders the OAuth2ClientField component with initial values', () => {
+  test('renders the OAuth2ClientField component with initial values', () => {
     const { getByTestId, getByText } = render(
       <OAuth2ClientField {...defaultProps} />,
     );
@@ -112,7 +112,7 @@ describe('OAuth2ClientField', () => {
     expect(getByTestId('client-scope')).toHaveValue('test-scope');
   });
 
-  it('handles input changes and triggers onEncryptedExtraInputChange', () => {
+  test('handles input changes and triggers onEncryptedExtraInputChange', () => {
     const { getByTestId, getByText } = render(
       <OAuth2ClientField {...defaultProps} />,
     );
@@ -140,7 +140,7 @@ describe('OAuth2ClientField', () => {
     );
   });
 
-  it('does not render when supports_oauth2 is false', () => {
+  test('does not render when supports_oauth2 is false', () => {
     const props = {
       ...defaultProps,
       db: {
@@ -156,7 +156,7 @@ describe('OAuth2ClientField', () => {
     expect(queryByTestId('client-id')).not.toBeInTheDocument();
   });
 
-  it('renders empty fields when masked_encrypted_extra is empty', () => {
+  test('renders empty fields when masked_encrypted_extra is empty', () => {
     const props = {
       ...defaultProps,
       db: {

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
@@ -67,6 +67,7 @@ const defaultDb = {
   parameters: {}, // added dummy value for parameters
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ExtraOptions Component', () => {
   const onInputChange = jest.fn();
   const onTextChange = jest.fn();

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
@@ -91,7 +91,7 @@ describe('ExtraOptions Component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders all main panels', () => {
+  test('renders all main panels', () => {
     renderComponent();
 
     expect(screen.getByText(t('SQL Lab'))).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('ExtraOptions Component', () => {
     expect(screen.getByText(t('Other'))).toBeInTheDocument();
   });
 
-  it('calls onInputChange when "Expose database in SQL Lab" checkbox is clicked', () => {
+  test('calls onInputChange when "Expose database in SQL Lab" checkbox is clicked', () => {
     renderComponent();
     const sqlLabText = screen.getByText(t('SQL Lab'));
     fireEvent.click(sqlLabText);
@@ -110,7 +110,7 @@ describe('ExtraOptions Component', () => {
     expect(onInputChange).toHaveBeenCalled();
   });
 
-  it('calls onExtraInputChange when "Enable query cost estimation" checkbox is clicked', () => {
+  test('calls onExtraInputChange when "Enable query cost estimation" checkbox is clicked', () => {
     renderComponent();
     const sqlLabText = screen.getByText(t('SQL Lab'));
     fireEvent.click(sqlLabText);
@@ -119,7 +119,7 @@ describe('ExtraOptions Component', () => {
     expect(onExtraInputChange).toHaveBeenCalled();
   });
 
-  it('calls onExtraEditorChange when metadata_params json editor changes', async () => {
+  test('calls onExtraEditorChange when metadata_params json editor changes', async () => {
     renderComponent();
 
     // Click to open the editor tab/section
@@ -163,7 +163,7 @@ describe('ExtraOptions Component', () => {
     });
   });
 
-  it('calls onTextChange when server certificate textarea is changed', () => {
+  test('calls onTextChange when server certificate textarea is changed', () => {
     renderComponent();
     // Click to open the security tab/section
     const securityHeader = screen.getByText(t('Security'));
@@ -174,7 +174,7 @@ describe('ExtraOptions Component', () => {
     expect(onTextChange).toHaveBeenCalled();
   });
 
-  it('handles input change for schema cache timeout', () => {
+  test('handles input change for schema cache timeout', () => {
     renderComponent();
     const performanceHeader = screen.getByText(t('Performance'));
     fireEvent.click(performanceHeader);
@@ -183,7 +183,7 @@ describe('ExtraOptions Component', () => {
     expect(onExtraInputChange).toHaveBeenCalled();
   });
 
-  it('handles input change for table cache timeout', () => {
+  test('handles input change for table cache timeout', () => {
     renderComponent();
     const performanceHeader = screen.getByText(t('Performance'));
     fireEvent.click(performanceHeader);
@@ -192,7 +192,7 @@ describe('ExtraOptions Component', () => {
     expect(onExtraInputChange).toHaveBeenCalled();
   });
 
-  it('renders the collaps tab correctly and resets to default tab after closing', () => {
+  test('renders the collaps tab correctly and resets to default tab after closing', () => {
     const { rerender } = renderComponent();
     const sqlLabTab = screen.getByRole('tab', {
       name: /SQL Lab./i,

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -73,6 +73,7 @@ const databaseFixture: DatabaseObject = {
   driver: 'psycopg2',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatabaseModal', () => {
   beforeEach(() => {
     fetchMock.post(DATABASE_CONNECT_ENDPOINT, {
@@ -326,6 +327,7 @@ describe('DatabaseModal', () => {
       useRedux: true,
     });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Visual: New database connection', () => {
     test('renders the initial load of Step 1 correctly', async () => {
       setup();
@@ -1062,6 +1064,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Functional: Create new database', () => {
     test('directs databases to the appropriate form (dynamic vs. SQL Alchemy)', async () => {
       setup();
@@ -1096,6 +1099,7 @@ describe('DatabaseModal', () => {
       expect(sqlAlchemyFormStepText).toBeInTheDocument();
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('SQL Alchemy form flow', () => {
       test('enters step 2 of 2 when proper database is selected', async () => {
         setup();
@@ -1126,6 +1130,7 @@ describe('DatabaseModal', () => {
         expect.anything();
       });
 
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('step 2 component interaction', () => {
         test('properly interacts with textboxes', async () => {
           setup();
@@ -1172,6 +1177,7 @@ describe('DatabaseModal', () => {
         });
       });
 
+      // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
       describe('SSH Tunnel Form interaction', () => {
         test('properly interacts with SSH Tunnel form textboxes for dynamic form', async () => {
           setup();
@@ -1317,6 +1323,7 @@ describe('DatabaseModal', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('Dynamic form flow', () => {
       test('enters step 2 of 3 when proper database is selected', async () => {
         setup();
@@ -1378,6 +1385,7 @@ describe('DatabaseModal', () => {
       });
     });
 
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('Import database flow', () => {
       test('imports a file', async () => {
         setup();
@@ -1401,6 +1409,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('DatabaseModal w/ Deeplinking Engine', () => {
     test('enters step 2 of 3 when proper database is selected', async () => {
       setup({ dbEngine: 'PostgreSQL' });
@@ -1409,6 +1418,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('DatabaseModal w/ GSheet Engine', () => {
     test('enters step 2 of 2 when proper database is selected', async () => {
       setup({ dbEngine: 'Google Sheets' });
@@ -1478,6 +1488,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('DatabaseModal w errors as objects', () => {
     jest.mock('src/views/CRUD/hooks', () => ({
       ...jest.requireActual('src/views/CRUD/hooks'),
@@ -1493,6 +1504,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('DatabaseModal w errors as strings', () => {
     jest.mock('src/views/CRUD/hooks', () => ({
       ...jest.requireActual('src/views/CRUD/hooks'),
@@ -1530,6 +1542,7 @@ describe('DatabaseModal', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('DatabaseModal w Extensions', () => {
     beforeAll(() => {
       const extensionsRegistry = getExtensionsRegistry();
@@ -1550,6 +1563,7 @@ describe('DatabaseModal', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('dbReducer', () => {
   test('it will reset state to null', () => {
     const action: DBReducerActionType = { type: ActionType.Reset };

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -907,7 +907,7 @@ describe('DatabaseModal', () => {
       expect(schemasForFileUploadText).not.toBeInTheDocument();
     });
 
-    it('renders the "Advanced" - SECURITY tab correctly after selecting Allow file uploads', async () => {
+    test('renders the "Advanced" - SECURITY tab correctly after selecting Allow file uploads', async () => {
       setup();
 
       // ---------- Components ----------
@@ -1410,13 +1410,13 @@ describe('DatabaseModal', () => {
   });
 
   describe('DatabaseModal w/ GSheet Engine', () => {
-    it('enters step 2 of 2 when proper database is selected', async () => {
+    test('enters step 2 of 2 when proper database is selected', async () => {
       setup({ dbEngine: 'Google Sheets' });
       const step2of2text = await screen.findByText(/step 2 of 2/i);
       expect(step2of2text).toBeInTheDocument();
     });
 
-    it('renders the "Advanced" - SECURITY tab without Allow File Upload Checkbox', async () => {
+    test('renders the "Advanced" - SECURITY tab without Allow File Upload Checkbox', async () => {
       setup({ dbEngine: 'Google Sheets' });
 
       // Click the "Advanced" tab
@@ -1454,7 +1454,7 @@ describe('DatabaseModal', () => {
       expect(schemasForFileUploadText).not.toBeInTheDocument();
     });
 
-    it('if the SSH Tunneling toggle is not displayed, nothing should get displayed', async () => {
+    test('if the SSH Tunneling toggle is not displayed, nothing should get displayed', async () => {
       setup({ dbEngine: 'Google Sheets' });
 
       const SSHTunnelingToggle = screen.queryByTestId('ssh-tunnel-switch');

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -124,6 +124,7 @@ const expectElementsNotVisible = (elements: any[]) => {
   });
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - General Information Elements', () => {
   test('CSV renders correctly', () => {
     render(<UploadDataModal {...csvProps} />, { useRedux: true });
@@ -212,6 +213,7 @@ describe('UploadDataModal - General Information Elements', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - File Settings Elements', () => {
   const openFileSettings = async () => {
     const panelHeader = screen.getByText(/file settings/i);
@@ -290,6 +292,7 @@ describe('UploadDataModal - File Settings Elements', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - Columns Elements', () => {
   const openColumns = async () => {
     const panelHeader = screen.getByText(/columns/i, { selector: 'strong' });
@@ -359,6 +362,7 @@ describe('UploadDataModal - Columns Elements', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - Rows Elements', () => {
   test('CSV/Excel rows render correctly', async () => {
     render(<UploadDataModal {...csvProps} />, { useRedux: true });
@@ -383,6 +387,7 @@ describe('UploadDataModal - Rows Elements', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - Database and Schema Population', () => {
   test('database and schema are correctly populated', async () => {
     render(<UploadDataModal {...csvProps} />, { useRedux: true });
@@ -412,6 +417,7 @@ describe('UploadDataModal - Database and Schema Population', () => {
   }, 60000);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - Form Validation', () => {
   test('form validation without required fields', async () => {
     render(<UploadDataModal {...csvProps} />, { useRedux: true });
@@ -431,6 +437,7 @@ describe('UploadDataModal - Form Validation', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal - Form Submission', () => {
   // Helper function to fill out form
   const fillForm = async (
@@ -508,6 +515,7 @@ describe('UploadDataModal - Form Submission', () => {
   }, 60000);
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('File Extension Validation', () => {
   const createTestFile = (fileName: string) => ({
     name: fileName,
@@ -516,6 +524,7 @@ describe('File Extension Validation', () => {
     type: 'text/csv',
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('CSV validation', () => {
     test('returns false for invalid extensions', () => {
       const invalidFiles = ['out', 'out.exe', 'out.csv.exe', '.csv', 'out.xls'];
@@ -536,6 +545,7 @@ describe('File Extension Validation', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Excel validation', () => {
     test('returns false for invalid extensions', () => {
       const invalidFiles = ['out', 'out.exe', 'out.xls.exe', '.csv', 'out.csv'];
@@ -562,6 +572,7 @@ describe('File Extension Validation', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Columnar validation', () => {
     test('returns false for invalid extensions', () => {
       const invalidFiles = [
@@ -600,6 +611,7 @@ describe('File Extension Validation', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UploadDataModal Collapse Tabs', () => {
   test('renders the collaps tab CSV correctly and resets to default tab after closing', async () => {
     const { rerender } = render(<UploadDataModal {...csvProps} />, {

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -601,7 +601,7 @@ describe('File Extension Validation', () => {
 });
 
 describe('UploadDataModal Collapse Tabs', () => {
-  it('renders the collaps tab CSV correctly and resets to default tab after closing', async () => {
+  test('renders the collaps tab CSV correctly and resets to default tab after closing', async () => {
     const { rerender } = render(<UploadDataModal {...csvProps} />, {
       useRedux: true,
     });
@@ -621,7 +621,7 @@ describe('UploadDataModal Collapse Tabs', () => {
     expect(generalInfoTab).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('renders the collaps tab Excel correctly and resets to default tab after closing', async () => {
+  test('renders the collaps tab Excel correctly and resets to default tab after closing', async () => {
     const { rerender } = render(<UploadDataModal {...excelProps} />, {
       useRedux: true,
     });
@@ -641,7 +641,7 @@ describe('UploadDataModal Collapse Tabs', () => {
     expect(generalInfoTab).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('renders the collaps tab Columnar correctly and resets to default tab after closing', async () => {
+  test('renders the collaps tab Columnar correctly and resets to default tab after closing', async () => {
     const { rerender } = render(<UploadDataModal {...columnarProps} />, {
       useRedux: true,
     });

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -42,6 +42,7 @@ jest.mock(
     ),
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasetPanel', () => {
   test('renders a blank state DatasetPanel', () => {
     render(<DatasetPanel hasError={false} columnList={[]} loading={false} />, {

--- a/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
@@ -63,6 +63,7 @@ const mockPropsWithDataset = {
   hasColumns: true,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Footer', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/superset-frontend/src/features/datasets/AddDataset/Header/Header.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Header/Header.test.tsx
@@ -19,6 +19,7 @@
 import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import Header, { DEFAULT_TITLE } from 'src/features/datasets/AddDataset/Header';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Header', () => {
   const mockSetDataset = jest.fn();
 

--- a/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
@@ -20,7 +20,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import RightPanel from 'src/features/datasets/AddDataset/RightPanel';
 
 describe('RightPanel', () => {
-  it('renders a blank state RightPanel', () => {
+  test('renders a blank state RightPanel', () => {
     render(<RightPanel />);
 
     expect(screen.getByText(/right panel/i)).toBeVisible();

--- a/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
@@ -19,6 +19,7 @@
 import { render, screen } from 'spec/helpers/testing-library';
 import RightPanel from 'src/features/datasets/AddDataset/RightPanel';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RightPanel', () => {
   test('renders a blank state RightPanel', () => {
     render(<RightPanel />);

--- a/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
@@ -32,6 +32,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DatasetLayout', () => {
   test('renders nothing when no components are passed in', () => {
     render(<DatasetLayout />, { useRouter: true });

--- a/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
@@ -33,7 +33,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('DatasetLayout', () => {
-  it('renders nothing when no components are passed in', () => {
+  test('renders nothing when no components are passed in', () => {
     render(<DatasetLayout />, { useRouter: true });
     const layoutWrapper = screen.getByTestId('dataset-layout-wrapper');
 
@@ -45,13 +45,13 @@ describe('DatasetLayout', () => {
   const waitForRender = () =>
     waitFor(() => render(<Header setDataset={mockSetDataset} />));
 
-  it('renders a Header when passed in', async () => {
+  test('renders a Header when passed in', async () => {
     await waitForRender();
 
     expect(screen.getByText(/new dataset/i)).toBeVisible();
   });
 
-  it('renders a LeftPanel when passed in', async () => {
+  test('renders a LeftPanel when passed in', async () => {
     render(
       <DatasetLayout leftPanel={<LeftPanel setDataset={() => null} />} />,
       { useRedux: true, useRouter: true },
@@ -63,7 +63,7 @@ describe('DatasetLayout', () => {
     expect(LeftPanel).toBeTruthy();
   });
 
-  it('renders a DatasetPanel when passed in', () => {
+  test('renders a DatasetPanel when passed in', () => {
     render(<DatasetLayout datasetPanel={<DatasetPanel />} />, {
       useRouter: true,
     });
@@ -75,13 +75,13 @@ describe('DatasetLayout', () => {
     expect(blankDatasetTitle).toBeVisible();
   });
 
-  it('renders a RightPanel when passed in', () => {
+  test('renders a RightPanel when passed in', () => {
     render(<DatasetLayout rightPanel={RightPanel()} />, { useRouter: true });
 
     expect(screen.getByText(/right panel/i)).toBeVisible();
   });
 
-  it('renders a Footer when passed in', () => {
+  test('renders a Footer when passed in', () => {
     render(<DatasetLayout footer={<Footer url="" />} />, {
       useRedux: true,
       useRouter: true,

--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -142,7 +142,7 @@ describe('DashboardTable', () => {
     }));
   });
 
-  it('renders loading state initially', () => {
+  test('renders loading state initially', () => {
     render(
       <Router history={history}>
         <DashboardTable {...defaultProps} />
@@ -152,7 +152,7 @@ describe('DashboardTable', () => {
     expect(screen.getByRole('img', { name: 'empty' })).toBeInTheDocument();
   });
 
-  it('renders empty state when no dashboards', async () => {
+  test('renders empty state when no dashboards', async () => {
     render(
       <Router history={history}>
         <DashboardTable {...defaultProps} />
@@ -165,7 +165,7 @@ describe('DashboardTable', () => {
     });
   });
 
-  it('renders dashboard cards when data is loaded', async () => {
+  test('renders dashboard cards when data is loaded', async () => {
     jest.spyOn(hooks, 'useListViewResource').mockImplementation(() => ({
       state: {
         loading: false,
@@ -195,7 +195,7 @@ describe('DashboardTable', () => {
     });
   });
 
-  it('switches to Mine tab correctly', async () => {
+  test('switches to Mine tab correctly', async () => {
     const props = {
       ...defaultProps,
       mine: mockDashboards,
@@ -215,7 +215,7 @@ describe('DashboardTable', () => {
     });
   });
 
-  it('handles create dashboard button click', async () => {
+  test('handles create dashboard button click', async () => {
     const assignMock = jest.fn();
     Object.defineProperty(window, 'location', {
       value: { assign: assignMock },
@@ -234,7 +234,7 @@ describe('DashboardTable', () => {
     expect(assignMock).toHaveBeenCalledWith('/dashboard/new');
   });
 
-  it('switches to Other tab when available', async () => {
+  test('switches to Other tab when available', async () => {
     const props = {
       ...defaultProps,
       otherTabData: mockDashboards,
@@ -253,7 +253,7 @@ describe('DashboardTable', () => {
     expect(otherTab).toHaveClass('active');
   });
 
-  it('handles bulk dashboard export', async () => {
+  test('handles bulk dashboard export', async () => {
     const props = {
       ...defaultProps,
       mine: mockDashboards,
@@ -282,7 +282,7 @@ describe('DashboardTable', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('handles dashboard deletion confirmation', async () => {
+  test('handles dashboard deletion confirmation', async () => {
     const props = {
       ...defaultProps,
       mine: mockDashboards,

--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -94,6 +94,7 @@ const defaultProps = {
   otherTabTitle: 'Examples',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardTable', () => {
   const history = createMemoryHistory();
   const store = configureStore({

--- a/superset-frontend/src/features/home/EmptyState.test.tsx
+++ b/superset-frontend/src/features/home/EmptyState.test.tsx
@@ -64,7 +64,7 @@ describe('EmptyState', () => {
   ];
 
   variants.forEach(variant => {
-    it(`renders an ${variant.tab} ${variant.tableName} empty state`, () => {
+    test(`renders an ${variant.tab} ${variant.tableName} empty state`, () => {
       const { container } = render(<EmptyState {...variant} />);
 
       // Select the first description node
@@ -76,7 +76,7 @@ describe('EmptyState', () => {
   });
 
   recents.forEach(recent => {
-    it(`renders a ${recent.tab} ${recent.tableName} empty state`, () => {
+    test(`renders a ${recent.tab} ${recent.tableName} empty state`, () => {
       const { container } = render(<EmptyState {...recent} />);
 
       // Select the first description node

--- a/superset-frontend/src/features/home/EmptyState.test.tsx
+++ b/superset-frontend/src/features/home/EmptyState.test.tsx
@@ -21,6 +21,7 @@ import { render, screen } from 'spec/helpers/testing-library';
 import EmptyState, { EmptyStateProps } from './EmptyState';
 import { WelcomeTable } from './types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('EmptyState', () => {
   const variants: EmptyStateProps[] = [
     {

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -131,6 +131,7 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Header Report Dropdown', () => {
   beforeAll(() => {
     mockedIsFeatureEnabled.mockImplementation(

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -142,7 +142,7 @@ describe('Header Report Dropdown', () => {
     mockedIsFeatureEnabled.mockRestore();
   });
 
-  it('renders correctly', () => {
+  test('renders correctly', () => {
     const mockedProps = createProps();
     act(() => {
       setup(mockedProps, stateWithUserAndReport);
@@ -150,7 +150,7 @@ describe('Header Report Dropdown', () => {
     expect(screen.getAllByRole('menuitem')[0]).toBeInTheDocument();
   });
 
-  it('renders the dropdown correctly', async () => {
+  test('renders the dropdown correctly', async () => {
     const mockedProps = createProps();
     act(() => {
       setup(mockedProps, stateWithUserAndReport);
@@ -160,7 +160,7 @@ describe('Header Report Dropdown', () => {
     expect(screen.getByText('Delete email report')).toBeInTheDocument();
   });
 
-  it('opens an edit modal', async () => {
+  test('opens an edit modal', async () => {
     const mockedProps = createProps();
     mockedProps.showReportModal = jest.fn();
     act(() => {
@@ -171,7 +171,7 @@ describe('Header Report Dropdown', () => {
     expect(mockedProps.showReportModal).toHaveBeenCalled();
   });
 
-  it('opens a delete modal', async () => {
+  test('opens a delete modal', async () => {
     const mockedProps = createProps();
     mockedProps.setCurrentReportDeleting = jest.fn();
     act(() => {
@@ -182,7 +182,7 @@ describe('Header Report Dropdown', () => {
     expect(mockedProps.setCurrentReportDeleting).toHaveBeenCalled();
   });
 
-  it('renders Manage Email Reports Menu if there is a report', async () => {
+  test('renders Manage Email Reports Menu if there is a report', async () => {
     const mockedProps = createProps();
     act(() => {
       setup(mockedProps, stateWithUserAndReport);
@@ -192,7 +192,7 @@ describe('Header Report Dropdown', () => {
     expect(screen.getByText('Delete email report')).toBeInTheDocument();
   });
 
-  it('renders Schedule Email Reports if there is a report', async () => {
+  test('renders Schedule Email Reports if there is a report', async () => {
     const mockedProps = createProps();
 
     act(() => {
@@ -203,7 +203,7 @@ describe('Header Report Dropdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders Schedule Email Reports as long as user has permission through any role', async () => {
+  test('renders Schedule Email Reports as long as user has permission through any role', async () => {
     const mockedProps = createProps();
     act(() => {
       setup(mockedProps, stateWithNonAdminUser);
@@ -214,7 +214,7 @@ describe('Header Report Dropdown', () => {
     ).toBeInTheDocument();
   });
 
-  it('do not render Schedule Email Reports if user no permission', () => {
+  test('do not render Schedule Email Reports if user no permission', () => {
     const mockedProps = createProps();
 
     act(() => {

--- a/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
@@ -57,6 +57,7 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Email Report Modal', () => {
   beforeEach(() => {
     mockedIsFeatureEnabled.mockImplementation(
@@ -109,6 +110,7 @@ describe('Email Report Modal', () => {
     expect(addButton).toBeDisabled();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Email Report Modal', () => {
     let dispatch: any;
 

--- a/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
@@ -65,7 +65,7 @@ describe('Email Report Modal', () => {
     render(<ReportModal {...defaultProps} />, { useRedux: true });
   });
 
-  it('inputs respond correctly', () => {
+  test('inputs respond correctly', () => {
     // ----- Report name textbox
     // Initial value
     const reportNameTextbox = screen.getByTestId('report-name-test');
@@ -92,7 +92,7 @@ describe('Email Report Modal', () => {
     expect(crontabInputs).toHaveLength(5);
   });
 
-  it('does not allow user to create a report without a name', () => {
+  test('does not allow user to create a report without a name', () => {
     // Grab name textbox and add button
     const reportNameTextbox = screen.getByTestId('report-name-test');
     const addButton = screen.getByRole('button', { name: /add/i });
@@ -116,7 +116,7 @@ describe('Email Report Modal', () => {
       dispatch = sinon.spy();
     });
 
-    it('creates a new email report', async () => {
+    test('creates a new email report', async () => {
       // ---------- Render/value setup ----------
       const reportValues = {
         id: 1,

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
@@ -154,7 +154,7 @@ describe('Rule modal', () => {
     return mounted;
   }
 
-  it('Sets correct title for adding new rule', async () => {
+  test('Sets correct title for adding new rule', async () => {
     await renderAndWait(addNewRuleDefaultProps);
     const title = screen.getByText('Add Rule');
     expect(title).toBeInTheDocument();
@@ -163,7 +163,7 @@ describe('Rule modal', () => {
     expect(fetchMock.calls(getRelatedRolesEndpoint)).toHaveLength(0);
   });
 
-  it('Sets correct title for editing existing rule', async () => {
+  test('Sets correct title for editing existing rule', async () => {
     await renderAndWait({
       ...addNewRuleDefaultProps,
       rule: {
@@ -181,7 +181,7 @@ describe('Rule modal', () => {
     expect(fetchMock.calls(getRelatedRolesEndpoint)).toHaveLength(0);
   });
 
-  it('Fills correct values when editing rule', async () => {
+  test('Fills correct values when editing rule', async () => {
     await renderAndWait({
       ...addNewRuleDefaultProps,
       rule: {
@@ -225,7 +225,7 @@ describe('Rule modal', () => {
     expect(description).toHaveValue('test description');
   });
 
-  it('Does not allow to create rule without name, tables and clause', async () => {
+  test('Does not allow to create rule without name, tables and clause', async () => {
     jest.setTimeout(10000);
     await renderAndWait(addNewRuleDefaultProps);
 
@@ -246,7 +246,7 @@ describe('Rule modal', () => {
     expect(addButton).toBeEnabled();
   });
 
-  it('Creates a new rule', async () => {
+  test('Creates a new rule', async () => {
     await renderAndWait(addNewRuleDefaultProps);
 
     const addButton = screen.getByRole('button', { name: /add/i });
@@ -269,7 +269,7 @@ describe('Rule modal', () => {
     );
   });
 
-  it('Updates existing rule', async () => {
+  test('Updates existing rule', async () => {
     await renderAndWait({
       ...addNewRuleDefaultProps,
       rule: {

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
@@ -146,6 +146,7 @@ const addNewRuleDefaultProps: RowLevelSecurityModalProps = {
   onHide: NOOP,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Rule modal', () => {
   async function renderAndWait(props: RowLevelSecurityModalProps) {
     const mounted = act(async () => {

--- a/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
@@ -51,25 +51,25 @@ describe('RoleListAddModal', () => {
     ],
   };
 
-  it('renders modal with form fields', () => {
+  test('renders modal with form fields', () => {
     render(<RoleListAddModal {...mockProps} />);
     expect(screen.getByText('Add Role')).toBeInTheDocument();
     expect(screen.getByText('Role Name')).toBeInTheDocument();
     expect(screen.getByText('Permissions')).toBeInTheDocument();
   });
 
-  it('calls onHide when cancel button is clicked', () => {
+  test('calls onHide when cancel button is clicked', () => {
     render(<RoleListAddModal {...mockProps} />);
     fireEvent.click(screen.getByTestId('modal-cancel-button'));
     expect(mockProps.onHide).toHaveBeenCalled();
   });
 
-  it('disables save button when role name is empty', () => {
+  test('disables save button when role name is empty', () => {
     render(<RoleListAddModal {...mockProps} />);
     expect(screen.getByTestId('form-modal-save-button')).toBeDisabled();
   });
 
-  it('enables save button when role name is entered', () => {
+  test('enables save button when role name is entered', () => {
     render(<RoleListAddModal {...mockProps} />);
     fireEvent.change(screen.getByTestId('role-name-input'), {
       target: { value: 'New Role' },
@@ -77,7 +77,7 @@ describe('RoleListAddModal', () => {
     expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
   });
 
-  it('calls createRole when save button is clicked', async () => {
+  test('calls createRole when save button is clicked', async () => {
     render(<RoleListAddModal {...mockProps} />);
 
     fireEvent.change(screen.getByTestId('role-name-input'), {

--- a/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
@@ -40,6 +40,7 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
   useToasts: () => mockToasts,
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RoleListAddModal', () => {
   const mockProps = {
     show: true,

--- a/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
@@ -56,7 +56,7 @@ describe('RoleListDuplicateModal', () => {
     onSave: jest.fn(),
   };
 
-  it('renders modal with form fields', () => {
+  test('renders modal with form fields', () => {
     render(<RoleListDuplicateModal {...mockProps} />);
     expect(
       screen.getByText(`Duplicate role ${mockRole.name}`),
@@ -64,18 +64,18 @@ describe('RoleListDuplicateModal', () => {
     expect(screen.getByText('Role Name')).toBeInTheDocument();
   });
 
-  it('calls onHide when cancel button is clicked', () => {
+  test('calls onHide when cancel button is clicked', () => {
     render(<RoleListDuplicateModal {...mockProps} />);
     fireEvent.click(screen.getByTestId('modal-cancel-button'));
     expect(mockProps.onHide).toHaveBeenCalled();
   });
 
-  it('disables save button when role name is empty', () => {
+  test('disables save button when role name is empty', () => {
     render(<RoleListDuplicateModal {...mockProps} />);
     expect(screen.getByTestId('form-modal-save-button')).toBeDisabled();
   });
 
-  it('enables save button when role name is entered', () => {
+  test('enables save button when role name is entered', () => {
     render(<RoleListDuplicateModal {...mockProps} />);
     fireEvent.change(screen.getByTestId('role-name-input'), {
       target: { value: 'New Role' },
@@ -83,7 +83,7 @@ describe('RoleListDuplicateModal', () => {
     expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
   });
 
-  it('calls createRole when save button is clicked', async () => {
+  test('calls createRole when save button is clicked', async () => {
     mockCreateRole.mockResolvedValue({ json: { id: 2 } } as any);
 
     render(<RoleListDuplicateModal {...mockProps} />);

--- a/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
@@ -40,6 +40,7 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
   default: (Component: any) => Component,
   useToasts: () => mockToasts,
 }));
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RoleListDuplicateModal', () => {
   const mockRole = {
     id: 1,

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -58,6 +58,7 @@ jest.mock('@superset-ui/core', () => {
   };
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RoleListEditModal', () => {
   const mockRole = {
     id: 1,

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -110,7 +110,7 @@ describe('RoleListEditModal', () => {
     groups: mockGroups,
   };
 
-  it('renders modal with correct title and fields', () => {
+  test('renders modal with correct title and fields', () => {
     render(<RoleListEditModal {...mockProps} />);
     expect(screen.getAllByText('Edit Role')[0]).toBeInTheDocument();
     expect(screen.getByText('Role Name')).toBeInTheDocument();
@@ -118,13 +118,13 @@ describe('RoleListEditModal', () => {
     expect(screen.getAllByText('Users')[0]).toBeInTheDocument();
   });
 
-  it('calls onHide when cancel button is clicked', () => {
+  test('calls onHide when cancel button is clicked', () => {
     render(<RoleListEditModal {...mockProps} />);
     fireEvent.click(screen.getByTestId('modal-cancel-button'));
     expect(mockProps.onHide).toHaveBeenCalled();
   });
 
-  it('disables save button when role name is empty', () => {
+  test('disables save button when role name is empty', () => {
     render(<RoleListEditModal {...mockProps} />);
     fireEvent.change(screen.getByTestId('role-name-input'), {
       target: { value: '' },
@@ -132,7 +132,7 @@ describe('RoleListEditModal', () => {
     expect(screen.getByTestId('form-modal-save-button')).toBeDisabled();
   });
 
-  it('enables save button when role name is entered', () => {
+  test('enables save button when role name is entered', () => {
     render(<RoleListEditModal {...mockProps} />);
     fireEvent.change(screen.getByTestId('role-name-input'), {
       target: { value: 'Updated Role' },
@@ -140,7 +140,7 @@ describe('RoleListEditModal', () => {
     expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
   });
 
-  it('calls update functions when save button is clicked', async () => {
+  test('calls update functions when save button is clicked', async () => {
     (SupersetClient.get as jest.Mock).mockImplementation(({ endpoint }) => {
       if (endpoint?.includes('/api/v1/security/users/')) {
         return Promise.resolve({
@@ -196,7 +196,7 @@ describe('RoleListEditModal', () => {
     });
   });
 
-  it('switches tabs correctly', () => {
+  test('switches tabs correctly', () => {
     render(<RoleListEditModal {...mockProps} />);
 
     const usersTab = screen.getByRole('tab', { name: 'Users' });

--- a/superset-frontend/src/features/tags/BulkTagModal.test.tsx
+++ b/superset-frontend/src/features/tags/BulkTagModal.test.tsx
@@ -36,6 +36,7 @@ const mockedProps = {
   resourceName: 'dashboard',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('BulkTagModal', () => {
   afterEach(() => {
     fetchMock.reset();

--- a/superset-frontend/src/features/themes/ThemeModal.test.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.test.tsx
@@ -124,6 +124,7 @@ fetchMock.put('glob:*/api/v1/theme/1', {
 //   show: true,
 // };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ThemeModal', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/features/themes/api.test.ts
+++ b/superset-frontend/src/features/themes/api.test.ts
@@ -34,7 +34,7 @@ describe('Theme API', () => {
   });
 
   describe('setSystemDefaultTheme', () => {
-    it('should call the correct endpoint with theme id', async () => {
+    test('should call the correct endpoint with theme id', async () => {
       const mockResponse = { id: 1, result: 'success' };
       fetchMock.put('glob:*/api/v1/theme/1/set_system_default', mockResponse);
 
@@ -45,7 +45,7 @@ describe('Theme API', () => {
       );
     });
 
-    it('should handle errors properly', async () => {
+    test('should handle errors properly', async () => {
       fetchMock.put('glob:*/api/v1/theme/1/set_system_default', {
         throws: new Error('API Error'),
       });
@@ -55,7 +55,7 @@ describe('Theme API', () => {
   });
 
   describe('setSystemDarkTheme', () => {
-    it('should call the correct endpoint with theme id', async () => {
+    test('should call the correct endpoint with theme id', async () => {
       const mockResponse = { id: 2, result: 'success' };
       fetchMock.put('glob:*/api/v1/theme/2/set_system_dark', mockResponse);
 
@@ -66,7 +66,7 @@ describe('Theme API', () => {
       );
     });
 
-    it('should handle errors properly', async () => {
+    test('should handle errors properly', async () => {
       fetchMock.put('glob:*/api/v1/theme/2/set_system_dark', {
         throws: new Error('API Error'),
       });
@@ -76,7 +76,7 @@ describe('Theme API', () => {
   });
 
   describe('unsetSystemDefaultTheme', () => {
-    it('should call the correct endpoint', async () => {
+    test('should call the correct endpoint', async () => {
       const mockResponse = { result: 'success' };
       fetchMock.delete(
         'glob:*/api/v1/theme/unset_system_default',
@@ -90,7 +90,7 @@ describe('Theme API', () => {
       );
     });
 
-    it('should handle errors properly', async () => {
+    test('should handle errors properly', async () => {
       fetchMock.delete('glob:*/api/v1/theme/unset_system_default', {
         throws: new Error('API Error'),
       });
@@ -100,7 +100,7 @@ describe('Theme API', () => {
   });
 
   describe('unsetSystemDarkTheme', () => {
-    it('should call the correct endpoint', async () => {
+    test('should call the correct endpoint', async () => {
       const mockResponse = { result: 'success' };
       fetchMock.delete('glob:*/api/v1/theme/unset_system_dark', mockResponse);
 
@@ -111,7 +111,7 @@ describe('Theme API', () => {
       );
     });
 
-    it('should handle errors properly', async () => {
+    test('should handle errors properly', async () => {
       fetchMock.delete('glob:*/api/v1/theme/unset_system_dark', {
         throws: new Error('API Error'),
       });

--- a/superset-frontend/src/features/themes/api.test.ts
+++ b/superset-frontend/src/features/themes/api.test.ts
@@ -24,6 +24,7 @@ import {
   unsetSystemDarkTheme,
 } from './api';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Theme API', () => {
   beforeEach(() => {
     fetchMock.reset();
@@ -33,6 +34,7 @@ describe('Theme API', () => {
     fetchMock.restore();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('setSystemDefaultTheme', () => {
     test('should call the correct endpoint with theme id', async () => {
       const mockResponse = { id: 1, result: 'success' };
@@ -54,6 +56,7 @@ describe('Theme API', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('setSystemDarkTheme', () => {
     test('should call the correct endpoint with theme id', async () => {
       const mockResponse = { id: 2, result: 'success' };
@@ -75,6 +78,7 @@ describe('Theme API', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('unsetSystemDefaultTheme', () => {
     test('should call the correct endpoint', async () => {
       const mockResponse = { result: 'success' };
@@ -99,6 +103,7 @@ describe('Theme API', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('unsetSystemDarkTheme', () => {
     test('should call the correct endpoint', async () => {
       const mockResponse = { result: 'success' };

--- a/superset-frontend/src/features/themes/types.test.ts
+++ b/superset-frontend/src/features/themes/types.test.ts
@@ -21,7 +21,7 @@ import { ThemeObject } from './types';
 
 describe('Theme Types', () => {
   describe('ThemeObject', () => {
-    it('should accept valid theme objects', () => {
+    test('should accept valid theme objects', () => {
       const validTheme: ThemeObject = {
         id: 1,
         theme_name: 'Test Theme',
@@ -51,7 +51,7 @@ describe('Theme Types', () => {
       expect(validTheme.is_system_dark).toBe(false);
     });
 
-    it('should handle optional fields', () => {
+    test('should handle optional fields', () => {
       const minimalTheme: ThemeObject = {
         theme_name: 'Minimal Theme',
         json_data: '{}',
@@ -64,7 +64,7 @@ describe('Theme Types', () => {
       expect(minimalTheme.is_system_dark).toBeUndefined();
     });
 
-    it('should handle system theme fields correctly', () => {
+    test('should handle system theme fields correctly', () => {
       const systemTheme: ThemeObject = {
         id: 2,
         theme_name: 'System Theme',
@@ -79,7 +79,7 @@ describe('Theme Types', () => {
       expect(systemTheme.is_system_dark).toBe(false);
     });
 
-    it('should handle both system default and dark flags', () => {
+    test('should handle both system default and dark flags', () => {
       // This should not happen in practice (a theme shouldn't be both)
       // but the type allows it for flexibility
       const theme: ThemeObject = {
@@ -97,7 +97,7 @@ describe('Theme Types', () => {
   });
 
   describe('Theme JSON Data', () => {
-    it('should parse valid JSON data', () => {
+    test('should parse valid JSON data', () => {
       const theme: ThemeObject = {
         theme_name: 'Parse Test',
         json_data:
@@ -109,7 +109,7 @@ describe('Theme Types', () => {
       expect(parsed.token.colorSuccess).toBe('#52c41a');
     });
 
-    it('should handle empty JSON', () => {
+    test('should handle empty JSON', () => {
       const theme: ThemeObject = {
         theme_name: 'Empty Theme',
         json_data: '{}',
@@ -121,7 +121,7 @@ describe('Theme Types', () => {
   });
 
   describe('Type Guards', () => {
-    it('should identify system themes', () => {
+    test('should identify system themes', () => {
       const isSystemTheme = (theme: ThemeObject): boolean =>
         theme.is_system === true;
 
@@ -141,7 +141,7 @@ describe('Theme Types', () => {
       expect(isSystemTheme(userTheme)).toBe(false);
     });
 
-    it('should identify deletable themes', () => {
+    test('should identify deletable themes', () => {
       const isDeletable = (theme: ThemeObject): boolean =>
         !theme.is_system && !theme.is_system_default && !theme.is_system_dark;
 

--- a/superset-frontend/src/features/themes/types.test.ts
+++ b/superset-frontend/src/features/themes/types.test.ts
@@ -19,7 +19,9 @@
 
 import { ThemeObject } from './types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Theme Types', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('ThemeObject', () => {
     test('should accept valid theme objects', () => {
       const validTheme: ThemeObject = {
@@ -96,6 +98,7 @@ describe('Theme Types', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Theme JSON Data', () => {
     test('should parse valid JSON data', () => {
       const theme: ThemeObject = {
@@ -120,6 +123,7 @@ describe('Theme Types', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Type Guards', () => {
     test('should identify system themes', () => {
       const isSystemTheme = (theme: ThemeObject): boolean =>

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -104,7 +104,7 @@ describe('RangeFilterPlugin', () => {
     jest.clearAllMocks();
   });
 
-  it('should render two numerical inputs and a slider by default', () => {
+  test('should render two numerical inputs and a slider by default', () => {
     getWrapper();
 
     const inputs = screen.getAllByRole('spinbutton');
@@ -118,7 +118,7 @@ describe('RangeFilterPlugin', () => {
     expect(sliders.length).toBeGreaterThan(0);
   });
 
-  it('should set the data mask to error when the range is incorrect', async () => {
+  test('should set the data mask to error when the range is incorrect', async () => {
     getWrapper({ filterState: { value: [null, null] } });
 
     const inputs = screen.getAllByRole('spinbutton');
@@ -144,7 +144,7 @@ describe('RangeFilterPlugin', () => {
     });
   });
 
-  it('should call setDataMask with correct filter', () => {
+  test('should call setDataMask with correct filter', () => {
     getWrapper();
     expect(setDataMask).toHaveBeenCalledWith({
       extraFormData: {
@@ -170,7 +170,7 @@ describe('RangeFilterPlugin', () => {
     });
   });
 
-  it('should call setDataMask with correct greater than filter', () => {
+  test('should call setDataMask with correct greater than filter', () => {
     getWrapper({
       filterState: { value: [20, null] },
       formData: {
@@ -201,7 +201,7 @@ describe('RangeFilterPlugin', () => {
     expect(inputs[0]).toHaveValue('20');
   });
 
-  it('should call setDataMask with correct less than filter', () => {
+  test('should call setDataMask with correct less than filter', () => {
     getWrapper({
       filterState: { value: [null, 60] },
       formData: {
@@ -231,7 +231,7 @@ describe('RangeFilterPlugin', () => {
     expect(inputs[0]).toHaveValue('60');
   });
 
-  it('should call setDataMask with correct exact filter', () => {
+  test('should call setDataMask with correct exact filter', () => {
     getWrapper({
       formData: {
         enableSingleValue: SingleValueType.Exact,
@@ -262,7 +262,7 @@ describe('RangeFilterPlugin', () => {
   });
 
   describe('Range Display Modes', () => {
-    it('should render only the slider in slider mode', () => {
+    test('should render only the slider in slider mode', () => {
       getWrapper({
         formData: {
           rangeDisplayMode: RangeDisplayMode.Slider,
@@ -275,7 +275,7 @@ describe('RangeFilterPlugin', () => {
       expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
     });
 
-    it('should render only inputs in input mode', () => {
+    test('should render only inputs in input mode', () => {
       getWrapper({
         formData: {
           rangeDisplayMode: RangeDisplayMode.Input,
@@ -288,7 +288,7 @@ describe('RangeFilterPlugin', () => {
       expect(screen.queryAllByRole('slider')).toHaveLength(0);
     });
 
-    it('should render both slider and inputs in slider-and-input mode', () => {
+    test('should render both slider and inputs in slider-and-input mode', () => {
       getWrapper({
         formData: {
           rangeDisplayMode: RangeDisplayMode.SliderAndInput,
@@ -304,7 +304,7 @@ describe('RangeFilterPlugin', () => {
       expect(sliders.length).toBeGreaterThan(0);
     });
 
-    it('should default to slider-and-input mode when not specified', () => {
+    test('should default to slider-and-input mode when not specified', () => {
       getWrapper({
         formData: {
           // No rangeDisplayMode specified

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -84,6 +84,7 @@ const rangeProps = {
   appSection: AppSection.Dashboard,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RangeFilterPlugin', () => {
   const setDataMask = jest.fn();
   const getWrapper = (props: any = {}) =>
@@ -261,6 +262,7 @@ describe('RangeFilterPlugin', () => {
     expect(inputs[0]).toHaveValue('10');
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Range Display Modes', () => {
     test('should render only the slider in slider mode', () => {
       getWrapper({

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -69,6 +69,7 @@ const selectMultipleProps = {
   appSection: AppSection.Dashboard,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SelectFilterPlugin', () => {
   const setDataMask = jest.fn();
   const getWrapper = (props = {}) =>

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -38,7 +38,7 @@ describe('Select buildQuery', () => {
     width: 100,
   };
 
-  it('should build a default query', () => {
+  test('should build a default query', () => {
     const queryContext = buildQuery(formData);
     expect(queryContext.queries.length).toEqual(1);
     const [query] = queryContext.queries;
@@ -48,7 +48,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([]);
   });
 
-  it('should sort descending by metric', () => {
+  test('should sort descending by metric', () => {
     const queryContext = buildQuery({
       ...formData,
       sortMetric: 'my_metric',
@@ -61,7 +61,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([['my_metric', false]]);
   });
 
-  it('should sort ascending by metric', () => {
+  test('should sort ascending by metric', () => {
     const queryContext = buildQuery({
       ...formData,
       sortMetric: 'my_metric',
@@ -74,7 +74,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([['my_metric', true]]);
   });
 
-  it('should sort ascending by column', () => {
+  test('should sort ascending by column', () => {
     const queryContext = buildQuery({
       ...formData,
       sortAscending: true,
@@ -86,7 +86,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([['my_col', true]]);
   });
 
-  it('should sort descending by column', () => {
+  test('should sort descending by column', () => {
     const queryContext = buildQuery({
       ...formData,
       sortAscending: false,
@@ -98,7 +98,7 @@ describe('Select buildQuery', () => {
     expect(query.orderby).toEqual([['my_col', false]]);
   });
 
-  it('should add text search parameter for string to query filter', () => {
+  test('should add text search parameter for string to query filter', () => {
     const queryContext = buildQuery(formData, {
       ownState: {
         search: 'abc',
@@ -112,7 +112,7 @@ describe('Select buildQuery', () => {
     ]);
   });
 
-  it('should add text search parameter for numeric to query filter', () => {
+  test('should add text search parameter for numeric to query filter', () => {
     const queryContext = buildQuery(formData, {
       ownState: {
         search: '123',

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -20,6 +20,7 @@ import { GenericDataType } from '@apache-superset/core/api/core';
 import buildQuery from './buildQuery';
 import { PluginFilterSelectQueryFormData } from './types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Select buildQuery', () => {
   const formData: PluginFilterSelectQueryFormData = {
     datasource: '5__table',

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -33,7 +33,7 @@ import { FALSE_STRING, NULL_STRING, TRUE_STRING } from 'src/utils/common';
 
 describe('Filter utils', () => {
   describe('getRangeExtraFormData', () => {
-    it('getRangeExtraFormData - col: "testCol", lower: 1, upper: 2', () => {
+    test('getRangeExtraFormData - col: "testCol", lower: 1, upper: 2', () => {
       expect(getRangeExtraFormData('testCol', 1, 2)).toEqual({
         filters: [
           {
@@ -49,7 +49,7 @@ describe('Filter utils', () => {
         ],
       });
     });
-    it('getRangeExtraFormData - col: "testCol", lower: 0, upper: 0', () => {
+    test('getRangeExtraFormData - col: "testCol", lower: 0, upper: 0', () => {
       expect(getRangeExtraFormData('testCol', 0, 0)).toEqual({
         filters: [
           {
@@ -60,7 +60,7 @@ describe('Filter utils', () => {
         ],
       });
     });
-    it('getRangeExtraFormData - col: "testCol", lower: null, upper: 2', () => {
+    test('getRangeExtraFormData - col: "testCol", lower: null, upper: 2', () => {
       expect(getRangeExtraFormData('testCol', null, 2)).toEqual({
         filters: [
           {
@@ -71,7 +71,7 @@ describe('Filter utils', () => {
         ],
       });
     });
-    it('getRangeExtraFormData - col: "testCol", lower: 1, upper: undefined', () => {
+    test('getRangeExtraFormData - col: "testCol", lower: 1, upper: undefined', () => {
       expect(getRangeExtraFormData('testCol', 1, undefined)).toEqual({
         filters: [
           {
@@ -84,7 +84,7 @@ describe('Filter utils', () => {
     });
   });
   describe('getSelectExtraFormData', () => {
-    it('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: false, inverseSelection: false', () => {
+    test('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: false, inverseSelection: false', () => {
       expect(
         getSelectExtraFormData('testCol', ['value'], false, false),
       ).toEqual({
@@ -97,7 +97,7 @@ describe('Filter utils', () => {
         ],
       });
     });
-    it('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: true, inverseSelection: false', () => {
+    test('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: true, inverseSelection: false', () => {
       expect(getSelectExtraFormData('testCol', ['value'], true, false)).toEqual(
         {
           adhoc_filters: [
@@ -110,7 +110,7 @@ describe('Filter utils', () => {
         },
       );
     });
-    it('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: false, inverseSelection: true', () => {
+    test('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: false, inverseSelection: true', () => {
       expect(getSelectExtraFormData('testCol', ['value'], false, true)).toEqual(
         {
           filters: [
@@ -123,21 +123,21 @@ describe('Filter utils', () => {
         },
       );
     });
-    it('getSelectExtraFormData - col: "testCol", value: [], emptyFilter: false, inverseSelection: false', () => {
+    test('getSelectExtraFormData - col: "testCol", value: [], emptyFilter: false, inverseSelection: false', () => {
       expect(getSelectExtraFormData('testCol', [], false, false)).toEqual({});
     });
-    it('getSelectExtraFormData - col: "testCol", value: undefined, emptyFilter: false, inverseSelection: false', () => {
+    test('getSelectExtraFormData - col: "testCol", value: undefined, emptyFilter: false, inverseSelection: false', () => {
       expect(
         getSelectExtraFormData('testCol', undefined, false, false),
       ).toEqual({});
     });
-    it('getSelectExtraFormData - col: "testCol", value: null, emptyFilter: false, inverseSelection: false', () => {
+    test('getSelectExtraFormData - col: "testCol", value: null, emptyFilter: false, inverseSelection: false', () => {
       expect(getSelectExtraFormData('testCol', null, false, false)).toEqual({});
     });
   });
 
   describe('getDataRecordFormatter', () => {
-    it('default formatter returns expected values', () => {
+    test('default formatter returns expected values', () => {
       const formatter = getDataRecordFormatter();
       expect(formatter(null, GenericDataType.String)).toEqual(NULL_STRING);
       expect(formatter(null, GenericDataType.Numeric)).toEqual(NULL_STRING);
@@ -173,7 +173,7 @@ describe('Filter utils', () => {
       );
     });
 
-    it('formatter with defined formatters returns expected values', () => {
+    test('formatter with defined formatters returns expected values', () => {
       const formatter = getDataRecordFormatter({
         timeFormatter: getTimeFormatter(TimeFormats.DATABASE_DATETIME),
         numberFormatter: getNumberFormatter(NumberFormats.SMART_NUMBER),

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -31,7 +31,9 @@ import {
 } from 'src/filters/utils';
 import { FALSE_STRING, NULL_STRING, TRUE_STRING } from 'src/utils/common';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Filter utils', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getRangeExtraFormData', () => {
     test('getRangeExtraFormData - col: "testCol", lower: 1, upper: 2', () => {
       expect(getRangeExtraFormData('testCol', 1, 2)).toEqual({
@@ -83,6 +85,7 @@ describe('Filter utils', () => {
       });
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getSelectExtraFormData', () => {
     test('getSelectExtraFormData - col: "testCol", value: ["value"], emptyFilter: false, inverseSelection: false', () => {
       expect(
@@ -136,6 +139,7 @@ describe('Filter utils', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getDataRecordFormatter', () => {
     test('default formatter returns expected values', () => {
       const formatter = getDataRecordFormatter();

--- a/superset-frontend/src/hooks/apiResources/apiResources.test.ts
+++ b/superset-frontend/src/hooks/apiResources/apiResources.test.ts
@@ -52,7 +52,7 @@ describe('apiResource hooks', () => {
   });
 
   describe('useApiResourceFullBody', () => {
-    it('returns a loading state at the start', async () => {
+    test('returns a loading state at the start', async () => {
       const { result } = renderHook(() =>
         useApiResourceFullBody('/test/endpoint'),
       );
@@ -66,7 +66,7 @@ describe('apiResource hooks', () => {
       });
     });
 
-    it('resolves to the value from the api', async () => {
+    test('resolves to the value from the api', async () => {
       const { result } = renderHook(() =>
         useApiResourceFullBody('/test/endpoint'),
       );
@@ -80,7 +80,7 @@ describe('apiResource hooks', () => {
       });
     });
 
-    it('handles api errors', async () => {
+    test('handles api errors', async () => {
       const fakeError = new Error('fake api error');
       (makeApi as any).mockReturnValue(jest.fn().mockRejectedValue(fakeError));
       const { result } = renderHook(() =>
@@ -98,7 +98,7 @@ describe('apiResource hooks', () => {
   });
 
   describe('useTransformedResource', () => {
-    it('applies a transformation to the resource', () => {
+    test('applies a transformation to the resource', () => {
       const { result } = renderHook(() =>
         useTransformedResource(
           {
@@ -119,7 +119,7 @@ describe('apiResource hooks', () => {
       });
     });
 
-    it('works while loading', () => {
+    test('works while loading', () => {
       const nameToAllCaps = (thing: any) => ({
         ...thing,
         name: thing.name.toUpperCase(),
@@ -143,7 +143,7 @@ describe('apiResource hooks', () => {
   });
 
   describe('useApiV1Endpoint', () => {
-    it('resolves to the value from the api', async () => {
+    test('resolves to the value from the api', async () => {
       (makeApi as any).mockReturnValue(
         jest.fn().mockResolvedValue({
           meta: 'data',

--- a/superset-frontend/src/hooks/apiResources/apiResources.test.ts
+++ b/superset-frontend/src/hooks/apiResources/apiResources.test.ts
@@ -42,6 +42,7 @@ jest.mock('@superset-ui/core', () => ({
     .mockReturnValue(jest.fn().mockResolvedValue(fakeApiResult)),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('apiResource hooks', () => {
   beforeAll(() => {
     jest.useFakeTimers();
@@ -51,6 +52,7 @@ describe('apiResource hooks', () => {
     jest.useRealTimers();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('useApiResourceFullBody', () => {
     test('returns a loading state at the start', async () => {
       const { result } = renderHook(() =>
@@ -97,6 +99,7 @@ describe('apiResource hooks', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('useTransformedResource', () => {
     test('applies a transformation to the resource', () => {
       const { result } = renderHook(() =>
@@ -142,6 +145,7 @@ describe('apiResource hooks', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('useApiV1Endpoint', () => {
     test('resolves to the value from the api', async () => {
       (makeApi as any).mockReturnValue(

--- a/superset-frontend/src/hooks/apiResources/dashboards.test.ts
+++ b/superset-frontend/src/hooks/apiResources/dashboards.test.ts
@@ -20,6 +20,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import fetchMock from 'fetch-mock';
 import { useDashboardDatasets } from './dashboards';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useDashboardDatasets', () => {
   const mockDatasets = [
     {

--- a/superset-frontend/src/hooks/apiResources/dashboards.test.ts
+++ b/superset-frontend/src/hooks/apiResources/dashboards.test.ts
@@ -55,7 +55,7 @@ describe('useDashboardDatasets', () => {
     fetchMock.reset();
   });
 
-  it('adds currencyFormats to datasets', async () => {
+  test('adds currencyFormats to datasets', async () => {
     fetchMock.get('glob:*/api/v1/dashboard/*/datasets', {
       result: mockDatasets,
     });

--- a/superset-frontend/src/hooks/apiResources/schemas.test.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.test.ts
@@ -52,6 +52,7 @@ const expectedResult3 = fakeApiResult3.result.map((value: string) => ({
   title: value,
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useSchemas hook', () => {
   beforeEach(() => {
     fetchMock.reset();

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -70,6 +70,7 @@ const expectedHasMoreData = {
   hasMore: true,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useTables hook', () => {
   beforeEach(() => {
     fetchMock.reset();

--- a/superset-frontend/src/hooks/useDebounceValue.test.ts
+++ b/superset-frontend/src/hooks/useDebounceValue.test.ts
@@ -52,7 +52,7 @@ test('should update debounced value after delay', async () => {
   expect(result.current).toBe('world');
 });
 
-it('should cancel previous timeout when value changes', async () => {
+test('should cancel previous timeout when value changes', async () => {
   jest.useFakeTimers();
   const { result, rerender } = renderHook(
     ({ value, delay }) => useDebounceValue(value, delay),

--- a/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
@@ -66,7 +66,7 @@ describe('useThemeMenuItems', () => {
     jest.clearAllMocks();
   });
 
-  it('renders Light and Dark theme options by default', async () => {
+  test('renders Light and Dark theme options by default', async () => {
     renderThemeMenu();
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -76,7 +76,7 @@ describe('useThemeMenuItems', () => {
     expect(within(menu!).getByText('Dark')).toBeInTheDocument();
   });
 
-  it('does not render Match system option when allowOSPreference is false', async () => {
+  test('does not render Match system option when allowOSPreference is false', async () => {
     renderThemeMenu({ ...defaultProps, allowOSPreference: false });
     userEvent.hover(await screen.findByRole('menuitem'));
 
@@ -85,7 +85,7 @@ describe('useThemeMenuItems', () => {
     });
   });
 
-  it('renders with allowOSPreference as true by default', async () => {
+  test('renders with allowOSPreference as true by default', async () => {
     renderThemeMenu();
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -94,7 +94,7 @@ describe('useThemeMenuItems', () => {
     expect(within(menu).getByText('Match system')).toBeInTheDocument();
   });
 
-  it('renders clear option when both hasLocalOverride and onClearLocalSettings are provided', async () => {
+  test('renders clear option when both hasLocalOverride and onClearLocalSettings are provided', async () => {
     const mockClear = jest.fn();
     renderThemeMenu({
       ...defaultProps,
@@ -108,7 +108,7 @@ describe('useThemeMenuItems', () => {
     expect(within(menu).getByText('Clear local theme')).toBeInTheDocument();
   });
 
-  it('does not render clear option when hasLocalOverride is false', async () => {
+  test('does not render clear option when hasLocalOverride is false', async () => {
     const mockClear = jest.fn();
     renderThemeMenu({
       ...defaultProps,
@@ -123,7 +123,7 @@ describe('useThemeMenuItems', () => {
     });
   });
 
-  it('calls setThemeMode with DEFAULT when Light is clicked', async () => {
+  test('calls setThemeMode with DEFAULT when Light is clicked', async () => {
     const mockSet = jest.fn();
     renderThemeMenu({ ...defaultProps, setThemeMode: mockSet });
 
@@ -134,7 +134,7 @@ describe('useThemeMenuItems', () => {
     expect(mockSet).toHaveBeenCalledWith(ThemeMode.DEFAULT);
   });
 
-  it('calls setThemeMode with DARK when Dark is clicked', async () => {
+  test('calls setThemeMode with DARK when Dark is clicked', async () => {
     const mockSet = jest.fn();
     renderThemeMenu({ ...defaultProps, setThemeMode: mockSet });
 
@@ -145,7 +145,7 @@ describe('useThemeMenuItems', () => {
     expect(mockSet).toHaveBeenCalledWith(ThemeMode.DARK);
   });
 
-  it('calls setThemeMode with SYSTEM when Match system is clicked', async () => {
+  test('calls setThemeMode with SYSTEM when Match system is clicked', async () => {
     const mockSet = jest.fn();
     renderThemeMenu({ ...defaultProps, setThemeMode: mockSet });
 
@@ -156,7 +156,7 @@ describe('useThemeMenuItems', () => {
     expect(mockSet).toHaveBeenCalledWith(ThemeMode.SYSTEM);
   });
 
-  it('calls onClearLocalSettings when Clear local theme is clicked', async () => {
+  test('calls onClearLocalSettings when Clear local theme is clicked', async () => {
     const mockClear = jest.fn();
     renderThemeMenu({
       ...defaultProps,
@@ -171,27 +171,27 @@ describe('useThemeMenuItems', () => {
     expect(mockClear).toHaveBeenCalledTimes(1);
   });
 
-  it('displays sun icon for DEFAULT theme', () => {
+  test('displays sun icon for DEFAULT theme', () => {
     renderThemeMenu({ ...defaultProps, themeMode: ThemeMode.DEFAULT });
     expect(screen.getByTestId('sun')).toBeInTheDocument();
   });
 
-  it('displays moon icon for DARK theme', () => {
+  test('displays moon icon for DARK theme', () => {
     renderThemeMenu({ ...defaultProps, themeMode: ThemeMode.DARK });
     expect(screen.getByTestId('moon')).toBeInTheDocument();
   });
 
-  it('displays format-painter icon for SYSTEM theme', () => {
+  test('displays format-painter icon for SYSTEM theme', () => {
     renderThemeMenu({ ...defaultProps, themeMode: ThemeMode.SYSTEM });
     expect(screen.getByTestId('format-painter')).toBeInTheDocument();
   });
 
-  it('displays override icon when hasLocalOverride is true', () => {
+  test('displays override icon when hasLocalOverride is true', () => {
     renderThemeMenu({ ...defaultProps, hasLocalOverride: true });
     expect(screen.getByTestId('thunderbolt')).toBeInTheDocument();
   });
 
-  it('renders Theme group header', async () => {
+  test('renders Theme group header', async () => {
     renderThemeMenu();
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -200,7 +200,7 @@ describe('useThemeMenuItems', () => {
     expect(within(menu).getByText('Theme')).toBeInTheDocument();
   });
 
-  it('renders sun icon for Light theme option', async () => {
+  test('renders sun icon for Light theme option', async () => {
     renderThemeMenu();
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -210,7 +210,7 @@ describe('useThemeMenuItems', () => {
     expect(within(lightOption!).getByTestId('sun')).toBeInTheDocument();
   });
 
-  it('renders moon icon for Dark theme option', async () => {
+  test('renders moon icon for Dark theme option', async () => {
     renderThemeMenu();
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -220,7 +220,7 @@ describe('useThemeMenuItems', () => {
     expect(within(darkOption!).getByTestId('moon')).toBeInTheDocument();
   });
 
-  it('renders format-painter icon for Match system option', async () => {
+  test('renders format-painter icon for Match system option', async () => {
     renderThemeMenu({ ...defaultProps, allowOSPreference: true });
 
     userEvent.hover(await screen.findByRole('menuitem'));
@@ -232,7 +232,7 @@ describe('useThemeMenuItems', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders clear icon for Clear local theme option', async () => {
+  test('renders clear icon for Clear local theme option', async () => {
     renderThemeMenu({
       ...defaultProps,
       hasLocalOverride: true,
@@ -248,7 +248,7 @@ describe('useThemeMenuItems', () => {
     expect(within(clearOption!).getByTestId('clear')).toBeInTheDocument();
   });
 
-  it('renders divider before clear option when clear option is present', async () => {
+  test('renders divider before clear option when clear option is present', async () => {
     renderThemeMenu({
       ...defaultProps,
       hasLocalOverride: true,
@@ -263,7 +263,7 @@ describe('useThemeMenuItems', () => {
     expect(divider).toBeInTheDocument();
   });
 
-  it('does not render divider when clear option is not present', async () => {
+  test('does not render divider when clear option is not present', async () => {
     renderThemeMenu({ ...defaultProps });
 
     userEvent.hover(await screen.findByRole('menuitem'));

--- a/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
@@ -38,6 +38,7 @@ const TestComponent = (props: ThemeSubMenuProps) => {
   return <Menu items={[menuItem]} />;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useThemeMenuItems', () => {
   const defaultProps = {
     allowOSPreference: true,

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -31,7 +31,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 describe('useUnsavedChangesPrompt', () => {
-  it('should not show modal initially', () => {
+  test('should not show modal initially', () => {
     const { result } = renderHook(
       () =>
         useUnsavedChangesPrompt({
@@ -44,7 +44,7 @@ describe('useUnsavedChangesPrompt', () => {
     expect(result.current.showModal).toBe(false);
   });
 
-  it('should block navigation and show modal if there are unsaved changes', () => {
+  test('should block navigation and show modal if there are unsaved changes', () => {
     const { result } = renderHook(
       () =>
         useUnsavedChangesPrompt({
@@ -64,7 +64,7 @@ describe('useUnsavedChangesPrompt', () => {
     expect(result.current.showModal).toBe(true);
   });
 
-  it('should trigger onSave and hide modal on handleSaveAndCloseModal', async () => {
+  test('should trigger onSave and hide modal on handleSaveAndCloseModal', async () => {
     const onSave = jest.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(
@@ -84,7 +84,7 @@ describe('useUnsavedChangesPrompt', () => {
     expect(result.current.showModal).toBe(false);
   });
 
-  it('should trigger manual save and not show modal again', async () => {
+  test('should trigger manual save and not show modal again', async () => {
     const onSave = jest.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -30,6 +30,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   <Router history={history}>{children}</Router>
 );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useUnsavedChangesPrompt', () => {
   test('should not show modal initially', () => {
     const { result } = renderHook(

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -119,7 +119,7 @@ describe('asyncEvent middleware', () => {
       asyncEvent.init(config);
     });
 
-    it('resolves with chart data on event done status', async () => {
+    test('resolves with chart data on event done status', async () => {
       const actualResolved =
         await asyncEvent.waitForAsyncData(asyncPendingEvent);
       expect(actualResolved).toEqual([chartData]);
@@ -128,7 +128,7 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.calls(CACHED_DATA_ENDPOINT)).toHaveLength(1);
     });
 
-    it('rejects on event error status', async () => {
+    test('rejects on event error status', async () => {
       fetchMock.reset();
       fetchMock.get(EVENTS_ENDPOINT, {
         status: 200,
@@ -148,7 +148,7 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.calls(CACHED_DATA_ENDPOINT)).toHaveLength(0);
     });
 
-    it('rejects on cached data fetch error', async () => {
+    test('rejects on cached data fetch error', async () => {
       fetchMock.reset();
       fetchMock.get(EVENTS_ENDPOINT, {
         status: 200,
@@ -198,7 +198,7 @@ describe('asyncEvent middleware', () => {
       WS.clean();
     });
 
-    it('resolves with chart data on event done status', async () => {
+    test('resolves with chart data on event done status', async () => {
       await wsServer.connected;
 
       const promise = asyncEvent.waitForAsyncData(asyncPendingEvent);
@@ -211,7 +211,7 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.calls(EVENTS_ENDPOINT)).toHaveLength(0);
     });
 
-    it('rejects on event error status', async () => {
+    test('rejects on event error status', async () => {
       await wsServer.connected;
 
       const promise = asyncEvent.waitForAsyncData(asyncPendingEvent);
@@ -226,7 +226,7 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.calls(EVENTS_ENDPOINT)).toHaveLength(0);
     });
 
-    it('rejects on cached data fetch error', async () => {
+    test('rejects on cached data fetch error', async () => {
       fetchMock.reset();
       fetchMock.get(CACHED_DATA_ENDPOINT, {
         status: 400,
@@ -251,7 +251,7 @@ describe('asyncEvent middleware', () => {
       expect(fetchMock.calls(EVENTS_ENDPOINT)).toHaveLength(0);
     });
 
-    it('resolves when events are received before listener', async () => {
+    test('resolves when events are received before listener', async () => {
       await wsServer.connected;
 
       wsServer.send(JSON.stringify(asyncDoneEvent));

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -28,6 +28,7 @@ jest.mock('@superset-ui/core', () => ({
 
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('asyncEvent middleware', () => {
   const asyncPendingEvent = {
     status: 'pending',
@@ -100,6 +101,7 @@ describe('asyncEvent middleware', () => {
 
   afterAll(() => fetchMock.reset());
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('polling transport', () => {
     const config = {
       GLOBAL_ASYNC_QUERIES_TRANSPORT: 'polling',
@@ -172,6 +174,7 @@ describe('asyncEvent middleware', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('ws transport', () => {
     let wsServer: WS;
     const config = {

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -61,7 +61,7 @@ describe('logger middleware', () => {
     timeSandbox.clock.reset();
   });
 
-  it('should listen to LOG_EVENT action type', () => {
+  test('should listen to LOG_EVENT action type', () => {
     const action1 = {
       type: 'ACTION_TYPE',
       payload: {
@@ -72,7 +72,7 @@ describe('logger middleware', () => {
     expect(next.callCount).toBe(1);
   });
 
-  it('should POST an event to /superset/log/ when called', () => {
+  test('should POST an event to /superset/log/ when called', () => {
     logger(mockStore)(next)(action);
     expect(next.callCount).toBe(0);
 
@@ -83,7 +83,7 @@ describe('logger middleware', () => {
     );
   });
 
-  it('should include ts, start_offset, event_name, impression_id, source, and source_id in every event', () => {
+  test('should include ts, start_offset, event_name, impression_id, source, and source_id in every event', () => {
     const fetchLog = logger(mockStore)(next);
     fetchLog({
       type: LOG_EVENT,
@@ -113,7 +113,7 @@ describe('logger middleware', () => {
     expect(typeof events[0].start_offset).toBe('number');
   });
 
-  it('should debounce a few log requests to one', () => {
+  test('should debounce a few log requests to one', () => {
     logger(mockStore)(next)(action);
     logger(mockStore)(next)(action);
     logger(mockStore)(next)(action);
@@ -125,7 +125,7 @@ describe('logger middleware', () => {
     ).toHaveLength(3);
   });
 
-  it('should use navigator.sendBeacon if it exists', () => {
+  test('should use navigator.sendBeacon if it exists', () => {
     const beaconMock = jest.fn();
     Object.defineProperty(navigator, 'sendBeacon', {
       writable: true,
@@ -141,7 +141,7 @@ describe('logger middleware', () => {
     expect(endpoint).toMatch('/superset/log/');
   });
 
-  it('should pass a guest token to sendBeacon if present', () => {
+  test('should pass a guest token to sendBeacon if present', () => {
     const beaconMock = jest.fn();
     Object.defineProperty(navigator, 'sendBeacon', {
       writable: true,

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -25,6 +25,7 @@ import {
   LOG_ACTIONS_SPA_NAVIGATION,
 } from 'src/logger/LogUtils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('logger middleware', () => {
   const dashboardId = 123;
   const next = sinon.spy();

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
@@ -96,6 +96,7 @@ const renderAlertList = (props = {}) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AlertList', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
@@ -101,22 +101,22 @@ describe('AlertList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderAlertList();
     expect(await screen.findByText('Alerts & reports')).toBeInTheDocument();
   });
 
-  it('renders a SubMenu', async () => {
+  test('renders a SubMenu', async () => {
     renderAlertList();
     expect(await screen.findByRole('navigation')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderAlertList();
     expect(await screen.findByTestId('alerts-list-view')).toBeInTheDocument();
   });
 
-  it('renders switches', async () => {
+  test('renders switches', async () => {
     renderAlertList();
     // Wait for the list to load first
     await screen.findByTestId('alerts-list-view');
@@ -124,7 +124,7 @@ describe('AlertList', () => {
     expect(switches).toHaveLength(3);
   });
 
-  it('deletes', async () => {
+  test('deletes', async () => {
     renderAlertList();
 
     // Wait for list to load
@@ -148,7 +148,7 @@ describe('AlertList', () => {
     });
   }, 15000);
 
-  it('shows/hides bulk actions when bulk actions is clicked', async () => {
+  test('shows/hides bulk actions when bulk actions is clicked', async () => {
     renderAlertList();
 
     // Wait for list to load and initial state
@@ -167,7 +167,7 @@ describe('AlertList', () => {
     ).toBeInTheDocument();
   }, 15000);
 
-  it('hides bulk actions when switch between alert and report list', async () => {
+  test('hides bulk actions when switch between alert and report list', async () => {
     // Start with alert list
     renderAlertList();
 
@@ -233,7 +233,7 @@ describe('AlertList', () => {
     );
   }, 15000);
 
-  it('renders listview table correctly', async () => {
+  test('renders listview table correctly', async () => {
     renderAlertList();
     await screen.findByTestId('alerts-list-view');
 
@@ -242,7 +242,7 @@ describe('AlertList', () => {
     expect(table).toBeVisible();
   }, 15000);
 
-  it('renders correct column headers for alerts', async () => {
+  test('renders correct column headers for alerts', async () => {
     renderAlertList();
     await screen.findByTestId('alerts-list-view');
 
@@ -258,7 +258,7 @@ describe('AlertList', () => {
     expect(screen.getByText('Actions')).toBeInTheDocument();
   }, 15000);
 
-  it('renders correct column headers for reports', async () => {
+  test('renders correct column headers for reports', async () => {
     renderAlertList({ isReportEnabled: true });
     await screen.findByTestId('alerts-list-view');
 

--- a/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
@@ -91,24 +91,24 @@ describe('AnnotationLayersList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderAnnotationLayersList();
     expect(await screen.findByText('Annotation layers')).toBeInTheDocument();
   });
 
-  it('renders a SubMenu', async () => {
+  test('renders a SubMenu', async () => {
     renderAnnotationLayersList();
     expect(await screen.findByRole('navigation')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderAnnotationLayersList();
     expect(
       await screen.findByTestId('annotation-layers-list-view'),
     ).toBeInTheDocument();
   });
 
-  it('renders a modal', async () => {
+  test('renders a modal', async () => {
     renderAnnotationLayersList();
     const addButton = await screen.findByRole('button', {
       name: /annotation layer$/i,
@@ -117,7 +117,7 @@ describe('AnnotationLayersList', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
-  it('fetches layers', async () => {
+  test('fetches layers', async () => {
     renderAnnotationLayersList();
     await waitFor(() => {
       const calls = fetchMock.calls(/annotation_layer\/\?q/);
@@ -128,13 +128,13 @@ describe('AnnotationLayersList', () => {
     });
   });
 
-  it('renders Filters', async () => {
+  test('renders Filters', async () => {
     renderAnnotationLayersList();
     await screen.findByTestId('annotation-layers-list-view');
     expect(screen.getByPlaceholderText(/type a value/i)).toBeInTheDocument();
   });
 
-  it('searches', async () => {
+  test('searches', async () => {
     renderAnnotationLayersList();
 
     // Wait for list to load
@@ -155,7 +155,7 @@ describe('AnnotationLayersList', () => {
     });
   });
 
-  it('deletes', async () => {
+  test('deletes', async () => {
     renderAnnotationLayersList();
 
     // Wait for list to load
@@ -183,7 +183,7 @@ describe('AnnotationLayersList', () => {
     });
   });
 
-  it('shows bulk actions when bulk select is clicked', async () => {
+  test('shows bulk actions when bulk select is clicked', async () => {
     renderAnnotationLayersList();
 
     // Wait for list to load

--- a/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
@@ -86,6 +86,7 @@ const renderAnnotationLayersList = (props = {}) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AnnotationLayersList', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -54,6 +54,7 @@ jest.mock('src/explore/exploreUtils/getParsedExploreURLParams', () => ({
   getParsedExploreURLParams: jest.fn(),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -178,6 +179,7 @@ describe('ChartPage', () => {
     expect(getByText(expectedChartName)).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('with dashboardContextFormData', () => {
     const dashboardPageId = 'mockPageId';
 

--- a/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
@@ -54,6 +54,7 @@ const mockUser = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartList Card View Tests', () => {
   beforeEach(() => {
     setupMocks();

--- a/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
@@ -71,7 +71,7 @@ describe('ChartList Card View Tests', () => {
     fetchMock.restore();
   });
 
-  it('renders ChartList in card view', async () => {
+  test('renders ChartList in card view', async () => {
     renderChartList(mockUser);
 
     // Wait for chart list to load
@@ -94,7 +94,7 @@ describe('ChartList Card View Tests', () => {
     expect(listViewButton).not.toHaveClass('active');
   });
 
-  it('switches from card view to list view', async () => {
+  test('switches from card view to list view', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -113,7 +113,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('renders ChartList in card view with thumbnails enabled', async () => {
+  test('renders ChartList in card view with thumbnails enabled', async () => {
     // Enable thumbnails feature flag
     (
       isFeatureEnabled as jest.MockedFunction<typeof isFeatureEnabled>
@@ -137,7 +137,7 @@ describe('ChartList Card View Tests', () => {
     expect(allImages).toHaveLength(mockCharts.length);
   });
 
-  it('displays chart data correctly', async () => {
+  test('displays chart data correctly', async () => {
     renderChartList(mockUser);
 
     // Wait for chart list to load
@@ -174,7 +174,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('export chart api called when export button is clicked', async () => {
+  test('export chart api called when export button is clicked', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -199,7 +199,7 @@ describe('ChartList Card View Tests', () => {
     );
   });
 
-  it('opens edit properties modal when edit button is clicked', async () => {
+  test('opens edit properties modal when edit button is clicked', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -222,7 +222,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('opens delete confirmation when delete button is clicked', async () => {
+  test('opens delete confirmation when delete button is clicked', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -247,7 +247,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('displays certified badge only for certified charts', async () => {
+  test('displays certified badge only for certified charts', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -270,7 +270,7 @@ describe('ChartList Card View Tests', () => {
     expect(screen.getByText(mockCharts[3].slice_name)).toBeInTheDocument();
   });
 
-  it('can bulk deselect all charts', async () => {
+  test('can bulk deselect all charts', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -323,7 +323,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('can bulk export selected charts', async () => {
+  test('can bulk export selected charts', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -366,7 +366,7 @@ describe('ChartList Card View Tests', () => {
     );
   });
 
-  it('can bulk delete selected charts', async () => {
+  test('can bulk delete selected charts', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -407,7 +407,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('can bulk add tags to selected charts', async () => {
+  test('can bulk add tags to selected charts', async () => {
     // Enable tagging system for this test
     (
       isFeatureEnabled as jest.MockedFunction<typeof isFeatureEnabled>
@@ -459,7 +459,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('exit bulk select by hitting x on bulk select bar', async () => {
+  test('exit bulk select by hitting x on bulk select bar', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -491,7 +491,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('exit bulk select by clicking bulk select button again', async () => {
+  test('exit bulk select by clicking bulk select button again', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -520,7 +520,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('card click behavior changes in bulk select mode', async () => {
+  test('card click behavior changes in bulk select mode', async () => {
     renderChartList(mockUser);
 
     // Wait for cards to load
@@ -566,7 +566,7 @@ describe('ChartList Card View Tests', () => {
     });
   });
 
-  it('renders sort dropdown in card view', async () => {
+  test('renders sort dropdown in card view', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 

--- a/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
@@ -74,7 +74,7 @@ describe('ChartList - List View Tests', () => {
     fetchMock.restore();
   });
 
-  it('renders ChartList in list view', async () => {
+  test('renders ChartList in list view', async () => {
     renderChartList(mockUser);
 
     // Wait for component to load
@@ -93,7 +93,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('correctly displays dataset names with and without schema', async () => {
+  test('correctly displays dataset names with and without schema', async () => {
     // Create custom mock data with different datasource_name_text formats
     const customMockCharts = [
       {
@@ -171,7 +171,7 @@ describe('ChartList - List View Tests', () => {
     expect(dotsLink).toHaveTextContent('table.with.dots');
   });
 
-  it('switches from list view to card view', async () => {
+  test('switches from list view to card view', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -192,7 +192,7 @@ describe('ChartList - List View Tests', () => {
     expect(cards).toHaveLength(mockCharts.length);
   });
 
-  it('renders all required column headers', async () => {
+  test('renders all required column headers', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -222,7 +222,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('sorts table when clicking column headers', async () => {
+  test('sorts table when clicking column headers', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -275,7 +275,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('displays chart data correctly', async () => {
+  test('displays chart data correctly', async () => {
     /**
      * @todo Implement test logic for tagging.
      * If TAGGING_SYSTEM is ever deprecated to always be on,
@@ -354,7 +354,7 @@ describe('ChartList - List View Tests', () => {
     expect(within(chartRow).getByTestId('edit-alt')).toBeInTheDocument();
   });
 
-  it('export chart api called when export button is clicked', async () => {
+  test('export chart api called when export button is clicked', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -381,7 +381,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('opens edit properties modal when edit button is clicked', async () => {
+  test('opens edit properties modal when edit button is clicked', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -405,7 +405,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('opens delete confirmation when delete button is clicked', async () => {
+  test('opens delete confirmation when delete button is clicked', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -429,7 +429,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('displays certified badge only for certified charts', async () => {
+  test('displays certified badge only for certified charts', async () => {
     // Test certified chart (mockCharts[1] has certification)
     const certifiedChart = mockCharts[1];
     // Test uncertified chart (mockCharts[0] has no certification)
@@ -469,7 +469,7 @@ describe('ChartList - List View Tests', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('displays info icon only for charts with descriptions', async () => {
+  test('displays info icon only for charts with descriptions', async () => {
     // Test chart with description (mockCharts[0] has description)
     const chartWithDesc = mockCharts[0];
     // Test chart without description (mockCharts[2] has description: null)
@@ -507,7 +507,7 @@ describe('ChartList - List View Tests', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('displays chart with empty dataset column', async () => {
+  test('displays chart with empty dataset column', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -548,7 +548,7 @@ describe('ChartList - List View Tests', () => {
     expect(datasetLink).toHaveAttribute('href', '');
   });
 
-  it('displays chart with empty on dashboards column', async () => {
+  test('displays chart with empty on dashboards column', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -587,7 +587,7 @@ describe('ChartList - List View Tests', () => {
     expect(within(dashboardCell).queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('shows tag info when TAGGING_SYSTEM is enabled', async () => {
+  test('shows tag info when TAGGING_SYSTEM is enabled', async () => {
     // Enable tagging system feature flag
     mockIsFeatureEnabled.mockImplementation(
       feature => feature === 'TAGGING_SYSTEM',
@@ -627,7 +627,7 @@ describe('ChartList - List View Tests', () => {
     expect(tagLink).toHaveAttribute('target', '_blank');
   });
 
-  it('can bulk select and deselect all charts', async () => {
+  test('can bulk select and deselect all charts', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -691,7 +691,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('can bulk export selected charts', async () => {
+  test('can bulk export selected charts', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -739,7 +739,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('can bulk delete selected charts', async () => {
+  test('can bulk delete selected charts', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -787,7 +787,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('can bulk add tags to selected charts', async () => {
+  test('can bulk add tags to selected charts', async () => {
     // Enable tagging system feature flag
     mockIsFeatureEnabled.mockImplementation(
       feature => feature === 'TAGGING_SYSTEM',
@@ -840,7 +840,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('exit bulk select by hitting x on bulk select bar', async () => {
+  test('exit bulk select by hitting x on bulk select bar', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -886,7 +886,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('exit bulk select by clicking bulk select button again', async () => {
+  test('exit bulk select by clicking bulk select button again', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -928,7 +928,7 @@ describe('ChartList - List View Tests', () => {
     });
   });
 
-  it('displays dataset name without schema prefix correctly', async () => {
+  test('displays dataset name without schema prefix correctly', async () => {
     // Test just name case - should display the full name when no schema prefix
     renderChartList(mockUser);
 

--- a/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
@@ -64,6 +64,7 @@ const mockUser = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartList - List View Tests', () => {
   beforeEach(() => {
     mockHandleResourceExport.mockClear();

--- a/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
@@ -173,6 +173,7 @@ const renderWithPermissions = async (
   return result;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartList - Permission-based UI Tests', () => {
   beforeEach(() => {
     setupMocks();

--- a/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
@@ -186,7 +186,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     ).mockReset();
   });
 
-  it('shows all UI elements for admin users with full permissions', async () => {
+  test('shows all UI elements for admin users with full permissions', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
 
     // Wait for component to load
@@ -205,7 +205,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(favoriteStars).toHaveLength(mockCharts.length);
   });
 
-  it('renders basic UI for anonymous users without permissions', async () => {
+  test('renders basic UI for anonymous users without permissions', async () => {
     await renderWithPermissions(PERMISSIONS.NONE, undefined);
     await screen.findByTestId('chart-list-view');
 
@@ -226,7 +226,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
 
-  it('shows Actions column for users with admin permissions', async () => {
+  test('shows Actions column for users with admin permissions', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
     await screen.findByTestId('chart-list-view');
 
@@ -242,7 +242,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(deleteButtons).toHaveLength(mockCharts.length);
   });
 
-  it('hides Actions column for users with read-only permissions', async () => {
+  test('hides Actions column for users with read-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.READ_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -250,7 +250,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryAllByLabelText('more')).toHaveLength(0);
   });
 
-  it('hides Actions column for users with export-only permissions', async () => {
+  test('hides Actions column for users with export-only permissions', async () => {
     // Known issue: Actions column requires can_write permission
     await renderWithPermissions(PERMISSIONS.EXPORT_ONLY);
     await screen.findByTestId('chart-list-view');
@@ -259,7 +259,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryAllByLabelText('more')).toHaveLength(0);
   });
 
-  it('shows Actions column for users with write-only permissions', async () => {
+  test('shows Actions column for users with write-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.WRITE_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -275,7 +275,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(deleteButtons).toHaveLength(mockCharts.length);
   });
 
-  it('shows favorite stars for logged-in users', async () => {
+  test('shows favorite stars for logged-in users', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN, 1);
     await screen.findByTestId('chart-list-view');
 
@@ -283,7 +283,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(favoriteStars).toHaveLength(mockCharts.length);
   });
 
-  it('shows favorite stars even for users without userId', async () => {
+  test('shows favorite stars even for users without userId', async () => {
     // Current behavior: Component renders favorites regardless of userId
     await renderWithPermissions(PERMISSIONS.ADMIN, undefined);
     await screen.findByTestId('chart-list-view');
@@ -292,56 +292,56 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(favoriteStars).toHaveLength(mockCharts.length);
   });
 
-  it('shows Tags column when TAGGING_SYSTEM feature flag is enabled', async () => {
+  test('shows Tags column when TAGGING_SYSTEM feature flag is enabled', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN, 1, { tagging: true });
     await screen.findByTestId('chart-list-view');
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
   });
 
-  it('hides Tags column when TAGGING_SYSTEM feature flag is disabled', async () => {
+  test('hides Tags column when TAGGING_SYSTEM feature flag is disabled', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN, 1, { tagging: false });
     await screen.findByTestId('chart-list-view');
 
     expect(screen.queryByText('Tags')).not.toBeInTheDocument();
   });
 
-  it('shows Tags column based on feature flag regardless of user permissions', async () => {
+  test('shows Tags column based on feature flag regardless of user permissions', async () => {
     await renderWithPermissions(PERMISSIONS.READ_ONLY, 1, { tagging: true });
     await screen.findByTestId('chart-list-view');
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
   });
 
-  it('shows bulk select button for users with admin permissions', async () => {
+  test('shows bulk select button for users with admin permissions', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
     await screen.findByTestId('chart-list-view');
 
     expect(screen.getByTestId('bulk-select')).toBeInTheDocument();
   });
 
-  it('shows bulk select button for users with export-only permissions', async () => {
+  test('shows bulk select button for users with export-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.EXPORT_ONLY);
     await screen.findByTestId('chart-list-view');
 
     expect(screen.getByTestId('bulk-select')).toBeInTheDocument();
   });
 
-  it('shows bulk select button for users with write-only permissions', async () => {
+  test('shows bulk select button for users with write-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.WRITE_ONLY);
     await screen.findByTestId('chart-list-view');
 
     expect(screen.getByTestId('bulk-select')).toBeInTheDocument();
   });
 
-  it('hides bulk select button for users with read-only permissions', async () => {
+  test('hides bulk select button for users with read-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.READ_ONLY);
     await screen.findByTestId('chart-list-view');
 
     expect(screen.queryByTestId('bulk-select')).not.toBeInTheDocument();
   });
 
-  it('shows Create and Import buttons for users with write permissions', async () => {
+  test('shows Create and Import buttons for users with write permissions', async () => {
     await renderWithPermissions(PERMISSIONS.WRITE_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -349,7 +349,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
   });
 
-  it('shows Create and Import buttons for users with admin permissions', async () => {
+  test('shows Create and Import buttons for users with admin permissions', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
     await screen.findByTestId('chart-list-view');
 
@@ -357,7 +357,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.getByTestId('import-button')).toBeInTheDocument();
   });
 
-  it('hides Create and Import buttons for users with read-only permissions', async () => {
+  test('hides Create and Import buttons for users with read-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.READ_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -367,7 +367,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
 
-  it('hides Create and Import buttons for users with export-only permissions', async () => {
+  test('hides Create and Import buttons for users with export-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.EXPORT_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -377,7 +377,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
 
-  it('shows individual action buttons when user has admin permissions', async () => {
+  test('shows individual action buttons when user has admin permissions', async () => {
     await renderWithPermissions(PERMISSIONS.ADMIN);
     await screen.findByTestId('chart-list-view');
 
@@ -400,7 +400,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(actionButtons.length).toBeGreaterThanOrEqual(0);
   });
 
-  it('hides individual action buttons when user has read-only permissions', async () => {
+  test('hides individual action buttons when user has read-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.READ_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -412,7 +412,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(actionButtons).toHaveLength(0);
   });
 
-  it('shows individual action buttons when user has write-only permissions', async () => {
+  test('shows individual action buttons when user has write-only permissions', async () => {
     await renderWithPermissions(PERMISSIONS.WRITE_ONLY);
     await screen.findByTestId('chart-list-view');
 
@@ -428,7 +428,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     // The important verification is that Actions column is visible for write permissions
   });
 
-  it('shows correct UI elements for users with mixed permissions (export + tag read)', async () => {
+  test('shows correct UI elements for users with mixed permissions (export + tag read)', async () => {
     await renderWithPermissions(PERMISSIONS.MIXED, 1, { tagging: true });
     await screen.findByTestId('chart-list-view');
 
@@ -455,7 +455,7 @@ describe('ChartList - Permission-based UI Tests', () => {
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
   });
 
-  it('shows minimal UI for users with no permissions', async () => {
+  test('shows minimal UI for users with no permissions', async () => {
     await renderWithPermissions(PERMISSIONS.NONE, undefined);
     await screen.findByTestId('chart-list-view');
 

--- a/superset-frontend/src/pages/ChartList/ChartList.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.test.tsx
@@ -66,6 +66,7 @@ const findFilterByLabel = (labelText: string) => {
   return null;
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartList', () => {
   beforeEach(() => {
     setupMocks();
@@ -284,6 +285,7 @@ describe('ChartList', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ChartList - Global Filter Interactions', () => {
   beforeEach(() => {
     setupMocks();

--- a/superset-frontend/src/pages/ChartList/ChartList.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.test.tsx
@@ -81,14 +81,14 @@ describe('ChartList', () => {
     ).mockReset();
   });
 
-  it('renders component with basic structure', async () => {
+  test('renders component with basic structure', async () => {
     renderChartList(mockUser);
 
     expect(await screen.findByTestId('chart-list-view')).toBeInTheDocument();
     expect(screen.getByText('Charts')).toBeInTheDocument();
   });
 
-  it('verify New Chart button existence and functionality', async () => {
+  test('verify New Chart button existence and functionality', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -106,7 +106,7 @@ describe('ChartList', () => {
     });
   });
 
-  it('verify Import button existence and functionality', async () => {
+  test('verify Import button existence and functionality', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -125,7 +125,7 @@ describe('ChartList', () => {
     });
   });
 
-  it('shows loading state during initial data fetch', async () => {
+  test('shows loading state during initial data fetch', async () => {
     // Delay the chart data response to test loading state
     fetchMock.get(
       API_ENDPOINTS.CHARTS,
@@ -149,7 +149,7 @@ describe('ChartList', () => {
     );
   });
 
-  it('makes correct API calls on initial load', async () => {
+  test('makes correct API calls on initial load', async () => {
     renderChartList(mockUser);
 
     await waitFor(() => {
@@ -164,7 +164,7 @@ describe('ChartList', () => {
     });
   });
 
-  it('shows loading state while API calls are in progress', async () => {
+  test('shows loading state while API calls are in progress', async () => {
     // Mock delayed API responses
     fetchMock.get(
       API_ENDPOINTS.CHARTS_INFO,
@@ -203,7 +203,7 @@ describe('ChartList', () => {
     );
   });
 
-  it('maintains component structure during loading', async () => {
+  test('maintains component structure during loading', async () => {
     // Only delay data loading, not permissions
     fetchMock.get(
       API_ENDPOINTS.CHARTS,
@@ -244,7 +244,7 @@ describe('ChartList', () => {
     );
   });
 
-  it('handles API errors gracefully', async () => {
+  test('handles API errors gracefully', async () => {
     // Mock API failure
     fetchMock.get(
       API_ENDPOINTS.CHARTS_INFO,
@@ -259,7 +259,7 @@ describe('ChartList', () => {
     expect(screen.getByTestId('chart-list-view')).toBeInTheDocument();
   });
 
-  it('handles empty results', async () => {
+  test('handles empty results', async () => {
     // Mock empty chart data (not permissions)
     fetchMock.get(
       API_ENDPOINTS.CHARTS,
@@ -298,7 +298,7 @@ describe('ChartList - Global Filter Interactions', () => {
     ).mockReset();
   });
 
-  it('renders search filter correctly', async () => {
+  test('renders search filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -311,7 +311,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(screen.getByPlaceholderText(/type a value/i)).toBeInTheDocument();
   });
 
-  it('renders Type filter correctly', async () => {
+  test('renders Type filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -324,7 +324,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(typeFilter).toBeEnabled();
   });
 
-  it('renders Dataset filter correctly', async () => {
+  test('renders Dataset filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -337,7 +337,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(datasetFilter).toBeEnabled();
   });
 
-  it('renders Owner filter correctly', async () => {
+  test('renders Owner filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -350,7 +350,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(ownerFilter).toBeEnabled();
   });
 
-  it('renders Certified filter correctly', async () => {
+  test('renders Certified filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -362,7 +362,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(certifiedFilter).toBeEnabled();
   });
 
-  it('renders Favorite filter correctly', async () => {
+  test('renders Favorite filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -375,7 +375,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(favoriteFilter).toBeEnabled();
   });
 
-  it('renders Dashboard filter correctly', async () => {
+  test('renders Dashboard filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -388,7 +388,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(dashboardFilter).toBeEnabled();
   });
 
-  it('renders Modified by filter correctly', async () => {
+  test('renders Modified by filter correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 
@@ -401,7 +401,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(modifiedByFilter).toBeEnabled();
   });
 
-  it('renders Tags filter when TAGGING_SYSTEM is enabled', async () => {
+  test('renders Tags filter when TAGGING_SYSTEM is enabled', async () => {
     // Mock feature flag to enable tags
     (
       isFeatureEnabled as jest.MockedFunction<typeof isFeatureEnabled>
@@ -431,7 +431,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(tagsFilter).toBeEnabled();
   });
 
-  it('does not render Tags filter when TAGGING_SYSTEM is disabled', async () => {
+  test('does not render Tags filter when TAGGING_SYSTEM is disabled', async () => {
     (
       isFeatureEnabled as jest.MockedFunction<typeof isFeatureEnabled>
     ).mockImplementation(
@@ -455,7 +455,7 @@ describe('ChartList - Global Filter Interactions', () => {
     expect(filterLabels).not.toContain('Tag');
   });
 
-  it('allows filters to be reset correctly', async () => {
+  test('allows filters to be reset correctly', async () => {
     renderChartList(mockUser);
     await screen.findByTestId('chart-list-view');
 

--- a/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
+++ b/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
@@ -85,6 +85,7 @@ const renderCssTemplatesList = (props = {}) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('CssTemplatesList', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
+++ b/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
@@ -90,24 +90,24 @@ describe('CssTemplatesList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderCssTemplatesList();
     expect(await screen.findByText(/css templates/i)).toBeInTheDocument();
   });
 
-  it('renders a SubMenu', async () => {
+  test('renders a SubMenu', async () => {
     renderCssTemplatesList();
     expect(await screen.findByRole('navigation')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderCssTemplatesList();
     expect(
       await screen.findByTestId('css-templates-list-view'),
     ).toBeInTheDocument();
   });
 
-  it('fetches templates', async () => {
+  test('fetches templates', async () => {
     renderCssTemplatesList();
     await waitFor(() => {
       const calls = fetchMock.calls(/css_template\/\?q/);
@@ -118,13 +118,13 @@ describe('CssTemplatesList', () => {
     });
   });
 
-  it('renders Filters', async () => {
+  test('renders Filters', async () => {
     renderCssTemplatesList();
     await screen.findByTestId('css-templates-list-view');
     expect(screen.getByPlaceholderText(/type a value/i)).toBeInTheDocument();
   });
 
-  it('searches', async () => {
+  test('searches', async () => {
     renderCssTemplatesList();
 
     // Wait for list to load
@@ -145,7 +145,7 @@ describe('CssTemplatesList', () => {
     });
   });
 
-  it('deletes', async () => {
+  test('deletes', async () => {
     renderCssTemplatesList();
 
     // Wait for list to load
@@ -173,7 +173,7 @@ describe('CssTemplatesList', () => {
     });
   });
 
-  it('shows bulk actions when bulk select is clicked', async () => {
+  test('shows bulk actions when bulk select is clicked', async () => {
     renderCssTemplatesList();
 
     // Wait for list to load

--- a/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
@@ -106,19 +106,19 @@ describe('DashboardList', () => {
     isFeatureEnabled.mockRestore();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderDashboardList();
     expect(await screen.findByText('Dashboards')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderDashboardList();
     expect(
       await screen.findByTestId('dashboard-list-view'),
     ).toBeInTheDocument();
   });
 
-  it('fetches info', async () => {
+  test('fetches info', async () => {
     renderDashboardList();
     await waitFor(() => {
       const calls = fetchMock.calls(/dashboard\/_info/);
@@ -126,7 +126,7 @@ describe('DashboardList', () => {
     });
   });
 
-  it('fetches data', async () => {
+  test('fetches data', async () => {
     renderDashboardList();
     await waitFor(() => {
       const calls = fetchMock.calls(/dashboard\/\?q/);
@@ -139,7 +139,7 @@ describe('DashboardList', () => {
     );
   });
 
-  it('switches between card and table view', async () => {
+  test('switches between card and table view', async () => {
     renderDashboardList();
 
     // Wait for the list to load
@@ -159,7 +159,7 @@ describe('DashboardList', () => {
     fireEvent.click(cardViewButton);
   });
 
-  it('shows edit modal', async () => {
+  test('shows edit modal', async () => {
     renderDashboardList();
 
     // Wait for data to load
@@ -181,7 +181,7 @@ describe('DashboardList', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
-  it('shows delete confirmation', async () => {
+  test('shows delete confirmation', async () => {
     renderDashboardList();
 
     // Wait for data to load
@@ -205,7 +205,7 @@ describe('DashboardList', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders an "Import Dashboard" tooltip', async () => {
+  test('renders an "Import Dashboard" tooltip', async () => {
     renderDashboardList();
 
     const importButton = await screen.findByTestId('import-button');
@@ -220,7 +220,7 @@ describe('DashboardList', () => {
 });
 
 describe('DashboardList - anonymous view', () => {
-  it('does not render favorite stars for anonymous user', async () => {
+  test('does not render favorite stars for anonymous user', async () => {
     render(
       <MemoryRouter>
         <QueryParamProvider>

--- a/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
@@ -84,6 +84,7 @@ fetchMock.get(dashboardEndpoint, {
 global.URL.createObjectURL = jest.fn();
 fetchMock.get('/thumbnail', { body: new Blob(), sendAsJson: false });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardList', () => {
   const renderDashboardList = (props = {}, userProp = mockUser) =>
     render(
@@ -219,6 +220,7 @@ describe('DashboardList', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DashboardList - anonymous view', () => {
   test('does not render favorite stars for anonymous user', async () => {
     render(

--- a/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
+++ b/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
@@ -28,6 +28,7 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ datasetId: undefined }),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('AddDataset', () => {
   test('renders a blank state AddDataset', async () => {
     render(<AddDataset />, { useRedux: true, useRouter: true });

--- a/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
+++ b/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
@@ -29,7 +29,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('AddDataset', () => {
-  it('renders a blank state AddDataset', async () => {
+  test('renders a blank state AddDataset', async () => {
     render(<AddDataset />, { useRedux: true, useRouter: true });
 
     const blankeStateImgs = screen.getAllByRole('img', { name: /empty/i });

--- a/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
+++ b/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
@@ -59,6 +59,7 @@ const renderAndWait = (props = {}) =>
     useRouter: true,
   });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ExecutionLog', () => {
   beforeAll(() => renderAndWait());
 

--- a/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
+++ b/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
@@ -62,7 +62,7 @@ const renderAndWait = (props = {}) =>
 describe('ExecutionLog', () => {
   beforeAll(() => renderAndWait());
 
-  it('renders with a ListView', () => {
+  test('renders with a ListView', () => {
     expect(screen.getByText('Back to all')).toHaveAttribute(
       'href',
       '/alert/list/',
@@ -70,7 +70,7 @@ describe('ExecutionLog', () => {
     expect(screen.getByTestId('execution-log-list-view')).toBeVisible();
   });
 
-  it('fetches report/alert', () => {
+  test('fetches report/alert', () => {
     const callsQ = fetchMock.calls(/report\/1/);
     expect(callsQ).toHaveLength(2);
     expect(callsQ[1][0]).toMatchInlineSnapshot(
@@ -78,7 +78,7 @@ describe('ExecutionLog', () => {
     );
   });
 
-  it('fetches execution logs', () => {
+  test('fetches execution logs', () => {
     const callsQ = fetchMock.calls(/report\/1\/log/);
     expect(callsQ).toHaveLength(1);
     expect(callsQ[0][0]).toMatchInlineSnapshot(

--- a/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
+++ b/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
@@ -88,31 +88,31 @@ describe('GroupsList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders the page', async () => {
+  test('renders the page', async () => {
     await renderComponent();
     expect(await screen.findByText('List Groups')).toBeInTheDocument();
   });
 
-  it('fetches roles on load', async () => {
+  test('fetches roles on load', async () => {
     await renderComponent();
     await waitFor(() => {
       expect(fetchMock.calls(rolesEndpoint).length).toBeGreaterThan(0);
     });
   });
 
-  it('renders add group button and triggers modal', async () => {
+  test('renders add group button and triggers modal', async () => {
     await renderComponent();
     const addButton = screen.getByTestId('add-group-button');
     fireEvent.click(addButton);
     expect(await screen.findByTestId('Add Group-modal')).toBeInTheDocument();
   });
 
-  it('renders actions column for admin', async () => {
+  test('renders actions column for admin', async () => {
     await renderComponent();
     expect(screen.getByText('Actions')).toBeInTheDocument();
   });
 
-  it('renders the filters correctly', async () => {
+  test('renders the filters correctly', async () => {
     await renderComponent();
     const filtersSelect = screen.getAllByTestId('filters-select')[0];
 
@@ -123,7 +123,7 @@ describe('GroupsList', () => {
     expect(within(filtersSelect).getByText(/users/i)).toBeInTheDocument();
   });
 
-  it('renders correct columns in the table', async () => {
+  test('renders correct columns in the table', async () => {
     await renderComponent();
     const table = screen.getByRole('table');
 
@@ -132,7 +132,7 @@ describe('GroupsList', () => {
     expect(await within(table).findByText('Roles')).toBeInTheDocument();
   });
 
-  it('opens add group modal on button click', async () => {
+  test('opens add group modal on button click', async () => {
     await renderComponent();
     const addButton = screen.getByTestId('add-group-button');
     fireEvent.click(addButton);
@@ -140,7 +140,7 @@ describe('GroupsList', () => {
     expect(await screen.findByTestId('Add Group-modal')).toBeInTheDocument();
   });
 
-  it('opens edit modal on edit button click', async () => {
+  test('opens edit modal on edit button click', async () => {
     fetchMock.get('glob:*/security/groups/?*', {
       result: [
         {

--- a/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
+++ b/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
@@ -70,6 +70,7 @@ jest.mock('src/dashboard/util/permissionUtils', () => ({
   isUserAdmin: jest.fn(() => true),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('GroupsList', () => {
   const renderComponent = async () => {
     await act(async () => {

--- a/superset-frontend/src/pages/RolesList/RolesList.test.tsx
+++ b/superset-frontend/src/pages/RolesList/RolesList.test.tsx
@@ -100,6 +100,7 @@ fetchMock.get(usersEndpoint, {
 fetchMock.delete(roleEndpoint, {});
 fetchMock.put(roleEndpoint, {});
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RolesList', () => {
   async function renderAndWait() {
     const mounted = act(async () => {

--- a/superset-frontend/src/pages/RolesList/RolesList.test.tsx
+++ b/superset-frontend/src/pages/RolesList/RolesList.test.tsx
@@ -124,12 +124,12 @@ describe('RolesList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     await renderAndWait();
     expect(await screen.findByText('List Roles')).toBeInTheDocument();
   });
 
-  it('fetches roles on load', async () => {
+  test('fetches roles on load', async () => {
     await renderAndWait();
     await waitFor(() => {
       const calls = fetchMock.calls(rolesEndpoint);
@@ -137,7 +137,7 @@ describe('RolesList', () => {
     });
   });
 
-  it('fetches permissions on load', async () => {
+  test('fetches permissions on load', async () => {
     await renderAndWait();
     await waitFor(() => {
       const permissionCalls = fetchMock.calls(permissionsEndpoint);
@@ -145,14 +145,14 @@ describe('RolesList', () => {
     });
   });
 
-  it('renders filters options', async () => {
+  test('renders filters options', async () => {
     await renderAndWait();
 
     const typeFilter = screen.queryAllByTestId('filters-select');
     expect(typeFilter).toHaveLength(4);
   });
 
-  it('renders correct list columns', async () => {
+  test('renders correct list columns', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');
@@ -165,7 +165,7 @@ describe('RolesList', () => {
     expect(actionsColumn).toBeInTheDocument();
   });
 
-  it('opens add modal when Add Role button is clicked', async () => {
+  test('opens add modal when Add Role button is clicked', async () => {
     await renderAndWait();
 
     const addButton = screen.getByTestId('add-role-button');
@@ -174,7 +174,7 @@ describe('RolesList', () => {
     expect(screen.queryByTestId('Add Role-modal')).toBeInTheDocument();
   });
 
-  it('open duplicate modal when duplicate button is clicked', async () => {
+  test('open duplicate modal when duplicate button is clicked', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');
@@ -189,7 +189,7 @@ describe('RolesList', () => {
     ).toBeInTheDocument();
   });
 
-  it('open edit modal when edit button is clicked', async () => {
+  test('open edit modal when edit button is clicked', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');

--- a/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
@@ -110,17 +110,17 @@ describe('RuleList RTL', () => {
     return mounted;
   }
 
-  it('renders', async () => {
+  test('renders', async () => {
     await renderAndWait();
     expect(screen.getByText('Row Level Security')).toBeVisible();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     await renderAndWait();
     expect(screen.getByTestId('rls-list-view')).toBeInTheDocument();
   });
 
-  it('fetched data', async () => {
+  test('fetched data', async () => {
     fetchMock.resetHistory();
     await renderAndWait();
     const apiCalls = fetchMock.calls(/rowlevelsecurity\/\?q/);
@@ -131,7 +131,7 @@ describe('RuleList RTL', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders add rule button on empty state', async () => {
+  test('renders add rule button on empty state', async () => {
     fetchMock.get(
       ruleListEndpoint,
       { result: [], count: 0 },
@@ -148,7 +148,7 @@ describe('RuleList RTL', () => {
     );
   });
 
-  it('renders a "Rule" button to add a rule in bulk action', async () => {
+  test('renders a "Rule" button to add a rule in bulk action', async () => {
     await renderAndWait();
 
     const addRuleButton = await screen.findByTestId('add-rule');
@@ -157,7 +157,7 @@ describe('RuleList RTL', () => {
     expect(emptyAddRuleButton).not.toBeInTheDocument();
   });
 
-  it('renders filter options', async () => {
+  test('renders filter options', async () => {
     await renderAndWait();
 
     const searchFilters = screen.queryAllByTestId('filters-search');
@@ -167,7 +167,7 @@ describe('RuleList RTL', () => {
     expect(typeFilter).toHaveLength(3); // Update to expect 3 select filters
   });
 
-  it('renders correct list columns', async () => {
+  test('renders correct list columns', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');
@@ -188,7 +188,7 @@ describe('RuleList RTL', () => {
     expect(actionsColumn).toBeInTheDocument();
   });
 
-  it('renders correct action buttons with write permission', async () => {
+  test('renders correct action buttons with write permission', async () => {
     await renderAndWait();
 
     const deleteActionIcon = screen.queryAllByTestId('rls-list-trash-icon');
@@ -198,7 +198,7 @@ describe('RuleList RTL', () => {
     expect(editActionIcon).toHaveLength(2);
   });
 
-  it('should not renders correct action buttons without write permission', async () => {
+  test('should not renders correct action buttons without write permission', async () => {
     fetchMock.get(
       ruleInfoEndpoint,
       { permissions: ['can_read'] },
@@ -220,7 +220,7 @@ describe('RuleList RTL', () => {
     );
   });
 
-  it('renders popover on new clicking rule button', async () => {
+  test('renders popover on new clicking rule button', async () => {
     await renderAndWait();
 
     const modal = screen.queryByTestId('rls-modal-title');

--- a/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
@@ -94,6 +94,7 @@ const mockUser = {
   userId: 1,
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('RuleList RTL', () => {
   async function renderAndWait() {
     const mounted = act(async () => {

--- a/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
@@ -98,19 +98,19 @@ describe('SavedQueryList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderList();
     expect(await screen.findByText('Saved queries')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderList();
     expect(
       await screen.findByTestId('saved_query-list-view'),
     ).toBeInTheDocument();
   });
 
-  it('renders query information', async () => {
+  test('renders query information', async () => {
     renderList();
 
     // Wait for list to load
@@ -128,7 +128,7 @@ describe('SavedQueryList', () => {
     });
   });
 
-  it('handles query deletion', async () => {
+  test('handles query deletion', async () => {
     renderList();
 
     // Wait for list to load
@@ -151,7 +151,7 @@ describe('SavedQueryList', () => {
     });
   });
 
-  it('handles search filtering', async () => {
+  test('handles search filtering', async () => {
     renderList();
 
     // Wait for list to load
@@ -172,7 +172,7 @@ describe('SavedQueryList', () => {
     });
   });
 
-  it('fetches data', async () => {
+  test('fetches data', async () => {
     renderList();
     await waitFor(() => {
       const calls = fetchMock.calls(/saved_query\/\?q/);
@@ -182,7 +182,7 @@ describe('SavedQueryList', () => {
     });
   });
 
-  it('handles sorting', async () => {
+  test('handles sorting', async () => {
     renderList();
 
     // Wait for list to load
@@ -203,7 +203,7 @@ describe('SavedQueryList', () => {
     });
   });
 
-  it('shows/hides elements based on permissions', async () => {
+  test('shows/hides elements based on permissions', async () => {
     // Mock info response without write permission
     fetchMock.get(
       queriesInfoEndpoint,

--- a/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
@@ -93,6 +93,7 @@ const renderList = (props = {}, storeOverrides = {}) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SavedQueryList', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
@@ -104,17 +104,17 @@ describe('ThemesList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     renderThemesList();
     expect(await screen.findByText('Themes')).toBeInTheDocument();
   });
 
-  it('renders a ListView', async () => {
+  test('renders a ListView', async () => {
     renderThemesList();
     expect(await screen.findByTestId('themes-list-view')).toBeInTheDocument();
   });
 
-  it('renders theme information', async () => {
+  test('renders theme information', async () => {
     renderThemesList();
 
     // Wait for list to load
@@ -128,7 +128,7 @@ describe('ThemesList', () => {
     });
   });
 
-  it('shows system theme tags correctly', async () => {
+  test('shows system theme tags correctly', async () => {
     renderThemesList();
 
     // Wait for list to load
@@ -140,7 +140,7 @@ describe('ThemesList', () => {
     });
   });
 
-  it('handles theme deletion for non-system themes', async () => {
+  test('handles theme deletion for non-system themes', async () => {
     renderThemesList();
 
     // Wait for list to load
@@ -158,7 +158,7 @@ describe('ThemesList', () => {
     });
   });
 
-  it('shows apply action for themes', async () => {
+  test('shows apply action for themes', async () => {
     renderThemesList();
 
     // Wait for list to load
@@ -169,7 +169,7 @@ describe('ThemesList', () => {
     expect(applyButtons.length).toBe(mockThemes.length);
   });
 
-  it('fetches themes data on load', async () => {
+  test('fetches themes data on load', async () => {
     renderThemesList();
 
     await waitFor(() => {
@@ -178,7 +178,7 @@ describe('ThemesList', () => {
     });
   });
 
-  it('shows bulk select when user has permissions', async () => {
+  test('shows bulk select when user has permissions', async () => {
     renderThemesList();
 
     // Wait for list to load
@@ -188,7 +188,7 @@ describe('ThemesList', () => {
     expect(screen.getByText('Bulk select')).toBeInTheDocument();
   });
 
-  it('shows create theme button when user has permissions', async () => {
+  test('shows create theme button when user has permissions', async () => {
     renderThemesList();
 
     // Wait for list to load

--- a/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
@@ -99,6 +99,7 @@ const renderThemesList = (props = {}) =>
     },
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ThemesList', () => {
   beforeEach(() => {
     fetchMock.resetHistory();

--- a/superset-frontend/src/pages/ThemeList/index.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.test.tsx
@@ -93,6 +93,7 @@ const mockThemes = [
   },
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ThemesList', () => {
   beforeEach(() => {
     // Mock the useListViewResource hook

--- a/superset-frontend/src/pages/ThemeList/index.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.test.tsx
@@ -122,7 +122,7 @@ describe('ThemesList', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the themes list with proper structure', async () => {
+  test('renders the themes list with proper structure', async () => {
     render(
       <ThemesList addDangerToast={jest.fn()} addSuccessToast={jest.fn()} />,
       {
@@ -139,7 +139,7 @@ describe('ThemesList', () => {
     });
   });
 
-  it('shows system theme badges for default and dark themes', async () => {
+  test('shows system theme badges for default and dark themes', async () => {
     render(
       <ThemesList addDangerToast={jest.fn()} addSuccessToast={jest.fn()} />,
       {
@@ -162,7 +162,7 @@ describe('ThemesList', () => {
     expect(mockThemes[2].is_system_dark).toBe(false);
   });
 
-  it('uses flat theme structure for enableUiThemeAdministration', () => {
+  test('uses flat theme structure for enableUiThemeAdministration', () => {
     // Verify the component accesses the correct bootstrap data structure
     const { common } = getBootstrapData.default();
 
@@ -173,7 +173,7 @@ describe('ThemesList', () => {
     expect((common.theme as any).settings).toBeUndefined();
   });
 
-  it('shows admin controls when user has proper permissions', async () => {
+  test('shows admin controls when user has proper permissions', async () => {
     render(
       <ThemesList addDangerToast={jest.fn()} addSuccessToast={jest.fn()} />,
       {
@@ -192,7 +192,7 @@ describe('ThemesList', () => {
     expect(adminElements.length).toBeGreaterThan(0);
   });
 
-  it('calls setSystemDefaultTheme API when setting a theme as default', async () => {
+  test('calls setSystemDefaultTheme API when setting a theme as default', async () => {
     const { setSystemDefaultTheme } = themeApi;
     const addSuccessToast = jest.fn();
     const refreshData = jest.fn();
@@ -236,7 +236,7 @@ describe('ThemesList', () => {
     expect(setSystemDefaultTheme).toHaveBeenCalledWith(3);
   });
 
-  it('configures theme deletion endpoint', async () => {
+  test('configures theme deletion endpoint', async () => {
     const addDangerToast = jest.fn();
     const addSuccessToast = jest.fn();
     const refreshData = jest.fn();

--- a/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
+++ b/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
@@ -58,6 +58,7 @@ const mockUser: UserWithPermissionsAndRoles = {
   },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UserInfo', () => {
   const renderPage = async () =>
     act(async () => {

--- a/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
+++ b/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
@@ -86,7 +86,7 @@ describe('UserInfo', () => {
     fetchMock.restore();
   });
 
-  it('renders the user info page', async () => {
+  test('renders the user info page', async () => {
     await renderPage();
 
     expect(
@@ -101,14 +101,14 @@ describe('UserInfo', () => {
     expect(screen.getByText('john@example.com')).toBeInTheDocument();
   });
 
-  it('calls the /me endpoint on mount', async () => {
+  test('calls the /me endpoint on mount', async () => {
     await renderPage();
     await waitFor(() => {
       expect(fetchMock.called(meEndpoint)).toBe(true);
     });
   });
 
-  it('opens the reset password modal on button click', async () => {
+  test('opens the reset password modal on button click', async () => {
     await renderPage();
 
     const button = await screen.findByTestId('reset-password-button');
@@ -119,7 +119,7 @@ describe('UserInfo', () => {
     expect(await screen.findByText(/Reset password/i)).toBeInTheDocument();
   });
 
-  it('opens the edit user modal on button click', async () => {
+  test('opens the edit user modal on button click', async () => {
     await renderPage();
 
     const button = await screen.findByTestId('edit-user-button');

--- a/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
@@ -47,7 +47,7 @@ describe('UserRegistrations', () => {
       useQueryParams: true,
     });
   });
-  it('fetches and renders user registrations', async () => {
+  test('fetches and renders user registrations', async () => {
     expect(await screen.findByText('User registrations')).toBeVisible();
     const calls = fetchMock.calls(userRegistrationsEndpoint);
     expect(calls.length).toBeGreaterThan(0);

--- a/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
@@ -39,6 +39,7 @@ fetchMock.get(userRegistrationsEndpoint, {
   result: mockUserRegistrations,
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UserRegistrations', () => {
   beforeEach(() => {
     render(<UserRegistrations />, {

--- a/superset-frontend/src/pages/UsersList/UsersList.test.tsx
+++ b/superset-frontend/src/pages/UsersList/UsersList.test.tsx
@@ -109,12 +109,12 @@ describe('UsersList', () => {
     fetchMock.resetHistory();
   });
 
-  it('renders', async () => {
+  test('renders', async () => {
     await renderAndWait();
     expect(await screen.findByText('List Users')).toBeInTheDocument();
   });
 
-  it('fetches users on load', async () => {
+  test('fetches users on load', async () => {
     await renderAndWait();
     await waitFor(() => {
       const calls = fetchMock.calls(usersEndpoint);
@@ -122,7 +122,7 @@ describe('UsersList', () => {
     });
   });
 
-  it('fetches roles on load', async () => {
+  test('fetches roles on load', async () => {
     await renderAndWait();
     await waitFor(() => {
       const calls = fetchMock.calls(rolesEndpoint);
@@ -130,7 +130,7 @@ describe('UsersList', () => {
     });
   });
 
-  it('renders filters options', async () => {
+  test('renders filters options', async () => {
     await renderAndWait();
 
     const submenu = screen.queryAllByTestId('filters-select')[0];
@@ -145,7 +145,7 @@ describe('UsersList', () => {
     expect(within(submenu).getByText(/last login/i)).toBeInTheDocument();
   });
 
-  it('renders correct list columns', async () => {
+  test('renders correct list columns', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');
@@ -168,7 +168,7 @@ describe('UsersList', () => {
     expect(actionsColumn).toBeInTheDocument();
   });
 
-  it('opens add modal when Add User button is clicked', async () => {
+  test('opens add modal when Add User button is clicked', async () => {
     await renderAndWait();
 
     const addButton = screen.getByTestId('add-user-button');
@@ -177,7 +177,7 @@ describe('UsersList', () => {
     expect(screen.queryByTestId('Add User-modal')).toBeInTheDocument();
   });
 
-  it('open edit modal when edit button is clicked', async () => {
+  test('open edit modal when edit button is clicked', async () => {
     await renderAndWait();
 
     const table = screen.getByRole('table');

--- a/superset-frontend/src/pages/UsersList/UsersList.test.tsx
+++ b/superset-frontend/src/pages/UsersList/UsersList.test.tsx
@@ -90,6 +90,7 @@ const mockUser = {
   ],
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('UsersList', () => {
   async function renderAndWait() {
     const mounted = act(async () => {

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -101,6 +101,7 @@ const mockThemeObject = {
   theme: DEFAULT_THEME,
 } as unknown as Theme;
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('LocalStorageAdapter', () => {
   let adapter: LocalStorageAdapter;
   const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -174,6 +175,7 @@ describe('LocalStorageAdapter', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ThemeController', () => {
   let controller: ThemeController;
   const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -418,6 +420,7 @@ describe('ThemeController', () => {
     );
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Theme Management', () => {
     beforeEach(() => {
       controller = new ThemeController({
@@ -506,6 +509,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('System Theme Changes', () => {
     let mockMediaQuery: any;
 
@@ -593,6 +597,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Persistence', () => {
     beforeEach(() => {
       controller = new ThemeController({
@@ -641,6 +646,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Theme Structure', () => {
     beforeEach(() => {
       controller = new ThemeController({
@@ -736,6 +742,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Algorithm Combinations', () => {
     beforeEach(() => {
       mockGetBootstrapData.mockReturnValue(
@@ -802,6 +809,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Change Callbacks', () => {
     let callback: jest.Mock;
     let unsubscribe: () => void;
@@ -857,6 +865,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Error Handling', () => {
     beforeEach(() => {
       controller = new ThemeController({
@@ -894,6 +903,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Cleanup', () => {
     let mockMediaQueryInstance: any;
 
@@ -924,6 +934,7 @@ describe('ThemeController', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('setThemeConfig', () => {
     beforeEach(() => {
       mockGetBootstrapData.mockReturnValue(

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -118,7 +118,7 @@ describe('LocalStorageAdapter', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should return item from localStorage', () => {
+  test('should return item from localStorage', () => {
     mockLocalStorage.getItem.mockReturnValue('test-value');
 
     const result = adapter.getItem('test-key');
@@ -128,7 +128,7 @@ describe('LocalStorageAdapter', () => {
     expect(result).toBe('test-value');
   });
 
-  it('should set item in localStorage', () => {
+  test('should set item in localStorage', () => {
     adapter.setItem('test-key', 'test-value');
 
     expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
@@ -138,7 +138,7 @@ describe('LocalStorageAdapter', () => {
     );
   });
 
-  it('should handle localStorage errors while setting an item', () => {
+  test('should handle localStorage errors while setting an item', () => {
     mockLocalStorage.setItem.mockImplementation(() => {
       throw new Error('Storage error');
     });
@@ -152,14 +152,14 @@ describe('LocalStorageAdapter', () => {
     );
   });
 
-  it('should remove item from localStorage', () => {
+  test('should remove item from localStorage', () => {
     adapter.removeItem('test-key');
 
     expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(1);
     expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test-key');
   });
 
-  it('should handle localStorage errors while removing an item', () => {
+  test('should handle localStorage errors while removing an item', () => {
     mockLocalStorage.removeItem.mockImplementation(() => {
       throw new Error('Storage error');
     });
@@ -219,7 +219,7 @@ describe('ThemeController', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('should initialize with default options', () => {
+  test('should initialize with default options', () => {
     controller = new ThemeController({
       themeObject: mockThemeObject,
     });
@@ -227,7 +227,7 @@ describe('ThemeController', () => {
     expect(controller.getTheme()).toBe(mockThemeObject);
   });
 
-  it('should use BootstrapData themes when available', () => {
+  test('should use BootstrapData themes when available', () => {
     controller = new ThemeController({
       themeObject: mockThemeObject,
     });
@@ -243,7 +243,7 @@ describe('ThemeController', () => {
     );
   });
 
-  it('should fallback to Superset default theme when BootstrapData themes are empty', () => {
+  test('should fallback to Superset default theme when BootstrapData themes are empty', () => {
     mockGetBootstrapData.mockReturnValue(
       createMockBootstrapData({
         default: {},
@@ -272,7 +272,7 @@ describe('ThemeController', () => {
     );
   });
 
-  it('should handle system theme preference', () => {
+  test('should handle system theme preference', () => {
     mockGetBootstrapData.mockReturnValue(
       createMockBootstrapData({
         default: DEFAULT_THEME,
@@ -287,7 +287,7 @@ describe('ThemeController', () => {
     expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
   });
 
-  it('should handle only default theme', () => {
+  test('should handle only default theme', () => {
     mockGetBootstrapData.mockReturnValue(
       createMockBootstrapData({
         default: DEFAULT_THEME,
@@ -311,7 +311,7 @@ describe('ThemeController', () => {
     expect(mockSetConfig).not.toHaveBeenCalled();
   });
 
-  it('should handle only dark theme', () => {
+  test('should handle only dark theme', () => {
     mockGetBootstrapData.mockReturnValue(
       createMockBootstrapData({
         default: {},
@@ -351,7 +351,7 @@ describe('ThemeController', () => {
     expect(mockSetConfig).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle completely empty BootstrapData', () => {
+  test('should handle completely empty BootstrapData', () => {
     const fallbackTheme = {
       token: {
         colorBgBase: '#ffffff',
@@ -383,7 +383,7 @@ describe('ThemeController', () => {
     );
   });
 
-  it('should handle missing theme object', () => {
+  test('should handle missing theme object', () => {
     const fallbackTheme = { token: { colorPrimary: '#fallback' } };
 
     mockGetBootstrapData.mockReturnValue({
@@ -425,7 +425,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should update theme when allowed', () => {
+    test('should update theme when allowed', () => {
       const newTheme = {
         token: {
           colorBgBase: '#000000',
@@ -440,7 +440,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should change theme mode when allowed', () => {
+    test('should change theme mode when allowed', () => {
       // Clear initialization calls
       jest.clearAllMocks();
 
@@ -454,7 +454,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should handle missing theme gracefully', () => {
+    test('should handle missing theme gracefully', () => {
       mockGetBootstrapData.mockReturnValue(
         createMockBootstrapData({
           default: DEFAULT_THEME,
@@ -476,7 +476,7 @@ describe('ThemeController', () => {
       expect(consoleSpy).not.toHaveBeenCalled();
     });
 
-    it('should not change mode if already set', () => {
+    test('should not change mode if already set', () => {
       controller = new ThemeController({
         themeObject: mockThemeObject,
       });
@@ -490,7 +490,7 @@ describe('ThemeController', () => {
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
-    it('should reset to default theme', () => {
+    test('should reset to default theme', () => {
       controller.setThemeMode(ThemeMode.DARK);
       controller.resetTheme();
 
@@ -523,7 +523,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should listen to system theme changes', () => {
+    test('should listen to system theme changes', () => {
       expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
       expect(mockMediaQuery.addEventListener).toHaveBeenCalledWith(
         'change',
@@ -531,7 +531,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should update theme when system preference changes and mode is SYSTEM', () => {
+    test('should update theme when system preference changes and mode is SYSTEM', () => {
       controller.setThemeMode(ThemeMode.SYSTEM);
 
       // Simulate system theme change
@@ -543,7 +543,7 @@ describe('ThemeController', () => {
       expect(mockSetConfig).toHaveBeenCalled();
     });
 
-    it('should not update theme when mode is not SYSTEM', () => {
+    test('should not update theme when mode is not SYSTEM', () => {
       controller.setThemeMode(ThemeMode.DEFAULT);
 
       const initialCallCount = mockSetConfig.mock.calls.length;
@@ -557,7 +557,7 @@ describe('ThemeController', () => {
       expect(mockSetConfig).toHaveBeenCalledTimes(initialCallCount);
     });
 
-    it('should switch to dark theme when system is dark and mode is SYSTEM', () => {
+    test('should switch to dark theme when system is dark and mode is SYSTEM', () => {
       // Setup with both light and dark themes available
       mockGetBootstrapData.mockReturnValue(
         createMockBootstrapData({
@@ -600,7 +600,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should save theme mode to localStorage', () => {
+    test('should save theme mode to localStorage', () => {
       // Clear the call from controller initialization
       jest.clearAllMocks();
 
@@ -613,7 +613,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should load saved theme mode from localStorage', () => {
+    test('should load saved theme mode from localStorage', () => {
       mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
 
       controller = new ThemeController({
@@ -623,7 +623,7 @@ describe('ThemeController', () => {
       expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
     });
 
-    it('should handle invalid saved theme mode', () => {
+    test('should handle invalid saved theme mode', () => {
       mockGetBootstrapData.mockReturnValue(
         createMockBootstrapData({
           default: {},
@@ -648,7 +648,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should handle theme with token structure', () => {
+    test('should handle theme with token structure', () => {
       const customTheme = {
         token: {
           colorBgBase: '#ff0000',
@@ -674,7 +674,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should preserve algorithm property from dark theme', () => {
+    test('should preserve algorithm property from dark theme', () => {
       // Clear the call from controller initialization
       jest.clearAllMocks();
 
@@ -692,7 +692,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should handle theme without algorithm property', () => {
+    test('should handle theme without algorithm property', () => {
       // Clear the call from controller initialization
       jest.clearAllMocks();
 
@@ -715,7 +715,7 @@ describe('ThemeController', () => {
       expect(lastCall.algorithm).toBe(antdThemeImport.defaultAlgorithm);
     });
 
-    it('should handle color tokens correctly in theme switching', () => {
+    test('should handle color tokens correctly in theme switching', () => {
       // Start with default theme
       controller.setThemeMode(ThemeMode.DEFAULT);
 
@@ -753,7 +753,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should handle valid algorithm combinations', () => {
+    test('should handle valid algorithm combinations', () => {
       const themeWithAlgorithm = {
         ...DEFAULT_THEME,
         algorithm: [
@@ -782,7 +782,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should handle invalid algorithm combinations', () => {
+    test('should handle invalid algorithm combinations', () => {
       const themeWithInvalidAlgorithm = {
         ...DEFAULT_THEME,
         algorithm: ['invalid', 'combination'] as any as ThemeAlgorithm[],
@@ -814,14 +814,14 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should call callback on theme change', () => {
+    test('should call callback on theme change', () => {
       controller.setThemeMode(ThemeMode.DARK);
 
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith(mockThemeObject);
     });
 
-    it('should register additional callbacks', () => {
+    test('should register additional callbacks', () => {
       const additionalCallback = jest.fn();
       unsubscribe = controller.onChange(additionalCallback);
 
@@ -831,7 +831,7 @@ describe('ThemeController', () => {
       expect(additionalCallback).toHaveBeenCalled();
     });
 
-    it('should unsubscribe callbacks', () => {
+    test('should unsubscribe callbacks', () => {
       const additionalCallback = jest.fn();
       unsubscribe = controller.onChange(additionalCallback);
 
@@ -841,7 +841,7 @@ describe('ThemeController', () => {
       expect(additionalCallback).not.toHaveBeenCalled();
     });
 
-    it('should handle callback errors', () => {
+    test('should handle callback errors', () => {
       const errorCallback = jest.fn().mockImplementation(() => {
         throw new Error('Callback error');
       });
@@ -864,7 +864,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should handle theme application errors', () => {
+    test('should handle theme application errors', () => {
       // Mock setConfig to throw an error
       mockSetConfig.mockImplementationOnce(() => {
         throw new Error('Theme application error');
@@ -911,7 +911,7 @@ describe('ThemeController', () => {
       });
     });
 
-    it('should clean up listeners on destroy', () => {
+    test('should clean up listeners on destroy', () => {
       controller.destroy();
 
       expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledTimes(
@@ -941,7 +941,7 @@ describe('ThemeController', () => {
       jest.clearAllMocks();
     });
 
-    it('should set complete theme configuration', () => {
+    test('should set complete theme configuration', () => {
       const themeConfig = {
         theme_default: DEFAULT_THEME,
         theme_dark: DARK_THEME,
@@ -962,7 +962,7 @@ describe('ThemeController', () => {
       expect(controller.canSetMode()).toBe(true);
     });
 
-    it('should handle theme_default only', () => {
+    test('should handle theme_default only', () => {
       const themeConfig = {
         theme_default: DEFAULT_THEME,
       };
@@ -981,7 +981,7 @@ describe('ThemeController', () => {
       expect(controller.canSetMode()).toBe(false);
     });
 
-    it('should handle theme_default and theme_dark without settings', () => {
+    test('should handle theme_default and theme_dark without settings', () => {
       const themeConfig = {
         theme_default: DEFAULT_THEME,
         theme_dark: DARK_THEME,
@@ -1008,7 +1008,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should apply appropriate theme after configuration', () => {
+    test('should apply appropriate theme after configuration', () => {
       jest.clearAllMocks();
 
       const themeConfig = {
@@ -1039,7 +1039,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should handle missing theme_dark gracefully', () => {
+    test('should handle missing theme_dark gracefully', () => {
       const themeConfig = {
         theme_default: DEFAULT_THEME,
       };
@@ -1050,7 +1050,7 @@ describe('ThemeController', () => {
       expect(controller.canSetMode()).toBe(false);
     });
 
-    it('should preserve existing theme mode when possible', () => {
+    test('should preserve existing theme mode when possible', () => {
       // First create controller with dark theme available
       mockGetBootstrapData.mockReturnValue(
         createMockBootstrapData({
@@ -1078,7 +1078,7 @@ describe('ThemeController', () => {
       expect(controller.getCurrentMode()).toBe(initialMode);
     });
 
-    it('should trigger onChange callbacks', () => {
+    test('should trigger onChange callbacks', () => {
       const changeCallback = jest.fn();
       controller.onChange(changeCallback);
 
@@ -1093,7 +1093,7 @@ describe('ThemeController', () => {
       expect(changeCallback).toHaveBeenCalledWith(mockThemeObject);
     });
 
-    it('should handle error in theme application', () => {
+    test('should handle error in theme application', () => {
       mockSetConfig.mockImplementationOnce(() => {
         throw new Error('Theme application error');
       });
@@ -1112,7 +1112,7 @@ describe('ThemeController', () => {
       );
     });
 
-    it('should update stored theme mode', () => {
+    test('should update stored theme mode', () => {
       const themeConfig = {
         theme_default: DEFAULT_THEME,
         theme_dark: DARK_THEME,

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -61,6 +61,7 @@ const createWrapper =
     </SupersetThemeProvider>
   );
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('SupersetThemeProvider', () => {
   let mockThemeController: jest.Mocked<ThemeController>;
   let mockOnChangeCallback: jest.Mock;
@@ -91,6 +92,7 @@ describe('SupersetThemeProvider', () => {
     jest.clearAllMocks();
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Provider Initialization', () => {
     test('should render children within theme provider wrapper', () => {
       render(
@@ -143,6 +145,7 @@ describe('SupersetThemeProvider', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Theme State Updates', () => {
     test('should update theme state when controller notifies change', () => {
       const wrapper = createWrapper(mockThemeController);
@@ -183,6 +186,7 @@ describe('SupersetThemeProvider', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Theme Actions', () => {
     test('should call setTheme when invoked', () => {
       const wrapper = createWrapper(mockThemeController);

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -92,7 +92,7 @@ describe('SupersetThemeProvider', () => {
   });
 
   describe('Provider Initialization', () => {
-    it('should render children within theme provider wrapper', () => {
+    test('should render children within theme provider wrapper', () => {
       render(
         <SupersetThemeProvider themeController={mockThemeController}>
           <div data-test="test-child">Hello Superset</div>
@@ -103,7 +103,7 @@ describe('SupersetThemeProvider', () => {
       expect(screen.getByTestId('test-child')).toBeInTheDocument();
     });
 
-    it('should initialize theme state from controller', () => {
+    test('should initialize theme state from controller', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {
@@ -116,7 +116,7 @@ describe('SupersetThemeProvider', () => {
       expect(result.current.themeMode).toBe(ThemeMode.DEFAULT);
     });
 
-    it('should register onChange listener on mount', () => {
+    test('should register onChange listener on mount', () => {
       const wrapper = createWrapper(mockThemeController);
 
       renderHook((): ThemeContextType => useThemeContext(), { wrapper });
@@ -126,7 +126,7 @@ describe('SupersetThemeProvider', () => {
       );
     });
 
-    it('should unregister onChange listener on unmount', () => {
+    test('should unregister onChange listener on unmount', () => {
       const unsubscribeMock = jest.fn();
       mockThemeController.onChange.mockReturnValue(unsubscribeMock);
 
@@ -144,7 +144,7 @@ describe('SupersetThemeProvider', () => {
   });
 
   describe('Theme State Updates', () => {
-    it('should update theme state when controller notifies change', () => {
+    test('should update theme state when controller notifies change', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {
@@ -166,7 +166,7 @@ describe('SupersetThemeProvider', () => {
       expect(result.current.theme).toBe(mockDarkTheme);
     });
 
-    it('should update both theme and mode when controller changes', () => {
+    test('should update both theme and mode when controller changes', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {
@@ -184,7 +184,7 @@ describe('SupersetThemeProvider', () => {
   });
 
   describe('Theme Actions', () => {
-    it('should call setTheme when invoked', () => {
+    test('should call setTheme when invoked', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {
@@ -205,7 +205,7 @@ describe('SupersetThemeProvider', () => {
       expect(mockThemeController.setTheme).toHaveBeenCalledWith(customTheme);
     });
 
-    it('should call setThemeMode when invoked', () => {
+    test('should call setThemeMode when invoked', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {
@@ -221,7 +221,7 @@ describe('SupersetThemeProvider', () => {
       );
     });
 
-    it('should call resetTheme when invoked', () => {
+    test('should call resetTheme when invoked', () => {
       const wrapper = createWrapper(mockThemeController);
 
       const { result } = renderHook((): ThemeContextType => useThemeContext(), {

--- a/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
+++ b/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
@@ -19,6 +19,7 @@
 
 import DebouncedMessageQueue from './DebouncedMessageQueue';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('DebouncedMessageQueue', () => {
   test('should create a queue with default options', () => {
     const queue = new DebouncedMessageQueue();

--- a/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
+++ b/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
@@ -20,13 +20,13 @@
 import DebouncedMessageQueue from './DebouncedMessageQueue';
 
 describe('DebouncedMessageQueue', () => {
-  it('should create a queue with default options', () => {
+  test('should create a queue with default options', () => {
     const queue = new DebouncedMessageQueue();
     expect(queue).toBeDefined();
     expect(queue.trigger).toBeInstanceOf(Function);
   });
 
-  it('should accept custom configuration options', () => {
+  test('should accept custom configuration options', () => {
     const mockCallback = jest.fn();
     const queue = new DebouncedMessageQueue({
       callback: mockCallback,
@@ -36,7 +36,7 @@ describe('DebouncedMessageQueue', () => {
     expect(queue).toBeDefined();
   });
 
-  it('should append items to the queue', () => {
+  test('should append items to the queue', () => {
     const mockCallback = jest.fn();
     const queue = new DebouncedMessageQueue({ callback: mockCallback });
 
@@ -47,7 +47,7 @@ describe('DebouncedMessageQueue', () => {
     expect(() => queue.append(testEvent)).not.toThrow();
   });
 
-  it('should handle generic types properly', () => {
+  test('should handle generic types properly', () => {
     interface TestEvent {
       id: number;
       data: string;

--- a/superset-frontend/src/utils/cacheWrapper.test.ts
+++ b/superset-frontend/src/utils/cacheWrapper.test.ts
@@ -33,7 +33,7 @@ describe('cacheWrapper', () => {
     jest.clearAllMocks();
   });
 
-  it('calls fn with its arguments once when the key is not found', () => {
+  test('calls fn with its arguments once when the key is not found', () => {
     const returnedValue = wrappedFn(1, 2);
 
     expect(returnedValue).toEqual(fnResult);
@@ -42,7 +42,7 @@ describe('cacheWrapper', () => {
   });
 
   describe('subsequent calls', () => {
-    it('returns the correct value without fn being called multiple times', () => {
+    test('returns the correct value without fn being called multiple times', () => {
       const returnedValue1 = wrappedFn(1, 2);
       const returnedValue2 = wrappedFn(1, 2);
 
@@ -51,7 +51,7 @@ describe('cacheWrapper', () => {
       expect(fn).toHaveBeenCalledTimes(1);
     });
 
-    it('fn is called multiple times for different arguments', () => {
+    test('fn is called multiple times for different arguments', () => {
       wrappedFn(1, 2);
       wrappedFn(1, 3);
 
@@ -67,12 +67,12 @@ describe('cacheWrapper', () => {
       wrappedFn = cacheWrapper(fn, cache, (...args) => `key-${args[0]}`);
     });
 
-    it('saves fn result in cache under generated key', () => {
+    test('saves fn result in cache under generated key', () => {
       wrappedFn(1, 2);
       expect(cache.get('key-1')).toEqual(fnResult);
     });
 
-    it('subsequent calls with same generated key calls fn once, even if other arguments have changed', () => {
+    test('subsequent calls with same generated key calls fn once, even if other arguments have changed', () => {
       wrappedFn(1, 1);
       wrappedFn(1, 2);
       wrappedFn(1, 3);

--- a/superset-frontend/src/utils/cacheWrapper.test.ts
+++ b/superset-frontend/src/utils/cacheWrapper.test.ts
@@ -18,6 +18,7 @@
  */
 import { cacheWrapper } from 'src/utils/cacheWrapper';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('cacheWrapper', () => {
   const fnResult = 'fnResult';
   const fn = jest.fn<string, [number, number]>().mockReturnValue(fnResult);
@@ -41,6 +42,7 @@ describe('cacheWrapper', () => {
     expect(fn).toHaveBeenCalledWith(1, 2);
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('subsequent calls', () => {
     test('returns the correct value without fn being called multiple times', () => {
       const returnedValue1 = wrappedFn(1, 2);
@@ -59,6 +61,7 @@ describe('cacheWrapper', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('with custom keyFn', () => {
     let cache: Map<string, any>;
 

--- a/superset-frontend/src/utils/chartRegistry.test.ts
+++ b/superset-frontend/src/utils/chartRegistry.test.ts
@@ -28,7 +28,9 @@ import { nativeFilterGate } from 'src/dashboard/components/nativeFilters/utils';
  * This tests the pure functions used in ChartList for filtering chart types.
  */
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Chart Registry Utils', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Type filter option generation', () => {
     let registry: ReturnType<typeof getChartMetadataRegistry>;
 

--- a/superset-frontend/src/utils/chartRegistry.test.ts
+++ b/superset-frontend/src/utils/chartRegistry.test.ts
@@ -37,7 +37,7 @@ describe('Chart Registry Utils', () => {
       registry.clear();
     });
 
-    it('generates correct options from chart metadata registry', () => {
+    test('generates correct options from chart metadata registry', () => {
       // Register test chart types
       registry
         .registerValue(
@@ -88,7 +88,7 @@ describe('Chart Registry Utils', () => {
       ).toBeUndefined();
     });
 
-    it('handles empty registry gracefully', () => {
+    test('handles empty registry gracefully', () => {
       const options = registry
         .keys()
         .filter(k => nativeFilterGate(registry.get(k)?.behaviors || []))
@@ -97,7 +97,7 @@ describe('Chart Registry Utils', () => {
       expect(options).toEqual([]);
     });
 
-    it('falls back to chart key when name is missing', () => {
+    test('falls back to chart key when name is missing', () => {
       registry.registerValue(
         'custom_chart',
         new ChartMetadata({
@@ -117,7 +117,7 @@ describe('Chart Registry Utils', () => {
       ]);
     });
 
-    it('sorts options alphabetically by label', () => {
+    test('sorts options alphabetically by label', () => {
       registry
         .registerValue(
           'zebra',
@@ -162,7 +162,7 @@ describe('Chart Registry Utils', () => {
       ]);
     });
 
-    it('handles mixed chart behaviors correctly', () => {
+    test('handles mixed chart behaviors correctly', () => {
       registry
         .registerValue(
           'regular',

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -25,7 +25,9 @@ import {
   FALSE_STRING,
 } from 'src/utils/common';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('utils/common', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('optionFromValue', () => {
     test('converts values as expected', () => {
       expect(optionFromValue(false)).toEqual({
@@ -48,6 +50,7 @@ describe('utils/common', () => {
       expect(optionFromValue(5)).toEqual({ value: 5, label: '5' });
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('prepareCopyToClipboardTabularData', () => {
     test('converts empty array', () => {
       const data = [];
@@ -75,6 +78,7 @@ describe('utils/common', () => {
       );
     });
   });
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('applyFormattingToTabularData', () => {
     test('does not mutate empty array', () => {
       const data = [];

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -27,7 +27,7 @@ import {
 
 describe('utils/common', () => {
   describe('optionFromValue', () => {
-    it('converts values as expected', () => {
+    test('converts values as expected', () => {
       expect(optionFromValue(false)).toEqual({
         value: false,
         label: FALSE_STRING,
@@ -49,12 +49,12 @@ describe('utils/common', () => {
     });
   });
   describe('prepareCopyToClipboardTabularData', () => {
-    it('converts empty array', () => {
+    test('converts empty array', () => {
       const data = [];
       const columns = [];
       expect(prepareCopyToClipboardTabularData(data, columns)).toEqual('');
     });
-    it('converts non empty array', () => {
+    test('converts non empty array', () => {
       const data = [
         { column1: 'lorem', column2: 'ipsum' },
         { column1: 'dolor', column2: 'sit', column3: 'amet' },
@@ -64,7 +64,7 @@ describe('utils/common', () => {
         'column1\tcolumn2\tcolumn3\nlorem\tipsum\t\ndolor\tsit\tamet\n',
       );
     });
-    it('includes 0 values and handle column objects', () => {
+    test('includes 0 values and handle column objects', () => {
       const data = [
         { column1: 0, column2: 0 },
         { column1: 1, column2: -1, 0: 0 },
@@ -76,18 +76,18 @@ describe('utils/common', () => {
     });
   });
   describe('applyFormattingToTabularData', () => {
-    it('does not mutate empty array', () => {
+    test('does not mutate empty array', () => {
       const data = [];
       expect(applyFormattingToTabularData(data, [])).toEqual(data);
     });
-    it('does not mutate array without temporal column', () => {
+    test('does not mutate array without temporal column', () => {
       const data = [
         { column1: 'lorem', column2: 'ipsum' },
         { column1: 'dolor', column2: 'sit', column3: 'amet' },
       ];
       expect(applyFormattingToTabularData(data, [])).toEqual(data);
     });
-    it('changes formatting of columns selected for formatting', () => {
+    test('changes formatting of columns selected for formatting', () => {
       const originalData = [
         {
           __timestamp: null,

--- a/superset-frontend/src/utils/datasourceUtils.test.ts
+++ b/superset-frontend/src/utils/datasourceUtils.test.ts
@@ -84,6 +84,7 @@ const mockQueryEditor: QueryEditor = {
   templateParams: '{"param1": "value1"}',
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getDatasourceAsSaveableDataset', () => {
   test('should convert Datasource object correctly', () => {
     const result = getDatasourceAsSaveableDataset(mockDatasource);

--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -26,7 +26,7 @@ describe('getBootstrapData and helpers', () => {
   });
 
   describe('getBootstrapData()', () => {
-    it('should return DEFAULT_BOOTSTRAP_DATA when #app element does not exist', async () => {
+    test('should return DEFAULT_BOOTSTRAP_DATA when #app element does not exist', async () => {
       // Ensure no #app element exists.
       document.body.innerHTML = '';
 
@@ -37,7 +37,7 @@ describe('getBootstrapData and helpers', () => {
       expect(bootstrapData).toEqual(DEFAULT_BOOTSTRAP_DATA);
     });
 
-    it('should return parsed bootstrap data when #app element has valid data attribute', async () => {
+    test('should return parsed bootstrap data when #app element has valid data attribute', async () => {
       // Set up the fake #app element
       const customData = {
         common: {
@@ -56,7 +56,7 @@ describe('getBootstrapData and helpers', () => {
   });
 
   describe('Helper functions applicationRoot and staticAssetsPrefix', () => {
-    it('should return values without trailing slashes', async () => {
+    test('should return values without trailing slashes', async () => {
       // Setup a fake #app element with data-bootstrap attribute.
       const customData = {
         common: {
@@ -82,7 +82,7 @@ describe('getBootstrapData and helpers', () => {
       expect(staticAssetsPrefix()).toEqual('/custom-static');
     });
 
-    it('should return defaults without trailing slashes when #app element is missing', async () => {
+    test('should return defaults without trailing slashes when #app element is missing', async () => {
       // Ensure no #app element exists.
       document.body.innerHTML = '';
 
@@ -107,7 +107,7 @@ describe('getBootstrapData and helpers', () => {
       expect(staticAssetsPrefix()).toEqual(expectedStaticPrefix);
     });
 
-    it('should defaults without trailing slashes when #app element does not include application_root or static_assets_prefix', async () => {
+    test('should defaults without trailing slashes when #app element does not include application_root or static_assets_prefix', async () => {
       // Set up the fake #app element
       const customData = {
         common: {

--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -19,12 +19,14 @@
 
 import { DEFAULT_BOOTSTRAP_DATA } from '../constants';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getBootstrapData and helpers', () => {
   afterEach(() => {
     // Clean up the DOM
     document.body.innerHTML = '';
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getBootstrapData()', () => {
     test('should return DEFAULT_BOOTSTRAP_DATA when #app element does not exist', async () => {
       // Ensure no #app element exists.
@@ -55,6 +57,7 @@ describe('getBootstrapData and helpers', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('Helper functions applicationRoot and staticAssetsPrefix', () => {
     test('should return values without trailing slashes', async () => {
       // Setup a fake #app element with data-bootstrap attribute.

--- a/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
+++ b/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
@@ -27,7 +27,7 @@ jest.mock('../sanitizeFormData', () => ({
 }));
 
 describe('alterForComparison', () => {
-  it.each([
+  test.each([
     [null, null],
     ['', null],
     [[], null],
@@ -44,14 +44,14 @@ describe('alterForComparison', () => {
 });
 
 describe('isEqualish', () => {
-  it('returns true for semantically equal values with different formats', () => {
+  test('returns true for semantically equal values with different formats', () => {
     expect(isEqualish('', null)).toBe(true);
     expect(isEqualish([], null)).toBe(true);
     expect(isEqualish({}, null)).toBe(true);
     expect(isEqualish([1], [1])).toBe(true);
   });
 
-  it('returns false for clearly different values', () => {
+  test('returns false for clearly different values', () => {
     expect(isEqualish([1], [2])).toBe(false);
     expect(isEqualish({ a: 1 }, { a: 2 })).toBe(false);
     expect(isEqualish('foo', 'bar')).toBe(false);
@@ -59,7 +59,7 @@ describe('isEqualish', () => {
 });
 
 describe('getChartFormDiffs', () => {
-  it('returns diffs for changed values', () => {
+  test('returns diffs for changed values', () => {
     const original = { metric: 'count', adhoc_filters: [] };
     const current = { metric: 'sum__num', adhoc_filters: [] };
 
@@ -72,7 +72,7 @@ describe('getChartFormDiffs', () => {
     });
   });
 
-  it('ignores noisy keys', () => {
+  test('ignores noisy keys', () => {
     const original = { where: 'a = 1', metric: 'count' };
     const current = { where: 'a = 2', metric: 'sum__num' };
 
@@ -82,7 +82,7 @@ describe('getChartFormDiffs', () => {
     expect(diffs).toHaveProperty('metric');
   });
 
-  it('does not include values that are equalish', () => {
+  test('does not include values that are equalish', () => {
     const original = { filters: [], metric: 'count' };
     const current = { filters: null, metric: 'count' };
 
@@ -91,7 +91,7 @@ describe('getChartFormDiffs', () => {
     expect(diffs).toEqual({});
   });
 
-  it('handles missing keys in original or current gracefully', () => {
+  test('handles missing keys in original or current gracefully', () => {
     const original = { metric: 'count' };
     const current = { metric: 'count', new_field: 'value' };
 
@@ -104,7 +104,7 @@ describe('getChartFormDiffs', () => {
     });
   });
 
-  it('ignores keys that are missing in current and not explicitly changed', () => {
+  test('ignores keys that are missing in current and not explicitly changed', () => {
     const original = { metric: 'count', removed_field: 'gone' };
     const current = { metric: 'count' };
 

--- a/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
+++ b/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
@@ -26,6 +26,7 @@ jest.mock('../sanitizeFormData', () => ({
   }),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('alterForComparison', () => {
   test.each([
     [null, null],
@@ -43,6 +44,7 @@ describe('alterForComparison', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('isEqualish', () => {
   test('returns true for semantically equal values with different formats', () => {
     expect(isEqualish('', null)).toBe(true);
@@ -58,6 +60,7 @@ describe('isEqualish', () => {
   });
 });
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getChartFormDiffs', () => {
   test('returns diffs for changed values', () => {
     const original = { metric: 'count', adhoc_filters: [] };

--- a/superset-frontend/src/utils/getControlsForVizType.test.js
+++ b/superset-frontend/src/utils/getControlsForVizType.test.js
@@ -75,7 +75,7 @@ describe('getControlsForVizType', () => {
     );
   });
 
-  it('returns a map of the controls', () => {
+  test('returns a map of the controls', () => {
     expect(
       JSON.stringify(getControlsForVizType('chart_controls_inventory_fake')),
     ).toEqual(

--- a/superset-frontend/src/utils/getControlsForVizType.test.js
+++ b/superset-frontend/src/utils/getControlsForVizType.test.js
@@ -67,6 +67,7 @@ const fakePluginControls = {
   ],
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getControlsForVizType', () => {
   beforeEach(() => {
     getChartControlPanelRegistry().registerValue(

--- a/superset-frontend/src/utils/getControlsForVizType.test.ts
+++ b/superset-frontend/src/utils/getControlsForVizType.test.ts
@@ -75,7 +75,7 @@ describe('getControlsForVizType', () => {
     );
   });
 
-  it('returns a map of the controls', () => {
+  test('returns a map of the controls', () => {
     expect(
       JSON.stringify(getControlsForVizType('chart_controls_inventory_fake')),
     ).toEqual(

--- a/superset-frontend/src/utils/getControlsForVizType.test.ts
+++ b/superset-frontend/src/utils/getControlsForVizType.test.ts
@@ -67,6 +67,7 @@ const fakePluginControls: JsonObject = {
   ],
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('getControlsForVizType', () => {
   beforeEach(() => {
     getChartControlPanelRegistry().registerValue(

--- a/superset-frontend/src/utils/hostNamesConfig.test.ts
+++ b/superset-frontend/src/utils/hostNamesConfig.test.ts
@@ -19,6 +19,7 @@
 
 import { availableDomains, allowCrossDomain } from './hostNamesConfig';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('hostNamesConfig', () => {
   beforeEach(() => {
     // Reset DOM

--- a/superset-frontend/src/utils/localStorageHelpers.test.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.test.ts
@@ -31,13 +31,13 @@ describe('localStorageHelpers', () => {
     localStorage.clear();
   });
 
-  it('gets a value that was set', () => {
+  test('gets a value that was set', () => {
     setItem(LocalStorageKeys.IsDatapanelOpen, false);
 
     expect(getItem(LocalStorageKeys.IsDatapanelOpen, true)).toBe(false);
   });
 
-  it('returns the default value for an unset value', () => {
+  test('returns the default value for an unset value', () => {
     expect(getItem(LocalStorageKeys.IsDatapanelOpen, true)).toBe(true);
   });
 });

--- a/superset-frontend/src/utils/localStorageHelpers.test.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.test.ts
@@ -22,6 +22,7 @@ import {
   LocalStorageKeys,
 } from 'src/utils/localStorageHelpers';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('localStorageHelpers', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/superset-frontend/src/utils/parseCookie.test.ts
+++ b/superset-frontend/src/utils/parseCookie.test.ts
@@ -23,17 +23,17 @@ describe('parseCookie', () => {
   Object.defineProperty(document, 'cookie', {
     get: jest.fn().mockImplementation(() => cookieVal),
   });
-  it('parses cookie strings', () => {
+  test('parses cookie strings', () => {
     cookieVal = 'val1=foo; val2=bar';
     expect(parseCookie()).toEqual({ val1: 'foo', val2: 'bar' });
   });
 
-  it('parses empty cookie strings', () => {
+  test('parses empty cookie strings', () => {
     cookieVal = '';
     expect(parseCookie()).toEqual({});
   });
 
-  it('accepts an arg', () => {
+  test('accepts an arg', () => {
     expect(parseCookie('val=foo')).toEqual({ val: 'foo' });
   });
 });

--- a/superset-frontend/src/utils/parseCookie.test.ts
+++ b/superset-frontend/src/utils/parseCookie.test.ts
@@ -18,6 +18,7 @@
  */
 import parseCookie from 'src/utils/parseCookie';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('parseCookie', () => {
   let cookieVal = '';
   Object.defineProperty(document, 'cookie', {

--- a/superset-frontend/src/utils/safeStringify.test.ts
+++ b/superset-frontend/src/utils/safeStringify.test.ts
@@ -23,7 +23,7 @@ class Noise {
 }
 
 describe('Stringify utility testing', () => {
-  it('correctly parses a simple object just like JSON', () => {
+  test('correctly parses a simple object just like JSON', () => {
     const noncircular = {
       b: 'foo',
       c: 'bar',
@@ -45,7 +45,7 @@ describe('Stringify utility testing', () => {
     );
   });
 
-  it('handles simple circular json as expected', () => {
+  test('handles simple circular json as expected', () => {
     const ping = new Noise();
     const pong = new Noise();
     const pang = new Noise();
@@ -61,7 +61,7 @@ describe('Stringify utility testing', () => {
     expect(safeString).toEqual(ordinaryString);
   });
 
-  it('creates a parseable object even when the input is circular', () => {
+  test('creates a parseable object even when the input is circular', () => {
     const ping = new Noise();
     const pong = new Noise();
     ping.next = pong;
@@ -72,7 +72,7 @@ describe('Stringify utility testing', () => {
     expect(newNoise.next).toEqual({});
   });
 
-  it('does not remove noncircular duplicates', () => {
+  test('does not remove noncircular duplicates', () => {
     const a = {
       foo: 'bar',
     };
@@ -86,7 +86,7 @@ describe('Stringify utility testing', () => {
     expect(safeStringify(repeating)).toEqual(JSON.stringify(repeating));
   });
 
-  it('does not remove nodes with empty objects', () => {
+  test('does not remove nodes with empty objects', () => {
     const emptyObjectValues = {
       a: {},
       b: 'foo',
@@ -100,7 +100,7 @@ describe('Stringify utility testing', () => {
     );
   });
 
-  it('does not remove nested same keys', () => {
+  test('does not remove nested same keys', () => {
     const nestedKeys = {
       a: 'b',
       c: {

--- a/superset-frontend/src/utils/safeStringify.test.ts
+++ b/superset-frontend/src/utils/safeStringify.test.ts
@@ -22,6 +22,7 @@ class Noise {
   public next?: Noise;
 }
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Stringify utility testing', () => {
   test('correctly parses a simple object just like JSON', () => {
     const noncircular = {

--- a/superset-frontend/src/utils/testUtils.test.ts
+++ b/superset-frontend/src/utils/testUtils.test.ts
@@ -19,6 +19,7 @@
 
 import { testWithId } from './testUtils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('testUtils', () => {
   test('testWithId with prefix only', () => {
     expect(testWithId('prefix')()).toEqual({ 'data-test': 'prefix' });

--- a/superset-frontend/src/utils/testUtils.test.ts
+++ b/superset-frontend/src/utils/testUtils.test.ts
@@ -20,35 +20,35 @@
 import { testWithId } from './testUtils';
 
 describe('testUtils', () => {
-  it('testWithId with prefix only', () => {
+  test('testWithId with prefix only', () => {
     expect(testWithId('prefix')()).toEqual({ 'data-test': 'prefix' });
   });
 
-  it('testWithId with prefix only and idOnly', () => {
+  test('testWithId with prefix only and idOnly', () => {
     expect(testWithId('prefix', true)()).toEqual('prefix');
   });
 
-  it('testWithId with id only', () => {
+  test('testWithId with id only', () => {
     expect(testWithId()('id')).toEqual({ 'data-test': 'id' });
   });
 
-  it('testWithId with id only and idOnly', () => {
+  test('testWithId with id only and idOnly', () => {
     expect(testWithId(undefined, true)('id')).toEqual('id');
   });
 
-  it('testWithId with prefix and id', () => {
+  test('testWithId with prefix and id', () => {
     expect(testWithId('prefix')('id')).toEqual({ 'data-test': 'prefix__id' });
   });
 
-  it('testWithId with prefix and id and idOnly', () => {
+  test('testWithId with prefix and id and idOnly', () => {
     expect(testWithId('prefix', true)('id')).toEqual('prefix__id');
   });
 
-  it('testWithId without prefix and id', () => {
+  test('testWithId without prefix and id', () => {
     expect(testWithId()()).toEqual({ 'data-test': '' });
   });
 
-  it('testWithId without prefix and id and idOnly', () => {
+  test('testWithId without prefix and id and idOnly', () => {
     expect(testWithId(undefined, true)()).toEqual('');
   });
 });

--- a/superset-frontend/src/utils/urlUtils.test.ts
+++ b/superset-frontend/src/utils/urlUtils.test.ts
@@ -54,43 +54,43 @@ test('parseUrl', () => {
 });
 
 describe('toQueryString', () => {
-  it('should return an empty string if the input is an empty object', () => {
+  test('should return an empty string if the input is an empty object', () => {
     expect(toQueryString({})).toBe('');
   });
 
-  it('should correctly convert a single key-value pair to a query string', () => {
+  test('should correctly convert a single key-value pair to a query string', () => {
     expect(toQueryString({ key: 'value' })).toBe('?key=value');
   });
 
-  it('should correctly convert multiple key-value pairs to a query string', () => {
+  test('should correctly convert multiple key-value pairs to a query string', () => {
     expect(toQueryString({ key1: 'value1', key2: 'value2' })).toBe(
       '?key1=value1&key2=value2',
     );
   });
 
-  it('should encode URI components', () => {
+  test('should encode URI components', () => {
     expect(
       toQueryString({ 'a key': 'a value', email: 'test@example.com' }),
     ).toBe('?a%20key=a%20value&email=test%40example.com');
   });
 
-  it('should omit keys with undefined values', () => {
+  test('should omit keys with undefined values', () => {
     expect(toQueryString({ key1: 'value1', key2: undefined })).toBe(
       '?key1=value1',
     );
   });
 
-  it('should omit keys with null values', () => {
+  test('should omit keys with null values', () => {
     expect(toQueryString({ key1: 'value1', key2: null })).toBe('?key1=value1');
   });
 
-  it('should handle numbers and boolean values as parameter values', () => {
+  test('should handle numbers and boolean values as parameter values', () => {
     expect(toQueryString({ number: 123, truth: true, lie: false })).toBe(
       '?number=123&truth=true&lie=false',
     );
   });
 
-  it('should handle special characters in keys and values', () => {
+  test('should handle special characters in keys and values', () => {
     expect(toQueryString({ 'user@domain': 'me&you' })).toBe(
       '?user%40domain=me%26you',
     );

--- a/superset-frontend/src/utils/urlUtils.test.ts
+++ b/superset-frontend/src/utils/urlUtils.test.ts
@@ -53,46 +53,45 @@ test('parseUrl', () => {
   expect(parseUrl('#anchor')).toEqual('#anchor');
 });
 
-describe('toQueryString', () => {
-  test('should return an empty string if the input is an empty object', () => {
-    expect(toQueryString({})).toBe('');
-  });
+// toQueryString
+test('toQueryString should return an empty string if the input is an empty object', () => {
+  expect(toQueryString({})).toBe('');
+});
 
-  test('should correctly convert a single key-value pair to a query string', () => {
-    expect(toQueryString({ key: 'value' })).toBe('?key=value');
-  });
+test('toQueryString should correctly convert a single key-value pair to a query string', () => {
+  expect(toQueryString({ key: 'value' })).toBe('?key=value');
+});
 
-  test('should correctly convert multiple key-value pairs to a query string', () => {
-    expect(toQueryString({ key1: 'value1', key2: 'value2' })).toBe(
-      '?key1=value1&key2=value2',
-    );
-  });
+test('toQueryString should correctly convert multiple key-value pairs to a query string', () => {
+  expect(toQueryString({ key1: 'value1', key2: 'value2' })).toBe(
+    '?key1=value1&key2=value2',
+  );
+});
 
-  test('should encode URI components', () => {
-    expect(
-      toQueryString({ 'a key': 'a value', email: 'test@example.com' }),
-    ).toBe('?a%20key=a%20value&email=test%40example.com');
-  });
+test('toQueryString should encode URI components', () => {
+  expect(toQueryString({ 'a key': 'a value', email: 'test@example.com' })).toBe(
+    '?a%20key=a%20value&email=test%40example.com',
+  );
+});
 
-  test('should omit keys with undefined values', () => {
-    expect(toQueryString({ key1: 'value1', key2: undefined })).toBe(
-      '?key1=value1',
-    );
-  });
+test('toQueryString should omit keys with undefined values', () => {
+  expect(toQueryString({ key1: 'value1', key2: undefined })).toBe(
+    '?key1=value1',
+  );
+});
 
-  test('should omit keys with null values', () => {
-    expect(toQueryString({ key1: 'value1', key2: null })).toBe('?key1=value1');
-  });
+test('toQueryString should omit keys with null values', () => {
+  expect(toQueryString({ key1: 'value1', key2: null })).toBe('?key1=value1');
+});
 
-  test('should handle numbers and boolean values as parameter values', () => {
-    expect(toQueryString({ number: 123, truth: true, lie: false })).toBe(
-      '?number=123&truth=true&lie=false',
-    );
-  });
+test('toQueryString should handle numbers and boolean values as parameter values', () => {
+  expect(toQueryString({ number: 123, truth: true, lie: false })).toBe(
+    '?number=123&truth=true&lie=false',
+  );
+});
 
-  test('should handle special characters in keys and values', () => {
-    expect(toQueryString({ 'user@domain': 'me&you' })).toBe(
-      '?user%40domain=me%26you',
-    );
-  });
+test('toQueryString should handle special characters in keys and values', () => {
+  expect(toQueryString({ 'user@domain': 'me&you' })).toBe(
+    '?user%40domain=me%26you',
+  );
 });

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -26,7 +26,7 @@ describe('useListViewResource', () => {
     jest.restoreAllMocks();
   });
 
-  it('should fetch data with correct query parameters', async () => {
+  test('should fetch data with correct query parameters', async () => {
     const pageIndex = 0; // Declare and initialize the pageIndex variable
     const pageSize = 10; // Declare and initialize the pageSize variable
     const baseFilters = [{ id: 'status', operator: 'equals', value: 'active' }];
@@ -59,7 +59,7 @@ describe('useListViewResource', () => {
     });
   });
 
-  it('should pass the selectColumns to the fetch call', async () => {
+  test('should pass the selectColumns to the fetch call', async () => {
     const pageIndex = 0; // Declare and initialize the pageIndex variable
     const pageSize = 10; // Declare and initialize the pageSize variable
     const baseFilters = [{ id: 'status', operator: 'equals', value: 'active' }];
@@ -108,7 +108,7 @@ describe('useListViewResource', () => {
       jest.restoreAllMocks();
     });
 
-    it('converts Type filter to correct API call for charts', async () => {
+    test('converts Type filter to correct API call for charts', async () => {
       const fetchSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [], count: 0 },
       } as unknown as JsonResponse);
@@ -140,7 +140,7 @@ describe('useListViewResource', () => {
       expect(endpoint).toMatch(/order_direction:desc/);
     });
 
-    it('converts chart search filter with ChartAllText operator', async () => {
+    test('converts chart search filter with ChartAllText operator', async () => {
       const fetchSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [], count: 0 },
       } as unknown as JsonResponse);
@@ -172,7 +172,7 @@ describe('useListViewResource', () => {
       expect(endpoint).toContain("value%3A'test+chart'");
     });
 
-    it('converts chart-specific favorite filter', async () => {
+    test('converts chart-specific favorite filter', async () => {
       const fetchSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [], count: 0 },
       } as unknown as JsonResponse);
@@ -200,7 +200,7 @@ describe('useListViewResource', () => {
       expect(endpoint).toContain('value:!t');
     });
 
-    it('handles multiple chart filters correctly', async () => {
+    test('handles multiple chart filters correctly', async () => {
       const fetchSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [], count: 0 },
       } as unknown as JsonResponse);
@@ -231,7 +231,7 @@ describe('useListViewResource', () => {
       expect(endpoint).toMatch(/value:test/);
     });
 
-    it('handles chart sorting scenarios', async () => {
+    test('handles chart sorting scenarios', async () => {
       const fetchSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
         json: { result: [], count: 0 },
       } as unknown as JsonResponse);

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -21,6 +21,7 @@ import { JsonResponse, SupersetClient } from '@superset-ui/core';
 
 import { useListViewResource } from './hooks';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('useListViewResource', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -103,6 +104,7 @@ describe('useListViewResource', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('ChartList-specific filter scenarios', () => {
     afterEach(() => {
       jest.restoreAllMocks();

--- a/superset-frontend/src/views/routes.test.tsx
+++ b/superset-frontend/src/views/routes.test.tsx
@@ -21,13 +21,13 @@ import { isFrontendRoute, routes } from './routes';
 jest.mock('src/pages/Home', () => () => <div data-test="mock-home" />);
 
 describe('isFrontendRoute', () => {
-  it('returns true if a route matches', () => {
+  test('returns true if a route matches', () => {
     routes.forEach(r => {
       expect(isFrontendRoute(r.path)).toBe(true);
     });
   });
 
-  it('returns false if a route does not match', () => {
+  test('returns false if a route does not match', () => {
     expect(isFrontendRoute('/nonexistent/path/')).toBe(false);
   });
 });

--- a/superset-frontend/src/views/routes.test.tsx
+++ b/superset-frontend/src/views/routes.test.tsx
@@ -20,6 +20,7 @@ import { isFrontendRoute, routes } from './routes';
 
 jest.mock('src/pages/Home', () => () => <div data-test="mock-home" />);
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('isFrontendRoute', () => {
   test('returns true if a route matches', () => {
     routes.forEach(r => {

--- a/superset-frontend/src/views/theme.bootstrap.test.ts
+++ b/superset-frontend/src/views/theme.bootstrap.test.ts
@@ -34,7 +34,7 @@ describe('Theme Bootstrap Data', () => {
       },
     };
 
-    it('should load themes from database when available', () => {
+    test('should load themes from database when available', () => {
       // This tests that when enableUiThemeAdministration is true,
       // the system attempts to load themes from the database
       expect(mockBootstrapData.theme.enableUiThemeAdministration).toBe(true);
@@ -42,7 +42,7 @@ describe('Theme Bootstrap Data', () => {
       expect(mockBootstrapData.theme.dark).toBeDefined();
     });
 
-    it('should have proper theme structure', () => {
+    test('should have proper theme structure', () => {
       expect(mockBootstrapData.theme).toHaveProperty('default');
       expect(mockBootstrapData.theme).toHaveProperty('dark');
       expect(mockBootstrapData.theme).toHaveProperty(
@@ -60,7 +60,7 @@ describe('Theme Bootstrap Data', () => {
       },
     };
 
-    it('should use config-based themes', () => {
+    test('should use config-based themes', () => {
       // When enableUiThemeAdministration is false,
       // themes should come from configuration files
       expect(mockBootstrapData.theme.enableUiThemeAdministration).toBe(false);
@@ -70,7 +70,7 @@ describe('Theme Bootstrap Data', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle missing theme gracefully', () => {
+    test('should handle missing theme gracefully', () => {
       const mockBootstrapData = {
         theme: {
           default: {},
@@ -84,7 +84,7 @@ describe('Theme Bootstrap Data', () => {
       expect(mockBootstrapData.theme.dark).toEqual({});
     });
 
-    it('should handle invalid theme settings', () => {
+    test('should handle invalid theme settings', () => {
       const mockBootstrapData = {
         theme: {
           default: {},
@@ -100,7 +100,7 @@ describe('Theme Bootstrap Data', () => {
   });
 
   describe('permissions integration', () => {
-    it('should respect admin-only access for system themes', () => {
+    test('should respect admin-only access for system themes', () => {
       const mockBootstrapData = {
         theme: {
           default: {},
@@ -114,7 +114,7 @@ describe('Theme Bootstrap Data', () => {
       expect(mockBootstrapData.theme.enableUiThemeAdministration).toBe(true);
     });
 
-    it('should allow all users to view themes', () => {
+    test('should allow all users to view themes', () => {
       const mockBootstrapData = {
         theme: {
           default: { colors: { primary: '#1890ff' } },

--- a/superset-frontend/src/views/theme.bootstrap.test.ts
+++ b/superset-frontend/src/views/theme.bootstrap.test.ts
@@ -24,7 +24,9 @@
  * by testing the expected bootstrap data structure
  */
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Theme Bootstrap Data', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('when UI theme administration is enabled', () => {
     const mockBootstrapData = {
       theme: {
@@ -51,6 +53,7 @@ describe('Theme Bootstrap Data', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('when UI theme administration is disabled', () => {
     const mockBootstrapData = {
       theme: {
@@ -69,6 +72,7 @@ describe('Theme Bootstrap Data', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('edge cases', () => {
     test('should handle missing theme gracefully', () => {
       const mockBootstrapData = {
@@ -99,6 +103,7 @@ describe('Theme Bootstrap Data', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('permissions integration', () => {
     test('should respect admin-only access for system themes', () => {
       const mockBootstrapData = {

--- a/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
@@ -19,6 +19,7 @@
 import { render, screen } from '@superset-ui/core/spec';
 import LeftCell from './LeftCell';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('LeftCell', () => {
   test('should render column label for column row type', () => {
     const columnRow = {

--- a/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.test.tsx
@@ -26,6 +26,7 @@ const mockEntries = [
   { time: '2023-01-04', sales: 400 },
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('Sparkline', () => {
   test('should render basic sparkline without time ratio', () => {
     const column = {

--- a/superset-frontend/src/visualizations/TimeTable/components/ValueCell/ValueCell.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/ValueCell/ValueCell.test.tsx
@@ -31,6 +31,7 @@ const mockEntries = [
   { time: '2023-01-01', sales: 100, price: 10 },
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('ValueCell', () => {
   test('should render simple value without special column type', () => {
     render(

--- a/superset-frontend/src/visualizations/TimeTable/config/controlPanel/controlPanel.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/config/controlPanel/controlPanel.test.ts
@@ -18,6 +18,7 @@
  */
 import { controlPanel as controlPanelConfig } from './controlPanel';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TimeTable Control Panel', () => {
   test('should have required control panel structure', () => {
     expect(controlPanelConfig).toBeDefined();

--- a/superset-frontend/src/visualizations/TimeTable/config/transformProps/transformProps.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/config/transformProps/transformProps.test.ts
@@ -127,6 +127,7 @@ function createMockChartProps(
   return tableChartProps;
 }
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('TimeTable transformProps', () => {
   test('should transform props correctly for metric rows', () => {
     const props = createMockChartProps();

--- a/superset-frontend/src/visualizations/TimeTable/utils/colorUtils/colorUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/colorUtils/colorUtils.test.ts
@@ -18,6 +18,7 @@
  */
 import { colorFromBounds } from './colorUtils';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('colorFromBounds', () => {
   test('should return null when no bounds are provided', () => {
     expect(colorFromBounds(50)).toBeNull();

--- a/superset-frontend/src/visualizations/TimeTable/utils/rowProcessing/rowProcessing.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/rowProcessing/rowProcessing.test.ts
@@ -24,6 +24,7 @@ const mockData = {
   '2023-01-03': { sales: 300 },
 };
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('processTimeTableData', () => {
   test('should convert data to sorted entries', () => {
     const result = processTimeTableData(mockData);

--- a/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.test.ts
@@ -33,6 +33,7 @@ jest.mock('src/utils/sortNumericValues', () => ({
   }),
 }));
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('sortNumberWithMixedTypes', () => {
   const createMockRow = (value: any) => ({
     values: {

--- a/superset-frontend/src/visualizations/TimeTable/utils/sparklineDataUtils/sparklineDataUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sparklineDataUtils/sparklineDataUtils.test.ts
@@ -32,6 +32,7 @@ const mockEntries = [
   { time: '2023-01-04', sales: 400 },
 ];
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('sparklineDataUtils', () => {
   test('parseTimeRatio should parse string values', () => {
     expect(parseTimeRatio('5')).toBe(5);

--- a/superset-frontend/src/visualizations/TimeTable/utils/sparklineHelpers/sparklineHelpers.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sparklineHelpers/sparklineHelpers.test.ts
@@ -24,7 +24,9 @@ import {
   transformChartData,
 } from './sparklineHelpers';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('sparklineHelpers', () => {
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getSparklineTextWidth', () => {
     test('should return a positive number for text width', () => {
       const result = getSparklineTextWidth('123.45');
@@ -39,6 +41,7 @@ describe('sparklineHelpers', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('isValidBoundValue', () => {
     test('should return true for valid numbers', () => {
       expect(isValidBoundValue(0)).toBe(true);
@@ -56,6 +59,7 @@ describe('sparklineHelpers', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('getDataBounds', () => {
     test('should return correct min and max for valid data', () => {
       const data = [10, 5, 20, 15];
@@ -90,6 +94,7 @@ describe('sparklineHelpers', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('createYScaleConfig', () => {
     test('should use data bounds when no axis bounds provided', () => {
       const validData = [10, 20, 30];
@@ -144,6 +149,7 @@ describe('sparklineHelpers', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('transformChartData', () => {
     test('should transform data with indices', () => {
       const data = [10, 20, 30];

--- a/superset-frontend/src/visualizations/TimeTable/utils/valueCalculations/valueCalculations.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/valueCalculations/valueCalculations.test.ts
@@ -25,6 +25,7 @@ import {
 } from './valueCalculations';
 import type { ColumnConfig, Entry } from '../../types';
 
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
 describe('valueCalculations', () => {
   const mockEntries: Entry[] = [
     { time: '2023-01-03', sales: 300, price: 30 },
@@ -32,6 +33,7 @@ describe('valueCalculations', () => {
     { time: '2023-01-01', sales: 100, price: 10 },
   ];
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('calculateTimeValue', () => {
     test('should calculate diff comparison correctly', () => {
       const column: ColumnConfig = {
@@ -125,6 +127,7 @@ describe('valueCalculations', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('calculateContribution', () => {
     test('should calculate contribution correctly', () => {
       const result = calculateContribution(300, mockEntries);
@@ -152,6 +155,7 @@ describe('valueCalculations', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('calculateAverage', () => {
     test('should calculate average correctly', () => {
       const column: ColumnConfig = {
@@ -213,6 +217,7 @@ describe('valueCalculations', () => {
     });
   });
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('calculateCellValue', () => {
     test('should route to time calculation', () => {
       const column: ColumnConfig = {


### PR DESCRIPTION
## Summary

This PR implements a comprehensive migration strategy to move away from nested `describe`/`it` test patterns to flat `test()` functions, following [Kent C. Dodds' "avoid nesting when testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing) best practices.

## Changes

### 1. ESLint Rules Enforcement
- Added `jest/consistent-test-it` rule to enforce `test` over `it`
- Added `no-restricted-globals` rule to error on `describe` and `it` usage
- Configured in `superset-frontend/src/.eslintrc.json`

### 2. Automated Migrations
- **Auto-migrated all `it` to `test`**: 194 files updated via `npm run lint-fix`
- **Flattened simple describe blocks**: 5 files with no hooks or complex setup safely migrated

### 3. Legacy Code Handling
- Added `eslint-disable` comments with TODO markers to 243 files containing `describe` blocks
- Marked 1,080 existing `describe` blocks with: `// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks`
- This allows existing code to work while preventing new usage

## Migration Statistics

- **Total test files**: 482
- **`it` → `test` migration**: 100% complete (194 files)
- **`describe` blocks removed**: 5 files (simple cases without hooks)
- **`describe` blocks with TODOs**: 243 files (to be migrated gradually)
- **Files with hooks requiring manual migration**: 198

## Files Successfully Flattened

These files had simple `describe` blocks without hooks and were safely migrated:
- `utils/urlUtils.test.ts`
- `explore/controlPanels/Separator.test.ts`
- `components/ErrorMessage/ErrorAlert.test.tsx`
- `components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx`
- `components/MessageToasts/reducers.test.js`

## Benefits

1. **Enforces modern patterns**: New tests cannot use `describe`/`it` (ESLint error)
2. **Preserves functionality**: All existing tests continue to work
3. **Clear technical debt**: TODO markers make legacy patterns visible
4. **Gradual migration path**: Files can be updated as they're touched
5. **Better test readability**: Flat structure is easier to understand and maintain

## Testing Instructions

1. Run tests to confirm everything still passes:
   ```bash
   npm run test
   ```

2. Try adding a new `describe` block - it should trigger an ESLint error:
   ```javascript
   describe('NewComponent', () => {  // ❌ ESLint error
     test('works', () => {});
   });
   ```

3. New tests should use flat structure:
   ```javascript
   test('NewComponent works', () => {  // ✅ Correct pattern
     // test implementation
   });
   ```

## Additional Information

This migration follows React Testing Library and Jest best practices. The flat test structure:
- Reduces nesting complexity
- Makes test names more descriptive
- Eliminates confusion about hook scopes
- Improves test maintainability

The TODO markers allow us to track and gradually migrate the remaining `describe` blocks without breaking existing tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>