### PR TITLE
fix: edit dataset modal visual fixes

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
@@ -28,6 +28,7 @@ export const StyledHeader = styled.span<{ headerPosition: string }>`
     text-overflow: ellipsis;
     white-space: nowrap;
     margin-right: ${headerPosition === 'left' ? theme.sizeUnit * 2 : 0}px;
+    font-size: ${theme.fontSizeSM}px;
   `}
 `;
 

--- a/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
+++ b/superset-frontend/src/explore/components/controls/TextAreaControl.jsx
@@ -208,8 +208,7 @@ class TextAreaControl extends Component {
                 buttonSize="small"
                 style={{ marginTop: this.props.theme.sizeUnit }}
               >
-                {t('Edit')} <strong>{this.props.language}</strong>{' '}
-                {t('in modal')}
+                {t('Edit %s in modal', this.props.language)}
               </Button>
             }
             modalBody={this.renderModalBody(true)}


### PR DESCRIPTION
### SUMMARY
  This PR fixes visual inconsistencies in the edit dataset modal by standardizing label styling across form fields.

  **Changes:**
  1. **AsyncSelect header font-size**: Added `font-size: ${theme.fontSizeSM}px` to `StyledHeader` component to match the font-size of other form labels in the Settings tab (e.g., Description, Default URL). Previously, the Owners label appeared larger than other labels due to missing font-size styling.

  2. **TextAreaControl button text**: Improved the "Edit in modal" button text, it was previously using `strong` and this caused an inconsistent styling standard.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
  **Before**: (1. edit sql in modal styles 2. Owners label with larger font)
<img width="1786" height="2428" alt="dataset_settings_bug" src="https://github.com/user-attachments/assets/53467879-7499-452d-a92d-f84cff1e6ea5" />

  **After**: Consistent styling
<img width="450" height="544" alt="Screenshot 2025-10-22 at 13 25 51" src="https://github.com/user-attachments/assets/102d504a-40c6-439c-b599-7e2c6ac41e1a" />


  ### TESTING INSTRUCTIONS
  1. Navigate to http://localhost:9000/tablemodelview/list/
  2. Click the edit icon on any dataset
  3. Navigate to the Settings tab
  4. Verify that the "Owners" label font-size matches other labels like "Description", "Default URL", "Autocomplete filters", etc.
  5. Verify that the "Edit sql in modal" button style is consistent with the UI

  ### ADDITIONAL INFORMATION
  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API