### PR TITLE
fix(explore): Remove query autotrigger

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/Shared_DeckGL.tsx
@@ -505,6 +505,7 @@ export const tooltipTemplate = {
   config: {
     type: TooltipTemplateControl,
     label: t('Customize tooltips template'),
+    renderTrigger: true,
     debounceDelay: 30,
     default: '',
     description: '',

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -371,15 +371,6 @@ function ExploreViewContainer(props) {
     props.form_data,
   ]);
 
-  // Simple debounced auto-query for non-renderTrigger controls
-  const debouncedAutoQuery = useMemo(
-    () =>
-      debounce(() => {
-        onQuery();
-      }, 1000), // 1 second delay
-    [onQuery],
-  );
-
   const handleKeydown = useCallback(
     event => {
       const controlOrCommand = event.ctrlKey || event.metaKey;
@@ -573,25 +564,8 @@ function ExploreViewContainer(props) {
       if (displayControlsChanged.length > 0) {
         reRenderChart(displayControlsChanged);
       }
-
-      // Auto-update for non-renderTrigger controls
-      const queryControlsChanged = changedControlKeys.filter(
-        key =>
-          !props.controls[key].renderTrigger &&
-          !props.controls[key].dontRefreshOnChange,
-      );
-      if (queryControlsChanged.length > 0) {
-        // Check if there are no validation errors before auto-updating
-        const hasErrors = Object.values(props.controls).some(
-          control =>
-            control.validationErrors && control.validationErrors.length > 0,
-        );
-        if (!hasErrors) {
-          debouncedAutoQuery();
-        }
-      }
     }
-  }, [props.controls, props.ownState, debouncedAutoQuery]);
+  }, [props.controls, props.ownState]);
 
   const chartIsStale = useMemo(() => {
     if (lastQueriedControls) {


### PR DESCRIPTION
### SUMMARY
PR https://github.com/apache/superset/pull/34276 added autotriggering a query after any change in the control panel. This is not an expected feature - triggering a query should be a conscious choice by the user.
This PR removes that feature and adds `renderTrigger` prop to the deckgl handlebars input.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
1. Open a deckgl chart in Explore
2. Change some controls - verify that the query is not triggered automatically
3. Make some changes in "Customize tooltips template" - verify that your changes are reflected in the chart without triggering a query

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
