### PR TITLE
fix(theme): align "Clear local theme" option with other theme menu items

### DIFF
--- a/superset-frontend/src/hooks/useThemeMenuItems.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.tsx
@@ -104,22 +104,14 @@ export const useThemeMenuItems = ({
       : []),
   ];
 
-  const children: MenuItem[] = [
-    {
-      type: 'group' as const,
-      label: t('Theme'),
-      key: 'theme-group',
-      children: themeOptions,
-    },
-  ];
-
-  // Add clear settings option only when there's a local theme active
+  // Add clear settings option to theme options if there's a local theme active
+  const themeGroupOptions = [...themeOptions];
   if (onClearLocalSettings && hasLocalOverride) {
-    children.push({
+    themeGroupOptions.push({
       type: 'divider' as const,
       key: 'theme-divider',
     });
-    children.push({
+    themeGroupOptions.push({
       key: 'clear-local',
       label: (
         <>
@@ -129,6 +121,15 @@ export const useThemeMenuItems = ({
       onClick: onClearLocalSettings,
     });
   }
+
+  const children: MenuItem[] = [
+    {
+      type: 'group' as const,
+      label: t('Theme'),
+      key: 'theme-group',
+      children: themeGroupOptions,
+    },
+  ];
 
   return {
     key: 'theme-sub-menu',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes misalignment of the "Clear local theme" option in the theme dropdown menu. The option was appearing at the root level instead of inside the theme group, causing it to have different indentation and styling compared to other theme options (Light, Dark, Match system).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="329" height="317" alt="image" src="https://github.com/user-attachments/assets/8188aca9-17f7-4d7e-831e-aac488345fa4" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
