### PR TITLE
fix(dashboard): exit markdown edit mode when clicking outside of element

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.jsx
@@ -269,9 +269,9 @@ class Markdown extends PureComponent {
     }
   }
 
-  shouldFocusMarkdown(event, container) {
+  shouldFocusMarkdown(event, container, menuRef) {
     if (container?.contains(event.target)) return true;
-    if (event.target.closest?.('.menu-item')) return true;
+    if (menuRef?.contains(event.target)) return true;
 
     return false;
   }

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.jsx
@@ -132,6 +132,7 @@ class Markdown extends PureComponent {
     this.handleDeleteComponent = this.handleDeleteComponent.bind(this);
     this.handleResizeStart = this.handleResizeStart.bind(this);
     this.setEditor = this.setEditor.bind(this);
+    this.shouldFocusMarkdown = this.shouldFocusMarkdown.bind(this);
   }
 
   componentDidMount() {
@@ -268,6 +269,13 @@ class Markdown extends PureComponent {
     }
   }
 
+  shouldFocusMarkdown(event, container) {
+    if (container?.contains(event.target)) return true;
+    if (event.target.closest?.('.menu-item')) return true;
+
+    return false;
+  }
+
   renderEditMode() {
     return (
       <MarkdownEditor
@@ -343,6 +351,7 @@ class Markdown extends PureComponent {
         {({ dragSourceRef }) => (
           <WithPopoverMenu
             onChangeFocus={this.handleChangeFocus}
+            shouldFocus={this.shouldFocusMarkdown}
             menuItems={[
               <MarkdownModeDropdown
                 id={`${component.id}-mode`}

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -51,6 +51,7 @@ describe('Markdown', () => {
   };
 
   beforeAll(() => {
+    const originalError = console.error;
     jest.spyOn(console, 'error').mockImplementation(msg => {
       if (
         typeof msg === 'string' &&
@@ -59,7 +60,7 @@ describe('Markdown', () => {
         !msg.includes('Warning: React does not recognize') &&
         !msg.includes("Warning: Can't perform a React state update")
       ) {
-        console.error(msg);
+        originalError.call(console, msg);
       }
     });
   });
@@ -349,9 +350,7 @@ describe('Markdown', () => {
       'dashboard-component-chart-holder',
     );
 
-    await act(async () => {
-      await userEvent.click(markdownContainer);
-    });
+    userEvent.click(markdownContainer);
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
   });
@@ -363,16 +362,12 @@ describe('Markdown', () => {
       'dashboard-component-chart-holder',
     );
 
-    await act(async () => {
-      await userEvent.click(markdownContainer);
-    });
+    userEvent.click(markdownContainer);
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
-    await act(async () => {
-      await userEvent.click(document.body);
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    userEvent.click(document.body);
+    await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
@@ -384,18 +379,14 @@ describe('Markdown', () => {
       'dashboard-component-chart-holder',
     );
 
-    await act(async () => {
-      await userEvent.click(markdownContainer);
-    });
+    userEvent.click(markdownContainer);
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
     const editButton = screen.getByText('Edit');
 
-    await act(async () => {
-      await userEvent.click(editButton);
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    userEvent.click(editButton);
+    await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(screen.queryByRole('textbox')).toBeInTheDocument();
   });
@@ -407,9 +398,7 @@ describe('Markdown', () => {
       'dashboard-component-chart-holder',
     );
 
-    await act(async () => {
-      await userEvent.click(markdownContainer);
-    });
+    userEvent.click(markdownContainer);
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
@@ -417,10 +406,8 @@ describe('Markdown', () => {
     outsideElement.className = 'grid-row';
     document.body.appendChild(outsideElement);
 
-    await act(async () => {
-      await userEvent.click(outsideElement);
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    userEvent.click(outsideElement);
+    await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
 

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -335,4 +335,89 @@ describe('Markdown', () => {
     // Check that width is no longer 248px
     expect(updatedParent).not.toHaveStyle('width: 248px');
   });
+
+  test('shouldFocusMarkdown returns true when clicking inside markdown container', async () => {
+    await setup({ editMode: true });
+
+    const markdownContainer = screen.getByTestId(
+      'dashboard-component-chart-holder',
+    );
+
+    await act(async () => {
+      fireEvent.click(markdownContainer);
+    });
+
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('shouldFocusMarkdown returns false when clicking outside markdown container', async () => {
+    await setup({ editMode: true });
+
+    const markdownContainer = screen.getByTestId(
+      'dashboard-component-chart-holder',
+    );
+
+    await act(async () => {
+      fireEvent.click(markdownContainer);
+    });
+
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(document.body);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  test('shouldFocusMarkdown keeps focus when clicking on menu items', async () => {
+    await setup({ editMode: true });
+
+    const markdownContainer = screen.getByTestId(
+      'dashboard-component-chart-holder',
+    );
+
+    await act(async () => {
+      fireEvent.click(markdownContainer);
+    });
+
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
+
+    const editButton = screen.getByText('Edit');
+
+    await act(async () => {
+      fireEvent.click(editButton);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(screen.queryByRole('textbox')).toBeInTheDocument();
+  });
+
+  test('should exit edit mode when clicking outside in same row', async () => {
+    await setup({ editMode: true });
+
+    const markdownContainer = screen.getByTestId(
+      'dashboard-component-chart-holder',
+    );
+
+    await act(async () => {
+      fireEvent.click(markdownContainer);
+    });
+
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
+
+    const outsideElement = document.createElement('div');
+    outsideElement.className = 'grid-row';
+    document.body.appendChild(outsideElement);
+
+    await act(async () => {
+      fireEvent.click(outsideElement);
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    document.body.removeChild(outsideElement);
+  });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.jsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import { Provider } from 'react-redux';
-import { act, render, screen, fireEvent } from 'spec/helpers/testing-library';
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  userEvent,
+} from 'spec/helpers/testing-library';
 import { mockStore } from 'spec/fixtures/mockStore';
 import { dashboardLayout as mockLayout } from 'spec/fixtures/mockDashboardLayout';
 import MarkdownConnected from './Markdown';
@@ -344,7 +350,7 @@ describe('Markdown', () => {
     );
 
     await act(async () => {
-      fireEvent.click(markdownContainer);
+      await userEvent.click(markdownContainer);
     });
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
@@ -358,13 +364,13 @@ describe('Markdown', () => {
     );
 
     await act(async () => {
-      fireEvent.click(markdownContainer);
+      await userEvent.click(markdownContainer);
     });
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.click(document.body);
+      await userEvent.click(document.body);
       await new Promise(resolve => setTimeout(resolve, 50));
     });
 
@@ -379,7 +385,7 @@ describe('Markdown', () => {
     );
 
     await act(async () => {
-      fireEvent.click(markdownContainer);
+      await userEvent.click(markdownContainer);
     });
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
@@ -387,7 +393,7 @@ describe('Markdown', () => {
     const editButton = screen.getByText('Edit');
 
     await act(async () => {
-      fireEvent.click(editButton);
+      await userEvent.click(editButton);
       await new Promise(resolve => setTimeout(resolve, 50));
     });
 
@@ -402,7 +408,7 @@ describe('Markdown', () => {
     );
 
     await act(async () => {
-      fireEvent.click(markdownContainer);
+      await userEvent.click(markdownContainer);
     });
 
     expect(await screen.findByRole('textbox')).toBeInTheDocument();
@@ -412,7 +418,7 @@ describe('Markdown', () => {
     document.body.appendChild(outsideElement);
 
     await act(async () => {
-      fireEvent.click(outsideElement);
+      await userEvent.click(outsideElement);
       await new Promise(resolve => setTimeout(resolve, 50));
     });
 

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.test.jsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.test.jsx
@@ -81,3 +81,94 @@ test('should use the passed shouldFocus func to determine if it should focus', (
     container.querySelector('.with-popover-menu--focused'),
   ).not.toBeInTheDocument();
 });
+
+test('should NOT stop event propagation when disableClick=true and not handling focus', () => {
+  const onChangeFocus = jest.fn();
+  const mockEvent = {
+    target: document.createElement('div'),
+    stopPropagation: jest.fn(),
+  };
+
+  const { container } = setup({
+    editMode: true,
+    disableClick: true,
+    shouldFocus: () => false,
+    onChangeFocus,
+  });
+
+  const menuComponent = container.querySelector('.with-popover-menu');
+  fireEvent.click(menuComponent, mockEvent);
+
+  expect(mockEvent.stopPropagation).not.toHaveBeenCalled();
+});
+
+test('should stop event propagation when handling focus', () => {
+  const onChangeFocus = jest.fn();
+  let stopPropagationCalled = false;
+
+  const { container } = setup({
+    editMode: true,
+    disableClick: false,
+    shouldFocus: () => true,
+    onChangeFocus,
+  });
+
+  const menuComponent = container.querySelector('.with-popover-menu');
+
+  const clickEvent = new MouseEvent('click', { bubbles: true });
+  const originalStopPropagation = clickEvent.stopPropagation;
+  clickEvent.stopPropagation = function () {
+    stopPropagationCalled = true;
+    return originalStopPropagation.call(this);
+  };
+
+  menuComponent.dispatchEvent(clickEvent);
+
+  expect(stopPropagationCalled).toBe(true);
+  expect(onChangeFocus).toHaveBeenCalledWith(true);
+});
+
+test('should stop event propagation when handling unfocus', () => {
+  const onChangeFocus = jest.fn();
+  let stopPropagationCount = 0;
+
+  const { container } = setup({
+    editMode: true,
+    disableClick: false,
+    shouldFocus: () => true,
+    onChangeFocus,
+    isFocused: false,
+  });
+
+  const menuComponent = container.querySelector('.with-popover-menu');
+
+  const focusEvent = new MouseEvent('click', { bubbles: true });
+  focusEvent.stopPropagation = function () {
+    stopPropagationCount += 1;
+  };
+
+  menuComponent.dispatchEvent(focusEvent);
+
+  const unfocusEvent = new MouseEvent('click', { bubbles: true });
+  unfocusEvent.stopPropagation = function () {
+    stopPropagationCount += 1;
+  };
+
+  setup({
+    editMode: true,
+    disableClick: false,
+    shouldFocus: () => false,
+    onChangeFocus,
+    isFocused: true,
+  });
+
+  const refocusedComponent = container.querySelector(
+    '.with-popover-menu--focused',
+  );
+
+  if (refocusedComponent) {
+    refocusedComponent.dispatchEvent(unfocusEvent);
+  }
+
+  expect(stopPropagationCount).toBeGreaterThan(0);
+});

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -150,12 +150,20 @@ export default class WithPopoverMenu extends PureComponent<
     this.container = ref;
   }
 
+  shouldHandleFocusChange(shouldFocus: Boolean): boolean {
+    const { disableClick } = this.props;
+    const { isFocused } = this.state;
+
+    return (
+      (!disableClick && shouldFocus && !isFocused) ||
+      (!shouldFocus && isFocused)
+    );
+  }
+
   handleClick(event: any) {
     if (!this.props.editMode) {
       return;
     }
-
-    event.stopPropagation();
 
     const {
       onChangeFocus,
@@ -164,6 +172,11 @@ export default class WithPopoverMenu extends PureComponent<
     } = this.props;
 
     const shouldFocus = shouldFocusFunc(event, this.container);
+
+    // Only stop propagation if we're actually handling a focus state change
+    if (this.shouldHandleFocusChange(shouldFocus)) {
+      event.stopPropagation();
+    }
 
     if (!disableClick && shouldFocus && !this.state.isFocused) {
       // if not focused, set focus and add a window event listener to capture outside clicks

--- a/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
+++ b/superset-frontend/src/dashboard/components/menu/WithPopoverMenu.tsx
@@ -173,27 +173,22 @@ export default class WithPopoverMenu extends PureComponent<
 
     const shouldFocus = shouldFocusFunc(event, this.container);
 
-    // Only stop propagation if we're actually handling a focus state change
-    if (this.shouldHandleFocusChange(shouldFocus)) {
-      event.stopPropagation();
-    }
-
     if (!disableClick && shouldFocus && !this.state.isFocused) {
-      // if not focused, set focus and add a window event listener to capture outside clicks
-      // this enables us to not set a click listener for ever item on a dashboard
+      event.stopPropagation();
       document.addEventListener('click', this.handleClick);
       document.addEventListener('drag', this.handleClick);
+
       this.setState(() => ({ isFocused: true }));
-      if (onChangeFocus) {
-        onChangeFocus(true);
-      }
+
+      if (onChangeFocus) onChangeFocus(true);
     } else if (!shouldFocus && this.state.isFocused) {
       document.removeEventListener('click', this.handleClick);
       document.removeEventListener('drag', this.handleClick);
+
+      event.stopPropagation();
       this.setState(() => ({ isFocused: false }));
-      if (onChangeFocus) {
-        onChangeFocus(false);
-      }
+
+      if (onChangeFocus) onChangeFocus(false);
     }
   }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed a bug where the Markdown element would not exit edit mode when clicking on whitespace within the same row. Previously, the element would only switch to preview mode when clicking between rows or outside the dashboard edit area.

Fixes: #35486
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
https://github.com/user-attachments/assets/acf4b11e-8b9f-4e94-948c-4016f6ba497e

After:
![markdown-fix](https://github.com/user-attachments/assets/34fb4c0a-24fe-4104-8ed7-742160a5f178)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open Superset and navigate to any dashboard in edit mode
2. Add a Markdown component to the dashboard
3. Click on the Markdown element to enter edit mode
4. Click on the whitespace in the same row --> Should exit to preview mode
5. Click on whitespace between rows --> Should exit to preview mode
6. Click inside the Markdown editor --> Should stay in edit mode
7. Click outside the dashboard --> Should exit to preview mode

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
