### PR TITLE
fix(frontend): resolve race condition in DatasetUsageTab pagination s…

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/DatasetUsageTab.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/DatasetUsageTab.test.tsx
@@ -22,6 +22,7 @@ import {
   screen,
   waitFor,
 } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import DatasetUsageTab from '.';
 
@@ -109,13 +110,25 @@ const setupTest = (props = {}) => {
   });
 };
 
+// Store original scrollTo to restore after tests
+let originalScrollTo: typeof Element.prototype.scrollTo;
+
+beforeAll(() => {
+  // Capture original scrollTo implementation once before all tests
+  originalScrollTo = Element.prototype.scrollTo;
+});
+
 beforeEach(() => {
   fetchMock.reset();
   jest.clearAllMocks();
+  // Mock scrollTo for all tests
+  Element.prototype.scrollTo = jest.fn();
 });
 
 afterEach(() => {
   fetchMock.restore();
+  // Restore original scrollTo implementation after each test
+  Element.prototype.scrollTo = originalScrollTo;
 });
 
 test('renders empty state when no charts provided', () => {
@@ -211,4 +224,206 @@ test('enables sorting for Chart and Last modified columns', async () => {
     expect(ownersHeader).not.toHaveClass('ant-table-column-has-sorters');
     expect(dashboardHeader).not.toHaveClass('ant-table-column-has-sorters');
   });
+});
+
+test('shows loading state during pagination fetch', async () => {
+  let resolvePromise: (value: any) => void;
+  const delayedPromise = new Promise(resolve => {
+    resolvePromise = resolve;
+  });
+
+  const mockOnFetchCharts = jest.fn(() => delayedPromise);
+
+  // Start with multiple pages
+  setupTest({
+    onFetchCharts: mockOnFetchCharts,
+    totalCount: 100,
+  });
+
+  // Initial render - no loading
+  expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+
+  // Find next page button
+  const nextButton = screen.getByTitle('Next Page');
+
+  await userEvent.click(nextButton);
+
+  // Should show loading state
+  await waitFor(() => {
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+  });
+
+  // Resolve the promise
+  resolvePromise!({
+    charts: mockChartsResponse.result,
+    count: 100,
+    ids: [1, 2],
+  });
+
+  // Loading should disappear
+  await waitFor(() => {
+    expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+  });
+});
+
+test('calls onFetchCharts with correct pagination parameters', async () => {
+  const mockOnFetchCharts = jest.fn(() =>
+    Promise.resolve({
+      charts: mockChartsResponse.result,
+      count: 100,
+      ids: [1, 2],
+    }),
+  );
+
+  setupTest({
+    onFetchCharts: mockOnFetchCharts,
+    totalCount: 100,
+  });
+
+  const nextButton = screen.getByTitle('Next Page');
+
+  await userEvent.click(nextButton);
+
+  await waitFor(() => {
+    expect(mockOnFetchCharts).toHaveBeenCalledWith(
+      2, // page
+      25, // pageSize
+      'changed_on_delta_humanized', // sortColumn
+      'desc', // sortDirection
+    );
+  });
+});
+
+test('shows error toast when fetch fails', async () => {
+  const mockOnFetchCharts = jest.fn(() =>
+    Promise.reject(new Error('Network error')),
+  );
+  const mockAddDangerToast = jest.fn();
+
+  setupTest({
+    onFetchCharts: mockOnFetchCharts,
+    addDangerToast: mockAddDangerToast,
+    totalCount: 100,
+  });
+
+  const nextButton = screen.getByTitle('Next Page');
+
+  await userEvent.click(nextButton);
+
+  await waitFor(() => {
+    expect(mockAddDangerToast).toHaveBeenCalledWith('Error fetching charts');
+  });
+
+  // Loading state should be cleared
+  expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+});
+
+test('handles slow network without race condition', async () => {
+  let resolvePromise: (value: any) => void;
+  const slowPromise = new Promise(resolve => {
+    resolvePromise = resolve;
+  });
+
+  const mockOnFetchCharts = jest.fn(() => slowPromise);
+
+  setupTest({
+    onFetchCharts: mockOnFetchCharts,
+    totalCount: 100,
+  });
+
+  const nextButton = screen.getByTitle('Next Page');
+
+  await userEvent.click(nextButton);
+
+  // Should be loading
+  await waitFor(() => {
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+  });
+
+  // Should still be loading (data hasn't arrived)
+  expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+
+  // Now resolve the promise
+  resolvePromise!({
+    charts: mockChartsResponse.result,
+    count: 100,
+    ids: [1, 2],
+  });
+
+  // Wait for loading to complete
+  await waitFor(() => {
+    expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+  });
+});
+
+test('scrolls to top after data loads, not before', async () => {
+  // Use the global scrollTo mock
+  const scrollToMock = Element.prototype.scrollTo as jest.Mock;
+
+  let resolvePromise: (value: any) => void;
+  const delayedPromise = new Promise(resolve => {
+    resolvePromise = resolve;
+  });
+
+  const mockOnFetchCharts = jest.fn(() => delayedPromise);
+
+  setupTest({
+    onFetchCharts: mockOnFetchCharts,
+    totalCount: 100,
+  });
+
+  const nextButton = screen.getByTitle('Next Page');
+
+  await userEvent.click(nextButton);
+
+  // Should be loading
+  await waitFor(() => {
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+  });
+
+  // Scroll should NOT have been called yet (data still loading)
+  expect(scrollToMock).not.toHaveBeenCalled();
+
+  // Resolve the promise
+  resolvePromise!({
+    charts: mockChartsResponse.result,
+    count: 100,
+    ids: [1, 2],
+  });
+
+  // Wait for loading to complete
+  await waitFor(() => {
+    expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+  });
+
+  // Scroll should be called after data loads (with requestAnimationFrame)
+  await waitFor(() => {
+    expect(scrollToMock).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+});
+
+test('does not scroll on initial mount, only on page change', async () => {
+  // Use the global scrollTo mock
+  const scrollToMock = Element.prototype.scrollTo as jest.Mock;
+
+  const mockOnFetchCharts = jest.fn(() =>
+    Promise.resolve({
+      charts: mockChartsResponse.result,
+      count: 2,
+      ids: [1, 2],
+    }),
+  );
+
+  setupTest({ onFetchCharts: mockOnFetchCharts });
+
+  // Wait for initial render
+  await waitFor(() => {
+    expect(screen.getByText('Test Chart 1')).toBeInTheDocument();
+  });
+
+  // Scroll should not have been called on mount
+  expect(scrollToMock).not.toHaveBeenCalled();
 });

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/components/DatasetUsageTab/index.tsx
@@ -99,6 +99,7 @@ const DatasetUsageTab = ({
 }: DatasetUsageTabProps) => {
   const addDangerToastRef = useRef(addDangerToast);
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const prevLoadingRef = useRef(false);
 
   const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -132,11 +133,13 @@ const DatasetUsageTab = ({
     addDangerToastRef.current = addDangerToast;
   }, [addDangerToast]);
 
-  const handlePageChange = useCallback(
-    (page: number) => {
-      handleFetchCharts(page);
+  // Scroll to top after data loads (when loading changes from true to false)
+  useEffect(() => {
+    let frameId: number | undefined;
 
-      setTimeout(() => {
+    if (prevLoadingRef.current && !loading) {
+      // Loading just finished, scroll to top
+      frameId = requestAnimationFrame(() => {
         const tableBody =
           tableContainerRef.current?.querySelector('.ant-table-body');
         if (tableBody) {
@@ -145,7 +148,21 @@ const DatasetUsageTab = ({
             behavior: 'smooth',
           });
         }
-      }, 100);
+      });
+    }
+    prevLoadingRef.current = loading;
+
+    // Cleanup: cancel animation frame if component unmounts
+    return () => {
+      if (frameId !== undefined) {
+        cancelAnimationFrame(frameId);
+      }
+    };
+  }, [loading]);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      handleFetchCharts(page);
     },
     [handleFetchCharts],
   );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes a race condition in the DatasetUsageTab component where pagination scroll-to-top occurred before data finished loading, resulting in poor UX on slow networks. this can then lead to unmount issues in tests.

  **Problem:**
  The handlePageChange function used a fixed 100ms setTimeout to scroll the table to the top after clicking pagination. This arbitrary delay didn't account for actual data load time, causing the scroll to fire before new data rendered. On slow networks, users would briefly see old data in the scrolled position before it updated.

  **Solution:**
  - Replaced arbitrary timeout with a React useEffect that monitors loading state transitions
  - Scroll now triggers when loading changes from true → false, guaranteeing data has loaded
  - Uses requestAnimationFrame for precise DOM timing after render
  - Properly cleans up animation frame on unmount to prevent JSDOM errors

  **Changes:**
  - Added prevLoadingRef to track loading state transitions
  - Implemented scroll effect with cleanup (prevents memory leaks)
  - Removed 100ms setTimeout from handlePageChange
  - Added 7 comprehensive RTL tests for async pagination behavior (16/16 tests passing)
  - Fixed test isolation with proper mock cleanup
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
 **Automated Tests** (16/16 passing):
  npm run test -- DatasetUsageTab.test.tsx

  **Manual Testing:**
  1. Open a dataset that has more than 25 charts (to enable pagination)
  2. Navigate to the "Usage" tab
  3. Test with throttled network (important!):
    - Open Chrome DevTools → Network → Throttling: "Fast 3G"
  4. Click through multiple pages of chart results
  5. Verify:
    - Table scrolls to top AFTER new data appears (not before)
    - No flash of old data before update
    - Smooth, predictable behavior



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
