### PR TITLE
fix(pinot): `DATE_SUB` function

### DIFF
--- a/superset/sql/dialects/pinot.py
+++ b/superset/sql/dialects/pinot.py
@@ -104,7 +104,7 @@ class Pinot(MySQL):
             ),
             exp.DateSub: lambda self, e: self.func(
                 "DATE_SUB",
-                e.args.get("unit"),
+                exp.Literal.string(str(e.args.get("unit").name)),
                 e.args.get("expression"),
                 e.this,
             ),

--- a/superset/sql/dialects/pinot.py
+++ b/superset/sql/dialects/pinot.py
@@ -59,6 +59,11 @@ class Pinot(MySQL):
                 expression=seq_get(args, 1),
                 unit=seq_get(args, 0),
             ),
+            "DATE_SUB": lambda args: exp.DateSub(
+                this=seq_get(args, 2),
+                expression=seq_get(args, 1),
+                unit=seq_get(args, 0),
+            ),
         }
 
     class Generator(MySQL.Generator):
@@ -94,6 +99,12 @@ class Pinot(MySQL):
             exp.DateAdd: lambda self, e: self.func(
                 "DATE_ADD",
                 exp.Literal.string(str(e.args.get("unit").name)),
+                e.args.get("expression"),
+                e.this,
+            ),
+            exp.DateSub: lambda self, e: self.func(
+                "DATE_SUB",
+                e.args.get("unit"),
                 e.args.get("expression"),
                 e.this,
             ),

--- a/tests/unit_tests/sql/dialects/pinot_tests.py
+++ b/tests/unit_tests/sql/dialects/pinot_tests.py
@@ -576,3 +576,17 @@ def test_pinot_date_sub_simple() -> None:
         # Verify that it generates valid SQL
         generated = parsed.sql(dialect=Pinot)
         assert "DATE_SUB" in generated.upper()
+
+
+def test_pinot_date_sub_unit_quoted() -> None:
+    """
+    Test that DATE_SUB preserves quotes around the unit argument.
+
+    Pinot requires the unit to be a quoted string, not an identifier.
+    """
+    sql = "dt_epoch_ms >= date_sub('day', -180, now())"
+    result = sqlglot.parse_one(sql, Pinot).sql(Pinot)
+
+    # The unit should be quoted: 'DAY' not DAY
+    assert "DATE_SUB('DAY', -180, NOW())" in result
+    assert "DATE_SUB(DAY," not in result


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Similar to https://github.com/apache/superset/pull/35424, but for `DATE_SUB`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
