### PR TITLE
fix(reports): Add celery task execution ID to email notification logs

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -507,6 +507,7 @@ class BaseReportState:
             "dashboard_id": dashboard_id,
             "owners": self._report_schedule.owners,
             "slack_channels": slack_channels,
+            "execution_id": str(self._execution_id),
         }
         return log_data
 

--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -253,7 +253,11 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                 header_data=content.header_data,
             )
             logger.info(
-                "Report sent to email, notification content is %s", content.header_data
+                "Report sent to email, task_id: %s, notification content is %s",
+                content.header_data.get("execution_id")
+                if content.header_data
+                else None,
+                content.header_data,
             )
         except SupersetErrorsException as ex:
             raise NotificationError(

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -216,6 +216,7 @@ class HeaderDataType(TypedDict):
     chart_id: int | None
     dashboard_id: int | None
     slack_channels: list[str] | None
+    execution_id: str | None
 
 
 class DatasourceDict(TypedDict):

--- a/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
+++ b/tests/integration_tests/reports/commands/execute_dashboard_report_tests.py
@@ -117,4 +117,4 @@ def test_report_with_header_data(
         assert header_data.get("notification_format") == report_schedule.report_format
         assert header_data.get("notification_source") == ReportSourceFormat.DASHBOARD
         assert header_data.get("notification_type") == report_schedule.type
-        assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 7
+        assert len(send_email_smtp_mock.call_args.kwargs["header_data"]) == 8

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -64,6 +64,7 @@ def test_log_data_with_chart(mocker: MockerFixture) -> None:
         "dashboard_id": None,
         "owners": [1, 2],
         "slack_channels": None,
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result
@@ -94,6 +95,7 @@ def test_log_data_with_dashboard(mocker: MockerFixture) -> None:
         "dashboard_id": 123,
         "owners": [1, 2],
         "slack_channels": None,
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result
@@ -128,6 +130,7 @@ def test_log_data_with_email_recipients(mocker: MockerFixture) -> None:
         "dashboard_id": 123,
         "owners": [1, 2],
         "slack_channels": [],
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result
@@ -162,6 +165,7 @@ def test_log_data_with_slack_recipients(mocker: MockerFixture) -> None:
         "dashboard_id": 123,
         "owners": [1, 2],
         "slack_channels": ["channel_1", "channel_2"],
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result
@@ -195,6 +199,7 @@ def test_log_data_no_owners(mocker: MockerFixture) -> None:
         "dashboard_id": 123,
         "owners": [],
         "slack_channels": ["channel_1", "channel_2"],
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result
@@ -230,6 +235,7 @@ def test_log_data_with_missing_values(mocker: MockerFixture) -> None:
         "dashboard_id": None,
         "owners": [1, 2],
         "slack_channels": ["channel_1", "channel_2"],
+        "execution_id": "execution_id_example",
     }
 
     assert result == expected_result

--- a/tests/unit_tests/reports/notifications/email_tests.py
+++ b/tests/unit_tests/reports/notifications/email_tests.py
@@ -47,6 +47,7 @@ def test_render_description_with_html() -> None:
             "chart_id": None,
             "dashboard_id": None,
             "slack_channels": None,
+            "execution_id": "test-execution-id",
         },
     )
     email_body = (
@@ -91,6 +92,7 @@ def test_email_subject_with_datetime() -> None:
             "chart_id": None,
             "dashboard_id": None,
             "slack_channels": None,
+            "execution_id": "test-execution-id",
         },
     )
     subject = EmailNotification(

--- a/tests/unit_tests/reports/notifications/slack_tests.py
+++ b/tests/unit_tests/reports/notifications/slack_tests.py
@@ -36,6 +36,7 @@ def mock_header_data() -> HeaderDataType:
         "chart_id": None,
         "dashboard_id": None,
         "slack_channels": ["some_channel"],
+        "execution_id": "test-execution-id",
     }
 
 


### PR DESCRIPTION
### SUMMARY
This PR adds the celery task execution ID to the email notification log message to improve traceability when debugging report and alert executions.

Previously, the log message "Report sent to email, notification content is %s" did not include the task execution ID, making it difficult to correlate email notifications with specific celery task executions. This change adds the task_id to the log output.

**Changes:**
- Added `execution_id` field to `HeaderDataType` TypedDict
- Updated `_get_log_data()` method to include execution_id in the log data
- Modified email notification log to display task_id before notification content
- Updated all unit tests to include execution_id in expected results

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a logging enhancement

### TESTING INSTRUCTIONS
1. Set up a report or alert with email notifications
2. Trigger the report/alert execution
3. Check the application logs for the email notification message
4. Verify that the log now includes `task_id: <execution_id>` in the format:
   ```
   Report sent to email, task_id: <uuid>, notification content is {...}
   ```
5. Run unit tests to verify they pass:
   ```bash
   pytest tests/unit_tests/commands/report/execute_test.py
   ```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)