### PR TITLE
fix(Actions): Improper spacing

### DIFF
--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -103,6 +103,9 @@ const Actions = styled.div`
         }
       }
       color: ${theme.colorTextDisabled};
+      &:hover {
+        cursor: not-allowed;
+      }
       .ant-menu-item:hover {
         cursor: default;
       }
@@ -479,7 +482,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                   <span
                     role="button"
                     tabIndex={0}
-                    className={allowEdit ? 'action-button' : 'disabled'}
+                    className={`action-button ${allowEdit ? '' : 'disabled'}`}
                     onClick={allowEdit ? handleEdit : undefined}
                   >
                     <Icons.EditOutlined iconSize="l" />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fix improper spacing of disabled edit icon on Datasets list.

### BEFORE
<img width="1431" height="748" alt="Screenshot 2025-10-03 at 12 10 05" src="https://github.com/user-attachments/assets/27d050dc-9dd3-4a9e-8ecc-59830cb9b425" />

### AFTER
<img width="1505" height="222" alt="Screenshot 2025-10-19 at 15 42 26" src="https://github.com/user-attachments/assets/add2357f-a1ab-4583-9076-66ac98e4d086" />


### TESTING INSTRUCTIONS
1. Visit the datasets list
2. Find a virtual dataset for which you don't have permissions to edit
3. The actions should be spaced correctly


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
