### PR TITLE
feat(alerts): Include screenshots in alert/report failure emails

### DIFF
--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -196,6 +196,10 @@ class ReportSchedulePreviousWorkingError(CommandException):
     status = 429
     message = _("Report Schedule is still working, refusing to re-compute.")
 
+    def __init__(self, working_timeout: int | None = None) -> None:
+        super().__init__()
+        self.working_timeout = working_timeout
+
 
 class ReportScheduleWorkingTimeoutError(CommandException):
     status = 408

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -257,6 +257,10 @@ class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
     message = _("A timeout occurred while taking a screenshot.")
 
+    def __init__(self, screenshots: list[bytes] | None = None) -> None:
+        super().__init__()
+        self.screenshots = screenshots or []
+
 
 class ReportScheduleCsvTimeout(CommandException):
     status = 408

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -257,9 +257,14 @@ class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
     message = _("A timeout occurred while taking a screenshot.")
 
-    def __init__(self, screenshots: list[bytes] | None = None) -> None:
+    def __init__(
+        self,
+        screenshots: list[bytes] | None = None,
+        elapsed_seconds: float | None = None,
+    ) -> None:
         super().__init__()
         self.screenshots = screenshots or []
+        self.elapsed_seconds = elapsed_seconds
 
 
 class ReportScheduleCsvTimeout(CommandException):

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -664,8 +664,35 @@ class BaseReportState:
             header_data,
             self._execution_id,
         )
+
+        # Try to capture screenshot even on failure - best effort
+        screenshot_data = []
+        try:
+            screenshot_data = self._get_screenshots()
+            logger.info(
+                "Successfully captured screenshot for error notification: %s",
+                self._execution_id,
+            )
+        except (
+            ReportScheduleScreenshotTimeout,
+            ReportScheduleScreenshotFailedError,
+        ) as ex:
+            logger.warning(
+                "Could not capture screenshot for error notification: %s", str(ex)
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning(
+                "Unexpected error while capturing screenshot for error "
+                "notification: %s",
+                str(ex),
+            )
+
         notification_content = NotificationContent(
-            name=name, text=message, header_data=header_data, url=url
+            name=name,
+            text=message,
+            header_data=header_data,
+            url=url,
+            screenshots=screenshot_data,
         )
 
         # filter recipients to recipients who are also owners

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -831,7 +831,9 @@ class ReportWorkingState(BaseReportState):
                 error_message=str(exception_timeout),
             )
             raise exception_timeout
-        exception_working = ReportSchedulePreviousWorkingError()
+        exception_working = ReportSchedulePreviousWorkingError(
+            working_timeout=self._report_schedule.working_timeout
+        )
         self.update_report_schedule_and_log(
             ReportState.WORKING,
             error_message=str(exception_working),

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -665,34 +665,11 @@ class BaseReportState:
             self._execution_id,
         )
 
-        # Try to capture screenshot even on failure - best effort
-        screenshot_data = []
-        try:
-            screenshot_data = self._get_screenshots()
-            logger.info(
-                "Successfully captured screenshot for error notification: %s",
-                self._execution_id,
-            )
-        except (
-            ReportScheduleScreenshotTimeout,
-            ReportScheduleScreenshotFailedError,
-        ) as ex:
-            logger.warning(
-                "Could not capture screenshot for error notification: %s", str(ex)
-            )
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.warning(
-                "Unexpected error while capturing screenshot for error "
-                "notification: %s",
-                str(ex),
-            )
-
         notification_content = NotificationContent(
             name=name,
             text=message,
             header_data=header_data,
             url=url,
-            screenshots=screenshot_data,
         )
 
         # filter recipients to recipients who are also owners

--- a/superset/reports/notifications/base.py
+++ b/superset/reports/notifications/base.py
@@ -34,6 +34,7 @@ class NotificationContent:
     description: Optional[str] = ""
     url: Optional[str] = None  # url to chart/dashboard for this screenshot
     embedded_data: Optional[pd.DataFrame] = None
+    elapsed_seconds: Optional[float] = None  # time spent loading before timeout
 
 
 class BaseNotification:  # pylint: disable=too-few-public-methods

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -109,17 +109,23 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 seconds=int(self._content.elapsed_seconds),
             )
             if img_tag:
-                # ruff: noqa: E501
                 optimization_guidance = __(
                     """
-                    <p><strong>Screenshot:</strong> Below is a screenshot of how much was loaded when the timeout occurred.
-                    This partial rendering indicates that your dashboard/chart queries may be too slow.</p>
+                    <p><strong>Screenshot:</strong> Below is a screenshot of how much
+                    was loaded when the timeout occurred. This partial rendering
+                    indicates that your dashboard/chart queries may be too slow.</p>
                     <p><strong>Performance Recommendations:</strong></p>
                     <ul>
-                        <li>Optimize your queries to run faster (add indexes, reduce data volume, simplify calculations)</li>
-                        <li>Enable and utilize <a href="https://superset.apache.org/docs/configuration/cache/">cached data</a> to avoid re-running expensive queries</li>
-                        <li>Consider breaking complex dashboards into smaller, focused views</li>
-                        <li>Review your database performance and query execution plans</li>
+                        <li>Optimize your queries to run faster (add indexes,
+                        reduce data volume, simplify calculations)</li>
+                        <li>Enable and utilize
+                        <a href="https://superset.apache.org/docs/configuration/cache/">
+                        cached data</a>
+                        to avoid re-running expensive queries</li>
+                        <li>Consider breaking complex dashboards into smaller,
+                        focused views</li>
+                        <li>Review your database performance and query execution
+                        plans</li>
                     </ul>
                     """
                 )

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -123,10 +123,12 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                     make_msgid(domain)[1:-1]: screenshot
                     for screenshot in self._content.screenshots
                 }
+                img_tag_parts = []
                 for msgid in images.keys():
-                    img_tag_str += (
+                    img_tag_parts.append(
                         f'<div class="image"><img width="1000" src="cid:{msgid}"></div>'
                     )
+                img_tag_str = "".join(img_tag_parts)
 
             return EmailContent(
                 body=self._error_template(self._content.text, img_tag_str),

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -599,11 +599,13 @@ class WebDriverSelenium(WebDriverProxy):
                 )
             except TimeoutException:
                 had_timeout = True
+                elapsed = time() - start_time
                 logger.warning(
-                    "Selenium timed out locating element %s at url %s - will "
-                    "attempt to capture current page state",
+                    "Selenium timed out locating element %s at url %s after %.2f "
+                    "seconds - will attempt to capture current page state",
                     element_name,
                     url,
+                    elapsed,
                 )
                 # Try to find element anyway for screenshot
                 try:
@@ -625,6 +627,7 @@ class WebDriverSelenium(WebDriverProxy):
                 )
             except TimeoutException:
                 had_timeout = True
+                elapsed = time() - start_time
 
                 # Collect diagnostic information about the timeout
                 chart_elements = driver.find_elements(By.CLASS_NAME, "chart-container")
@@ -643,10 +646,11 @@ class WebDriverSelenium(WebDriverProxy):
                         chart_ids.append(chart_id)
 
                 logger.warning(
-                    "Timeout waiting for chart containers at url %s; "
-                    "%d chart containers found, %d grid containers present, "
+                    "Timeout waiting for chart containers at url %s after %.2f "
+                    "seconds; %d chart containers found, %d grid containers present, "
                     "%d loading elements still visible; sample chart identifiers: %s",
                     url,
+                    elapsed,
                     len(chart_elements),
                     len(grid_elements),
                     len(loading_elements),
@@ -682,10 +686,12 @@ class WebDriverSelenium(WebDriverProxy):
                 )
             except TimeoutException:
                 had_timeout = True
+                elapsed = time() - start_time
                 logger.warning(
-                    "Selenium timed out waiting for charts to load at url %s - "
-                    "will capture current state with loading indicators",
+                    "Selenium timed out waiting for charts to load at url %s after "
+                    "%.2f seconds - will capture current state with loading indicators",
                     url,
+                    elapsed,
                 )
 
             selenium_animation_wait = app.config["SCREENSHOT_SELENIUM_ANIMATION_WAIT"]

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from enum import Enum
-from time import sleep
+from time import sleep, time
 from typing import Any, TYPE_CHECKING
 
 from flask import current_app as app
@@ -573,8 +573,6 @@ class WebDriverSelenium(WebDriverProxy):
         return error_messages
 
     def get_screenshot(self, url: str, element_name: str, user: User) -> bytes | None:  # noqa: C901
-        from time import time
-
         from superset.commands.report.exceptions import ReportScheduleScreenshotTimeout
 
         start_time = time()

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -573,8 +573,11 @@ class WebDriverSelenium(WebDriverProxy):
         return error_messages
 
     def get_screenshot(self, url: str, element_name: str, user: User) -> bytes | None:  # noqa: C901
+        from time import time
+
         from superset.commands.report.exceptions import ReportScheduleScreenshotTimeout
 
+        start_time = time()
         driver = self.auth(user)
         driver.set_window_size(*self._window)
         driver.get(url)
@@ -715,7 +718,10 @@ class WebDriverSelenium(WebDriverProxy):
             # raise an exception with the screenshot attached so error notification
             # is sent with the partial screenshot
             if had_timeout and img:
-                raise ReportScheduleScreenshotTimeout(screenshots=[img])
+                elapsed_seconds = time() - start_time
+                raise ReportScheduleScreenshotTimeout(
+                    screenshots=[img], elapsed_seconds=elapsed_seconds
+                )
 
         except StaleElementReferenceException:
             logger.exception(

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -274,14 +274,17 @@ class TestWebDriverSelenium:
         # Should create driver without errors
         mock_driver_class.assert_called_once()
 
+    @patch("superset.utils.webdriver.time")
     @patch("superset.utils.webdriver.app")
     @patch("superset.utils.webdriver.chrome")
     @patch("superset.utils.webdriver.logger")
     @patch("superset.utils.webdriver.WebDriverWait")
     def test_get_screenshot_logs_chart_timeout_details(
-        self, mock_wait, mock_chrome, mock_logger, mock_app_patch, mock_app
+        self, mock_wait, mock_logger, mock_chrome, mock_app_patch, mock_time, mock_app
     ):
         """Test that chart timeout logs detailed diagnostic information."""
+        # Mock time to return consistent values for elapsed time calculation
+        mock_time.return_value = 100.0  # Start time
         mock_app_patch.config = {
             "WEBDRIVER_TYPE": "chrome",
             "WEBDRIVER_OPTION_ARGS": [],
@@ -289,6 +292,10 @@ class TestWebDriverSelenium:
             "SCREENSHOT_LOAD_WAIT": 10,
             "WEBDRIVER_WINDOW": {"dashboard": (1600, 1200)},
             "WEBDRIVER_CONFIGURATION": {},
+            "SCREENSHOT_SELENIUM_HEADSTART": 0,
+            "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 0,
+            "SCREENSHOT_REPLACE_UNEXPECTED_ERRORS": False,
+            "SCREENSHOT_SELENIUM_RETRIES": 2,
         }
 
         # Setup mocks


### PR DESCRIPTION
### SUMMARY
When an alert or report times out during screenshot capture, this PR now captures the partially loaded state and includes it in the error notification email along with timing information and actionable performance optimization guidance. This helps admins/owners quickly identify performance issues and understand how much content loaded before the timeout.

**Key features:**
- **Screenshot capture on timeout**: Captures the current state when Selenium timeouts occur, showing what was loaded
- **Elapsed time tracking**: Records and displays how long the page was loading before timing out
- **Performance recommendations**: Provides actionable guidance in error emails (query optimization, caching, dashboard simplification)
- **Diagnostic logging**: Logs detailed timeout information including chart IDs, element counts, and DOM previews for debugging
- **Best-effort approach**: Screenshots captured if possible, but failures don't prevent error notifications

**Implementation details:**
- Enhanced `ReportScheduleScreenshotTimeout` exception to carry screenshot bytes and elapsed time
- Modified Selenium WebDriver to track timeout state and continue screenshot capture after TimeoutException
- Updated error email template to conditionally display timing info and optimization recommendations
- Added `working_timeout` parameter to `ReportSchedulePreviousWorkingError` for better error context
- Comprehensive diagnostic logging with chart identifiers and DOM previews for timeout troubleshooting

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** 
- Timeout errors provided no screenshot
- No indication of how long the page loaded or what content appeared
- No guidance on how to resolve performance issues

**After:** 
Error emails for timeout failures now include:
- Screenshot of the partially loaded dashboard/chart
- "Loading Time: The page was loading for X seconds before timing out"
- Performance optimization recommendations with links to documentation
- Internal logs include detailed diagnostic information (chart IDs, element counts, DOM preview)

### TESTING INSTRUCTIONS
1. Set up a dashboard with slow-loading charts that will timeout during screenshot capture
2. Configure an alert/report with aggressive timeout settings (e.g., `SCREENSHOT_LOAD_WAIT=5`)
3. Trigger the report execution
4. Verify the error notification email includes:
   - Elapsed time message showing how long it loaded
   - Screenshot of partial rendering
   - Performance recommendations section
5. Check server logs for diagnostic information (chart IDs, element counts, DOM preview)
6. Run unit tests:
   ```bash
   pytest tests/unit_tests/utils/webdriver_test.py::TestWebDriverSelenium::test_get_screenshot_logs_chart_timeout_details -v
   pytest tests/unit_tests/reports/notifications/email_tests.py -v
   ```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags: None
- [ ] Changes UI: Yes (email template)
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No (enhances existing error notifications)
- [ ] Removes existing feature or API: No

**Documentation:**
See [PROJECT.md](https://github.com/apache/superset/blob/log-alert-screenshot/PROJECT.md) for detailed architecture and implementation notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)