### PR TITLE
fix(reports): improve timeout error messages for chart data fetching

### DIFF
--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -255,17 +255,29 @@ class AlertQueryTimeout(CommandException):
 
 class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
-    message = _("A timeout occurred while taking a screenshot.")
+
+    def __init__(
+        self, message: str = "A timeout occurred while taking a screenshot."
+    ) -> None:
+        super().__init__(message)
 
 
 class ReportScheduleCsvTimeout(CommandException):
     status = 408
-    message = _("A timeout occurred while generating a csv.")
+
+    def __init__(
+        self, message: str = "A timeout occurred while generating a csv."
+    ) -> None:
+        super().__init__(message)
 
 
 class ReportScheduleDataFrameTimeout(CommandException):
     status = 408
-    message = _("A timeout occurred while generating a dataframe.")
+
+    def __init__(
+        self, message: str = "A timeout occurred while generating a dataframe."
+    ) -> None:
+        super().__init__(message)
 
 
 class ReportScheduleAlertGracePeriodError(CommandException):

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -255,29 +255,17 @@ class AlertQueryTimeout(CommandException):
 
 class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
-
-    def __init__(
-        self, message: str = _("A timeout occurred while taking a screenshot.")
-    ) -> None:
-        super().__init__(message)
+    message = _("A timeout occurred while taking a screenshot.")
 
 
 class ReportScheduleCsvTimeout(CommandException):
     status = 408
-
-    def __init__(
-        self, message: str = _("A timeout occurred while generating a csv.")
-    ) -> None:
-        super().__init__(message)
+    message = _("A timeout occurred while generating a csv.")
 
 
 class ReportScheduleDataFrameTimeout(CommandException):
     status = 408
-
-    def __init__(
-        self, message: str = _("A timeout occurred while generating a dataframe.")
-    ) -> None:
-        super().__init__(message)
+    message = _("A timeout occurred while generating a dataframe.")
 
 
 class ReportScheduleAlertGracePeriodError(CommandException):

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -257,7 +257,7 @@ class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
 
     def __init__(
-        self, message: str = "A timeout occurred while taking a screenshot."
+        self, message: str = _("A timeout occurred while taking a screenshot.")
     ) -> None:
         super().__init__(message)
 
@@ -266,7 +266,7 @@ class ReportScheduleCsvTimeout(CommandException):
     status = 408
 
     def __init__(
-        self, message: str = "A timeout occurred while generating a csv."
+        self, message: str = _("A timeout occurred while generating a csv.")
     ) -> None:
         super().__init__(message)
 
@@ -275,7 +275,7 @@ class ReportScheduleDataFrameTimeout(CommandException):
     status = 408
 
     def __init__(
-        self, message: str = "A timeout occurred while generating a dataframe."
+        self, message: str = _("A timeout occurred while generating a dataframe.")
     ) -> None:
         super().__init__(message)
 

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -430,7 +430,6 @@ class BaseReportState:
                 f"second timeout limit. Consider optimizing the chart query "
                 f"or increasing the working timeout."
             )
-            logger.error(error_msg)
             raise ReportScheduleCsvTimeout(error_msg) from ex
         except Exception as ex:
             raise ReportScheduleCsvFailedError(
@@ -472,7 +471,6 @@ class BaseReportState:
                 f"second timeout limit. Consider optimizing the chart query "
                 f"or increasing the working timeout."
             )
-            logger.error(error_msg)
             raise ReportScheduleDataFrameTimeout(error_msg) from ex
         except Exception as ex:
             raise ReportScheduleDataFrameFailedError(

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -423,11 +423,13 @@ class BaseReportState:
             timeout = self._report_schedule.working_timeout or app.config.get(
                 "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
             )
-            error_msg = (
-                f"CSV timeout: chart_id={chart_id}, "
-                f"execution_id={self._execution_id}, timeout={timeout}s"
+            logger.error(
+                "CSV timeout: chart_id=%s, execution_id=%s, timeout=%ss",
+                chart_id,
+                self._execution_id,
+                timeout,
             )
-            raise ReportScheduleCsvTimeout(error_msg) from ex
+            raise ReportScheduleCsvTimeout() from ex
         except Exception as ex:
             raise ReportScheduleCsvFailedError(
                 f"Failed generating csv {str(ex)}"
@@ -461,11 +463,13 @@ class BaseReportState:
             timeout = self._report_schedule.working_timeout or app.config.get(
                 "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
             )
-            error_msg = (
-                f"DataFrame timeout: chart_id={chart_id}, "
-                f"execution_id={self._execution_id}, timeout={timeout}s"
+            logger.error(
+                "DataFrame timeout: chart_id=%s, execution_id=%s, timeout=%ss",
+                chart_id,
+                self._execution_id,
+                timeout,
             )
-            raise ReportScheduleDataFrameTimeout(error_msg) from ex
+            raise ReportScheduleDataFrameTimeout() from ex
         except Exception as ex:
             raise ReportScheduleDataFrameFailedError(
                 f"Failed generating dataframe {str(ex)}"

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -419,7 +419,19 @@ class BaseReportState:
             logger.info("Getting chart from %s as user %s", url, user.username)
             csv_data = get_chart_csv_data(chart_url=url, auth_cookies=auth_cookies)
         except SoftTimeLimitExceeded as ex:
-            raise ReportScheduleCsvTimeout() from ex
+            chart_id = self._report_schedule.chart_id
+            chart_name = self._report_schedule.chart.slice_name
+            timeout = self._report_schedule.working_timeout or app.config.get(
+                "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
+            )
+            error_msg = (
+                f"Timeout fetching CSV data for chart '{chart_name}' "
+                f"(ID: {chart_id}). The chart query exceeded the {timeout} "
+                f"second timeout limit. Consider optimizing the chart query "
+                f"or increasing the working timeout."
+            )
+            logger.error(error_msg)
+            raise ReportScheduleCsvTimeout(error_msg) from ex
         except Exception as ex:
             raise ReportScheduleCsvFailedError(
                 f"Failed generating csv {str(ex)}"
@@ -449,7 +461,19 @@ class BaseReportState:
             logger.info("Getting chart from %s as user %s", url, user.username)
             dataframe = get_chart_dataframe(url, auth_cookies)
         except SoftTimeLimitExceeded as ex:
-            raise ReportScheduleDataFrameTimeout() from ex
+            chart_id = self._report_schedule.chart_id
+            chart_name = self._report_schedule.chart.slice_name
+            timeout = self._report_schedule.working_timeout or app.config.get(
+                "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
+            )
+            error_msg = (
+                f"Timeout fetching data for chart '{chart_name}' "
+                f"(ID: {chart_id}). The chart query exceeded the {timeout} "
+                f"second timeout limit. Consider optimizing the chart query "
+                f"or increasing the working timeout."
+            )
+            logger.error(error_msg)
+            raise ReportScheduleDataFrameTimeout(error_msg) from ex
         except Exception as ex:
             raise ReportScheduleDataFrameFailedError(
                 f"Failed generating dataframe {str(ex)}"

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -420,15 +420,12 @@ class BaseReportState:
             csv_data = get_chart_csv_data(chart_url=url, auth_cookies=auth_cookies)
         except SoftTimeLimitExceeded as ex:
             chart_id = self._report_schedule.chart_id
-            chart_name = self._report_schedule.chart.slice_name
             timeout = self._report_schedule.working_timeout or app.config.get(
                 "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
             )
             error_msg = (
-                f"Timeout fetching CSV data for chart '{chart_name}' "
-                f"(ID: {chart_id}). The chart query exceeded the {timeout} "
-                f"second timeout limit. Consider optimizing the chart query "
-                f"or increasing the working timeout."
+                f"CSV timeout: chart_id={chart_id}, "
+                f"execution_id={self._execution_id}, timeout={timeout}s"
             )
             raise ReportScheduleCsvTimeout(error_msg) from ex
         except Exception as ex:
@@ -461,15 +458,12 @@ class BaseReportState:
             dataframe = get_chart_dataframe(url, auth_cookies)
         except SoftTimeLimitExceeded as ex:
             chart_id = self._report_schedule.chart_id
-            chart_name = self._report_schedule.chart.slice_name
             timeout = self._report_schedule.working_timeout or app.config.get(
                 "ALERT_REPORTS_DEFAULT_WORKING_TIMEOUT", 3600
             )
             error_msg = (
-                f"Timeout fetching data for chart '{chart_name}' "
-                f"(ID: {chart_id}). The chart query exceeded the {timeout} "
-                f"second timeout limit. Consider optimizing the chart query "
-                f"or increasing the working timeout."
+                f"DataFrame timeout: chart_id={chart_id}, "
+                f"execution_id={self._execution_id}, timeout={timeout}s"
             )
             raise ReportScheduleDataFrameTimeout(error_msg) from ex
         except Exception as ex:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -2134,7 +2134,7 @@ def test_soft_timeout_csv(
 
     assert_log(
         ReportState.ERROR,
-        error_message="CSV timeout: chart_id=",
+        error_message="A timeout occurred while generating a csv.",
     )
 
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -162,8 +162,10 @@ def assert_log(state: str, error_message: Optional[str] = None):
     assert state in log_states
     if error_message is not None:
         error_messages = [log.error_message for log in logs]
-        assert any(error_message in (msg or "") for msg in error_messages), (
-            f"Expected '{error_message}' in error messages: {error_messages}"
+        # Convert error_message to string in case it's a LazyString from lazy_gettext
+        error_message_str = str(error_message)
+        assert any(error_message_str in (msg or "") for msg in error_messages), (
+            f"Expected '{error_message_str}' in error messages: {error_messages}"
         )
 
     for log in logs:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -160,7 +160,10 @@ def assert_log(state: str, error_message: Optional[str] = None):
     log_states = [log.state for log in logs]
     assert ReportState.WORKING in log_states
     assert state in log_states
-    assert error_message in [log.error_message for log in logs]
+    error_messages = [log.error_message for log in logs]
+    assert any(error_message in (msg or "") for msg in error_messages), (
+        f"Expected '{error_message}' in error messages: {error_messages}"
+    )
 
     for log in logs:
         if log.state == ReportState.WORKING:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -2128,7 +2128,7 @@ def test_soft_timeout_csv(
 
     assert_log(
         ReportState.ERROR,
-        error_message="A timeout occurred while generating a csv.",
+        error_message="CSV timeout: chart_id=",
     )
 
 

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -160,10 +160,11 @@ def assert_log(state: str, error_message: Optional[str] = None):
     log_states = [log.state for log in logs]
     assert ReportState.WORKING in log_states
     assert state in log_states
-    error_messages = [log.error_message for log in logs]
-    assert any(error_message in (msg or "") for msg in error_messages), (
-        f"Expected '{error_message}' in error messages: {error_messages}"
-    )
+    if error_message is not None:
+        error_messages = [log.error_message for log in logs]
+        assert any(error_message in (msg or "") for msg in error_messages), (
+            f"Expected '{error_message}' in error messages: {error_messages}"
+        )
 
     for log in logs:
         if log.state == ReportState.WORKING:


### PR DESCRIPTION
### SUMMARY

Improves error logging when report execution times out during chart data fetching (CSV/DataFrame generation). When a Celery soft timeout (`SoftTimeLimitExceeded`) occurs while fetching chart data, the error is now properly logged with diagnostic context including:

- Chart ID
- Execution ID
- Configured timeout value

**Problem**: When chart queries exceed Celery's soft timeout during report execution, the timeout exception was caught but provided no diagnostic context about which chart failed or the timeout configuration. This made debugging customer issues extremely difficult, as seen in the Stonebridge case where an execution ID was assigned but no meaningful error information was logged.

**Solution**: Added detailed `logger.error()` calls that capture chart_id, execution_id, and timeout values when `SoftTimeLimitExceeded` occurs during chart data fetching. User-facing error messages remain translated and simple, while detailed diagnostic information is logged separately for debugging purposes.

**Note**: This addresses Celery-level timeouts during chart data fetching, which is different from the working timeout check that runs between execution attempts. The Celery timeout happens at the task/worker level and can occur before Superset's working timeout logic executes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before**: 
- User sees: `A timeout occurred while generating a csv.`
- Logs contain: No additional context

**After**:
- User sees: `A timeout occurred while generating a csv.` (translated)
- Logs contain: `CSV timeout: chart_id=691, execution_id=abc123, timeout=1800s`

This separation ensures user-facing messages can be translated while diagnostic information is captured for debugging.

### TESTING INSTRUCTIONS

**Test Celery-level timeout with enhanced logging:**

1. Set `CELERYD_TASK_SOFT_TIME_LIMIT` to a low value (e.g., 60 seconds)
2. Create a report with a chart query that takes longer than 60 seconds
3. Trigger report execution
4. When timeout occurs:
   - Check execution log shows the translated user-facing error message
   - Check application logs show detailed error with chart_id, execution_id, and timeout value

**Verify translation still works:**

1. Change locale/language settings
2. Trigger a timeout
3. Verify the error message is properly translated for users

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [ ] Changes UI: No (only improves error logging)
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No