### PR TITLE
chore: add guidelines for using test() instead of describe()/it()

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -102,6 +102,17 @@ superset/
 - **`selectOption()`** - Select component helper
 - **React Testing Library** - NO Enzyme (removed)
 
+### Test Structure Guidelines
+- **Use `test()` instead of `describe()` and `it()`** - Follow the [avoid nesting when testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing) principle
+  - **Why**: Reduces unnecessary nesting, improves test isolation, and makes tests more readable
+  - **Pattern**: Write flat test files with descriptive test names that fully describe what's being tested
+  - **Example**: Instead of nested `describe('Component', () => { it('should render', ...) })`, use `test('Component renders correctly', ...)`
+  - **Benefits**:
+    - Each test stands alone with a clear, searchable name
+    - Easier to run individual tests
+    - Forces you to write more descriptive test names
+    - Reduces cognitive overhead from nested context switching
+
 ### Test Database Patterns
 - **Mock patterns**: Use `MagicMock()` for config objects, avoid `AsyncMock` for synchronous code
 - **API tests**: Update expected columns when adding new model fields


### PR DESCRIPTION
### SUMMARY
Added comprehensive testing structure guidelines to LLMS.md that explain why and how to use `test()` instead of `describe()` and `it()`, following the "avoid nesting when testing" principle championed by Kent C. Dodds.

This guideline promotes:
- Better test isolation - each test stands alone
- Improved readability - flat structure with descriptive test names
- Easier test execution - simpler to run individual tests
- Reduced cognitive overhead - less nested context switching

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Documentation only change

### TESTING INSTRUCTIONS
1. Review the updated LLMS.md file
2. Verify the guidelines are clear and comprehensive
3. Check that the example provided effectively illustrates the pattern

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: No
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

This aligns with the ongoing testing strategy migration mentioned in the document and provides concrete guidance for developers writing tests in the Superset codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)