### PR TITLE
fix(explore): close unsaved changes modal when discarding changes

### DIFF
--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/index.ts
@@ -41,6 +41,7 @@ export const useUnsavedChangesPrompt = ({
   const manualSaveRef = useRef(false); // Track if save was user-initiated (not via navigation)
 
   const handleConfirmNavigation = useCallback(() => {
+    setShowModal(false);
     confirmNavigationRef.current?.();
   }, []);
 

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -103,4 +103,33 @@ describe('useUnsavedChangesPrompt', () => {
     expect(onSave).toHaveBeenCalled();
     expect(result.current.showModal).toBe(false);
   });
+
+  it('should close modal when handleConfirmNavigation is called', () => {
+    const onSave = jest.fn();
+
+    const { result } = renderHook(
+      () =>
+        useUnsavedChangesPrompt({
+          hasUnsavedChanges: true,
+          onSave,
+        }),
+      { wrapper },
+    );
+
+    // First, trigger navigation to show the modal
+    act(() => {
+      const unblock = history.block((tx: any) => tx);
+      unblock();
+      history.push('/another-page');
+    });
+
+    expect(result.current.showModal).toBe(true);
+
+    // Then call handleConfirmNavigation to discard changes
+    act(() => {
+      result.current.handleConfirmNavigation();
+    });
+
+    expect(result.current.showModal).toBe(false);
+  });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes the unsaved changes modal not closing when user clicks "Discard" during chart editing navigation. 

  Root cause: The handleConfirmNavigation function was missing setShowModal(false) call, causing the modal to remain open after navigation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open any chart
2. change something like time grain or metric
3. click the back button in the browser
4. click on discard button

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
