### PR TITLE
fix(cache): ensure SQL is sanitized before cache key generation

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -129,6 +129,11 @@ class QueryContextProcessor:
         self, query_obj: QueryObject, force_cached: bool | None = False
     ) -> dict[str, Any]:
         """Handles caching around the df payload retrieval"""
+        if query_obj:
+            # Always validate the query object before generating cache key
+            # This ensures sanitize_clause() is called and extras are normalized
+            query_obj.validate()
+
         cache_key = self.query_cache_key(query_obj)
         timeout = self.get_cache_timeout()
         force_query = self._query_context.force or timeout == CACHE_DISABLED_TIMEOUT
@@ -138,10 +143,6 @@ class QueryContextProcessor:
             force_query=force_query,
             force_cached=force_cached,
         )
-
-        if query_obj:
-            # Always validate the query object before processing
-            query_obj.validate()
 
         if query_obj and cache_key and not cache.is_loaded:
             try:

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1480,6 +1480,15 @@ def sanitize_clause(clause: str, engine: str) -> str:
     Make sure the SQL clause is valid.
     """
     try:
-        return SQLStatement(clause, engine).format()
+        statement = SQLStatement(clause, engine)
+        dialect = SQLGLOT_DIALECTS.get(engine)
+        from sqlglot.dialects.dialect import Dialect
+
+        return Dialect.get_or_raise(dialect).generate(
+            statement._parsed,  # pylint: disable=protected-access
+            copy=True,
+            comments=False,
+            pretty=False,
+        )
     except SupersetParseError as ex:
         raise QueryClauseValidationException(f"Invalid SQL clause: {clause}") from ex

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -729,7 +729,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         rv = self.post_assert_metric(CHART_DATA_URI, self.query_context_payload, "data")
         result = rv.json["result"][0]["query"]
         if get_example_database().backend != "presto":
-            assert "(\n  'boy' = 'boy'\n)" in result
+            assert "('boy' = 'boy')" in result
 
     @unittest.skip("Extremely flaky test on MySQL")
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -273,22 +273,31 @@ class TestQueryContext(SupersetTestCase):
     def test_query_cache_key_consistent_with_different_sql_formatting(self):
         """
         Test that cache keys are consistent regardless of SQL clause formatting.
+
+        This test verifies the fix for the cache key mismatch issue where different
+        whitespace formatting in WHERE/HAVING clauses caused different cache keys
+        to be generated between server and worker processes.
         """
         # Create payload with compact WHERE clause
-        payload = get_query_context("birth_names")
-        payload["queries"][0]["extras"] = {"where": "(name = 'Amy')"}
+        payload1 = get_query_context("birth_names")
+        payload1["queries"][0]["extras"] = {"where": "(name = 'Amy')"}
 
-        query_context1 = ChartDataQueryContextSchema().load(payload)
-        query_object1 = query_context1.queries[0]
-        cache_key1 = query_context1.query_cache_key(query_object1)
+        query_context1 = ChartDataQueryContextSchema().load(payload1)
+        # Use get_df_payload which is the actual code path, not query_cache_key directly
+        result1 = query_context1.get_df_payload(
+            query_context1.queries[0], force_cached=False
+        )
+        cache_key1 = result1.get("cache_key")
 
         # Create same payload but with pretty-formatted WHERE clause (with newlines)
         payload2 = get_query_context("birth_names")
         payload2["queries"][0]["extras"] = {"where": "(\n  name = 'Amy'\n)"}
 
         query_context2 = ChartDataQueryContextSchema().load(payload2)
-        query_object2 = query_context2.queries[0]
-        cache_key2 = query_context2.query_cache_key(query_object2)
+        result2 = query_context2.get_df_payload(
+            query_context2.queries[0], force_cached=False
+        )
+        cache_key2 = result2.get("cache_key")
 
         # Cache keys should be identical after sanitization
         assert cache_key1 == cache_key2
@@ -298,15 +307,19 @@ class TestQueryContext(SupersetTestCase):
         payload3["queries"][0]["extras"] = {"having": "(sum__num > 100)"}
 
         query_context3 = ChartDataQueryContextSchema().load(payload3)
-        query_object3 = query_context3.queries[0]
-        cache_key3 = query_context3.query_cache_key(query_object3)
+        result3 = query_context3.get_df_payload(
+            query_context3.queries[0], force_cached=False
+        )
+        cache_key3 = result3.get("cache_key")
 
         payload4 = get_query_context("birth_names")
         payload4["queries"][0]["extras"] = {"having": "(\n  sum__num > 100\n)"}
 
         query_context4 = ChartDataQueryContextSchema().load(payload4)
-        query_object4 = query_context4.queries[0]
-        cache_key4 = query_context4.query_cache_key(query_object4)
+        result4 = query_context4.get_df_payload(
+            query_context4.queries[0], force_cached=False
+        )
+        cache_key4 = result4.get("cache_key")
 
         # Cache keys should be identical after sanitization
         assert cache_key3 == cache_key4

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -624,3 +624,81 @@ def test_processing_time_offsets_date_range_enabled(processor):
                                 assert isinstance(result["df"], pd.DataFrame)
                                 assert isinstance(result["queries"], list)
                                 assert isinstance(result["cache_keys"], list)
+
+
+def test_get_df_payload_validates_before_cache_key_generation():
+    """
+    Test that get_df_payload calls validate() before generating cache key.
+    """
+    from superset.common.query_object import QueryObject
+
+    # Create a mock query context
+    mock_query_context = MagicMock()
+    mock_query_context.force = False
+    mock_query_context.result_type = "full"
+
+    # Create a mock datasource
+    mock_datasource = MagicMock()
+    mock_datasource.id = 123
+    mock_datasource.uid = "test_datasource"
+    mock_datasource.cache_timeout = None
+    mock_datasource.database.db_engine_spec.engine = "postgresql"
+
+    # Create processor
+    processor = QueryContextProcessor(mock_query_context)
+    processor._qc_datasource = mock_datasource
+
+    # Create a query object with unsanitized where clause
+    query_obj = QueryObject(
+        datasource=mock_datasource,
+        columns=["col1"],
+        metrics=[],
+        extras={"where": "(\n  col1 > 0\n)"},  # Unsanitized with newlines
+    )
+
+    # Track the order of calls
+    call_order = []
+
+    original_validate = query_obj.validate
+
+    def mock_validate(*args, **kwargs):
+        call_order.append("validate")
+        # Update extras to simulate sanitization
+        query_obj.extras["where"] = "(col1 > 0)"  # Sanitized, compact format
+        return original_validate(*args, **kwargs)
+
+    original_cache_key = query_obj.cache_key
+
+    def mock_cache_key(*args, **kwargs):
+        call_order.append("cache_key")
+        # Verify that extras have been sanitized at this point
+        assert query_obj.extras["where"] == "(col1 > 0)", (
+            f"Expected sanitized clause in cache_key, got: {query_obj.extras['where']}"
+        )
+        return original_cache_key(*args, **kwargs)
+
+    with patch.object(query_obj, "validate", side_effect=mock_validate):
+        with patch.object(query_obj, "cache_key", side_effect=mock_cache_key):
+            with patch(
+                "superset.common.query_context_processor.QueryCacheManager"
+            ) as mock_cache_manager:
+                mock_cache = MagicMock()
+                mock_cache.is_loaded = True
+                mock_cache.df = pd.DataFrame({"col1": [1, 2, 3]})
+                mock_cache.query = "SELECT * FROM table"
+                mock_cache.error_message = None
+                mock_cache.status = "success"
+                mock_cache_manager.get.return_value = mock_cache
+
+                # Call get_df_payload
+                try:
+                    processor.get_df_payload(query_obj, force_cached=False)
+                except Exception:
+                    # We expect some errors due to mocking, but we only care about call order
+                    pass
+
+    # Verify validate was called before cache_key
+    assert call_order == ["validate", "cache_key"], (
+        f"Expected validate to be called before cache_key, "
+        f"but got call order: {call_order}"
+    )

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -643,6 +643,9 @@ def test_get_df_payload_validates_before_cache_key_generation():
     mock_datasource.uid = "test_datasource"
     mock_datasource.cache_timeout = None
     mock_datasource.database.db_engine_spec.engine = "postgresql"
+    mock_datasource.database.extra = "{}"
+    mock_datasource.get_extra_cache_keys.return_value = []
+    mock_datasource.changed_on = None
 
     # Create processor
     processor = QueryContextProcessor(mock_query_context)
@@ -691,11 +694,7 @@ def test_get_df_payload_validates_before_cache_key_generation():
                 mock_cache_manager.get.return_value = mock_cache
 
                 # Call get_df_payload
-                try:
-                    processor.get_df_payload(query_obj, force_cached=False)
-                except Exception:
-                    # We expect some errors due to mocking, but we only care about call order
-                    pass
+                processor.get_df_payload(query_obj, force_cached=False)
 
     # Verify validate was called before cache_key
     assert call_order == ["validate", "cache_key"], (

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2593,9 +2593,17 @@ def test_is_valid_cvas(sql: str, engine: str, expected: bool) -> None:
     [
         ("col = 1", "col = 1", "base"),
         ("1=\t\n1", "1 = 1", "base"),
-        ("(col = 1)", "(\n  col = 1\n)", "base"),
-        ("(col1 = 1) AND (col2 = 2)", "(\n  col1 = 1\n) AND (\n  col2 = 2\n)", "base"),
-        ("col = 'abc' -- comment", "col = 'abc' /* comment */", "base"),
+        ("(col = 1)", "(col = 1)", "base"),  # Compact format without newlines
+        (
+            "(col1 = 1) AND (col2 = 2)",
+            "(col1 = 1) AND (col2 = 2)",
+            "base",
+        ),  # Compact format
+        (
+            "col = 'abc' -- comment",
+            "col = 'abc'",
+            "base",
+        ),  # Comments removed for compact format
         ("col = 'col1 = 1) AND (col2 = 2'", "col = 'col1 = 1) AND (col2 = 2'", "base"),
         ("col = 'select 1; select 2'", "col = 'select 1; select 2'", "base"),
         ("col = 'abc -- comment'", "col = 'abc -- comment'", "base"),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes an isssue where we get a cache miss because we sanitize SQL clauses (where/having) when caching a query object, but not when reading it from the cache. With the migration to `sqlglot` this introduces additional whitespace to the clauses, which significantly alters them, causing the cache miss. But the root of the problem is the inconsistent validation when genereating the cache key on write vs. read.

I also changed the `sanitize_clause` method to strip whitespace and comments, making the key more compact and consistent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Updated and added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
