### PR TITLE
fix(Select): Prevent closing the select when clicking on a tag

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -779,6 +779,38 @@ test('Renders only an overflow tag if dropdown is open in oneLine mode', async (
   expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
 });
 
+// Test for checking the issue described in: https://github.com/apache/superset/issues/35132
+test('Maintains stable maxTagCount to prevent click target disappearing in oneLine mode', async () => {
+  render(
+    <Select
+      {...defaultProps}
+      value={[OPTIONS[0], OPTIONS[1], OPTIONS[2]]}
+      mode="multiple"
+      oneLine
+    />,
+  );
+
+  const withinSelector = within(getElementByClassName('.ant-select-selector'));
+  expect(withinSelector.getByText(OPTIONS[0].label)).toBeVisible();
+  expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
+
+  await userEvent.click(getSelect());
+  expect(withinSelector.getByText(OPTIONS[0].label)).toBeVisible();
+
+  await waitFor(() => {
+    expect(
+      withinSelector.queryByText(OPTIONS[0].label),
+    ).not.toBeInTheDocument();
+    expect(withinSelector.getByText('+ 3 ...')).toBeVisible();
+  });
+
+  // Close dropdown
+  await type('{esc}');
+
+  expect(await withinSelector.findByText(OPTIONS[0].label)).toBeVisible();
+  expect(withinSelector.getByText('+ 2 ...')).toBeVisible();
+});
+
 test('does not render "Select all" when there are 0 or 1 options', async () => {
   const { rerender } = render(
     <Select {...defaultProps} options={[]} mode="multiple" allowNewOptions />,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes an issue where clicking on tags in the Select component's `oneLine` mode would cause the dropdown to not open because the click target would disappear during the click event.

The problem occurred when `oneLine` mode changed `maxTagCount` from 1 to 0 immediately when the dropdown was opened, causing the tag element to disappear while the user was clicking on it, preventing the click from registering.

**Solution:**
- Introduced a stable `maxTagCount` state that doesn't change immediately during click events
- Used `requestAnimationFrame` to delay the tag count change until after the DOM has settled
- Added proper state management with `useRef` to track when the dropdown is opening to prevent race conditions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before:** Clicking on tags in oneLine mode would sometimes fail to open the dropdown because the tag would disappear mid-click.

**After:** Tags remain stable during click events, ensuring the dropdown opens reliably when clicking on any tag.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a Select component with `mode="multiple"` and `oneLine={true}`
2. Set a value with multiple options so tags are displayed with overflow (e.g., 3+ options)
3. Click directly on the first visible tag
4. Verify that the dropdown opens consistently every time
5. Verify that when the dropdown opens, only the overflow tag is shown
6. Close the dropdown and verify the first tag reappears immediately

**Test case:**
```tsx
<Select
  mode="multiple"
  oneLine
  value={[option1, option2, option3]}
  options={options}
/>
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35132
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API