### PR TITLE
fix(sqllab): fix blank bottom section in SQL Lab left panel

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -168,6 +168,9 @@ const StyledToolbar = styled.div`
 
 const StyledSidebar = styled.div`
   padding: ${({ theme }) => theme.sizeUnit * 2.5}px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 `;
 
 const StyledSqlEditor = styled.div`

--- a/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorLeftBar/index.tsx
@@ -47,7 +47,6 @@ import TableElement from '../TableElement';
 
 export interface SqlEditorLeftBarProps {
   queryEditorId: string;
-  height?: number;
   database?: DatabaseObject;
 }
 
@@ -72,7 +71,6 @@ const LeftBarStyles = styled.div`
 const SqlEditorLeftBar = ({
   database,
   queryEditorId,
-  height = 500,
 }: SqlEditorLeftBarProps) => {
   const allSelectedTables = useSelector<SqlLabRootState, Table[]>(
     ({ sqlLab }) =>
@@ -171,7 +169,6 @@ const SqlEditorLeftBar = ({
   };
 
   const shouldShowReset = window.location.search === '?reset=1';
-  const tableMetaDataHeight = height - 130; // 130 is the height of the selects above
 
   const handleCatalogChange = useCallback(
     (catalog: string | null) => {
@@ -228,22 +225,16 @@ const SqlEditorLeftBar = ({
       />
       <div className="divider" />
       <StyledScrollbarContainer>
-        <div
-          css={css`
-            height: ${tableMetaDataHeight}px;
-          `}
-        >
-          {tables.map(table => (
-            <TableElement
-              table={table}
-              key={table.id}
-              activeKey={tables
-                .filter(({ expanded }) => expanded)
-                .map(({ id }) => id)}
-              onChange={onToggleTable}
-            />
-          ))}
-        </div>
+        {tables.map(table => (
+          <TableElement
+            table={table}
+            key={table.id}
+            activeKey={tables
+              .filter(({ expanded }) => expanded)
+              .map(({ id }) => id)}
+            onChange={onToggleTable}
+          />
+        ))}
       </StyledScrollbarContainer>
       {shouldShowReset && (
         <Button


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed an issue where the bottom half of the SQL Lab left panel was appearing blank. The problem was caused by improper height calculations using fixed pixel values instead of flexbox layout. The component was using a hardcoded height prop (defaulting to 500px) and calculating the table area as `height - 130px`, which left empty space at the bottom

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="420" height="1008" alt="image (4)" src="https://github.com/user-attachments/assets/c65b8c12-4101-4f0b-bbb0-e17699a0920c" />

After:
<img width="235" height="661" alt="image" src="https://github.com/user-attachments/assets/20161219-7726-4b90-8036-5bdccdf6ae43" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open SQL Lab
2. Select a database and schema in the left panel
3. Add some tables to view their columns
4. Verify that the left panel properly fills the entire height without blank space at the bottom
5. Test resizing the browser window to ensure the layout remains responsive
6. Switch between different databases/schemas to ensure the layout remains consistent

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
