### PR TITLE
fix: AceEditor Autocomplete Highlight

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/index.tsx
@@ -193,6 +193,11 @@ const AceEditorWrapper = ({
             width: ${theme.sizeUnit * 130}px !important;
           }
 
+          .ace_completion-highlight {
+            color: ${theme.colorPrimaryText} !important;
+            background-color: ${theme.colorPrimaryBgHover};
+          }
+
           .ace_tooltip {
             max-width: ${SQL_EDITOR_LEFTBAR_WIDTH}px;
           }


### PR DESCRIPTION
### SUMMARY
Fixes #35313

### AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1489" height="389" alt="Screenshot 2025-09-27 at 14 07 45" src="https://github.com/user-attachments/assets/4ff659dc-6f50-4651-a233-64a3b92bc2bc" />

### TESTING INSTRUCTIONS
1. Visit SQL Lab
2. Change the SQL in the editor so that the autocomplete appears
3. Highlight text should be visible in both dark and light mode

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
