### PR TITLE
fix: no fs logging of extensions unless flag is set

### DIFF
--- a/superset-frontend/src/extensions/ExtensionsManager.ts
+++ b/superset-frontend/src/extensions/ExtensionsManager.ts
@@ -16,12 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {
-  FeatureFlag,
-  SupersetClient,
-  isFeatureEnabled,
-  logging,
-} from '@superset-ui/core';
+import { SupersetClient, logging } from '@superset-ui/core';
 import type { contributions, core } from '@apache-superset/core';
 import { ExtensionContext } from '../core/models';
 
@@ -62,9 +57,6 @@ class ExtensionsManager {
    * @throws Error if initialization fails.
    */
   public async initializeExtensions(): Promise<void> {
-    if (!isFeatureEnabled(FeatureFlag.EnableExtensions)) {
-      return;
-    }
     const response = await SupersetClient.get({
       endpoint: '/api/v1/extensions/',
     });

--- a/superset-frontend/src/extensions/ExtensionsStartup.tsx
+++ b/superset-frontend/src/extensions/ExtensionsStartup.tsx
@@ -19,7 +19,7 @@
 import { useEffect, useState } from 'react';
 // eslint-disable-next-line no-restricted-syntax
 import * as supersetCore from '@apache-superset/core';
-import { logging } from '@superset-ui/core';
+import { FeatureFlag, isFeatureEnabled, logging } from '@superset-ui/core';
 import {
   authentication,
   core,
@@ -75,14 +75,15 @@ const ExtensionsStartup = () => {
     };
 
     // Initialize extensions
-    try {
-      ExtensionsManager.getInstance().initializeExtensions();
-      logging.info('Extensions initialized successfully.');
-    } catch (error) {
-      logging.error('Error setting up extensions:', error);
-    } finally {
-      setInitialized(true);
+    if (isFeatureEnabled(FeatureFlag.EnableExtensions)) {
+      try {
+        ExtensionsManager.getInstance().initializeExtensions();
+        logging.info('Extensions initialized successfully.');
+      } catch (error) {
+        logging.error('Error setting up extensions:', error);
+      }
     }
+    setInitialized(true);
   }, [initialized, userId]);
 
   return null;


### PR DESCRIPTION
### SUMMARY
Currently we're logging that extensions are initialized successfully even if the feature flag isn't set. This moves the feature flag check one level up to avoid triggering this log unless the FF is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
