### PR TITLE
fix(db2): update time grain expressions for DAY to use DATE function

### DIFF
--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -48,11 +48,7 @@ class Db2EngineSpec(BaseEngineSpec):
         " - MINUTE({col}) MINUTES"
         " - SECOND({col}) SECONDS"
         " - MICROSECOND({col}) MICROSECONDS ",
-        TimeGrain.DAY: "CAST({col} as TIMESTAMP)"
-        " - HOUR({col}) HOURS"
-        " - MINUTE({col}) MINUTES"
-        " - SECOND({col}) SECONDS"
-        " - MICROSECOND({col}) MICROSECONDS",
+        TimeGrain.DAY: "DATE({col})",
         TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
         TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
         TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -138,7 +138,7 @@ def test_time_grain_day_parseable() -> None:
     from superset.db_engine_specs.db2 import Db2EngineSpec
 
     expression = Db2EngineSpec._time_grain_expressions[TimeGrain.DAY].format(
-        col="my_timestamp_col"
+        col="my_timestamp_col",
     )
     sql = f"SELECT {expression} FROM my_table"  # noqa: S608
 

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -18,6 +18,7 @@
 import pytest  # noqa: F401
 from pytest_mock import MockerFixture
 from sqlglot import parse_one
+from sqlglot.errors import ParseError
 
 from superset.constants import TimeGrain
 from superset.sql.parse import Table
@@ -83,7 +84,7 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize(
-    "grain,expected_expression",
+    ("grain", "expected_expression"),
     [
         (None, "my_col"),
         (
@@ -145,5 +146,5 @@ def test_time_grain_day_parseable() -> None:
     try:
         parsed = parse_one(sql)
         assert parsed is not None
-    except Exception as e:
+    except ParseError as e:
         pytest.fail(f"Failed to parse DAY time grain SQL: {e}")

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -17,7 +17,9 @@
 
 import pytest  # noqa: F401
 from pytest_mock import MockerFixture
+from sqlglot import parse_one
 
+from superset.constants import TimeGrain
 from superset.sql.parse import Table
 
 
@@ -78,3 +80,70 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
     assert Db2EngineSpec.get_prequeries(database, schema="my_schema") == [
         'set current_schema "my_schema"'
     ]
+
+
+@pytest.mark.parametrize(
+    "grain,expected_expression",
+    [
+        (None, "my_col"),
+        (
+            TimeGrain.SECOND,
+            "CAST(my_col as TIMESTAMP) - MICROSECOND(my_col) MICROSECONDS",
+        ),
+        (
+            TimeGrain.MINUTE,
+            "CAST(my_col as TIMESTAMP)"
+            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS",
+        ),
+        (
+            TimeGrain.HOUR,
+            "CAST(my_col as TIMESTAMP)"
+            " - MINUTE(my_col) MINUTES"
+            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS ",
+        ),
+        (TimeGrain.DAY, "DATE(my_col)"),
+        (TimeGrain.WEEK, "my_col - (DAYOFWEEK(my_col)) DAYS"),
+        (TimeGrain.MONTH, "my_col - (DAY(my_col)-1) DAYS"),
+        (
+            TimeGrain.QUARTER,
+            "my_col - (DAY(my_col)-1) DAYS"
+            " - (MONTH(my_col)-1) MONTHS + ((QUARTER(my_col)-1) * 3) MONTHS",
+        ),
+        (
+            TimeGrain.YEAR,
+            "my_col - (DAY(my_col)-1) DAYS - (MONTH(my_col)-1) MONTHS",
+        ),
+    ],
+)
+def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> None:
+    """
+    Test that time grain expressions generate the expected SQL.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    actual = Db2EngineSpec._time_grain_expressions[grain].format(col="my_col")
+    assert actual == expected_expression
+
+
+def test_time_grain_day_parseable() -> None:
+    """
+    Test that the DAY time grain expression generates valid SQL
+    that can be parsed by sqlglot.
+
+    This test addresses the bug where the previous expression
+    "CAST({col} as TIMESTAMP) - HOUR({col}) HOURS - ..."
+    could not be parsed by sqlglot.
+    """
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    expression = Db2EngineSpec._time_grain_expressions[TimeGrain.DAY].format(
+        col="my_timestamp_col"
+    )
+    sql = f"SELECT {expression} FROM my_table"  # noqa: S608
+
+    # This should not raise a ParseError
+    try:
+        parsed = parse_one(sql)
+        assert parsed is not None
+    except Exception as e:
+        pytest.fail(f"Failed to parse DAY time grain SQL: {e}")


### PR DESCRIPTION
fix(db2): use DATE() function for DAY time grain to fix sqlglot parsing error

### SUMMARY
Fixes the DB2 DAY time grain expression to use the standard `DATE()` function instead of complex timestamp arithmetic that could not be parsed by sqlglot. This resolves chart creation failures when applying daily time grains to timestamp columns in DB2 databases.

**Problem:**
The previous implementation used an invalid SQL expression for the DAY time grain:
```sql
CAST({col} as TIMESTAMP) - HOUR({col}) HOURS - MINUTE({col}) MINUTES - SECOND({col}) SECONDS - MICROSECOND({col}) MICROSECONDS
```

This syntax could not be parsed by sqlglot, causing `ParseError` exceptions and preventing users from creating charts with daily aggregations on DB2 databases.

**Solution:**
Changed the `TimeGrain.DAY` expression to use the simpler and more standard:
```sql
DATE({col})
```

This approach:
- Is valid DB2 SQL syntax that sqlglot can parse correctly
- Is more efficient and cleaner than the previous implementation
- Follows the same pattern used by MySQL's engine spec
- Maintains compatibility with all DB2 versions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend fix for SQL generation

### TESTING INSTRUCTIONS
1. Connect Superset to a DB2 database with a table containing timestamp columns
2. Create a chart using a timestamp column
3. Apply a "Day" time grain to the timestamp column
4. Verify the chart loads successfully without ParseError
5. Run unit tests: `pytest test_db2.py -v`
6. Verify all 14 tests pass, including the new `test_time_grain_day_parseable` test

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #35792 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Changes:**
- Modified db2.py - Updated `TimeGrain.DAY` expression
- Enhanced test_db2.py - Added comprehensive time grain tests including sqlglot parsing validation

**Test Coverage:**
- Added `test_time_grain_expressions` - Validates all time grain SQL expressions
- Added `test_time_grain_day_parseable` - Specifically tests that DAY grain produces parseable SQL
- All existing DB2 tests continue to pass
