### PR TITLE
fix(csv upload): Correctly casting to string numbers with floating points (e+)

### DIFF
--- a/superset/commands/database/uploaders/csv_reader.py
+++ b/superset/commands/database/uploaders/csv_reader.py
@@ -357,7 +357,28 @@ class CSVReader(BaseDataReader):
         kwargs["low_memory"] = False
 
         try:
-            types = kwargs.pop("dtype", None)
+            # Only pop types that are not str or object
+            original_types = kwargs.get("dtype", None)
+            types = None
+            if original_types:
+                # keep str/object in kwargs, extract others for custom casting
+                pandas_types = {}
+                custom_types = {}
+                for col, dtype in original_types.items():
+                    if dtype in ("str", "object", "string"):
+                        pandas_types[col] = dtype
+                    else:
+                        custom_types[col] = dtype
+
+                # Update kwargs with only str/object types for pandas to handle
+                if pandas_types:
+                    kwargs["dtype"] = pandas_types
+                else:
+                    kwargs.pop("dtype", None)
+
+                # Custom types for our manual casting
+                types = custom_types if custom_types else None
+
             if "chunksize" in kwargs:
                 chunks = []
                 total_rows = 0

--- a/tests/unit_tests/commands/databases/csv_reader_test.py
+++ b/tests/unit_tests/commands/databases/csv_reader_test.py
@@ -854,6 +854,33 @@ def test_csv_reader_successful_numeric_conversion():
     assert df.iloc[0]["ID"] == 1001
 
 
+def test_csv_reader_successful_string_conversion_with_floats():
+    csv_data = [
+        ["id"],
+        [1439403621518935563],
+        [42286989],
+        [1413660691875593351],
+        [8.26839e17],
+    ]
+
+    csv_reader = CSVReader(
+        options=CSVReaderOptions(
+            column_data_types={
+                "id": "str",
+            }
+        )
+    )
+
+    df = csv_reader.file_to_dataframe(create_csv_file(csv_data))
+
+    assert df.shape == (4, 1)
+    assert df["id"].dtype == "object"
+    assert df.iloc[0]["id"] == "1439403621518935563"
+    assert df.iloc[1]["id"] == "42286989"
+    assert df.iloc[2]["id"] == "1413660691875593351"
+    assert df.iloc[3]["id"] == "8.26839e+17"
+
+
 def test_csv_reader_error_detection_improvements_summary():
     csv_data_with_custom_header = [
         ["metadata_row", "skip", "this"],


### PR DESCRIPTION
### SUMMARY
Improved CSV reader type casting by allowing pandas to handle `str`, `object`, and `string` types directly instead of forcing all type conversions through custom casting logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**Before**
<img width="207" height="149" alt="image" src="https://github.com/user-attachments/assets/3c3ba4c3-eab2-4a1e-956f-865ab523b072" />


**After**
<img width="207" height="149" alt="image" src="https://github.com/user-attachments/assets/f5cc01ab-9987-4675-a82a-b08fff7e6d90" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Upload a .csv with the following column and values, define the typing as {"id":"str"}

```
id
1439403621518935563
42286989
1413660691875593351
8.26839E+17

```
The dataset created should have the exact same values as in the csv 


### REVIEWERS
@justinpark @michael-s-molina 

