### PR TITLE
feat: use  in deck.gl custom tooltip instead of SafeMarkdown

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
@@ -17,9 +17,8 @@
  * under the License.
  */
 import { useEffect, useState, memo } from 'react';
-import { styled, t } from '@superset-ui/core';
+import { styled, t, sanitizeHtml } from '@superset-ui/core';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
-import { SafeMarkdown } from '@superset-ui/core/components';
 import Handlebars from 'handlebars';
 import { isPlainObject } from 'lodash';
 
@@ -45,8 +44,6 @@ export const HandlebarsRenderer: React.FC<HandlebarsRendererProps> = memo(
       appContainer?.getAttribute('data-bootstrap') || '{}',
     );
     const htmlSanitization = common?.conf?.HTML_SANITIZATION ?? true;
-    const htmlSchemaOverrides =
-      common?.conf?.HTML_SANITIZATION_SCHEMA_EXTENSIONS || {};
 
     useEffect(() => {
       try {
@@ -65,6 +62,10 @@ export const HandlebarsRenderer: React.FC<HandlebarsRendererProps> = memo(
     }
 
     if (renderedTemplate || renderedTemplate === '') {
+      const htmlContent = htmlSanitization
+        ? sanitizeHtml(renderedTemplate)
+        : renderedTemplate;
+
       return (
         <div
           style={{
@@ -73,13 +74,9 @@ export const HandlebarsRenderer: React.FC<HandlebarsRendererProps> = memo(
             fontSize: '12px',
             lineHeight: '1.4',
           }}
-        >
-          <SafeMarkdown
-            source={renderedTemplate || ''}
-            htmlSanitization={htmlSanitization}
-            htmlSchemaOverrides={htmlSchemaOverrides}
-          />
-        </div>
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: htmlContent }}
+        />
       );
     }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/utilities/HandlebarsRenderer.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useEffect, useState, memo } from 'react';
+import { useEffect, useState, memo, useMemo } from 'react';
 import { styled, t, sanitizeHtml } from '@superset-ui/core';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import Handlebars from 'handlebars';
@@ -57,15 +57,17 @@ export const HandlebarsRenderer: React.FC<HandlebarsRendererProps> = memo(
       }
     }, [templateSource, data]);
 
+    const htmlContent = useMemo(
+      () =>
+        htmlSanitization ? sanitizeHtml(renderedTemplate) : renderedTemplate,
+      [renderedTemplate, htmlSanitization],
+    );
+
     if (error) {
       return <ErrorContainer>{error}</ErrorContainer>;
     }
 
     if (renderedTemplate || renderedTemplate === '') {
-      const htmlContent = htmlSanitization
-        ? sanitizeHtml(renderedTemplate)
-        : renderedTemplate;
-
       return (
         <div
           style={{

--- a/superset/config.py
+++ b/superset/config.py
@@ -972,7 +972,7 @@ CORS_OPTIONS: dict[Any, Any] = {
 # Disabling this option is not recommended for security reasons. If you wish to allow
 # valid safe elements that are not included in the default sanitization schema, use the
 # HTML_SANITIZATION_SCHEMA_EXTENSIONS configuration.
-HTML_SANITIZATION = False
+HTML_SANITIZATION = True
 
 # Use this configuration to extend the HTML sanitization schema.
 # By default we use the GitHub schema defined in


### PR DESCRIPTION
###   SUMMARY

-  Fixes deck.gl custom tooltips to work with HTML_SANITIZATION=True.

#### Problem
- HTML_SANITIZATION=True caused the custom tooltips to not work properly because SafeMarkdown was stripping all style attributes.

#### Solution
  - Replace SafeMarkdown with sanitizeHtml() in HandlebarsRenderer.tsx
  - sanitizeHtml uses the xss library which allows style attributes while still preventing XSS attacks
  - Reset HTML_SANITIZATION = True in config.py

###  BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="648" height="516" alt="Screenshot 2025-10-15 at 14 39 03" src="https://github.com/user-attachments/assets/ec3006d0-543c-4418-872b-be1b17d8b559" />

###  TESTING INSTRUCTIONS

  1. Create a deck.gl chart (scatter, arc, etc.)
  2. Add a custom tooltip with inline styles:
```
  <div style="background: #2c3e50; color: white; padding: 10px;">
    Year: {{YEAR}}
  </div>
```
  3. Hover over a data point - verify styling is preserved
  4. Confirm HTML_SANITIZATION = True in config.py

  ADDITIONAL INFORMATION

  - Has associated issue: Fixes regression from #34276
  - Required feature flags:
  - Changes UI
  - Includes DB Migration
  - Introduces new feature or API
  - Removes existing feature or API
