### PR TITLE
docs(db_engine_specs): restructure feature table for GitHub rendering

### DIFF
--- a/superset/db_engine_specs/README.md
+++ b/superset/db_engine_specs/README.md
@@ -51,68 +51,510 @@ Note that DB engine specs are completely optional. Superset can connect to any d
 
 ## Features
 
-The table below (generated via `python superset/db_engine_specs/lib.py`) summarizes the information about the status of all DB engine specs in Superset (note that this excludes 3rd party DB engine specs):
+The tables below (generated via `python superset/db_engine_specs/lib.py`) summarize the status of all DB engine specs in Superset, organized by feature category for easier navigation (note that this excludes 3rd party DB engine specs).
 
-| Feature | Amazon Athena | Amazon DynamoDB | Amazon Redshift | Apache Drill | Apache Druid | Apache Hive | Apache Impala | Apache Kylin | Apache Pinot | Apache Solr | Apache Spark SQL | Ascend | Aurora MySQL (Data API) | Aurora PostgreSQL (Data API) | Azure Synapse | ClickHouse | ClickHouse Connect (Superset) | CockroachDB | CrateDB | Databricks | Databricks Interactive Cluster | Databricks SQL Endpoint | Dremio | DuckDB | ElasticSearch (OpenDistro SQL) | ElasticSearch (SQL API) | Exasol | Firebird | Firebolt | Google BigQuery | Google Sheets | IBM Db2 | IBM Netezza Performance Server | KustoKQL | KustoSQL | Microsoft SQL Server | MySQL | Ocient | Oracle | PostgreSQL | Presto | RisingWave | SAP HANA | SQLite | Shillelagh | Snowflake | StarRocks | Teradata | Trino | Vertica | base |
-|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|  ---|
-| Module | superset.db_engine_specs.athena | superset.db_engine_specs.dynamodb | superset.db_engine_specs.redshift | superset.db_engine_specs.drill | superset.db_engine_specs.druid | superset.db_engine_specs.hive | superset.db_engine_specs.impala | superset.db_engine_specs.kylin | superset.db_engine_specs.pinot | superset.db_engine_specs.solr | superset.db_engine_specs.spark | superset.db_engine_specs.ascend | superset.db_engine_specs.aurora | superset.db_engine_specs.aurora | superset.db_engine_specs.mssql | superset.db_engine_specs.clickhouse | superset.db_engine_specs.clickhouse | superset.db_engine_specs.cockroachdb | superset.db_engine_specs.crate | superset.db_engine_specs.databricks | superset.db_engine_specs.databricks | superset.db_engine_specs.databricks | superset.db_engine_specs.dremio | superset.db_engine_specs.duckdb | superset.db_engine_specs.elasticsearch | superset.db_engine_specs.elasticsearch | superset.db_engine_specs.exasol | superset.db_engine_specs.firebird | superset.db_engine_specs.firebolt | superset.db_engine_specs.bigquery | superset.db_engine_specs.gsheets | superset.db_engine_specs.db2 | superset.db_engine_specs.netezza | superset.db_engine_specs.kusto | superset.db_engine_specs.kusto | superset.db_engine_specs.mssql | superset.db_engine_specs.mysql | superset.db_engine_specs.ocient | superset.db_engine_specs.oracle | superset.db_engine_specs.postgres | superset.db_engine_specs.presto | superset.db_engine_specs.risingwave | superset.db_engine_specs.hana | superset.db_engine_specs.sqlite | superset.db_engine_specs.shillelagh | superset.db_engine_specs.snowflake | superset.db_engine_specs.starrocks | superset.db_engine_specs.teradata | superset.db_engine_specs.trino | superset.db_engine_specs.vertica | superset.db_engine_specs.presto |
-| Method used to limit the rows in the subquery | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | WRAP_SQL | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FETCH_MANY | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | WRAP_SQL | FORCE_LIMIT | WRAP_SQL | WRAP_SQL | WRAP_SQL | FORCE_LIMIT | FORCE_LIMIT | WRAP_SQL | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | WRAP_SQL | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT | WRAP_SQL | FORCE_LIMIT | FORCE_LIMIT | FORCE_LIMIT |
-| Supports JOINs | True | True | True | True | False | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Supports subqueries | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Allows aliases in the SELECT statement | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Allows referencing aliases in the ORDER BY statement | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Supports secondary time columns | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Allows omitting time filters from inline GROUP BYs | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Able to use source column when an alias overshadows it | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | True | False | False |
-| Allows aggregations in ORDER BY not present in the SELECT | True | True | True | True | True | False | True | True | True | True | False | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Allows expressions in ORDER BY | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Allows CTE as a subquery | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Allows LIMIT clause (instead of TOP) | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True |
-| Maximum column name | None | None | 127 | None | None | 767 | None | None | None | None | 767 | None | 64 | 63 | 128 | None | None | 63 | None | None | 767 | None | None | None | None | None | 128 | None | None | 128 | None | 30 | None | None | None | 128 | 64 | 30 | 30 | None | None | 63 | None | 30 | None | None | 256 | 64 | 30 | None | None | None |
-| Allows comments | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Colons must be escaped | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain SECOND | True | True | True | True | True | True | False | True | True | False | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True |
-| Has time grain FIVE_SECONDS | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False |
-| Has time grain THIRTY_SECONDS | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False |
-| Has time grain MINUTE | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain FIVE_MINUTES | False | False | False | False | True | False | False | False | True | False | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | True | True | False | False | False | False | False | False | False | False | True | True | True | False | False | False | False | False |
-| Has time grain TEN_MINUTES | False | False | False | False | True | False | False | False | True | False | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | True | True | False | False | False | False | False | False | False | False | True | True | True | False | False | False | False | False |
-| Has time grain FIFTEEN_MINUTES | False | False | False | True | True | False | False | False | True | False | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | True | True | False | False | False | False | False | False | False | False | True | True | True | False | False | False | False | False |
-| Has time grain THIRTY_MINUTES | False | False | False | True | True | False | False | False | True | False | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | True | False | False | False | False | False | False | False | False | True | True | True | False | False | False | False | False |
-| Has time grain HALF_HOUR | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | True | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False |
-| Has time grain HOUR | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain SIX_HOURS | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False |
-| Has time grain DAY | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain WEEK | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | False | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True |
-| Has time grain WEEK_STARTING_SUNDAY | True | True | False | False | True | True | False | False | False | False | True | False | False | False | True | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | True | False | False | False | True | True | False | False | False | False | True | False | False | False | True | True | False | False | False | True | False | True |
-| Has time grain WEEK_STARTING_MONDAY | False | True | False | False | False | False | False | False | False | False | False | False | True | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | True | True | True | False | False | False | True | False | False | False | True | True | False | True | False | True | False | True |
-| Has time grain WEEK_ENDING_SATURDAY | True | True | False | False | True | True | False | False | False | False | True | False | False | False | False | False | False | False | False | True | True | True | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | True | True | False | False | False | True | False | True |
-| Has time grain WEEK_ENDING_SUNDAY | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | True | True | False | False | False | True | False | True |
-| Has time grain MONTH | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain QUARTER | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | False | True | True | True | True | True | False | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Has time grain QUARTER_YEAR | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | True | False | False | False | False | False | False | True | True | False | False | False | False | False | False |
-| Has time grain YEAR | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Masks/unmasks encrypted_extra | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Has column type mappings | False | False | False | False | False | True | False | False | False | False | True | False | True | True | True | True | True | True | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | True | False | False | False | True | True | False | False | False | False | False | True | False | True | False | True |
-| Returns a list of function names | False | False | False | False | False | True | False | False | False | False | True | False | False | False | False | True | True | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | True | True | False | False | False | True | False | True |
-| Supports user impersonation | False | False | False | True | False | True | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | True | False | True | False | False |
-| Support file upload | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True |
-| Returns extra table metadata | False | False | False | False | False | True | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | True | False | False |
-| Maps driver exceptions to Superset exceptions | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Parses error messages and returns Superset errors | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Supports changing the schema per-query | False | False | False | True | False | True | False | False | False | False | True | False | True | True | False | False | False | True | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | True | True | False | False | False | False | True | True | False | True | False | True |
-| Supports catalogs | False | False | True | False | False | False | False | False | False | False | False | False | False | True | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | True | False | False | True | False | False | False | False | False | False | True | False | True | False | True | False | False | True | False | False | False | True | False |
-| Supports changing the catalog per-query | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Can be connected thru an SSH tunnel | False | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True | True | True | True | True | True | True | True | False | False | True | True | True | True | True | True |
-| Allows query to be canceled | False | False | True | False | False | True | True | False | False | False | True | True | True | True | False | False | False | True | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | True | False | False | True | True | False | False | False | False | True | True | False | True | False | False |
-| Returns additional metrics on dataset creation | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False |
-| Supports querying the latest partition only | False | False | False | False | False | True | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | True | False | True |
-| Expands complex types (arrays, structs) into rows/columns | False | False | False | False | False | True | False | False | False | False | True | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False |
-| Supports query cost estimation | False | False | False | False | False | True | False | False | False | False | True | False | False | True | False | False | False | True | False | False | True | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | True | True | False | False | False | False | False | False | False | True | False | True |
-| Supports validating SQL before running query | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | False | True | False | False | False | False | False | False | False | False | False | False | False |
-| Score | 20 | 32 | 48 | 50 | 37 | 120 | 37 | 28 | 32 | 20 | 120 | 38 | 59 | 88 | 44 | 41 | 41 | 78 | 28 | 40 | 120 | 30 | 28 | 28 | 26 | 26 | 28 | 26 | 28 | 63 | 61 | 28 | 38 | 26 | 44 | 44 | 59 | 38 | 28 | 38 | 132 | 78 | 28 | 37 | 41 | 41 | 62 | 59 | 27 | 112 | 38 | 82 |
+### Quick Navigation
 
-(Note, this table is generated via: `python superset/db_engine_specs/lib.py`.)
+- [Feature Overview](#feature-overview) - High-level summary of support across all databases
+- [Database Information](#database-information) - Module paths and core metadata
+- [SQL Capabilities](#sql-capabilities) - SQL language features and capabilities
+- [Time Grains – Common](#time-grains--common) - Standard time granularity support
+- [Time Grains – Extended](#time-grains--extended) - Sub-hour and week variant time grains
+- [Core Platform & Metadata Features](#core-platform--metadata-features) - Platform integration and metadata capabilities
+- [Operational & Advanced Features](#operational--advanced-features) - Advanced operational capabilities
+
+### Feature Overview
+
+| Database | Score | SQL Basics | Advanced SQL | Common Time Grains | Extended Time Grains | Integrations | Advanced Features |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Presto | 159 | Supported | Partial | Supported | Partial | Partial | Supported |
+| Trino | 149 | Supported | Partial | Supported | Partial | Partial | Partial |
+| Apache Hive | 140 | Supported | Not supported | Supported | Partial | Partial | Partial |
+| Apache Spark SQL | 140 | Supported | Not supported | Supported | Partial | Partial | Partial |
+| Databricks Interactive Cluster | 140 | Supported | Not supported | Supported | Partial | Partial | Partial |
+| base | 109 | Supported | Partial | Supported | Partial | Partial | Partial |
+| Aurora PostgreSQL (Data API) | 104 | Supported | Partial | Supported | Partial | Partial | Partial |
+| CockroachDB | 94 | Supported | Partial | Supported | Partial | Partial | Partial |
+| RisingWave | 94 | Supported | Partial | Supported | Partial | Partial | Partial |
+| Google BigQuery | 83 | Supported | Partial | Supported | Partial | Partial | Partial |
+| Apache Doris | 79 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Snowflake | 72 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Databricks | 70 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Databricks (legacy) | 70 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| StarRocks | 69 | Supported | Partial | Supported | Partial | Partial | Partial |
+| SingleStore | 68 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| ClickHouse Connect (Superset) | 61 | Supported | Partial | Partial | Partial | Partial | Not supported |
+| Google Sheets | 61 | Supported | Partial | Supported | Supported | Partial | Partial |
+| Aurora MySQL (Data API) | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| MariaDB | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| MySQL | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| OceanBase | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| MotherDuck | 58 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| KustoSQL | 54 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| ClickHouse | 51 | Supported | Partial | Partial | Partial | Partial | Not supported |
+| Databend | 51 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Apache Drill | 50 | Supported | Partial | Supported | Partial | Partial | Partial |
+| Apache Druid | 47 | Partial | Partial | Supported | Partial | Partial | Not supported |
+| Amazon Redshift | 44 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Azure Synapse | 44 | Partial | Partial | Supported | Partial | Partial | Not supported |
+| Microsoft SQL Server | 44 | Partial | Partial | Supported | Partial | Partial | Not supported |
+| SQLite | 41 | Supported | Partial | Supported | Supported | Not supported | Not supported |
+| Shillelagh | 41 | Supported | Partial | Supported | Supported | Not supported | Not supported |
+| KustoKQL | 40 | Supported | Partial | Partial | Partial | Partial | Not supported |
+| Ascend | 38 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| DuckDB | 38 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| IBM Db2 | 38 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| IBM Db2 for i | 38 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Ocient | 38 | Partial | Partial | Partial | Partial | Partial | Not supported |
+| Apache Impala | 37 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| ElasticSearch (SQL API) | 37 | Partial | Partial | Partial | Not supported | Partial | Not supported |
+| PostgreSQL | 34 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Vertica | 34 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Amazon DynamoDB | 32 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Apache Pinot | 32 | Partial | Partial | Supported | Partial | Partial | Not supported |
+| Superset meta database | 31 | Supported | Partial | Supported | Supported | Not supported | Not supported |
+| Databricks SQL Endpoint | 30 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Apache Kylin | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| CrateDB | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Dremio | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Exasol | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Firebolt | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| IBM Netezza Performance Server | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Oracle | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Parseable | 28 | Supported | Partial | Supported | Not supported | Partial | Not supported |
+| Couchbase | 27 | Partial | Partial | Partial | Not supported | Partial | Not supported |
+| Denodo | 27 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| SAP HANA | 27 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| Teradata | 27 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| ElasticSearch (OpenDistro SQL) | 26 | Partial | Partial | Partial | Not supported | Partial | Not supported |
+| Firebird | 26 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| TDengine | 25 | Supported | Partial | Partial | Not supported | Partial | Not supported |
+| YDB | 23 | Supported | Partial | Supported | Partial | Partial | Not supported |
+| Amazon Athena | 20 | Supported | Partial | Supported | Partial | Not supported | Not supported |
+| Apache Solr | 20 | Partial | Partial | Not supported | Not supported | Partial | Not supported |
+
+### Database Information
+
+| Database | Module | Limit Method | Limit Clause | Max Column Name |
+| --- | --- | --- | --- | --- |
+| Amazon Athena | superset.db_engine_specs.athena | FORCE_LIMIT | True | None |
+| Amazon DynamoDB | superset.db_engine_specs.dynamodb | FORCE_LIMIT | True | None |
+| Amazon Redshift | superset.db_engine_specs.redshift | FORCE_LIMIT | True | 127 |
+| Apache Doris | superset.db_engine_specs.doris | FORCE_LIMIT | True | 64 |
+| Apache Drill | superset.db_engine_specs.drill | FORCE_LIMIT | True | None |
+| Apache Druid | superset.db_engine_specs.druid | FORCE_LIMIT | True | None |
+| Apache Hive | superset.db_engine_specs.hive | FORCE_LIMIT | True | 767 |
+| Apache Impala | superset.db_engine_specs.impala | FORCE_LIMIT | True | None |
+| Apache Kylin | superset.db_engine_specs.kylin | FORCE_LIMIT | True | None |
+| Apache Pinot | superset.db_engine_specs.pinot | FORCE_LIMIT | True | None |
+| Apache Solr | superset.db_engine_specs.solr | FORCE_LIMIT | True | None |
+| Apache Spark SQL | superset.db_engine_specs.spark | FORCE_LIMIT | True | 767 |
+| Ascend | superset.db_engine_specs.ascend | FORCE_LIMIT | True | None |
+| Aurora MySQL (Data API) | superset.db_engine_specs.aurora | FORCE_LIMIT | True | 64 |
+| Aurora PostgreSQL (Data API) | superset.db_engine_specs.aurora | FORCE_LIMIT | True | 63 |
+| Azure Synapse | superset.db_engine_specs.mssql | FORCE_LIMIT | True | 128 |
+| ClickHouse | superset.db_engine_specs.clickhouse | FORCE_LIMIT | True | None |
+| ClickHouse Connect (Superset) | superset.db_engine_specs.clickhouse | FORCE_LIMIT | True | None |
+| CockroachDB | superset.db_engine_specs.cockroachdb | FORCE_LIMIT | True | 63 |
+| Couchbase | superset.db_engine_specs.couchbase | FORCE_LIMIT | True | None |
+| CrateDB | superset.db_engine_specs.crate | FORCE_LIMIT | True | None |
+| Databend | superset.db_engine_specs.databend | FORCE_LIMIT | True | None |
+| Databricks | superset.db_engine_specs.databricks | FORCE_LIMIT | True | None |
+| Databricks (legacy) | superset.db_engine_specs.databricks | FORCE_LIMIT | True | None |
+| Databricks Interactive Cluster | superset.db_engine_specs.databricks | FORCE_LIMIT | True | 767 |
+| Databricks SQL Endpoint | superset.db_engine_specs.databricks | FORCE_LIMIT | True | None |
+| Denodo | superset.db_engine_specs.denodo | FORCE_LIMIT | True | None |
+| Dremio | superset.db_engine_specs.dremio | FORCE_LIMIT | True | None |
+| DuckDB | superset.db_engine_specs.duckdb | FORCE_LIMIT | True | None |
+| ElasticSearch (OpenDistro SQL) | superset.db_engine_specs.elasticsearch | FORCE_LIMIT | True | None |
+| ElasticSearch (SQL API) | superset.db_engine_specs.elasticsearch | FORCE_LIMIT | True | None |
+| Exasol | superset.db_engine_specs.exasol | FORCE_LIMIT | True | 128 |
+| Firebird | superset.db_engine_specs.firebird | FETCH_MANY | True | None |
+| Firebolt | superset.db_engine_specs.firebolt | FORCE_LIMIT | True | None |
+| Google BigQuery | superset.db_engine_specs.bigquery | FORCE_LIMIT | True | 128 |
+| Google Sheets | superset.db_engine_specs.gsheets | FORCE_LIMIT | True | None |
+| IBM Db2 | superset.db_engine_specs.db2 | WRAP_SQL | True | 30 |
+| IBM Db2 for i | superset.db_engine_specs.ibmi | WRAP_SQL | True | 128 |
+| IBM Netezza Performance Server | superset.db_engine_specs.netezza | FORCE_LIMIT | True | None |
+| KustoKQL | superset.db_engine_specs.kusto | FORCE_LIMIT | True | None |
+| KustoSQL | superset.db_engine_specs.kusto | WRAP_SQL | True | None |
+| MariaDB | superset.db_engine_specs.mariadb | FORCE_LIMIT | True | 64 |
+| Microsoft SQL Server | superset.db_engine_specs.mssql | FORCE_LIMIT | True | 128 |
+| MotherDuck | superset.db_engine_specs.duckdb | FORCE_LIMIT | True | None |
+| MySQL | superset.db_engine_specs.mysql | FORCE_LIMIT | True | 64 |
+| OceanBase | superset.db_engine_specs.oceanbase | FORCE_LIMIT | True | 128 |
+| Ocient | superset.db_engine_specs.ocient | FORCE_LIMIT | True | 30 |
+| Oracle | superset.db_engine_specs.oracle | FORCE_LIMIT | True | 128 |
+| Parseable | superset.db_engine_specs.parseable | FORCE_LIMIT | True | None |
+| PostgreSQL | superset.db_engine_specs.postgres | FORCE_LIMIT | True | None |
+| Presto | superset.db_engine_specs.presto | FORCE_LIMIT | True | None |
+| RisingWave | superset.db_engine_specs.risingwave | FORCE_LIMIT | True | 63 |
+| SAP HANA | superset.db_engine_specs.hana | WRAP_SQL | True | 30 |
+| SQLite | superset.db_engine_specs.sqlite | FORCE_LIMIT | True | None |
+| Shillelagh | superset.db_engine_specs.shillelagh | FORCE_LIMIT | True | None |
+| SingleStore | superset.db_engine_specs.singlestore | FORCE_LIMIT | True | 256 |
+| Snowflake | superset.db_engine_specs.snowflake | FORCE_LIMIT | True | 256 |
+| StarRocks | superset.db_engine_specs.starrocks | FORCE_LIMIT | True | 64 |
+| Superset meta database | superset.db_engine_specs.superset | FORCE_LIMIT | True | None |
+| TDengine | superset.db_engine_specs.tdengine | FORCE_LIMIT | True | 64 |
+| Teradata | superset.db_engine_specs.teradata | FORCE_LIMIT | True | 30 |
+| Trino | superset.db_engine_specs.trino | FORCE_LIMIT | True | None |
+| Vertica | superset.db_engine_specs.vertica | FORCE_LIMIT | True | None |
+| YDB | superset.db_engine_specs.ydb | FORCE_LIMIT | True | None |
+| base | superset.db_engine_specs.presto | FORCE_LIMIT | True | None |
+
+### SQL Capabilities
+
+| Database | JOINs | Subqueries | Aliases in SELECT | Aliases in ORDER BY | CTEs | Comments | Escaped Colons | Inline Time Groupby | Source Column When Aliased | Aggregations in ORDER BY | Expressions in ORDER BY |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Amazon Athena | True | True | True | True | True | True | False | False | False | True | False |
+| Amazon DynamoDB | True | True | True | True | True | True | True | False | False | True | False |
+| Amazon Redshift | True | True | True | True | True | True | True | False | False | True | False |
+| Apache Doris | True | True | True | True | True | True | True | False | False | True | False |
+| Apache Drill | True | True | True | True | True | True | True | False | False | True | False |
+| Apache Druid | False | True | True | True | True | True | True | False | False | True | False |
+| Apache Hive | True | True | True | True | True | True | True | False | False | False | False |
+| Apache Impala | True | True | True | True | True | True | True | False | False | True | False |
+| Apache Kylin | True | True | True | True | True | True | True | False | False | True | False |
+| Apache Pinot | False | False | False | False | True | True | True | False | False | True | False |
+| Apache Solr | False | False | True | True | True | True | True | False | False | True | False |
+| Apache Spark SQL | True | True | True | True | True | True | True | False | False | False | False |
+| Ascend | True | True | True | True | True | True | True | False | False | True | False |
+| Aurora MySQL (Data API) | True | True | True | True | True | True | True | False | False | True | False |
+| Aurora PostgreSQL (Data API) | True | True | True | True | True | True | True | False | False | True | False |
+| Azure Synapse | True | True | True | True | False | True | True | False | False | True | False |
+| ClickHouse | True | True | True | True | True | True | True | True | False | True | False |
+| ClickHouse Connect (Superset) | True | True | True | True | True | True | True | True | False | True | False |
+| CockroachDB | True | True | True | True | True | True | True | False | False | True | False |
+| Couchbase | False | False | True | True | True | True | True | False | False | True | False |
+| CrateDB | True | True | True | True | True | True | True | False | False | True | False |
+| Databend | True | True | True | True | True | True | True | True | False | True | False |
+| Databricks | True | True | True | True | True | True | True | False | False | True | False |
+| Databricks (legacy) | True | True | True | True | True | True | True | False | False | True | False |
+| Databricks Interactive Cluster | True | True | True | True | True | True | True | False | False | False | False |
+| Databricks SQL Endpoint | True | True | True | True | True | True | True | False | False | True | False |
+| Denodo | True | True | True | True | True | True | True | False | False | True | False |
+| Dremio | True | True | True | True | True | True | True | False | False | True | False |
+| DuckDB | True | True | True | True | True | True | True | False | False | True | False |
+| ElasticSearch (OpenDistro SQL) | False | True | True | True | True | False | True | True | False | True | False |
+| ElasticSearch (SQL API) | False | True | True | True | True | False | True | True | False | True | False |
+| Exasol | True | True | True | True | True | True | True | False | False | True | False |
+| Firebird | True | True | True | True | True | True | True | False | False | True | False |
+| Firebolt | True | True | True | True | True | True | True | False | False | True | False |
+| Google BigQuery | True | True | True | True | True | True | True | False | False | True | True |
+| Google Sheets | True | True | True | True | True | True | True | False | False | True | False |
+| IBM Db2 | True | True | True | True | True | True | True | False | False | True | False |
+| IBM Db2 for i | True | True | True | True | True | True | True | False | False | True | False |
+| IBM Netezza Performance Server | True | True | True | True | True | True | True | False | False | True | False |
+| KustoKQL | True | True | True | True | True | False | True | True | False | True | False |
+| KustoSQL | True | True | True | True | True | False | True | True | False | True | False |
+| MariaDB | True | True | True | True | True | True | True | False | False | True | False |
+| Microsoft SQL Server | True | True | True | True | False | True | True | False | False | True | False |
+| MotherDuck | True | True | True | True | True | True | True | False | False | True | False |
+| MySQL | True | True | True | True | True | True | True | False | False | True | False |
+| OceanBase | True | True | True | True | True | True | True | False | False | True | False |
+| Ocient | True | True | True | True | False | True | True | False | False | True | False |
+| Oracle | True | True | True | True | True | True | True | False | False | True | False |
+| Parseable | True | True | True | True | True | True | True | False | False | True | False |
+| PostgreSQL | True | True | True | True | True | True | True | False | False | True | False |
+| Presto | True | True | True | True | True | True | True | False | True | True | False |
+| RisingWave | True | True | True | True | True | True | True | False | False | True | False |
+| SAP HANA | True | True | True | True | True | True | True | False | False | True | False |
+| SQLite | True | True | True | True | True | True | True | False | False | True | False |
+| Shillelagh | True | True | True | True | True | True | True | False | False | True | False |
+| SingleStore | True | True | True | True | True | True | True | False | False | True | False |
+| Snowflake | True | True | True | True | True | True | True | False | False | True | False |
+| StarRocks | True | True | True | True | True | True | True | False | False | True | False |
+| Superset meta database | True | True | True | True | True | True | True | False | False | True | False |
+| TDengine | True | True | True | True | True | True | True | False | False | True | False |
+| Teradata | True | True | True | True | True | True | True | False | False | True | False |
+| Trino | True | True | True | True | True | True | True | False | True | True | False |
+| Vertica | True | True | True | True | True | True | True | False | False | True | False |
+| YDB | True | True | True | True | True | True | True | False | False | True | False |
+| base | True | True | True | True | True | True | True | False | False | True | False |
+
+### Time Grains – Common
+
+| Database | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH | QUARTER | YEAR |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Amazon Athena | True | True | True | True | True | True | True | True |
+| Amazon DynamoDB | True | True | True | True | True | True | True | True |
+| Amazon Redshift | True | True | True | True | True | True | True | True |
+| Apache Doris | True | True | True | True | True | True | True | True |
+| Apache Drill | True | True | True | True | True | True | True | True |
+| Apache Druid | True | True | True | True | True | True | True | True |
+| Apache Hive | True | True | True | True | True | True | True | True |
+| Apache Impala | False | True | True | True | True | True | True | True |
+| Apache Kylin | True | True | True | True | True | True | True | True |
+| Apache Pinot | True | True | True | True | True | True | True | True |
+| Apache Solr | False | False | False | False | False | False | False | False |
+| Apache Spark SQL | True | True | True | True | True | True | True | True |
+| Ascend | True | True | True | True | True | True | True | True |
+| Aurora MySQL (Data API) | True | True | True | True | True | True | True | True |
+| Aurora PostgreSQL (Data API) | True | True | True | True | True | True | True | True |
+| Azure Synapse | True | True | True | True | True | True | True | True |
+| ClickHouse | False | True | True | True | True | True | True | True |
+| ClickHouse Connect (Superset) | False | True | True | True | True | True | True | True |
+| CockroachDB | True | True | True | True | True | True | True | True |
+| Couchbase | True | True | True | True | False | True | True | True |
+| CrateDB | True | True | True | True | True | True | True | True |
+| Databend | True | True | True | True | True | True | True | True |
+| Databricks | True | True | True | True | True | True | True | True |
+| Databricks (legacy) | True | True | True | True | True | True | True | True |
+| Databricks Interactive Cluster | True | True | True | True | True | True | True | True |
+| Databricks SQL Endpoint | True | True | True | True | True | True | True | True |
+| Denodo | False | True | True | True | True | True | True | True |
+| Dremio | True | True | True | True | True | True | True | True |
+| DuckDB | True | True | True | True | True | True | True | True |
+| ElasticSearch (OpenDistro SQL) | True | True | True | True | False | True | False | True |
+| ElasticSearch (SQL API) | True | True | True | True | True | True | False | True |
+| Exasol | True | True | True | True | True | True | True | True |
+| Firebird | True | True | True | True | False | True | False | True |
+| Firebolt | True | True | True | True | True | True | True | True |
+| Google BigQuery | True | True | True | True | True | True | True | True |
+| Google Sheets | True | True | True | True | True | True | True | True |
+| IBM Db2 | True | True | True | True | True | True | True | True |
+| IBM Db2 for i | True | True | True | True | True | True | True | True |
+| IBM Netezza Performance Server | True | True | True | True | True | True | True | True |
+| KustoKQL | True | True | True | True | True | True | False | True |
+| KustoSQL | True | True | True | True | True | True | True | True |
+| MariaDB | True | True | True | True | True | True | True | True |
+| Microsoft SQL Server | True | True | True | True | True | True | True | True |
+| MotherDuck | True | True | True | True | True | True | True | True |
+| MySQL | True | True | True | True | True | True | True | True |
+| OceanBase | True | True | True | True | True | True | True | True |
+| Ocient | True | True | True | True | True | True | False | True |
+| Oracle | True | True | True | True | True | True | True | True |
+| Parseable | True | True | True | True | True | True | True | True |
+| PostgreSQL | True | True | True | True | True | True | True | True |
+| Presto | True | True | True | True | True | True | True | True |
+| RisingWave | True | True | True | True | True | True | True | True |
+| SAP HANA | True | True | True | True | False | True | True | True |
+| SQLite | True | True | True | True | True | True | True | True |
+| Shillelagh | True | True | True | True | True | True | True | True |
+| SingleStore | True | True | True | True | True | True | True | True |
+| Snowflake | True | True | True | True | True | True | True | True |
+| StarRocks | True | True | True | True | True | True | True | True |
+| Superset meta database | True | True | True | True | True | True | True | True |
+| TDengine | True | True | True | True | True | False | False | False |
+| Teradata | False | True | True | True | True | True | True | True |
+| Trino | True | True | True | True | True | True | True | True |
+| Vertica | True | True | True | True | True | True | True | True |
+| YDB | True | True | True | True | True | True | True | True |
+| base | True | True | True | True | True | True | True | True |
+
+### Time Grains – Extended
+
+| Database | FIVE_SECONDS | THIRTY_SECONDS | FIVE_MINUTES | TEN_MINUTES | FIFTEEN_MINUTES | THIRTY_MINUTES | HALF_HOUR | SIX_HOURS | WEEK_STARTING_SUNDAY | WEEK_STARTING_MONDAY | WEEK_ENDING_SATURDAY | WEEK_ENDING_SUNDAY | QUARTER_YEAR |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Amazon Athena | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Amazon DynamoDB | False | False | False | False | False | False | False | False | True | True | True | True | False |
+| Amazon Redshift | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| Apache Doris | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| Apache Drill | False | False | False | False | True | True | False | False | False | False | False | False | False |
+| Apache Druid | True | True | True | True | True | True | False | True | True | False | True | False | False |
+| Apache Hive | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Apache Impala | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Apache Kylin | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Apache Pinot | False | False | True | True | True | True | False | False | False | False | False | False | False |
+| Apache Solr | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Apache Spark SQL | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Ascend | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Aurora MySQL (Data API) | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| Aurora PostgreSQL (Data API) | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| Azure Synapse | False | False | True | True | True | True | False | False | True | True | False | False | False |
+| ClickHouse | False | False | True | True | True | True | False | False | False | False | False | False | False |
+| ClickHouse Connect (Superset) | False | False | True | True | True | True | False | False | False | False | False | False | False |
+| CockroachDB | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| Couchbase | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| CrateDB | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Databend | False | False | True | True | True | False | False | False | False | False | False | False | False |
+| Databricks | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Databricks (legacy) | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Databricks Interactive Cluster | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Databricks SQL Endpoint | False | False | False | False | False | False | False | False | True | False | True | False | False |
+| Denodo | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Dremio | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| DuckDB | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| ElasticSearch (OpenDistro SQL) | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| ElasticSearch (SQL API) | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Exasol | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Firebird | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Firebolt | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Google BigQuery | False | False | True | True | True | True | False | False | False | True | False | False | False |
+| Google Sheets | True | True | True | True | True | True | True | True | True | True | True | True | True |
+| IBM Db2 | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| IBM Db2 for i | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| IBM Netezza Performance Server | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| KustoKQL | False | True | True | False | False | True | False | False | False | False | False | False | False |
+| KustoSQL | False | False | True | True | True | False | True | False | True | True | False | False | False |
+| MariaDB | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| Microsoft SQL Server | False | False | True | True | True | True | False | False | True | True | False | False | False |
+| MotherDuck | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| MySQL | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| OceanBase | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| Ocient | False | False | False | False | False | False | False | False | False | False | False | False | True |
+| Oracle | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Parseable | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| PostgreSQL | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| Presto | True | True | True | True | True | False | True | True | True | True | True | True | False |
+| RisingWave | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| SAP HANA | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| SQLite | True | True | True | True | True | True | True | True | True | True | True | True | True |
+| Shillelagh | True | True | True | True | True | True | True | True | True | True | True | True | True |
+| SingleStore | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Snowflake | False | False | True | True | True | True | False | False | False | False | False | False | False |
+| StarRocks | False | False | False | False | False | False | False | False | False | True | False | False | False |
+| Superset meta database | True | True | True | True | True | True | True | True | True | True | True | True | True |
+| TDengine | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Teradata | False | False | False | False | False | False | False | False | False | False | False | False | False |
+| Trino | True | True | True | True | True | False | True | True | True | True | True | True | False |
+| Vertica | True | True | True | True | True | True | False | False | False | False | False | False | False |
+| YDB | False | True | True | True | True | True | False | False | False | False | False | False | False |
+| base | True | True | True | True | True | False | True | True | True | True | True | True | False |
+
+### Core Platform & Metadata Features
+
+
+Integration with platform features and metadata handling.
+
+| Database | Masked Encrypted Extra | Column Type Mappings | Function Names | File Upload | Dynamic Schema | Catalog | Dynamic Catalog | SSH Tunneling | Latest Partition | Query Cancellation | Get Metrics | Extra Table Metadata | Exception Mapping | Custom Errors |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Amazon Athena | False | False | False | True | False | False | False | False | False | False | False | False | False | False |
+| Amazon DynamoDB | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Amazon Redshift | False | False | False | True | False | False | False | True | False | True | False | False | False | False |
+| Apache Doris | False | True | False | True | True | True | True | True | False | True | False | False | False | False |
+| Apache Drill | False | False | False | True | True | False | False | True | False | False | False | False | False | False |
+| Apache Druid | False | False | False | True | False | False | False | True | False | False | False | False | True | False |
+| Apache Hive | False | True | True | True | True | True | True | True | True | True | False | True | False | False |
+| Apache Impala | False | False | False | True | False | False | False | True | False | True | False | False | False | False |
+| Apache Kylin | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Apache Pinot | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Apache Solr | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Apache Spark SQL | False | True | True | True | True | True | True | True | True | True | False | True | False | False |
+| Ascend | False | False | False | True | False | False | False | True | False | True | False | False | False | False |
+| Aurora MySQL (Data API) | False | True | False | True | True | False | False | True | False | True | False | False | False | False |
+| Aurora PostgreSQL (Data API) | False | True | False | True | True | True | True | True | False | True | False | False | False | False |
+| Azure Synapse | False | True | False | True | False | False | False | True | False | False | False | False | False | False |
+| ClickHouse | False | True | True | False | False | False | False | True | False | False | False | False | True | False |
+| ClickHouse Connect (Superset) | False | True | True | False | True | False | False | True | False | False | False | False | True | False |
+| CockroachDB | False | True | False | True | True | True | True | True | False | True | False | False | False | False |
+| Couchbase | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| CrateDB | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Databend | False | True | True | False | False | False | False | True | False | False | False | False | True | False |
+| Databricks | False | False | False | True | True | True | True | True | False | False | False | False | False | True |
+| Databricks (legacy) | False | False | False | True | True | True | True | True | False | False | False | False | False | True |
+| Databricks Interactive Cluster | False | True | True | True | True | True | True | True | True | True | False | True | False | False |
+| Databricks SQL Endpoint | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Denodo | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Dremio | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| DuckDB | False | True | False | True | False | False | False | True | False | False | False | False | False | False |
+| ElasticSearch (OpenDistro SQL) | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| ElasticSearch (SQL API) | False | False | False | True | False | False | False | True | False | False | False | False | True | False |
+| Exasol | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Firebird | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Firebolt | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Google BigQuery | False | False | False | True | False | True | True | False | True | False | False | True | True | False |
+| Google Sheets | False | False | True | True | False | False | False | False | False | False | False | True | False | False |
+| IBM Db2 | False | False | False | True | True | False | False | True | False | False | False | False | False | False |
+| IBM Db2 for i | False | False | False | True | True | False | False | True | False | False | False | False | False | False |
+| IBM Netezza Performance Server | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| KustoKQL | False | False | False | True | False | False | False | True | False | False | False | False | True | False |
+| KustoSQL | False | True | False | True | False | False | False | True | False | False | False | False | True | False |
+| MariaDB | False | True | False | True | True | False | False | True | False | True | False | False | False | False |
+| Microsoft SQL Server | False | True | False | True | False | False | False | True | False | False | False | False | False | False |
+| MotherDuck | False | True | False | True | False | True | True | True | False | False | False | False | False | False |
+| MySQL | False | True | False | True | True | False | False | True | False | True | False | False | False | False |
+| OceanBase | False | True | False | True | True | False | False | True | False | True | False | False | False | False |
+| Ocient | False | False | False | True | False | False | False | True | False | True | False | False | False | False |
+| Oracle | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Parseable | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| PostgreSQL | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Presto | False | True | True | True | True | True | True | True | True | True | False | True | False | False |
+| RisingWave | False | True | False | True | True | True | True | True | False | True | False | False | False | False |
+| SAP HANA | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| SQLite | False | False | True | True | False | False | False | False | False | False | False | False | False | False |
+| Shillelagh | False | False | True | True | False | False | False | False | False | False | False | False | False | False |
+| SingleStore | False | True | True | True | True | False | False | True | False | True | False | False | False | False |
+| Snowflake | False | False | False | True | True | True | True | True | False | True | False | False | False | False |
+| StarRocks | False | True | False | True | True | False | False | True | False | True | False | False | False | False |
+| Superset meta database | False | False | True | False | False | False | False | False | False | False | False | False | False | False |
+| TDengine | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Teradata | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| Trino | False | True | True | True | True | True | True | True | True | True | False | True | True | False |
+| Vertica | False | False | False | True | False | False | False | True | False | False | False | False | False | False |
+| YDB | False | False | False | False | False | False | False | True | False | False | False | False | False | False |
+| base | False | True | True | True | True | True | True | True | True | False | False | False | False | False |
+
+### Operational & Advanced Features
+
+| Database | User Impersonation | Expand Data | Cost Estimation | SQL Validation |
+| --- | --- | --- | --- | --- |
+| Amazon Athena | False | False | False | False |
+| Amazon DynamoDB | False | False | False | False |
+| Amazon Redshift | False | False | False | False |
+| Apache Doris | False | False | False | False |
+| Apache Drill | True | False | False | False |
+| Apache Druid | False | False | False | False |
+| Apache Hive | True | True | True | False |
+| Apache Impala | False | False | False | False |
+| Apache Kylin | False | False | False | False |
+| Apache Pinot | False | False | False | False |
+| Apache Solr | False | False | False | False |
+| Apache Spark SQL | True | True | True | False |
+| Ascend | False | False | False | False |
+| Aurora MySQL (Data API) | False | False | False | False |
+| Aurora PostgreSQL (Data API) | False | False | True | True |
+| Azure Synapse | False | False | False | False |
+| ClickHouse | False | False | False | False |
+| ClickHouse Connect (Superset) | False | False | False | False |
+| CockroachDB | False | False | True | False |
+| Couchbase | False | False | False | False |
+| CrateDB | False | False | False | False |
+| Databend | False | False | False | False |
+| Databricks | False | False | False | False |
+| Databricks (legacy) | False | False | False | False |
+| Databricks Interactive Cluster | True | True | True | False |
+| Databricks SQL Endpoint | False | False | False | False |
+| Denodo | False | False | False | False |
+| Dremio | False | False | False | False |
+| DuckDB | False | False | False | False |
+| ElasticSearch (OpenDistro SQL) | False | False | False | False |
+| ElasticSearch (SQL API) | False | False | False | False |
+| Exasol | False | False | False | False |
+| Firebird | False | False | False | False |
+| Firebolt | False | False | False | False |
+| Google BigQuery | False | False | True | False |
+| Google Sheets | True | False | False | False |
+| IBM Db2 | False | False | False | False |
+| IBM Db2 for i | False | False | False | False |
+| IBM Netezza Performance Server | False | False | False | False |
+| KustoKQL | False | False | False | False |
+| KustoSQL | False | False | False | False |
+| MariaDB | False | False | False | False |
+| Microsoft SQL Server | False | False | False | False |
+| MotherDuck | False | False | False | False |
+| MySQL | False | False | False | False |
+| OceanBase | False | False | False | False |
+| Ocient | False | False | False | False |
+| Oracle | False | False | False | False |
+| Parseable | False | False | False | False |
+| PostgreSQL | False | False | False | False |
+| Presto | True | True | True | True |
+| RisingWave | False | False | True | False |
+| SAP HANA | False | False | False | False |
+| SQLite | False | False | False | False |
+| Shillelagh | False | False | False | False |
+| SingleStore | False | False | False | False |
+| Snowflake | False | False | False | False |
+| StarRocks | True | False | False | False |
+| Superset meta database | False | False | False | False |
+| TDengine | False | False | False | False |
+| Teradata | False | False | False | False |
+| Trino | True | False | True | False |
+| Vertica | False | False | False | False |
+| YDB | False | False | False | False |
+| base | False | False | True | False |
 
 ## Database information
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes the unreadable feature comparison table in superset/db_engine_specs/README.md by restructuring it from a single 52-column × 58-row table into 7 focused tables organized by feature category.

  
  **TECHNICAL CHANGES**

  superset/db_engine_specs/lib.py

  - Added calculate_support_level() to compute Supported/Partial/Not supported status
  - Added format_markdown_table() helper for consistent formatting
  - Refactored generate_focused_table() with preserve_order parameter
  - Rewrote generate_feature_tables() to output 7 tables instead of 1
  - Fixed limit_clause to use documented allow_limit_clause attribute (defaults to True)
  - Aligned Feature Overview calculations with detail tables

  superset/db_engine_specs/README.md

  - Added Quick Navigation table of contents
  - Replaced single table with 7 focused tables
  - Updated intro text to explain organization
  - Fixed heading hierarchy (h3 for tables under h2 Features)
  - All feature documentation preserved


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

  Before

  - Single massive table: 52 columns × 58 rows
  - Databases as columns → horizontal growth with each new connector
  - GitHub markdown renderer fails on tables with >15 columns
  - Table was completely unreadable on GitHub

  After

  - 7 focused tables with 4-15 columns each
  - Databases as rows → sustainable vertical scaling
  - Tables grouped by feature category:
    a. Feature Overview (8 cols) - Quick summary with Supported/Partial/Not supported
    b. Database Information (5 cols) - Module paths, limit methods
    c. SQL Capabilities (12 cols) - JOINs, CTEs, subqueries, etc.
    d. Time Grains – Common (9 cols) - SECOND through YEAR
    e. Time Grains – Extended (14 cols) - Sub-hour and week variants
    f. Core Platform & Metadata Features (15 cols) - Integration capabilities
    g. Operational & Advanced Features (5 cols) - User impersonation, cost estimation, SQL validation
  - All 65 databases fully documented in each table
  - Table of contents with anchor links for easy navigation
  - All tables render perfectly on GitHub


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Regenerate tables (verify auto-generation still works):
  python superset/db_engine_specs/lib.py
  2. View on GitHub (the real test):
    - Navigate to the README on GitHub
    - Verify all 7 tables render correctly
    - Check that horizontal scrolling is minimal/none
    - Verify table of contents anchor links work
  3. Verify data accuracy:
    - Spot-check specific database features (e.g., PostgreSQL should show limit_clause: True)
    - Verify Feature Overview status matches detail tables
    - Confirm all 65 databases appear in each table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #35692
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
