### PR TITLE
fix: add utc=True to pd.to_datetime for timezone-aware datetimes

### DIFF
--- a/superset/result_set.py
+++ b/superset/result_set.py
@@ -170,7 +170,7 @@ class SupersetResultSet:
                             if sample.tzinfo:
                                 tz = sample.tzinfo
                                 series = pd.Series(array[column])
-                                series = pd.to_datetime(series)
+                                series = pd.to_datetime(series, utc=True)
                                 pa_data[i] = pa.Array.from_pandas(
                                     series,
                                     type=pa.timestamp("ns", tz=tz),


### PR DESCRIPTION
### SUMMARY

Fixes a production error where timezone-aware datetime columns from database query results failed to convert to PyArrow tables.

**Error**: [`ValueError: Tz-aware datetime.datetime cannot be converted to datetime64 unless utc=True`](https://app.datadoghq.com/logs?query=environment%3Aproduction%20service%3Asuperset%20status%3Aerror%20%40component%3Aapp&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&fromUser=true&refresh_mode=sliding&saved-view-id=864224&storage=hot&viz=pattern&from_ts=1758129033878&to_ts=1759425033878&live=true) 

**Root Cause**: When pandas encounters timezone-aware datetime objects, it requires the `utc=True` parameter in `pd.to_datetime()` to properly handle timezone information.

**Solution**: Added `utc=True` parameter to `pd.to_datetime()` call in `superset/result_set.py:173`

This ensures timezone information is preserved when converting query results to PyArrow tables while maintaining backward compatibility with existing timezone-naive datetime handling.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend fix

### TESTING INSTRUCTIONS

1. Run the existing unit test that covers this scenario:
   ```bash
   pytest tests/unit_tests/result_set_test.py::test_timezone_series -v
   ```

2. The test verifies that timezone-aware datetimes are correctly converted without raising exceptions

3. All 5 unit tests in `result_set_test.py` pass

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API