### PR TITLE
fix(echarts): fix time shift color matching functionality

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -200,6 +200,7 @@ export default function transformProps(
     zoomable,
     stackDimension,
   }: EchartsTimeseriesFormData = { ...DEFAULT_FORM_DATA, ...formData };
+
   const refs: Refs = {};
   const groupBy = ensureIsArray(groupby);
   const labelMap: { [key: string]: string[] } = Object.entries(
@@ -301,7 +302,24 @@ export default function transformProps(
 
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
-    const colorScaleKey = getOriginalSeries(seriesName, array);
+
+    let colorScaleKey = getOriginalSeries(seriesName, array);
+
+    // If this series name exactly matches a time compare value, it's a time-shifted series
+    // and we need to find the corresponding original series for color matching
+    if (array && array.includes(seriesName)) {
+      // Find the original series (first non-time-compare series)
+      const originalSeries = rawSeries.find(s => {
+        const sName = inverted[String(s.name || '')] || String(s.name || '');
+        return !array.includes(sName);
+      });
+      if (originalSeries) {
+        const originalSeriesName =
+          inverted[String(originalSeries.name || '')] ||
+          String(originalSeries.name || '');
+        colorScaleKey = getOriginalSeries(originalSeriesName, array);
+      }
+    }
 
     const transformedSeries = transformSeries(
       entry,


### PR DESCRIPTION
## Summary
Fixes the "Match time shift color with original series" checkbox functionality in ECharts timeseries charts.

The checkbox was not working because time-shifted series names (e.g., "28 days ago") could not be properly mapped back to their original series for color matching.

## Changes
- Added logic in `transformProps.ts` to detect time-shifted series by checking if series names match time comparison values
- When a time-shifted series is detected, the code now finds the corresponding original series and uses its color key
- This ensures time-shifted series use the same colors as their original series when the checkbox is enabled

## Test plan
- [x] Create a line chart or any ECharts timeseries chart
- [x] Add a time comparison (e.g., "28 days ago")
- [x] Enable the "Match time shift color with original series" checkbox in Customize tab
- [x] Verify that both original and time-shifted series now use the same colors
- [x] Disable the checkbox and verify they use different colors again

## Before/After
**Before**: Time-shifted series always used different colors regardless of checkbox state
**After**: Time-shifted series match original series colors when checkbox is enabled

🤖 Generated with [Claude Code](https://claude.ai/code)