### PR TITLE
fix(pinot): dialect date truncation

### DIFF
--- a/superset/sql/dialects/pinot.py
+++ b/superset/sql/dialects/pinot.py
@@ -78,6 +78,12 @@ class Pinot(MySQL):
             exp.DataType.Type.UBIGINT: "UNSIGNED",
         }
 
+        TRANSFORMS = {
+            **MySQL.Generator.TRANSFORMS,
+        }
+        # Remove DATE_TRUNC transformation - Pinot supports standard SQL DATE_TRUNC
+        TRANSFORMS.pop(exp.DateTrunc, None)
+
         def datatype_sql(self, expression: exp.DataType) -> str:
             # Don't use MySQL's VARCHAR size requirement logic
             # Just use TYPE_MAPPING for all types
@@ -95,3 +101,8 @@ class Pinot(MySQL):
                 return f"{type_sql} UNSIGNED{nested}"
 
             return f"{type_sql}{nested}"
+
+        def cast_sql(self, expression: exp.Cast, safe_prefix: str | None = None) -> str:
+            # Pinot doesn't support MySQL's TIMESTAMP() function
+            # Use standard CAST syntax instead
+            return super(MySQL.Generator, self).cast_sql(expression, safe_prefix)

--- a/tests/unit_tests/sql/dialects/pinot_tests.py
+++ b/tests/unit_tests/sql/dialects/pinot_tests.py
@@ -431,7 +431,7 @@ def test_date_trunc_preserved() -> None:
     result = sqlglot.parse_one(sql, Pinot).sql(Pinot)
 
     assert "DATE_TRUNC" in result
-    assert "DATE_TRUNC('day'" in result or "DATE_TRUNC('DAY'" in result
+    assert "date_trunc('day'" in result.lower()
     # Should not be converted to MySQL's DATE() function
     assert result != "SELECT DATE(dt_column) FROM table"
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix time truncation in the Pinot dialect. Because it's based off the MySQL dialect it's converting:

```sql
SELECT CAST(DATE_TRUNC('day', col) AS TIMESTAMP)
```

Into:

```sql
SELECT TIMESTAMP(DATE(col))
```

Which is invalid since `TIMESTAMP()` is not a Pinot function.

With the changes in this PR it remains valid:

```sql
SELECT CAST(DATE_TRUNC('DAY', col) AS TIMESTAMP)
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
