### PR TITLE
fix(dashboard): Navigate to new dashboard when saved as a new one

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -58,7 +58,7 @@ import { safeStringify } from 'src/utils/safeStringify';
 import { logEvent } from 'src/logger/actions';
 import { LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA } from 'src/logger/LogUtils';
 import { isEqual } from 'lodash';
-import { navigateWithState } from 'src/utils/navigationUtils';
+import { navigateWithState, navigateTo } from 'src/utils/navigationUtils';
 import { UPDATE_COMPONENTS_PARENTS_LIST } from './dashboardLayout';
 import {
   saveChartConfiguration,
@@ -368,6 +368,7 @@ export function saveDashboardRequest(data, id, saveType) {
         }),
       );
       dispatch(saveDashboardFinished());
+      navigateTo(`/superset/dashboard/${response.json.result.id}/`);
       dispatch(addSuccessToast(t('This dashboard was saved successfully.')));
       return response;
     };

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -30,6 +30,7 @@ import {
   DASHBOARD_GRID_ID,
   SAVE_TYPE_OVERWRITE,
   SAVE_TYPE_OVERWRITE_CONFIRMED,
+  SAVE_TYPE_NEWDASHBOARD,
 } from 'src/dashboard/util/constants';
 import {
   filterId,
@@ -37,10 +38,16 @@ import {
 } from 'spec/fixtures/mockSliceEntities';
 import { emptyFilters } from 'spec/fixtures/mockDashboardFilters';
 import mockDashboardData from 'spec/fixtures/mockDashboardData';
+import { navigateTo } from 'src/utils/navigationUtils';
 
 jest.mock('@superset-ui/core', () => ({
   ...jest.requireActual('@superset-ui/core'),
   isFeatureEnabled: jest.fn(),
+}));
+
+jest.mock('src/utils/navigationUtils', () => ({
+  navigateTo: jest.fn(),
+  navigateWithState: jest.fn(),
 }));
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
@@ -196,6 +203,35 @@ describe('dashboardState actions', () => {
         const { body } = putStub.getCall(0).args[0];
         expect(body).toBe(JSON.stringify(confirmedDashboardData));
       });
+    });
+
+    test('should navigate to the new dashboard after Save As', async () => {
+      const newDashboardId = 999;
+      const { getState, dispatch } = setup({
+        dashboardState: { hasUnsavedChanges: true },
+      });
+      
+      postStub.restore();
+      postStub = sinon.stub(SupersetClient, 'post').resolves({
+        json: {
+          result: {
+            ...mockDashboardData,
+            id: newDashboardId,
+          },
+        },
+      });
+
+      const thunk = saveDashboardRequest(
+        newDashboardData,
+        null,
+        SAVE_TYPE_NEWDASHBOARD,
+      );
+      await thunk(dispatch, getState);
+
+      await waitFor(() => expect(postStub.callCount).toBe(1));
+      expect(navigateTo).toHaveBeenCalledWith(
+        `/superset/dashboard/${newDashboardId}/`,
+      );
     });
   });
 });

--- a/superset-frontend/src/dashboard/actions/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.js
@@ -210,7 +210,7 @@ describe('dashboardState actions', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: true },
       });
-      
+
       postStub.restore();
       postStub = sinon.stub(SupersetClient, 'post').resolves({
         json: {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using the `Save as` functionality, after saving a new dashboard redirect user to that one.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Navigate to Dashboards
2. Open an existing one
3. Click on 3 dot menu and select save as
4. Click on save
5. The new dashboard is saved and loaded

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
