### PR TITLE
fix(explore): Include chart canvases in the screenshot

### DIFF
--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -393,6 +393,7 @@ export const useExploreAdditionalActionsMenu = (
             '.panel-body .chart-container',
             slice?.slice_name ?? t('New chart'),
             true,
+            theme,
           )(e.domEvent);
           setIsDropdownVisible(false);
           dispatch(

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -209,9 +209,8 @@ const preserveCanvasContent = (original: Element, clone: Element) => {
   const originalCanvases = original.querySelectorAll('canvas');
   const clonedCanvases = clone.querySelectorAll('canvas');
 
-  for (let i = 0; i < originalCanvases.length; i++) {
+  originalCanvases.forEach((originalCanvas, i) => {
     if (originalCanvases[i] && clonedCanvases[i]) {
-      const originalCanvas = originalCanvases[i] as HTMLCanvasElement;
       const clonedCanvas = clonedCanvases[i] as HTMLCanvasElement;
       const ctx = clonedCanvas.getContext('2d');
       if (ctx) {
@@ -220,7 +219,7 @@ const preserveCanvasContent = (original: Element, clone: Element) => {
         ctx.drawImage(originalCanvas, 0, 0);
       }
     }
-  }
+  });
 };
 
 const createEnhancedClone = (

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -205,11 +205,30 @@ const processCloneForVisibility = (clone: HTMLElement) => {
     });
 };
 
+const preserveCanvasContent = (original: Element, clone: Element) => {
+  const originalCanvases = original.querySelectorAll('canvas');
+  const clonedCanvases = clone.querySelectorAll('canvas');
+  
+  for (let i = 0; i < originalCanvases.length; i++) {
+    if (originalCanvases[i] && clonedCanvases[i]) {
+      const originalCanvas = originalCanvases[i] as HTMLCanvasElement;
+      const clonedCanvas = clonedCanvases[i] as HTMLCanvasElement;
+      const ctx = clonedCanvas.getContext('2d');
+      if (ctx) {
+        clonedCanvas.width = originalCanvas.width;
+        clonedCanvas.height = originalCanvas.height;
+        ctx.drawImage(originalCanvas, 0, 0);
+      }
+    }
+  }
+};
+
 const createEnhancedClone = (
   originalElement: Element,
 ): { clone: HTMLElement; cleanup: () => void } => {
   const clone = originalElement.cloneNode(true) as HTMLElement;
   copyAllComputedStyles(originalElement, clone);
+  preserveCanvasContent(originalElement, clone);
 
   const tempContainer = document.createElement('div');
   tempContainer.style.cssText = `

--- a/superset-frontend/src/utils/downloadAsImage.ts
+++ b/superset-frontend/src/utils/downloadAsImage.ts
@@ -208,7 +208,7 @@ const processCloneForVisibility = (clone: HTMLElement) => {
 const preserveCanvasContent = (original: Element, clone: Element) => {
   const originalCanvases = original.querySelectorAll('canvas');
   const clonedCanvases = clone.querySelectorAll('canvas');
-  
+
   for (let i = 0; i < originalCanvases.length; i++) {
     if (originalCanvases[i] && clonedCanvases[i]) {
       const originalCanvas = originalCanvases[i] as HTMLCanvasElement;


### PR DESCRIPTION
### SUMMARY
Fixes the "Download as image" functionality in Explore view that was exporting blank images. The issue was that Canvas elements lose their pixel data when cloned using `cloneNode(true)`, which is used in the image download process to hide UI elements and handle styling.

This PR adds Canvas content preservation to the cloning process by:
- Adding a `preserveCanvasContent` function that copies Canvas pixel data using `drawImage()`
- Maintaining all existing cloning benefits (hiding menus, handling scrollable content, copying computed styles)
- Ensuring chart visualizations render correctly in downloaded images

The root cause was that many chart libraries (D3.js, etc.) use Canvas elements for rendering, and these were being cloned as empty canvases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** Download as image exported only background color (blank image)
**After:** Download as image captures the complete chart visualization

### TESTING INSTRUCTIONS
1. Go to Explore view and create any chart (line chart, bar chart, etc.)
2. Click the menu button (⋮) in the top right
3. Select "Download" → "Download as image"
4. Verify the downloaded image contains the chart visualization and is not blank

### ADDITIONAL INFORMATION
- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API