### PR TITLE
fix(TimeTable): resolve TypeScript OOM by simplifying sparkline series type

### DIFF
--- a/superset-frontend/src/visualizations/TimeTable/components/SparklineCell/SparklineCell.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/SparklineCell/SparklineCell.tsx
@@ -28,8 +28,6 @@ import {
   Tooltip,
   XYChart,
   buildChartTheme,
-  type SeriesProps,
-  AxisScale,
 } from '@visx/xychart';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 import {
@@ -134,14 +132,16 @@ const SparklineCell = ({
   const xAccessor = (d: { x: number; y: number }) => d.x;
   const yAccessor = (d: { x: number; y: number }) => d.y;
 
-  const chartSeriesMap: Record<
-    SparkType,
-    (props: SeriesProps<AxisScale, AxisScale, object>) => JSX.Element
-  > = {
+  type SparklineSeriesComponent =
+    | typeof LineSeries
+    | typeof BarSeries
+    | typeof AreaSeries;
+
+  const chartSeriesMap = {
     line: LineSeries,
     bar: BarSeries,
     area: AreaSeries,
-  };
+  } as const satisfies Record<SparkType, SparklineSeriesComponent>;
 
   const SeriesComponent = chartSeriesMap[sparkType] || LineSeries;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  
Fixes TypeScript heap out of memory error during compilation caused by overly complex type annotation in `SparklineCell.tsx`. This was part of PR #35180.

The issue occurs when TypeScript attempts to resolve `Record<SparkType, (props: SeriesProps<AxisScale, AxisScale, object>) => JSX.Element>`, which forces full resolution of deeply recursive generics from `@visx/xychart`, causing exponential type inference complexity and memory exhaustion.

**Solution**: Replace explicit type annotation with type inference using `as const satisfies` pattern:

  ```typescript
  type SparklineSeriesComponent =
    | typeof LineSeries
    | typeof BarSeries
    | typeof AreaSeries;

  const chartSeriesMap = {
    line: LineSeries,
    bar: BarSeries,
    area: AreaSeries,
  } as const satisfies Record<SparkType, SparklineSeriesComponent>;
 ```

  This approach:
  - Avoids forcing TypeScript to resolve expensive SeriesProps generics
  - Preserves full type safety with precise union types
  - Follows "NO any types" modernization guideline
  - No runtime behavior changes

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
