### PR TITLE
fix(chart): allow custom date format for week range in Big Number with Trendline

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/utils.ts
@@ -49,7 +49,7 @@ export const getDateFormatter = (
 ) =>
   timeFormat === SMART_DATE_ID
     ? getTimeFormatterForGranularity(granularity)
-    : getTimeFormatter(timeFormat ?? fallbackFormat);
+    : getTimeFormatter(timeFormat ?? fallbackFormat, granularity);
 
 export function getOriginalLabel(
   metric: QueryFormMetric,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BigNumber/transformProps.test.ts
@@ -133,10 +133,34 @@ describe('BigNumberWithTrendline', () => {
       // bigNumberFallback is only set when bigNumber is null after aggregation
       expect(transformed.bigNumberFallback).toBeNull();
 
-      // should successfully formatTime by granularity
+      // granularity (QUARTER) is honored, so the default format renders the
+      // full quarter range rather than only the start date
       // @ts-expect-error
       expect(transformed.formatTime(new Date('2020-01-01'))).toStrictEqual(
-        '2020-01-01 00:00:00',
+        '2020 Q1',
+      );
+    });
+
+    test('should format the week range with a custom date format', () => {
+      // Regression test for #35636: a custom date format combined with a Week
+      // time grain should render the full week range, not just the start date.
+      const propsWithWeekGranularity = {
+        ...props,
+        rawFormData: {
+          ...rawFormData,
+          time_grain_sqla: TimeGranularity.WEEK,
+        },
+        formData: {
+          ...props.formData,
+          timeGrainSqla: TimeGranularity.WEEK,
+          timeFormat: '%d-%m-%Y',
+        },
+      } as unknown as BigNumberWithTrendlineChartProps;
+
+      const transformed = transformProps(propsWithWeekGranularity);
+      // @ts-expect-error
+      expect(transformed.formatTime(new Date('2025-10-13'))).toStrictEqual(
+        '13-10-2025 — 19-10-2025',
       );
     });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

This PR fixes an issue where the **Big Number with Trendline** chart only displayed the **start date** of a weekly range when a **custom date format** was applied.
Previously, setting a custom format like `%d-%m-%Y` would show only the week’s start date (e.g., `13-10-2025`), even though the adaptive format correctly displayed the full range (`2025-10-13 — 2025-10-19`).

**Change details:**

Optional granularity variable was not passed down the stack (except for adaptive format case)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
<img width="1861" height="974" alt="image" src="https://github.com/user-attachments/assets/b3c802f1-ac71-4e86-b6ce-5740e537ba67" />

After:
<img width="1856" height="969" alt="image" src="https://github.com/user-attachments/assets/3215f9bc-2ae6-452e-8245-f56ef9ffeed8" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a **Big Number with Trendline** chart.
2. Set **Time grain** → *Week*.
3. Under **Customize → Date format**, enter a custom format such as `%d-%m-%Y`.
4. Verify that the chart now displays the full week range (e.g., `13-10-2025 — 19-10-2025`).

### ADDITIONAL INFORMATION

<!--- Check any relevant boxes with "x" -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

* [x] Has associated issue: Fixes #35636
* [ ] Required feature flags:
* [x] Changes UI
* [ ] Includes DB Migration (follow approval process in [[SIP-59](https://github.com/apache/superset/issues/13351)](https://github.com/apache/superset/issues/13351))

* [ ] Migration is atomic, supports rollback & is backwards-compatible
* [ ] Confirm DB migration upgrade and downgrade tested
* [ ] Runtime estimates and downtime expectations provided
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API