### PR TITLE
fix: Extension events not fired in SQL Lab tabs

### DIFF
--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -30,7 +30,6 @@ import {
 } from 'src/SqlLab/actions/sqlLab';
 import { RootState, store } from 'src/views/store';
 import { AnyListenerPredicate } from '@reduxjs/toolkit';
-import memoizeOne from 'memoize-one';
 import type { SqlLabRootState } from 'src/SqlLab/types';
 import { Disposable } from '../models';
 import { createActionListener } from '../utils';
@@ -198,13 +197,10 @@ const getActiveEditorImmutableId = () => {
   return activeEditor?.immutableId;
 };
 
-// Memoized version to avoid repeated store lookups when active editor hasn't changed
-const getActiveEditorId = memoizeOne(getActiveEditorImmutableId);
-
 const predicate = (actionType: string): AnyListenerPredicate<RootState> => {
   // Capture the immutable ID of the active editor at the time the listener is created
   // This ID never changes for a tab, ensuring stable event routing
-  const registrationImmutableId = getActiveEditorId();
+  const registrationImmutableId = getActiveEditorImmutableId();
 
   return action => {
     if (action.type !== actionType) return false;


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the use of a memoization function was generating the same immutable IDs for different tabs in SQL Lab, preventing events from being fired for newly created tabs.

### TESTING INSTRUCTIONS
1. Create a new tab in SQL Lab.
2. Run a query.
3. Check that an extension rendered in the new tab receives the `onDidQueryRun` event.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
