### PR TITLE
fix(deckgl): scatterplot fix categorical color

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -163,6 +163,25 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
           }));
         }
         case COLOR_SCHEME_TYPES.categorical_palette: {
+          // If no dimension selected, fall back to fixed color
+          if (!fd.dimension) {
+            const fallbackColor = fd.color_picker || {
+              r: 0,
+              g: 0,
+              b: 0,
+              a: 100,
+            };
+            return data.map(d => ({
+              ...d,
+              color: [
+                fallbackColor.r,
+                fallbackColor.g,
+                fallbackColor.b,
+                fallbackColor.a * 255,
+              ],
+            }));
+          }
+
           return data.map(d => ({
             ...d,
             color: hexToRGB(colorFn(d.cat_color, fd.slice_id)),

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/CategoricalDeckGLContainer.tsx
@@ -156,14 +156,11 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
       switch (selectedColorScheme) {
         case COLOR_SCHEME_TYPES.fixed_color: {
           color = fd.color_picker || { r: 0, g: 0, b: 0, a: 100 };
+          const colorArray = [color.r, color.g, color.b, color.a * 255];
 
-          return data.map(d => ({
-            ...d,
-            color: [color.r, color.g, color.b, color.a * 255],
-          }));
+          return data.map(d => ({ ...d, color: colorArray }));
         }
         case COLOR_SCHEME_TYPES.categorical_palette: {
-          // If no dimension selected, fall back to fixed color
           if (!fd.dimension) {
             const fallbackColor = fd.color_picker || {
               r: 0,
@@ -171,15 +168,13 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
               b: 0,
               a: 100,
             };
-            return data.map(d => ({
-              ...d,
-              color: [
-                fallbackColor.r,
-                fallbackColor.g,
-                fallbackColor.b,
-                fallbackColor.a * 255,
-              ],
-            }));
+            const colorArray = [
+              fallbackColor.r,
+              fallbackColor.g,
+              fallbackColor.b,
+              fallbackColor.a * 255,
+            ];
+            return data.map(d => ({ ...d, color: colorArray }));
           }
 
           return data.map(d => ({
@@ -209,17 +204,17 @@ const CategoricalDeckGLContainer = (props: CategoricalDeckGLContainerProps) => {
                   d.metric <= breakpoint.maxValue,
               );
 
-            return {
-              ...d,
-              color: breakpointForPoint
-                ? [
-                    breakpointForPoint?.color.r,
-                    breakpointForPoint?.color.g,
-                    breakpointForPoint?.color.b,
-                    breakpointForPoint?.color.a * 255,
-                  ]
-                : defaultBreakpointColor,
-            };
+            if (breakpointForPoint) {
+              const pointColor = [
+                breakpointForPoint.color.r,
+                breakpointForPoint.color.g,
+                breakpointForPoint.color.b,
+                breakpointForPoint.color.a * 255,
+              ];
+              return { ...d, color: pointColor };
+            }
+
+            return { ...d, color: defaultBreakpointColor };
           });
         }
         default: {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -46,14 +46,14 @@ export interface DeckScatterFormData
   min_radius?: number;
   max_radius?: number;
   color_picker?: { r: number; g: number; b: number; a: number };
-  category_name?: string;
+  dimension?: string;
 }
 
 export default function buildQuery(formData: DeckScatterFormData) {
   const {
     spatial,
     point_radius_fixed,
-    category_name,
+    dimension,
     js_columns,
     tooltip_contents,
   } = formData;
@@ -67,8 +67,8 @@ export default function buildQuery(formData: DeckScatterFormData) {
       const spatialColumns = getSpatialColumns(spatial);
       let columns = [...(baseQueryObject.columns || []), ...spatialColumns];
 
-      if (category_name) {
-        columns.push(category_name);
+      if (dimension) {
+        columns.push(dimension);
       }
 
       const columnStrings = columns.map(col =>

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.ts
@@ -134,9 +134,7 @@ const config: ControlPanelConfig = {
       controlSetRows: [
         [legendPosition],
         [legendFormat],
-        ...generateDeckGLColorSchemeControls({
-          defaultSchemeType: COLOR_SCHEME_TYPES.fixed_color,
-        }),
+        ...generateDeckGLColorSchemeControls({}),
       ],
     },
     {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/controlPanel.ts
@@ -37,7 +37,6 @@ import {
   tooltipContents,
   tooltipTemplate,
 } from '../../utilities/Shared_DeckGL';
-import { COLOR_SCHEME_TYPES } from '../../utilities/utils';
 
 const config: ControlPanelConfig = {
   onInit: controlState => ({

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -95,7 +95,7 @@ function processScatterData(
 
 export default function transformProps(chartProps: ChartProps) {
   const { rawFormData: formData } = chartProps;
-  const { spatial, point_radius_fixed, category_name, js_columns } =
+  const { spatial, point_radius_fixed, dimension, js_columns } =
     formData as DeckScatterFormData;
 
   const radiusMetricLabel = getMetricLabelFromFormData(point_radius_fixed);
@@ -104,7 +104,7 @@ export default function transformProps(chartProps: ChartProps) {
     records,
     spatial,
     radiusMetricLabel,
-    category_name,
+    dimension,
     js_columns,
   );
 


### PR DESCRIPTION
### SUMMARY
There was an issue with the deck.gl Scatterplot chart categorical color after refactor from legacy API.
1. Fixes the categorical colors. It was not showing points at all when categorical color was selected
2. When no categorical column is selected, it falls back to the fixed color value if available
3. Changes the default color palette from fixed to categorical

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: Fixes #35499
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
