### PR TITLE
fix(reports): improve error handling for report schedule execution

### DIFF
--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -20,8 +20,10 @@ from uuid import uuid4
 
 import pytest
 from flask import current_app
+from sqlalchemy.orm.exc import StaleDataError
 
 from superset.commands.dashboard.permalink.create import CreateDashboardPermalinkCommand
+from superset.commands.report.exceptions import ReportScheduleUnexpectedError
 from superset.commands.report.execute import AsyncExecuteReportScheduleCommand
 from superset.models.dashboard import Dashboard
 from superset.reports.models import ReportSourceFormat
@@ -118,3 +120,40 @@ def test_report_with_header_data(
         assert header_data.get("notification_source") == ReportSourceFormat.DASHBOARD
         assert header_data.get("notification_type") == report_schedule.type
         assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 8
+
+
+@patch("superset.reports.notifications.email.send_email_smtp")
+@patch("superset.commands.report.execute.DashboardScreenshot")
+@pytest.mark.usefixtures("login_as_admin")
+def test_report_schedule_stale_data_error_preserves_cause(
+    dashboard_screenshot_mock: MagicMock,
+    send_email_smtp_mock: MagicMock,
+    tabbed_dashboard: Dashboard,  # noqa: F811
+) -> None:
+    """
+    Test that when db.session.commit raises StaleDataError during logging,
+    we surface ReportScheduleUnexpectedError while preserving the original
+    StaleDataError as the cause.
+    """
+    dashboard_screenshot_mock.get_screenshot.return_value = b"test-image"
+    current_app.config["ALERT_REPORTS_NOTIFICATION_DRY_RUN"] = False
+
+    with create_dashboard_report(
+        dashboard=tabbed_dashboard,
+        extra={},
+        name="test stale data error",
+    ) as report_schedule:
+        # Mock db.session.commit to raise StaleDataError during log creation
+        with patch("superset.db.session.commit") as mock_commit:
+            mock_commit.side_effect = StaleDataError("test stale data")
+
+            # Execute the report and expect ReportScheduleUnexpectedError
+            with pytest.raises(ReportScheduleUnexpectedError) as exc_info:
+                AsyncExecuteReportScheduleCommand(
+                    str(uuid4()), report_schedule.id, datetime.utcnow()
+                ).run()
+
+            # Verify the original StaleDataError is preserved as the cause
+            assert exc_info.value.__cause__ is not None
+            assert isinstance(exc_info.value.__cause__, StaleDataError)
+            assert str(exc_info.value.__cause__) == "test stale data"


### PR DESCRIPTION
### SUMMARY

This PR fixes critical error handling issues in the report scheduling system that were causing:
1. Confusing cascading errors with "UPDATE" messages
2. Silent error swallowing where failures weren't logged to the dashboard
3. Recursive failures when database logging itself failed

**Root Cause**: When a report schedule is deleted/modified by another process during execution, SQLAlchemy raises `StaleDataError`. The original code didn't handle this, leading to session rollback and subsequent `PendingRollbackError` when trying to access lazy-loaded attributes.

**Changes**:
1. **Handle StaleDataError gracefully** in `create_log()`: Catch the exception, rollback the session, and raise a clear error message that won't be redacted
2. **Fix silent error swallowing** in `ReportSuccessState.next()`: Add missing `raise` statement so errors actually propagate
3. **Prevent recursive logging failures**: Add exception guards around all `update_report_schedule_and_log()` calls to prevent infinite loops when logging itself fails

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend error handling improvement

### TESTING INSTRUCTIONS

1. **Test StaleDataError handling**:
   - Start a long-running report execution (e.g., with a slow query)
   - Delete the report schedule while it's running
   - Verify: Error is logged to `report_execution_log` table with clear message
   - Verify: No cascade of `PendingRollbackError` exceptions

2. **Test error propagation**:
   - Create a report with a chart that will fail (e.g., broken SQL)
   - Run the report
   - Verify: Error appears in dashboard logs and system logs
   - Verify: Error notification is sent to owners

3. **Test normal execution**:
   - Run a successful report
   - Verify: No regressions in normal operation

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API