### PR TITLE
fix: Support metric macro for  embedded users

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -1088,10 +1088,9 @@ def metric_macro(
 
     # Embedded user access is validated at the dashboard level, so we bypass
     # the regular DAO filter for them
-    dataset = (
-        DatasetDAO.find_by_id(dataset_id)
-        if not security_manager.is_guest_user()
-        else DatasetDAO.find_by_id(dataset_id, skip_base_filter=True)
+    dataset = DatasetDAO.find_by_id(
+        dataset_id,
+        skip_base_filter=security_manager.is_guest_user(),
     )
     if not dataset:
         raise DatasetNotFoundError(f"Dataset ID {dataset_id} not found.")

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -1086,7 +1086,13 @@ def metric_macro(
     if not dataset_id:
         dataset_id = get_dataset_id_from_context(metric_key)
 
-    dataset = DatasetDAO.find_by_id(dataset_id)
+    # Embedded user access is validated at the dashboard level, so we bypass
+    # the regular DAO filter for them
+    dataset = (
+        DatasetDAO.find_by_id(dataset_id)
+        if not security_manager.is_guest_user()
+        else DatasetDAO.find_by_id(dataset_id, skip_base_filter=True)
+    )
     if not dataset:
         raise DatasetNotFoundError(f"Dataset ID {dataset_id} not found.")
 

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1252,6 +1252,79 @@ def test_metric_macro_no_dataset_id_available_in_request_form_data(
         assert metric_macro(env, {}, "macro_key") == "COUNT(*)"
 
 
+def test_metric_macro_regular_user_uses_base_filter(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` uses base filter for regular users.
+
+    Regular users should have standard RBAC/RLS filters applied when accessing datasets.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = False
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = SqlaTable(
+        table_name="test_dataset",
+        metrics=[
+            SqlMetric(metric_name="count", expression="COUNT(*)"),
+        ],
+        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
+        schema="my_schema",
+        sql=None,
+    )
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    # Verify that find_by_id was called without skip_base_filter
+    DatasetDAO.find_by_id.assert_called_once_with(1, skip_base_filter=False)
+
+
+def test_metric_macro_regular_user_raises_no_access(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` raises for regular user without dataset access.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = False
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = None
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    with pytest.raises(DatasetNotFoundError) as excinfo:
+        assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    assert str(excinfo.value) == "Dataset ID 1 not found."
+    DatasetDAO.find_by_id.assert_called_once_with(1, skip_base_filter=False)
+
+
+def test_metric_macro_embedded_user_skips_base_filter(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` skips base filter for embedded users.
+
+    Embedded users have dashboard-level access control via their embedding token,
+    so we bypass the regular dataset DAO filters for them.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = True
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = SqlaTable(
+        table_name="test_dataset",
+        metrics=[
+            SqlMetric(metric_name="count", expression="COUNT(*)"),
+        ],
+        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
+        schema="my_schema",
+        sql=None,
+    )
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    # Verify that find_by_id was called with skip_base_filter=True
+    DatasetDAO.find_by_id.assert_called_once_with(1, skip_base_filter=True)
+
+
 @pytest.mark.parametrize(
     "description,args,kwargs,sqlalchemy_uri,queries,time_filter,removed_filters,applied_filters",
     [
@@ -1566,76 +1639,3 @@ def test_jinja2_server_error_handling(mocker: MockerFixture) -> None:
         assert "Internal Jinja2 template error" in str(exception)
         assert "MemoryError" in str(exception)
         assert "Out of memory" in str(exception)
-
-
-def test_metric_macro_regular_user_uses_base_filter(mocker: MockerFixture) -> None:
-    """
-    Test that the ``metric_macro`` uses base filter for regular users.
-
-    Regular users should have standard RBAC/RLS filters applied when accessing datasets.
-    """
-    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
-    mock_is_guest_user.return_value = False
-
-    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
-    DatasetDAO.find_by_id.return_value = SqlaTable(
-        table_name="test_dataset",
-        metrics=[
-            SqlMetric(metric_name="count", expression="COUNT(*)"),
-        ],
-        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
-        schema="my_schema",
-        sql=None,
-    )
-
-    env = SandboxedEnvironment(undefined=DebugUndefined)
-    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
-
-    # Verify that find_by_id was called without skip_base_filter
-    DatasetDAO.find_by_id.assert_called_once_with(1)
-
-
-def test_metric_macro_regular_user_raises_no_access(mocker: MockerFixture) -> None:
-    """
-    Test that the ``metric_macro`` raises for regular user without dataset access.
-    """
-    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
-    mock_is_guest_user.return_value = False
-
-    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
-    DatasetDAO.find_by_id.return_value = None
-
-    env = SandboxedEnvironment(undefined=DebugUndefined)
-    with pytest.raises(DatasetNotFoundError) as excinfo:
-        assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
-
-    assert str(excinfo.value) == "Dataset ID 1 not found."
-    DatasetDAO.find_by_id.assert_called_once_with(1)
-
-
-def test_metric_macro_embedded_user_skips_base_filter(mocker: MockerFixture) -> None:
-    """
-    Test that the ``metric_macro`` skips base filter for embedded users.
-
-    Embedded users have dashboard-level access control via their embedding token,
-    so we bypass the regular dataset DAO filters for them.
-    """
-    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
-    mock_is_guest_user.return_value = True
-
-    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
-    DatasetDAO.find_by_id.return_value = SqlaTable(
-        table_name="test_dataset",
-        metrics=[
-            SqlMetric(metric_name="count", expression="COUNT(*)"),
-        ],
-        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
-        schema="my_schema",
-        sql=None,
-    )
-
-    env = SandboxedEnvironment(undefined=DebugUndefined)
-    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
-
-    # Verify that find_by_id was called with skip_base_filter=True
-    DatasetDAO.find_by_id.assert_called_once_with(1, skip_base_filter=True)

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -1566,3 +1566,76 @@ def test_jinja2_server_error_handling(mocker: MockerFixture) -> None:
         assert "Internal Jinja2 template error" in str(exception)
         assert "MemoryError" in str(exception)
         assert "Out of memory" in str(exception)
+
+
+def test_metric_macro_regular_user_uses_base_filter(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` uses base filter for regular users.
+
+    Regular users should have standard RBAC/RLS filters applied when accessing datasets.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = False
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = SqlaTable(
+        table_name="test_dataset",
+        metrics=[
+            SqlMetric(metric_name="count", expression="COUNT(*)"),
+        ],
+        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
+        schema="my_schema",
+        sql=None,
+    )
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    # Verify that find_by_id was called without skip_base_filter
+    DatasetDAO.find_by_id.assert_called_once_with(1)
+
+
+def test_metric_macro_regular_user_raises_no_access(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` raises for regular user without dataset access.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = False
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = None
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    with pytest.raises(DatasetNotFoundError) as excinfo:
+        assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    assert str(excinfo.value) == "Dataset ID 1 not found."
+    DatasetDAO.find_by_id.assert_called_once_with(1)
+
+
+def test_metric_macro_embedded_user_skips_base_filter(mocker: MockerFixture) -> None:
+    """
+    Test that the ``metric_macro`` skips base filter for embedded users.
+
+    Embedded users have dashboard-level access control via their embedding token,
+    so we bypass the regular dataset DAO filters for them.
+    """
+    mock_is_guest_user = mocker.patch("superset.security_manager.is_guest_user")
+    mock_is_guest_user.return_value = True
+
+    DatasetDAO = mocker.patch("superset.daos.dataset.DatasetDAO")  # noqa: N806
+    DatasetDAO.find_by_id.return_value = SqlaTable(
+        table_name="test_dataset",
+        metrics=[
+            SqlMetric(metric_name="count", expression="COUNT(*)"),
+        ],
+        database=Database(database_name="my_database", sqlalchemy_uri="sqlite://"),
+        schema="my_schema",
+        sql=None,
+    )
+
+    env = SandboxedEnvironment(undefined=DebugUndefined)
+    assert metric_macro(env, {}, "count", 1) == "COUNT(*)"
+
+    # Verify that find_by_id was called with skip_base_filter=True
+    DatasetDAO.find_by_id.assert_called_once_with(1, skip_base_filter=True)


### PR DESCRIPTION
### SUMMARY
The `{{ metric() }}` macro checks if the current user has access to the dataset the metric syntax is coming from. This check is currently not working for embedded users, as they don't have access to datasets.

This PR fixes this issue by skipping this validation for embedded users, as the embedded permission is granted at the dashboard level (if the guest user has access to the dashboard, they should see all in it).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
No UI changes.

### TESTING INSTRUCTIONS
1. Create a chart using the `{{ metric() }}` macro.
2. Access it in embedded mode and confirm the chart works properly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
