### PR TITLE
fix: fix intermittent unmount test failures

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/DatasetUsageTab.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/DatasetUsageTab.test.tsx
@@ -17,7 +17,9 @@
  * under the License.
  */
 import {
+  act,
   createWrapper,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -83,6 +85,9 @@ const mockChartsResponse = {
   ids: [1, 2],
 };
 
+// Store original scrollTo to restore after tests
+let originalScrollTo: typeof Element.prototype.scrollTo;
+
 const setupTest = (props = {}) => {
   const mockOnFetchCharts = jest.fn(() =>
     Promise.resolve({
@@ -101,21 +106,45 @@ const setupTest = (props = {}) => {
     ...props,
   };
 
-  return render(<DatasetUsageTab {...defaultProps} />, {
+  const result = render(<DatasetUsageTab {...defaultProps} />, {
     wrapper: createWrapper({
       useRedux: true,
       useRouter: true,
     }),
   });
+
+  return { ...result, mockOnFetchCharts };
 };
 
 beforeEach(() => {
   fetchMock.reset();
   jest.clearAllMocks();
+
+  // Save original scrollTo and mock it for JSDOM compatibility
+  originalScrollTo = Element.prototype.scrollTo;
+  Object.defineProperty(Element.prototype, 'scrollTo', {
+    value: jest.fn(),
+    configurable: true,
+    writable: true,
+  });
 });
 
 afterEach(() => {
   fetchMock.restore();
+
+  // Restore real timers in case a test with fakeTimers failed mid-test
+  jest.useRealTimers();
+
+  // Restore original scrollTo to avoid test pollution
+  if (originalScrollTo) {
+    Object.defineProperty(Element.prototype, 'scrollTo', {
+      value: originalScrollTo,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    delete (Element.prototype as any).scrollTo;
+  }
 });
 
 test('renders empty state when no charts provided', () => {
@@ -210,5 +239,156 @@ test('enables sorting for Chart and Last modified columns', async () => {
 
     expect(ownersHeader).not.toHaveClass('ant-table-column-has-sorters');
     expect(dashboardHeader).not.toHaveClass('ant-table-column-has-sorters');
+  });
+});
+
+test('clears scroll timeout on unmount to prevent async updates', async () => {
+  jest.useFakeTimers();
+
+  // Reuse the scrollTo mock from beforeEach
+  const scrollToMock = Element.prototype.scrollTo as jest.Mock;
+  scrollToMock.mockClear();
+
+  // Need enough charts to trigger pagination (PAGE_SIZE = 25)
+  const manyCharts = Array.from({ length: 51 }, (_, i) => ({
+    id: i + 1,
+    slice_name: `Test Chart ${i + 1}`,
+    url: `/explore/${i + 1}/`,
+    owners: [],
+    changed_on_delta_humanized: '1 day ago',
+    changed_by: null,
+    dashboards: [],
+  }));
+
+  const { unmount, mockOnFetchCharts } = setupTest({
+    charts: manyCharts,
+    totalCount: 51,
+  });
+
+  // Wait for pagination to appear
+  await waitFor(() => {
+    // Ant Design wires click handlers to the <a> element inside the <li>
+    expect(screen.getByRole('link', { name: '2' })).toBeInTheDocument();
+  });
+
+  // Trigger pagination change which starts a 100ms setTimeout
+  const page2Link = screen.getByRole('link', { name: '2' });
+  fireEvent.click(page2Link);
+
+  // Verify pagination was triggered
+  expect(mockOnFetchCharts).toHaveBeenCalledWith(2, 25, expect.any(String), expect.any(String));
+
+  // Unmount before timeout fires
+  unmount();
+
+  // Fast-forward time - scroll should NOT be called because timeout was cleared
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  // Critical assertion: scrollTo should never be called after unmount
+  expect(scrollToMock).not.toHaveBeenCalled();
+});
+
+test('clears pending scroll timeout on rapid pagination clicks', async () => {
+  jest.useFakeTimers();
+
+  // Reuse the scrollTo mock from beforeEach
+  const scrollToMock = Element.prototype.scrollTo as jest.Mock;
+  scrollToMock.mockClear();
+
+  // Need enough charts to trigger pagination (PAGE_SIZE = 25)
+  const manyCharts = Array.from({ length: 60 }, (_, i) => ({
+    id: i + 1,
+    slice_name: `Test Chart ${i + 1}`,
+    url: `/explore/${i + 1}/`,
+    owners: [],
+    changed_on_delta_humanized: '1 day ago',
+    changed_by: null,
+    dashboards: [],
+  }));
+
+  const { mockOnFetchCharts } = setupTest({
+    charts: manyCharts,
+    totalCount: 60,
+  });
+
+  // Wait for pagination to appear
+  await waitFor(() => {
+    // Ant Design wires click handlers to the <a> element inside the <li>
+    expect(screen.getByRole('link', { name: '2' })).toBeInTheDocument();
+  });
+
+  // Simulate rapid pagination clicks
+  const page2Link = screen.getByRole('link', { name: '2' });
+  const page3Link = screen.getByRole('link', { name: '3' });
+
+  fireEvent.click(page2Link); // Page 2 - starts timeout #1
+  expect(mockOnFetchCharts).toHaveBeenCalledWith(2, 25, expect.any(String), expect.any(String));
+
+  act(() => {
+    jest.advanceTimersByTime(50); // Halfway through timeout #1
+  });
+
+  fireEvent.click(page3Link); // Page 3 - should clear timeout #1, start timeout #2
+  expect(mockOnFetchCharts).toHaveBeenCalledWith(3, 25, expect.any(String), expect.any(String));
+
+  // Only the second timeout should execute
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  // Should only scroll once (second timeout), not twice
+  expect(scrollToMock).toHaveBeenCalledTimes(1);
+  expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+});
+
+test('scrolls table to top after pagination with delay', async () => {
+  jest.useFakeTimers();
+
+  // Reuse the scrollTo mock from beforeEach
+  const scrollToMock = Element.prototype.scrollTo as jest.Mock;
+  scrollToMock.mockClear();
+
+  // Need enough charts to trigger pagination (PAGE_SIZE = 25)
+  const manyCharts = Array.from({ length: 30 }, (_, i) => ({
+    id: i + 1,
+    slice_name: `Test Chart ${i + 1}`,
+    url: `/explore/${i + 1}/`,
+    owners: [],
+    changed_on_delta_humanized: '1 day ago',
+    changed_by: null,
+    dashboards: [],
+  }));
+
+  const { mockOnFetchCharts } = setupTest({
+    charts: manyCharts,
+    totalCount: 30,
+  });
+
+  // Wait for pagination to appear, then trigger it
+  await waitFor(() => {
+    // Ant Design wires click handlers to the <a> element inside the <li>
+    expect(screen.getByRole('link', { name: '2' })).toBeInTheDocument();
+  });
+
+  // Click page 2
+  const page2Link = screen.getByRole('link', { name: '2' });
+  fireEvent.click(page2Link);
+
+  // Verify pagination was triggered with correct page number
+  expect(mockOnFetchCharts).toHaveBeenCalledWith(2, 25, expect.any(String), expect.any(String));
+
+  // Scroll should not happen immediately
+  expect(scrollToMock).not.toHaveBeenCalled();
+
+  // After 100ms timeout, scroll should execute
+  act(() => {
+    jest.advanceTimersByTime(100);
+  });
+
+  expect(scrollToMock).toHaveBeenCalledWith({
+    top: 0,
+    behavior: 'smooth',
   });
 });

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
@@ -99,6 +99,7 @@ const DatasetUsageTab = ({
 }: DatasetUsageTabProps) => {
   const addDangerToastRef = useRef(addDangerToast);
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -132,11 +133,26 @@ const DatasetUsageTab = ({
     addDangerToastRef.current = addDangerToast;
   }, [addDangerToast]);
 
+  // Cleanup scroll timeout on unmount
+  useEffect(() => {
+    // eslint-disable-next-line arrow-body-style
+    return () => {
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handlePageChange = useCallback(
     (page: number) => {
       handleFetchCharts(page);
 
-      setTimeout(() => {
+      // Clear any pending scroll timeout
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+
+      scrollTimeoutRef.current = setTimeout(() => {
         const tableBody =
           tableContainerRef.current?.querySelector('.ant-table-body');
         if (tableBody) {
@@ -145,6 +161,7 @@ const DatasetUsageTab = ({
             behavior: 'smooth',
           });
         }
+        scrollTimeoutRef.current = null;
       }, 100);
     },
     [handleFetchCharts],
@@ -264,6 +281,7 @@ const DatasetUsageTab = ({
         recordCount={totalCount}
         usePagination
         defaultPageSize={PAGE_SIZE}
+        pagination={{ hideOnSinglePage: false }}
         loading={loading}
         size={TableSize.Middle}
         rowKey={(record: Chart) =>

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
@@ -261,14 +261,9 @@ const DatasetUsageTab = ({
         sticky
         columns={columns}
         data={charts}
-        pagination={{
-          current: currentPage,
-          total: totalCount,
-          pageSize: PAGE_SIZE,
-          onChange: handlePageChange,
-          showSizeChanger: false,
-          size: 'default',
-        }}
+        recordCount={totalCount}
+        usePagination
+        defaultPageSize={PAGE_SIZE}
         loading={loading}
         size={TableSize.Middle}
         rowKey={(record: Chart) =>

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
@@ -134,8 +134,8 @@ const DatasetUsageTab = ({
   }, [addDangerToast]);
 
   // Cleanup scroll timeout on unmount
+  // eslint-disable-next-line arrow-body-style
   useEffect(() => {
-    // eslint-disable-next-line arrow-body-style
     return () => {
       if (scrollTimeoutRef.current) {
         clearTimeout(scrollTimeoutRef.current);

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
@@ -281,7 +281,12 @@ const DatasetUsageTab = ({
         recordCount={totalCount}
         usePagination
         defaultPageSize={PAGE_SIZE}
-        pagination={{ hideOnSinglePage: false }}
+        pagination={{
+          current: currentPage,
+          total: totalCount,
+          pageSize: PAGE_SIZE,
+          hideOnSinglePage: false,
+        }}
         loading={loading}
         size={TableSize.Middle}
         rowKey={(record: Chart) =>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Fixes intermittent test failure in DatasetUsageTab causing "document global was defined..." React error.

**Problem**: PR #34707 introduced an unmanaged `setTimeout` in the `handlePageChange` callback that caused async updates after test cleanup. When the component unmounted before the 100ms timeout fired, React would throw an error about the missing document global.

**Root Cause**: The pagination scroll behavior used a bare `setTimeout` without cleanup:
  ```typescript
  setTimeout(() => {
    const tableBody = tableContainerRef.current?.querySelector('.ant-table-body');
    if (tableBody) {
      tableBody.scrollTo({ top: 0, behavior: 'smooth' });
    }
  }, 100);
 ```

**Solution:** Implement proper timeout cleanup using useRef + useEffect:
  - Track timeout IDs with scrollTimeoutRef
  - Clear timeout on component unmount via cleanup function
  - Clear pending timeouts before setting new ones (prevents duplicate scrolls)
  - Set ref to null after timeout executes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Verify tests pass: `npm test -- DatasetUsageTab.test.tsx`
2. Expected: All 12 tests pass, including the 3 new timeout cleanup tests
3. Verify no intermittent errors: `npm test -- ExploreChartPanel DatasetUsageTab`
4. Expected: All 20 tests pass without "document global was defined..." error
5. Test manual pagination (if testing UI):
    - Navigate to a dataset with >25 charts
    - Click pagination rapidly (page 2 → page 3 → page 4)
    - Verify table scrolls to top smoothly without duplicate scroll operations

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
