### PR TITLE
fix(export): replace iframe with fetch to avoid CSP frame-src violations

### DIFF
--- a/superset-frontend/src/features/home/ChartTable.test.tsx
+++ b/superset-frontend/src/features/home/ChartTable.test.tsx
@@ -129,14 +129,13 @@ test('renders mine tab on click', async () => {
 
 test('handles chart export with correct ID and shows spinner', async () => {
   // Mock export to take some time before calling the done callback
-  mockExport.mockImplementation(
-    (resource: string, ids: number[], done: () => void) =>
-      new Promise(resolve => {
-        setTimeout(() => {
-          done();
-          resolve();
-        }, 100);
-      }),
+  mockExport.mockImplementation((resource: string, ids: number[], done: () => void) =>
+    new Promise(resolve => {
+      setTimeout(() => {
+        done();
+        resolve();
+      }, 100);
+    }),
   );
 
   await renderChartTable(mineTabProps);

--- a/superset-frontend/src/features/home/ChartTable.test.tsx
+++ b/superset-frontend/src/features/home/ChartTable.test.tsx
@@ -129,13 +129,14 @@ test('renders mine tab on click', async () => {
 
 test('handles chart export with correct ID and shows spinner', async () => {
   // Mock export to take some time before calling the done callback
-  mockExport.mockImplementation((resource: string, ids: number[], done: () => void) =>
-    new Promise(resolve => {
-      setTimeout(() => {
-        done();
-        resolve();
-      }, 100);
-    }),
+  mockExport.mockImplementation(
+    (resource: string, ids: number[], done: () => void) =>
+      new Promise(resolve => {
+        setTimeout(() => {
+          done();
+          resolve();
+        }, 100);
+      }),
   );
 
   await renderChartTable(mineTabProps);

--- a/superset-frontend/src/features/home/ChartTable.test.tsx
+++ b/superset-frontend/src/features/home/ChartTable.test.tsx
@@ -47,7 +47,7 @@ fetchMock.get(chartsEndpoint, {
 });
 
 fetchMock.get(chartsInfoEndpoint, {
-  permissions: ['can_add', 'can_edit', 'can_delete'],
+  permissions: ['can_add', 'can_edit', 'can_delete', 'can_export'],
 });
 
 fetchMock.get(chartFavoriteStatusEndpoint, {

--- a/superset-frontend/src/features/home/ChartTable.test.tsx
+++ b/superset-frontend/src/features/home/ChartTable.test.tsx
@@ -117,10 +117,11 @@ test('renders mine tab on click', async () => {
 });
 
 test('handles chart export with correct ID and shows spinner', async () => {
-  const mockExport = jest.fn().mockImplementation(() => {
-    // Simulate async export that takes some time
-    return new Promise(resolve => setTimeout(resolve, 100));
-  });
+  const mockExport = jest
+    .fn()
+    .mockImplementation(() =>
+      new Promise(resolve => setTimeout(resolve, 100)),
+    );
 
   jest.mock('src/utils/export', () => ({
     __esModule: true,

--- a/superset-frontend/src/features/home/ChartTable.tsx
+++ b/superset-frontend/src/features/home/ChartTable.tsx
@@ -132,12 +132,17 @@ function ChartTable({
     setLoaded(true);
   }, [activeTab]);
 
-  const handleBulkChartExport = (chartsToExport: Chart[]) => {
+  const handleBulkChartExport = async (chartsToExport: Chart[]) => {
     const ids = chartsToExport.map(({ id }) => id);
-    handleResourceExport('chart', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('chart', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected charts'));
+    }
   };
 
   const menuTabs = [

--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -28,8 +28,8 @@ import { Router } from 'react-router-dom';
 import { configureStore } from '@reduxjs/toolkit';
 import fetchMock from 'fetch-mock';
 import * as hooks from 'src/views/CRUD/hooks';
-import DashboardTable from './DashboardTable';
 import handleResourceExport from 'src/utils/export';
+import DashboardTable from './DashboardTable';
 
 // Mock the export module
 jest.mock('src/utils/export', () => ({

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -118,12 +118,17 @@ function DashboardTable({
     setLoaded(true);
   }, [activeTab]);
 
-  const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
+  const handleBulkDashboardExport = async (dashboardsToExport: Dashboard[]) => {
     const ids = dashboardsToExport.map(({ id }) => id);
-    handleResourceExport('dashboard', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('dashboard', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected dashboards'));
+    }
   };
 
   const handleDashboardEdit = (edits: Dashboard) =>

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -241,12 +241,17 @@ function ChartList(props: ChartListProps) {
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
-  const handleBulkChartExport = (chartsToExport: Chart[]) => {
+  const handleBulkChartExport = async (chartsToExport: Chart[]) => {
     const ids = chartsToExport.map(({ id }) => id);
-    handleResourceExport('chart', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('chart', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected charts'));
+    }
   };
 
   function handleBulkChartDelete(chartsToDelete: Chart[]) {

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -274,12 +274,19 @@ function DashboardList(props: DashboardListProps) {
     );
   }
 
-  const handleBulkDashboardExport = (dashboardsToExport: Dashboard[]) => {
+  const handleBulkDashboardExport = async (
+    dashboardsToExport: Dashboard[],
+  ) => {
     const ids = dashboardsToExport.map(({ id }) => id);
-    handleResourceExport('dashboard', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('dashboard', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected dashboards'));
+    }
   };
 
   function handleBulkDashboardDelete(dashboardsToDelete: Dashboard[]) {

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -274,9 +274,7 @@ function DashboardList(props: DashboardListProps) {
     );
   }
 
-  const handleBulkDashboardExport = async (
-    dashboardsToExport: Dashboard[],
-  ) => {
+  const handleBulkDashboardExport = async (dashboardsToExport: Dashboard[]) => {
     const ids = dashboardsToExport.map(({ id }) => id);
     setPreparingExport(true);
     try {

--- a/superset-frontend/src/pages/DatabaseList/index.tsx
+++ b/superset-frontend/src/pages/DatabaseList/index.tsx
@@ -331,15 +331,20 @@ function DatabaseList({
     ];
   }
 
-  function handleDatabaseExport(database: DatabaseObject) {
+  async function handleDatabaseExport(database: DatabaseObject) {
     if (database.id === undefined) {
       return;
     }
 
-    handleResourceExport('database', [database.id], () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('database', [database.id], () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the database'));
+    }
   }
 
   function handleDatabasePermSync(database: DatabaseObject) {

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -275,12 +275,17 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
     setDatasetCurrentlyDuplicating(dataset);
   };
 
-  const handleBulkDatasetExport = (datasetsToExport: Dataset[]) => {
+  const handleBulkDatasetExport = async (datasetsToExport: Dataset[]) => {
     const ids = datasetsToExport.map(({ id }) => id);
-    handleResourceExport('dataset', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('dataset', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected datasets'));
+    }
   };
 
   const columns = useMemo(

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -291,14 +291,19 @@ function SavedQueryList({
     );
   };
 
-  const handleBulkSavedQueryExport = (
+  const handleBulkSavedQueryExport = async (
     savedQueriesToExport: SavedQueryObject[],
   ) => {
     const ids = savedQueriesToExport.map(({ id }) => id);
-    handleResourceExport('saved_query', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('saved_query', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected queries'));
+    }
   };
 
   const handleBulkQueryDelete = (queriesToDelete: SavedQueryObject[]) => {

--- a/superset-frontend/src/pages/ThemeList/index.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.tsx
@@ -221,14 +221,19 @@ function ThemesList({
     setAppliedThemeId(null);
   }
 
-  const handleBulkThemeExport = (themesToExport: ThemeObject[]) => {
+  const handleBulkThemeExport = async (themesToExport: ThemeObject[]) => {
     const ids = themesToExport
       .map(({ id }) => id)
       .filter((id): id is number => id !== undefined);
-    handleResourceExport('theme', ids, () => {
-      setPreparingExport(false);
-    });
     setPreparingExport(true);
+    try {
+      await handleResourceExport('theme', ids, () => {
+        setPreparingExport(false);
+      });
+    } catch (error) {
+      setPreparingExport(false);
+      addDangerToast(t('There was an issue exporting the selected themes'));
+    }
   };
 
   const openThemeImportModal = () => {

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { SupersetClient } from '@superset-ui/core';
+import { SupersetClient, logging } from '@superset-ui/core';
 import contentDisposition from 'content-disposition';
 import handleResourceExport from './export';
 
@@ -214,7 +214,6 @@ test('parses filename from Content-Disposition with quotes', async () => {
 });
 
 test('warns when export exceeds maximum blob size', async () => {
-  const { logging } = jest.requireMock('@superset-ui/core');
   const largeFileSize = 150 * 1024 * 1024; // 150MB
 
   mockResponse = {

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -74,15 +74,20 @@ beforeEach(() => {
   createObjectURLSpy = jest
     .spyOn(window.URL, 'createObjectURL')
     .mockReturnValue('blob:mock-url');
-  revokeObjectURLSpy = jest
-    .spyOn(window.URL, 'revokeObjectURL')
-    .mockImplementation(() => {});
+
+  // Create revokeObjectURL if it doesn't exist
+  if (!window.URL.revokeObjectURL) {
+    window.URL.revokeObjectURL = jest.fn();
+  }
+  revokeObjectURLSpy = jest.spyOn(window.URL, 'revokeObjectURL');
 });
 
 afterEach(() => {
   createElementSpy.mockRestore();
   createObjectURLSpy.mockRestore();
-  revokeObjectURLSpy.mockRestore();
+  if (revokeObjectURLSpy) {
+    revokeObjectURLSpy.mockRestore();
+  }
 });
 
 test('exports resource with correct endpoint and headers', async () => {

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -118,7 +118,7 @@ test('creates blob and triggers download', async () => {
   const anchor = document.createElement('a');
   expect(anchor.href).toBe('blob:mock-url');
   expect(anchor.download).toBe('dashboard_export.zip');
-  expect(anchor).toHaveStyle({ display: 'none' });
+  expect(anchor.style.display).toBe('none');
 
   // Check that click was triggered
   expect(anchor.click).toHaveBeenCalled();

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SupersetClient } from '@superset-ui/core';
+import handleResourceExport from './export';
+
+// Mock dependencies
+jest.mock('@superset-ui/core', () => ({
+  SupersetClient: {
+    get: jest.fn(),
+  },
+  logging: {
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('content-disposition', () => ({
+  parse: jest.fn(),
+}));
+
+jest.mock('./pathUtils', () => ({
+  ensureAppRoot: jest.fn((path: string) => path),
+}));
+
+describe('handleResourceExport', () => {
+  let mockBlob: Blob;
+  let mockResponse: Response;
+  let createElementSpy: jest.SpyInstance;
+  let createObjectURLSpy: jest.SpyInstance;
+  let revokeObjectURLSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Mock Blob
+    mockBlob = new Blob(['test data'], { type: 'application/zip' });
+
+    // Mock Response with Headers
+    mockResponse = {
+      headers: new Headers({
+        'Content-Disposition': 'attachment; filename="dashboard_export.zip"',
+      }),
+      blob: jest.fn().mockResolvedValue(mockBlob),
+    } as unknown as Response;
+
+    // Mock SupersetClient.get
+    (SupersetClient.get as jest.Mock).mockResolvedValue(mockResponse);
+
+    // Mock DOM APIs
+    const mockAnchor = document.createElement('a');
+    mockAnchor.click = jest.fn();
+    createElementSpy = jest
+      .spyOn(document, 'createElement')
+      .mockReturnValue(mockAnchor);
+    jest.spyOn(document.body, 'appendChild').mockImplementation(() => mockAnchor);
+    jest.spyOn(document.body, 'removeChild').mockImplementation(() => mockAnchor);
+
+    // Mock URL.createObjectURL and revokeObjectURL
+    createObjectURLSpy = jest
+      .spyOn(window.URL, 'createObjectURL')
+      .mockReturnValue('blob:mock-url');
+    revokeObjectURLSpy = jest
+      .spyOn(window.URL, 'revokeObjectURL')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    createElementSpy.mockRestore();
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+  });
+
+  test('exports resource with correct endpoint and headers', async () => {
+    const doneMock = jest.fn();
+    await handleResourceExport('dashboard', [1, 2, 3], doneMock);
+
+    expect(SupersetClient.get).toHaveBeenCalledWith({
+      endpoint: '/api/v1/dashboard/export/?q=!(1,2,3)',
+      headers: {
+        Accept: 'application/zip, application/x-zip-compressed, text/plain',
+      },
+      parseMethod: 'raw',
+    });
+  });
+
+  test('creates blob and triggers download', async () => {
+    const doneMock = jest.fn();
+    await handleResourceExport('dashboard', [1], doneMock);
+
+    // Check that blob was created
+    expect(mockResponse.blob).toHaveBeenCalled();
+
+    // Check that object URL was created
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+
+    // Check that anchor element was created and configured
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const anchor = document.createElement('a');
+    expect(anchor.href).toBe('blob:mock-url');
+    expect(anchor.download).toBe('dashboard_export.zip');
+
+    // Check that click was triggered
+    expect(anchor.click).toHaveBeenCalled();
+
+    // Check cleanup
+    expect(document.body.removeChild).toHaveBeenCalled();
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  test('calls done callback on success', async () => {
+    const doneMock = jest.fn();
+    await handleResourceExport('dashboard', [1], doneMock);
+
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  test('uses default filename when Content-Disposition is missing', async () => {
+    mockResponse = {
+      headers: new Headers(),
+      blob: jest.fn().mockResolvedValue(mockBlob),
+    } as unknown as Response;
+    (SupersetClient.get as jest.Mock).mockResolvedValue(mockResponse);
+
+    const doneMock = jest.fn();
+    await handleResourceExport('chart', [42], doneMock);
+
+    const anchor = document.createElement('a');
+    expect(anchor.download).toBe('chart_export.zip');
+  });
+
+  test('handles Content-Disposition parsing errors gracefully', async () => {
+    const contentDisposition = require('content-disposition');
+    contentDisposition.parse.mockImplementationOnce(() => {
+      throw new Error('Invalid header');
+    });
+
+    const doneMock = jest.fn();
+    await handleResourceExport('dashboard', [1], doneMock);
+
+    // Should fall back to default filename
+    const anchor = document.createElement('a');
+    expect(anchor.download).toBe('dashboard_export.zip');
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  test('handles API errors and calls done callback', async () => {
+    const apiError = new Error('API Error');
+    (SupersetClient.get as jest.Mock).mockRejectedValue(apiError);
+
+    const doneMock = jest.fn();
+
+    await expect(
+      handleResourceExport('dashboard', [1], doneMock),
+    ).rejects.toThrow('API Error');
+
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  test('handles blob conversion errors', async () => {
+    const blobError = new Error('Blob conversion failed');
+    mockResponse.blob = jest.fn().mockRejectedValue(blobError);
+    (SupersetClient.get as jest.Mock).mockResolvedValue(mockResponse);
+
+    const doneMock = jest.fn();
+
+    await expect(
+      handleResourceExport('dashboard', [1], doneMock),
+    ).rejects.toThrow('Blob conversion failed');
+
+    expect(doneMock).toHaveBeenCalled();
+  });
+
+  test('exports multiple resources with correct IDs', async () => {
+    const doneMock = jest.fn();
+    await handleResourceExport('dataset', [10, 20, 30, 40], doneMock);
+
+    expect(SupersetClient.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: '/api/v1/dataset/export/?q=!(10,20,30,40)',
+      }),
+    );
+  });
+
+  test('parses filename from Content-Disposition with quotes', async () => {
+    const contentDisposition = require('content-disposition');
+    contentDisposition.parse.mockReturnValueOnce({
+      type: 'attachment',
+      parameters: { filename: 'my_custom_export.zip' },
+    });
+
+    const doneMock = jest.fn();
+    await handleResourceExport('dashboard', [1], doneMock);
+
+    const anchor = document.createElement('a');
+    expect(anchor.download).toBe('my_custom_export.zip');
+  });
+
+  test('handles various resource types', async () => {
+    const resources = ['dashboard', 'chart', 'dataset', 'database', 'query'];
+    const doneMock = jest.fn();
+
+    for (const resource of resources) {
+      await handleResourceExport(resource, [1], doneMock);
+      expect(SupersetClient.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: `/api/v1/${resource}/export/?q=!(1)`,
+        }),
+      );
+    }
+
+    expect(doneMock).toHaveBeenCalledTimes(resources.length);
+  });
+});

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -118,7 +118,7 @@ test('creates blob and triggers download', async () => {
   const anchor = document.createElement('a');
   expect(anchor.href).toBe('blob:mock-url');
   expect(anchor.download).toBe('dashboard_export.zip');
-  expect(anchor.style.display).toBe('none');
+  expect(anchor).toHaveStyle({ display: 'none' });
 
   // Check that click was triggered
   expect(anchor.click).toHaveBeenCalled();

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -118,6 +118,7 @@ test('creates blob and triggers download', async () => {
   const anchor = document.createElement('a');
   expect(anchor.href).toBe('blob:mock-url');
   expect(anchor.download).toBe('dashboard_export.zip');
+  // eslint-disable-next-line jest-dom/prefer-to-have-style -- toHaveStyle not available without React Testing Library
   expect(anchor.style.display).toBe('none');
 
   // Check that click was triggered

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -67,12 +67,8 @@ beforeEach(() => {
   createElementSpy = jest
     .spyOn(document, 'createElement')
     .mockReturnValue(mockAnchor);
-  jest
-    .spyOn(document.body, 'appendChild')
-    .mockImplementation(() => mockAnchor);
-  jest
-    .spyOn(document.body, 'removeChild')
-    .mockImplementation(() => mockAnchor);
+  jest.spyOn(document.body, 'appendChild').mockImplementation(() => mockAnchor);
+  jest.spyOn(document.body, 'removeChild').mockImplementation(() => mockAnchor);
 
   // Mock URL.createObjectURL and revokeObjectURL
   createObjectURLSpy = jest
@@ -117,7 +113,7 @@ test('creates blob and triggers download', async () => {
   const anchor = document.createElement('a');
   expect(anchor.href).toBe('blob:mock-url');
   expect(anchor.download).toBe('dashboard_export.zip');
-  expect(anchor.style.display).toBe('none');
+  expect(anchor).toHaveStyle({ display: 'none' });
 
   // Check that click was triggered
   expect(anchor.click).toHaveBeenCalled();


### PR DESCRIPTION
### SUMMARY

Replaces iframe-based resource export with fetch API and blob downloads to prevent Content Security Policy (CSP) `frame-src` violations.

**The Problem:**
The previous export implementation created hidden iframes to trigger downloads, which violates strict CSP policies that set `frame-src 'none'`. This resulted in console errors:
```
Refused to frame '...' because it violates the following Content Security Policy directive: "frame-src 'none'"
```

**The Solution:**
- Use `SupersetClient.get()` with `parseMethod: 'raw'` to fetch export files as blobs
- Parse `Content-Disposition` headers for proper filenames
- Programmatically create download links and trigger them
- Add proper async/await error handling with user-friendly toast messages

**Benefits:**
- ✅ No CSP violations - never attempts to frame URLs
- ✅ Better error handling - catches and displays errors to users
- ✅ Consistent with existing patterns - follows same approach as dashboard screenshot downloads
- ✅ Works with strict Content Security Policies

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Browser console shows CSP violation errors when exporting dashboards/charts
**After:** Exports work cleanly without CSP violations

### TESTING INSTRUCTIONS

1. **Setup**: Ensure your Superset instance has a strict CSP configured (or use browser dev tools to simulate)
2. **Test Dashboard Export**:
   - Go to Dashboard List (`/dashboard/list/`)
   - Select one or more dashboards
   - Click "Export" from the actions menu or bulk actions
   - Verify the ZIP file downloads successfully
   - Check browser console - no CSP errors should appear
3. **Test Chart Export**:
   - Go to Chart List (`/chart/list/`)
   - Select one or more charts
   - Click "Export" 
   - Verify download and no console errors
4. **Test Other Resource Types**:
   - Repeat for Datasets, Databases, Saved Queries, and Themes
5. **Test Error Handling**:
   - Use network throttling or mock a failed API response
   - Verify error toast appears with helpful message
   - Verify loading state clears properly

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [ ] Changes UI: No (backend behavior only)
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

**Files Changed:**
- `superset-frontend/src/utils/export.ts` - Core export utility (iframe → fetch)
- `superset-frontend/src/utils/export.test.ts` - Comprehensive unit tests
- 8 files - Updated export handlers with async/await and error handling:
  - DashboardList, ChartList, DatasetList, DatabaseList
  - SavedQueryList, ThemeList, ChartTable, DashboardTable

**Test Coverage:**
- Unit tests cover success paths, error cases, and edge cases
- Tests verify correct API calls, blob handling, filename parsing, and cleanup