### PR TITLE
refactor(db): use Dialect instead of Engine in select_star to avoid SSH tunnels

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1651,7 +1651,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         cls,
         database: Database,
         table: Table,
-        engine: Engine,
+        dialect: Dialect,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -1665,7 +1665,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
 
         :param database: Database instance
         :param table: Table instance
-        :param engine: SqlAlchemy Engine instance
+        :param dialect: SqlAlchemy Dialect instance
         :param limit: limit to impose on query
         :param show_cols: Show columns in query; otherwise use "*"
         :param indent: Add indentation to query
@@ -1685,7 +1685,7 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         if show_cols:
             fields = cls._get_fields(cols)
 
-        full_table_name = cls.quote_table(table, engine.dialect)
+        full_table_name = cls.quote_table(table, dialect)
         qry = select(fields).select_from(text(full_table_name))
 
         qry = qry.limit(limit)

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -32,6 +32,7 @@ from marshmallow import fields, Schema
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import column, func, types
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql import column as sql_column, select, sqltypes
@@ -721,7 +722,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         cls,
         database: Database,
         table: Table,
-        engine: Engine,
+        dialect: Dialect,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -781,7 +782,7 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         return super().select_star(
             database,
             table,
-            engine,
+            dialect,
             limit,
             show_cols,
             indent,

--- a/superset/db_engine_specs/hive.py
+++ b/superset/db_engine_specs/hive.py
@@ -31,7 +31,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from flask import current_app as app, g
 from sqlalchemy import Column, text, types
-from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.sql.expression import ColumnClause, Select
@@ -492,7 +492,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         cls,
         database: Database,
         table: Table,
-        engine: Engine,
+        dialect: Dialect,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -505,7 +505,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         return super(PrestoEngineSpec, cls).select_star(
             database,
             table,
-            engine,
+            dialect,
             limit,
             show_cols,
             indent,

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -34,7 +34,7 @@ from flask import current_app as app
 from flask_babel import gettext as __, lazy_gettext as _
 from packaging.version import Version
 from sqlalchemy import Column, literal_column, types
-from sqlalchemy.engine.base import Engine
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.result import Row as ResultRow
 from sqlalchemy.engine.url import URL
@@ -1100,7 +1100,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         cls,
         database: Database,
         table: Table,
-        engine: Engine,
+        dialect: Dialect,
         limit: int = 100,
         show_cols: bool = False,
         indent: bool = True,
@@ -1124,7 +1124,7 @@ class PrestoEngineSpec(PrestoBaseEngineSpec):
         return super().select_star(
             database,
             table,
-            engine,
+            dialect,
             limit,
             show_cols,
             indent,

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -833,17 +833,17 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
         cols: list[ResultSetColumnType] | None = None,
     ) -> str:
         """Generates a ``select *`` statement in the proper dialect"""
-        with self.get_sqla_engine(catalog=table.catalog, schema=table.schema) as engine:
-            return self.db_engine_spec.select_star(
-                self,
-                table,
-                engine=engine,
-                limit=limit,
-                show_cols=show_cols,
-                indent=indent,
-                latest_partition=latest_partition,
-                cols=cols,
-            )
+        dialect = self.get_dialect()
+        return self.db_engine_spec.select_star(
+            self,
+            table,
+            dialect=dialect,
+            limit=limit,
+            show_cols=show_cols,
+            indent=indent,
+            latest_partition=latest_partition,
+            cols=cols,
+        )
 
     def apply_limit_to_sql(
         self,

--- a/tests/unit_tests/db_engine_specs/test_base.py
+++ b/tests/unit_tests/db_engine_specs/test_base.py
@@ -229,13 +229,12 @@ def test_select_star(mocker: MockerFixture) -> None:
         query.compile(dialect=sqlite.dialect())
     )
 
-    engine = mocker.MagicMock()
-    engine.dialect = sqlite.dialect()
+    dialect = sqlite.dialect()
 
     sql = BaseEngineSpec.select_star(
         database=database,
         table=Table("my_table", "my_schema", "my_catalog"),
-        engine=engine,
+        dialect=dialect,
         limit=100,
         show_cols=True,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -154,13 +154,12 @@ def test_select_star(mocker: MockerFixture) -> None:
         query.compile(dialect=BigQueryDialect(), compile_kwargs={"literal_binds": True})
     )
 
-    engine = mocker.MagicMock()
-    engine.dialect = BigQueryDialect()
+    dialect = BigQueryDialect()
 
     sql = BigQueryEngineSpec.select_star(
         database=database,
         table=Table("my_table"),
-        engine=engine,
+        dialect=dialect,
         limit=100,
         show_cols=True,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_hive.py
+++ b/tests/unit_tests/db_engine_specs/test_hive.py
@@ -71,7 +71,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     from superset.db_engine_specs.hive import HiveEngineSpec
 
     database = mocker.MagicMock()
-    engine = mocker.MagicMock()
+    dialect = mocker.MagicMock()
 
     def quote_table(table: Table, dialect: Dialect) -> str:
         return ".".join(
@@ -83,7 +83,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     HiveEngineSpec.select_star(
         database=database,
         table=Table("my_table", "my_schema", "my_catalog"),
-        engine=engine,
+        dialect=dialect,
         limit=100,
         show_cols=False,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -252,7 +252,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     Test the ``select_star`` method.
     """
     database = mocker.MagicMock()
-    engine = mocker.MagicMock()
+    dialect = mocker.MagicMock()
 
     def quote_table(table: Table, dialect: Dialect) -> str:
         return ".".join(
@@ -264,7 +264,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     spec.select_star(
         database=database,
         table=Table("my_table", "my_schema", "my_catalog"),
-        engine=engine,
+        dialect=dialect,
         limit=100,
         show_cols=False,
         indent=True,

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -314,7 +314,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     from superset.db_engine_specs.presto import PrestoEngineSpec as spec  # noqa: N813
 
     database = mocker.MagicMock()
-    engine = mocker.MagicMock()
+    dialect = mocker.MagicMock()
 
     def quote_table(table: Table, dialect: Dialect) -> str:
         return ".".join(
@@ -326,7 +326,7 @@ def test_select_star(mocker: MockerFixture) -> None:
     spec.select_star(
         database=database,
         table=Table("my_table", "my_schema", "my_catalog"),
-        engine=engine,
+        dialect=dialect,
         limit=100,
         show_cols=False,
         indent=True,


### PR DESCRIPTION
### SUMMARY
Refactors the `select_star` method across all database engine specs to use `dialect: Dialect` instead of `engine: Engine` as a parameter. This optimization prevents unnecessary SSH tunnel connections from being created when only the database dialect is needed for SQL generation.

**Problem**: The previous implementation used `get_sqla_engine()` which establishes a full database connection (including SSH tunnels when configured), but the `select_star` method only needs the dialect to generate SQL statements.

**Solution**: 
- Changed `select_star` method signature from `engine: Engine` to `dialect: Dialect` in `BaseEngineSpec` and all subclasses (BigQuery, Hive, Presto)
- Updated `Database.select_star()` to call lightweight `get_dialect()` instead of `get_sqla_engine()`
- Removed unused `Engine` imports from Hive and Presto engine specs
- Updated all related unit tests to pass `dialect` instead of `engine`

**Impact**: This reduces unnecessary connection overhead, particularly for databases configured with SSH tunnels, improving performance when generating SELECT statements for table previews.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend refactoring only, no UI changes

### TESTING INSTRUCTIONS
1. Run the updated unit tests:
   ```bash
   pytest tests/unit_tests/db_engine_specs/ -k select_star -v
   ```
   All 5 tests should pass (base, bigquery, hive, postgres, presto)

2. Verify type checking passes:
   ```bash
   pre-commit run mypy
   ```

3. (Optional) Test with a database configured with SSH tunnel:
   - Configure a database connection with SSH tunnel
   - View a table in SQL Lab
   - Verify table preview loads correctly without creating extra SSH connections

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)