### PR TITLE
refactor(llm): rename LLMS.md to AGENTS.md for modern AI tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../LLMS.md
+../AGENTS.md

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -82,6 +82,7 @@ intro_header.txt
 
 # for LLMs
 llm-context.md
+AGENTS.md
 LLMS.md
 CLAUDE.md
 CURSOR.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ superset/
 
 ### Apache License Headers
 - **New files require ASF license headers** - When creating new code files, include the standard Apache Software Foundation license header
-- **LLM instruction files are excluded** - Files like LLMS.md, CLAUDE.md, etc. are in `.rat-excludes` to avoid header token overhead
+- **LLM instruction files are excluded** - Files like AGENTS.md, CLAUDE.md, etc. are in `.rat-excludes` to avoid header token overhead
 
 ### Code Comments
 - **Avoid time-specific language** - Don't use words like "now", "currently", "today" in code comments as they become outdated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-LLMS.md
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,1 @@
-LLMS.md
+AGENTS.md

--- a/GPT.md
+++ b/GPT.md
@@ -1,1 +1,1 @@
-LLMS.md
+AGENTS.md


### PR DESCRIPTION
Standardize on AGENTS.md as the master instruction file, which is the convention expected by modern coding assistants. All platform-specific files (CLAUDE.md, GEMINI.md, GPT.md, copilot-instructions.md) now symlink to AGENTS.md instead of LLMS.md.
