### PR TITLE
chore: bump pretty-ms to 9.3.0

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -64090,7 +64090,7 @@
         "jed": "^1.1.1",
         "lodash": "^4.17.21",
         "math-expression-evaluator": "^2.0.6",
-        "pretty-ms": "^9.2.0",
+        "pretty-ms": "^9.3.0",
         "re-resizable": "^6.11.2",
         "react-ace": "^14.0.1",
         "react-draggable": "^4.5.0",
@@ -64999,6 +64999,20 @@
         }
       ],
       "license": "MIT"
+    },
+    "packages/superset-ui-core/node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/superset-ui-core/node_modules/re-resizable": {
       "version": "6.11.2",

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -49,7 +49,7 @@
     "jed": "^1.1.1",
     "lodash": "^4.17.21",
     "math-expression-evaluator": "^2.0.6",
-    "pretty-ms": "^9.2.0",
+    "pretty-ms": "^9.3.0",
     "re-resizable": "^6.11.2",
     "react-ace": "^14.0.1",
     "react-js-cron": "^5.2.0",


### PR DESCRIPTION
### SUMMARY
Created a new PR to bump `pretty-ms` to latest stable version as #35599 didn't bump the lock file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
