### PR TITLE
fix: Replace deprecated min parameter with validate=Range() to support marshmallow>=4.0.0

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -657,7 +657,14 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "the future",
             "example": 7,
         },
-        min=0,
+        # Use validate=Range() instead of min parameter for Marshmallow 4.0+ compatibility
+        validate=[
+            Range(
+                min=0,
+                min_inclusive=True,
+                error=_("`periods` must be greater than or equal to 0"),
+            )
+        ],
         required=True,
     )
     confidence_interval = fields.Float(

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -657,13 +657,14 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "the future",
             "example": 7,
         },
-        # Use validate=Range() instead of min parameter for Marshmallow 4.0+ compatibility
         validate=[
             Range(
                 min=0,
                 min_inclusive=True,
-                error=_("`periods` must be greater than or equal to 0"),
-            )
+                error=_(
+                    "`periods` must be greater than or equal to 0"
+                    ),
+            ),
         ],
         required=True,
     )

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -661,9 +661,7 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             Range(
                 min=0,
                 min_inclusive=True,
-                error=_(
-                    "`periods` must be greater than or equal to 0"
-                    ),
+                error=_("`periods` must be greater than or equal to 0"),
             ),
         ],
         required=True,


### PR DESCRIPTION
…shmallow>=4.0.0

Fixes #33162 : update Prophet schema for Marshmallow>=4.0.0 compatibility



### SUMMARY
Fixes Marshmallow 4.0 compatibility issue in `ChartDataProphetOptionsSchema`. 

periods field was using `min` which was deprecated in the marshmallow>=4.0.0. This caused a `TypeError: __init__() got an unexpected keyword argument 'min'`

Used `validate=Range()` instead of `min`, which is compatible with both Marshmallow>=4.0.0.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend schema validation fix
