### PR TITLE
fix(dataset): render default URL description properly in settings

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -1019,10 +1019,16 @@ class DatasourceEditor extends PureComponent {
         <Field
           fieldKey="default_endpoint"
           label={t('Default URL')}
-          description={t(
-            `Default URL to redirect to when accessing from the dataset list page.
-            Accepts relative URLs such as <span style=„white-space: nowrap;”>/superset/dashboard/{id}/</span>`,
-          )}
+          description={
+            <>
+              {t(
+                'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as',
+              )}{' '}
+              <Typography.Text code>
+                /superset/dashboard/{'{id}'}/
+              </Typography.Text>
+            </>
+          }
           control={<TextControl controlId="default_endpoint" />}
         />
         <Field


### PR DESCRIPTION
### SUMMARY
Fixes the dataset edit modal's default URL field description which was displaying escaped HTML tags as plain text instead of rendering them properly.

The description text included `<span style=„white-space: nowrap;">` tags that were being shown literally to users. This has been replaced with proper React JSX using `Typography.Text` component with the `code` prop to display the example URL path `/superset/dashboard/{id}/` in a code-formatted style.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** The description showed raw HTML text:
```
Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as <span style=„white-space: nowrap;">/superset/dashboard/{id}/</span>
```

<img width="515" height="207" alt="Screenshot 2025-10-16 at 9 53 57 AM" src="https://github.com/user-attachments/assets/cff2d797-64cd-4ba8-a4f7-ef13e1884966" />

**After:** The description now renders properly with the example URL in code format:

<img width="503" height="154" alt="Screenshot 2025-10-16 at 9 53 05 AM" src="https://github.com/user-attachments/assets/92b61531-0a7f-42b8-be86-71f543771fb5" />

### TESTING INSTRUCTIONS
1. Navigate to any dataset
2. Click "Edit Dataset" 
3. Go to the "Settings" tab
4. Locate the "Default URL" field
5. Verify the description text displays properly with the example path `/superset/dashboard/{id}/` shown in code format (not as escaped HTML)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)