### PR TITLE
feat(mcp): PR3 - add dashboard and dataset listing and info tools

### DIFF
--- a/superset/mcp_service/CLAUDE.md
+++ b/superset/mcp_service/CLAUDE.md
@@ -1,0 +1,431 @@
+# MCP Service - LLM Agent Guide
+
+This guide helps LLM agents understand the Superset MCP (Model Context Protocol) service architecture and development conventions.
+
+## ⚠️ CRITICAL: Apache License Headers
+
+**EVERY Python file in the MCP service MUST have the Apache Software Foundation license header.**
+
+This includes:
+- All `.py` files (tool files, schemas, __init__.py files, etc.)
+- **NEVER remove existing license headers during refactoring or edits**
+- **ALWAYS add license headers when creating new files**
+- **ALWAYS verify license headers are present after editing files**
+
+If you see a file without a license header, ADD IT IMMEDIATELY. If you accidentally remove one during editing, ADD IT BACK.
+
+Use this exact template at the top of EVERY Python file:
+
+```python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+```
+
+**Note**: LLM instruction files like `CLAUDE.md`, `AGENTS.md`, etc. are excluded from this requirement (listed in `.rat-excludes`) to avoid token overhead, but ALL other Python files require it.
+
+## Architecture Overview
+
+The MCP service provides programmatic access to Superset via the Model Context Protocol, allowing AI assistants to interact with dashboards, charts, datasets, SQL Lab, and instance metadata.
+
+### Key Components
+
+```
+superset/mcp_service/
+├── app.py                      # FastMCP app factory and tool registration
+├── auth.py                     # Authentication and authorization
+├── mcp_config.py              # Default configuration
+├── mcp_core.py                # Reusable core classes for tools
+├── flask_singleton.py         # Flask app singleton for MCP context
+├── chart/                     # Chart-related tools
+│   ├── schemas.py            # Pydantic schemas for chart responses
+│   └── tool/                 # Chart tool implementations
+│       ├── __init__.py       # Tool exports
+│       ├── list_charts.py
+│       └── get_chart_info.py
+├── dashboard/                 # Dashboard-related tools
+│   ├── schemas.py
+│   └── tool/
+├── dataset/                   # Dataset-related tools
+│   ├── schemas.py
+│   └── tool/
+└── system/                    # System/instance tools
+    ├── schemas.py
+    └── tool/
+```
+
+## Critical Convention: Tool Registration
+
+**IMPORTANT**: When creating new MCP tools, you MUST add their imports to `app.py` for auto-registration. Do NOT add them to `server.py` - that approach doesn't work properly.
+
+### How to Add a New Tool
+
+1. **Create the tool file** in the appropriate directory (e.g., `chart/tool/my_new_tool.py`)
+2. **Decorate with `@mcp.tool`** to register it with FastMCP
+3. **Add import to `app.py`** at the bottom of the file where other tools are imported (around line 207-224)
+
+**Example**:
+```python
+# superset/mcp_service/chart/tool/my_new_tool.py
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+
+@mcp.tool
+@mcp_auth_hook
+def my_new_tool(param: str) -> dict:
+    """Tool description for LLMs."""
+    return {"result": "success"}
+```
+
+**Then add to app.py**:
+```python
+# superset/mcp_service/app.py (at the bottom, around line 207-224)
+from superset.mcp_service.chart.tool import (  # noqa: F401, E402
+    get_chart_info,
+    list_charts,
+    my_new_tool,  # ADD YOUR TOOL HERE
+)
+```
+
+**Why this matters**: Tools use `@mcp.tool` decorators and register automatically on import. The import MUST be in `app.py` at the bottom of the file (after the `mcp` instance is created). If you don't import the tool in `app.py`, it won't be available to MCP clients. DO NOT add imports to `server.py` - that file is for running the server only.
+
+## Tool Development Patterns
+
+### 1. Use Core Classes for Reusability
+
+The `mcp_core.py` module provides reusable patterns:
+
+- **`ModelListCore`**: For listing resources (dashboards, charts, datasets)
+- **`ModelGetInfoCore`**: For getting resource details by ID/UUID
+- **`ModelGetAvailableFiltersCore`**: For retrieving filterable columns
+
+**Example**:
+```python
+from superset.mcp_service.mcp_core import ModelListCore
+from superset.daos.dashboard import DashboardDAO
+from superset.mcp_service.dashboard.schemas import DashboardList
+
+list_core = ModelListCore(
+    dao_class=DashboardDAO,
+    output_schema=DashboardList,
+    logger=logger,
+)
+
+@mcp.tool
+@mcp_auth_hook
+def list_dashboards(filters: List[DashboardFilter], page: int = 1) -> DashboardList:
+    return list_core.run_tool(filters=filters, page=page, page_size=10)
+```
+
+### 2. Always Use Authentication
+
+**Every tool must use `@mcp_auth_hook`** to ensure:
+- User authentication from JWT or configured admin user
+- Permission checking via JWT scopes
+- Audit logging of tool access
+
+```python
+from superset.mcp_service.auth import mcp_auth_hook
+
+@mcp.tool
+@mcp_auth_hook  # REQUIRED
+def my_tool() -> dict:
+    # g.user is set by mcp_auth_hook
+    return {"user": g.user.username}
+```
+
+### 3. Use Pydantic Schemas
+
+**All tool inputs and outputs must be Pydantic models** for:
+- Automatic validation
+- LLM-friendly schema generation
+- Type safety
+
+**Convention**: Place schemas in `{module}/schemas.py`
+
+```python
+from pydantic import BaseModel, Field
+
+class MyToolRequest(BaseModel):
+    param: str = Field(..., description="Parameter description for LLMs")
+
+class MyToolResponse(BaseModel):
+    result: str = Field(..., description="Result description")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Response timestamp"
+    )
+```
+
+### 4. Follow the DAO Pattern
+
+**Use Superset's DAO (Data Access Object) layer** instead of direct database queries:
+
+```python
+from superset.daos.dashboard import DashboardDAO
+
+# GOOD: Use DAO
+dashboard = DashboardDAO.find_by_id(dashboard_id)
+
+# BAD: Don't query directly
+dashboard = db.session.query(Dashboard).filter_by(id=dashboard_id).first()
+```
+
+### 5. Python Type Hints (Python 3.10+ Style)
+
+**CRITICAL**: Always use modern Python 3.10+ union syntax for type hints.
+
+```python
+# GOOD - Modern Python 3.10+ syntax
+from typing import List, Dict, Any
+from pydantic import BaseModel, Field
+
+class MySchema(BaseModel):
+    name: str | None = Field(None, description="Optional name")
+    tags: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+def my_function(
+    id: int,
+    filters: List[str] | None = None,
+    options: Dict[str, Any] | None = None
+) -> MySchema | None:
+    pass
+
+# BAD - Old-style Optional (DO NOT USE)
+from typing import Optional, List, Dict, Any
+
+class MySchema(BaseModel):
+    name: Optional[str] = Field(None, description="Optional name")  # Wrong!
+
+def my_function(
+    id: int,
+    filters: Optional[List[str]] = None,  # Wrong!
+    options: Optional[Dict[str, Any]] = None  # Wrong!
+) -> Optional[MySchema]:  # Wrong!
+    pass
+```
+
+**Key rules:**
+- Use `T | None` instead of `Optional[T]`
+- Do NOT import `Optional` from typing
+- Still import `List`, `Dict`, `Any`, etc. from typing (for now)
+- All new code must follow this pattern
+
+### 6. Error Handling
+
+**Use consistent error schemas**:
+
+```python
+class MyError(BaseModel):
+    error: str = Field(..., description="Error message")
+    error_type: str = Field(..., description="Type of error")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="Error timestamp"
+    )
+
+@mcp.tool
+@mcp_auth_hook
+def my_tool(id: int) -> MyResponse:
+    try:
+        result = process_data(id)
+        return MyResponse(data=result)
+    except NotFound:
+        raise ValueError(f"Resource {id} not found")
+```
+
+## Testing Conventions
+
+### Unit Tests
+
+Place unit tests in `tests/unit_tests/mcp_service/{module}/tool/test_{tool_name}.py`
+
+**Test structure**:
+```python
+from unittest.mock import MagicMock, patch
+import pytest
+
+class TestMyTool:
+    @pytest.fixture
+    def mock_dao(self):
+        """Create mock DAO for testing."""
+        dao = MagicMock()
+        dao.find_by_id.return_value = create_mock_object()
+        return dao
+
+    @patch("superset.mcp_service.chart.tool.my_tool.ChartDAO")
+    def test_my_tool_success(self, mock_dao_class, mock_dao):
+        """Test successful tool execution."""
+        mock_dao_class.return_value = mock_dao
+
+        result = my_tool(id=1)
+
+        assert result.data is not None
+        mock_dao.find_by_id.assert_called_once_with(1)
+```
+
+### Integration Tests
+
+Use Flask test client for integration tests:
+
+```python
+def test_tool_with_flask_context(app):
+    """Test tool with full Flask app context."""
+    with app.app_context():
+        result = my_tool(id=1)
+        assert result is not None
+```
+
+## Common Pitfalls to Avoid
+
+### 1. ❌ Forgetting Tool Import in app.py
+**Problem**: Tool exists but isn't available to MCP clients.
+**Solution**: Always add tool import to `app.py` (at the bottom) after creating it. Never add to `server.py`.
+
+### 2. ❌ Adding Tool Imports to server.py
+**Problem**: Tools won't register properly, causing runtime errors.
+**Solution**: Tool imports must be in `app.py` at the bottom of the file, not in `server.py`. The `server.py` file is only for running the server.
+
+### 3. ❌ Missing @mcp_auth_hook Decorator
+**Problem**: Tool bypasses authentication and authorization.
+**Solution**: Always use `@mcp_auth_hook` on every tool.
+
+### 4. ❌ Using `Optional` Instead of Union Syntax
+**Problem**: Old-style Optional[T] is not Python 3.10+ style.
+**Solution**: Use `T | None` instead of `Optional[T]` for all type hints.
+```python
+# GOOD - Modern Python 3.10+ syntax
+def my_function(param: str | None = None) -> int | None:
+    pass
+
+# BAD - Old-style Optional
+from typing import Optional
+def my_function(param: Optional[str] = None) -> Optional[int]:
+    pass
+```
+
+### 5. ❌ Using `any` Types in Schemas
+**Problem**: Violates TypeScript modernization goals, no validation.
+**Solution**: Use proper Pydantic types with Field descriptions.
+
+### 6. ❌ Direct Database Queries
+**Problem**: Bypasses Superset's security and caching layers.
+**Solution**: Use DAO classes (ChartDAO, DashboardDAO, etc.).
+
+### 7. ❌ Not Using Core Classes
+**Problem**: Duplicating list/get_info/filter logic across tools.
+**Solution**: Use ModelListCore, ModelGetInfoCore, ModelGetAvailableFiltersCore.
+
+### 8. ❌ Missing Apache License Headers
+**Problem**: CI fails on license check.
+**Solution**: Add Apache license header to all new .py files. Use this exact template at the top of every new Python file:
+
+```python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+```
+
+**Note**: LLM instruction files like `CLAUDE.md`, `AGENTS.md`, etc. are excluded from this requirement (listed in `.rat-excludes`) to avoid token overhead.
+
+### 9. ❌ Using `@mcp.tool()` with Empty Parentheses
+**Problem**: Inconsistent decorator style.
+**Solution**: Use `@mcp.tool` without parentheses unless passing arguments.
+```python
+# GOOD
+@mcp.tool
+def my_tool():
+    pass
+
+# BAD
+@mcp.tool()
+def my_tool():
+    pass
+```
+
+### 10. ❌ Circular Imports
+**Problem**: Importing `mcp` from `app.py` creates circular dependency.
+**Solution**: Import `mcp` at module level in tool files:
+```python
+# GOOD
+from superset.mcp_service.app import mcp
+
+@mcp.tool
+def my_tool():
+    pass
+
+# BAD - causes circular import
+from superset.mcp_service.app import mcp, some_other_function
+```
+
+## Configuration
+
+Default configuration is in `mcp_config.py`. Users can override in `superset_config.py`:
+
+```python
+# superset_config.py
+MCP_ADMIN_USERNAME = "your_admin"
+MCP_AUTH_ENABLED = True
+MCP_JWT_PUBLIC_KEY = "your_public_key"
+```
+
+## Tool Discovery
+
+MCP clients discover tools via:
+1. **Tool listing**: All tools with `@mcp.tool` are automatically listed
+2. **Schema introspection**: Pydantic schemas generate JSON Schema for LLMs
+3. **Instructions**: `DEFAULT_INSTRUCTIONS` in `app.py` documents available tools
+
+## Resources for Learning
+
+- **MCP Specification**: https://modelcontextprotocol.io/
+- **FastMCP Documentation**: https://github.com/jlowin/fastmcp
+- **Superset DAO Patterns**: See `superset/daos/` for examples
+- **Pydantic Documentation**: https://docs.pydantic.dev/
+
+## Quick Checklist for New Tools
+
+- [ ] Created tool file in `{module}/tool/{tool_name}.py`
+- [ ] Added `@mcp.tool` decorator
+- [ ] Added `@mcp_auth_hook` decorator
+- [ ] Created Pydantic request/response schemas in `{module}/schemas.py`
+- [ ] Used DAO classes instead of direct queries
+- [ ] Added tool import to `app.py` (around line 207-224)
+- [ ] Added Apache license header to new files
+- [ ] Created unit tests in `tests/unit_tests/mcp_service/{module}/tool/test_{tool_name}.py`
+- [ ] Updated `DEFAULT_INSTRUCTIONS` in `app.py` if adding new capability
+- [ ] Tested locally with MCP client (e.g., Claude Desktop)
+
+## Getting Help
+
+- Check existing tool implementations for patterns (chart/tool/, dashboard/tool/)
+- Review core classes in `mcp_core.py` for reusable functionality
+- See `CLAUDE.md` in project root for general Superset development guidelines
+- Consult Superset documentation: https://superset.apache.org/docs/

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -204,9 +204,22 @@ def create_mcp_app(
 # Tool modules can import this and use @mcp.tool decorators
 mcp = create_mcp_app()
 
+# Import all MCP tools to register them with the mcp instance
+# NOTE: Always add new tool imports here when creating new MCP tools.
+# Tools use @mcp.tool decorators and register automatically on import.
 from superset.mcp_service.chart.tool import (  # noqa: F401, E402
     get_chart_info,
     list_charts,
+)
+from superset.mcp_service.dashboard.tool import (  # noqa: F401, E402
+    get_dashboard_available_filters,
+    get_dashboard_info,
+    list_dashboards,
+)
+from superset.mcp_service.dataset.tool import (  # noqa: F401, E402
+    get_dataset_available_filters,
+    get_dataset_info,
+    list_datasets,
 )
 from superset.mcp_service.system.tool import health_check  # noqa: F401, E402
 

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -21,6 +21,8 @@ Pydantic schemas for chart-related responses
 
 from __future__ import annotations
 
+import html
+import re
 from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, List, Literal, Protocol
 
@@ -28,12 +30,18 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
     model_validator,
     PositiveInt,
 )
 
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
-from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.common.cache_schemas import (
+    CacheStatus,
+    FormDataCacheControl,
+    MetadataCacheControl,
+    QueryCacheControl,
+)
 from superset.mcp_service.system.schemas import (
     PaginationInfo,
     TagInfo,
@@ -101,6 +109,25 @@ class ChartInfo(BaseModel):
     model_config = ConfigDict(from_attributes=True, ser_json_timedelta="iso8601")
 
 
+class GetChartAvailableFiltersRequest(BaseModel):
+    """
+    Request schema for get_chart_available_filters tool.
+
+    Currently has no parameters but provides consistent API for future extensibility.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+    )
+
+
+class ChartAvailableFiltersResponse(BaseModel):
+    column_operators: Dict[str, Any] = Field(
+        ..., description="Available filter operators and metadata for each column"
+    )
+
+
 class ChartError(BaseModel):
     error: str = Field(..., description="Error message")
     error_type: str = Field(..., description="Type of error")
@@ -109,6 +136,63 @@ class ChartError(BaseModel):
         description="Error timestamp",
     )
     model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+
+class ChartCapabilities(BaseModel):
+    """Describes what the chart can do for LLM understanding."""
+
+    supports_interaction: bool = Field(description="Chart supports user interaction")
+    supports_real_time: bool = Field(description="Chart supports live data updates")
+    supports_drill_down: bool = Field(
+        description="Chart supports drill-down navigation"
+    )
+    supports_export: bool = Field(description="Chart can be exported to other formats")
+    optimal_formats: List[str] = Field(description="Recommended preview formats")
+    data_types: List[str] = Field(
+        description="Types of data shown (time_series, categorical, etc)"
+    )
+
+
+class ChartSemantics(BaseModel):
+    """Semantic information for LLM reasoning."""
+
+    primary_insight: str = Field(
+        description="Main insight or pattern the chart reveals"
+    )
+    data_story: str = Field(description="Narrative description of what the data shows")
+    recommended_actions: List[str] = Field(
+        description="Suggested next steps based on data"
+    )
+    anomalies: List[str] = Field(description="Notable outliers or unusual patterns")
+    statistical_summary: Dict[str, Any] = Field(
+        description="Key statistics (mean, median, trends)"
+    )
+
+
+class PerformanceMetadata(BaseModel):
+    """Performance information for LLM cost understanding."""
+
+    query_duration_ms: int = Field(description="Query execution time")
+    estimated_cost: str | None = Field(None, description="Resource cost estimate")
+    cache_status: str = Field(description="Cache hit/miss status")
+    optimization_suggestions: List[str] = Field(
+        default_factory=list, description="Performance improvement tips"
+    )
+
+
+class AccessibilityMetadata(BaseModel):
+    """Accessibility information for inclusive visualization."""
+
+    color_blind_safe: bool = Field(description="Uses colorblind-safe palette")
+    alt_text: str = Field(description="Screen reader description")
+    high_contrast_available: bool = Field(description="High contrast version available")
+
+
+class VersionedResponse(BaseModel):
+    """Base class for versioned API responses."""
+
+    schema_version: str = Field("2.0", description="Response schema version")
+    api_version: str = Field("v1", description="MCP API version")
 
 
 class GetChartInfoRequest(BaseModel):
@@ -167,6 +251,53 @@ def serialize_chart_object(chart: ChartLike | None) -> ChartInfo | None:
     )
 
 
+class GenerateChartResponse(BaseModel):
+    """Comprehensive chart creation response with rich metadata."""
+
+    # Core chart information
+    chart: ChartInfo | None = Field(None, description="Complete chart metadata")
+
+    # Multiple preview formats available
+    previews: Dict[str, "ChartPreviewContent"] = Field(
+        default_factory=dict,
+        description="Available preview formats keyed by format type",
+    )
+
+    # LLM-friendly capabilities
+    capabilities: ChartCapabilities | None = Field(
+        None, description="Chart interaction capabilities"
+    )
+    semantics: ChartSemantics | None = Field(
+        None, description="Semantic chart understanding"
+    )
+
+    # Navigation and context
+    explore_url: str | None = Field(None, description="Edit chart in Superset")
+    embed_code: str | None = Field(None, description="HTML embed snippet")
+    api_endpoints: Dict[str, str] = Field(
+        default_factory=dict, description="Related API endpoints for data/updates"
+    )
+
+    # Performance and accessibility
+    performance: PerformanceMetadata | None = Field(
+        None, description="Performance metrics"
+    )
+    accessibility: AccessibilityMetadata | None = Field(
+        None, description="Accessibility info"
+    )
+
+    # Success/error handling
+    success: bool = Field(True, description="Whether chart creation succeeded")
+    error: ChartError | None = Field(
+        None, description="Error details if creation failed"
+    )
+    warnings: List[str] = Field(default_factory=list, description="Non-fatal warnings")
+
+    # Inherit versioning
+    schema_version: str = Field("2.0", description="Response schema version")
+    api_version: str = Field("v1", description="MCP API version")
+
+
 class ChartFilter(ColumnOperator):
     """
     Filter object for chart listing.
@@ -212,6 +343,412 @@ class ChartList(BaseModel):
     pagination: PaginationInfo | None = None
     timestamp: datetime | None = None
     model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+
+# --- Simplified schemas for generate_chart tool ---
+
+
+# Common pieces
+class ColumnRef(BaseModel):
+    name: str = Field(
+        ...,
+        description="Column name",
+        min_length=1,
+        max_length=255,
+        pattern=r"^[a-zA-Z0-9_][a-zA-Z0-9_\s\-\.]*$",
+    )
+    label: str | None = Field(
+        None, description="Display label for the column", max_length=500
+    )
+    dtype: str | None = Field(None, description="Data type hint")
+    aggregate: (
+        Literal[
+            "SUM",
+            "COUNT",
+            "AVG",
+            "MIN",
+            "MAX",
+            "COUNT_DISTINCT",
+            "STDDEV",
+            "VAR",
+            "MEDIAN",
+            "PERCENTILE",
+        ]
+        | None
+    ) = Field(
+        None,
+        description="SQL aggregation function. Only these validated functions are "
+        "supported to prevent SQL errors.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def sanitize_name(cls, v: str) -> str:
+        """Sanitize column name to prevent XSS and SQL injection."""
+        if not v or not v.strip():
+            raise ValueError("Column name cannot be empty")
+
+        # Length check first to prevent ReDoS attacks
+        if len(v) > 255:
+            raise ValueError(
+                f"Column name too long ({len(v)} characters). "
+                f"Maximum allowed length is 255 characters."
+            )
+
+        # Remove HTML tags and decode entities
+        sanitized = html.escape(v.strip())
+
+        # Check for dangerous tags using simple substring checks (not regex)
+        # This avoids ReDoS vulnerabilities while still detecting attacks
+        dangerous_substrings = [
+            "<script",
+            "</script>",
+            "<iframe",
+            "<object",
+            "<embed",
+            "javascript:",
+            "vbscript:",
+            "data:text/html",
+        ]
+        v_lower = v.lower()
+        for substring in dangerous_substrings:
+            if substring in v_lower:
+                raise ValueError(
+                    "Column name contains potentially malicious script content"
+                )
+
+        # Basic SQL injection patterns (basic protection)
+        # Use simple patterns without backtracking
+        dangerous_patterns = [
+            r"[;|&$`]",  # Dangerous shell characters
+            r"\b(DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|EXEC|EXECUTE)\b",
+            r"--",  # SQL comment
+            r"/\*",  # SQL comment start (just check for start, not full pattern)
+        ]
+
+        for pattern in dangerous_patterns:
+            if re.search(pattern, v, re.IGNORECASE):
+                raise ValueError(
+                    "Column name contains potentially unsafe characters or SQL keywords"
+                )
+
+        return sanitized
+
+    @field_validator("label")
+    @classmethod
+    def sanitize_label(cls, v: str | None) -> str | None:
+        """Sanitize display label to prevent XSS attacks."""
+        if v is None:
+            return v
+
+        # Strip whitespace
+        v = v.strip()
+        if not v:
+            return None
+
+        # Length check first to prevent ReDoS attacks
+        if len(v) > 500:
+            raise ValueError(
+                f"Label too long ({len(v)} characters). "
+                f"Maximum allowed length is 500 characters."
+            )
+
+        # Check for dangerous HTML tags and JavaScript protocols using substring checks
+        # This avoids ReDoS vulnerabilities from regex patterns
+        dangerous_substrings = [
+            "<script",
+            "</script>",
+            "<iframe",
+            "</iframe>",
+            "<object",
+            "</object>",
+            "<embed",
+            "</embed>",
+            "<link",
+            "<meta",
+            "javascript:",
+            "vbscript:",
+            "data:text/html",
+        ]
+
+        v_lower = v.lower()
+        for substring in dangerous_substrings:
+            if substring in v_lower:
+                raise ValueError(
+                    "Label contains potentially malicious content. "
+                    "HTML tags, JavaScript, and event handlers are not allowed "
+                    "in labels."
+                )
+
+        # Check for event handlers (onclick, onload, etc) with simple regex
+        if re.search(r"on\w+\s*=", v, re.IGNORECASE):
+            raise ValueError(
+                "Label contains potentially malicious content. "
+                "HTML tags, JavaScript, and event handlers are not allowed in labels."
+            )
+
+        # Filter dangerous Unicode characters
+        v = re.sub(
+            r"[\u200B-\u200D\uFEFF\u0000-\u0008\u000B\u000C\u000E-\u001F]", "", v
+        )
+
+        # HTML escape the cleaned content
+        sanitized = html.escape(v)
+
+        return sanitized if sanitized else None
+
+
+class AxisConfig(BaseModel):
+    title: str | None = Field(None, description="Axis title", max_length=200)
+    scale: Literal["linear", "log"] | None = Field(
+        "linear", description="Axis scale type"
+    )
+    format: str | None = Field(
+        None, description="Format string (e.g. '$,.2f')", max_length=50
+    )
+
+
+class LegendConfig(BaseModel):
+    show: bool = Field(True, description="Whether to show legend")
+    position: Literal["top", "bottom", "left", "right"] | None = Field(
+        "right", description="Legend position"
+    )
+
+
+class FilterConfig(BaseModel):
+    column: str = Field(
+        ..., description="Column to filter on", min_length=1, max_length=255
+    )
+    op: Literal["=", ">", "<", ">=", "<=", "!="] = Field(
+        ..., description="Filter operator"
+    )
+    value: str | int | float | bool = Field(..., description="Filter value")
+
+    @field_validator("column")
+    @classmethod
+    def sanitize_column(cls, v: str) -> str:
+        """Sanitize filter column name to prevent injection attacks."""
+        if not v or not v.strip():
+            raise ValueError("Filter column name cannot be empty")
+
+        # Length check first to prevent ReDoS attacks
+        if len(v) > 255:
+            raise ValueError(
+                f"Filter column name too long ({len(v)} characters). "
+                f"Maximum allowed length is 255 characters."
+            )
+
+        # Remove HTML tags and decode entities
+        sanitized = html.escape(v.strip())
+
+        # Check for dangerous patterns using substring checks (not regex)
+        dangerous_substrings = ["<script", "</script>", "javascript:", "vbscript:"]
+        v_lower = v.lower()
+        for substring in dangerous_substrings:
+            if substring in v_lower:
+                raise ValueError(
+                    "Filter column contains potentially malicious script content"
+                )
+
+        return sanitized
+
+    @field_validator("value")
+    @classmethod
+    def sanitize_value(cls, v: str | int | float | bool) -> str | int | float | bool:
+        """Sanitize filter value to prevent XSS and SQL injection attacks."""
+        if isinstance(v, str):
+            # Strip whitespace
+            v = v.strip()
+
+            # Length check FIRST to prevent ReDoS attacks
+            if len(v) > 1000:
+                raise ValueError(
+                    f"Filter value too long ({len(v)} characters). "
+                    f"Maximum allowed length is 1000 characters."
+                )
+
+            # Check for dangerous substrings using simple substring checks
+            # This avoids ReDoS vulnerabilities while still detecting attacks
+            dangerous_substrings = [
+                "<script",
+                "</script>",
+                "<iframe",
+                "<object",
+                "<embed",
+                "javascript:",
+                "vbscript:",
+                "data:text/html",
+                "xp_cmdshell",
+                "sp_executesql",
+            ]
+            v_lower = v.lower()
+            for substring in dangerous_substrings:
+                if substring in v_lower:
+                    raise ValueError(
+                        "Filter value contains potentially malicious content. "
+                        "HTML tags and JavaScript are not allowed."
+                    )
+
+            # SQL injection patterns - use simple patterns without backtracking
+            sql_patterns = [
+                r";\s*(DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|EXEC|EXECUTE)\b",
+                r"'\s*OR\s*'",
+                r"'\s*AND\s*'",
+                r"--\s*",
+                r"/\*",  # Just check for comment start, not full pattern
+                r"UNION\s+SELECT",
+            ]
+
+            for pattern in sql_patterns:
+                if re.search(pattern, v, re.IGNORECASE):
+                    raise ValueError(
+                        "Filter value contains potentially malicious SQL patterns."
+                    )
+
+            # Check for command injection - simple character checks
+            if re.search(r"[;&|`$()]", v):
+                raise ValueError(
+                    "Filter value contains potentially unsafe shell characters."
+                )
+
+            # Check for event handlers
+            if re.search(r"on\w+\s*=", v, re.IGNORECASE):
+                raise ValueError(
+                    "Filter value contains potentially malicious event handlers."
+                )
+
+            # Check for hex encoding attempts
+            if re.search(r"\\x[0-9a-fA-F]{2}", v):
+                raise ValueError(
+                    "Filter value contains hex encoding which is not allowed."
+                )
+
+            # Filter dangerous Unicode characters
+            v = re.sub(
+                r"[\u200B-\u200D\uFEFF\u0000-\u0008\u000B\u000C\u000E-\u001F]", "", v
+            )
+
+            # HTML escape the cleaned content
+            sanitized = html.escape(v)
+            return sanitized
+
+        return v  # Return non-string values as-is
+
+
+# Actual chart types
+class TableChartConfig(BaseModel):
+    chart_type: Literal["table"] = Field("table", description="Chart type")
+    columns: List[ColumnRef] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Columns to display. Must have at least one column. Each column must have "
+            "a unique label "
+            "(either explicitly set via 'label' field or auto-generated "
+            "from name/aggregate)"
+        ),
+    )
+    filters: List[FilterConfig] | None = Field(None, description="Filters to apply")
+    sort_by: List[str] | None = Field(None, description="Columns to sort by")
+
+    @model_validator(mode="after")
+    def validate_unique_column_labels(self) -> "TableChartConfig":
+        """Ensure all column labels are unique."""
+        labels_seen = set()
+        duplicates = []
+
+        for i, col in enumerate(self.columns):
+            # Generate the label that will be used (same logic as create_metric_object)
+            if col.aggregate:
+                label = col.label or f"{col.aggregate}({col.name})"
+            else:
+                label = col.label or col.name
+
+            if label in labels_seen:
+                duplicates.append(f"columns[{i}]: '{label}'")
+            else:
+                labels_seen.add(label)
+
+        if duplicates:
+            raise ValueError(
+                f"Duplicate column/metric labels: {', '.join(duplicates)}. "
+                f"Please make sure all columns and metrics have a unique label. "
+                f"Use the 'label' field to provide custom names for columns."
+            )
+
+        return self
+
+
+class XYChartConfig(BaseModel):
+    chart_type: Literal["xy"] = Field("xy", description="Chart type")
+    x: ColumnRef = Field(..., description="X-axis column")
+    y: List[ColumnRef] = Field(
+        ...,
+        min_length=1,
+        description="Y-axis columns (metrics). Must have at least one Y-axis column. "
+        "Each column must have a unique label "
+        "that doesn't conflict with x-axis or group_by labels",
+    )
+    kind: Literal["line", "bar", "area", "scatter"] = Field(
+        "line", description="Chart visualization type"
+    )
+    group_by: ColumnRef | None = Field(None, description="Column to group by")
+    x_axis: AxisConfig | None = Field(None, description="X-axis configuration")
+    y_axis: AxisConfig | None = Field(None, description="Y-axis configuration")
+    legend: LegendConfig | None = Field(None, description="Legend configuration")
+    filters: List[FilterConfig] | None = Field(None, description="Filters to apply")
+
+    @model_validator(mode="after")
+    def validate_unique_column_labels(self) -> "XYChartConfig":
+        """Ensure all column labels are unique across x, y, and group_by."""
+        labels_seen = {}  # label -> field_name for error reporting
+        duplicates = []
+
+        # Check X-axis label
+        x_label = self.x.label or self.x.name
+        labels_seen[x_label] = "x"
+
+        # Check Y-axis labels
+        for i, col in enumerate(self.y):
+            if col.aggregate:
+                label = col.label or f"{col.aggregate}({col.name})"
+            else:
+                label = col.label or col.name
+
+            if label in labels_seen:
+                duplicates.append(
+                    f"y[{i}]: '{label}' (conflicts with {labels_seen[label]})"
+                )
+            else:
+                labels_seen[label] = f"y[{i}]"
+
+        # Check group_by label if present
+        if self.group_by:
+            group_label = self.group_by.label or self.group_by.name
+            if group_label in labels_seen:
+                duplicates.append(
+                    f"group_by: '{group_label}' "
+                    f"(conflicts with {labels_seen[group_label]})"
+                )
+
+        if duplicates:
+            raise ValueError(
+                f"Duplicate column/metric labels: {', '.join(duplicates)}. "
+                f"Please make sure all columns and metrics have a unique label. "
+                f"Use the 'label' field to provide custom names for columns."
+            )
+
+        return self
+
+
+# Discriminated union entry point with custom error handling
+ChartConfig = Annotated[
+    XYChartConfig | TableChartConfig,
+    Field(
+        discriminator="chart_type",
+        description="Chart configuration - specify chart_type as 'xy' or 'table'",
+    ),
+]
 
 
 class ListChartsRequest(MetadataCacheControl):
@@ -281,3 +818,346 @@ class ListChartsRequest(MetadataCacheControl):
                 "or 'filters' for precise column-based filtering, but not both."
             )
         return self
+
+
+# The tool input models
+class GenerateChartRequest(QueryCacheControl):
+    dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
+    config: ChartConfig = Field(..., description="Chart configuration")
+    save_chart: bool = Field(
+        default=True,
+        description="Whether to permanently save the chart in Superset",
+    )
+    generate_preview: bool = Field(
+        default=True,
+        description="Whether to generate a preview image",
+    )
+    preview_formats: List[
+        Literal["url", "interactive", "ascii", "vega_lite", "table", "base64"]
+    ] = Field(
+        default_factory=lambda: ["url"],
+        description="List of preview formats to generate",
+    )
+
+    @model_validator(mode="after")
+    def validate_cache_timeout(self) -> "GenerateChartRequest":
+        """Validate cache timeout is non-negative."""
+        if (
+            hasattr(self, "cache_timeout")
+            and self.cache_timeout is not None
+            and self.cache_timeout < 0
+        ):
+            raise ValueError(
+                "cache_timeout must be non-negative (0 or positive integer)"
+            )
+        return self
+
+
+class GenerateExploreLinkRequest(FormDataCacheControl):
+    dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
+    config: ChartConfig = Field(..., description="Chart configuration")
+
+
+class UpdateChartRequest(QueryCacheControl):
+    identifier: int | str = Field(..., description="Chart identifier (ID, UUID)")
+    config: ChartConfig = Field(..., description="New chart configuration")
+    chart_name: str | None = Field(
+        None,
+        description="New chart name (optional, will auto-generate if not provided)",
+        max_length=255,
+    )
+    generate_preview: bool = Field(
+        default=True,
+        description="Whether to generate a preview after updating",
+    )
+    preview_formats: List[
+        Literal["url", "interactive", "ascii", "vega_lite", "table", "base64"]
+    ] = Field(
+        default_factory=lambda: ["url"],
+        description="List of preview formats to generate",
+    )
+
+    @field_validator("chart_name")
+    @classmethod
+    def sanitize_chart_name(cls, v: str | None) -> str | None:
+        """Sanitize chart name to prevent XSS attacks."""
+        if v is None:
+            return v
+
+        # Strip whitespace
+        v = v.strip()
+        if not v:
+            return None
+
+        # Length check first to prevent ReDoS attacks
+        if len(v) > 255:
+            raise ValueError(
+                f"Chart name too long ({len(v)} characters). "
+                f"Maximum allowed length is 255 characters."
+            )
+
+        # Check for dangerous HTML tags and JavaScript protocols using substring checks
+        # This avoids ReDoS vulnerabilities while still detecting attacks
+        dangerous_substrings = [
+            "<script",
+            "</script>",
+            "<iframe",
+            "</iframe>",
+            "<object",
+            "</object>",
+            "<embed",
+            "</embed>",
+            "<link",
+            "<meta",
+            "javascript:",
+            "vbscript:",
+            "data:text/html",
+        ]
+
+        v_lower = v.lower()
+        for substring in dangerous_substrings:
+            if substring in v_lower:
+                raise ValueError(
+                    "Chart name contains potentially malicious content. "
+                    "HTML tags and JavaScript are not allowed in chart names."
+                )
+
+        # Check for event handlers with simple regex
+        if re.search(r"on\w+\s*=", v, re.IGNORECASE):
+            raise ValueError(
+                "Chart name contains potentially malicious event handlers."
+            )
+
+        # Filter dangerous Unicode characters
+        v = re.sub(
+            r"[\u200B-\u200D\uFEFF\u0000-\u0008\u000B\u000C\u000E-\u001F]", "", v
+        )
+
+        # HTML escape the cleaned content
+        sanitized = html.escape(v)
+
+        return sanitized if sanitized else None
+
+
+class UpdateChartPreviewRequest(FormDataCacheControl):
+    form_data_key: str = Field(..., description="Existing form_data_key to update")
+    dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
+    config: ChartConfig = Field(..., description="New chart configuration")
+    generate_preview: bool = Field(
+        default=True,
+        description="Whether to generate a preview after updating",
+    )
+    preview_formats: List[
+        Literal["url", "interactive", "ascii", "vega_lite", "table", "base64"]
+    ] = Field(
+        default_factory=lambda: ["url"],
+        description="List of preview formats to generate",
+    )
+
+
+class GetChartDataRequest(QueryCacheControl):
+    """Request for chart data with cache control."""
+
+    identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    limit: int | None = Field(
+        default=100, description="Maximum number of data rows to return"
+    )
+    format: Literal["json", "csv", "excel"] = Field(
+        default="json", description="Data export format"
+    )
+
+
+class DataColumn(BaseModel):
+    """Enhanced column metadata with semantic information."""
+
+    name: str = Field(..., description="Column name")
+    display_name: str = Field(..., description="Human-readable column name")
+    data_type: str = Field(..., description="Inferred data type")
+    sample_values: List[Any] = Field(description="Representative sample values")
+    null_count: int = Field(description="Number of null values")
+    unique_count: int = Field(description="Number of unique values")
+    statistics: Dict[str, Any] | None = Field(
+        None, description="Column statistics if numeric"
+    )
+    semantic_type: str | None = Field(
+        None, description="Semantic type (currency, percentage, etc)"
+    )
+
+
+class ChartData(BaseModel):
+    """Rich chart data response with statistical insights."""
+
+    # Basic information
+    chart_id: int
+    chart_name: str
+    chart_type: str
+
+    # Enhanced data description
+    columns: List[DataColumn] = Field(description="Rich column metadata")
+    data: List[Dict[str, Any]] = Field(description="Actual data rows")
+
+    # Data insights
+    row_count: int = Field(description="Rows returned")
+    total_rows: int | None = Field(description="Total available rows")
+    data_freshness: datetime | None = Field(description="When data was last updated")
+
+    # LLM-friendly summaries
+    summary: str = Field(description="Human-readable data summary")
+    insights: List[str] = Field(description="Key patterns discovered in the data")
+    data_quality: Dict[str, Any] = Field(description="Data quality assessment")
+    recommended_visualizations: List[str] = Field(
+        description="Suggested chart types for this data"
+    )
+
+    # Performance and metadata
+    performance: PerformanceMetadata = Field(description="Query performance metrics")
+    cache_status: CacheStatus | None = Field(
+        None, description="Cache usage information"
+    )
+
+    # Export format fields
+    csv_data: str | None = Field(None, description="CSV content when format='csv'")
+    excel_data: str | None = Field(
+        None, description="Base64-encoded Excel content when format='excel'"
+    )
+    format: str | None = Field(
+        None, description="Export format used (json, csv, excel)"
+    )
+
+    # Inherit versioning
+    schema_version: str = Field("2.0", description="Response schema version")
+    api_version: str = Field("v1", description="MCP API version")
+
+
+class GetChartPreviewRequest(QueryCacheControl):
+    """Request for chart preview with cache control."""
+
+    identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    format: Literal["url", "ascii", "table", "base64", "vega_lite"] = Field(
+        default="url",
+        description=(
+            "Preview format: 'url' for image URL, 'ascii' for text art, "
+            "'table' for data table, 'base64' for embedded image, "
+            "'vega_lite' for interactive JSON specification"
+        ),
+    )
+    width: int | None = Field(
+        default=800,
+        description="Preview image width in pixels (for url/base64 formats)",
+    )
+    height: int | None = Field(
+        default=600,
+        description="Preview image height in pixels (for url/base64 formats)",
+    )
+    ascii_width: int | None = Field(
+        default=80, description="ASCII chart width in characters (for ascii format)"
+    )
+    ascii_height: int | None = Field(
+        default=20, description="ASCII chart height in lines (for ascii format)"
+    )
+
+
+# Discriminated union preview formats for type safety
+class URLPreview(BaseModel):
+    """URL-based image preview format."""
+
+    type: Literal["url"] = "url"
+    preview_url: str = Field(..., description="Direct image URL")
+    width: int = Field(..., description="Image width in pixels")
+    height: int = Field(..., description="Image height in pixels")
+    supports_interaction: bool = Field(
+        False, description="Static image, no interaction"
+    )
+
+
+class InteractivePreview(BaseModel):
+    """Interactive HTML preview with JavaScript controls."""
+
+    type: Literal["interactive"] = "interactive"
+    html_content: str = Field(..., description="Embeddable HTML with Plotly/D3")
+    preview_url: str = Field(..., description="Iframe-compatible URL")
+    width: int = Field(..., description="Viewport width")
+    height: int = Field(..., description="Viewport height")
+    supports_pan: bool = Field(True, description="Supports pan interaction")
+    supports_zoom: bool = Field(True, description="Supports zoom interaction")
+    supports_hover: bool = Field(True, description="Supports hover details")
+
+
+class ASCIIPreview(BaseModel):
+    """ASCII art text representation."""
+
+    type: Literal["ascii"] = "ascii"
+    ascii_content: str = Field(..., description="Unicode art representation")
+    width: int = Field(..., description="Character width")
+    height: int = Field(..., description="Line height")
+    supports_color: bool = Field(False, description="Uses ANSI color codes")
+
+
+class VegaLitePreview(BaseModel):
+    """Vega-Lite grammar of graphics specification."""
+
+    type: Literal["vega_lite"] = "vega_lite"
+    specification: Dict[str, Any] = Field(..., description="Vega-Lite JSON spec")
+    data_url: str | None = Field(None, description="External data URL")
+    supports_streaming: bool = Field(False, description="Supports live data updates")
+
+
+class TablePreview(BaseModel):
+    """Tabular data preview format."""
+
+    type: Literal["table"] = "table"
+    table_data: str = Field(..., description="Formatted table content")
+    row_count: int = Field(..., description="Number of rows displayed")
+    supports_sorting: bool = Field(False, description="Table supports sorting")
+
+
+# Modern discriminated union using | syntax
+ChartPreviewContent = Annotated[
+    URLPreview | InteractivePreview | ASCIIPreview | VegaLitePreview | TablePreview,
+    Field(discriminator="type"),
+]
+
+
+class ChartPreview(BaseModel):
+    """Enhanced chart preview with discriminated union content."""
+
+    chart_id: int
+    chart_name: str
+    chart_type: str = Field(description="Type of chart visualization")
+    explore_url: str = Field(description="URL to open chart in Superset for editing")
+
+    # Type-safe preview content
+    content: ChartPreviewContent = Field(
+        description="Preview content in requested format"
+    )
+
+    # Rich metadata
+    chart_description: str = Field(
+        description="Human-readable description of the chart"
+    )
+    accessibility: AccessibilityMetadata = Field(
+        description="Accessibility information"
+    )
+    performance: PerformanceMetadata = Field(description="Performance metrics")
+
+    # Backward compatibility fields (populated based on content type)
+    format: str | None = Field(
+        None, description="Format of the preview (url, ascii, table, base64)"
+    )
+    preview_url: str | None = Field(None, description="Image URL for 'url' format")
+    ascii_chart: str | None = Field(
+        None, description="ASCII art chart for 'ascii' format"
+    )
+    table_data: str | None = Field(
+        None, description="Formatted table for 'table' format"
+    )
+    width: int | None = Field(
+        None, description="Width (pixels for images, characters for ASCII)"
+    )
+    height: int | None = Field(
+        None, description="Height (pixels for images, lines for ASCII)"
+    )
+
+    # Inherit versioning
+    schema_version: str = Field("2.0", description="Response schema version")
+    api_version: str = Field("v1", description="MCP API version")

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1,0 +1,418 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Pydantic schemas for dashboard-related responses
+
+This module contains Pydantic models for serializing dashboard data
+in a consistent and type-safe manner.
+
+Example usage:
+    # For detailed dashboard info
+    dashboard_info = DashboardInfo(
+        id=1,
+        dashboard_title="Sales Dashboard",
+        published=True,
+        owners=[UserInfo(id=1, username="admin")],
+        charts=[ChartInfo(id=1, slice_name="Sales Chart")]
+    )
+
+    # For dashboard list responses
+    dashboard_list = DashboardList(
+        dashboards=[
+            DashboardInfo(
+                id=1,
+                dashboard_title="Sales Dashboard",
+                published=True,
+                tags=[TagInfo(id=1, name="sales")]
+            )
+        ],
+        count=1,
+        total_count=1,
+        page=0,
+        page_size=10,
+        total_pages=1,
+        has_next=False,
+        has_previous=False,
+        columns_requested=["id", "dashboard_title"],
+        columns_loaded=["id", "dashboard_title", "published"],
+        filters_applied={"published": True},
+        pagination=PaginationInfo(
+            page=0,
+            page_size=10,
+            total_count=1,
+            total_pages=1,
+            has_next=False,
+            has_previous=False
+        ),
+        timestamp=datetime.now(timezone.utc)
+    )
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any, Dict, List, Literal, TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt
+
+if TYPE_CHECKING:
+    from superset.models.dashboard import Dashboard
+
+from superset.daos.base import ColumnOperator, ColumnOperatorEnum
+from superset.mcp_service.chart.schemas import ChartInfo, serialize_chart_object
+from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.system.schemas import (
+    PaginationInfo,
+    RoleInfo,
+    TagInfo,
+    UserInfo,
+)
+
+
+class DashboardError(BaseModel):
+    """Error response for dashboard operations"""
+
+    error: str = Field(..., description="Error message")
+    error_type: str = Field(..., description="Type of error")
+    timestamp: str | datetime | None = Field(None, description="Error timestamp")
+
+    model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+    @classmethod
+    def create(cls, error: str, error_type: str) -> "DashboardError":
+        """Create a standardized DashboardError with timestamp."""
+        from datetime import datetime
+
+        return cls(error=error, error_type=error_type, timestamp=datetime.now())
+
+
+def serialize_user_object(user: Any) -> UserInfo | None:
+    """Serialize a user object to UserInfo"""
+    if not user:
+        return None
+
+    return UserInfo(
+        id=getattr(user, "id", None),
+        username=getattr(user, "username", None),
+        first_name=getattr(user, "first_name", None),
+        last_name=getattr(user, "last_name", None),
+        email=getattr(user, "email", None),
+        active=getattr(user, "active", None),
+    )
+
+
+def serialize_tag_object(tag: Any) -> TagInfo | None:
+    """Serialize a tag object to TagInfo"""
+    if not tag:
+        return None
+
+    return TagInfo(
+        id=getattr(tag, "id", None),
+        name=getattr(tag, "name", None),
+        type=getattr(tag, "type", None),
+        description=getattr(tag, "description", None),
+    )
+
+
+def serialize_role_object(role: Any) -> RoleInfo | None:
+    """Serialize a role object to RoleInfo"""
+    if not role:
+        return None
+
+    return RoleInfo(
+        id=getattr(role, "id", None),
+        name=getattr(role, "name", None),
+        permissions=[perm.name for perm in getattr(role, "permissions", [])]
+        if hasattr(role, "permissions")
+        else None,
+    )
+
+
+# TODO (Phase 3+): Add DashboardAvailableFilters for
+# get_dashboard_available_filters tool
+
+
+class DashboardFilter(ColumnOperator):
+    """
+    Filter object for dashboard listing.
+    col: The column to filter on. Must be one of the allowed filter fields.
+    opr: The operator to use. Must be one of the supported operators.
+    value: The value to filter by (type depends on col and opr).
+    """
+
+    col: Literal[
+        "dashboard_title",
+        "published",
+        "favorite",
+    ] = Field(
+        ...,
+        description="Column to filter on. See get_dashboard_available_filters for "
+        "allowed values.",
+    )
+    opr: ColumnOperatorEnum = Field(
+        ...,
+        description="Operator to use. See get_dashboard_available_filters for "
+        "allowed values.",
+    )
+    value: str | int | float | bool | List[str | int | float | bool] = Field(
+        ..., description="Value to filter by (type depends on col and opr)"
+    )
+
+
+class ListDashboardsRequest(MetadataCacheControl):
+    """Request schema for list_dashboards with clear, unambiguous types."""
+
+    filters: Annotated[
+        List[DashboardFilter],
+        Field(
+            default_factory=list,
+            description="List of filter objects (column, operator, value). Each "
+            "filter is an object with 'col', 'opr', and 'value' properties. "
+            "Cannot be used together with 'search'.",
+        ),
+    ]
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: [
+                "id",
+                "dashboard_title",
+                "slug",
+                "published",
+                "changed_on",
+                "created_on",
+                "uuid",
+            ],
+            description="List of columns to select. Defaults to common columns "
+            "if not specified.",
+        ),
+    ]
+    search: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Text search string to match against dashboard fields. "
+            "Cannot be used together with 'filters'.",
+        ),
+    ]
+    order_column: Annotated[
+        str | None, Field(default=None, description="Column to order results by")
+    ]
+    order_direction: Annotated[
+        Literal["asc", "desc"],
+        Field(
+            default="asc", description="Direction to order results ('asc' or 'desc')"
+        ),
+    ]
+    page: Annotated[
+        PositiveInt,
+        Field(default=1, description="Page number for pagination (1-based)"),
+    ]
+    page_size: Annotated[
+        PositiveInt, Field(default=10, description="Number of items per page")
+    ]
+
+    @model_validator(mode="after")
+    def validate_search_and_filters(self) -> "ListDashboardsRequest":
+        """Prevent using both search and filters simultaneously to avoid query
+        conflicts."""
+        if self.search and self.filters:
+            raise ValueError(
+                "Cannot use both 'search' and 'filters' parameters simultaneously. "
+                "Use either 'search' for text-based searching across multiple fields, "
+                "or 'filters' for precise column-based filtering, but not both."
+            )
+        return self
+
+
+class GetDashboardInfoRequest(MetadataCacheControl):
+    """Request schema for get_dashboard_info with support for ID, UUID, or slug."""
+
+    identifier: Annotated[
+        int | str,
+        Field(
+            description="Dashboard identifier - can be numeric ID, UUID string, or slug"
+        ),
+    ]
+
+
+class DashboardInfo(BaseModel):
+    id: int = Field(..., description="Dashboard ID")
+    dashboard_title: str = Field(..., description="Dashboard title")
+    slug: str | None = Field(None, description="Dashboard slug")
+    description: str | None = Field(None, description="Dashboard description")
+    css: str | None = Field(None, description="Custom CSS for the dashboard")
+    certified_by: str | None = Field(None, description="Who certified the dashboard")
+    certification_details: str | None = Field(None, description="Certification details")
+    json_metadata: str | None = Field(
+        None, description="Dashboard metadata (JSON string)"
+    )
+    position_json: str | None = Field(None, description="Chart positions (JSON string)")
+    published: bool | None = Field(
+        None, description="Whether the dashboard is published"
+    )
+    is_managed_externally: bool | None = Field(
+        None, description="Whether managed externally"
+    )
+    external_url: str | None = Field(None, description="External URL")
+    created_on: str | datetime | None = Field(None, description="Creation timestamp")
+    changed_on: str | datetime | None = Field(
+        None, description="Last modification timestamp"
+    )
+    created_by: str | None = Field(None, description="Dashboard creator (username)")
+    changed_by: str | None = Field(None, description="Last modifier (username)")
+    uuid: str | None = Field(None, description="Dashboard UUID (converted to string)")
+    url: str | None = Field(None, description="Dashboard URL")
+    thumbnail_url: str | None = Field(None, description="Thumbnail URL")
+    created_on_humanized: str | None = Field(
+        None, description="Humanized creation time"
+    )
+    changed_on_humanized: str | None = Field(
+        None, description="Humanized modification time"
+    )
+    chart_count: int = Field(0, description="Number of charts in the dashboard")
+    owners: List[UserInfo] = Field(default_factory=list, description="Dashboard owners")
+    tags: List[TagInfo] = Field(default_factory=list, description="Dashboard tags")
+    roles: List[RoleInfo] = Field(default_factory=list, description="Dashboard roles")
+    charts: List[ChartInfo] = Field(
+        default_factory=list, description="Dashboard charts"
+    )
+    model_config = ConfigDict(from_attributes=True, ser_json_timedelta="iso8601")
+
+
+class DashboardList(BaseModel):
+    dashboards: List[DashboardInfo]
+    count: int
+    total_count: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_previous: bool
+    has_next: bool
+    columns_requested: List[str] | None = None
+    columns_loaded: List[str] | None = None
+    filters_applied: List[DashboardFilter] = Field(
+        default_factory=list,
+        description="List of advanced filter dicts applied to the query.",
+    )
+    pagination: PaginationInfo | None = None
+    timestamp: datetime | None = None
+    model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+
+class DashboardAvailableFilters(BaseModel):
+    column_operators: Dict[str, Any] = Field(
+        ..., description="Available filter operators and metadata for each column"
+    )
+
+
+class GetDashboardAvailableFiltersRequest(BaseModel):
+    """
+    Request schema for get_dashboard_available_filters tool.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+def dashboard_serializer(dashboard: "Dashboard") -> DashboardInfo:
+    return DashboardInfo(
+        id=dashboard.id,
+        dashboard_title=dashboard.dashboard_title or "Untitled",
+        slug=dashboard.slug or "",
+        description=dashboard.description,
+        css=dashboard.css,
+        certified_by=dashboard.certified_by,
+        certification_details=dashboard.certification_details,
+        json_metadata=dashboard.json_metadata,
+        position_json=dashboard.position_json,
+        published=dashboard.published,
+        is_managed_externally=dashboard.is_managed_externally,
+        external_url=dashboard.external_url,
+        created_on=dashboard.created_on,
+        changed_on=dashboard.changed_on,
+        created_by=getattr(dashboard.created_by, "username", None)
+        if dashboard.created_by
+        else None,
+        changed_by=getattr(dashboard.changed_by, "username", None)
+        if dashboard.changed_by
+        else None,
+        uuid=str(dashboard.uuid) if dashboard.uuid else None,
+        url=dashboard.url,
+        thumbnail_url=dashboard.thumbnail_url,
+        created_on_humanized=dashboard.created_on_humanized,
+        changed_on_humanized=dashboard.changed_on_humanized,
+        chart_count=len(dashboard.slices) if dashboard.slices else 0,
+        owners=[
+            UserInfo.model_validate(owner, from_attributes=True)
+            for owner in dashboard.owners
+        ]
+        if dashboard.owners
+        else [],
+        tags=[
+            TagInfo.model_validate(tag, from_attributes=True) for tag in dashboard.tags
+        ]
+        if dashboard.tags
+        else [],
+        roles=[
+            RoleInfo.model_validate(role, from_attributes=True)
+            for role in dashboard.roles
+        ]
+        if dashboard.roles
+        else [],
+        charts=[serialize_chart_object(chart) for chart in dashboard.slices]
+        if dashboard.slices
+        else [],
+    )
+
+
+def serialize_dashboard_object(dashboard: Any) -> DashboardInfo:
+    """Simple dashboard serializer that safely handles object attributes."""
+    return DashboardInfo(
+        id=getattr(dashboard, "id", None),
+        dashboard_title=getattr(dashboard, "dashboard_title", None),
+        slug=getattr(dashboard, "slug", None),
+        url=getattr(dashboard, "url", None),
+        published=getattr(dashboard, "published", None),
+        changed_by_name=getattr(dashboard, "changed_by_name", None),
+        changed_on=getattr(dashboard, "changed_on", None),
+        changed_on_humanized=getattr(dashboard, "changed_on_humanized", None),
+        created_by_name=getattr(dashboard, "created_by_name", None),
+        created_on=getattr(dashboard, "created_on", None),
+        created_on_humanized=getattr(dashboard, "created_on_humanized", None),
+        description=getattr(dashboard, "description", None),
+        css=getattr(dashboard, "css", None),
+        certified_by=getattr(dashboard, "certified_by", None),
+        certification_details=getattr(dashboard, "certification_details", None),
+        json_metadata=getattr(dashboard, "json_metadata", None),
+        position_json=getattr(dashboard, "position_json", None),
+        is_managed_externally=getattr(dashboard, "is_managed_externally", None),
+        external_url=getattr(dashboard, "external_url", None),
+        uuid=str(getattr(dashboard, "uuid", ""))
+        if getattr(dashboard, "uuid", None)
+        else None,
+        thumbnail_url=getattr(dashboard, "thumbnail_url", None),
+        chart_count=len(getattr(dashboard, "slices", [])),
+        owners=getattr(dashboard, "owners", []),
+        tags=getattr(dashboard, "tags", []),
+        roles=getattr(dashboard, "roles", []),
+        charts=[
+            serialize_chart_object(chart) for chart in getattr(dashboard, "slices", [])
+        ]
+        if getattr(dashboard, "slices", None)
+        else [],
+    )

--- a/superset/mcp_service/dashboard/tool/__init__.py
+++ b/superset/mcp_service/dashboard/tool/__init__.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .get_dashboard_available_filters import get_dashboard_available_filters
+from .get_dashboard_info import get_dashboard_info
+from .list_dashboards import list_dashboards
+
+__all__ = [
+    "list_dashboards",
+    "get_dashboard_info",
+    "get_dashboard_available_filters",
+]

--- a/superset/mcp_service/dashboard/tool/get_dashboard_available_filters.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_available_filters.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Get available filters FastMCP tool
+"""
+
+import logging
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dashboard.schemas import (
+    DashboardAvailableFilters,
+    GetDashboardAvailableFiltersRequest,
+)
+from superset.mcp_service.mcp_core import ModelGetAvailableFiltersCore
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool
+@mcp_auth_hook
+async def get_dashboard_available_filters(
+    request: GetDashboardAvailableFiltersRequest, ctx: Context
+) -> DashboardAvailableFilters:
+    """Get available dashboard filter fields and operators."""
+    from superset.daos.dashboard import DashboardDAO
+
+    tool = ModelGetAvailableFiltersCore(
+        dao_class=DashboardDAO,
+        output_schema=DashboardAvailableFilters,
+        logger=logger,
+    )
+    return tool.run_tool()

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Get dashboard info FastMCP tool
+
+This module contains the FastMCP tool for getting detailed information
+about a specific dashboard.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dashboard.schemas import (
+    dashboard_serializer,
+    DashboardError,
+    DashboardInfo,
+    GetDashboardInfoRequest,
+)
+from superset.mcp_service.mcp_core import ModelGetInfoCore
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool
+@mcp_auth_hook
+async def get_dashboard_info(
+    request: GetDashboardInfoRequest, ctx: Context
+) -> DashboardInfo | DashboardError:
+    """
+    Get dashboard metadata by ID, UUID, or slug.
+
+    Returns title, charts, and layout details.
+    """
+    await ctx.info("Retrieving dashboard information: %s" % (request.identifier,))
+    await ctx.debug(
+        "Metadata cache settings: use_cache=%s, refresh_metadata=%s, force_refresh=%s"
+        % (request.use_cache, request.refresh_metadata, request.force_refresh)
+    )
+
+    try:
+        from superset.daos.dashboard import DashboardDAO
+
+        tool = ModelGetInfoCore(
+            dao_class=DashboardDAO,
+            output_schema=DashboardInfo,
+            error_schema=DashboardError,
+            serializer=dashboard_serializer,
+            supports_slug=True,  # Dashboards support slugs
+            logger=logger,
+        )
+
+        result = tool.run_tool(request.identifier)
+
+        if isinstance(result, DashboardInfo):
+            await ctx.info(
+                "Dashboard information retrieved successfully: id=%s, title=%s, "
+                "chart_count=%s, published=%s"
+                % (
+                    result.id,
+                    result.dashboard_title,
+                    result.chart_count,
+                    result.published,
+                )
+            )
+        else:
+            await ctx.warning(
+                "Dashboard retrieval failed: error_type=%s, error=%s"
+                % (result.error_type, result.error)
+            )
+
+        return result
+
+    except Exception as e:
+        await ctx.error(
+            "Dashboard information retrieval failed: identifier=%s, error=%s, "
+            "error_type=%s" % (request.identifier, str(e), type(e).__name__)
+        )
+        return DashboardError(
+            error=f"Failed to get dashboard info: {str(e)}",
+            error_type="InternalError",
+            timestamp=datetime.now(timezone.utc),
+        )

--- a/superset/mcp_service/dashboard/tool/list_dashboards.py
+++ b/superset/mcp_service/dashboard/tool/list_dashboards.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+List dashboards FastMCP tool (Advanced with metadata cache control)
+
+This module contains the FastMCP tool for listing dashboards using
+advanced filtering with clear, unambiguous request schema and metadata cache control.
+"""
+
+import logging
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dashboard.schemas import (
+    DashboardFilter,
+    DashboardInfo,
+    DashboardList,
+    ListDashboardsRequest,
+    serialize_dashboard_object,
+)
+from superset.mcp_service.mcp_core import ModelListCore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DASHBOARD_COLUMNS = [
+    "id",
+    "dashboard_title",
+    "slug",
+    "uuid",
+    "published",
+    "changed_on",
+    "created_on",
+]
+
+SORTABLE_DASHBOARD_COLUMNS = [
+    "id",
+    "dashboard_title",
+    "slug",
+    "published",
+    "changed_on",
+    "created_on",
+]
+
+
+@mcp.tool
+@mcp_auth_hook
+async def list_dashboards(
+    request: ListDashboardsRequest, ctx: Context
+) -> DashboardList:
+    """List dashboards with filtering and search. Returns dashboard metadata
+    including title, slug, and charts.
+
+    Sortable columns for order_column: id, dashboard_title, slug, published,
+    changed_on, created_on
+    """
+
+    from superset.daos.dashboard import DashboardDAO
+
+    tool = ModelListCore(
+        dao_class=DashboardDAO,
+        output_schema=DashboardInfo,
+        item_serializer=lambda obj, cols: serialize_dashboard_object(obj),
+        filter_type=DashboardFilter,
+        default_columns=DEFAULT_DASHBOARD_COLUMNS,
+        search_columns=[
+            "dashboard_title",
+            "slug",
+            "uuid",
+        ],
+        list_field_name="dashboards",
+        output_list_schema=DashboardList,
+        logger=logger,
+    )
+    return tool.run_tool(
+        filters=request.filters,
+        search=request.search,
+        select_columns=request.select_columns,
+        order_column=request.order_column,
+        order_direction=request.order_direction,
+        page=max(request.page - 1, 0),
+        page_size=request.page_size,
+    )

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -1,0 +1,349 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Pydantic schemas for dataset-related responses
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any, Dict, List, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator, PositiveInt
+
+from superset.daos.base import ColumnOperator, ColumnOperatorEnum
+from superset.mcp_service.common.cache_schemas import MetadataCacheControl
+from superset.mcp_service.system.schemas import (
+    PaginationInfo,
+    TagInfo,
+    UserInfo,
+)
+from superset.utils import json
+
+
+class GetDatasetAvailableFiltersRequest(BaseModel):
+    """
+    Request schema for get_dataset_available_filters tool.
+
+    Currently has no parameters but provides consistent API for future extensibility.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+    )
+
+
+class DatasetAvailableFilters(BaseModel):
+    column_operators: Dict[str, List[str]] = Field(
+        ...,
+        description="Available filter operators for each column: mapping from column "
+        "name to list of supported operators",
+    )
+
+
+class DatasetFilter(ColumnOperator):
+    """
+    Filter object for dataset listing.
+    col: The column to filter on. Must be one of the allowed filter fields.
+    opr: The operator to use. Must be one of the supported operators.
+    value: The value to filter by (type depends on col and opr).
+    """
+
+    col: Literal[
+        "table_name",
+        "schema",
+        "owner",
+        "favorite",
+    ] = Field(
+        ...,
+        description="Column to filter on. See get_dataset_available_filters for "
+        "allowed values.",
+    )
+    opr: ColumnOperatorEnum = Field(
+        ...,
+        description="Operator to use. See get_dataset_available_filters for "
+        "allowed values.",
+    )
+    value: str | int | float | bool | List[str | int | float | bool] = Field(
+        ..., description="Value to filter by (type depends on col and opr)"
+    )
+
+
+class TableColumnInfo(BaseModel):
+    column_name: str = Field(..., description="Column name")
+    verbose_name: str | None = Field(None, description="Verbose name")
+    type: str | None = Field(None, description="Column type")
+    is_dttm: bool | None = Field(None, description="Is datetime column")
+    groupby: bool | None = Field(None, description="Is groupable")
+    filterable: bool | None = Field(None, description="Is filterable")
+    description: str | None = Field(None, description="Column description")
+
+
+class SqlMetricInfo(BaseModel):
+    metric_name: str = Field(..., description="Metric name")
+    verbose_name: str | None = Field(None, description="Verbose name")
+    expression: str | None = Field(None, description="SQL expression")
+    description: str | None = Field(None, description="Metric description")
+    d3format: str | None = Field(None, description="D3 format string")
+
+
+class DatasetInfo(BaseModel):
+    id: int | None = Field(None, description="Dataset ID")
+    table_name: str | None = Field(None, description="Table name")
+    schema_name: str | None = Field(None, description="Schema name", alias="schema")
+    database_name: str | None = Field(None, description="Database name")
+    description: str | None = Field(None, description="Dataset description")
+    changed_by: str | None = Field(None, description="Last modifier (username)")
+    changed_on: str | datetime | None = Field(
+        None, description="Last modification timestamp"
+    )
+    changed_on_humanized: str | None = Field(
+        None, description="Humanized modification time"
+    )
+    created_by: str | None = Field(None, description="Dataset creator (username)")
+    created_on: str | datetime | None = Field(None, description="Creation timestamp")
+    created_on_humanized: str | None = Field(
+        None, description="Humanized creation time"
+    )
+    tags: List[TagInfo] = Field(default_factory=list, description="Dataset tags")
+    owners: List[UserInfo] = Field(
+        default_factory=list, description="DatasetInfo owners"
+    )
+    is_virtual: bool | None = Field(
+        None, description="Whether the dataset is virtual (uses SQL)"
+    )
+    database_id: int | None = Field(None, description="Database ID")
+    uuid: str | None = Field(None, description="Dataset UUID")
+    schema_perm: str | None = Field(None, description="Schema permission string")
+    url: str | None = Field(None, description="Dataset URL")
+    sql: str | None = Field(None, description="SQL for virtual datasets")
+    main_dttm_col: str | None = Field(None, description="Main datetime column")
+    offset: int | None = Field(None, description="Offset")
+    cache_timeout: int | None = Field(None, description="Cache timeout")
+    params: Dict[str, Any | None] | None = Field(None, description="Extra params")
+    template_params: Dict[str, Any | None] | None = Field(
+        None, description="Template params"
+    )
+    extra: Dict[str, Any | None] | None = Field(None, description="Extra metadata")
+    columns: List[TableColumnInfo] = Field(
+        default_factory=list, description="Columns in the dataset"
+    )
+    metrics: List[SqlMetricInfo] = Field(
+        default_factory=list, description="Metrics in the dataset"
+    )
+    is_favorite: bool | None = Field(
+        None, description="Whether this dataset is favorited by the current user"
+    )
+    model_config = ConfigDict(
+        from_attributes=True,
+        ser_json_timedelta="iso8601",
+        populate_by_name=True,  # Allow both 'schema' (alias) and 'schema_name' (field)
+    )
+
+
+class DatasetList(BaseModel):
+    datasets: List[DatasetInfo]
+    count: int
+    total_count: int
+    page: int
+    page_size: int
+    total_pages: int
+    has_previous: bool
+    has_next: bool
+    columns_requested: List[str] | None = None
+    columns_loaded: List[str] | None = None
+    filters_applied: List[DatasetFilter] = Field(
+        default_factory=list,
+        description="List of advanced filter dicts applied to the query.",
+    )
+    pagination: PaginationInfo | None = None
+    timestamp: datetime | None = None
+    model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+
+class ListDatasetsRequest(MetadataCacheControl):
+    """Request schema for list_datasets with clear, unambiguous types."""
+
+    filters: Annotated[
+        List[DatasetFilter],
+        Field(
+            default_factory=list,
+            description="List of filter objects (column, operator, value). Each "
+            "filter is an object with 'col', 'opr', and 'value' "
+            "properties. Cannot be used together with 'search'.",
+        ),
+    ]
+    select_columns: Annotated[
+        List[str],
+        Field(
+            default_factory=lambda: [
+                "id",
+                "table_name",
+                "schema",
+                "database_name",
+                "changed_by_name",
+                "changed_on",
+                "created_by_name",
+                "created_on",
+                "metrics",
+                "columns",
+                "uuid",
+            ],
+            description="List of columns to select. Defaults to common columns if not "
+            "specified.",
+        ),
+    ]
+    search: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Text search string to match against dataset fields. Cannot "
+            "be used together with 'filters'.",
+        ),
+    ]
+    order_column: Annotated[
+        str | None, Field(default=None, description="Column to order results by")
+    ]
+    order_direction: Annotated[
+        Literal["asc", "desc"],
+        Field(
+            default="desc", description="Direction to order results ('asc' or 'desc')"
+        ),
+    ]
+    page: Annotated[
+        PositiveInt,
+        Field(default=1, description="Page number for pagination (1-based)"),
+    ]
+    page_size: Annotated[
+        PositiveInt, Field(default=10, description="Number of items per page")
+    ]
+
+    @model_validator(mode="after")
+    def validate_search_and_filters(self) -> "ListDatasetsRequest":
+        """Prevent using both search and filters simultaneously to avoid query
+        conflicts."""
+        if self.search and self.filters:
+            raise ValueError(
+                "Cannot use both 'search' and 'filters' parameters simultaneously. "
+                "Use either 'search' for text-based searching across multiple fields, "
+                "or 'filters' for precise column-based filtering, but not both."
+            )
+        return self
+
+
+class DatasetError(BaseModel):
+    error: str = Field(..., description="Error message")
+    error_type: str = Field(..., description="Type of error")
+    timestamp: str | datetime | None = Field(None, description="Error timestamp")
+    model_config = ConfigDict(ser_json_timedelta="iso8601")
+
+    @classmethod
+    def create(cls, error: str, error_type: str) -> "DatasetError":
+        """Create a standardized DatasetError with timestamp."""
+        from datetime import datetime
+
+        return cls(error=error, error_type=error_type, timestamp=datetime.now())
+
+
+class GetDatasetInfoRequest(MetadataCacheControl):
+    """Request schema for get_dataset_info with support for ID or UUID."""
+
+    identifier: Annotated[
+        int | str,
+        Field(description="Dataset identifier - can be numeric ID or UUID string"),
+    ]
+
+
+def serialize_dataset_object(dataset: Any) -> DatasetInfo | None:
+    if not dataset:
+        return None
+    params = getattr(dataset, "params", None)
+    if isinstance(params, str):
+        try:
+            params = json.loads(params)
+        except Exception:
+            params = None
+    columns = [
+        TableColumnInfo(
+            column_name=getattr(col, "column_name", None),
+            verbose_name=getattr(col, "verbose_name", None),
+            type=getattr(col, "type", None),
+            is_dttm=getattr(col, "is_dttm", None),
+            groupby=getattr(col, "groupby", None),
+            filterable=getattr(col, "filterable", None),
+            description=getattr(col, "description", None),
+        )
+        for col in getattr(dataset, "columns", [])
+    ]
+    metrics = [
+        SqlMetricInfo(
+            metric_name=getattr(metric, "metric_name", None),
+            verbose_name=getattr(metric, "verbose_name", None),
+            expression=getattr(metric, "expression", None),
+            description=getattr(metric, "description", None),
+            d3format=getattr(metric, "d3format", None),
+        )
+        for metric in getattr(dataset, "metrics", [])
+    ]
+    return DatasetInfo(
+        id=getattr(dataset, "id", None),
+        table_name=getattr(dataset, "table_name", None),
+        schema_name=getattr(dataset, "schema", None),
+        database_name=getattr(dataset.database, "database_name", None)
+        if getattr(dataset, "database", None)
+        else None,
+        description=getattr(dataset, "description", None),
+        changed_by=getattr(dataset, "changed_by_name", None)
+        or (str(dataset.changed_by) if getattr(dataset, "changed_by", None) else None),
+        changed_on=getattr(dataset, "changed_on", None),
+        changed_on_humanized=getattr(dataset, "changed_on_humanized", None),
+        created_by=getattr(dataset, "created_by_name", None)
+        or (str(dataset.created_by) if getattr(dataset, "created_by", None) else None),
+        created_on=getattr(dataset, "created_on", None),
+        created_on_humanized=getattr(dataset, "created_on_humanized", None),
+        tags=[
+            TagInfo.model_validate(tag, from_attributes=True)
+            for tag in getattr(dataset, "tags", [])
+        ]
+        if getattr(dataset, "tags", None)
+        else [],
+        owners=[
+            UserInfo.model_validate(owner, from_attributes=True)
+            for owner in getattr(dataset, "owners", [])
+        ]
+        if getattr(dataset, "owners", None)
+        else [],
+        is_virtual=getattr(dataset, "is_virtual", None),
+        database_id=getattr(dataset, "database_id", None),
+        uuid=str(getattr(dataset, "uuid", ""))
+        if getattr(dataset, "uuid", None)
+        else None,
+        schema_perm=getattr(dataset, "schema_perm", None),
+        url=getattr(dataset, "url", None),
+        sql=getattr(dataset, "sql", None),
+        main_dttm_col=getattr(dataset, "main_dttm_col", None),
+        offset=getattr(dataset, "offset", None),
+        cache_timeout=getattr(dataset, "cache_timeout", None),
+        params=params,
+        template_params=getattr(dataset, "template_params", None),
+        extra=getattr(dataset, "extra", None),
+        columns=columns,
+        metrics=metrics,
+        is_favorite=getattr(dataset, "is_favorite", None),
+    )

--- a/superset/mcp_service/dataset/tool/__init__.py
+++ b/superset/mcp_service/dataset/tool/__init__.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .get_dataset_available_filters import get_dataset_available_filters
+from .get_dataset_info import get_dataset_info
+from .list_datasets import list_datasets
+
+__all__ = [
+    "list_datasets",
+    "get_dataset_info",
+    "get_dataset_available_filters",
+]

--- a/superset/mcp_service/dataset/tool/get_dataset_available_filters.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_available_filters.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Get available dataset filters FastMCP tool
+"""
+
+import logging
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dataset.schemas import (
+    DatasetAvailableFilters,
+    GetDatasetAvailableFiltersRequest,
+)
+from superset.mcp_service.mcp_core import ModelGetAvailableFiltersCore
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool
+@mcp_auth_hook
+async def get_dataset_available_filters(
+    request: GetDatasetAvailableFiltersRequest, ctx: Context
+) -> DatasetAvailableFilters:
+    """Get available dataset filter fields and operators."""
+    from superset.daos.dataset import DatasetDAO
+
+    tool = ModelGetAvailableFiltersCore(
+        dao_class=DatasetDAO,
+        output_schema=DatasetAvailableFilters,
+        logger=logger,
+    )
+    return tool.run_tool()

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Get dataset info FastMCP tool
+
+This module contains the FastMCP tool for getting detailed information
+about a specific dataset.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dataset.schemas import (
+    DatasetError,
+    DatasetInfo,
+    GetDatasetInfoRequest,
+    serialize_dataset_object,
+)
+from superset.mcp_service.mcp_core import ModelGetInfoCore
+
+logger = logging.getLogger(__name__)
+
+
+@mcp.tool
+@mcp_auth_hook
+async def get_dataset_info(
+    request: GetDatasetInfoRequest, ctx: Context
+) -> DatasetInfo | DatasetError:
+    """Get dataset metadata by ID or UUID.
+
+    Returns columns, metrics, and schema details.
+    """
+    await ctx.info(
+        "Retrieving dataset information: identifier=%s" % (request.identifier,)
+    )
+    await ctx.debug(
+        "Metadata cache settings: use_cache=%s refresh_metadata=%s force_refresh=%s"
+        % (
+            request.use_cache,
+            request.refresh_metadata,
+            request.force_refresh,
+        )
+    )
+
+    try:
+        from superset.daos.dataset import DatasetDAO
+
+        tool = ModelGetInfoCore(
+            dao_class=DatasetDAO,
+            output_schema=DatasetInfo,
+            error_schema=DatasetError,
+            serializer=serialize_dataset_object,
+            supports_slug=False,  # Datasets don't have slugs
+            logger=logger,
+        )
+
+        result = tool.run_tool(request.identifier)
+
+        if isinstance(result, DatasetInfo):
+            await ctx.info(
+                "Dataset information retrieved successfully: "
+                "dataset_id=%s, table_name=%s, columns_count=%s, metrics_count=%s"
+                % (
+                    result.id,
+                    result.table_name,
+                    len(result.columns) if result.columns else 0,
+                    len(result.metrics) if result.metrics else 0,
+                )
+            )
+        else:
+            await ctx.warning(
+                "Dataset retrieval failed: error_type=%s, error=%s"
+                % (result.error_type, result.error)
+            )
+
+        return result
+
+    except Exception as e:
+        await ctx.error(
+            "Dataset information retrieval failed: identifier=%s, error=%s, "
+            "error_type=%s"
+            % (
+                request.identifier,
+                str(e),
+                type(e).__name__,
+            )
+        )
+        return DatasetError(
+            error=f"Failed to get dataset info: {str(e)}",
+            error_type="InternalError",
+            timestamp=datetime.now(timezone.utc),
+        )

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+List datasets FastMCP tool (Advanced with metadata cache control)
+
+This module contains the FastMCP tool for listing datasets using
+advanced filtering with clear, unambiguous request schema and metadata cache control.
+"""
+
+import logging
+
+from fastmcp import Context
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.auth import mcp_auth_hook
+from superset.mcp_service.dataset.schemas import (
+    DatasetFilter,
+    DatasetInfo,
+    DatasetList,
+    ListDatasetsRequest,
+    serialize_dataset_object,
+)
+from superset.mcp_service.mcp_core import ModelListCore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATASET_COLUMNS = [
+    "id",
+    "table_name",
+    "schema",
+    "uuid",
+    "database_name",
+    "changed_by_name",
+    "changed_on",
+    "created_by_name",
+    "created_on",
+    "metrics",
+    "columns",
+]
+
+SORTABLE_DATASET_COLUMNS = [
+    "id",
+    "table_name",
+    "schema",
+    "changed_on",
+    "created_on",
+]
+
+
+@mcp.tool
+@mcp_auth_hook
+async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetList:
+    """List datasets with filtering and search.
+
+    Returns dataset metadata including columns and metrics.
+
+    Sortable columns for order_column: id, table_name, schema, changed_on,
+    created_on
+    """
+    await ctx.info(
+        "Listing datasets: page=%s, page_size=%s, search=%s"
+        % (
+            request.page,
+            request.page_size,
+            request.search,
+        )
+    )
+    await ctx.debug(
+        "Dataset listing parameters: filters=%s, order_column=%s, "
+        "order_direction=%s, select_columns=%s"
+        % (
+            request.filters,
+            request.order_column,
+            request.order_direction,
+            request.select_columns,
+        )
+    )
+    await ctx.debug(
+        "Metadata cache settings: use_cache=%s, refresh_metadata=%s, force_refresh=%s"
+        % (
+            request.use_cache,
+            request.refresh_metadata,
+            request.force_refresh,
+        )
+    )
+
+    try:
+        from superset.daos.dataset import DatasetDAO
+
+        # Create tool with standard serialization
+        tool = ModelListCore(
+            dao_class=DatasetDAO,
+            output_schema=DatasetInfo,
+            item_serializer=lambda obj, cols: serialize_dataset_object(obj),
+            filter_type=DatasetFilter,
+            default_columns=DEFAULT_DATASET_COLUMNS,
+            search_columns=["schema", "sql", "table_name", "uuid"],
+            list_field_name="datasets",
+            output_list_schema=DatasetList,
+            logger=logger,
+        )
+
+        result = tool.run_tool(
+            filters=request.filters,
+            search=request.search,
+            select_columns=request.select_columns,
+            order_column=request.order_column,
+            order_direction=request.order_direction,
+            page=max(request.page - 1, 0),
+            page_size=request.page_size,
+        )
+
+        await ctx.info(
+            "Datasets listed successfully: count=%s, total_count=%s, total_pages=%s"
+            % (
+                len(result.datasets) if hasattr(result, "datasets") else 0,
+                getattr(result, "total_count", None),
+                getattr(result, "total_pages", None),
+            )
+        )
+
+        return result
+
+    except Exception as e:
+        await ctx.error(
+            "Dataset listing failed: page=%s, page_size=%s, error=%s, error_type=%s"
+            % (
+                request.page,
+                request.page_size,
+                str(e),
+                type(e).__name__,
+            )
+        )
+        raise

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Any, Callable, Generic, List, Literal, Type, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Literal, Type, TypeVar
 
 from pydantic import BaseModel
 
@@ -294,4 +294,211 @@ class ModelGetInfoCore(BaseCore):
             return response
         except Exception as context_error:
             self._log_error(context_error)
+            raise
+
+
+class InstanceInfoCore(BaseCore):
+    """
+    Configurable tool for generating comprehensive instance information.
+
+    Provides a flexible way to gather and present statistics about a Superset
+    instance with configurable metrics, time windows, and data aggregations.
+    Supports custom metric calculators and result transformers for extensibility.
+    """
+
+    def __init__(
+        self,
+        dao_classes: Dict[str, Type[BaseDAO[Any]]],
+        output_schema: Type[BaseModel],
+        metric_calculators: Dict[str, Callable[..., Any]],
+        time_windows: Dict[str, int] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """
+        Initialize the instance info tool.
+
+        Args:
+            dao_classes: Dict mapping entity names to their DAO classes
+            output_schema: Pydantic schema for the response
+            metric_calculators: Dict of custom metric calculation functions
+            time_windows: Dict of time window configurations (days)
+            logger: Optional logger instance
+        """
+        super().__init__(logger)
+        self.dao_classes = dao_classes
+        self.output_schema = output_schema
+        self.metric_calculators = metric_calculators
+        self.time_windows = time_windows or {
+            "recent": 7,
+            "monthly": 30,
+            "quarterly": 90,
+        }
+
+    def _calculate_basic_counts(self) -> Dict[str, int]:
+        """Calculate basic entity counts using DAOs."""
+        counts = {}
+        for entity_name, dao_class in self.dao_classes.items():
+            try:
+                counts[f"total_{entity_name}"] = dao_class.count()
+            except Exception as e:
+                self._log_warning(f"Failed to count {entity_name}: {e}")
+                counts[f"total_{entity_name}"] = 0
+        return counts
+
+    def _calculate_time_based_metrics(
+        self, base_counts: Dict[str, int]
+    ) -> Dict[str, Dict[str, int]]:
+        """Calculate time-based metrics for recent activity."""
+        from datetime import datetime, timedelta, timezone
+
+        from superset.daos.base import ColumnOperator, ColumnOperatorEnum
+
+        now = datetime.now(timezone.utc)
+        time_metrics = {}
+
+        for window_name, days in self.time_windows.items():
+            cutoff_date = now - timedelta(days=days)
+            window_metrics = {}
+
+            # Calculate created and modified counts for each entity
+            for entity_name, dao_class in self.dao_classes.items():
+                # Skip entities without time tracking
+                if not hasattr(dao_class.model_cls, "created_on"):
+                    continue
+
+                try:
+                    # Use list() with filters (count() has no params)
+                    _, created_count = dao_class.list(
+                        column_operators=[
+                            ColumnOperator(
+                                col="created_on",
+                                opr=ColumnOperatorEnum.gte,
+                                value=cutoff_date,
+                            )
+                        ],
+                        page_size=1,  # We only need the count
+                        columns=["id"],  # Minimal data transfer
+                    )
+                    window_metrics[f"{entity_name}_created"] = created_count
+
+                    # Modified count (if changed_on exists)
+                    if hasattr(dao_class.model_cls, "changed_on"):
+                        _, modified_count = dao_class.list(
+                            column_operators=[
+                                ColumnOperator(
+                                    col="changed_on",
+                                    opr=ColumnOperatorEnum.gte,
+                                    value=cutoff_date,
+                                )
+                            ],
+                            page_size=1,  # We only need the count
+                            columns=["id"],  # Minimal data transfer
+                        )
+                        window_metrics[f"{entity_name}_modified"] = modified_count
+
+                except Exception as e:
+                    self._log_warning(
+                        f"Failed to calculate {window_name} metrics for "
+                        f"{entity_name}: {e}"
+                    )
+                    window_metrics[f"{entity_name}_created"] = 0
+                    window_metrics[f"{entity_name}_modified"] = 0
+
+            time_metrics[window_name] = window_metrics
+
+        return time_metrics
+
+    def _calculate_custom_metrics(
+        self, base_counts: Dict[str, int], time_metrics: Dict[str, Dict[str, int]]
+    ) -> Dict[str, Any]:
+        """Calculate custom metrics using provided calculators."""
+        custom_metrics = {}
+
+        for metric_name, calculator in self.metric_calculators.items():
+            try:
+                # Pass context to calculator functions
+                result = calculator(
+                    base_counts=base_counts,
+                    time_metrics=time_metrics,
+                    dao_classes=self.dao_classes,
+                )
+                # Only include successful calculations
+                if result is not None:
+                    custom_metrics[metric_name] = result
+            except Exception as e:
+                self._log_warning(f"Failed to calculate {metric_name}: {e}")
+                # Don't add failed metrics to avoid validation errors
+
+        return custom_metrics
+
+    def run_tool(self) -> BaseModel:
+        """Tool interface for generating comprehensive instance information."""
+        return self._generate_instance_info()
+
+    def get_resource(self) -> str:
+        """Resource interface for generating instance metadata as JSON."""
+        from superset.utils import json
+
+        instance_info = self._generate_instance_info()
+        return json.dumps(instance_info.model_dump(), indent=2)
+
+    def _generate_instance_info(self) -> BaseModel:
+        """Generate comprehensive instance information."""
+        try:
+            # Calculate all metrics
+            base_counts = self._calculate_basic_counts()
+            time_metrics = self._calculate_time_based_metrics(base_counts)
+            custom_metrics = self._calculate_custom_metrics(base_counts, time_metrics)
+
+            # Combine all data with fallbacks for required fields
+            from datetime import datetime, timezone
+
+            response_data = {
+                **base_counts,
+                **time_metrics,
+                **custom_metrics,
+                "timestamp": datetime.now(timezone.utc),
+            }
+
+            # Create response using the configured schema
+            response = self.output_schema(**response_data)
+
+            self._log_info("Successfully generated instance information")
+            return response
+
+        except Exception as e:
+            self._log_error(e, "generating instance info")
+            raise
+
+
+class ModelGetAvailableFiltersCore(BaseCore, Generic[S]):
+    """
+    Generic tool for retrieving available filterable columns and operators for a
+    model. Used for get_dataset_available_filters, get_chart_available_filters,
+    get_dashboard_available_filters, etc.
+    """
+
+    def __init__(
+        self,
+        dao_class: Type[BaseDAO[Any]],
+        output_schema: Type[S],
+        logger: logging.Logger | None = None,
+    ) -> None:
+        super().__init__(logger)
+        self.dao_class = dao_class
+        self.output_schema = output_schema
+
+    def run_tool(self) -> S:
+        try:
+            filterable = self.dao_class.get_filterable_columns_and_operators()
+            # Ensure column_operators is a plain dict, not a custom type
+            column_operators = dict(filterable)
+            response = self.output_schema(column_operators=column_operators)
+            self._log_info(
+                f"Successfully retrieved available filters for "
+                f"{self.dao_class.__class__.__name__}"
+            )
+            return response
+        except Exception as e:
+            self._log_error(e)
             raise

--- a/superset/mcp_service/system/schemas.py
+++ b/superset/mcp_service/system/schemas.py
@@ -16,10 +16,14 @@
 # under the License.
 
 """
-Pydantic schemas for shared system types (UserInfo, TagInfo, PaginationInfo)
+Pydantic schemas for system-level (instance/info) responses
+
+This module contains Pydantic models for serializing Superset instance metadata and
+system-level info.
 """
 
-from typing import List
+from datetime import datetime
+from typing import Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -39,9 +43,90 @@ class HealthCheckResponse(BaseModel):
     uptime_seconds: float
 
 
-class UserInfo(BaseModel):
-    """User information schema."""
+class GetSupersetInstanceInfoRequest(BaseModel):
+    """
+    Request schema for get_superset_instance_info tool.
 
+    Currently has no parameters but provides consistent API for future extensibility.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+    )
+
+
+class InstanceSummary(BaseModel):
+    total_dashboards: int = Field(..., description="Total number of dashboards")
+    total_charts: int = Field(..., description="Total number of charts")
+    total_datasets: int = Field(..., description="Total number of datasets")
+    total_databases: int = Field(..., description="Total number of databases")
+    total_users: int = Field(..., description="Total number of users")
+    total_roles: int = Field(..., description="Total number of roles")
+    total_tags: int = Field(..., description="Total number of tags")
+    avg_charts_per_dashboard: float = Field(
+        ..., description="Average number of charts per dashboard"
+    )
+
+
+class RecentActivity(BaseModel):
+    dashboards_created_last_30_days: int = Field(
+        ..., description="Dashboards created in the last 30 days"
+    )
+    charts_created_last_30_days: int = Field(
+        ..., description="Charts created in the last 30 days"
+    )
+    datasets_created_last_30_days: int = Field(
+        ..., description="Datasets created in the last 30 days"
+    )
+    dashboards_modified_last_7_days: int = Field(
+        ..., description="Dashboards modified in the last 7 days"
+    )
+    charts_modified_last_7_days: int = Field(
+        ..., description="Charts modified in the last 7 days"
+    )
+    datasets_modified_last_7_days: int = Field(
+        ..., description="Datasets modified in the last 7 days"
+    )
+
+
+class DashboardBreakdown(BaseModel):
+    published: int = Field(..., description="Number of published dashboards")
+    unpublished: int = Field(..., description="Number of unpublished dashboards")
+    certified: int = Field(..., description="Number of certified dashboards")
+    with_charts: int = Field(..., description="Number of dashboards with charts")
+    without_charts: int = Field(..., description="Number of dashboards without charts")
+
+
+class DatabaseBreakdown(BaseModel):
+    by_type: Dict[str, int] = Field(..., description="Breakdown of databases by type")
+
+
+class PopularContent(BaseModel):
+    top_tags: List[str] = Field(..., description="Most popular tags")
+    top_creators: List[str] = Field(..., description="Most active creators")
+
+
+class InstanceInfo(BaseModel):
+    instance_summary: InstanceSummary = Field(
+        ..., description="Instance summary information"
+    )
+    recent_activity: RecentActivity = Field(
+        ..., description="Recent activity information"
+    )
+    dashboard_breakdown: DashboardBreakdown = Field(
+        ..., description="Dashboard breakdown information"
+    )
+    database_breakdown: DatabaseBreakdown = Field(
+        ..., description="Database breakdown by type"
+    )
+    popular_content: PopularContent = Field(
+        ..., description="Popular content information"
+    )
+    timestamp: datetime = Field(..., description="Response timestamp")
+
+
+class UserInfo(BaseModel):
     id: int | None = None
     username: str | None = None
     first_name: str | None = None
@@ -51,17 +136,19 @@ class UserInfo(BaseModel):
 
 
 class TagInfo(BaseModel):
-    """Tag information schema."""
-
     id: int | None = None
     name: str | None = None
     type: str | None = None
     description: str | None = None
 
 
-class PaginationInfo(BaseModel):
-    """Pagination metadata."""
+class RoleInfo(BaseModel):
+    id: int | None = None
+    name: str | None = None
+    permissions: List[str] | None = None
 
+
+class PaginationInfo(BaseModel):
     page: int = Field(..., description="Current page number")
     page_size: int = Field(..., description="Number of items per page")
     total_count: int = Field(..., description="Total number of items")
@@ -69,11 +156,3 @@ class PaginationInfo(BaseModel):
     has_next: bool = Field(..., description="Whether there is a next page")
     has_previous: bool = Field(..., description="Whether there is a previous page")
     model_config = ConfigDict(ser_json_timedelta="iso8601")
-
-
-class RoleInfo(BaseModel):
-    """Role information schema (for future use)."""
-
-    id: int | None = None
-    name: str | None = None
-    permissions: List[str] | None = None

--- a/superset/mcp_service/utils/retry_utils.py
+++ b/superset/mcp_service/utils/retry_utils.py
@@ -1,0 +1,341 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Retry utilities for handling transient failures in MCP service operations.
+"""
+
+import asyncio
+import functools
+import logging
+import secrets
+import time
+from typing import Any, Callable, Type, TypeVar
+
+from sqlalchemy.exc import OperationalError, TimeoutError
+from starlette.exceptions import HTTPException
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Default retryable exceptions
+DEFAULT_RETRYABLE_EXCEPTIONS = (
+    OperationalError,  # Database connection issues
+    TimeoutError,  # Database timeouts
+    ConnectionError,  # Network issues
+    OSError,  # File system issues (for screenshots)
+)
+
+
+def exponential_backoff(
+    attempt: int, base_delay: float = 1.0, max_delay: float = 60.0, jitter: bool = True
+) -> float:
+    """
+    Calculate exponential backoff delay with optional jitter.
+
+    Args:
+        attempt: Current attempt number (0-based)
+        base_delay: Base delay in seconds
+        max_delay: Maximum delay in seconds
+        jitter: Whether to add random jitter to avoid thundering herd
+
+    Returns:
+        Delay in seconds
+    """
+    delay = base_delay * (2**attempt)
+    delay = min(delay, max_delay)
+
+    if jitter:
+        # Add up to 25% jitter using cryptographically secure random
+        jitter_amount = delay * 0.25
+        random_gen = secrets.SystemRandom()
+        delay += random_gen.uniform(-jitter_amount, jitter_amount)
+
+    return max(0, delay)
+
+
+def retry_on_exception(
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exceptions: tuple[Type[Exception], ...] = DEFAULT_RETRYABLE_EXCEPTIONS,
+    jitter: bool = True,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Decorator to retry function calls on specific exceptions with exponential backoff.
+
+    Args:
+        max_attempts: Maximum number of attempts (including initial attempt)
+        base_delay: Base delay in seconds for exponential backoff
+        max_delay: Maximum delay in seconds between retries
+        exceptions: Tuple of exception types to retry on
+        jitter: Whether to add random jitter to backoff delays
+
+    Returns:
+        Decorated function
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            last_exception = None
+
+            for attempt in range(max_attempts):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:  # noqa: PERF203
+                    last_exception = e
+
+                    if attempt == max_attempts - 1:
+                        # Last attempt, don't wait
+                        break
+
+                    delay = exponential_backoff(attempt, base_delay, max_delay, jitter)
+
+                    logger.warning(
+                        "Attempt %s/%s failed for %s: %s. Retrying in %.2fs...",
+                        attempt + 1,
+                        max_attempts,
+                        func.__name__,
+                        e,
+                        delay,
+                    )
+
+                    time.sleep(delay)
+                except Exception as e:
+                    # Non-retryable exception, fail immediately
+                    logger.error("Non-retryable exception in %s: %s", func.__name__, e)
+                    raise
+
+            # All attempts failed
+            if last_exception is not None:
+                logger.error(
+                    "All %s attempts failed for %s: %s",
+                    max_attempts,
+                    func.__name__,
+                    last_exception,
+                )
+                raise last_exception
+            logger.error("All %s attempts failed for %s", max_attempts, func.__name__)
+            raise RuntimeError(
+                f"All {max_attempts} attempts failed for {func.__name__}"
+            )
+
+        return wrapper
+
+    return decorator
+
+
+def async_retry_on_exception(
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exceptions: tuple[Type[Exception], ...] = DEFAULT_RETRYABLE_EXCEPTIONS,
+    jitter: bool = True,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Async version of retry_on_exception decorator.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            last_exception = None
+
+            for attempt in range(max_attempts):
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions as e:  # noqa: PERF203
+                    last_exception = e
+
+                    if attempt == max_attempts - 1:
+                        # Last attempt, don't wait
+                        break
+
+                    delay = exponential_backoff(attempt, base_delay, max_delay, jitter)
+
+                    logger.warning(
+                        "Attempt %s/%s failed for %s: %s. Retrying in %.2fs...",
+                        attempt + 1,
+                        max_attempts,
+                        func.__name__,
+                        e,
+                        delay,
+                    )
+
+                    await asyncio.sleep(delay)
+                except Exception as e:
+                    # Non-retryable exception, fail immediately
+                    logger.error("Non-retryable exception in %s: %s", func.__name__, e)
+                    raise
+
+            # All attempts failed
+            if last_exception is not None:
+                logger.error(
+                    "All %s attempts failed for %s: %s",
+                    max_attempts,
+                    func.__name__,
+                    last_exception,
+                )
+                raise last_exception
+            logger.error("All %s attempts failed for %s", max_attempts, func.__name__)
+            raise RuntimeError(
+                f"All {max_attempts} attempts failed for {func.__name__}"
+            )
+
+        return wrapper
+
+    return decorator
+
+
+class RetryableOperation:
+    """
+    Context manager for retryable operations with custom logic.
+    """
+
+    def __init__(
+        self,
+        operation_name: str,
+        max_attempts: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 60.0,
+        exceptions: tuple[Type[Exception], ...] = DEFAULT_RETRYABLE_EXCEPTIONS,
+        jitter: bool = True,
+    ) -> None:
+        self.operation_name = operation_name
+        self.max_attempts = max_attempts
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.exceptions = exceptions
+        self.jitter = jitter
+        self.current_attempt = 0
+        self.last_exception: Exception | None = None
+
+    def __enter__(self) -> "RetryableOperation":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[Exception] | None,
+        exc_val: Exception | None,
+        exc_tb: Any,
+    ) -> bool:
+        if exc_type is None:
+            # No exception, operation succeeded
+            return False
+
+        if not issubclass(exc_type, self.exceptions):
+            # Non-retryable exception
+            logger.error(
+                "Non-retryable exception in %s: %s", self.operation_name, exc_val
+            )
+            return False
+
+        self.last_exception = exc_val
+        self.current_attempt += 1
+
+        if self.current_attempt >= self.max_attempts:
+            # Max attempts reached
+            logger.error(
+                "All %s attempts failed for %s. ",
+                self.max_attempts,
+                self.operation_name,
+            )
+            return False
+
+        # Calculate delay and wait
+        delay = exponential_backoff(
+            self.current_attempt - 1, self.base_delay, self.max_delay, self.jitter
+        )
+
+        logger.warning(
+            "Attempt %s/%s failed for %s: %s. Retrying in %.2fs...",
+            self.current_attempt,
+            self.max_attempts,
+            self.operation_name,
+            exc_val,
+            delay,
+        )
+
+        time.sleep(delay)
+        return True  # Suppress the exception and continue
+
+    def should_retry(self) -> bool:
+        """Check if we should continue retrying"""
+        return self.current_attempt < self.max_attempts
+
+
+# Convenience functions for common operations
+def retry_database_operation(
+    func: Callable[..., T], *args: Any, max_attempts: int = 3, **kwargs: Any
+) -> T:
+    """
+    Execute a database operation with retry logic.
+    """
+
+    @retry_on_exception(
+        max_attempts=max_attempts,
+        exceptions=(OperationalError, TimeoutError),
+        base_delay=0.5,
+        max_delay=30.0,
+    )
+    def _wrapped() -> T:
+        return func(*args, **kwargs)
+
+    return _wrapped()
+
+
+async def async_retry_database_operation(
+    func: Callable[..., Any], *args: Any, max_attempts: int = 3, **kwargs: Any
+) -> Any:
+    """
+    Execute an async database operation with retry logic.
+    """
+
+    @async_retry_on_exception(
+        max_attempts=max_attempts,
+        exceptions=(OperationalError, TimeoutError),
+        base_delay=0.5,
+        max_delay=30.0,
+    )
+    async def _wrapped() -> Any:
+        return await func(*args, **kwargs)
+
+    return await _wrapped()
+
+
+def retry_screenshot_operation(
+    func: Callable[..., T],
+    *args: Any,
+    max_attempts: int = 2,  # Screenshots are expensive, fewer retries
+    **kwargs: Any,
+) -> T:
+    """
+    Execute a screenshot operation with retry logic.
+    """
+
+    @retry_on_exception(
+        max_attempts=max_attempts,
+        exceptions=(OSError, ConnectionError, HTTPException),
+        base_delay=2.0,  # Longer initial delay for screenshots
+        max_delay=30.0,
+    )
+    def _wrapped() -> T:
+        return func(*args, **kwargs)
+
+    return _wrapped()

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for MCP chart schema validation.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from superset.mcp_service.chart.schemas import (
+    ColumnRef,
+    TableChartConfig,
+    XYChartConfig,
+)
+
+
+class TestTableChartConfig:
+    """Test TableChartConfig validation."""
+
+    def test_duplicate_labels_rejected(self) -> None:
+        """Test that TableChartConfig rejects duplicate labels."""
+        with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
+            TableChartConfig(
+                columns=[
+                    ColumnRef(name="product_line", label="product_line"),
+                    ColumnRef(name="sales", aggregate="SUM", label="product_line"),
+                ]
+            )
+
+    def test_unique_labels_accepted(self) -> None:
+        """Test that TableChartConfig accepts unique labels."""
+        config = TableChartConfig(
+            columns=[
+                ColumnRef(name="product_line", label="Product Line"),
+                ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
+            ]
+        )
+        assert len(config.columns) == 2
+
+
+class TestXYChartConfig:
+    """Test XYChartConfig validation."""
+
+    def test_different_labels_accepted(self) -> None:
+        """Test that different labels for x and y are accepted."""
+        config = XYChartConfig(
+            x=ColumnRef(name="product_line"),  # Label: "product_line"
+            y=[
+                ColumnRef(
+                    name="product_line", aggregate="COUNT"
+                ),  # Label: "COUNT(product_line)"
+            ],
+        )
+        assert config.x.name == "product_line"
+        assert config.y[0].aggregate == "COUNT"
+
+    def test_explicit_duplicate_label_rejected(self) -> None:
+        """Test that explicit duplicate labels are rejected."""
+        with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
+            XYChartConfig(
+                x=ColumnRef(name="product_line"),
+                y=[ColumnRef(name="sales", label="product_line")],
+            )
+
+    def test_duplicate_y_axis_labels_rejected(self) -> None:
+        """Test that duplicate y-axis labels are rejected."""
+        with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
+            XYChartConfig(
+                x=ColumnRef(name="date"),
+                y=[
+                    ColumnRef(name="sales", aggregate="SUM"),
+                    ColumnRef(name="revenue", aggregate="SUM", label="SUM(sales)"),
+                ],
+            )
+
+    def test_unique_labels_accepted(self) -> None:
+        """Test that unique labels are accepted."""
+        config = XYChartConfig(
+            x=ColumnRef(name="date", label="Order Date"),
+            y=[
+                ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
+                ColumnRef(name="profit", aggregate="AVG", label="Average Profit"),
+            ],
+        )
+        assert len(config.y) == 2
+
+    def test_group_by_duplicate_with_x_rejected(self) -> None:
+        """Test that group_by conflicts with x are rejected."""
+        with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
+            XYChartConfig(
+                x=ColumnRef(name="region"),
+                y=[ColumnRef(name="sales", aggregate="SUM")],
+                group_by=ColumnRef(name="category", label="region"),
+            )
+
+    def test_realistic_chart_configurations(self) -> None:
+        """Test realistic chart configurations."""
+        # This should work - COUNT(product_line) != product_line
+        config = XYChartConfig(
+            x=ColumnRef(name="product_line"),
+            y=[
+                ColumnRef(name="product_line", aggregate="COUNT"),
+                ColumnRef(name="sales", aggregate="SUM"),
+            ],
+        )
+        assert config.x.name == "product_line"
+        assert len(config.y) == 2
+
+    def test_time_series_chart_configuration(self) -> None:
+        """Test time series chart configuration works."""
+        # This should PASS now - the chart creation logic fixes duplicates
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date"),
+            y=[
+                ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
+                ColumnRef(name="price_each", aggregate="AVG", label="Avg Price"),
+            ],
+            kind="line",
+        )
+        assert config.x.name == "order_date"
+        assert config.kind == "line"
+
+    def test_time_series_with_custom_x_axis_label(self) -> None:
+        """Test time series chart with custom x-axis label."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="order_date", label="Order Date"),
+            y=[
+                ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
+                ColumnRef(name="price_each", aggregate="AVG", label="Avg Price"),
+            ],
+            kind="line",
+        )
+        assert config.x.label == "Order Date"
+
+    def test_area_chart_configuration(self) -> None:
+        """Test area chart configuration."""
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="category"),
+            y=[ColumnRef(name="sales", aggregate="SUM", label="Total Sales")],
+            kind="area",
+        )
+        assert config.kind == "area"

--- a/tests/unit_tests/mcp_service/dashboard/__init__.py
+++ b/tests/unit_tests/mcp_service/dashboard/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/dashboard/tool/__init__.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -1,0 +1,573 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Unit tests for MCP dashboard tools (list_dashboards, get_dashboard_info)
+"""
+
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.dashboard.schemas import (
+    ListDashboardsRequest,
+)
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests."""
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_basic(mock_list, mcp_server):
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Test Dashboard"
+    dashboard.slug = "test-dashboard"
+    dashboard.url = "/dashboard/1"
+    dashboard.published = True
+    dashboard.changed_by_name = "admin"
+    dashboard.changed_on = None
+    dashboard.changed_on_humanized = None
+    dashboard.created_by_name = "admin"
+    dashboard.created_on = None
+    dashboard.created_on_humanized = None
+    dashboard.tags = []
+    dashboard.owners = []
+    dashboard.slices = []
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.position_json = None
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.uuid = "test-dashboard-uuid-1"
+    dashboard.thumbnail_url = None
+    dashboard.roles = []
+    dashboard.charts = []
+    dashboard._mapping = {
+        "id": dashboard.id,
+        "dashboard_title": dashboard.dashboard_title,
+        "slug": dashboard.slug,
+        "url": dashboard.url,
+        "published": dashboard.published,
+        "changed_by_name": dashboard.changed_by_name,
+        "changed_on": dashboard.changed_on,
+        "changed_on_humanized": dashboard.changed_on_humanized,
+        "created_by_name": dashboard.created_by_name,
+        "created_on": dashboard.created_on,
+        "created_on_humanized": dashboard.created_on_humanized,
+        "tags": dashboard.tags,
+        "owners": dashboard.owners,
+        "charts": [],
+    }
+    mock_list.return_value = ([dashboard], 1)
+    async with Client(mcp_server) as client:
+        request = ListDashboardsRequest(page=1, page_size=10)
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+        dashboards = result.data.dashboards
+        assert len(dashboards) == 1
+        assert dashboards[0].dashboard_title == "Test Dashboard"
+        assert dashboards[0].uuid == "test-dashboard-uuid-1"
+        assert dashboards[0].slug == "test-dashboard"
+        assert dashboards[0].published is True
+
+        # Verify UUID and slug are in default columns
+        assert "uuid" in result.data.columns_requested
+        assert "slug" in result.data.columns_requested
+        assert "uuid" in result.data.columns_loaded
+        assert "slug" in result.data.columns_loaded
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_with_filters(mock_list, mcp_server):
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Filtered Dashboard"
+    dashboard.slug = "filtered-dashboard"
+    dashboard.url = "/dashboard/2"
+    dashboard.published = True
+    dashboard.changed_by_name = "admin"
+    dashboard.changed_on = None
+    dashboard.changed_on_humanized = None
+    dashboard.created_by_name = "admin"
+    dashboard.created_on = None
+    dashboard.created_on_humanized = None
+    dashboard.tags = []
+    dashboard.owners = []
+    dashboard.slices = []
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.position_json = None
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.uuid = None
+    dashboard.thumbnail_url = None
+    dashboard.roles = []
+    dashboard.charts = []
+    dashboard._mapping = {
+        "id": dashboard.id,
+        "dashboard_title": dashboard.dashboard_title,
+        "slug": dashboard.slug,
+        "url": dashboard.url,
+        "published": dashboard.published,
+        "changed_by_name": dashboard.changed_by_name,
+        "changed_on": dashboard.changed_on,
+        "changed_on_humanized": dashboard.changed_on_humanized,
+        "created_by_name": dashboard.created_by_name,
+        "created_on": dashboard.created_on,
+        "created_on_humanized": dashboard.created_on_humanized,
+        "tags": dashboard.tags,
+        "owners": dashboard.owners,
+        "charts": [],
+    }
+    mock_list.return_value = ([dashboard], 1)
+    async with Client(mcp_server) as client:
+        filters = [
+            {"col": "dashboard_title", "opr": "sw", "value": "Sales"},
+            {"col": "published", "opr": "eq", "value": True},
+        ]
+        request = ListDashboardsRequest(
+            filters=filters,
+            select_columns=["id", "dashboard_title"],
+            order_column="changed_on",
+            order_direction="desc",
+            page=1,
+            page_size=50,
+        )
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+        assert result.data.count == 1
+        assert result.data.dashboards[0].dashboard_title == "Filtered Dashboard"
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_with_string_filters(mock_list, mcp_server):
+    mock_list.return_value = ([], 0)
+    async with Client(mcp_server) as client:  # noqa: F841
+        filters = '[{"col": "dashboard_title", "opr": "sw", "value": "Sales"}]'
+
+        # Test that string filters cause validation error at schema level
+        with pytest.raises(ValueError, match="validation error"):
+            ListDashboardsRequest(filters=filters)  # noqa: F841
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_api_error(mock_list, mcp_server):
+    mock_list.side_effect = ToolError("API request failed")
+    async with Client(mcp_server) as client:
+        with pytest.raises(ToolError) as excinfo:  # noqa: PT012
+            request = ListDashboardsRequest()
+            await client.call_tool("list_dashboards", {"request": request.model_dump()})
+        assert "API request failed" in str(excinfo.value)
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_with_search(mock_list, mcp_server):
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "search_dashboard"
+    dashboard.slug = "search-dashboard"
+    dashboard.url = "/dashboard/1"
+    dashboard.published = True
+    dashboard.changed_by_name = "admin"
+    dashboard.changed_on = None
+    dashboard.changed_on_humanized = None
+    dashboard.created_by_name = "admin"
+    dashboard.created_on = None
+    dashboard.created_on_humanized = None
+    dashboard.tags = []
+    dashboard.owners = []
+    dashboard.slices = []
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.position_json = None
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.uuid = None
+    dashboard.thumbnail_url = None
+    dashboard.roles = []
+    dashboard.charts = []
+    dashboard._mapping = {
+        "id": dashboard.id,
+        "dashboard_title": dashboard.dashboard_title,
+        "slug": dashboard.slug,
+        "url": dashboard.url,
+        "published": dashboard.published,
+        "changed_by_name": dashboard.changed_by_name,
+        "changed_on": dashboard.changed_on,
+        "changed_on_humanized": dashboard.changed_on_humanized,
+        "created_by_name": dashboard.created_by_name,
+        "created_on": dashboard.created_on,
+        "created_on_humanized": dashboard.created_on_humanized,
+        "tags": dashboard.tags,
+        "owners": dashboard.owners,
+        "charts": [],
+    }
+    mock_list.return_value = ([dashboard], 1)
+    async with Client(mcp_server) as client:
+        request = ListDashboardsRequest(search="search_dashboard")
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+        assert result.data.count == 1
+        assert result.data.dashboards[0].dashboard_title == "search_dashboard"
+        args, kwargs = mock_list.call_args
+        assert kwargs["search"] == "search_dashboard"
+        assert "dashboard_title" in kwargs["search_columns"]
+        assert "slug" in kwargs["search_columns"]
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_with_simple_filters(mock_list, mcp_server):
+    mock_list.return_value = ([], 0)
+    async with Client(mcp_server) as client:
+        filters = [
+            {"col": "dashboard_title", "opr": "eq", "value": "Sales"},
+            {"col": "published", "opr": "eq", "value": True},
+        ]
+        request = ListDashboardsRequest(filters=filters)
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+        assert hasattr(result.data, "count")
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_success(mock_info, mcp_server):
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Test Dashboard"
+    dashboard.slug = "test-dashboard"
+    dashboard.description = "Test description"
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.position_json = None
+    dashboard.published = True
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.created_on = None
+    dashboard.changed_on = None
+    dashboard.created_by = None
+    dashboard.changed_by = None
+    dashboard.uuid = None
+    dashboard.url = "/dashboard/1"
+    dashboard.thumbnail_url = None
+    dashboard.created_on_humanized = None
+    dashboard.changed_on_humanized = None
+    dashboard.slices = []
+    dashboard.owners = []
+    dashboard.tags = []
+    dashboard.roles = []
+    dashboard.charts = []
+    dashboard._mapping = {
+        "id": dashboard.id,
+        "dashboard_title": dashboard.dashboard_title,
+        "slug": dashboard.slug,
+        "url": dashboard.url,
+        "published": dashboard.published,
+        "changed_by_name": dashboard.changed_by_name,
+        "changed_on": dashboard.changed_on,
+        "changed_on_humanized": dashboard.changed_on_humanized,
+        "created_by_name": dashboard.created_by_name,
+        "created_on": dashboard.created_on,
+        "created_on_humanized": dashboard.created_on_humanized,
+        "tags": dashboard.tags,
+        "owners": dashboard.owners,
+        "charts": [],
+    }
+    mock_info.return_value = dashboard  # Only the dashboard object
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": 1}}
+        )
+        assert result.data["dashboard_title"] == "Test Dashboard"
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_not_found(mock_info, mcp_server):
+    mock_info.return_value = None  # Not found returns None
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": 999}}
+        )
+        assert result.data["error_type"] == "not_found"
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_access_denied(mock_info, mcp_server):
+    mock_info.return_value = None  # Access denied returns None
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": 1}}
+        )
+        assert result.data["error_type"] == "not_found"
+
+
+# TODO (Phase 3+): Add tests for get_dashboard_available_filters tool
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore._find_object")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_by_uuid(mock_find_object, mcp_server):
+    """Test getting dashboard info using UUID identifier."""
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Test Dashboard UUID"
+    dashboard.slug = "test-dashboard-uuid"
+    dashboard.description = "Test description"
+    dashboard.css = ""
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = "{}"
+    dashboard.position_json = "{}"
+    dashboard.published = True
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.created_on = None
+    dashboard.changed_on = None
+    dashboard.created_by = None
+    dashboard.changed_by = None
+    dashboard.uuid = "c3d4e5f6-g7h8-9012-cdef-gh3456789012"
+    dashboard.url = "/dashboard/1"
+    dashboard.thumbnail_url = None
+    dashboard.created_on_humanized = "2 days ago"
+    dashboard.changed_on_humanized = "1 day ago"
+    dashboard.slices = []
+    dashboard.owners = []
+    dashboard.tags = []
+    dashboard.roles = []
+
+    mock_find_object.return_value = dashboard
+    async with Client(mcp_server) as client:
+        uuid_str = "c3d4e5f6-g7h8-9012-cdef-gh3456789012"
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": uuid_str}}
+        )
+        assert result.data["dashboard_title"] == "Test Dashboard UUID"
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore._find_object")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_by_slug(mock_find_object, mcp_server):
+    """Test getting dashboard info using slug identifier."""
+    dashboard = Mock()
+    dashboard.id = 2
+    dashboard.dashboard_title = "Test Dashboard Slug"
+    dashboard.slug = "test-dashboard-slug"
+    dashboard.description = "Test description"
+    dashboard.css = ""
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = "{}"
+    dashboard.position_json = "{}"
+    dashboard.published = True
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.created_on = None
+    dashboard.changed_on = None
+    dashboard.created_by = None
+    dashboard.changed_by = None
+    dashboard.uuid = "d4e5f6g7-h8i9-0123-defg-hi4567890123"
+    dashboard.url = "/dashboard/2"
+    dashboard.thumbnail_url = None
+    dashboard.created_on_humanized = "2 days ago"
+    dashboard.changed_on_humanized = "1 day ago"
+    dashboard.slices = []
+    dashboard.owners = []
+    dashboard.tags = []
+    dashboard.roles = []
+
+    mock_find_object.return_value = dashboard
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": "test-dashboard-slug"}}
+        )
+        assert result.data["dashboard_title"] == "Test Dashboard Slug"
+
+
+@patch("superset.daos.dashboard.DashboardDAO.list")
+@pytest.mark.asyncio
+async def test_list_dashboards_custom_uuid_slug_columns(mock_list, mcp_server):
+    """Test that custom column selection includes UUID and slug when explicitly
+    requested."""
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Custom Columns Dashboard"
+    dashboard.slug = "custom-dashboard"
+    dashboard.uuid = "test-custom-uuid-123"
+    dashboard.url = "/dashboard/1"
+    dashboard.published = True
+    dashboard.changed_by_name = "admin"
+    dashboard.changed_on = None
+    dashboard.changed_on_humanized = None
+    dashboard.created_by_name = "admin"
+    dashboard.created_on = None
+    dashboard.created_on_humanized = None
+    dashboard.tags = []
+    dashboard.owners = []
+    dashboard.slices = []
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = None
+    dashboard.position_json = None
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.thumbnail_url = None
+    dashboard.roles = []
+    dashboard.charts = []
+    dashboard._mapping = {
+        "id": dashboard.id,
+        "dashboard_title": dashboard.dashboard_title,
+        "slug": dashboard.slug,
+        "uuid": dashboard.uuid,
+        "url": dashboard.url,
+        "published": dashboard.published,
+        "changed_by_name": dashboard.changed_by_name,
+        "changed_on": dashboard.changed_on,
+        "changed_on_humanized": dashboard.changed_on_humanized,
+        "created_by_name": dashboard.created_by_name,
+        "created_on": dashboard.created_on,
+        "created_on_humanized": dashboard.created_on_humanized,
+        "tags": dashboard.tags,
+        "owners": dashboard.owners,
+        "charts": [],
+    }
+    mock_list.return_value = ([dashboard], 1)
+    async with Client(mcp_server) as client:
+        request = ListDashboardsRequest(
+            select_columns=["id", "dashboard_title", "uuid", "slug"],
+            page=1,
+            page_size=10,
+        )
+        result = await client.call_tool(
+            "list_dashboards", {"request": request.model_dump()}
+        )
+        dashboards = result.data.dashboards
+        assert len(dashboards) == 1
+        assert dashboards[0].uuid == "test-custom-uuid-123"
+        assert dashboards[0].slug == "custom-dashboard"
+
+        # Verify custom columns include UUID and slug
+        assert "uuid" in result.data.columns_requested
+        assert "slug" in result.data.columns_requested
+        assert "uuid" in result.data.columns_loaded
+        assert "slug" in result.data.columns_loaded
+
+
+class TestDashboardSortableColumns:
+    """Test sortable columns configuration for dashboard tools."""
+
+    def test_dashboard_sortable_columns_definition(self):
+        """Test that dashboard sortable columns are properly defined."""
+        from superset.mcp_service.dashboard.tool.list_dashboards import (
+            SORTABLE_DASHBOARD_COLUMNS,
+        )
+
+        assert SORTABLE_DASHBOARD_COLUMNS == [
+            "id",
+            "dashboard_title",
+            "slug",
+            "published",
+            "changed_on",
+            "created_on",
+        ]
+        # Ensure no computed properties are included
+        assert "changed_on_delta_humanized" not in SORTABLE_DASHBOARD_COLUMNS
+        assert "changed_by_name" not in SORTABLE_DASHBOARD_COLUMNS
+        assert "uuid" not in SORTABLE_DASHBOARD_COLUMNS
+
+    @patch("superset.daos.dashboard.DashboardDAO.list")
+    @pytest.mark.asyncio
+    async def test_list_dashboards_with_valid_order_column(self, mock_list, mcp_server):
+        """Test list_dashboards with valid order column."""
+        mock_list.return_value = ([], 0)
+
+        async with Client(mcp_server) as client:
+            # Test with valid sortable column
+            request = ListDashboardsRequest(
+                order_column="dashboard_title", order_direction="desc"
+            )
+            result = await client.call_tool(
+                "list_dashboards", {"request": request.model_dump()}
+            )
+
+            # Verify the DAO was called with the correct order column
+            mock_list.assert_called_once()
+            call_args = mock_list.call_args[1]
+            assert call_args["order_column"] == "dashboard_title"
+            assert call_args["order_direction"] == "desc"
+
+            # Verify the result
+            assert result.data.count == 0
+            assert result.data.dashboards == []
+
+    def test_sortable_columns_in_docstring(self):
+        """Test that sortable columns are documented in tool docstring."""
+        from superset.mcp_service.dashboard.tool.list_dashboards import (
+            list_dashboards,
+            SORTABLE_DASHBOARD_COLUMNS,
+        )
+
+        # Check list_dashboards docstring (stored in description after @mcp.tool)
+        assert hasattr(list_dashboards, "description")
+        assert "Sortable columns for order_column:" in list_dashboards.description
+        for col in SORTABLE_DASHBOARD_COLUMNS:
+            assert col in list_dashboards.description

--- a/tests/unit_tests/mcp_service/dataset/__init__.py
+++ b/tests/unit_tests/mcp_service/dataset/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/dataset/tool/__init__.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -1,0 +1,1231 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fastmcp
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from superset.mcp_service.app import mcp
+from superset.mcp_service.dataset.schemas import ListDatasetsRequest
+from superset.utils import json
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+def create_mock_dataset(
+    dataset_id=1,
+    table_name="Test DatasetInfo",
+    schema="main",
+    database_name="examples",
+    columns=None,
+    metrics=None,
+):
+    """Factory function to create mock dataset objects with sensible defaults."""
+    dataset = MagicMock()
+    dataset.id = dataset_id
+    dataset.table_name = table_name
+    dataset.schema = schema
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = f"[{database_name}].[{schema}]"
+    dataset.url = f"/tablemodelview/edit/{dataset_id}"
+    dataset.database = MagicMock()
+    dataset.database.database_name = database_name
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.uuid = f"test-dataset-uuid-{dataset_id}"
+    dataset.columns = columns or []
+    dataset.metrics = metrics or []
+    return dataset
+
+
+@pytest.fixture
+def mcp_server():
+    return mcp
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication for all tests."""
+    from unittest.mock import Mock, patch
+
+    with patch("superset.mcp_service.auth.get_user_from_request") as mock_get_user:
+        mock_user = Mock()
+        mock_user.id = 1
+        mock_user.username = "admin"
+        mock_get_user.return_value = mock_user
+        yield mock_get_user
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_basic(mock_list, mcp_server):
+    """Test basic dataset listing functionality.
+
+    Note: Dataset tests use json.loads(result.content[0].text) pattern
+    for response parsing, which differs from dashboard/chart tests that
+    use result.data directly. This is intentional based on how the
+    dataset tool responses are structured.
+    """
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "Test DatasetInfo"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/1"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.uuid = "test-dataset-uuid-1"
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    col2 = MagicMock()
+    col2.column_name = "name"
+    col2.verbose_name = "Name"
+    col2.type = "VARCHAR"
+    col2.is_dttm = False
+    col2.groupby = True
+    col2.filterable = True
+    col2.description = "Name column"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "count"
+    metric1.verbose_name = "Count"
+    metric1.expression = "COUNT(*)"
+    metric1.description = "Row count"
+    metric1.d3format = None
+
+    dataset.columns = [col1, col2]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(page=1, page_size=10)
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 1
+        assert data["datasets"][0]["table_name"] == "Test DatasetInfo"
+        assert data["datasets"][0]["uuid"] == "test-dataset-uuid-1"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 2
+        assert len(data["datasets"][0]["metrics"]) == 1
+        assert data["datasets"][0]["columns"][0]["column_name"] == "id"
+        assert data["datasets"][0]["metrics"][0]["metric_name"] == "count"
+
+        # Verify UUID is in default columns (datasets don't have slugs)
+        assert "uuid" in data["columns_requested"]
+        assert "uuid" in data["columns_loaded"]
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_custom_uuid_columns(mock_list, mcp_server):
+    """Test that custom column selection includes UUID when explicitly requested."""
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "custom_dataset"
+    dataset.schema = "public"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[public]"
+    dataset.url = "/tablemodelview/edit/1"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "test_db"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.uuid = "test-custom-dataset-uuid"
+    dataset.columns = []
+    dataset.metrics = []
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "uuid": dataset.uuid,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+        "columns": dataset.columns,
+        "metrics": dataset.metrics,
+    }
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(
+            select_columns=["id", "table_name", "uuid"], page=1, page_size=10
+        )
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        data = json.loads(result.content[0].text)
+        assert data["count"] == 1
+        assert data["datasets"][0]["uuid"] == "test-custom-dataset-uuid"
+
+        # Verify custom columns include UUID
+        assert "uuid" in data["columns_requested"]
+        assert "uuid" in data["columns_loaded"]
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_with_filters(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 2
+    dataset.table_name = "Filtered Dataset"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/2"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "sum"
+    metric1.verbose_name = "Sum"
+    metric1.expression = "SUM(value)"
+    metric1.description = "Sum of values"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    filters = [
+        {"col": "table_name", "opr": "sw", "value": "Sales"},
+        {"col": "schema", "opr": "eq", "value": "main"},
+    ]
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(
+            filters=filters,
+            select_columns=["id", "table_name"],
+            order_column="changed_on",
+            order_direction="desc",
+            page=1,
+            page_size=50,
+        )
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 2
+        assert data["datasets"][0]["table_name"] == "Filtered Dataset"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 1
+        assert len(data["datasets"][0]["metrics"]) == 1
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_with_string_filters(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 3
+    dataset.table_name = "String Filter Dataset"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/3"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:  # noqa: F841
+        with pytest.raises(ValueError, match="Input should be a valid list"):
+            # This should fail validation since filters expects a list, not a string
+            ListDatasetsRequest(  # noqa: F841
+                filters='[{"col": "table_name", "opr": "sw", "value": "Sales"}]'
+            )
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_api_error(mock_list, mcp_server):
+    mock_list.side_effect = ToolError("API request failed")
+    async with Client(mcp_server) as client:
+        with pytest.raises(ToolError) as excinfo:  # noqa: PT012
+            request = ListDatasetsRequest()
+            await client.call_tool("list_datasets", {"request": request.model_dump()})
+        assert "API request failed" in str(excinfo.value)
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_with_search(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "search_table"
+    dataset.schema = "public"
+    dataset.database_name = "test_db"
+    dataset.database = None
+    dataset.description = "A test dataset"
+    dataset.changed_by = "admin"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by = "admin"
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = None
+    dataset.url = None
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "count"
+    metric1.verbose_name = "Count"
+    metric1.expression = "COUNT(*)"
+    metric1.description = "Row count"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(search="search_table")
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 1
+        assert data["datasets"][0]["table_name"] == "search_table"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 1
+        assert len(data["datasets"][0]["metrics"]) == 1
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_simple_with_search(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 2
+    dataset.table_name = "simple_search"
+    dataset.schema = "analytics"
+    dataset.database_name = "analytics_db"
+    dataset.database = None
+    dataset.description = "Another test dataset"
+    dataset.changed_by = "user"
+    dataset.changed_by_name = "user"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by = "user"
+    dataset.created_by_name = "user"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = True
+    dataset.database_id = 2
+    dataset.schema_perm = None
+    dataset.url = None
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "count"
+    metric1.verbose_name = "Count"
+    metric1.expression = "COUNT(*)"
+    metric1.description = "Row count"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(search="simple_search")
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 2
+        assert data["datasets"][0]["table_name"] == "simple_search"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 1
+        assert len(data["datasets"][0]["metrics"]) == 1
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_simple_basic(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "Test DatasetInfo"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/1"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "count"
+    metric1.verbose_name = "Count"
+    metric1.expression = "COUNT(*)"
+    metric1.description = "Row count"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    filters = [
+        {"col": "table_name", "opr": "eq", "value": "Test DatasetInfo"},
+        {"col": "schema", "opr": "eq", "value": "main"},
+    ]
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(filters=filters)
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 1
+        assert data["datasets"][0]["table_name"] == "Test DatasetInfo"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 1
+        assert len(data["datasets"][0]["metrics"]) == 1
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_simple_with_filters(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 2
+    dataset.table_name = "Sales Dataset"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/2"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "sum"
+    metric1.verbose_name = "Sum"
+    metric1.expression = "SUM(value)"
+    metric1.description = "Sum of values"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    dataset._mapping = {
+        "id": dataset.id,
+        "table_name": dataset.table_name,
+        "schema": dataset.schema,
+        "database_name": dataset.database.database_name,
+        "description": dataset.description,
+        "changed_by_name": dataset.changed_by_name,
+        "changed_on": dataset.changed_on,
+        "changed_on_humanized": dataset.changed_on_humanized,
+        "created_by_name": dataset.created_by_name,
+        "created_on": dataset.created_on,
+        "created_on_humanized": dataset.created_on_humanized,
+        "tags": dataset.tags,
+        "owners": dataset.owners,
+        "is_virtual": dataset.is_virtual,
+        "database_id": dataset.database_id,
+        "schema_perm": dataset.schema_perm,
+        "url": dataset.url,
+        "sql": dataset.sql,
+        "main_dttm_col": dataset.main_dttm_col,
+        "offset": dataset.offset,
+        "cache_timeout": dataset.cache_timeout,
+        "params": dataset.params,
+        "template_params": dataset.template_params,
+        "extra": dataset.extra,
+    }
+    mock_list.return_value = ([dataset], 1)
+    filters = [
+        {"col": "table_name", "opr": "sw", "value": "Sales"},
+        {"col": "schema", "opr": "eq", "value": "main"},
+    ]
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(filters=filters)
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["datasets"] is not None
+        assert len(data["datasets"]) == 1
+        assert data["datasets"][0]["id"] == 2
+        assert data["datasets"][0]["table_name"] == "Sales Dataset"
+        # Check that columns and metrics are included
+        assert len(data["datasets"][0]["columns"]) == 1
+        assert len(data["datasets"][0]["metrics"]) == 1
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_simple_api_error(mock_list, mcp_server):
+    mock_list.side_effect = Exception("API request failed")
+    filters = [
+        {"col": "table_name", "opr": "sw", "value": "Sales"},
+        {"col": "schema", "opr": "eq", "value": "main"},
+    ]
+    async with Client(mcp_server) as client:
+        with pytest.raises(ToolError) as excinfo:  # noqa: PT012
+            request = ListDatasetsRequest(filters=filters)
+            await client.call_tool("list_datasets", {"request": request.model_dump()})
+        assert "API request failed" in str(excinfo.value)
+
+
+@patch("superset.daos.dataset.DatasetDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dataset_info_success(mock_info, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "Test DatasetInfo"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/1"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    # Add proper mock columns and metrics
+    col1 = MagicMock()
+    col1.column_name = "id"
+    col1.verbose_name = "ID"
+    col1.type = "INTEGER"
+    col1.is_dttm = False
+    col1.groupby = True
+    col1.filterable = True
+    col1.description = "Primary key"
+
+    metric1 = MagicMock()
+    metric1.metric_name = "count"
+    metric1.verbose_name = "Count"
+    metric1.expression = "COUNT(*)"
+    metric1.description = "Row count"
+    metric1.d3format = None
+
+    dataset.columns = [col1]
+    dataset.metrics = [metric1]
+    mock_info.return_value = dataset
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dataset_info", {"request": {"identifier": 1}}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["id"] == 1
+        assert data["table_name"] == "Test DatasetInfo"
+        assert data["database_name"] == "examples"
+        # Check that columns and metrics are included
+        assert len(data["columns"]) == 1
+        assert len(data["metrics"]) == 1
+        assert data["columns"][0]["column_name"] == "id"
+        assert data["metrics"][0]["metric_name"] == "count"
+
+
+@patch("superset.daos.dataset.DatasetDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dataset_info_not_found(mock_info, mcp_server):
+    mock_info.return_value = None  # Not found returns None
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dataset_info", {"request": {"identifier": 999}}
+        )
+        assert result.data["error_type"] == "not_found"
+
+
+# TODO (Phase 3+): Add tests for get_dataset_available_filters tool
+
+
+@pytest.mark.asyncio
+async def test_invalid_filter_column_raises(mcp_server):
+    async with fastmcp.Client(mcp_server) as client:  # noqa: F841
+        with pytest.raises(ValueError, match="Input should be"):
+            # This should fail validation at the schema level due to invalid column name
+            ListDatasetsRequest(  # noqa: F841
+                filters=[{"col": "not_a_column", "opr": "eq", "value": "foo"}]
+            )
+
+
+@patch("superset.daos.dataset.DatasetDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dataset_info_includes_columns_and_metrics(mock_info, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 10
+    dataset.table_name = "Dataset With Columns"
+    dataset.schema = "main"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/10"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.columns = [
+        MagicMock(
+            column_name="col1",
+            verbose_name="Column 1",
+            type="INTEGER",
+            is_dttm=False,
+            groupby=True,
+            filterable=True,
+            description="First column",
+        ),
+        MagicMock(
+            column_name="col2",
+            verbose_name="Column 2",
+            type="VARCHAR",
+            is_dttm=False,
+            groupby=False,
+            filterable=True,
+            description="Second column",
+        ),
+    ]
+    dataset.metrics = [
+        MagicMock(
+            metric_name="sum_sales",
+            verbose_name="Sum Sales",
+            expression="SUM(sales)",
+            description="Total sales",
+            d3format=None,
+        ),
+        MagicMock(
+            metric_name="count_orders",
+            verbose_name="Count Orders",
+            expression="COUNT(orders)",
+            description="Order count",
+            d3format=None,
+        ),
+    ]
+    mock_info.return_value = dataset
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dataset_info", {"request": {"identifier": 10}}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["table_name"] == "Dataset With Columns"
+        assert data["database_name"] == "examples"
+        # Check that columns and metrics are included
+        assert len(data["columns"]) == 2
+        assert len(data["metrics"]) == 2
+        assert data["columns"][0]["column_name"] == "col1"
+        assert data["columns"][1]["column_name"] == "col2"
+        assert data["metrics"][0]["metric_name"] == "sum_sales"
+        assert data["metrics"][1]["metric_name"] == "count_orders"
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+async def test_list_datasets_includes_columns_and_metrics(mock_list, mcp_server):
+    dataset = MagicMock()
+    dataset.id = 11
+    dataset.table_name = "DatasetList With Columns"
+    dataset.schema = "main"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/11"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.columns = [
+        MagicMock(
+            column_name="colA",
+            verbose_name="Column A",
+            type="FLOAT",
+            is_dttm=False,
+            groupby=True,
+            filterable=True,
+            description="A column",
+        ),
+    ]
+    dataset.metrics = [
+        MagicMock(
+            metric_name="avg_value",
+            verbose_name="Avg Value",
+            expression="AVG(value)",
+            description="Average value",
+            d3format=None,
+        ),
+    ]
+    mock_list.return_value = ([dataset], 1)
+    async with Client(mcp_server) as client:
+        request = ListDatasetsRequest(page=1, page_size=10)
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+        datasets = result.data.datasets
+        assert len(datasets) == 1
+        ds = datasets[0]
+        assert hasattr(ds, "columns")
+        assert hasattr(ds, "metrics")
+        assert isinstance(ds.columns, list)
+        assert isinstance(ds.metrics, list)
+        assert len(ds.columns) == 1
+        assert len(ds.metrics) == 1
+        assert ds.columns[0].column_name == "colA"
+        assert ds.metrics[0].metric_name == "avg_value"
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore._find_object")
+@pytest.mark.asyncio
+async def test_get_dataset_info_by_uuid(mock_find_object, mcp_server):
+    """Test getting dataset info using UUID identifier."""
+    dataset = MagicMock()
+    dataset.id = 1
+    dataset.table_name = "Test Dataset UUID"
+    dataset.schema = "main"
+    dataset.description = "desc"
+    dataset.changed_by_name = "admin"
+    dataset.changed_on = None
+    dataset.changed_on_humanized = None
+    dataset.created_by_name = "admin"
+    dataset.created_on = None
+    dataset.created_on_humanized = None
+    dataset.tags = []
+    dataset.owners = []
+    dataset.is_virtual = False
+    dataset.database_id = 1
+    dataset.schema_perm = "[examples].[main]"
+    dataset.url = "/tablemodelview/edit/1"
+    dataset.database = MagicMock()
+    dataset.database.database_name = "examples"
+    dataset.sql = None
+    dataset.main_dttm_col = None
+    dataset.offset = 0
+    dataset.cache_timeout = 0
+    dataset.params = {}
+    dataset.template_params = {}
+    dataset.extra = {}
+    dataset.columns = []
+    dataset.metrics = []
+
+    mock_find_object.return_value = dataset
+    async with Client(mcp_server) as client:
+        uuid_str = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        result = await client.call_tool(
+            "get_dataset_info", {"request": {"identifier": uuid_str}}
+        )
+        assert result.content is not None
+        data = json.loads(result.content[0].text)
+        assert data["id"] == 1
+        assert data["table_name"] == "Test Dataset UUID"
+
+
+class TestDatasetSortableColumns:
+    """Test sortable columns configuration for dataset tools."""
+
+    def test_dataset_sortable_columns_definition(self):
+        """Test that dataset sortable columns are properly defined."""
+        from superset.mcp_service.dataset.tool.list_datasets import (
+            SORTABLE_DATASET_COLUMNS,
+        )
+
+        assert SORTABLE_DATASET_COLUMNS == [
+            "id",
+            "table_name",
+            "schema",
+            "changed_on",
+            "created_on",
+        ]
+        # Ensure no computed properties are included
+        assert "changed_on_delta_humanized" not in SORTABLE_DATASET_COLUMNS
+        assert "changed_by_name" not in SORTABLE_DATASET_COLUMNS
+        assert "database_name" not in SORTABLE_DATASET_COLUMNS
+        assert "uuid" not in SORTABLE_DATASET_COLUMNS
+
+    @patch("superset.daos.dataset.DatasetDAO")
+    @patch("superset.mcp_service.auth.get_user_from_request")
+    @pytest.mark.asyncio
+    async def test_list_datasets_with_valid_order_column(
+        self, mock_get_user, mock_dataset_dao
+    ):
+        """Test list_datasets with valid order column."""
+        from superset.mcp_service.dataset.tool.list_datasets import list_datasets
+
+        mock_get_user.return_value = MagicMock(id=1)
+        mock_tool = MagicMock()
+        mock_tool.run_tool.return_value = MagicMock(datasets=[], count=0)
+        mock_ctx = MagicMock()
+        mock_ctx.info = AsyncMock()
+        mock_ctx.debug = AsyncMock()
+
+        with patch(
+            "superset.mcp_service.dataset.tool.list_datasets.ModelListCore",
+            return_value=mock_tool,
+        ):
+            # Test with valid sortable column
+            request = ListDatasetsRequest(
+                order_column="table_name", order_direction="asc"
+            )
+            await list_datasets.fn(request, mock_ctx)
+
+            # Verify the tool was called with the correct order column
+            mock_tool.run_tool.assert_called_once()
+            call_args = mock_tool.run_tool.call_args[1]
+            assert call_args["order_column"] == "table_name"
+            assert call_args["order_direction"] == "asc"
+
+    def test_sortable_columns_in_docstring(self):
+        """Test that sortable columns are documented in tool docstring."""
+        from superset.mcp_service.dataset.tool.list_datasets import (
+            list_datasets,
+            SORTABLE_DATASET_COLUMNS,
+        )
+
+        # Check list_datasets docstring (stored in description after @mcp.tool)
+        assert hasattr(list_datasets, "description")
+        assert "Sortable columns for order_column:" in list_datasets.description
+        for col in SORTABLE_DATASET_COLUMNS:
+            assert col in list_datasets.description
+
+    @pytest.mark.asyncio
+    async def test_default_ordering(self):
+        """Test default ordering behavior for datasets."""
+        from superset.mcp_service.dataset.tool.list_datasets import list_datasets
+
+        # Test that when no order_column is specified, None is passed
+        with patch(
+            "superset.mcp_service.dataset.tool.list_datasets.ModelListCore"
+        ) as mock_tool:
+            with patch("superset.mcp_service.auth.get_user_from_request"):
+                mock_tool.return_value.run_tool.return_value = MagicMock(
+                    datasets=[], count=0
+                )
+                mock_ctx = MagicMock()
+                mock_ctx.info = AsyncMock()
+                mock_ctx.debug = AsyncMock()
+                request = ListDatasetsRequest()  # No order specified
+                await list_datasets.fn(request, mock_ctx)
+
+                call_args = mock_tool.return_value.run_tool.call_args[1]
+                assert call_args["order_column"] is None  # None when not specified
+                assert (
+                    call_args["order_direction"] == "desc"
+                )  # From ListDatasetsRequest default


### PR DESCRIPTION
### SUMMARY

This PR adds 6 new MCP tools for dashboard and dataset management, expanding the MCP service to provide comprehensive read access to Superset's core resources.

**Built on top of:** PR #6 (feat/mcp_service_pr2_chart_listing_and_info) - Chart listing and info tools

**What's Included:**

## Dashboard Tools (3 tools)

**list_dashboards** - Paginated dashboard listing
- Filter by: dashboard_title, published, favorite
- Search across dashboard fields
- Sort by: id, dashboard_title, slug, published, changed_on, created_on
- Returns: DashboardList with UUID, slug, charts, owners
- 1-based pagination (page, page_size parameters)

**get_dashboard_info** - Retrieve dashboard details
- Lookup by integer ID, UUID string, or slug
- Returns: Complete dashboard metadata (title, position_json, charts, owners, roles)
- Supports all three identifier types (ID/UUID/slug)
- Consistent error responses with DashboardError schema

**get_dashboard_available_filters** - List filterable columns
- Returns available filter fields and operators
- Helps LLMs discover what dashboard fields can be filtered
- Returns: DashboardAvailableFilters with column/operator metadata

## Dataset Tools (3 tools)

**list_datasets** - Paginated dataset listing
- Filter by: table_name, schema, owner, favorite
- Search across dataset fields
- Sort by: id, table_name, schema, changed_on, created_on
- Returns: DatasetList with columns and metrics for each dataset
- 1-based pagination (page, page_size parameters)

**get_dataset_info** - Retrieve dataset details
- Lookup by integer ID or UUID string
- Returns: Complete dataset metadata including:
  - Column definitions with types and expressions
  - Metrics with SQL expressions
  - Schema, database, table information
- Consistent error responses with DatasetError schema

**get_dataset_available_filters** - List filterable columns
- Returns available filter fields and operators
- Helps LLMs discover what dataset fields can be filtered
- Returns: DatasetAvailableFilters with column/operator metadata

## Core Infrastructure (579 lines)

**mcp_core.py** (expanded to 506 lines, +209 lines):
- **ModelGetAvailableFiltersCore**: Generic base class for get_*_available_filters tools
  - Type-safe with `Generic[T]` for proper type inference
  - Works with any Superset DAO (DashboardDAO, DatasetDAO, etc.)
  - Returns filterable columns and supported operators

**utils/retry_utils.py** (340 lines):
- RetryableOperation class for database resilience
- Exponential backoff for transient failures
- Used by DAO operations throughout MCP service

**CLAUDE.md** (431 lines):
- Comprehensive guide for LLM agents working on MCP service
- Architecture overview and directory structure
- Tool development patterns and conventions
- Critical pitfalls to avoid
- Quick checklist for adding new tools

## Schemas (1,107 lines)

**dashboard/schemas.py** (418 lines):
- `DashboardInfo`: Detailed dashboard metadata model
- `DashboardList`: Paginated list response with PaginationInfo
- `DashboardError`: Consistent error responses
- `DashboardFilter`: Filter specification (col, opr, value)
- `ListDashboardsRequest`, `GetDashboardInfoRequest`: Tool request models
- `DashboardAvailableFilters`, `GetDashboardAvailableFiltersRequest`: Filter metadata

**dataset/schemas.py** (349 lines):
- `DatasetInfo`: Detailed dataset metadata model with columns/metrics
- `DatasetList`: Paginated list response with PaginationInfo
- `DatasetError`: Consistent error responses
- `DatasetFilter`: Filter specification (col, opr, value)
- `ListDatasetsRequest`, `GetDatasetInfoRequest`: Tool request models
- `DatasetAvailableFilters`, `GetDatasetAvailableFiltersRequest`: Filter metadata

**chart/schemas.py** (expanded to 793 lines, +510 lines):
- Added `serialize_chart_object()` helper for dashboard chart serialization
- Enhanced chart metadata extraction
- Used by dashboard tools to serialize embedded charts

**system/schemas.py** (expanded to 111 lines, +24 lines):
- Enhanced type safety with TYPE_CHECKING imports
- Additional shared schemas used across tools

## Testing (1,804 lines)

**test_dashboard_tools.py** (573 lines, 15 tests):
- Schema validation tests for DashboardInfo, DashboardList, DashboardFilter
- Request/response model validation
- list_dashboards: Basic, filters, search, custom columns, sorting tests
- get_dashboard_info: ID lookup, UUID lookup, slug lookup, not found cases
- Filter specification tests

**test_dataset_tools.py** (1,231 lines, 20 tests):
- Schema validation tests for DatasetInfo, DatasetList, DatasetFilter
- Request/response model validation
- list_datasets: Basic, filters, search, custom columns, sorting tests
- get_dataset_info: ID lookup, UUID lookup, not found cases, columns/metrics
- Filter specification tests
- Default ordering tests

**test_chart_schemas.py** (160 lines, 11 tests):
- XYChartConfig validation tests (label uniqueness, duplicate detection)
- TableChartConfig validation tests
- Chart configuration edge cases

**Total: 62 MCP tests passing** (11 chart + 15 dashboard + 20 dataset + 16 core)

## Integration

**app.py** (13 new lines):
```python
from superset.mcp_service.dashboard.tool import (  # noqa: F401, E402
    get_dashboard_available_filters,
    get_dashboard_info,
    list_dashboards,
)
from superset.mcp_service.dataset.tool import (  # noqa: F401, E402
    get_dataset_available_filters,
    get_dataset_info,
    list_datasets,
)
```

This follows the established pattern: tool imports in app.py auto-register via `@mcp.tool` decorators.

## Architecture & Patterns

All 6 tools follow the same reusable patterns established in PR #6:

1. **Use core classes**: ModelListCore for listing, ModelGetInfoCore for retrieval, ModelGetAvailableFiltersCore for filter metadata
2. **Pydantic schemas**: Type-safe requests/responses with Field descriptions for LLMs
3. **DAO pattern**: DashboardDAO and DatasetDAO for database access
4. **Authentication**: All tools use @mcp_auth_hook for security
5. **Type safety**: Modern Python 3.10+ type hints (`T | None` instead of `Optional[T]`)
6. **Consistent errors**: Structured error responses with timestamps

**Reusability:**
- Core classes work with any Superset entity (charts, dashboards, datasets, etc.)
- Just provide the DAO class and schema - the rest is handled automatically
- Same pattern will be used for upcoming chart creation and SQL Lab tools

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend MCP service infrastructure only, no UI changes.

**Example tool usage via Claude Desktop:**

```
User: "List all published dashboards"
Claude calls: list_dashboards({
  "filters": [{"col": "published", "opr": "eq", "value": true}]
})

User: "Show me the Sales Dashboard details"
Claude calls: get_dashboard_info({"identifier": "sales-dashboard"})

User: "List datasets in the analytics schema"
Claude calls: list_datasets({
  "filters": [{"col": "schema", "opr": "eq", "value": "analytics"}]
})

User: "What columns are in dataset 42?"
Claude calls: get_dataset_info({"identifier": 42})
```

### TESTING INSTRUCTIONS

**Prerequisites:**
- Superset running with PR #6 (chart tools) merged
- Python 3.10 or 3.11
- fastmcp installed (`pip install -e .[development]`)

**Setup:**

```bash
# 1. Ensure database is initialized
export FLASK_APP=superset
superset db upgrade
superset init

# 2. Create admin user (if not already done)
superset fab create-admin \
  --username admin \
  --firstname Admin \
  --lastname Admin \
  --email admin@localhost \
  --password admin

# 3. Load example data (for testing)
superset load-examples
```

**Run Tests:**

```bash
# Run all MCP service unit tests
pytest tests/unit_tests/mcp_service/ -v

# Should see:
# - test_chart_schemas.py: 11 chart schema tests passing
# - test_list_charts.py: Chart tool tests passing
# - test_dashboard_tools.py: 15 dashboard tests passing
# - test_dataset_tools.py: 20 dataset tests passing
# - test_mcp_core.py: Core infrastructure tests passing
# Total: 62 tests passing
```

**Test with MCP Server:**

```bash
# Terminal 1: Start Superset
superset run -p 9001

# Terminal 2: Start MCP service
superset mcp run --port 5008 --debug

# Terminal 3: Test with curl
curl http://localhost:5008/health

# Expected: {"status": "ok", "timestamp": "...", ...}
```

**Test Tools via Claude Desktop:**

Configure Claude Desktop with:
```json
{
  "mcpServers": {
    "superset": {
      "command": "superset",
      "args": ["mcp", "run", "--port", "5008"]
    }
  }
}
```

Then test queries:
- "List all dashboards" → Should call list_dashboards tool
- "Show me dashboard 1" → Should call get_dashboard_info tool
- "List all datasets" → Should call list_datasets tool
- "What columns are in dataset 5?" → Should call get_dataset_info tool
- "What can I filter dashboards by?" → Should call get_dashboard_available_filters

**Verify Error Handling:**

```python
# Test in Python shell with Flask app context
from superset.mcp_service.dashboard.tool import list_dashboards, get_dashboard_info
from superset.mcp_service.dataset.tool import list_datasets, get_dataset_info

# Test pagination
result = list_dashboards.fn(page=1, page_size=10)
assert result.pagination.page == 1

# Test filtering
result = list_dashboards.fn(filters=[{"col": "published", "opr": "eq", "value": True}])
assert all(d.published for d in result.dashboards)

# Test not found
result = get_dashboard_info.fn(identifier=99999)
assert result.error is not None

# Test dataset with columns
result = get_dataset_info.fn(identifier=1)
assert result.columns is not None
assert len(result.columns) > 0
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [x] Introduces new feature or API: Yes - MCP dashboard and dataset tools
- [ ] Removes existing feature or API: No

**Stats:**
- 24 files changed
- 5,294 insertions, 19 deletions
- 1,804 lines of tests (35 test cases: 15 dashboard + 20 dataset)
- 100% mypy compliant
- All pre-commit hooks passing

**Future PRs will add:**
- Chart creation tools (generate_chart, update_chart, generate_chart_preview)
- Dashboard creation tools (generate_dashboard, add_chart_to_dashboard)
- SQL Lab integration tools (execute_sql, open_sql_lab_with_context)
- Advanced authentication (JWT validation, user impersonation)
- Field-level permissions and audit logging

**Notes:**
- Builds cleanly on PR #6 (chart tools)
- Minimal changes to existing code (only app.py imports)
- No database migrations
- No UI changes
- Optional dependency (fastmcp in development requirements only)
- All tools follow established patterns from PR #6
