### PR TITLE
fix: Log Celery task failures with a signal handler

### DIFF
--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -41,19 +41,33 @@ from superset.utils.log import get_logger_from_status
 
 logger = logging.getLogger(__name__)
 
+
 @task_failure.connect
-def log_task_failure(sender=None, task_id=None, exception=None, args=None, kwargs=None, traceback=None, einfo=None, **kw):
-    logger.exception(f"Celery task {sender.name} failed: {exception}", exc_info=einfo)
+def log_task_failure(  # pylint: disable=unused-argument
+    sender: Task | None = None,
+    task_id: str | None = None,
+    exception: Exception | None = None,
+    args: tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    traceback: Any = None,
+    einfo: Any = None,
+    **kw: Any,
+) -> None:
+    task_name = sender.name if sender else "Unknown"
+    logger.exception("Celery task %s failed: %s", task_name, exception, exc_info=einfo)
 
 
 @celery_app.task(
     name="reports.scheduler",
     bind=True,
     autoretry_for=(Exception,),
-    retry_kwargs={"max_retries": 3, "countdown": 60},  # Retry up to 3 times, wait 60s between
+    retry_kwargs={
+        "max_retries": 3,
+        "countdown": 60,
+    },  # Retry up to 3 times, wait 60s between
     retry_backoff=True,  # exponential backoff
 )
-def scheduler() -> None:
+def scheduler(self: Task) -> None:  # pylint: disable=unused-argument
     """
     Celery beat main scheduler for reports
     """


### PR DESCRIPTION
Added a signal handler to log task failures for Celery tasks and also retries.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a retry and more logging on the reports.schedule task to help with silent failures. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
TBD
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
