### PR TITLE
fix(doris): Don't set supports_cross_catalog_queries to true

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -181,8 +181,10 @@ dnspython==2.7.0
     #   email-validator
 docker==7.0.0
     # via apache-superset
-duckdb==1.3.2
-    # via duckdb-engine
+duckdb==0.10.3
+    # via
+    #   apache-superset
+    #   duckdb-engine
 duckdb-engine==0.17.0
     # via apache-superset
 email-validator==2.2.0

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -117,6 +117,8 @@ class DorisEngineSpec(MySQLEngineSpec):
     encryption_parameters = {"ssl": "0"}
     supports_dynamic_schema = True
     supports_catalog = supports_dynamic_catalog = True
+    # while technically supported by Doris, this generates invalid table identifiers
+    supports_cross_catalog_queries = False
 
     column_type_mappings = (  # type: ignore
         (

--- a/superset/db_engine_specs/doris.py
+++ b/superset/db_engine_specs/doris.py
@@ -116,7 +116,7 @@ class DorisEngineSpec(MySQLEngineSpec):
     )
     encryption_parameters = {"ssl": "0"}
     supports_dynamic_schema = True
-    supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
+    supports_catalog = supports_dynamic_catalog = True
 
     column_type_mappings = (  # type: ignore
         (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After https://github.com/apache/superset/pull/33000 doris engine spec caused issues such as https://github.com/apache/superset/issues/34996 when creating tables. This pr rolls back that property to default `False`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a doris connection
2. Create a dataset and a chart

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #34996
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
