### PR TITLE
fix(alerts): log execution_id instead of report schedule name in query timing

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -181,7 +181,7 @@ class AlertCommand(BaseCommand):
                 stop = default_timer()
                 logger.info(
                     "Query for %s took %.2f ms",
-                    self._report_schedule.name,
+                    self._execution_id,
                     (stop - start) * 1000.0,
                 )
                 return df


### PR DESCRIPTION
## Description

This PR improves logging for alert/report execution by logging the `execution_id` instead of the report schedule name in query timing logs. This makes it easier to correlate logs across the execution flow when debugging issues.

### Relevant ticket(s)
* Internal debugging improvement - no external ticket

### Screenshots
N/A - logging change only

## Test plan

- [x] Code review - verify the change logs execution_id instead of report schedule name
- [x] Verify pre-commit hooks pass
- [ ] Manual testing: Execute an alert and verify the log message includes execution_id

Test env URL (if any): N/A