### PR TITLE
feat(reports): allow custom na values

### DIFF
--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -344,13 +344,12 @@ def apply_client_processing(  # noqa: C901
             # Use custom NA values configuration for
             # reports to avoid unwanted conversions
             # This allows users to control which values should be treated as null/NA
-            na_values = current_app.config.get("REPORTS_CSV_NA_NAMES", None)
-            if na_values is not None:
-                df = pd.read_csv(
-                    StringIO(data), keep_default_na=False, na_values=na_values
-                )
-            else:
-                df = pd.read_csv(StringIO(data))
+            na_values = current_app.config["REPORTS_CSV_NA_NAMES"]
+            df = pd.read_csv(
+                StringIO(data),
+                keep_default_na=na_value is None,
+                na_values=na_values,
+            )
 
         # convert all columns to verbose (label) name
         if datasource:

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -345,7 +345,10 @@ def apply_client_processing(  # noqa: C901
             # reports to avoid unwanted conversions
             # This allows users to control which values should be treated as null/NA
             na_values = current_app.config.get("REPORTS_CSV_NA_NAMES", None)
-            df = pd.read_csv(StringIO(data), keep_default_na=False, na_values=na_values)
+            if na_values is not None:
+                df = pd.read_csv(StringIO(data), keep_default_na=False, na_values=na_values)
+            else:
+                df = pd.read_csv(StringIO(data))
 
         # convert all columns to verbose (label) name
         if datasource:

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -347,7 +347,7 @@ def apply_client_processing(  # noqa: C901
             na_values = current_app.config["REPORTS_CSV_NA_NAMES"]
             df = pd.read_csv(
                 StringIO(data),
-                keep_default_na=na_value is None,
+                keep_default_na=na_values is None,
                 na_values=na_values,
             )
 

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -30,6 +30,7 @@ from typing import Any, Optional, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd
+from flask import current_app
 from flask_babel import gettext as __
 
 from superset.common.chart_data import ChartDataResultFormat
@@ -340,7 +341,11 @@ def apply_client_processing(  # noqa: C901
         if query["result_format"] == ChartDataResultFormat.JSON:
             df = pd.DataFrame.from_dict(data)
         elif query["result_format"] == ChartDataResultFormat.CSV:
-            df = pd.read_csv(StringIO(data))
+            # Use custom NA values configuration for
+            # reports to avoid unwanted conversions
+            # This allows users to control which values should be treated as null/NA
+            na_values = current_app.config.get("REPORTS_CSV_NA_NAMES", None)
+            df = pd.read_csv(StringIO(data), keep_default_na=False, na_values=na_values)
 
         # convert all columns to verbose (label) name
         if datasource:

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -346,7 +346,9 @@ def apply_client_processing(  # noqa: C901
             # This allows users to control which values should be treated as null/NA
             na_values = current_app.config.get("REPORTS_CSV_NA_NAMES", None)
             if na_values is not None:
-                df = pd.read_csv(StringIO(data), keep_default_na=False, na_values=na_values)
+                df = pd.read_csv(
+                    StringIO(data), keep_default_na=False, na_values=na_values
+                )
             else:
                 df = pd.read_csv(StringIO(data))
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1354,6 +1354,15 @@ ALLOWED_USER_CSV_SCHEMA_FUNC = allowed_schemas_for_csv_upload
 # Values that should be treated as nulls for the csv uploads.
 CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
 
+# Values that should be treated as nulls for scheduled reports CSV processing.
+# By default, uses the same values as CSV uploads. Set to None to disable
+# automatic NA conversion (preserving original string values like "NA"),
+# or provide a custom list of values that should be treated as null.
+# Examples:
+# REPORTS_CSV_NA_NAMES = None  # Disable all automatic NA conversion
+# REPORTS_CSV_NA_NAMES = ["", "NULL", "null"]  # Only treat these as NA
+REPORTS_CSV_NA_NAMES = CSV_DEFAULT_NA_NAMES
+
 # Chunk size for reading CSV files during uploads
 # Smaller values use less memory but may be slower for large files
 READ_CSV_CHUNK_SIZE = 1000

--- a/superset/config.py
+++ b/superset/config.py
@@ -1361,7 +1361,7 @@ CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
 # REPORTS_CSV_NA_NAMES = None  # Use default pandas NA handling (backwards compatible)
 # REPORTS_CSV_NA_NAMES = []    # Disable all automatic NA conversion
 # REPORTS_CSV_NA_NAMES = ["", "NULL", "null"]  # Only treat these specific values as NA
-REPORTS_CSV_NA_NAMES = list(CSV_DEFAULT_NA_NAMES)
+REPORTS_CSV_NA_NAMES: list[str] | None = None
 
 # Chunk size for reading CSV files during uploads
 # Smaller values use less memory but may be slower for large files

--- a/superset/config.py
+++ b/superset/config.py
@@ -1355,12 +1355,12 @@ ALLOWED_USER_CSV_SCHEMA_FUNC = allowed_schemas_for_csv_upload
 CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
 
 # Values that should be treated as nulls for scheduled reports CSV processing.
-# By default, uses the same values as CSV uploads. Set to None to disable
-# automatic NA conversion (preserving original string values like "NA"),
-# or provide a custom list of values that should be treated as null.
+# If not set or None, defaults to standard pandas NA handling behavior.
+# Set to a custom list to control which values should be treated as null.
 # Examples:
-# REPORTS_CSV_NA_NAMES = None  # Disable all automatic NA conversion
-# REPORTS_CSV_NA_NAMES = ["", "NULL", "null"]  # Only treat these as NA
+# REPORTS_CSV_NA_NAMES = None  # Use default pandas NA handling (backwards compatible)
+# REPORTS_CSV_NA_NAMES = []    # Disable all automatic NA conversion
+# REPORTS_CSV_NA_NAMES = ["", "NULL", "null"]  # Only treat these specific values as NA
 REPORTS_CSV_NA_NAMES = list(CSV_DEFAULT_NA_NAMES)
 
 # Chunk size for reading CSV files during uploads

--- a/superset/config.py
+++ b/superset/config.py
@@ -1361,7 +1361,7 @@ CSV_DEFAULT_NA_NAMES = list(STR_NA_VALUES)
 # Examples:
 # REPORTS_CSV_NA_NAMES = None  # Disable all automatic NA conversion
 # REPORTS_CSV_NA_NAMES = ["", "NULL", "null"]  # Only treat these as NA
-REPORTS_CSV_NA_NAMES = CSV_DEFAULT_NA_NAMES
+REPORTS_CSV_NA_NAMES = list(CSV_DEFAULT_NA_NAMES)
 
 # Chunk size for reading CSV files during uploads
 # Smaller values use less memory but may be slower for large files

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2657,8 +2657,8 @@ def test_pivot_multi_level_index():
 
 def test_apply_client_processing_csv_format_preserves_na_strings():
     """
-    Test that apply_client_processing preserves "NA" strings
-    when REPORTS_CSV_NA_NAMES is set to empty list.
+    Test that apply_client_processing preserves "NA" when REPORTS_CSV_NA_NAMES is [].
+
     This ensures that scheduled reports can be configured to
     preserve strings like "NA" as literal values.
     """

--- a/tests/unit_tests/utils/csv_tests.py
+++ b/tests/unit_tests/utils/csv_tests.py
@@ -127,6 +127,21 @@ def fake_get_chart_csv_data_hierarchical(chart_url, auth_cookies=None):
     return json.dumps(fake_result).encode("utf-8")
 
 
+def fake_get_chart_csv_data_with_na_values(chart_url, auth_cookies=None):
+    # Return JSON with data containing "NA" string value that will be treated as null
+    fake_result = {
+        "result": [
+            {
+                "data": {"first_name": ["Jeff", "Alice"], "last_name": ["Smith", "NA"]},
+                "coltypes": [GenericDataType.STRING, GenericDataType.STRING],
+                "colnames": ["first_name", "last_name"],
+                "indexnames": ["idx1", "idx2"],
+            }
+        ]
+    }
+    return json.dumps(fake_result).encode("utf-8")
+
+
 def test_df_to_escaped_csv():
     df = pd.DataFrame(
         data={
@@ -263,3 +278,39 @@ def test_get_chart_dataframe_with_hierarchical_columns(monkeypatch: pytest.Monke
 | ('idx',) |                 2 |
 """
     assert markdown_str.strip() == expected_markdown_str.strip()
+
+
+def test_get_chart_dataframe_removes_na_string_values(monkeypatch: pytest.MonkeyPatch):
+    """
+    Test that get_chart_dataframe currently removes rows containing "NA" string values.
+    This test verifies the existing behavior before implementing custom NA handling.
+    """
+    monkeypatch.setattr(
+        csv, "get_chart_csv_data", fake_get_chart_csv_data_with_na_values
+    )
+    df = get_chart_dataframe("http://dummy-url")
+    assert df is not None
+
+    # Verify the DataFrame structure
+    expected_columns = pd.MultiIndex.from_tuples([("first_name",), ("last_name",)])
+    pd.testing.assert_index_equal(df.columns, expected_columns)
+
+    expected_index = pd.MultiIndex.from_tuples([("idx1",), ("idx2",)])
+    pd.testing.assert_index_equal(df.index, expected_index)
+
+    # Check that we have both rows initially
+    assert len(df) == 2
+
+    # Verify the data contains the "NA" string value (not converted to NaN)
+    pd.testing.assert_series_equal(
+        df[("first_name",)],
+        pd.Series(["Jeff", "Alice"], name=("first_name",), index=df.index),
+    )
+    pd.testing.assert_series_equal(
+        df[("last_name",)],
+        pd.Series(["Smith", "NA"], name=("last_name",), index=df.index),
+    )
+
+    last_name_values = df[("last_name",)].values
+    assert last_name_values[0] == "Smith"
+    assert last_name_values[1] == "NA"

--- a/tests/unit_tests/utils/csv_tests.py
+++ b/tests/unit_tests/utils/csv_tests.py
@@ -280,11 +280,14 @@ def test_get_chart_dataframe_with_hierarchical_columns(monkeypatch: pytest.Monke
     assert markdown_str.strip() == expected_markdown_str.strip()
 
 
- def test_get_chart_dataframe_preserves_na_string_values(monkeypatch: pytest.MonkeyPatch):
-     """
-     Test that get_chart_dataframe currently preserves rows containing "NA" string values.
-     This test verifies the existing behavior before implementing custom NA handling.
-     """
+def test_get_chart_dataframe_preserves_na_string_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that get_chart_dataframe currently preserves rows containing "NA"
+    string values.
+    This test verifies the existing behavior before implementing custom NA handling.
+    """
     monkeypatch.setattr(
         csv, "get_chart_csv_data", fake_get_chart_csv_data_with_na_values
     )

--- a/tests/unit_tests/utils/csv_tests.py
+++ b/tests/unit_tests/utils/csv_tests.py
@@ -280,11 +280,11 @@ def test_get_chart_dataframe_with_hierarchical_columns(monkeypatch: pytest.Monke
     assert markdown_str.strip() == expected_markdown_str.strip()
 
 
-def test_get_chart_dataframe_removes_na_string_values(monkeypatch: pytest.MonkeyPatch):
-    """
-    Test that get_chart_dataframe currently removes rows containing "NA" string values.
-    This test verifies the existing behavior before implementing custom NA handling.
-    """
+ def test_get_chart_dataframe_preserves_na_string_values(monkeypatch: pytest.MonkeyPatch):
+     """
+     Test that get_chart_dataframe currently preserves rows containing "NA" string values.
+     This test verifies the existing behavior before implementing custom NA handling.
+     """
     monkeypatch.setattr(
         csv, "get_chart_csv_data", fake_get_chart_csv_data_with_na_values
     )


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
We have encountered a case wherein a user's surname is being excluded from a report as the name is `NA`. Pandas' exclusion list for `null` values includes the value `NA`. I propose that we add a new feature flag to complement the existing one in place for uploads to allow users to customise which values are or are not allowed, `CSV_DEFAULT_NA_NAMES`. 

For instance, in our use case, we would set the configuration as follows:

```python
CSV_DEFAULT_NA_NAMES = [value for value in list(STR_NA_VALUES) if value != 'NA']
REPORTS_CSV_NA_NAMES = list(CSV_DEFAULT_NA_NAMES)
```

The video below shows the before and after effect of this in action. To start, we see the config using the default value of 

```python
from pandas._libs.parsers import STR_NA_VALUES
```

Afterwards, I reload the config with the above example, where we filter out `NA` from the list, allowing our user to have their data sent in a report.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/76d406d0-ec85-41d9-9a15-d989936c7ab7


### TESTING INSTRUCTIONS
I have added unit tests as well as deployed the changes locally. However, to test:
1. Build and launch this branch
2. Create a new Dataset with the following query: `select 'NANANANA' as first_name, 'JEFF' as middle_name, 'NA' as last_name`
3. Create a report with a Chart based on this query
4. Update the config to filter out `NA` from the list
5. Rerun report

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
