### PR TITLE
test(tasks): Add tests for log_task_failure signal handler

### DIFF
--- a/tests/integration_tests/reports/scheduler_tests.py
+++ b/tests/integration_tests/reports/scheduler_tests.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from random import randint
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask_appbuilder.security.sqla.models import User
@@ -25,7 +25,7 @@ from freezegun.api import FakeDatetime
 
 from superset.extensions import db
 from superset.reports.models import ReportScheduleType
-from superset.tasks.scheduler import execute, scheduler
+from superset.tasks.scheduler import execute, log_task_failure, scheduler
 from tests.integration_tests.reports.utils import insert_report_schedule
 from tests.integration_tests.test_app import app
 
@@ -201,3 +201,48 @@ def test_execute_task_with_command_exception(
 
     db.session.delete(report_schedule)
     db.session.commit()
+
+
+@patch("superset.tasks.scheduler.logger")
+def test_log_task_failure_with_sender(logger_mock):
+    """
+    Test that log_task_failure logs correctly when sender is provided
+    """
+    mock_task = MagicMock()
+    mock_task.name = "test.task.name"
+    mock_exception = Exception("Test error")
+    mock_einfo = MagicMock()
+
+    log_task_failure(
+        sender=mock_task,
+        task_id="test-task-id",
+        exception=mock_exception,
+        einfo=mock_einfo,
+    )
+
+    logger_mock.exception.assert_called_once_with(
+        "Celery task %s failed: %s",
+        "test.task.name",
+        mock_exception,
+        exc_info=mock_einfo,
+    )
+
+
+@patch("superset.tasks.scheduler.logger")
+def test_log_task_failure_without_sender(logger_mock):
+    """
+    Test that log_task_failure logs correctly when sender is None
+    """
+    mock_exception = Exception("Test error")
+    mock_einfo = MagicMock()
+
+    log_task_failure(
+        sender=None,
+        task_id="test-task-id",
+        exception=mock_exception,
+        einfo=mock_einfo,
+    )
+
+    logger_mock.exception.assert_called_once_with(
+        "Celery task %s failed: %s", "Unknown", mock_exception, exc_info=mock_einfo
+    )


### PR DESCRIPTION
### SUMMARY
This PR adds test coverage for the `log_task_failure` signal handler that was introduced in #35595.

The original PR added the signal handler to log Celery task failures, but did not include tests. This follow-up PR adds comprehensive test coverage for the handler.

Related to #35595

### TESTING INSTRUCTIONS
Run the new tests:
```bash
pytest tests/integration_tests/reports/scheduler_tests.py::test_log_task_failure_with_sender tests/integration_tests/reports/scheduler_tests.py::test_log_task_failure_without_sender -v
```

Both tests should pass, verifying:
- The handler logs correctly when a task sender is provided
- The handler gracefully handles None sender and logs "Unknown"

### ADDITIONAL INFORMATION
- [ ] Has associated issue: Related to #35595
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API