### PR TITLE
fix(frontend): double prefixed API url

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -41,7 +41,6 @@ import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
-import { ensureAppRoot } from 'src/utils/pathUtils';
 import { safeStringify } from 'src/utils/safeStringify';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 
@@ -558,7 +557,7 @@ export function redirectSQLLab(formData, history) {
             },
           });
         } else {
-          SupersetClient.postForm(ensureAppRoot(redirectUrl), {
+          SupersetClient.postForm(redirectUrl, {
             form_data: safeStringify(payload),
           });
         }

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -39,6 +39,7 @@ import {
   UNSAVED_CHART_ID,
 } from 'src/explore/constants';
 import { DashboardStandaloneMode } from 'src/dashboard/util/constants';
+import { applicationRoot } from 'src/utils/getBootstrapData';
 
 export function getChartKey(explore) {
   const { slice, form_data } = explore;
@@ -258,10 +259,10 @@ export const exportChart = async ({
       formData,
       endpointType,
       allowDomainSharding: false,
-    });
+    }).replace(new RegExp(`^${applicationRoot()}`), ''); // appRoot will be added in SuperstClient.postForm method
     payload = formData;
   } else {
-    url = ensureAppRoot('/api/v1/chart/data');
+    url = '/api/v1/chart/data';
     payload = await buildV1ChartDataPayload({
       formData,
       force,


### PR DESCRIPTION
### SUMMARY
When app root prefix is applied (e.g. `SUPERSET_APP_ROOT="/app-prefix"`), it's applied twice - e.g. when exporting graph to CSV 

```javascript

// in this handler url is build with appRoot prefix
exportChart = async (...) => {
    ...
    url = ensureAppRoot('/api/v1/chart/data'); 
    // now the url is /app-prefix/api/v1/chart/data

    // postForm is called with prefixed url
    SupersetClient.postForm(url, ...)
    ...
}

// this method is called with already prefixed url
async postForm(endpoint, ...) {
    ...
    hiddenForm.action = this.getUrl({ endpoint });
    // now the url is /app-prefix/app-prefix/api/v1/chart/data
    ...
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="1430" height="867" alt="Snímek obrazovky z 2025-10-14 14-53-35" src="https://github.com/user-attachments/assets/cb224e24-3d58-4bba-9237-cec528c454d9" />

### TESTING INSTRUCTIONS
Test downloading CSV file.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
