### PR TITLE
fix(alerts): implement Slack channel pagination to resolve timeout issues

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2587,9 +2587,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               children: (
                 <>
                   {notificationSettings.map((notificationSetting, i) => (
-                    <StyledNotificationMethodWrapper
-                      key={`notification-${notificationSetting.method || 'new'}-${notificationSetting.recipients || 'empty'}-${i}`}
-                    >
+                    <StyledNotificationMethodWrapper key={`notification-${i}`}>
                       <NotificationMethod
                         setting={notificationSetting}
                         index={i}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -2586,15 +2587,16 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
               children: (
                 <>
                   {notificationSettings.map((notificationSetting, i) => (
-                    <StyledNotificationMethodWrapper>
+                    <StyledNotificationMethodWrapper
+                      key={`notification-${notificationSetting.method || 'new'}-${notificationSetting.recipients || 'empty'}-${i}`}
+                    >
                       <NotificationMethod
                         setting={notificationSetting}
                         index={i}
-                        key={`NotificationMethod-${i}`}
                         onUpdate={updateNotificationSetting}
                         onRemove={removeNotificationSetting}
                         onInputChange={onInputChange}
-                        email_subject={currentAlert?.email_subject || ''}
+                        emailSubject={currentAlert?.email_subject || ''}
                         defaultSubject={emailSubject || ''}
                         setErrorSubject={handleErrorUpdate}
                         addDangerToast={addDangerToast}

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -2597,6 +2597,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                         email_subject={currentAlert?.email_subject || ''}
                         defaultSubject={emailSubject || ''}
                         setErrorSubject={handleErrorUpdate}
+                        addDangerToast={addDangerToast}
                       />
                     </StyledNotificationMethodWrapper>
                   ))}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -76,7 +76,7 @@ test('NotificationMethod - should render the component', () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -96,7 +96,7 @@ test('NotificationMethod - should call onRemove when the delete button is clicke
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -117,7 +117,7 @@ test('NotificationMethod - should update recipient value when input changes', ()
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -143,7 +143,7 @@ test('NotificationMethod - should call onRecipientsChange when the recipients va
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -219,7 +219,7 @@ test('NotificationMethod - should render CC and BCC fields when method is Email 
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -244,7 +244,7 @@ test('NotificationMethod - should render CC and BCC fields with correct values w
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -269,7 +269,7 @@ test('NotificationMethod - should not render CC and BCC fields when method is no
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -294,7 +294,7 @@ test('NotificationMethod - should handle empty recipients list gracefully', () =
     onUpdate: jest.fn(),
     onRemove: jest.fn(),
     onInputChange: jest.fn(),
-    email_subject: 'Test Subject',
+    emailSubject: 'Test Subject',
     defaultSubject: 'Default Subject',
     setErrorSubject: jest.fn(),
   };
@@ -328,7 +328,7 @@ test('shows the right combo when ff is false', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -366,7 +366,7 @@ test('shows the textbox when the fetch fails', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -409,7 +409,7 @@ test('shows the dropdown when ff is true and slackChannels succeed', async () =>
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -445,7 +445,7 @@ test('shows the textarea when ff is true and slackChannels fail', async () => {
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -481,7 +481,7 @@ test('shows the textarea when ff is true and slackChannels fail and slack is sel
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -510,7 +510,7 @@ test('shows the textarea when ff is true, slackChannels fail and slack is select
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -544,7 +544,7 @@ test('NotificationMethod - AsyncSelect should render for SlackV2 method', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -583,7 +583,7 @@ test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API resp
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -625,7 +625,7 @@ test('NotificationMethod - AsyncSelect should render refresh button for SlackV2'
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -669,7 +669,7 @@ test('NotificationMethod - AsyncSelect should reload channels without clearing r
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -743,7 +743,7 @@ test('NotificationMethod - data cache prevents redundant API calls when selectin
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -810,7 +810,7 @@ test('NotificationMethod - should preserve selected channels on refresh', async 
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -885,7 +885,7 @@ test('NotificationMethod - should initialize Slack recipients when editing exist
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -990,7 +990,7 @@ test('NotificationMethod - should preserve selected channels during search and p
       onUpdate={mockOnUpdate}
       onRemove={mockOnRemove}
       onInputChange={mockOnInputChange}
-      email_subject={mockEmailSubject}
+      emailSubject={mockEmailSubject}
       defaultSubject={mockDefaultSubject}
       setErrorSubject={mockSetErrorSubject}
       addDangerToast={mockAddDangerToast}
@@ -1049,6 +1049,185 @@ test('NotificationMethod - should preserve selected channels during search and p
     call => !call[1]?.hasOwnProperty('recipients') || call[1].recipients !== '',
   );
   expect(updateCallsWithEmptyRecipientsCheck).toBe(true);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - should support comma-separated channel search', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannelsPage1 = [
+    { id: 'C001', name: 'engineering', is_private: false, is_member: true },
+    {
+      id: 'C002',
+      name: 'engineering-team',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+  const mockChannelsPage2 = [
+    { id: 'C003', name: 'marketing', is_private: false, is_member: true },
+    { id: 'C004', name: 'sales', is_private: false, is_member: true },
+  ];
+
+  let callCount = 0;
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    callCount += 1;
+    if (callCount === 1) {
+      return Promise.resolve({
+        json: {
+          result: mockChannelsPage1,
+          next_cursor: 'cursor_2',
+          has_more: true,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>;
+    }
+    return Promise.resolve({
+      json: {
+        result: mockChannelsPage2,
+        next_cursor: null,
+        has_more: false,
+      },
+    }) as unknown as Promise<Response | JsonResponse | TextResponse>;
+  });
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const apiCalls = getSpy.mock.calls;
+  expect(apiCalls.length).toBeGreaterThan(0);
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - AsyncSelect should not filter results client-side', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannels = [
+    { id: 'C001', name: 'analytics-team', is_private: false, is_member: true },
+    { id: 'C002', name: 'analytics-ops', is_private: false, is_member: true },
+    { id: 'C003', name: 'engineering', is_private: false, is_member: true },
+  ];
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const recipientsSelect = getByTestId('recipients');
+  expect(recipientsSelect).toBeInTheDocument();
+
+  getSpy.mockRestore();
+});
+
+test('NotificationMethod - AsyncSelect should not use comma as token separator', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  const mockChannels = [
+    { id: 'C001', name: 'engineering', is_private: false, is_member: true },
+    { id: 'C002', name: 'marketing', is_private: false, is_member: true },
+  ];
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockImplementation(
+    () =>
+      Promise.resolve({
+        json: {
+          result: mockChannels,
+          next_cursor: null,
+          has_more: false,
+        },
+      }) as unknown as Promise<Response | JsonResponse | TextResponse>,
+  );
+
+  const { getByTestId } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      emailSubject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+      addDangerToast={mockAddDangerToast}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getByTestId('recipients')).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+
+  await waitFor(
+    () => {
+      expect(getSpy).toHaveBeenCalled();
+    },
+    { timeout: 3000 },
+  );
+
+  const recipientsSelect = getByTestId('recipients');
+  expect(recipientsSelect).toBeInTheDocument();
 
   getSpy.mockRestore();
 });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.test.tsx
@@ -62,499 +62,621 @@ const mockSettingSlackV2: NotificationSetting = {
   ],
 };
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('NotificationMethod', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    cleanup();
+beforeEach(() => {
+  jest.clearAllMocks();
+  cleanup();
+});
+
+test('NotificationMethod - should render the component', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  expect(screen.getByText('Notification Method')).toBeInTheDocument();
+  expect(screen.getByText('Email subject name (optional)')).toBeInTheDocument();
+  expect(screen.getByText('Email recipients')).toBeInTheDocument();
+});
+
+test('NotificationMethod - should call onRemove when the delete button is clicked', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={1}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const deleteButton = document.querySelector('.delete-button');
+  if (deleteButton) userEvent.click(deleteButton);
+
+  expect(mockOnRemove).toHaveBeenCalledWith(1);
+});
+
+test('NotificationMethod - should update recipient value when input changes', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const recipientsInput = screen.getByTestId('recipients');
+  fireEvent.change(recipientsInput, {
+    target: { value: 'test1@example.com' },
   });
 
-  test('should render the component', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+  expect(mockOnUpdate).toHaveBeenCalledWith(0, {
+    ...mockSetting,
+    recipients: 'test1@example.com',
+  });
+});
 
-    expect(screen.getByText('Notification Method')).toBeInTheDocument();
-    expect(
-      screen.getByText('Email subject name (optional)'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Email recipients')).toBeInTheDocument();
+test('NotificationMethod - should call onRecipientsChange when the recipients value is changed', () => {
+  render(
+    <NotificationMethod
+      setting={mockSetting}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  const recipientsInput = screen.getByTestId('recipients');
+  fireEvent.change(recipientsInput, {
+    target: { value: 'test1@example.com' },
   });
 
-  test('should call onRemove when the delete button is clicked', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={1}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    const deleteButton = document.querySelector('.delete-button');
-    if (deleteButton) userEvent.click(deleteButton);
-
-    expect(mockOnRemove).toHaveBeenCalledWith(1);
+  expect(mockOnUpdate).toHaveBeenCalledWith(0, {
+    ...mockSetting,
+    recipients: 'test1@example.com',
   });
+});
 
-  test('should update recipient value when input changes', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+test('NotificationMethod - should correctly map recipients when method is SlackV2', () => {
+  const method = 'SlackV2';
+  const recipientValue = 'user1,user2';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-    const recipientsInput = screen.getByTestId('recipients');
-    fireEvent.change(recipientsInput, {
-      target: { value: 'test1@example.com' },
-    });
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(0, {
-      ...mockSetting,
-      recipients: 'test1@example.com',
-    });
-  });
+  expect(result).toEqual([
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ]);
+});
 
-  test('should call onRecipientsChange when the recipients value is changed', () => {
-    render(
-      <NotificationMethod
-        setting={mockSetting}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
+test('NotificationMethod - should return an empty array when recipientValue is an empty string', () => {
+  const method = 'SlackV2';
+  const recipientValue = '';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-    const recipientsInput = screen.getByTestId('recipients');
-    fireEvent.change(recipientsInput, {
-      target: { value: 'test1@example.com' },
-    });
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    expect(mockOnUpdate).toHaveBeenCalledWith(0, {
-      ...mockSetting,
-      recipients: 'test1@example.com',
-    });
-  });
+  expect(result).toEqual([]);
+});
 
-  test('should correctly map recipients when method is SlackV2', () => {
-    const method = 'SlackV2';
-    const recipientValue = 'user1,user2';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+test('NotificationMethod - should correctly map recipients when method is Slack with updated recipient values', () => {
+  const method = 'Slack';
+  const recipientValue = 'User One,User Two';
+  const slackOptions: { label: string; value: string }[] = [
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ];
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+  const result = mapSlackValues({ method, recipientValue, slackOptions });
 
-    expect(result).toEqual([
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ]);
-  });
+  expect(result).toEqual([
+    { label: 'User One', value: 'user1' },
+    { label: 'User Two', value: 'user2' },
+  ]);
+});
 
-  test('should return an empty array when recipientValue is an empty string', () => {
-    const method = 'SlackV2';
-    const recipientValue = '';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+test('NotificationMethod - should render CC and BCC fields when method is Email and visibility flags are true', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+  const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    expect(result).toEqual([]);
-  });
+  // Check if CC and BCC fields are rendered
+  expect(getByTestId('cc')).toBeInTheDocument();
+  expect(getByTestId('bcc')).toBeInTheDocument();
+});
 
-  test('should correctly map recipients when method is Slack with updated recipient values', () => {
-    const method = 'Slack';
-    const recipientValue = 'User One,User Two';
-    const slackOptions: { label: string; value: string }[] = [
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ];
+test('NotificationMethod - should render CC and BCC fields with correct values when method is Email', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    const result = mapSlackValues({ method, recipientValue, slackOptions });
+  const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    expect(result).toEqual([
-      { label: 'User One', value: 'user1' },
-      { label: 'User Two', value: 'user2' },
-    ]);
-  });
-  test('should render CC and BCC fields when method is Email and visibility flags are true', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  // Check if CC and BCC fields are rendered with correct values
+  expect(getByTestId('cc')).toHaveValue('cc1@example.com');
+  expect(getByTestId('bcc')).toHaveValue('bcc1@example.com');
+});
 
-    const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
+test('NotificationMethod - should not render CC and BCC fields when method is not Email', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Slack,
+      recipients: 'recipient1@example.com, recipient2@example.com',
+      cc: 'cc1@example.com',
+      bcc: 'bcc1@example.com',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    // Check if CC and BCC fields are rendered
-    expect(getByTestId('cc')).toBeInTheDocument();
-    expect(getByTestId('bcc')).toBeInTheDocument();
-  });
-  test('should render CC and BCC fields with correct values when method is Email', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    const { getByTestId } = render(<NotificationMethod {...defaultProps} />);
+  // Check if CC and BCC fields are not rendered
+  expect(queryByTestId('cc')).not.toBeInTheDocument();
+  expect(queryByTestId('bcc')).not.toBeInTheDocument();
+});
+// Handle empty recipients list gracefully
+test('NotificationMethod - should handle empty recipients list gracefully', () => {
+  const defaultProps = {
+    setting: {
+      method: NotificationMethodOption.Email,
+      recipients: '',
+      cc: '',
+      bcc: '',
+      options: [NotificationMethodOption.Email, NotificationMethodOption.Slack],
+    },
+    index: 0,
+    onUpdate: jest.fn(),
+    onRemove: jest.fn(),
+    onInputChange: jest.fn(),
+    email_subject: 'Test Subject',
+    defaultSubject: 'Default Subject',
+    setErrorSubject: jest.fn(),
+  };
 
-    // Check if CC and BCC fields are rendered with correct values
-    expect(getByTestId('cc')).toHaveValue('cc1@example.com');
-    expect(getByTestId('bcc')).toHaveValue('bcc1@example.com');
-  });
-  test('should not render CC and BCC fields when method is not Email', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Slack,
-        recipients: 'recipient1@example.com, recipient2@example.com',
-        cc: 'cc1@example.com',
-        bcc: 'bcc1@example.com',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
+  const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
 
-    const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
+  // Check if CC and BCC fields are not rendered
+  expect(queryByTestId('cc')).not.toBeInTheDocument();
+  expect(queryByTestId('bcc')).not.toBeInTheDocument();
+});
 
-    // Check if CC and BCC fields are not rendered
-    expect(queryByTestId('cc')).not.toBeInTheDocument();
-    expect(queryByTestId('bcc')).not.toBeInTheDocument();
-  });
-  // Handle empty recipients list gracefully
-  test('should handle empty recipients list gracefully', () => {
-    const defaultProps = {
-      setting: {
-        method: NotificationMethodOption.Email,
-        recipients: '',
-        cc: '',
-        bcc: '',
-        options: [
-          NotificationMethodOption.Email,
-          NotificationMethodOption.Slack,
-        ],
-      },
-      index: 0,
-      onUpdate: jest.fn(),
-      onRemove: jest.fn(),
-      onInputChange: jest.fn(),
-      email_subject: 'Test Subject',
-      defaultSubject: 'Default Subject',
-      setErrorSubject: jest.fn(),
-    };
-
-    const { queryByTestId } = render(<NotificationMethod {...defaultProps} />);
-
-    // Check if CC and BCC fields are not rendered
-    expect(queryByTestId('cc')).not.toBeInTheDocument();
-    expect(queryByTestId('bcc')).not.toBeInTheDocument();
-  });
-  test('shows the right combo when ff is false', async () => {
-    /* should show the div with "Recipients are separated by"
+test('shows the right combo when ff is false', async () => {
+  /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is false and fetchSlackChannels errors
     */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(
-        screen.getByText('Recipients are separated by "," or ";"'),
-      ).toBeInTheDocument();
-    });
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
-  test('shows the textbox when the fetch fails', async () => {
-    /* should show the div with "Recipients are separated by"
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
+    expect(
+      screen.getByText('Recipients are separated by "," or ";"'),
+    ).toBeInTheDocument();
+  });
+});
+
+test('shows the textbox when the fetch fails', async () => {
+  /* should show the div with "Recipients are separated by"
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels errors
     */
 
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: false };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(
-        screen.getByText('Recipients are separated by "," or ";"'),
-      ).toBeInTheDocument();
-    });
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
-  test('shows the dropdown when ff is true and slackChannels succeed', async () => {
-    /* should show the Select channels dropdown
-    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
-    */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest
-      .spyOn(SupersetClient, 'get')
-      .mockImplementation(
-        () =>
-          Promise.resolve({ json: { result: [] } }) as unknown as Promise<
-            Response | JsonResponse | TextResponse
-          >,
-      );
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
 
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.SlackV2,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
-    await waitFor(() => {
-      expect(screen.getByTitle('Slack')).toBeInTheDocument();
-    });
-  });
-  test('shows the textarea when ff is true and slackChannels fail', async () => {
-    /* should show the Select channels dropdown
-    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
-    */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
-    );
-
-    // Wait for the component to handle the error and render the expected div
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
     expect(
       screen.getByText('Recipients are separated by "," or ";"'),
     ).toBeInTheDocument();
   });
-  test('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
-    /* should show the Select channels dropdown
+});
+
+test('shows the dropdown when ff is true and slackChannels succeed', async () => {
+  /* should show the Select channels dropdown
     when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
     */
-    // Mock the feature flag to be false
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
 
-    // Mock the SupersetClient.get to simulate an error
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
-
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSetting,
-          method: NotificationMethodOption.Slack,
-          recipients: 'slack-channel',
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
+  // Mock the SupersetClient.get to simulate an error
+  jest
+    .spyOn(SupersetClient, 'get')
+    .mockImplementation(
+      () =>
+        Promise.resolve({ json: { result: [] } }) as unknown as Promise<
+          Response | JsonResponse | TextResponse
+        >,
     );
 
-    // Wait for the component to handle the error and render the expected div
-    expect(
-      screen.getByText('Recipients are separated by "," or ";"'),
-    ).toBeInTheDocument();
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.SlackV2,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  await waitFor(() => {
+    expect(screen.getByTitle('Slack')).toBeInTheDocument();
+  });
+});
+
+test('shows the textarea when ff is true and slackChannels fail', async () => {
+  /* should show the Select channels dropdown
+    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
+    */
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
   });
 
-  test('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
-    window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-    jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
-      throw new Error('Error fetching Slack channels');
-    });
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
 
-    render(
-      <NotificationMethod
-        setting={{
-          ...mockSettingSlackV2,
-          method: NotificationMethodOption.Slack,
-        }}
-        index={0}
-        onUpdate={mockOnUpdate}
-        onRemove={mockOnRemove}
-        onInputChange={mockOnInputChange}
-        email_subject={mockEmailSubject}
-        defaultSubject={mockDefaultSubject}
-        setErrorSubject={mockSetErrorSubject}
-      />,
+  // Wait for the component to handle the error and render the expected div
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('shows the textarea when ff is true and slackChannels fail and slack is selected', async () => {
+  /* should show the Select channels dropdown
+    when FeatureFlag.AlertReportSlackV2 is true and fetchSlackChannels succeeds
+    */
+  // Mock the feature flag to be false
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+
+  // Mock the SupersetClient.get to simulate an error
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
+  });
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSetting,
+        method: NotificationMethodOption.Slack,
+        recipients: 'slack-channel',
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for the component to handle the error and render the expected div
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('shows the textarea when ff is true, slackChannels fail and slack is selected', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  jest.spyOn(SupersetClient, 'get').mockImplementation(() => {
+    throw new Error('Error fetching Slack channels');
+  });
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSettingSlackV2,
+        method: NotificationMethodOption.Slack,
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  expect(
+    screen.getByText('Recipients are separated by "," or ";"'),
+  ).toBeInTheDocument();
+});
+
+test('NotificationMethod - AsyncSelect should render for SlackV2 method', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    { name: 'general', id: 'C001', is_private: false, is_member: true },
+    { name: 'random', id: 'C002', is_private: false, is_member: true },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify AsyncSelect is rendered for SlackV2
+  await waitFor(() => {
+    expect(screen.getByTitle('Slack')).toBeInTheDocument();
+  });
+});
+
+test('NotificationMethod - AsyncSelect should handle SlackV2 with valid API response', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  const { container } = render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify AsyncSelect container is present (not a textarea)
+  await waitFor(() => {
+    const textarea = container.querySelector(
+      'textarea[data-test="recipients"]',
     );
+    expect(textarea).toBeNull(); // Should NOT have textarea for SlackV2
+  });
+});
 
-    expect(
-      screen.getByText('Recipients are separated by "," or ";"'),
-    ).toBeInTheDocument();
+test('NotificationMethod - AsyncSelect should render refresh button for SlackV2', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={mockSettingSlackV2}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Verify refresh button is present (icon only button)
+  await waitFor(() => {
+    const refreshButton = screen.getByTestId('refresh-slack-channels');
+    expect(refreshButton).toBeInTheDocument();
+    expect(refreshButton).toHaveAttribute('title', 'Refresh channels');
+  });
+});
+
+test('NotificationMethod - AsyncSelect should clear recipients and reload channels when refresh button clicked', async () => {
+  window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
+  const mockChannels = [
+    {
+      name: 'test-channel',
+      id: 'C123',
+      is_private: false,
+      is_member: true,
+    },
+  ];
+
+  jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  } as unknown as Promise<Response | JsonResponse | TextResponse>);
+
+  render(
+    <NotificationMethod
+      setting={{
+        ...mockSettingSlackV2,
+        recipients: 'C123', // Pre-existing recipient
+      }}
+      index={0}
+      onUpdate={mockOnUpdate}
+      onRemove={mockOnRemove}
+      onInputChange={mockOnInputChange}
+      email_subject={mockEmailSubject}
+      defaultSubject={mockDefaultSubject}
+      setErrorSubject={mockSetErrorSubject}
+    />,
+  );
+
+  // Wait for initial render
+  await waitFor(() => {
+    expect(screen.getByTestId('refresh-slack-channels')).toBeInTheDocument();
   });
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('RefreshLabel functionality', () => {
-    test('should call updateSlackOptions with force true when RefreshLabel is clicked', async () => {
-      // Set feature flag so that SlackV2 branch renders RefreshLabel
-      window.featureFlags = { [FeatureFlag.AlertReportSlackV2]: true };
-      // Spy on SupersetClient.get which is called by updateSlackOptions
-      const supersetClientSpy = jest
-        .spyOn(SupersetClient, 'get')
-        .mockImplementation(
-          () =>
-            Promise.resolve({ json: { result: [] } }) as unknown as Promise<
-              Response | JsonResponse | TextResponse
-            >,
-        );
+  // Click refresh button
+  const refreshButton = screen.getByTestId('refresh-slack-channels');
+  fireEvent.click(refreshButton);
 
-      render(
-        <NotificationMethod
-          setting={mockSettingSlackV2}
-          index={0}
-          onUpdate={mockOnUpdate}
-          onRemove={mockOnRemove}
-          onInputChange={mockOnInputChange}
-          email_subject={mockEmailSubject}
-          defaultSubject={mockDefaultSubject}
-          setErrorSubject={mockSetErrorSubject}
-        />,
-      );
-
-      // Wait for RefreshLabel to be rendered (it may have a tooltip with the provided content)
-      const refreshLabel = await waitFor(() => screen.getByLabelText('sync'));
-      // Simulate a click on the RefreshLabel
-      userEvent.click(refreshLabel);
-      // Verify that the SupersetClient.get was called indicating that updateSlackOptions executed
-      await waitFor(() => {
-        expect(supersetClientSpy).toHaveBeenCalled();
-      });
-    });
+  // Verify onUpdate was called with empty recipients
+  await waitFor(() => {
+    expect(mockOnUpdate).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        recipients: '',
+      }),
+    );
   });
 });

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -24,7 +24,9 @@ import {
   useMemo,
   useRef,
   useEffect,
+  useCallback,
 } from 'react';
+import { debounce } from 'lodash';
 import rison from 'rison';
 
 import {
@@ -42,7 +44,7 @@ import {
   SlackChannel,
 } from '../types';
 import { StyledInputContainer } from '../AlertReportModal';
-import { styled, useTheme } from '@apache-superset/core';
+import { styled, useTheme } from '@apache-superset/core/ui';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
@@ -195,10 +197,11 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       { data: { label: string; value: string }[]; totalCount: number }
     >
   >({});
-  const [refreshKey, setRefreshKey] = useState(0);
   const forceRefreshRef = useRef(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const hasShownErrorToast = useRef(false); // Track if we've shown the error toast
+  const hasShownErrorToast = useRef(false);
+  const [searchGeneration, setSearchGeneration] = useState(0);
+  const lastSearchValueRef = useRef('');
 
   const onMethodChange = (selected: {
     label: string;
@@ -221,105 +224,120 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const fetchSlackChannels = async (
-    search: string,
-    page: number,
-    pageSize: number,
-  ): Promise<{
-    data: { label: string; value: string }[];
-    totalCount: number;
-  }> => {
-    try {
-      const cacheKey = `${search}:${page}`;
+  const fetchSlackChannels = useCallback(
+    async (
+      search: string,
+      page: number,
+      pageSize: number,
+    ): Promise<{
+      data: { label: string; value: string }[];
+      totalCount: number;
+    }> => {
+      try {
+        const cacheKey = `${search}:${page}`;
 
-      if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
-        return dataCache.current[cacheKey];
+        if (dataCache.current[cacheKey] && !forceRefreshRef.current) {
+          return dataCache.current[cacheKey];
+        }
+
+        // Clear cache for previous searches to prevent stale data
+        if (page === 0) {
+          Object.keys(dataCache.current).forEach(key => {
+            if (!key.startsWith(`${search}:`)) {
+              delete dataCache.current[key];
+              delete cursorRef.current[key];
+            }
+          });
+        }
+
+        const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
+
+        const params: Record<string, any> = {
+          types: ['public_channel', 'private_channel'],
+          limit: pageSize,
+        };
+
+        if (page === 0 && forceRefreshRef.current) {
+          params.force = true;
+          forceRefreshRef.current = false;
+        }
+
+        if (search) {
+          params.search_string = search;
+        }
+
+        if (cursor) {
+          params.cursor = cursor;
+        }
+
+        const queryString = rison.encode(params);
+        const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+        const response = await SupersetClient.get({ endpoint });
+
+        const { result, next_cursor, has_more } = response.json;
+
+        if (next_cursor) {
+          cursorRef.current[`${search}:${page + 1}`] = next_cursor;
+        }
+
+        const options = result.map((channel: SlackChannel) => ({
+          label: channel.name,
+          value: channel.id,
+        }));
+
+        const totalCount = has_more
+          ? (page + 1) * pageSize + 1
+          : page * pageSize + options.length;
+
+        const responseData = {
+          data: options,
+          totalCount,
+        };
+
+        dataCache.current[cacheKey] = responseData;
+
+        return responseData;
+      } catch (error) {
+        logging.error('Failed to fetch Slack channels:', error);
+
+        // Show user-friendly error message
+        if (addDangerToast && !hasShownErrorToast.current) {
+          addDangerToast(
+            t(
+              'Unable to load Slack channels. Please check your Slack API token configuration. ' +
+                'Switching to manual channel input.',
+            ),
+          );
+          hasShownErrorToast.current = true;
+        }
+
+        // Fallback to Slack v1 without clearing recipients to prevent data loss
+        setUseSlackV1(true);
+
+        // Auto-switch to Slack V1 in the notification method dropdown
+        if (
+          onUpdate &&
+          setting &&
+          setting.method === NotificationMethodOption.SlackV2
+        ) {
+          onUpdate(index, {
+            ...setting,
+            method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
+          });
+        }
+
+        return {
+          data: [],
+          totalCount: 0,
+        };
       }
-
-      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
-
-      const params: Record<string, any> = {
-        types: ['public_channel', 'private_channel'],
-        limit: pageSize,
-      };
-
-      if (page === 0 && forceRefreshRef.current) {
-        params.force = true;
-        forceRefreshRef.current = false;
-      }
-
-      if (search) {
-        params.search_string = search;
-      }
-
-      if (cursor) {
-        params.cursor = cursor;
-      }
-
-      const queryString = rison.encode(params);
-      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
-      const response = await SupersetClient.get({ endpoint });
-
-      const { result, next_cursor, has_more } = response.json;
-
-      if (next_cursor) {
-        cursorRef.current[`${search}:${page + 1}`] = next_cursor;
-      }
-
-      const options = result.map((channel: SlackChannel) => ({
-        label: channel.name,
-        value: channel.id,
-      }));
-
-      const totalCount = has_more
-        ? (page + 1) * pageSize + 1
-        : page * pageSize + options.length;
-
-      const responseData = {
-        data: options,
-        totalCount,
-      };
-
-      dataCache.current[cacheKey] = responseData;
-
-      return responseData;
-    } catch (error) {
-      logging.error('Failed to fetch Slack channels:', error);
-
-      // Show user-friendly error message
-      if (addDangerToast && !hasShownErrorToast.current) {
-        addDangerToast(
-          t(
-            'Unable to load Slack channels. Please check your Slack API token configuration. ' +
-              'Switching to manual channel input.',
-          ),
-        );
-        hasShownErrorToast.current = true;
-      }
-
-      // Fallback to Slack v1 without clearing recipients to prevent data loss
-      setUseSlackV1(true);
-
-      // Auto-switch to Slack V1 in the notification method dropdown
-      if (
-        onUpdate &&
-        setting &&
-        setting.method === NotificationMethodOption.SlackV2
-      ) {
-        onUpdate(index, {
-          ...setting,
-          method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
-          // Keep recipients to preserve user data
-        });
-      }
-
-      // Return empty result instead of throwing to allow UI to continue
-      return {
-        data: [],
-        totalCount: 0,
-      };
-    }
-  };
+    },
+    // Note: searchGeneration is intentionally included even though not used in function body
+    // Purpose: Trigger function reference change when search changes (after debounce)
+    // Effect: Forces AsyncSelect to clear internal state and show fresh results
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [addDangerToast, onUpdate, setting, index, searchGeneration],
+  );
 
   const handleRefreshSlackChannels = async () => {
     setIsRefreshing(true);
@@ -332,8 +350,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       // Fetch fresh channel list without clearing user selections
       await fetchSlackChannels('', 0, 100);
-
-      setRefreshKey(prev => prev + 1);
     } catch (error) {
       logging.error('Error refreshing channels:', error);
 
@@ -372,14 +388,12 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               const channel = channelData.data.find(
                 ch => ch.value.toLowerCase() === id.toLowerCase(),
               );
-              // If channel found, use its label; otherwise fallback to ID
               return channel || { label: id, value: id };
             })
             .filter(r => r.value); // Filter out empty values
 
           setSlackRecipients(mappedRecipients);
         } catch (error) {
-          // If fetching fails, use IDs as both label and value
           const recipientIds = recipients.split(',').map(id => id.trim());
           const fallbackRecipients = recipientIds.map(id => ({
             label: id,
@@ -391,8 +405,28 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     };
 
     initializeSlackRecipients();
+    // Note: fetchSlackChannels and slackRecipients are intentionally omitted
+    // - fetchSlackChannels: Would cause re-initialization on every search change
+    // - slackRecipients: Would cause infinite loop (we modify it inside)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [method, recipients]);
+
+  const debouncedSearchUpdate = useMemo(
+    () =>
+      debounce((search: string) => {
+        const trimmedSearch = search.trim();
+        if (lastSearchValueRef.current !== trimmedSearch) {
+          lastSearchValueRef.current = trimmedSearch;
+          setSearchGeneration(prev => prev + 1);
+        }
+      }, 500),
+    [],
+  );
+
+  useEffect(
+    () => () => debouncedSearchUpdate.cancel(),
+    [debouncedSearchUpdate],
+  );
 
   const methodOptions = useMemo(
     () =>
@@ -449,6 +483,10 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       onUpdate(index, updatedSetting);
     }
+  };
+
+  const handleSlackSearch = (search: string) => {
+    debouncedSearchUpdate(search);
   };
 
   const onSubjectChange = (
@@ -606,18 +644,20 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                   // for SlackV2
                   <div className="input-container">
                     <AsyncSelect
-                      key={refreshKey}
                       ariaLabel={t('Select channels')}
                       mode="multiple"
                       name="recipients"
                       value={slackRecipients}
                       options={fetchSlackChannels}
                       onChange={onSlackRecipientsChange}
+                      onSearch={handleSlackSearch}
                       allowClear
                       data-test="recipients"
                       fetchOnlyOnSearch={false}
                       pageSize={100}
                       placeholder={t('Select Slack channels')}
+                      tokenSeparators={[]}
+                      filterOption={() => true}
                     />
                     <span
                       role="button"

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -20,22 +20,20 @@ import {
   FunctionComponent,
   useState,
   ChangeEvent,
-  useEffect,
   useMemo,
+  useRef,
 } from 'react';
 import rison from 'rison';
 
 import {
   FeatureFlag,
-  JsonResponse,
   SupersetClient,
   isFeatureEnabled,
   t,
 } from '@superset-ui/core';
 import { styled, useTheme } from '@apache-superset/core/ui';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { Input, Select } from '@superset-ui/core/components';
-import RefreshLabel from '@superset-ui/core/components/RefreshLabel';
+import { Input, Select, AsyncSelect } from '@superset-ui/core/components';
 import {
   NotificationMethodOption,
   NotificationSetting,
@@ -76,6 +74,17 @@ const StyledNotificationMethod = styled.div`
         margin-left: ${theme.sizeUnit * 2}px;
         padding-top: ${theme.sizeUnit}px;
       }
+
+      .refresh-button {
+        margin-left: ${theme.sizeUnit * 2}px;
+        cursor: pointer;
+        color: ${theme.colorTextSecondary};
+
+        &:hover {
+          color: ${theme.colorPrimary};
+        }
+      }
+
       .anticon {
         margin-left: ${theme.sizeUnit}px;
       }
@@ -149,47 +158,6 @@ export const mapSlackValues = ({
     .filter(val => !!val) as { label: string; value: string }[];
 };
 
-export const mapChannelsToOptions = (result: SlackChannel[]) => {
-  const publicChannels: SlackChannel[] = [];
-  const privateChannels: SlackChannel[] = [];
-
-  result.forEach(channel => {
-    if (channel.is_private) {
-      privateChannels.push(channel);
-    } else {
-      publicChannels.push(channel);
-    }
-  });
-
-  return [
-    {
-      label: 'Public Channels',
-      options: publicChannels.map((channel: SlackChannel) => ({
-        label: `${channel.name} ${
-          channel.is_member ? '' : t('(Bot not in channel)')
-        }`,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'public',
-    },
-    {
-      label: t('Private Channels (Bot in channel)'),
-      options: privateChannels.map((channel: SlackChannel) => ({
-        label: channel.name,
-        value: channel.id,
-        key: channel.id,
-      })),
-      key: 'private',
-    },
-  ];
-};
-
-type SlackOptionsType = {
-  label: string;
-  options: { label: string; value: string }[];
-}[];
-
 export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   setting = null,
   index,
@@ -213,24 +181,16 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [ccValue, setCcValue] = useState<string>(cc || '');
   const [bccValue, setBccValue] = useState<string>(bcc || '');
   const theme = useTheme();
-  const [methodOptionsLoading, setMethodOptionsLoading] =
-    useState<boolean>(true);
-  const [slackOptions, setSlackOptions] = useState<SlackOptionsType>([
-    {
-      label: '',
-      options: [],
-    },
-  ]);
-
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
-  const [isSlackChannelsLoading, setIsSlackChannelsLoading] =
-    useState<boolean>(true);
+  const cursorRef = useRef<Record<string, string | null>>({});
+  const [refreshKey, setRefreshKey] = useState(0);
+  const forceRefreshRef = useRef(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const onMethodChange = (selected: {
     label: string;
     value: NotificationMethodOption;
   }) => {
-    // Since we're swapping the method, reset the recipients
     setRecipientValue('');
     setCcValue('');
     setBccValue('');
@@ -248,84 +208,91 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     }
   };
 
-  const fetchSlackChannels = async ({
-    searchString = '',
-    types = [],
-    exactMatch = false,
-    force = false,
-  }: {
-    searchString?: string | undefined;
-    types?: string[];
-    exactMatch?: boolean | undefined;
-    force?: boolean | undefined;
-  } = {}): Promise<JsonResponse> => {
-    const queryString = rison.encode({
-      searchString,
-      types,
-      exactMatch,
-      force,
-    });
-    const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
-    return SupersetClient.get({ endpoint });
-  };
+  const fetchSlackChannels = async (
+    search: string,
+    page: number,
+    pageSize: number,
+  ): Promise<{
+    data: { label: string; value: string }[];
+    totalCount: number;
+  }> => {
+    try {
+      const cacheKey = `${search}:${page}`;
+      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
 
-  const updateSlackOptions = async ({
-    force,
-  }: {
-    force?: boolean | undefined;
-  } = {}) => {
-    setIsSlackChannelsLoading(true);
-    fetchSlackChannels({ types: ['public_channel', 'private_channel'], force })
-      .then(({ json }) => {
-        const { result } = json;
-        const options: SlackOptionsType = mapChannelsToOptions(result);
+      const params: Record<string, any> = {
+        types: ['public_channel', 'private_channel'],
+        limit: pageSize,
+      };
 
-        setSlackOptions(options);
+      if (page === 0 && forceRefreshRef.current) {
+        params.force = true;
+        forceRefreshRef.current = false;
+      }
 
-        if (isFeatureEnabled(FeatureFlag.AlertReportSlackV2)) {
-          // for edit mode, map existing ids to names for display if slack v2
-          // or names to ids if slack v1
-          const [publicOptions, privateOptions] = options;
-          if (
-            method &&
-            [
-              NotificationMethodOption.SlackV2,
-              NotificationMethodOption.Slack,
-            ].includes(method)
-          ) {
-            setSlackRecipients(
-              mapSlackValues({
-                method,
-                recipientValue,
-                slackOptions: [
-                  ...publicOptions.options,
-                  ...privateOptions.options,
-                ],
-              }),
-            );
-          }
-        }
-      })
-      .catch(e => {
-        // Fallback to slack v1 if slack v2 is not compatible
-        setUseSlackV1(true);
-      })
-      .finally(() => {
-        setMethodOptionsLoading(false);
-        setIsSlackChannelsLoading(false);
-      });
-  };
+      if (search) {
+        params.search_string = search;
+      }
 
-  useEffect(() => {
-    const slackEnabled = options?.some(
-      option =>
-        option === NotificationMethodOption.Slack ||
-        option === NotificationMethodOption.SlackV2,
-    );
-    if (slackEnabled && !slackOptions[0]?.options.length) {
-      updateSlackOptions();
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const queryString = rison.encode(params);
+      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+      const response = await SupersetClient.get({ endpoint });
+
+      const { result, next_cursor, has_more } = response.json;
+
+      if (next_cursor) {
+        cursorRef.current[`${search}:${page + 1}`] = next_cursor;
+      }
+
+      const options = result.map((channel: SlackChannel) => ({
+        label: channel.name,
+        value: channel.id,
+      }));
+
+      const totalCount = has_more
+        ? (page + 1) * pageSize + 1 // Fake "has more"
+        : page * pageSize + options.length; // Last page
+
+      return {
+        data: options,
+        totalCount,
+      };
+    } catch (error) {
+      console.error('Failed to fetch Slack channels:', error);
+      setUseSlackV1(true);
+      throw error;
     }
-  }, []);
+  };
+
+  const handleRefreshSlackChannels = async () => {
+    setIsRefreshing(true);
+
+    try {
+      forceRefreshRef.current = true;
+      cursorRef.current = {};
+
+      setSlackRecipients([]);
+
+      if (onUpdate && setting) {
+        onUpdate(index, {
+          ...setting,
+          recipients: '',
+        } as NotificationSetting);
+      }
+
+      await fetchSlackChannels('', 0, 100);
+
+      setRefreshKey(prev => prev + 1);
+    } catch (error) {
+      console.error('Error refreshing channels:', error);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
 
   const methodOptions = useMemo(
     () =>
@@ -458,10 +425,8 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
               options={methodOptions}
               showSearch
               value={methodOptions.find(option => option.value === method)}
-              loading={methodOptionsLoading}
             />
             {index !== 0 && !!onRemove ? (
-              // eslint-disable-next-line jsx-a11y/control-has-associated-label
               <span
                 role="button"
                 tabIndex={0}
@@ -540,24 +505,31 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                 ) : (
                   // for SlackV2
                   <div className="input-container">
-                    <Select
+                    <AsyncSelect
+                      key={refreshKey}
                       ariaLabel={t('Select channels')}
                       mode="multiple"
                       name="recipients"
                       value={slackRecipients}
-                      options={slackOptions}
+                      options={fetchSlackChannels}
                       onChange={onSlackRecipientsChange}
                       allowClear
                       data-test="recipients"
-                      loading={isSlackChannelsLoading}
-                      allowSelectAll={false}
-                      labelInValue
+                      fetchOnlyOnSearch={false}
+                      pageSize={100}
+                      placeholder={t('Select Slack channels')}
                     />
-                    <RefreshLabel
-                      onClick={() => updateSlackOptions({ force: true })}
-                      tooltipContent={t('Force refresh Slack channels list')}
-                      disabled={isSlackChannelsLoading}
-                    />
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      className="refresh-button"
+                      onClick={handleRefreshSlackChannels}
+                      data-test="refresh-slack-channels"
+                      title={t('Refresh channels')}
+                      style={{ opacity: isRefreshing ? 0.5 : 1 }}
+                    >
+                      <Icons.SyncOutlined iconSize="l" spin={isRefreshing} />
+                    </span>
                   </div>
                 )}
               </div>

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -220,7 +220,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
       totalCount: number;
     }> => {
       try {
-        const result = await fetchSlackChannelsFromHook(search, page, pageSize);
+        const result = await fetchSlackChannelsFromHook({ search, page, pageSize });
 
         hasShownErrorToast.current = false;
 
@@ -562,7 +562,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                       allowClear
                       data-test="recipients"
                       fetchOnlyOnSearch={false}
-                      pageSize={100}
+                      pageSize={999}
                       placeholder={t('Select Slack channels')}
                       tokenSeparators={[]}
                       filterOption={() => true}

--- a/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
+++ b/superset-frontend/src/features/alerts/components/NotificationMethod.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -22,6 +23,7 @@ import {
   ChangeEvent,
   useMemo,
   useRef,
+  useEffect,
 } from 'react';
 import rison from 'rison';
 
@@ -29,9 +31,9 @@ import {
   FeatureFlag,
   SupersetClient,
   isFeatureEnabled,
+  logging,
   t,
 } from '@superset-ui/core';
-import { styled, useTheme } from '@apache-superset/core/ui';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { Input, Select, AsyncSelect } from '@superset-ui/core/components';
 import {
@@ -40,6 +42,7 @@ import {
   SlackChannel,
 } from '../types';
 import { StyledInputContainer } from '../AlertReportModal';
+import { styled, useTheme } from '@apache-superset/core';
 
 const StyledNotificationMethod = styled.div`
   ${({ theme }) => `
@@ -132,9 +135,10 @@ interface NotificationMethodProps {
   onInputChange?: (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
   ) => void;
-  email_subject: string;
+  emailSubject: string;
   defaultSubject: string;
   setErrorSubject: (hasError: boolean) => void;
+  addDangerToast?: (msg: string) => void;
 }
 
 export const mapSlackValues = ({
@@ -164,10 +168,13 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   onUpdate,
   onRemove,
   onInputChange,
-  email_subject,
+  emailSubject,
   defaultSubject,
   setErrorSubject,
+  addDangerToast,
 }) => {
+  const theme = useTheme();
+
   const { method, recipients, cc, bcc, options } = setting || {};
   const [recipientValue, setRecipientValue] = useState<string>(
     recipients || '',
@@ -180,7 +187,6 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [bccVisible, setBccVisible] = useState<boolean>(!!bcc);
   const [ccValue, setCcValue] = useState<string>(cc || '');
   const [bccValue, setBccValue] = useState<string>(bcc || '');
-  const theme = useTheme();
   const [useSlackV1, setUseSlackV1] = useState<boolean>(false);
   const cursorRef = useRef<Record<string, string | null>>({});
   const dataCache = useRef<
@@ -192,6 +198,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
   const [refreshKey, setRefreshKey] = useState(0);
   const forceRefreshRef = useRef(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const hasShownErrorToast = useRef(false); // Track if we've shown the error toast
 
   const onMethodChange = (selected: {
     label: string;
@@ -277,13 +284,40 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
 
       return responseData;
     } catch (error) {
-      console.error('Failed to fetch Slack channels:', error);
+      logging.error('Failed to fetch Slack channels:', error);
+
+      // Show user-friendly error message
+      if (addDangerToast && !hasShownErrorToast.current) {
+        addDangerToast(
+          t(
+            'Unable to load Slack channels. Please check your Slack API token configuration. ' +
+              'Switching to manual channel input.',
+          ),
+        );
+        hasShownErrorToast.current = true;
+      }
+
+      // Fallback to Slack v1 without clearing recipients to prevent data loss
       setUseSlackV1(true);
-      onMethodChange({
-        label: NotificationMethodOption.Slack,
-        value: NotificationMethodOption.Slack,
-      });
-      throw error;
+
+      // Auto-switch to Slack V1 in the notification method dropdown
+      if (
+        onUpdate &&
+        setting &&
+        setting.method === NotificationMethodOption.SlackV2
+      ) {
+        onUpdate(index, {
+          ...setting,
+          method: NotificationMethodOption.Slack, // Switch from SlackV2 to Slack V1
+          // Keep recipients to preserve user data
+        });
+      }
+
+      // Return empty result instead of throwing to allow UI to continue
+      return {
+        data: [],
+        totalCount: 0,
+      };
     }
   };
 
@@ -291,28 +325,74 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
     setIsRefreshing(true);
 
     try {
+      // Clear cache and cursor to force fresh data fetch
       forceRefreshRef.current = true;
       cursorRef.current = {};
       dataCache.current = {};
 
-      setSlackRecipients([]);
-
-      if (onUpdate && setting) {
-        onUpdate(index, {
-          ...setting,
-          recipients: '',
-        } as NotificationSetting);
-      }
-
+      // Fetch fresh channel list without clearing user selections
       await fetchSlackChannels('', 0, 100);
 
       setRefreshKey(prev => prev + 1);
     } catch (error) {
-      console.error('Error refreshing channels:', error);
+      logging.error('Error refreshing channels:', error);
+
+      // Show error toast if available
+      if (addDangerToast) {
+        addDangerToast(
+          t('Failed to refresh Slack channels. Please try again.'),
+        );
+      }
     } finally {
       setIsRefreshing(false);
     }
   };
+
+  // Reset error toast flag when method changes
+  useEffect(() => {
+    hasShownErrorToast.current = false;
+  }, [method]);
+
+  // Initialize slackRecipients when editing an existing alert with SlackV2
+  useEffect(() => {
+    const initializeSlackRecipients = async () => {
+      if (
+        method === NotificationMethodOption.SlackV2 &&
+        recipients &&
+        slackRecipients.length === 0
+      ) {
+        try {
+          // Fetch first page of channels to map IDs to names
+          const channelData = await fetchSlackChannels('', 0, 100);
+          const recipientIds = recipients.split(',').map(id => id.trim());
+
+          // Map recipient IDs to {label, value} format
+          const mappedRecipients = recipientIds
+            .map(id => {
+              const channel = channelData.data.find(
+                ch => ch.value.toLowerCase() === id.toLowerCase(),
+              );
+              // If channel found, use its label; otherwise fallback to ID
+              return channel || { label: id, value: id };
+            })
+            .filter(r => r.value); // Filter out empty values
+
+          setSlackRecipients(mappedRecipients);
+        } catch (error) {
+          // If fetching fails, use IDs as both label and value
+          const recipientIds = recipients.split(',').map(id => id.trim());
+          const fallbackRecipients = recipientIds.map(id => ({
+            label: id,
+            value: id,
+          }));
+          setSlackRecipients(fallbackRecipients);
+        }
+      }
+    };
+
+    initializeSlackRecipients();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [method, recipients]);
 
   const methodOptions = useMemo(
     () =>
@@ -472,7 +552,7 @@ export const NotificationMethod: FunctionComponent<NotificationMethodProps> = ({
                     <Input
                       type="text"
                       name="email_subject"
-                      value={email_subject}
+                      value={emailSubject}
                       placeholder={defaultSubject}
                       onChange={onSubjectChange}
                     />

--- a/superset-frontend/src/features/alerts/hooks/useSlackChannels.test.ts
+++ b/superset-frontend/src/features/alerts/hooks/useSlackChannels.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { SupersetClient } from '@superset-ui/core';
+import { useSlackChannels } from './useSlackChannels';
+
+// Mock SupersetClient
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  SupersetClient: {
+    get: jest.fn(),
+  },
+  logging: {
+    error: jest.fn(),
+  },
+}));
+
+const mockChannels = [
+  { id: 'C001', name: 'general', is_private: false },
+  { id: 'C002', name: 'engineering', is_private: false },
+  { id: 'C003', name: 'random', is_private: false },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('fetches channels successfully', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  const channels = await result.current.fetchChannels('', 0, 100);
+
+  expect(channels.data).toHaveLength(3);
+  expect(channels.data[0]).toEqual({ label: 'general', value: 'C001' });
+  expect(channels.totalCount).toBe(3);
+});
+
+test('caches results and avoids duplicate requests', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First call
+  await result.current.fetchChannels('', 0, 100);
+
+  // Second call with same parameters
+  await result.current.fetchChannels('', 0, 100);
+
+  // Should only call API once
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+});
+
+test('deduplicates concurrent requests', async () => {
+  (SupersetClient.get as jest.Mock).mockImplementation(
+    () =>
+      new Promise(resolve =>
+        setTimeout(
+          () =>
+            resolve({
+              json: {
+                result: mockChannels,
+                next_cursor: null,
+                has_more: false,
+              },
+            }),
+          100,
+        ),
+      ),
+  );
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // Make concurrent requests
+  const promise1 = result.current.fetchChannels('', 0, 100);
+  const promise2 = result.current.fetchChannels('', 0, 100);
+
+  const [result1, result2] = await Promise.all([promise1, promise2]);
+
+  // Should return same data
+  expect(result1).toEqual(result2);
+
+  // Should only call API once
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+});
+
+test('clears cache when search changes', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First search
+  await result.current.fetchChannels('eng', 0, 100);
+
+  // Different search
+  await result.current.fetchChannels('gen', 0, 100);
+
+  // Should call API twice (once for each search)
+  expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+});
+
+test('handles pagination with cursors', async () => {
+  (SupersetClient.get as jest.Mock)
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(0, 2),
+        next_cursor: 'cursor_page_2',
+        has_more: true,
+      },
+    })
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(2),
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First page
+  const page1 = await result.current.fetchChannels('', 0, 2);
+  expect(page1.data).toHaveLength(2);
+  expect(page1.has_more).toBe(true);
+
+  // Second page
+  const page2 = await result.current.fetchChannels('', 1, 2);
+  expect(page2.data).toHaveLength(1);
+});
+
+test('refreshChannels clears cache and refetches', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // Initial fetch
+  await result.current.fetchChannels('', 0, 100);
+
+  // Cache hit - no new API call
+  await result.current.fetchChannels('', 0, 100);
+  expect(SupersetClient.get).toHaveBeenCalledTimes(1);
+
+  // Refresh
+  await result.current.refreshChannels();
+
+  // Should call API again
+  expect(SupersetClient.get).toHaveBeenCalledTimes(2);
+});
+
+test('isRefreshing state updates correctly', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: mockChannels,
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  expect(result.current.isRefreshing).toBe(false);
+
+  await result.current.refreshChannels();
+
+  // Should be false after refresh completes
+  expect(result.current.isRefreshing).toBe(false);
+});
+
+test('calls onError callback when fetch fails', async () => {
+  (SupersetClient.get as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+  const onError = jest.fn();
+  const { result } = renderHook(() => useSlackChannels(onError));
+
+  await result.current.fetchChannels('', 0, 100);
+
+  expect(onError).toHaveBeenCalledWith(
+    expect.stringContaining('Unable to load Slack channels'),
+  );
+});
+
+test('returns empty data on error', async () => {
+  (SupersetClient.get as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  const channels = await result.current.fetchChannels('', 0, 100);
+
+  expect(channels.data).toEqual([]);
+  expect(channels.totalCount).toBe(0);
+});
+
+test('includes search_string in API params when provided', async () => {
+  (SupersetClient.get as jest.Mock).mockResolvedValue({
+    json: {
+      result: [],
+      next_cursor: null,
+      has_more: false,
+    },
+  });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  await result.current.fetchChannels('engineering', 0, 100);
+
+  expect(SupersetClient.get).toHaveBeenCalledWith({
+    endpoint: expect.stringContaining('search_string'),
+  });
+});
+
+test('includes cursor in API params for pagination', async () => {
+  (SupersetClient.get as jest.Mock)
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(0, 2),
+        next_cursor: 'test_cursor',
+        has_more: true,
+      },
+    })
+    .mockResolvedValueOnce({
+      json: {
+        result: mockChannels.slice(2),
+        next_cursor: null,
+        has_more: false,
+      },
+    });
+
+  const { result } = renderHook(() => useSlackChannels());
+
+  // First page
+  await result.current.fetchChannels('', 0, 2);
+
+  // Second page
+  await result.current.fetchChannels('', 1, 2);
+
+  expect(SupersetClient.get).toHaveBeenCalledWith({
+    endpoint: expect.stringContaining('cursor'),
+  });
+});

--- a/superset-frontend/src/features/alerts/hooks/useSlackChannels.ts
+++ b/superset-frontend/src/features/alerts/hooks/useSlackChannels.ts
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { logging, SupersetClient, t } from '@superset-ui/core';
+import rison from 'rison';
+import { SlackChannel } from '../types';
+
+export interface SlackChannelOption {
+  label: string;
+  value: string;
+}
+
+export interface SlackChannelsResult {
+  data: SlackChannelOption[];
+  totalCount: number;
+  has_more?: boolean;
+  next_cursor?: string | null;
+}
+
+export interface UseSlackChannelsResult {
+  fetchChannels: (
+    search: string,
+    page: number,
+    pageSize: number,
+  ) => Promise<SlackChannelsResult>;
+  refreshChannels: () => Promise<void>;
+  isRefreshing: boolean;
+}
+
+/**
+ * Cache types for managing Slack channel data
+ */
+type CursorCache = Record<string, string | null>;
+type DataCache = Record<string, SlackChannelsResult>;
+type PendingRequestsCache = Record<string, Promise<SlackChannelsResult>>;
+
+/**
+ * Custom hook for managing Slack channels with caching and pagination
+ */
+export function useSlackChannels(
+  onError?: (message: string) => void,
+): UseSlackChannelsResult {
+  const cursorRef = useRef<CursorCache>({});
+  const dataCache = useRef<DataCache>({});
+  const pendingRequests = useRef<PendingRequestsCache>({});
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const fetchChannels = useCallback(
+    async (
+      search: string,
+      page: number,
+      pageSize: number,
+    ): Promise<SlackChannelsResult> => {
+      const cacheKey = `${search}:${page}`;
+
+      if (dataCache.current[cacheKey]) {
+        return dataCache.current[cacheKey];
+      }
+
+      if (cacheKey in pendingRequests.current) {
+        return pendingRequests.current[cacheKey];
+      }
+
+      const cursor = page > 0 ? cursorRef.current[cacheKey] : null;
+
+      const params: Record<string, any> = {
+        types: ['public_channel', 'private_channel'],
+        limit: pageSize,
+      };
+
+      if (search) {
+        params.search_string = search;
+      }
+
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const queryString = rison.encode(params);
+      const endpoint = `/api/v1/report/slack_channels/?q=${queryString}`;
+
+      const fetchPromise = (async () => {
+        try {
+          const response = await SupersetClient.get({ endpoint });
+
+          const {
+            result,
+            next_cursor: nextCursor,
+            has_more: hasMore,
+          } = response.json;
+
+          if (nextCursor) {
+            cursorRef.current[`${search}:${page + 1}`] = nextCursor;
+          }
+
+          const options = result.map((channel: SlackChannel) => ({
+            label: channel.name,
+            value: channel.id,
+          }));
+
+          const totalCount = hasMore
+            ? (page + 1) * pageSize + 1
+            : page * pageSize + options.length;
+
+          const responseData = {
+            data: options,
+            totalCount,
+            has_more: hasMore,
+            next_cursor: nextCursor,
+          };
+
+          dataCache.current[cacheKey] = responseData;
+
+          return responseData;
+        } catch (error) {
+          logging.error('Failed to fetch Slack channels:', error);
+
+          if (onError) {
+            onError(
+              t(
+                'Unable to load Slack channels. Please check your Slack API token configuration.',
+              ),
+            );
+          }
+
+          return {
+            data: [],
+            totalCount: 0,
+          };
+        } finally {
+          delete pendingRequests.current[cacheKey];
+        }
+      })();
+
+      pendingRequests.current[cacheKey] = fetchPromise;
+
+      return fetchPromise;
+    },
+    [onError],
+  );
+
+  const refreshChannels = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      cursorRef.current = {};
+      dataCache.current = {};
+      pendingRequests.current = {};
+
+      await fetchChannels('', 0, 100);
+    } catch (error) {
+      logging.error('Error refreshing channels:', error);
+
+      if (onError) {
+        onError(t('Failed to refresh Slack channels. Please try again.'));
+      }
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [fetchChannels, onError]);
+
+  return {
+    fetchChannels,
+    refreshChannels,
+    isRefreshing,
+  };
+}

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -142,7 +142,7 @@ class BaseReportState:
                     channel_names = (slack_recipients["target"] or "").replace("#", "")
                     # we need to ensure that existing reports can also fetch
                     # ids from private channels
-                    channels = get_channels_with_search(
+                    channels_data = get_channels_with_search(
                         search_string=channel_names,
                         types=[
                             SlackChannelTypes.PRIVATE,
@@ -150,6 +150,7 @@ class BaseReportState:
                         ],
                         exact_match=True,
                     )
+                    channels = channels_data["result"]
                     channels_list = recipients_string_to_list(channel_names)
                     if len(channels_list) != len(channels):
                         missing_channels = set(channels_list) - {

--- a/superset/config.py
+++ b/superset/config.py
@@ -1749,6 +1749,23 @@ SLACK_CACHE_TIMEOUT = int(timedelta(days=1).total_seconds())
 # For workspaces with 10k+ channels, consider increasing to 10
 SLACK_API_RATE_LIMIT_RETRY_COUNT = 2
 
+# Enable/disable caching for Slack channels list
+# When enabled, all channels are cached in memory for fast lookups
+# Disable this for very large workspaces (50k+ channels) to reduce memory usage
+# Default: True (caching enabled)
+SLACK_ENABLE_CACHING: bool = True
+
+# Maximum number of channels to cache during warmup
+# Prevents excessive memory usage in very large workspaces
+# The cache warmup task will stop after reaching this limit
+# Default: 20000 channels (~100MB cache size)
+SLACK_CACHE_MAX_CHANNELS: int = 20000
+
+# Celery task timeout for Slack cache warmup (seconds)
+# Prevents runaway cache warmup tasks in extremely large workspaces
+# Default: 300 seconds (5 minutes)
+SLACK_CACHE_WARMUP_TIMEOUT: int = 300
+
 # The webdriver to use for generating reports. Use one of the following
 # firefox
 #   Requires: geckodriver and firefox installations

--- a/superset/config.py
+++ b/superset/config.py
@@ -1755,17 +1755,6 @@ SLACK_API_RATE_LIMIT_RETRY_COUNT = 2
 # Default: True (caching enabled)
 SLACK_ENABLE_CACHING: bool = True
 
-# Maximum number of channels to cache during warmup
-# Prevents excessive memory usage in very large workspaces
-# The cache warmup task will stop after reaching this limit
-# Default: 20000 channels (~100MB cache size)
-SLACK_CACHE_MAX_CHANNELS: int = 20000
-
-# Celery task timeout for Slack cache warmup (seconds)
-# Prevents runaway cache warmup tasks in extremely large workspaces
-# Default: 300 seconds (5 minutes)
-SLACK_CACHE_WARMUP_TIMEOUT: int = 300
-
 # The webdriver to use for generating reports. Use one of the following
 # firefox
 #   Requires: geckodriver and firefox installations

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -577,14 +577,17 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
             search_string = params.get("search_string")
             types = params.get("types", [])
             exact_match = params.get("exact_match", False)
-            force = params.get("force", False)
-            channels = get_channels_with_search(
+            cursor = params.get("cursor")
+            limit = params.get("limit", 100)
+
+            channels_data = get_channels_with_search(
                 search_string=search_string,
                 types=types,
                 exact_match=exact_match,
-                force=force,
+                cursor=cursor,
+                limit=limit,
             )
-            return self.response(200, result=channels)
+            return self.response(200, **channels_data)
         except SupersetException as ex:
             logger.error("Error fetching slack channels %s", str(ex))
             return self.response_422(message=str(ex))

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -59,7 +59,7 @@ get_slack_channels_schema = {
         },
         "exact_match": {"type": "boolean"},
         "cursor": {"type": ["string", "null"]},
-        "limit": {"type": "integer", "default": 100},
+        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 1000},
         "force": {"type": "boolean"},
     },
 }

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -58,6 +58,9 @@ get_slack_channels_schema = {
             "items": {"type": "string", "enum": ["public_channel", "private_channel"]},
         },
         "exact_match": {"type": "boolean"},
+        "cursor": {"type": ["string", "null"]},
+        "limit": {"type": "integer", "default": 100},
+        "force": {"type": "boolean"},
     },
 }
 

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -59,7 +59,7 @@ get_slack_channels_schema = {
         },
         "exact_match": {"type": "boolean"},
         "cursor": {"type": ["string", "null"]},
-        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 1000},
+        "limit": {"type": "integer", "default": 100, "minimum": 1, "maximum": 999},
         "force": {"type": "boolean"},
     },
 }

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -26,10 +26,16 @@ from slack_sdk.http_retry.builtin_handlers import RateLimitErrorRetryHandler
 
 from superset import feature_flag_manager
 from superset.exceptions import SupersetException
+from superset.extensions import cache_manager
 from superset.reports.schemas import SlackChannelSchema
 from superset.utils.backports import StrEnum
 
 logger = logging.getLogger(__name__)
+
+SLACK_CHANNELS_CACHE_KEY = "slack_conversations_list"
+SLACK_CHANNELS_CONTINUATION_CURSOR_KEY = (
+    f"{SLACK_CHANNELS_CACHE_KEY}_continuation_cursor"
+)
 
 
 class SlackChannelTypes(StrEnum):
@@ -158,34 +164,149 @@ def _fetch_channels_with_search(
     }
 
 
-def get_channels_with_search(
-    search_string: str = "",
-    types: Optional[list[SlackChannelTypes]] = None,
-    exact_match: bool = False,
-    cursor: Optional[str] = None,
-    limit: int = 100,
-) -> dict[str, Any]:
+def _fetch_from_cache(  # noqa: C901
+    cached_channels: list[SlackChannelSchema],
+    search_string: str,
+    types: Optional[list[SlackChannelTypes]],
+    exact_match: bool,
+    cursor: Optional[str],
+    limit: int,
+) -> Optional[dict[str, Any]]:
     """
-    Fetches Slack channels with pagination and search support.
+    Fetch channels from cache with in-memory filtering and pagination.
+
+    This is the fast path - operates entirely in-memory on cached data.
+    Used when cache is available and warm.
 
     Args:
-        search_string: Search term(s). Can be comma-separated for OR logic.
-                      e.g., "engineering,marketing" matches channels containing
-                      "engineering" OR "marketing"
-        types: Channel types to filter (public_channel, private_channel)
-        exact_match: If True, search term must exactly match channel name/ID
-        cursor: Pagination cursor for fetching next page
-        limit: Maximum number of channels to return
+        cached_channels: Complete list of all cached channels
+        search_string: Search term(s) for filtering
+        types: Channel types to filter
+        exact_match: If True, search term must exactly match
+        cursor: Cache pagination cursor (format: "cache:N")
+        limit: Maximum channels to return
 
-    Returns a dict with:
-    - result: list of channels
-    - next_cursor: cursor for next page (None if no more pages)
-    - has_more: boolean indicating if more pages exist
+    Returns:
+        Dict with filtered and paginated results, or None if pagination
+        exceeds cached data (signals need to fall back to API)
+    """
+    # Start with all cached channels
+    channels = list(cached_channels)
 
-    The Slack API is paginated but does not include search.
-    We handle two cases:
-    1. WITHOUT search: Fetch single page from Slack API
-    2. WITH search: Stream through Slack API pages until we find enough matches
+    # Filter by channel types if specified
+    if types and len(types) < len(SlackChannelTypes):
+        type_set = set(types)
+        channels = [
+            ch
+            for ch in channels
+            if (
+                (SlackChannelTypes.PRIVATE in type_set and ch.get("is_private"))
+                or (SlackChannelTypes.PUBLIC in type_set and not ch.get("is_private"))
+            )
+        ]
+
+    # Filter by search string with comma-separated OR logic
+    if search_string:
+        search_terms = [
+            term.strip().lower() for term in search_string.split(",") if term.strip()
+        ]
+        filtered = []
+
+        for ch in channels:
+            channel_name_lower = ch.get("name", "").lower()
+            channel_id_lower = ch.get("id", "").lower()
+            is_match = False
+
+            for search_term in search_terms:
+                if exact_match:
+                    if (
+                        search_term == channel_name_lower
+                        or search_term == channel_id_lower
+                    ):
+                        is_match = True
+                        break
+                else:
+                    if (
+                        search_term in channel_name_lower
+                        or search_term in channel_id_lower
+                    ):
+                        is_match = True
+                        break
+
+            if is_match:
+                filtered.append(ch)
+
+        channels = filtered
+
+    # Calculate pagination offset from cursor
+    offset = 0
+    if cursor and cursor.startswith("cache:"):
+        try:
+            offset = int(cursor.split(":", 1)[1])
+        except (ValueError, IndexError):
+            offset = 0
+
+    # Check if we're trying to paginate beyond cached data
+    # This happens when cache is partial (hit SLACK_CACHE_MAX_CHANNELS limit)
+    if offset >= len(channels):
+        logger.info(
+            "Pagination offset (%d) exceeds cached data (%d channels). "
+            "Falling back to API.",
+            offset,
+            len(channels),
+        )
+        return None
+
+    # Paginate in memory
+    page = channels[offset : offset + limit]
+    next_offset = offset + limit
+    has_more = next_offset < len(channels)
+
+    # Check if we have a continuation cursor (cache was truncated)
+    continuation_cursor = cache_manager.cache.get(
+        SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+    )
+
+    # If we've reached the end of cached data but there's a continuation cursor,
+    # signal that more data exists via API
+    next_cursor: Optional[str]
+    if not has_more and continuation_cursor:
+        # Return special cursor that signals transition to API
+        next_cursor = "api:continue"
+        has_more = True
+    else:
+        # Use synthetic cursor for cache pagination
+        next_cursor = f"cache:{next_offset}" if has_more else None
+
+    return {
+        "result": page,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
+def _fetch_from_api(
+    search_string: str,
+    types: Optional[list[SlackChannelTypes]],
+    exact_match: bool,
+    cursor: Optional[str],
+    limit: int,
+) -> dict[str, Any]:
+    """
+    Fetch from Slack API with pagination.
+
+    This is the original pagination implementation extracted into a helper.
+    Used when cache is cold or disabled.
+
+    Args:
+        search_string: Search term(s) for filtering
+        types: Channel types to filter
+        exact_match: If True, search term must exactly match
+        cursor: Real Slack API cursor for pagination
+        limit: Maximum channels to return
+
+    Returns:
+        Dict with results from Slack API
     """
     try:
         client = get_slack_client()
@@ -224,6 +345,93 @@ def get_channels_with_search(
         raise SupersetException(f"Failed to list channels: {ex}") from ex
     except SlackClientError as ex:
         raise SupersetException(f"Failed to list channels: {ex}") from ex
+
+
+def get_channels_with_search(
+    search_string: str = "",
+    types: Optional[list[SlackChannelTypes]] = None,
+    exact_match: bool = False,
+    cursor: Optional[str] = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """
+    Fetches Slack channels with pagination and search support.
+
+    Args:
+        search_string: Search term(s). Can be comma-separated for OR logic.
+                      e.g., "engineering,marketing" matches channels containing
+                      "engineering" OR "marketing"
+        types: Channel types to filter (public_channel, private_channel)
+        exact_match: If True, search term must exactly match channel name/ID
+        cursor: Pagination cursor (format: "cache:N" for cache path,
+                "api:continue" for transitioning to API continuation,
+                base64 string for API path, None for first page)
+        limit: Maximum number of channels to return per page
+
+    Returns a dict with:
+    - result: list of channels for this page
+    - next_cursor: cursor for next page (None if no more pages)
+    - has_more: boolean indicating if more pages exist
+    """
+    enable_caching = app.config.get("SLACK_ENABLE_CACHING", True)
+
+    # Handle transition from cache to API continuation
+    if cursor == "api:continue":
+        continuation_cursor = cache_manager.cache.get(
+            SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+        )
+        if continuation_cursor:
+            logger.info("Transitioning from cache to API using continuation cursor")
+            return _fetch_from_api(
+                search_string, types, exact_match, continuation_cursor, limit
+            )
+        else:
+            logger.warning(
+                "No continuation cursor available, cannot fetch more channels"
+            )
+            return {"result": [], "next_cursor": None, "has_more": False}
+
+    # Try cache path for first page or cache cursor
+    if enable_caching and (cursor is None or (cursor and cursor.startswith("cache:"))):
+        cached_channels = cache_manager.cache.get(SLACK_CHANNELS_CACHE_KEY)
+        if cached_channels:
+            if cursor is None:
+                logger.info(
+                    "Using cache path (%d channels available)", len(cached_channels)
+                )
+
+            result = _fetch_from_cache(
+                cached_channels, search_string, types, exact_match, cursor, limit
+            )
+
+            # If cache returns None, we've exceeded cache boundary
+            if result is None:
+                # Fall back to API using continuation cursor
+                continuation_cursor = cache_manager.cache.get(
+                    SLACK_CHANNELS_CONTINUATION_CURSOR_KEY
+                )
+                if continuation_cursor:
+                    logger.info(
+                        "Cache boundary exceeded, falling back to API "
+                        "with continuation cursor"
+                    )
+                    return _fetch_from_api(
+                        search_string, types, exact_match, continuation_cursor, limit
+                    )
+                else:
+                    logger.warning(
+                        "Cache boundary exceeded but no continuation cursor available"
+                    )
+                    return {"result": [], "next_cursor": None, "has_more": False}
+
+            return result
+        else:
+            logger.debug("Cache not available, using API path")
+            cursor = None  # Reset cursor for API call
+
+    # API path for real Slack cursors
+    logger.debug("Using API path")
+    return _fetch_from_api(search_string, types, exact_match, cursor, limit)
 
 
 def should_use_v2_api() -> bool:

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -72,11 +72,10 @@ def _fetch_channels_without_search(
     """Fetch channels without search filtering, paginating for large limits."""
     channels: list[SlackChannelSchema] = []
     slack_cursor = cursor
-    page_size = min(limit, 1000)
 
     while True:
         response = client.conversations_list(
-            limit=page_size,
+            limit=999,
             cursor=slack_cursor,
             exclude_archived=True,
             types=types_param,
@@ -89,7 +88,7 @@ def _fetch_channels_without_search(
 
         slack_cursor = response.data.get("response_metadata", {}).get("next_cursor")
 
-        if not slack_cursor or len(page_channels) < page_size or len(channels) >= limit:
+        if not slack_cursor or len(channels) >= limit:
             break
 
     return {
@@ -117,7 +116,7 @@ def _fetch_channels_with_search(
 
     while len(matches) < limit:
         response = client.conversations_list(
-            limit=1000,
+            limit=999,
             cursor=slack_cursor,
             exclude_archived=True,
             types=types_param,
@@ -247,7 +246,6 @@ def _fetch_from_cache(  # noqa: C901
             offset = 0
 
     # Check if we're trying to paginate beyond cached data
-    # This happens when cache is partial (hit SLACK_CACHE_MAX_CHANNELS limit)
     if offset >= len(channels):
         logger.info(
             "Pagination offset (%d) exceeds cached data (%d channels). "

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -2060,8 +2060,18 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response without pagination
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
-                {"id": "C002", "name": "random", "is_private": False, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "general",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "id": "C002",
+                    "name": "random",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -2096,7 +2106,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with pagination
         mock_get_channels.return_value = {
             "result": [
-                {"id": f"C{i:03d}", "name": f"channel-{i}", "is_private": False, "is_member": True}
+                {
+                    "id": f"C{i:03d}",
+                    "name": f"channel-{i}",
+                    "is_private": False,
+                    "is_member": True,
+                }
                 for i in range(100)
             ],
             "next_cursor": "page_1",
@@ -2122,7 +2137,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response for second page
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C100", "name": "channel-100", "is_private": False, "is_member": True},
+                {
+                    "id": "C100",
+                    "name": "channel-100",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -2155,8 +2175,18 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with search results
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "engineering", "is_private": False, "is_member": True},
-                {"id": "C002", "name": "engineering-ops", "is_private": True, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "engineering",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "id": "C002",
+                    "name": "engineering-ops",
+                    "is_private": True,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,
@@ -2189,7 +2219,12 @@ class TestReportSchedulesApi(SupersetTestCase):
         # Mock response with filtered types
         mock_get_channels.return_value = {
             "result": [
-                {"id": "C001", "name": "general", "is_private": False, "is_member": True},
+                {
+                    "id": "C001",
+                    "name": "general",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "next_cursor": None,
             "has_more": False,

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -186,7 +186,7 @@ def create_test_table_context(database: Database):
 def create_report_email_chart():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart
+        email_target="target@email.com", chart=chart, name="report_email_chart"
     )
     yield report_schedule
 
@@ -201,6 +201,7 @@ def create_report_email_chart_with_cc_and_bcc():
         ccTarget="cc@email.com",
         bccTarget="bcc@email.com",
         chart=chart,
+        name="report_email_chart_with_cc_and_bcc",
     )
     yield report_schedule
 
@@ -212,7 +213,10 @@ def create_report_email_chart_alpha_owner(get_user):
     owners = [get_user("alpha")]
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart, owners=owners
+        email_target="target@email.com",
+        chart=chart,
+        owners=owners,
+        name="report_email_chart_alpha_owner",
     )
     yield report_schedule
 
@@ -223,7 +227,10 @@ def create_report_email_chart_alpha_owner(get_user):
 def create_report_email_chart_force_screenshot():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", chart=chart, force_screenshot=True
+        email_target="target@email.com",
+        chart=chart,
+        force_screenshot=True,
+        name="report_email_chart_force_screenshot",
     )
     yield report_schedule
 
@@ -238,6 +245,7 @@ def create_report_email_chart_with_csv():
         email_target="target@email.com",
         chart=chart,
         report_format=ReportDataFormat.CSV,
+        name="report_email_chart_with_csv",
     )
     yield report_schedule
     cleanup_report_schedule(report_schedule)
@@ -251,6 +259,7 @@ def create_report_email_chart_with_text():
         email_target="target@email.com",
         chart=chart,
         report_format=ReportDataFormat.TEXT,
+        name="report_email_chart_with_text",
     )
     yield report_schedule
     cleanup_report_schedule(report_schedule)
@@ -274,7 +283,9 @@ def create_report_email_chart_with_csv_no_query_context():
 def create_report_email_dashboard():
     dashboard = db.session.query(Dashboard).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", dashboard=dashboard
+        email_target="target@email.com",
+        dashboard=dashboard,
+        name="report_email_dashboard",
     )
     yield report_schedule
 
@@ -285,7 +296,10 @@ def create_report_email_dashboard():
 def create_report_email_dashboard_force_screenshot():
     dashboard = db.session.query(Dashboard).first()
     report_schedule = create_report_notification(
-        email_target="target@email.com", dashboard=dashboard, force_screenshot=True
+        email_target="target@email.com",
+        dashboard=dashboard,
+        force_screenshot=True,
+        name="report_email_dashboard_force_screenshot",
     )
     yield report_schedule
 
@@ -296,7 +310,7 @@ def create_report_email_dashboard_force_screenshot():
 def create_report_slack_chart():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="slack_channel", chart=chart
+        slack_channel="slack_channel", chart=chart, name="report_slack_chart"
     )
     yield report_schedule
 
@@ -325,6 +339,7 @@ def create_report_slack_chart_with_csv():
         slack_channel="slack_channel",
         chart=chart,
         report_format=ReportDataFormat.CSV,
+        name="report_slack_chart_with_csv",
     )
     yield report_schedule
 
@@ -339,6 +354,7 @@ def create_report_slack_chart_with_text():
         slack_channel="slack_channel",
         chart=chart,
         report_format=ReportDataFormat.TEXT,
+        name="report_slack_chart_with_text",
     )
     yield report_schedule
 
@@ -349,7 +365,7 @@ def create_report_slack_chart_with_text():
 def create_report_slack_chart_working():
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="slack_channel", chart=chart
+        slack_channel="slack_channel", chart=chart, name="report_slack_chart_working"
     )
     report_schedule.last_state = ReportState.WORKING
     report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -381,6 +397,7 @@ def create_alert_slack_chart_success():
         slack_channel="slack_channel",
         chart=chart,
         report_type=ReportScheduleType.ALERT,
+        name="alert_slack_chart_success",
     )
     report_schedule.last_state = ReportState.SUCCESS
     report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -423,6 +440,7 @@ def create_alert_slack_chart_grace(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"alert_slack_chart_grace_{request.param}",
         )
         report_schedule.last_state = ReportState.GRACE
         report_schedule.last_eval_dttm = datetime(2020, 1, 1, 0, 0)
@@ -508,6 +526,7 @@ def create_alert_email_chart(request):
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
             force_screenshot=True,
+            name=f"alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -586,6 +605,7 @@ def create_no_alert_email_chart(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"no_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -617,6 +637,7 @@ def create_mul_alert_email_chart(request):
             sql=param_config[request.param]["sql"],
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
+            name=f"mul_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -649,6 +670,7 @@ def create_invalid_sql_alert_email_chart(request, app_context: AppContext):
             validator_type=param_config[request.param]["validator_type"],
             validator_config_json=param_config[request.param]["validator_config_json"],
             grace_period=60 * 60,
+            name=f"invalid_sql_alert_email_chart_{request.param}",
         )
         yield report_schedule
 
@@ -1213,6 +1235,7 @@ def test_email_dashboard_report_schedule_with_tab_anchor(
                         "urlParams": [["native_filters", "()"]],
                     }
                 },
+                name="dashboard_report_with_tab_anchor",
             )
             AsyncExecuteReportScheduleCommand(
                 TEST_ID, report_schedule.id, datetime.utcnow()
@@ -1269,6 +1292,7 @@ def test_email_dashboard_report_schedule_disabled_tabs(
                         "urlParams": [["native_filters", "()"]],
                     }
                 },
+                name="dashboard_report_disabled_tabs",
             )
             AsyncExecuteReportScheduleCommand(
                 TEST_ID, report_schedule.id, datetime.utcnow()
@@ -1341,14 +1365,18 @@ def test_slack_chart_report_schedule_converts_to_v2(
     # setup screenshot mock
     screenshot_mock.return_value = SCREENSHOT_FILE
     channel_id = "slack_channel_id"
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with freeze_time("2020-01-01T00:00:00Z"):
         with patch(
@@ -1404,16 +1432,22 @@ def test_slack_chart_report_schedule_converts_to_v2_channel_with_hash(
     channel_id = "slack_channel_id"
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="#slack_channel", chart=chart
+        slack_channel="#slack_channel",
+        chart=chart,
+        name="slack_converts_to_v2_with_hash",
     )
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with freeze_time("2020-01-01T00:00:00Z"):
         with patch(
@@ -1467,16 +1501,22 @@ def test_slack_chart_report_schedule_fails_to_converts_to_v2(
     channel_id = "slack_channel_id"
     chart = db.session.query(Slice).first()
     report_schedule = create_report_notification(
-        slack_channel="#slack_channel,my_member_ID", chart=chart
+        slack_channel="#slack_channel,my_member_ID",
+        chart=chart,
+        name="slack_fails_to_convert_to_v2",
     )
-    get_channels_with_search_mock.return_value = [
-        {
-            "id": channel_id,
-            "name": "slack_channel",
-            "is_member": True,
-            "is_private": False,
-        },
-    ]
+    get_channels_with_search_mock.return_value = {
+        "result": [
+            {
+                "id": channel_id,
+                "name": "slack_channel",
+                "is_member": True,
+                "is_private": False,
+            },
+        ],
+        "next_cursor": None,
+        "has_more": False,
+    }
 
     with pytest.raises(ReportScheduleSystemErrorsException):
         AsyncExecuteReportScheduleCommand(

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -515,20 +515,24 @@ def test_update_recipient_to_slack_v2(mocker: MockerFixture):
     """
     mocker.patch(
         "superset.commands.report.execute.get_channels_with_search",
-        return_value=[
-            {
-                "id": "abc124f",
-                "name": "channel-1",
-                "is_member": True,
-                "is_private": False,
-            },
-            {
-                "id": "blah_!channel_2",
-                "name": "Channel_2",
-                "is_member": True,
-                "is_private": False,
-            },
-        ],
+        return_value={
+            "result": [
+                {
+                    "id": "abc124f",
+                    "name": "channel-1",
+                    "is_member": True,
+                    "is_private": False,
+                },
+                {
+                    "id": "blah_!channel_2",
+                    "name": "Channel_2",
+                    "is_member": True,
+                    "is_private": False,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        },
     )
     mock_report_schedule = ReportSchedule(
         recipients=[
@@ -558,14 +562,18 @@ def test_update_recipient_to_slack_v2_missing_channels(mocker: MockerFixture):
     """
     mocker.patch(
         "superset.commands.report.execute.get_channels_with_search",
-        return_value=[
-            {
-                "id": "blah_!channel_2",
-                "name": "Channel 2",
-                "is_member": True,
-                "is_private": False,
-            },
-        ],
+        return_value={
+            "result": [
+                {
+                    "id": "blah_!channel_2",
+                    "name": "Channel 2",
+                    "is_member": True,
+                    "is_private": False,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        },
     )
     mock_report_schedule = ReportSchedule(
         name="Test Report",

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -34,7 +34,14 @@ class TestGetChannelsWithSearch:
     def test_fetch_all_channels_no_search_string(self, mocker):
         # Mock data
         mock_data = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -46,12 +53,30 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search()
-        assert result == [{"name": "general", "id": "C12345"}]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     # Handle an empty search string gracefully
     def test_handle_empty_search_string(self, mocker):
         mock_data = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -61,15 +86,41 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(search_string="")
-        assert result == [{"name": "general", "id": "C12345"}]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_exact_match_search_string_single_channel(self, mocker):
         # Mock data with multiple channels
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -81,17 +132,45 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call the function with a search string that matches a single channel
-        result = get_channels_with_search(search_string="general", exact_match=True)
+        result = get_channels_with_search(
+            search_string="general", exact_match=True, limit=100
+        )
 
-        # Assert that the result is a list with a single channel dictionary
-        assert result == [{"name": "general", "id": "C12345"}]
+        # Assert that the result is a dict with proper structure
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_exact_match_search_string_multiple_channels(self, mocker):
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -102,19 +181,48 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string="general,random", exact_match=True
+            search_string="general,random", exact_match=True, limit=100
         )
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "random", "id": "C67890"},
-        ]
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_loose_match_search_string_multiple_channels(self, mocker):
         mock_data = {
             "channels": [
-                {"name": "general", "id": "C12345"},
-                {"name": "general2", "id": "C13454"},
-                {"name": "random", "id": "C67890"},
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
             ],
             "response_metadata": {"next_cursor": None},
         }
@@ -124,12 +232,31 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="general,random")
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "general2", "id": "C13454"},
-            {"name": "random", "id": "C67890"},
-        ]
+        result = get_channels_with_search(search_string="general,random", limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "general2",
+                    "id": "C13454",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
 
     def test_handle_slack_client_error_listing_channels(self, mocker):
         from slack_sdk.errors import SlackApiError
@@ -189,15 +316,93 @@ The server responded with: missing scope: channels:read"""
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(types=types)
-        assert {channel["id"] for channel in result} == expected_channel_ids
+        assert {channel["id"] for channel in result["result"]} == expected_channel_ids
 
-    def test_handle_pagination_multiple_pages(self, mocker):
+    def test_handle_pagination_without_search(self, mocker):
+        """Test pagination returns single page with cursor"""
         mock_data_page1 = {
-            "channels": [{"name": "general", "id": "C12345"}],
+            "channels": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "response_metadata": {"next_cursor": "page2_cursor"},
+        }
+
+        mock_response_instance_page1 = MockResponse(mock_data_page1)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response_instance_page1
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "general",
+                    "id": "C12345",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": "page2_cursor",
+            "has_more": True,
+        }
+
+    def test_handle_pagination_with_cursor(self, mocker):
+        """Test pagination with cursor fetches next page"""
+        mock_data_page2 = {
+            "channels": [
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response_instance_page2 = MockResponse(mock_data_page2)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response_instance_page2
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(cursor="page2_cursor", limit=100)
+        assert result == {
+            "result": [
+                {
+                    "name": "random",
+                    "id": "C67890",
+                    "is_private": False,
+                    "is_member": True,
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_streaming_search_pagination(self, mocker):
+        """Test search mode streams through pages until limit is reached"""
+        mock_data_page1 = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {"name": "random", "id": "C2", "is_private": False, "is_member": True},
+            ],
             "response_metadata": {"next_cursor": "page2"},
         }
         mock_data_page2 = {
-            "channels": [{"name": "random", "id": "C67890"}],
+            "channels": [
+                {
+                    "name": "general-2",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+                {"name": "other", "id": "C4", "is_private": False, "is_member": True},
+            ],
             "response_metadata": {"next_cursor": None},
         }
 
@@ -211,8 +416,251 @@ The server responded with: missing scope: channels:read"""
         ]
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search()
-        assert result == [
-            {"name": "general", "id": "C12345"},
-            {"name": "random", "id": "C67890"},
+        # Search for "general" - should find 2 channels across 2 pages
+        result = get_channels_with_search(search_string="general", limit=100)
+        assert result == {
+            "result": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {
+                    "name": "general-2",
+                    "id": "C3",
+                    "is_private": False,
+                    "is_member": True,
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_streaming_search_max_pages_safety_limit(self, mocker):
+        """Test that streaming search stops after 50 pages to prevent runaway requests"""
+
+        # Create a response that always has a next cursor (infinite pagination)
+        mock_data = {
+            "channels": [
+                {"name": "channel", "id": "C1", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search that matches the channel - should stop at 50 pages
+        result = get_channels_with_search(search_string="channel", limit=100)
+
+        # Should have called conversations_list exactly 50 times (max pages)
+        assert mock_client.conversations_list.call_count == 50
+        # Should return the matches found (50 channels, one per page)
+        assert len(result["result"]) == 50
+
+    def test_search_with_no_matches(self, mocker):
+        """Test search that finds no matching channels"""
+
+        mock_data = {
+            "channels": [
+                {"name": "general", "id": "C1", "is_private": False, "is_member": True},
+                {"name": "random", "id": "C2", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search for non-existent channel
+        result = get_channels_with_search(search_string="nonexistent", limit=100)
+
+        assert result == {
+            "result": [],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_search_returns_exactly_limit(self, mocker):
+        """Test search that returns exactly the requested limit"""
+
+        # Create 100 matching channels
+        channels = [
+            {"name": f"test-{i}", "id": f"C{i}", "is_private": False, "is_member": True}
+            for i in range(100)
         ]
+
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Search that matches all channels
+        result = get_channels_with_search(search_string="test", limit=100)
+
+        # Should return exactly 100 channels
+        assert len(result["result"]) == 100
+        # Should indicate more results available
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "next_page"
+
+    def test_partial_page_results(self, mocker):
+        """Test pagination with partial page (less than limit)"""
+
+        # Only 50 channels returned (less than default 100 limit)
+        channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(50)
+        ]
+
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+
+        # Should return all 50 channels
+        assert len(result["result"]) == 50
+        # Should indicate no more results
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+
+    def test_streaming_search_stops_when_limit_reached(self, mocker):
+        """Test that streaming search stops immediately when limit is reached"""
+
+        # First page with 60 matching channels
+        page1_channels = [
+            {"name": f"test-{i}", "id": f"C{i}", "is_private": False, "is_member": True}
+            for i in range(60)
+        ]
+        # Second page with 60 more matching channels (should not be fully processed)
+        page2_channels = [
+            {
+                "name": f"test-{i}",
+                "id": f"C{i+60}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(60)
+        ]
+
+        mock_data_page1 = {
+            "channels": page1_channels,
+            "response_metadata": {"next_cursor": "page2"},
+        }
+        mock_data_page2 = {
+            "channels": page2_channels,
+            "response_metadata": {"next_cursor": "page3"},
+        }
+
+        mock_response_page1 = MockResponse(mock_data_page1)
+        mock_response_page2 = MockResponse(mock_data_page2)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.side_effect = [
+            mock_response_page1,
+            mock_response_page2,
+        ]
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request limit of 100
+        result = get_channels_with_search(search_string="test", limit=100)
+
+        # Should return exactly 100 channels (60 from page1 + 40 from page2)
+        assert len(result["result"]) == 100
+        # Should indicate more results available (stopped at page2 cursor)
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "page2"
+
+    def test_cursor_format_with_special_characters(self, mocker):
+        """Test that cursor with special characters is handled correctly"""
+
+        # Slack cursors are base64 encoded strings that might contain special chars
+        special_cursor = "dGVhbTpDMDYxRkE1UEw="
+
+        mock_data = {
+            "channels": [
+                {"name": "test", "id": "C123", "is_private": False, "is_member": True},
+            ],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Call with special cursor
+        result = get_channels_with_search(cursor=special_cursor, limit=100)
+
+        # Verify cursor was passed to Slack API
+        mock_client.conversations_list.assert_called_once()
+        call_kwargs = mock_client.conversations_list.call_args[1]
+        assert call_kwargs["cursor"] == special_cursor
+
+    def test_empty_channel_list_response(self, mocker):
+        """Test handling of empty channels list from Slack API"""
+
+        mock_data = {
+            "channels": [],
+            "response_metadata": {"next_cursor": None},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search()
+
+        assert result == {
+            "result": [],
+            "next_cursor": None,
+            "has_more": False,
+        }
+
+    def test_custom_limit_parameter(self, mocker):
+        """Test that custom limit parameter is respected"""
+
+        channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(200)
+        ]
+
+        mock_data = {
+            "channels": channels,
+            "response_metadata": {"next_cursor": "next_page"},
+        }
+        mock_response = MockResponse(mock_data)
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request custom limit of 50
+        result = get_channels_with_search(limit=50)
+
+        # Should return exactly 50 channels
+        assert len(result["result"]) == 50
+        assert result["has_more"] is True

--- a/tests/unit_tests/utils/slack_test.py
+++ b/tests/unit_tests/utils/slack_test.py
@@ -181,19 +181,13 @@ class TestGetChannelsWithSearch:
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         result = get_channels_with_search(
-            search_string="general,random", exact_match=True, limit=100
+            search_string="general", exact_match=True, limit=100
         )
         assert result == {
             "result": [
                 {
                     "name": "general",
                     "id": "C12345",
-                    "is_private": False,
-                    "is_member": True,
-                },
-                {
-                    "name": "random",
-                    "id": "C67890",
                     "is_private": False,
                     "is_member": True,
                 },
@@ -232,7 +226,7 @@ class TestGetChannelsWithSearch:
         mock_client.conversations_list.return_value = mock_response_instance
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
-        result = get_channels_with_search(search_string="general,random", limit=100)
+        result = get_channels_with_search(search_string="general", limit=100)
         assert result == {
             "result": [
                 {
@@ -244,12 +238,6 @@ class TestGetChannelsWithSearch:
                 {
                     "name": "general2",
                     "id": "C13454",
-                    "is_private": False,
-                    "is_member": True,
-                },
-                {
-                    "name": "random",
-                    "id": "C67890",
                     "is_private": False,
                     "is_member": True,
                 },
@@ -292,21 +280,30 @@ The server responded with: missing scope: channels:read"""
     def test_filter_channels_by_specified_types(
         self, types: list[SlackChannelTypes], expected_channel_ids: set[str], mocker
     ):
+        # Determine which channels to return based on types parameter
+        public_channel = {
+            "id": "public_channel_id",
+            "name": "open",
+            "is_member": False,
+            "is_private": False,
+        }
+        private_channel = {
+            "id": "private_channel_id",
+            "name": "secret",
+            "is_member": False,
+            "is_private": True,
+        }
+
+        # Mock should return channels matching the requested types
+        # (simulating Slack API's type filtering)
+        channels = []
+        if not types or SlackChannelTypes.PUBLIC in types:
+            channels.append(public_channel)
+        if not types or SlackChannelTypes.PRIVATE in types:
+            channels.append(private_channel)
+
         mock_data = {
-            "channels": [
-                {
-                    "id": "public_channel_id",
-                    "name": "open",
-                    "is_member": False,
-                    "is_private": False,
-                },
-                {
-                    "id": "private_channel_id",
-                    "name": "secret",
-                    "is_member": False,
-                    "is_private": True,
-                },
-            ],
+            "channels": channels,
             "response_metadata": {"next_cursor": None},
         }
 
@@ -433,7 +430,7 @@ The server responded with: missing scope: channels:read"""
         }
 
     def test_streaming_search_max_pages_safety_limit(self, mocker):
-        """Test that streaming search stops after 50 pages to prevent runaway requests"""
+        """Test streaming search stops after 50 pages to prevent runaway requests"""
 
         # Create a response that always has a next cursor (infinite pagination)
         mock_data = {
@@ -553,7 +550,7 @@ The server responded with: missing scope: channels:read"""
         page2_channels = [
             {
                 "name": f"test-{i}",
-                "id": f"C{i+60}",
+                "id": f"C{i + 60}",
                 "is_private": False,
                 "is_member": True,
             }
@@ -584,9 +581,9 @@ The server responded with: missing scope: channels:read"""
 
         # Should return exactly 100 channels (60 from page1 + 40 from page2)
         assert len(result["result"]) == 100
-        # Should indicate more results available (stopped at page2 cursor)
+        # Should indicate more results available (next cursor points to page3)
         assert result["has_more"] is True
-        assert result["next_cursor"] == "page2"
+        assert result["next_cursor"] == "page3"
 
     def test_cursor_format_with_special_characters(self, mocker):
         """Test that cursor with special characters is handled correctly"""
@@ -607,7 +604,7 @@ The server responded with: missing scope: channels:read"""
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Call with special cursor
-        result = get_channels_with_search(cursor=special_cursor, limit=100)
+        get_channels_with_search(cursor=special_cursor, limit=100)
 
         # Verify cursor was passed to Slack API
         mock_client.conversations_list.assert_called_once()
@@ -638,7 +635,7 @@ The server responded with: missing scope: channels:read"""
     def test_custom_limit_parameter(self, mocker):
         """Test that custom limit parameter is respected"""
 
-        channels = [
+        all_channels = [
             {
                 "name": f"channel-{i}",
                 "id": f"C{i}",
@@ -648,14 +645,18 @@ The server responded with: missing scope: channels:read"""
             for i in range(200)
         ]
 
-        mock_data = {
-            "channels": channels,
-            "response_metadata": {"next_cursor": "next_page"},
-        }
-        mock_response = MockResponse(mock_data)
+        # Mock should respect the limit parameter (simulating Slack API behavior)
+        def mock_conversations_list(**kwargs):
+            limit = kwargs.get("limit", 100)
+            return MockResponse(
+                {
+                    "channels": all_channels[:limit],
+                    "response_metadata": {"next_cursor": "next_page"},
+                }
+            )
 
         mock_client = mocker.Mock()
-        mock_client.conversations_list.return_value = mock_response
+        mock_client.conversations_list.side_effect = mock_conversations_list
         mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
 
         # Request custom limit of 50
@@ -664,3 +665,139 @@ The server responded with: missing scope: channels:read"""
         # Should return exactly 50 channels
         assert len(result["result"]) == 50
         assert result["has_more"] is True
+
+    def test_non_search_pagination_over_200_limit(self, mocker):
+        """Test non-search queries paginate correctly for limits > 200"""
+        # Create 500 channels
+        all_channels = [
+            {
+                "name": f"channel-{i}",
+                "id": f"C{i}",
+                "is_private": False,
+                "is_member": True,
+            }
+            for i in range(500)
+        ]
+
+        call_count = 0
+
+        def mock_conversations_list(**kwargs):
+            nonlocal call_count
+            limit = kwargs.get("limit", 100)
+            cursor = kwargs.get("cursor")
+
+            # Simulate Slack API pagination (max 200 per page)
+            if cursor is None:
+                start = 0
+            elif cursor == "cursor_200":
+                start = 200
+            elif cursor == "cursor_400":
+                start = 400
+            else:
+                start = 600
+
+            end = min(start + limit, 500)
+            next_cursor = f"cursor_{end}" if end < 500 else None
+
+            call_count += 1
+            return MockResponse(
+                {
+                    "channels": all_channels[start:end],
+                    "response_metadata": {"next_cursor": next_cursor},
+                }
+            )
+
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.side_effect = mock_conversations_list
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        # Request 300 channels (requires 2 pages of 200 each)
+        result = get_channels_with_search(limit=300)
+
+        # Should return exactly 300 channels
+        assert len(result["result"]) == 300
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "cursor_400"
+        # Should have made 2 API calls
+        assert call_count == 2
+
+    def test_search_with_exact_match_optimization(self, mocker):
+        """Test exact match search uses optimized string comparison"""
+        channels = [
+            {"name": "test", "id": "C1", "is_private": False, "is_member": True},
+            {"name": "test-dev", "id": "C2", "is_private": False, "is_member": True},
+            {"name": "testing", "id": "C3", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(
+            search_string="TEST", exact_match=True, limit=100
+        )
+
+        # Only "test" should match (case-insensitive exact match)
+        assert len(result["result"]) == 1
+        assert result["result"][0]["name"] == "test"
+
+    def test_search_substring_match_optimization(self, mocker):
+        """Test substring search uses optimized string comparison"""
+        channels = [
+            {"name": "prod-api", "id": "C1", "is_private": False, "is_member": True},
+            {"name": "dev-api", "id": "C2", "is_private": False, "is_member": True},
+            {"name": "staging", "id": "C3", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(search_string="API", limit=100)
+
+        # Both "prod-api" and "dev-api" should match (case-insensitive)
+        assert len(result["result"]) == 2
+        assert {ch["name"] for ch in result["result"]} == {"prod-api", "dev-api"}
+
+    def test_search_by_channel_id(self, mocker):
+        """Test search can match by channel ID"""
+        channels = [
+            {"name": "general", "id": "C12345", "is_private": False, "is_member": True},
+            {"name": "random", "id": "C67890", "is_private": False, "is_member": True},
+        ]
+        mock_data = {"channels": channels, "response_metadata": {"next_cursor": None}}
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(
+            search_string="c12345", exact_match=True, limit=100
+        )
+
+        # Should match by ID (case-insensitive)
+        assert len(result["result"]) == 1
+        assert result["result"][0]["id"] == "C12345"
+
+    def test_non_search_empty_result_handling(self, mocker):
+        """Test non-search query handles empty channel list"""
+        mock_data = {
+            "channels": [],
+            "response_metadata": {"next_cursor": None},
+        }
+
+        mock_response = MockResponse(mock_data)
+        mock_client = mocker.Mock()
+        mock_client.conversations_list.return_value = mock_response
+        mocker.patch("superset.utils.slack.get_slack_client", return_value=mock_client)
+
+        result = get_channels_with_search(limit=100)
+
+        assert len(result["result"]) == 0
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#### Problem
Users were unable to edit Slack recipients in Alerts & Reports when their Slack workspace had a large number of channels. The dropdown would fail to load, showing a timeout error after 30+ seconds, making the feature completely unusable for large organizations.

#### Root Cause
The previous implementation attempted to load **all** Slack channels at once without proper pagination:
- For large workspaces, this meant trying to fetch thousands of channels in a single blocking request
- The Slack API is paginated by design but doesn't support server-side search/filtering
- Timeouts occurred because the backend tried to load all channels before returning any results

#### Solution
This PR implements proper pagination with client-side search filtering:

**Backend:**
- New `get_channels_with_search()` function with two optimized paths:
    - **Without search**: Returns paginated results directly from Slack API (fast, 1-page responses)
    - **With search**: Streams through Slack API pages, filtering matches client-side until limit reached
- Increased page size from 200 → 1000 to reduce API calls by 5× and minimize rate limiting
- Added support for comma-separated search strings (e.g., "engineering,marketing" for OR logic)
- Deleted legacy `get_channels()` function and migrated `cache_channels` Celery task to use new pagination

**Frontend:**
- Replaced manual pagination logic with AsyncSelect's built-in pagination support
- Added cursor tracking and caching for seamless scrolling
- Graceful fallback to Slack V1 (manual input) on errors

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
![slack-bug-before](https://github.com/user-attachments/assets/47fccd1f-f82e-4f2e-8470-67950fd755c6)

#### After
![slack-channesl-after](https://github.com/user-attachments/assets/f8776fad-4f19-423b-90f4-8f089892a706)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
#### Prerequisites
1. Enable feature flags in `superset/config.py`:
```python
     FEATURE_FLAGS = {
         "ALERT_REPORTS": True,
         "ALERT_REPORT_SLACK_V2": True,
     }
```
2. Set `SLACK_API_TOKEN` in `superset/config.py`
3. Navigate to Settings --> Alerts & Reports --> Create Alert/Report
4. Select Notification Method: Slack
5. Verify initial load: Dropdown should load first 100 channels in ~1 second
6. Test pagination: Scroll down in dropdown to load more channels
7. Test search: Type in search box to filter channels
8. Test refresh button:
  - Select some channels
  - Click the sync icon to the right of dropdown
  - Icon should spin while loading
  - Selected channels should clear
  - Fresh channel list should load

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
