### PR TITLE
fix(pinot): restrict types in dialect

### DIFF
--- a/superset/sql/dialects/pinot.py
+++ b/superset/sql/dialects/pinot.py
@@ -24,7 +24,9 @@ double quotes are used for identifiers instead of string literals.
 
 from __future__ import annotations
 
+from sqlglot import exp
 from sqlglot.dialects.mysql import MySQL
+from sqlglot.tokens import TokenType
 
 
 class Pinot(MySQL):
@@ -41,3 +43,55 @@ class Pinot(MySQL):
         QUOTES = ["'"]  # Only single quotes for strings
         IDENTIFIERS = ['"', "`"]  # Backticks and double quotes for identifiers
         STRING_ESCAPES = ["'", "\\"]  # Remove double quote from string escapes
+        KEYWORDS = {
+            **MySQL.Tokenizer.KEYWORDS,
+            "STRING": TokenType.TEXT,
+            "LONG": TokenType.BIGINT,
+            "BYTES": TokenType.VARBINARY,
+        }
+
+    class Generator(MySQL.Generator):
+        TYPE_MAPPING = {
+            **MySQL.Generator.TYPE_MAPPING,
+            exp.DataType.Type.TINYINT: "INT",
+            exp.DataType.Type.SMALLINT: "INT",
+            exp.DataType.Type.INT: "INT",
+            exp.DataType.Type.BIGINT: "LONG",
+            exp.DataType.Type.FLOAT: "FLOAT",
+            exp.DataType.Type.DOUBLE: "DOUBLE",
+            exp.DataType.Type.BOOLEAN: "BOOLEAN",
+            exp.DataType.Type.TIMESTAMP: "TIMESTAMP",
+            exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
+            exp.DataType.Type.VARCHAR: "STRING",
+            exp.DataType.Type.CHAR: "STRING",
+            exp.DataType.Type.TEXT: "STRING",
+            exp.DataType.Type.BINARY: "BYTES",
+            exp.DataType.Type.VARBINARY: "BYTES",
+            exp.DataType.Type.JSON: "JSON",
+        }
+
+        # Override MySQL's CAST_MAPPING - don't convert integer or string types
+        CAST_MAPPING = {
+            exp.DataType.Type.LONGBLOB: exp.DataType.Type.VARBINARY,
+            exp.DataType.Type.MEDIUMBLOB: exp.DataType.Type.VARBINARY,
+            exp.DataType.Type.TINYBLOB: exp.DataType.Type.VARBINARY,
+            exp.DataType.Type.UBIGINT: "UNSIGNED",
+        }
+
+        def datatype_sql(self, expression: exp.DataType) -> str:
+            # Don't use MySQL's VARCHAR size requirement logic
+            # Just use TYPE_MAPPING for all types
+            type_value = expression.this
+            type_sql = (
+                self.TYPE_MAPPING.get(type_value, type_value.value)
+                if isinstance(type_value, exp.DataType.Type)
+                else type_value
+            )
+
+            interior = self.expressions(expression, flat=True)
+            nested = f"({interior})" if interior else ""
+
+            if expression.this in self.UNSIGNED_TYPE_MAPPING:
+                return f"{type_sql} UNSIGNED{nested}"
+
+            return f"{type_sql}{nested}"

--- a/tests/unit_tests/sql/dialects/pinot_tests.py
+++ b/tests/unit_tests/sql/dialects/pinot_tests.py
@@ -406,3 +406,18 @@ def test_type_mappings(cast_type: str, expected_type: str) -> None:
     generated = Pinot().generate(expression=ast)
 
     assert expected_type in generated
+
+
+def test_unsigned_type() -> None:
+    """
+    Test that unsigned integer types are handled correctly.
+    Tests the UNSIGNED_TYPE_MAPPING path in datatype_sql method.
+    """
+    from sqlglot import exp
+
+    # Create a UBIGINT DataType which is in UNSIGNED_TYPE_MAPPING
+    dt = exp.DataType(this=exp.DataType.Type.UBIGINT)
+    result = Pinot.Generator().datatype_sql(dt)
+
+    assert "UNSIGNED" in result
+    assert "BIGINT" in result


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR improves the Pinot dialect introduced in https://github.com/apache/superset/pull/35333, ensuring the types are consistent with [the documentation](https://docs.pinot.apache.org/configuration-reference/schema#data-types). This solves an issue where a query like this:

```sql
SELECT concat(account_open_date_month, cast(cohort_size AS string), ' - ')
FROM "default".credit_spend_activation_monthly
```

Was being converted into:

```sql
SELECT CONCAT(account_open_date_month, CAST(cohort_size AS CHAR), ' - ')
FROM "default".credit_spend_activation_monthly
```

Which is invalid in Pinot due to the `CHAR` type. (This happens because Pinot uses the MySQL dialect for its SQL, but not for its types.)

With this PR we get the right type after parsing the original SQL and generating it back.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
