### PR TITLE
feat(testing): enforce test() over describe() with grandfathered files

### DIFF
--- a/superset-frontend/.eslintrc.js
+++ b/superset-frontend/.eslintrc.js
@@ -349,6 +349,14 @@ module.exports = {
           },
         ],
         'no-only-tests/no-only-tests': 'error',
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'describe',
+            message:
+              'Use test() instead of describe() for better test organization',
+          },
+        ],
         'max-classes-per-file': 0,
         // temporary rules to help with migration - please re-enable!
         'testing-library/await-async-queries': 0,

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/metricColumnFilter.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/metricColumnFilter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnTypeLabel.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/ColumnTypeLabel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/index.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/aggregateOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/aggregateOperator.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/colorControls.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/colorControls.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/columnChoices.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/defineSavedMetrics.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/defineSavedMetrics.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/expandControlConfig.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/mainMetric.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/mainMetric.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/selectOptions.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/selectOptions.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/useJsonValidation.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/AsyncAceEditor/useJsonValidation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/AutoComplete/AutoComplete.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/AutoComplete/AutoComplete.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/CachedLabel/CachedLabel.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/CachedLabel/CachedLabel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Checkbox/Checkbox.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Checkbox/Checkbox.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/CodeSyntaxHighlighter/index.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/CodeSyntaxHighlighter/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Dropdown/Dropdown.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Dropdown/Dropdown.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/DynamicEditableTitle/DynamicEditableTitle.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DynamicEditableTitle/DynamicEditableTitle.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/EditableTitle.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EditableTitle/EditableTitle.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.test.jsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Form/LabeledErrorBoundInput.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Grid/Grid.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Grid/Grid.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/IconButton/IconButton.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/IconButton/IconButton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Layout/Layout.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Layout/Layout.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/ImageLoader.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/ImageLoader.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/ListViewCard.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/ListViewCard.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/FormModal.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/FormModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Radio/Radio.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Radio/Radio.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Skeleton/Skeleton.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Skeleton/Skeleton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Timer/Timer.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Timer/Timer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Tree/Tree.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tree/Tree.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TreeSelect/TreeSelect.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Typography/Typography.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Typography/Typography.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/components/Upload/Upload.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Upload/Upload.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/theme/Theme.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/theme/Theme.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/theme/utils/themeUtils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/theme/utils/themeUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/utils/dates.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/dates.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/src/utils/merge.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/merge.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart-composition/legend/WithLegend.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart-composition/legend/WithLegend.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart-composition/tooltip/TooltipFrame.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart-composition/tooltip/TooltipFrame.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart-composition/tooltip/TooltipTable.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart-composition/tooltip/TooltipTable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/clients/ChartClient.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/chart/clients/ChartClient.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/ChartDataProvider.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChart.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChartCore.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/SuperChartCore.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/createLoadableRenderer.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/createLoadableRenderer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/components/reactify.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/components/reactify.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/chart/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/models/ChartMetadata.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/chart/models/ChartMetadata.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/models/ChartPlugin.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/chart/models/ChartPlugin.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/chart/models/ChartProps.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/chart/models/ChartProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorNameSpace.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorNameSpace.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalColorScale.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/CategoricalSchemeRegistrySingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/CategoricalSchemeRegistrySingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/ColorScheme.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/ColorScheme.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/ColorSchemeRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/ColorSchemeRegistry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/LabelsColorMapSingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/LabelsColorMapSingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/SequentialScheme.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/SequentialScheme.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/SequentialSchemeRegistrySingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/SequentialSchemeRegistrySingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/colorSchemes.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/colorSchemes.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/color/utils.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/color/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/components/Icons/AsyncIcon.integration.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/test/components/Icons/AsyncIcon.integration.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/components/SafeMarkdown.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClient.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClient.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/callApi.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/callApi.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/callApiAndParseWithTimeout.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/callApiAndParseWithTimeout.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/parseResponse.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/connection/callApi/rejectAfterTimeout.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/callApi/rejectAfterTimeout.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/computeMaxFontSize.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/computeMaxFontSize.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/getMultipleTextDimensions.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/getMultipleTextDimensions.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/getTextDimension.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/getTextDimension.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/mergeMargin.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/mergeMargin.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/parseLength.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/parseLength.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/svg/LazyFactory.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/svg/LazyFactory.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/svg/getBBoxCeil.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/svg/getBBoxCeil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dimension/svg/updateTextNode.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dimension/svg/updateTextNode.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/dynamic-plugins/shared-modules.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/dynamic-plugins/shared-modules.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/ExtensibleFunction.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/ExtensibleFunction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/Plugin.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/Plugin.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/Preset.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/Preset.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/Registry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/Registry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/RegistryWithDefaultKey.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/RegistryWithDefaultKey.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/models/TypedRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/models/TypedRegistry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatterRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatterRegistry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatterRegistrySingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/NumberFormatterRegistrySingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createD3NumberFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createD3NumberFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSiAtMostNDigitFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSiAtMostNDigitFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSmartNumberFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSmartNumberFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/number-format/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/DatasourceKey.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/DatasourceKey.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/api/legacy/getDatasourceMetadata.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/legacy/getDatasourceMetadata.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/api/legacy/getFormData.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/legacy/getFormData.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/api/v1/getChartData.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/v1/getChartData.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/api/v1/handleError.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/v1/handleError.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/api/v1/makeApi.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/api/v1/makeApi.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryObject.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/convertFilter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/convertFilter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/extractExtras.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/extractExtras.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/extractQueryFields.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/extractQueryFields.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/extractTimegrain.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/extractTimegrain.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/getColumnLabel.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getColumnLabel.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/getMetricLabel.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getMetricLabel.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/normalizeOrderBy.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/processExtraFormData.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/processExtraFormData.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/processFilters.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/processFilters.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/types/AnnotationLayer.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/AnnotationLayer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/query/types/Filter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/types/Filter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/customTimeRangeDecode.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/customTimeRangeDecode.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/getComparisonFilters.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/getComparisonFilters.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/getComparisonInfo.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/getComparisonInfo.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-comparison/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-comparison/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatterRegistry.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatterRegistry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatterRegistrySingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/TimeFormatterRegistrySingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/factories/createD3TimeFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/factories/createD3TimeFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/factories/createMultiFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/factories/createMultiFormatter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDate.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDate.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDateDetailed.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDateDetailed.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDateVerbose.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/smartDateVerbose.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/utils/createTime.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/utils/createTime.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/utils/createTimeRangeFromGranularity.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/utils/createTimeRangeFromGranularity.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/time-format/utils/d3Time.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/utils/d3Time.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/Translator.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/TranslatorSingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/translation/index.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/translation/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/convertKeysToCamelCase.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/convertKeysToCamelCase.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/ensureIsArray.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/ensureIsArray.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/ensureIsInt.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/ensureIsInt.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/isDefined.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/isDefined.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/isRequired.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/isRequired.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/logging.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/logging.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable global-require */
 /**

--- a/superset-frontend/packages/superset-ui-core/test/utils/makeSingleton.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/makeSingleton.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/promiseTimeout.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/promiseTimeout.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/random.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/random.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/utils/removeDuplicates.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/removeDuplicates.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/legacyValidateInteger.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/legacyValidateInteger.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/legacyValidateNumber.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/legacyValidateNumber.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateInteger.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateInteger.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateMapboxStylesUrl.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateMapboxStylesUrl.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateNonEmpty.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateNonEmpty.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateNumber.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateNumber.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-core/test/validator/validateTimeComparisonRangeValues.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/validator/validateTimeComparisonRangeValues.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
+++ b/superset-frontend/packages/superset-ui-switchboard/src/switchboard.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-plugin-chart-map-box/test/utils/roundDecimal.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-map-box/test/utils/roundDecimal.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-plugin-chart-partition/test/OptionDescription.test.jsx
+++ b/superset-frontend/plugins/legacy-plugin-chart-partition/test/OptionDescription.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.test.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/common.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/spatialUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/spatialUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utils/crossFiltersDataMask.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/test/utils/colors.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/test/utils/colors.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/test/utils/getPointsFromPolygon.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/test/utils/getPointsFromPolygon.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils/isTruthy.test.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils/isTruthy.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
+++ b/superset-frontend/plugins/legacy-preset-chart-nvd3/test/utils/tokenize.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/components/chartLayer.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/components/chartLayer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/plugin/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/chartUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/chartUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/controlPanelUtil.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/controlPanelUtil.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/geometryUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/geometryUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/mapUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/mapUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/serviceUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/serviceUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/transformPropsUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/transformPropsUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/controlPanel.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberTotal/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberWithTrendline/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/themeOverrides.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/themeOverrides.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Bubble/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gauge/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Graph/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Graph/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Graph/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Radar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Radar/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/controlPanel.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Bar/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/constants.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/constants.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Tree/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Tree/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Tree/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Tree/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Waterfall/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/annotation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/controls.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/controls.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/formatters.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/formatters.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/transformers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/test/plugin/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/index.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/sortAlphanumericCaseInsensitive.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/test/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/AceEditorWrapper.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/App/App.test.tsx
+++ b/superset-frontend/src/SqlLab/components/App/App.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ColumnElement/ColumnElement.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/EstimateQueryCostButton/EstimateQueryCostButton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreResultsButton/ExploreResultsButton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryLimitSelect/QueryLimitSelect.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/QueryTable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetModal/SaveDatasetModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ShareSqlLabQuery/ShareSqlLabQuery.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditorTabHeader/SqlEditorTabHeader.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TabbedSqlEditors/TabbedSqlEditors.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TablePreview/TablePreview.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/TemplateParamsEditor.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
+++ b/superset-frontend/src/SqlLab/reducers/getInitialState.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
+++ b/superset-frontend/src/SqlLab/utils/emptyQueryResults.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
+++ b/superset-frontend/src/SqlLab/utils/newQueryTabName.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
+++ b/superset-frontend/src/components/AlteredSliceTag/utils/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartErrorMessage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Chart/chartReducers.test.js
+++ b/superset-frontend/src/components/Chart/chartReducers.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DashboardLinksExternal/DashboardLinksExternal.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DashboardLinksExternal/DashboardLinksExternal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorCurrency.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorRTL.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Datasource/utils/utils.test.tsx
+++ b/superset-frontend/src/components/Datasource/utils/utils.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/ErrorAlert.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/InvalidSQLErrorMessage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file

--- a/superset-frontend/src/components/ErrorMessage/MarshmallowErrorMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/MarshmallowErrorMessage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
+++ b/superset-frontend/src/components/ErrorMessage/OAuth2RedirectMessage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/FacePile/FacePile.test.tsx
+++ b/superset-frontend/src/components/FacePile/FacePile.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/GridTable/HeaderMenu.test.tsx
+++ b/superset-frontend/src/components/GridTable/HeaderMenu.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ListView/ListView.test.jsx
+++ b/superset-frontend/src/components/ListView/ListView.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/MessageToasts/reducers.test.js
+++ b/superset-frontend/src/components/MessageToasts/reducers.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
+++ b/superset-frontend/src/components/ModalTitleWithIcon/ModalTitleWithIcon.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
+++ b/superset-frontend/src/components/ResizableSidebar/useStoredSidebarWidth.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
+++ b/superset-frontend/src/components/SQLEditorWithValidation/SQLEditorWithValidation.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/Tag/utils.test.tsx
+++ b/superset-frontend/src/components/Tag/utils.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/components/TagsList/TagsList.test.tsx
+++ b/superset-frontend/src/components/TagsList/TagsList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
+++ b/superset-frontend/src/dashboard/components/AnchorLink/AnchorLink.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/FiltersBadge/FiltersBadge.test.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/FiltersBadge.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/MissingChart.test.tsx
+++ b/superset-frontend/src/dashboard/components/MissingChart.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/StylingSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/StylingSection.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragDroppable.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/ChartHolder/ChartHolder.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Divider/Divider.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/DynamicComponent/DynamicComponent.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Header/Header.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/TabsRenderer/TabsRenderer.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/TabsRenderer/TabsRenderer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/new/DraggableNewComponent.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/ActionButtons.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/CollapsibleControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeInitialization.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/__tests__/TreeSelection.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/getControlItemsMap.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableContainer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
+++ b/superset-frontend/src/dashboard/components/resizable/ResizableHandle.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardFilters.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardLayout.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
+++ b/superset-frontend/src/dashboard/reducers/sliceEntities.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
+++ b/superset-frontend/src/dashboard/util/componentIsResizable.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/dnd-reorder.test.js
+++ b/superset-frontend/src/dashboard/util/dnd-reorder.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
+++ b/superset-frontend/src/dashboard/util/dropOverflowsParent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
+++ b/superset-frontend/src/dashboard/util/extractUrlParams.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
+++ b/superset-frontend/src/dashboard/util/findFirstParentContainer.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/findParentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findParentId.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
+++ b/superset-frontend/src/dashboard/util/findTabIndexByComponentId.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getChartAndLabelComponentIdFromPath.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsFromLayout.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
+++ b/superset-frontend/src/dashboard/util/getDashboardUrl.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
+++ b/superset-frontend/src/dashboard/util/getDetailedComponentWidth.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
+++ b/superset-frontend/src/dashboard/util/getDirectPathToTabIndex.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getDropPosition.test.js
+++ b/superset-frontend/src/dashboard/util/getDropPosition.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
+++ b/superset-frontend/src/dashboard/util/getEffectiveExtraFilters.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterConfigsFromFormdata.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
+++ b/superset-frontend/src/dashboard/util/getFilterScopeFromNodesTree.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/getFormDataWithExtraFilters.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getKeyForFilterScopeTree.test.ts
+++ b/superset-frontend/src/dashboard/util/getKeyForFilterScopeTree.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
+++ b/superset-frontend/src/dashboard/util/getLeafComponentIdFromPath.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardEmpty.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
+++ b/superset-frontend/src/dashboard/util/isDashboardLoading.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/isValidChild.test.ts
+++ b/superset-frontend/src/dashboard/util/isValidChild.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/logging/childChartsDidLoad.test.ts
+++ b/superset-frontend/src/dashboard/util/logging/childChartsDidLoad.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/newComponentFactory.test.js
+++ b/superset-frontend/src/dashboard/util/newComponentFactory.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
+++ b/superset-frontend/src/dashboard/util/newEntitiesFromDrop.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/serializeFilterScopes.test.ts
+++ b/superset-frontend/src/dashboard/util/serializeFilterScopes.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
+++ b/superset-frontend/src/dashboard/util/updateComponentParentsList.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
+++ b/superset-frontend/src/dashboard/util/useFilterFocusHighlightStyles.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/actions/exploreActions.test.js
+++ b/superset-frontend/src/explore/actions/exploreActions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/DataTablesPane.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartPanel/ExploreChartPanel.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/CheckboxControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointOption.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverTrigger.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointPopoverTrigger.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorBreakpointsControl/ColorBreakpointsControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ColorPickerControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/CalendarFrame.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/Option.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/FilterControl/adhocFilterType.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/adhocFilterType.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetric.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AggregateOption.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/FilterDefinitionOption.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/SelectControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/TimeOffsetControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/ViewportControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
+++ b/superset-frontend/src/explore/components/controls/ZoomConfigControl/zoomUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
+++ b/superset-frontend/src/explore/components/controls/withAsyncVerification.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/DashboardsSubMenu.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/controlPanels/Separator.test.ts
+++ b/superset-frontend/src/explore/controlPanels/Separator.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
+++ b/superset-frontend/src/explore/exploreUtils/exploreUtils.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/getChartDataUri.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/explore/store.test.jsx
+++ b/superset-frontend/src/explore/store.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
+++ b/superset-frontend/src/features/alerts/components/RecipientIcon.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
+++ b/superset-frontend/src/features/allEntities/AllEntitiesTable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/EncryptedField.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/DatabaseConnectionForm/OAuth2ClientField.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
+++ b/superset-frontend/src/features/databases/UploadDataModel/UploadDataModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/datasets/AddDataset/Header/Header.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Header/Header.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/RightPanel/RightPanel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
+++ b/superset-frontend/src/features/datasets/DatasetLayout/DatasetLayout.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/home/EmptyState.test.tsx
+++ b/superset-frontend/src/features/home/EmptyState.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/HeaderReportDropdown/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
+++ b/superset-frontend/src/features/rls/RowLevelSecurityModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListAddModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListDuplicateModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/tags/BulkTagModal.test.tsx
+++ b/superset-frontend/src/features/tags/BulkTagModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file

--- a/superset-frontend/src/features/themes/ThemeModal.test.tsx
+++ b/superset-frontend/src/features/themes/ThemeModal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/themes/api.test.ts
+++ b/superset-frontend/src/features/themes/api.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/features/themes/types.test.ts
+++ b/superset-frontend/src/features/themes/types.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/filters/components/Select/buildQuery.test.ts
+++ b/superset-frontend/src/filters/components/Select/buildQuery.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/filters/utils.test.ts
+++ b/superset-frontend/src/filters/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/apiResources/apiResources.test.ts
+++ b/superset-frontend/src/hooks/apiResources/apiResources.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/apiResources/dashboards.test.ts
+++ b/superset-frontend/src/hooks/apiResources/dashboards.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/apiResources/schemas.test.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/apiResources/tables.test.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
+++ b/superset-frontend/src/hooks/useUnsavedChangesPrompt/useUnsavedChangesPrompt.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/middleware/logger.test.js
+++ b/superset-frontend/src/middleware/logger.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
+++ b/superset-frontend/src/pages/AlertReportList/AlertReportList.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/AnnotationLayerList.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/Chart/Chart.test.tsx
+++ b/superset-frontend/src/pages/Chart/Chart.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.cardview.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.permissions.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ChartList/ChartList.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
+++ b/superset-frontend/src/pages/CssTemplateList/CssTemplateList.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
+++ b/superset-frontend/src/pages/DatasetCreation/DatasetCreation.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
+++ b/superset-frontend/src/pages/ExecutionLogList/ExecutionLogList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
+++ b/superset-frontend/src/pages/GroupsList/GroupsList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/RolesList/RolesList.test.tsx
+++ b/superset-frontend/src/pages/RolesList/RolesList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/RowLevelSecurityList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/SavedQueryList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/ThemeList/index.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
+++ b/superset-frontend/src/pages/UserInfo/UserInfo.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
+++ b/superset-frontend/src/pages/UserRegistrations/UserRegistrations.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/pages/UsersList/UsersList.test.tsx
+++ b/superset-frontend/src/pages/UsersList/UsersList.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
+++ b/superset-frontend/src/utils/DebouncedMessageQueue.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/cacheWrapper.test.ts
+++ b/superset-frontend/src/utils/cacheWrapper.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/chartRegistry.test.ts
+++ b/superset-frontend/src/utils/chartRegistry.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/common.test.jsx
+++ b/superset-frontend/src/utils/common.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/datasourceUtils.test.ts
+++ b/superset-frontend/src/utils/datasourceUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/getBootstrapData.test.ts
+++ b/superset-frontend/src/utils/getBootstrapData.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
+++ b/superset-frontend/src/utils/getChartFormDiffs/getChartFormDiffs.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/getControlsForVizType.test.js
+++ b/superset-frontend/src/utils/getControlsForVizType.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/getControlsForVizType.test.ts
+++ b/superset-frontend/src/utils/getControlsForVizType.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/hostNamesConfig.test.ts
+++ b/superset-frontend/src/utils/hostNamesConfig.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/localStorageHelpers.test.ts
+++ b/superset-frontend/src/utils/localStorageHelpers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/parseCookie.test.ts
+++ b/superset-frontend/src/utils/parseCookie.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/safeStringify.test.ts
+++ b/superset-frontend/src/utils/safeStringify.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/testUtils.test.ts
+++ b/superset-frontend/src/utils/testUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/utils/urlUtils.test.ts
+++ b/superset-frontend/src/utils/urlUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/views/routes.test.tsx
+++ b/superset-frontend/src/views/routes.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/views/theme.bootstrap.test.ts
+++ b/superset-frontend/src/views/theme.bootstrap.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/Sparkline/Sparkline.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/components/ValueCell/ValueCell.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/ValueCell/ValueCell.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/config/controlPanel/controlPanel.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/config/controlPanel/controlPanel.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/config/transformProps/transformProps.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/config/transformProps/transformProps.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/colorUtils/colorUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/colorUtils/colorUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/rowProcessing/rowProcessing.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/rowProcessing/rowProcessing.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sortUtils/sortUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/sparklineDataUtils/sparklineDataUtils.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sparklineDataUtils/sparklineDataUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/sparklineHelpers/sparklineHelpers.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/sparklineHelpers/sparklineHelpers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/superset-frontend/src/visualizations/TimeTable/utils/valueCalculations/valueCalculations.test.ts
+++ b/superset-frontend/src/visualizations/TimeTable/utils/valueCalculations/valueCalculations.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Add ESLint rule to ban describe() usage in favor of test() for better test organization. All 474 existing test files using describe() have been grandfathered with eslint-disable comments to avoid disruption while enforcing the new guideline for future tests.
