### PR TITLE
fix(tables): Dark mode scrollbar styles for webkit

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
@@ -170,8 +170,8 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
       
       /* Chrome/Safari/Edge webkit scrollbar styling */
       &::-webkit-scrollbar {
-        width: 8px;
-        height: 8px;
+        width: ${theme.sizeUnit * 2}px;
+        height: ${theme.sizeUnit * 2}px;
       }
       
       &::-webkit-scrollbar-track {
@@ -180,7 +180,7 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
       
       &::-webkit-scrollbar-thumb {
         background: ${theme.colorFillSecondary};
-        border-radius: 4px;
+        border-radius: ${theme.sizeUnit}px;
         
         &:hover {
           background: ${theme.colorFillTertiary};

--- a/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
@@ -167,6 +167,33 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
     .ant-table-body {
       overflow: auto;
       height: ${height ? `${height}px` : undefined};
+      
+      /* Chrome/Safari/Edge webkit scrollbar styling */
+      &::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+      }
+      
+      &::-webkit-scrollbar-track {
+        background: ${theme.colorFillQuaternary};
+      }
+      
+      &::-webkit-scrollbar-thumb {
+        background: ${theme.colorFillSecondary};
+        border-radius: 4px;
+        
+        &:hover {
+          background: ${theme.colorFillTertiary};
+        }
+      }
+      
+      &::-webkit-scrollbar-corner {
+        background: ${theme.colorFillQuaternary};
+      }
+      
+      /* Firefox scrollbar styling */
+      scrollbar-width: thin;
+      scrollbar-color: ${theme.colorFillSecondary} ${theme.colorFillQuaternary};
     }
 
     .ant-spin-nested-loading .ant-spin .ant-spin-dot {

--- a/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
@@ -170,8 +170,8 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
 
       /* Chrome/Safari/Edge webkit scrollbar styling */
       &::-webkit-scrollbar {
-        width: ${theme.sizeUnit * 2}px;
-        height: ${theme.sizeUnit * 2}px;
+        width: 8px;
+        height: 8px;
       }
 
       &::-webkit-scrollbar-track {
@@ -180,7 +180,7 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
 
       &::-webkit-scrollbar-thumb {
         background: ${theme.colorFillSecondary};
-        border-radius: ${theme.sizeUnit}px;
+        border-radius: ${theme.borderRadiusSM}px;
 
         &:hover {
           background: ${theme.colorFillTertiary};

--- a/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Table/index.tsx
@@ -167,30 +167,30 @@ const StyledTable = styled(AntTable as FC<AntTableProps>)<{ height?: number }>(
     .ant-table-body {
       overflow: auto;
       height: ${height ? `${height}px` : undefined};
-      
+
       /* Chrome/Safari/Edge webkit scrollbar styling */
       &::-webkit-scrollbar {
         width: ${theme.sizeUnit * 2}px;
         height: ${theme.sizeUnit * 2}px;
       }
-      
+
       &::-webkit-scrollbar-track {
         background: ${theme.colorFillQuaternary};
       }
-      
+
       &::-webkit-scrollbar-thumb {
         background: ${theme.colorFillSecondary};
         border-radius: ${theme.sizeUnit}px;
-        
+
         &:hover {
           background: ${theme.colorFillTertiary};
         }
       }
-      
+
       &::-webkit-scrollbar-corner {
         background: ${theme.colorFillQuaternary};
       }
-      
+
       /* Firefox scrollbar styling */
       scrollbar-width: thin;
       scrollbar-color: ${theme.colorFillSecondary} ${theme.colorFillQuaternary};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -62,8 +62,8 @@ const PivotTableWrapper = styled.div`
     
     /* Chrome/Safari/Edge webkit scrollbar styling */
     &::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
+      width: ${theme.sizeUnit * 2}px;
+      height: ${theme.sizeUnit * 2}px;
     }
     
     &::-webkit-scrollbar-track {
@@ -72,7 +72,7 @@ const PivotTableWrapper = styled.div`
     
     &::-webkit-scrollbar-thumb {
       background: ${theme.colorFillSecondary};
-      border-radius: 4px;
+      border-radius: ${theme.sizeUnit}px;
       
       &:hover {
         background: ${theme.colorFillTertiary};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -62,8 +62,8 @@ const PivotTableWrapper = styled.div`
 
     /* Chrome/Safari/Edge webkit scrollbar styling */
     &::-webkit-scrollbar {
-      width: ${theme.sizeUnit * 2}px;
-      height: ${theme.sizeUnit * 2}px;
+      width: 8px;
+      height: 8px;
     }
 
     &::-webkit-scrollbar-track {
@@ -72,7 +72,7 @@ const PivotTableWrapper = styled.div`
 
     &::-webkit-scrollbar-thumb {
       background: ${theme.colorFillSecondary};
-      border-radius: ${theme.sizeUnit}px;
+      border-radius: ${theme.borderRadiusSM}px;
 
       &:hover {
         background: ${theme.colorFillTertiary};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -55,9 +55,38 @@ const Styles = styled.div<PivotTableStylesProps>`
 `;
 
 const PivotTableWrapper = styled.div`
-  height: 100%;
-  max-width: inherit;
-  overflow: auto;
+  ${({ theme }) => `
+    height: 100%;
+    max-width: inherit;
+    overflow: auto;
+    
+    /* Chrome/Safari/Edge webkit scrollbar styling */
+    &::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+    
+    &::-webkit-scrollbar-track {
+      background: ${theme.colorFillQuaternary};
+    }
+    
+    &::-webkit-scrollbar-thumb {
+      background: ${theme.colorFillSecondary};
+      border-radius: 4px;
+      
+      &:hover {
+        background: ${theme.colorFillTertiary};
+      }
+    }
+    
+    &::-webkit-scrollbar-corner {
+      background: ${theme.colorFillQuaternary};
+    }
+    
+    /* Firefox scrollbar styling */
+    scrollbar-width: thin;
+    scrollbar-color: ${theme.colorFillSecondary} ${theme.colorFillQuaternary};
+  `}
 `;
 
 const METRIC_KEY = t('Metric');

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -59,30 +59,30 @@ const PivotTableWrapper = styled.div`
     height: 100%;
     max-width: inherit;
     overflow: auto;
-    
+
     /* Chrome/Safari/Edge webkit scrollbar styling */
     &::-webkit-scrollbar {
       width: ${theme.sizeUnit * 2}px;
       height: ${theme.sizeUnit * 2}px;
     }
-    
+
     &::-webkit-scrollbar-track {
       background: ${theme.colorFillQuaternary};
     }
-    
+
     &::-webkit-scrollbar-thumb {
       background: ${theme.colorFillSecondary};
       border-radius: ${theme.sizeUnit}px;
-      
+
       &:hover {
         background: ${theme.colorFillTertiary};
       }
     }
-    
+
     &::-webkit-scrollbar-corner {
       background: ${theme.colorFillQuaternary};
     }
-    
+
     /* Firefox scrollbar styling */
     scrollbar-width: thin;
     scrollbar-color: ${theme.colorFillSecondary} ${theme.colorFillQuaternary};

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -127,7 +127,7 @@ function StickyWrap({
   sticky?: StickyState; // current sticky element sizes
 }) {
   const theme = useTheme();
-  
+
   if (!table || table.type !== 'table') {
     throw new Error('<StickyWrap> must have only one <table> element as child');
   }
@@ -224,6 +224,26 @@ function StickyWrap({
   let footerTable: ReactElement | undefined;
   let bodyTable: ReactElement | undefined;
 
+  const scrollBarStyles = css`
+    &::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+    &::-webkit-scrollbar-track {
+      background: ${theme.colorFillQuaternary};
+    }
+    &::-webkit-scrollbar-thumb {
+      background: ${theme.colorFillSecondary};
+      border-radius: 4px;
+      &:hover {
+        background: ${theme.colorFillTertiary};
+      }
+    }
+    &::-webkit-scrollbar-corner {
+      background: ${theme.colorFillQuaternary};
+    }
+  `;
+
   if (needSizer) {
     const theadWithRef = cloneElement(thead, { ref: theadRef });
     const tfootWithRef = tfoot && cloneElement(tfoot, { ref: tfootRef });
@@ -236,25 +256,7 @@ function StickyWrap({
           visibility: 'hidden',
           scrollbarGutter: 'stable',
         }}
-        css={css`
-          &::-webkit-scrollbar {
-            width: 8px;
-            height: 8px;
-          }
-          &::-webkit-scrollbar-track {
-            background: ${theme.colorFillQuaternary};
-          }
-          &::-webkit-scrollbar-thumb {
-            background: ${theme.colorFillSecondary};
-            border-radius: 4px;
-            &:hover {
-              background: ${theme.colorFillTertiary};
-            }
-          }
-          &::-webkit-scrollbar-corner {
-            background: ${theme.colorFillQuaternary};
-          }
-        `}
+        css={scrollBarStyles}
         role="presentation"
       >
         {cloneElement(
@@ -338,25 +340,7 @@ function StickyWrap({
           overflow: 'auto',
           scrollbarGutter: 'stable',
         }}
-        css={css`
-          &::-webkit-scrollbar {
-            width: 8px;
-            height: 8px;
-          }
-          &::-webkit-scrollbar-track {
-            background: ${theme.colorFillQuaternary};
-          }
-          &::-webkit-scrollbar-thumb {
-            background: ${theme.colorFillSecondary};
-            border-radius: 4px;
-            &:hover {
-              background: ${theme.colorFillTertiary};
-            }
-          }
-          &::-webkit-scrollbar-corner {
-            background: ${theme.colorFillQuaternary};
-          }
-        `}
+        css={scrollBarStyles}
         onScroll={sticky.hasHorizontalScroll ? onScroll : undefined}
         role="presentation"
       >

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -234,7 +234,7 @@ function StickyWrap({
     }
     &::-webkit-scrollbar-thumb {
       background: ${theme.colorFillSecondary};
-      border-radius: 4px;
+      border-radius: ${theme.borderRadiusSM}px;
       &:hover {
         background: ${theme.colorFillTertiary};
       }

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -30,6 +30,7 @@ import {
   UIEventHandler,
 } from 'react';
 import { TableInstance, Hooks } from 'react-table';
+import { useTheme, css } from '@superset-ui/core';
 import getScrollBarSize from '../utils/getScrollBarSize';
 import needScrollBar from '../utils/needScrollBar';
 import useMountedMemo from '../utils/useMountedMemo';
@@ -125,6 +126,8 @@ function StickyWrap({
   children: Table;
   sticky?: StickyState; // current sticky element sizes
 }) {
+  const theme = useTheme();
+  
   if (!table || table.type !== 'table') {
     throw new Error('<StickyWrap> must have only one <table> element as child');
   }
@@ -233,6 +236,25 @@ function StickyWrap({
           visibility: 'hidden',
           scrollbarGutter: 'stable',
         }}
+        css={css`
+          &::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+          }
+          &::-webkit-scrollbar-track {
+            background: ${theme.colorFillQuaternary};
+          }
+          &::-webkit-scrollbar-thumb {
+            background: ${theme.colorFillSecondary};
+            border-radius: 4px;
+            &:hover {
+              background: ${theme.colorFillTertiary};
+            }
+          }
+          &::-webkit-scrollbar-corner {
+            background: ${theme.colorFillQuaternary};
+          }
+        `}
         role="presentation"
       >
         {cloneElement(
@@ -316,6 +338,25 @@ function StickyWrap({
           overflow: 'auto',
           scrollbarGutter: 'stable',
         }}
+        css={css`
+          &::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+          }
+          &::-webkit-scrollbar-track {
+            background: ${theme.colorFillQuaternary};
+          }
+          &::-webkit-scrollbar-thumb {
+            background: ${theme.colorFillSecondary};
+            border-radius: 4px;
+            &:hover {
+              background: ${theme.colorFillTertiary};
+            }
+          }
+          &::-webkit-scrollbar-corner {
+            background: ${theme.colorFillQuaternary};
+          }
+        `}
         onScroll={sticky.hasHorizontalScroll ? onScroll : undefined}
         role="presentation"
       >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Scrollbar styles for chart components did not apply on chrome on dark mode. This pr fixes that by specifying scrollbar styles for webkit

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1613" height="802" alt="image" src="https://github.com/user-attachments/assets/c97d804d-7d01-40e8-9270-921a93523b4f" />

After:
<img width="1613" height="888" alt="image" src="https://github.com/user-attachments/assets/4e621fe6-b137-4f7c-8c2b-d9708bf1f326" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Visual testing of table charts in dark mode


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
