### PR TITLE
fix(slice): Fix using isdigit when id passed as int

### DIFF
--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -367,7 +367,9 @@ class Slice(  # pylint: disable=too-many-public-methods
         return qry.one_or_none()
 
 
-def id_or_uuid_filter(id_or_uuid: str) -> BinaryExpression:
+def id_or_uuid_filter(id_or_uuid: str | int) -> BinaryExpression:
+    if isinstance(id_or_uuid, int):
+        return Slice.id == id_or_uuid
     if id_or_uuid.isdigit():
         return Slice.id == int(id_or_uuid)
     return Slice.uuid == id_or_uuid

--- a/tests/unit_tests/models/slice_test.py
+++ b/tests/unit_tests/models/slice_test.py
@@ -78,6 +78,7 @@ class TestSlice:
             ("numeric_id", "123"),
             ("uuid_format", "550e8400-e29b-41d4-a716-446655440000"),
             ("invalid_string", "not-a-number"),
+            ("integer_id", 123),
         ]
     )
     def test_id_or_uuid_filter(self, test_name, input_value):


### PR DESCRIPTION
### SUMMARY
Addressing the following error on the helper for slices when a thumbnail is retrieved from cache by the celery tasks.

```
line 371, in id_or_uuid_filter
    if id_or_uuid.isdigit():
AttributeError: 'int' object has no attribute 'isdigit'
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
