### PR TITLE
chore(docs): switch to markdown headlines for available macros

### DIFF
--- a/docs/docs/configuration/sql-templating.mdx
+++ b/docs/docs/configuration/sql-templating.mdx
@@ -182,7 +182,7 @@ The available validators and names can be found in
 
 In this section, we'll walkthrough the pre-defined Jinja macros in Superset.
 
-**Current Username**
+### Current Username
 
 The `{{ current_username() }}` macro returns the `username` of the currently logged in user.
 
@@ -197,7 +197,7 @@ cache key by adding the following parameter to your Jinja code:
 {{ current_username(add_to_cache_keys=False) }}
 ```
 
-**Current User ID**
+### Current User ID
 
 The `{{ current_user_id() }}` macro returns the account ID of the currently logged in user.
 
@@ -212,7 +212,7 @@ cache key by adding the following parameter to your Jinja code:
 {{ current_user_id(add_to_cache_keys=False) }}
 ```
 
-**Current User Email**
+### Current User Email
 
 The `{{ current_user_email() }}` macro returns the email address of the currently logged in user.
 
@@ -227,7 +227,7 @@ cache key by adding the following parameter to your Jinja code:
 {{ current_user_email(add_to_cache_keys=False) }}
 ```
 
-**Current User Roles**
+### Current User Roles
 
 The `{{ current_user_roles() }}` macro returns an array of roles for the logged in user.
 
@@ -257,7 +257,7 @@ Will be rendered as:
 SELECT * FROM users WHERE role IN ('admin', 'viewer')
 ```
 
-**Current User RLS Rules**
+### Current User RLS Rules
 
 The `{{ current_user_rls_rules() }}` macro returns an array of RLS rules applied to the current dataset for the logged in user.
 
@@ -265,7 +265,7 @@ If you have caching enabled in your Superset configuration, then the list of RLS
 by Superset when calculating the cache key. A cache key is a unique identifier that determines if there's a
 cache hit in the future and Superset can retrieve cached data.
 
-**Custom URL Parameters**
+### Custom URL Parameters
 
 The `{{ url_param('custom_variable') }}` macro lets you define arbitrary URL
 parameters and reference them in your SQL code.
@@ -299,7 +299,7 @@ Here's a concrete example:
   WHERE country_code = 'US'
   ```
 
-**Explicitly Including Values in Cache Key**
+### Explicitly Including Values in Cache Key
 
 The `{{ cache_key_wrapper() }}` function explicitly instructs Superset to add a value to the
 accumulated list of values used in the calculation of the cache key.
@@ -311,7 +311,7 @@ in the cache key. You can gain more context
 Note that this function powers the caching of the `user_id` and `username` values
 in the `current_user_id()` and `current_username()` function calls (if you have caching enabled).
 
-**Filter Values**
+### Filter Values
 
 You can retrieve the value for a specific filter as a list using `{{ filter_values() }}`.
 
@@ -332,7 +332,7 @@ GROUP BY action
 
 There `where_in` filter converts the list of values from `filter_values('action_type')` into a string suitable for an `IN` expression.
 
-**Filters for a Specific Column**
+### Filters for a Specific Column
 
 The `{{ get_filters() }}` macro returns the filters applied to a given column. In addition to
 returning the values (similar to how `filter_values()` does), the `get_filters()` macro
@@ -394,7 +394,7 @@ Here's a concrete example:
     order by lineage, level
 ```
 
-**Time Filter**
+### Time Filter
 
 The `{{ get_time_filter() }}` macro returns the time filter applied to a specific column. This is useful if you want
 to handle time filters inside the virtual dataset, as by default the time filter is placed on the outer query. This can
@@ -469,7 +469,7 @@ WHERE
   AND dttm < {{ time_filter.to_expr }}
 ```
 
-**Datasets**
+### Datasets
 
 It's possible to query physical and virtual datasets using the `dataset` macro. This is useful if you've defined computed columns and metrics on your datasets, and want to reuse the definition in adhoc SQL Lab queries.
 
@@ -493,7 +493,7 @@ Since metrics are aggregations, the resulting SQL expression will be grouped by 
 SELECT * FROM {{ dataset(42, include_metrics=True, columns=["ds", "category"]) }} LIMIT 10
 ```
 
-**Metrics**
+### Metrics
 
 The `{{ metric('metric_key', dataset_id) }}` macro can be used to retrieve the metric SQL syntax from a dataset. This can be useful for different purposes:
 
@@ -511,7 +511,7 @@ The parameter can be used in SQL Lab, or when fetching a metric from another dat
 
 Superset supports [builtin filters from the Jinja2 templating package](https://jinja.palletsprojects.com/en/stable/templates/#builtin-filters). Custom filters have also been implemented:
 
-**Where In**
+### Where In
 Parses a list into a SQL-compatible statement. This is useful with macros that return an array (for example the `filter_values` macro):
 
 ```
@@ -528,7 +528,7 @@ Dashboard filter without any value applied
 {{ filter_values('column')|where_in(default_to_none=True) }} => None
 ```
 
-**To Datetime**
+### To Datetime
 
 Loads a string as a `datetime` object. This is useful when performing date operations. For example:
 ```


### PR DESCRIPTION
### SUMMARY

It's currently not possible to deep link to one available macro in the page because the headers are just bold text. switching to proper Markdown headers fixes this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1261" height="415" alt="image" src="https://github.com/user-attachments/assets/6ae4b7d5-69f8-40b4-bfb1-33b289712711" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
