### PR TITLE
fix(sqlglot): adhoc expressions

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1467,7 +1467,7 @@ class SqlaTable(
 
             if not processed:
                 try:
-                    expression = self._process_sql_expression(
+                    expression = self._process_select_expression(
                         expression=expression,
                         database_id=self.database_id,
                         engine=self.database.backend,
@@ -1502,7 +1502,7 @@ class SqlaTable(
         """
         label = utils.get_column_name(col)
         try:
-            expression = self._process_sql_expression(
+            expression = self._process_select_expression(
                 expression=col["sqlExpression"],
                 database_id=self.database_id,
                 engine=self.database.backend,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1922,12 +1922,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                             template_processor=template_processor,
                         )
                     else:
-                        selected = validate_adhoc_subquery(
-                            selected,
-                            self.database,
-                            self.catalog,
-                            self.schema,
-                            self.database.db_engine_spec.engine,
+                        selected = self._process_select_expression(
+                            expression=selected,
+                            database_id=self.database_id,
+                            engine=self.database.backend,
+                            schema=self.schema,
+                            template_processor=template_processor,
                         )
                         outer = literal_column(f"({selected})")
                         outer = self.make_sqla_column_compatible(outer, selected)
@@ -1951,12 +1951,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     _sql = quote(selected)
                     _column_label = selected
 
-                selected = validate_adhoc_subquery(
-                    _sql,
-                    self.database,
-                    self.catalog,
-                    self.schema,
-                    self.database.db_engine_spec.engine,
+                selected = self._process_select_expression(
+                    expression=_sql,
+                    database_id=self.database_id,
+                    engine=self.database.backend,
+                    schema=self.schema,
+                    template_processor=template_processor,
                 )
 
                 select_exprs.append(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -871,6 +871,40 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 raise QueryObjectValidationError(ex.message) from ex
         return expression
 
+    def _process_select_expression(
+        self,
+        expression: Optional[str],
+        database_id: int,
+        engine: str,
+        schema: str,
+        template_processor: Optional[BaseTemplateProcessor],
+    ) -> Optional[str]:
+        """
+        Validate and process an adhoc expression used as a column or metric.
+
+        This requires prefixing the expression with a dummy SELECT statement, so it can
+        be properly parsed and validated.
+        """
+        if expression:
+            expression = f"SELECT {expression}"
+
+        if processed := self._process_sql_expression(
+            expression=expression,
+            database_id=database_id,
+            engine=engine,
+            schema=schema,
+            template_processor=template_processor,
+        ):
+            prefix, expression = re.split(
+                r"SELECT\s+",
+                processed,
+                maxsplit=1,
+                flags=re.IGNORECASE,
+            )
+            return expression.strip()
+
+        return None
+
     def _process_orderby_expression(
         self,
         expression: Optional[str],
@@ -1200,7 +1234,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             expression = metric.get("sqlExpression")
 
             if not processed:
-                expression = self._process_sql_expression(
+                expression = self._process_select_expression(
                     expression=metric["sqlExpression"],
                     database_id=self.database_id,
                     engine=self.database.backend,
@@ -2196,7 +2230,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         if extras:
             where = extras.get("where")
             if where:
-                where = self._process_sql_expression(
+                where = self._process_select_expression(
                     expression=where,
                     database_id=self.database_id,
                     engine=self.database.backend,
@@ -2206,7 +2240,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 where_clause_and += [self.text(where)]
             having = extras.get("having")
             if having:
-                having = self._process_sql_expression(
+                having = self._process_select_expression(
                     expression=having,
                     database_id=self.database_id,
                     engine=self.database.backend,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR refactors adhoc SQL expression validation to properly handle expressions used as columns and metrics (e.g., `COUNT(*)`, `DISTINCT owners`, `CASE` statements).

**Problem:**
Adhoc SQL expressions in metrics, columns, WHERE, and HAVING clauses were being validated using `_process_sql_expression()`, which doesn't wrap them in a SELECT statement. This caused sqlglot parsing failures for valid expressions like `distinct owners` because they're not complete SQL statements on their own.

**Solution:**
- Introduced new `_process_select_expression()` method that wraps expressions in `SELECT {expression}` for validation, then extracts the processed result
- Updated all adhoc expression processing to use the appropriate method:
  - `_process_select_expression()` for metrics, columns, WHERE, and HAVING clauses
  - `_process_orderby_expression()` (existing) for ORDER BY clauses
  - `_process_sql_expression()` remains for complete SQL statements
- Applied changes consistently across both `ExploreMixin` (base) and `SqlaTable` (override)
- Added comprehensive unit tests including end-to-end validation with real sqlglot processing

**Files Changed:**
- `superset/models/helpers.py`: Added `_process_select_expression()` and updated 5 call sites
- `superset/connectors/sqla/models.py`: Updated 2 override methods to use new function
- `tests/unit_tests/models/helpers_test.py`: Added 9 unit tests covering edge cases and end-to-end flows

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before: 😢 

<img width="1728" height="1080" alt="Screenshot 2025-10-03 at 11 38 15 AM" src="https://github.com/user-attachments/assets/e8b1c99e-1f34-46ca-ac08-aa0dbc7e7619" />

After: 😍 

<img width="1728" height="1080" alt="Screenshot 2025-10-03 at 11 38 42 AM" src="https://github.com/user-attachments/assets/a76758b0-19a1-490a-b2ae-33e900d58e1b" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
