### PR TITLE
fix: drag a metric very quickly，the order is chaotic.

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -96,7 +96,7 @@ function DndColumnSelect(props: DndColumnSelectProps) {
 
   const onShiftOptions = useCallback(
     (dragIndex: number, hoverIndex: number) => {
-      optionSelector.swap(dragIndex, hoverIndex);
+      optionSelector.reorder(dragIndex, hoverIndex);
       onChange(optionSelector.getValues());
     },
     [onChange, optionSelector],

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndColumnSelect.tsx
@@ -108,7 +108,7 @@ function DndColumnSelect(props: DndColumnSelectProps) {
 
   const onShiftOptions = useCallback(
     (dragIndex: number, hoverIndex: number) => {
-      optionSelector.swap(dragIndex, hoverIndex);
+      optionSelector.reorder(dragIndex, hoverIndex);
       onChange(optionSelector.getValues());
     },
     [onChange, optionSelector],

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -35,6 +35,7 @@ import {
   within,
 } from 'spec/helpers/testing-library';
 import { useDroppable } from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
 import AdhocMetric from 'src/explore/components/controls/MetricControl/AdhocMetric';
 import AdhocFilter from 'src/explore/components/controls/FilterControl/AdhocFilter';
 import { Operators } from 'src/explore/constants';
@@ -48,8 +49,11 @@ import { DndItemType } from '../../DndItemType';
 import { Datasource } from '../../../types';
 import {
   CapturedDroppable,
+  CapturedSortables,
   captureDroppableData,
+  captureSortableData,
   simulateDrop,
+  simulateReorder,
 } from './dndTestUtils';
 
 jest.mock('src/core/editors', () => ({
@@ -63,14 +67,22 @@ jest.mock('@dnd-kit/core', () => ({
   useDroppable: jest.fn(),
 }));
 
+jest.mock('@dnd-kit/sortable', () => ({
+  ...jest.requireActual('@dnd-kit/sortable'),
+  useSortable: jest.fn(),
+}));
+
 const captured: CapturedDroppable = { current: undefined };
+const sortables: CapturedSortables = { items: [] };
 
 beforeEach(() => {
   jest.clearAllMocks();
   captured.current = undefined;
+  sortables.items = [];
   (useDroppable as jest.Mock).mockImplementation(
     captureDroppableData(captured),
   );
+  (useSortable as jest.Mock).mockImplementation(captureSortableData(sortables));
 });
 
 const defaultProps: Omit<DndFilterSelectProps, 'datasource'> = {
@@ -135,6 +147,45 @@ test('renders with value', async () => {
     store,
   });
   expect(await screen.findByText('COUNT(*)')).toBeInTheDocument();
+});
+
+test('reorder commits the new filter order to onChange', async () => {
+  // Pins the fast-drag persistence fix: onShiftOptions must both update local
+  // state AND commit to the parent. Previously it only called setValues, so the
+  // reordered order showed in the UI but was never persisted (reverted on
+  // reload). Assert the COMMITTED array, not just the rendered order.
+  const onChange = jest.fn();
+  const filterA = new AdhocFilter({
+    sqlExpression: 'expr_a',
+    expressionType: ExpressionTypes.Sql,
+  });
+  const filterB = new AdhocFilter({
+    sqlExpression: 'expr_b',
+    expressionType: ExpressionTypes.Sql,
+  });
+  const filterC = new AdhocFilter({
+    sqlExpression: 'expr_c',
+    expressionType: ExpressionTypes.Sql,
+  });
+
+  render(
+    <DndFilterSelect
+      {...defaultProps}
+      datasource={PLACEHOLDER_DATASOURCE}
+      value={[filterA, filterB, filterC]}
+      onChange={onChange}
+    />,
+    { useDndKit: true, store },
+  );
+
+  // Move the first filter to the end: a multi-index move a swap would corrupt.
+  simulateReorder(sortables, 0, 2);
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  const committed = (onChange.mock.calls[0][0] as AdhocFilter[]).map(
+    filter => filter.sqlExpression,
+  );
+  expect(committed).toEqual(['expr_b', 'expr_c', 'expr_a']);
 });
 
 test('renders options with saved metric', async () => {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -252,12 +252,19 @@ const DndFilterSelect = (props: DndFilterSelectProps) => {
 
   const onShiftOptions = useCallback(
     (dragIndex: number, hoverIndex: number) => {
-      const newValues = [...values];
-      [newValues[hoverIndex], newValues[dragIndex]] = [
-        newValues[dragIndex],
-        newValues[hoverIndex],
-      ];
-      setValues(newValues);
+      if (
+        dragIndex === hoverIndex ||
+        dragIndex < 0 ||
+        hoverIndex < 0 ||
+        dragIndex >= values.length ||
+        hoverIndex >= values.length
+      ) {
+        return;
+      }
+      const newValue = [...values];
+      const [moved] = newValue.splice(dragIndex, 1);
+      newValue.splice(hoverIndex, 0, moved);
+      setValues(newValue);
     },
     [values],
   );

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -266,8 +266,12 @@ const DndFilterSelect = (props: DndFilterSelectProps) => {
       const [moved] = newValues.splice(dragIndex, 1);
       newValues.splice(hoverIndex, 0, moved);
       setValues(newValues);
+      // Commit the reordered array to the parent so the new order persists. The
+      // filter path has no separate drop-commit callback (unlike metrics), so
+      // this is the only place the reorder can propagate to form data.
+      onChange(newValues);
     },
-    [values],
+    [onChange, values],
   );
 
   const getMetricExpression = useCallback(

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.tsx
@@ -253,11 +253,18 @@ const DndFilterSelect = (props: DndFilterSelectProps) => {
 
   const onShiftOptions = useCallback(
     (dragIndex: number, hoverIndex: number) => {
+      if (
+        dragIndex === hoverIndex ||
+        dragIndex < 0 ||
+        hoverIndex < 0 ||
+        dragIndex >= values.length ||
+        hoverIndex >= values.length
+      ) {
+        return;
+      }
       const newValues = [...values];
-      [newValues[hoverIndex], newValues[dragIndex]] = [
-        newValues[dragIndex],
-        newValues[hoverIndex],
-      ];
+      const [moved] = newValues.splice(dragIndex, 1);
+      newValues.splice(hoverIndex, 0, moved);
       setValues(newValues);
     },
     [values],

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.test.tsx
@@ -437,6 +437,33 @@ test('can drag metrics (reorder dispatches through the reorder + drop path)', ()
   expect(onChange).toHaveBeenCalled();
 });
 
+test('reorder commits the new order to onChange, not the stale pre-drag order', () => {
+  // Pins the fast-drag persistence fix (#33951 follow-up): resolveDragEnd fires
+  // the reorder callback and the drop-commit in the same synchronous tick. A
+  // drop-commit that closes over the pre-drag `value` would re-commit the old
+  // order, so the reorder shows in the UI but reverts on reload. Assert the
+  // COMMITTED array (what reaches onChange), not just the rendered order.
+  const onChange = jest.fn();
+  render(
+    <DndMetricSelect
+      {...defaultProps}
+      value={['metric_a', 'metric_b', 'metric_c']}
+      onChange={onChange}
+      multi
+    />,
+    { useDndKit: true, useRedux: true },
+  );
+
+  // Move the first metric to the end: a multi-index move a swap would corrupt.
+  simulateReorder(sortables, 0, 2);
+
+  expect(onChange).toHaveBeenLastCalledWith([
+    'metric_b',
+    'metric_c',
+    'metric_a',
+  ]);
+});
+
 test('cannot drop a duplicated item', () => {
   const onChange = jest.fn();
   render(

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -238,14 +238,23 @@ const DndMetricSelect = (props: any) => {
 
   const moveLabel = useCallback(
     (dragIndex: number, hoverIndex: number) => {
-      const newValues = [...value];
-      [newValues[hoverIndex], newValues[dragIndex]] = [
-        newValues[dragIndex],
-        newValues[hoverIndex],
-      ];
-      setValue(newValues);
+      if (
+        dragIndex === hoverIndex ||
+        dragIndex < 0 ||
+        hoverIndex < 0 ||
+        dragIndex >= value.length ||
+        hoverIndex >= value.length
+      ) {
+        return;
+      }
+      // Use a pure function to reorder the array
+      const newValue = [...value];
+      const [moved] = newValue.splice(dragIndex, 1);
+      newValue.splice(hoverIndex, 0, moved);
+      setValue(newValue);
+      onChange(newValue);
     },
-    [value],
+    [value, onChange],
   );
 
   const newSavedMetricOptions = useMemo(

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -300,8 +300,13 @@ const DndMetricSelect = (props: any) => {
       const [moved] = newValues.splice(dragIndex, 1);
       newValues.splice(hoverIndex, 0, moved);
       setValue(newValues);
+      // Commit the freshly reordered array here rather than in handleDropLabel.
+      // resolveDragEnd fires the reorder callback and the drop-commit in the
+      // same synchronous tick, so a drop-commit that closes over `value` would
+      // re-commit the stale pre-drag order and revert the reorder on reload.
+      handleChange(newValues);
     },
-    [value],
+    [handleChange, value],
   );
 
   const newSavedMetricOptions = useMemo(
@@ -319,10 +324,10 @@ const DndMetricSelect = (props: any) => {
     [props.savedMetrics, props.value],
   );
 
-  const handleDropLabel = useCallback(
-    () => onChange(multi ? value : value[0]),
-    [multi, onChange, value],
-  );
+  // moveLabel already commits the reordered array via handleChange. The drop
+  // event is a no-op so it cannot re-commit the stale pre-drag `value` that its
+  // closure would otherwise capture (see resolveDragEnd + moveLabel above).
+  const handleDropLabel = useCallback(() => {}, []);
 
   const valueRenderer = useCallback(
     (option: ValueType, index: number) => (

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndMetricSelect.tsx
@@ -287,11 +287,18 @@ const DndMetricSelect = (props: any) => {
 
   const moveLabel = useCallback(
     (dragIndex: number, hoverIndex: number) => {
+      if (
+        dragIndex === hoverIndex ||
+        dragIndex < 0 ||
+        hoverIndex < 0 ||
+        dragIndex >= value.length ||
+        hoverIndex >= value.length
+      ) {
+        return;
+      }
       const newValues = [...value];
-      [newValues[hoverIndex], newValues[dragIndex]] = [
-        newValues[dragIndex],
-        newValues[hoverIndex],
-      ];
+      const [moved] = newValues.splice(dragIndex, 1);
+      newValues.splice(hoverIndex, 0, moved);
       setValue(newValues);
     },
     [value],

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.test.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.test.ts
@@ -40,3 +40,15 @@ test('reorder to the same index leaves the order unchanged', () => {
   selector.reorder(1, 1);
   expect(selector.getValues()).toEqual(['a', 'b', 'c']);
 });
+
+test('reorder ignores out-of-range indices instead of splicing in undefined', () => {
+  // A fast drag can resolve to a stale endpoint. Without a bounds guard, an
+  // out-of-range `from` splices `undefined` into the values and corrupts the
+  // list, blowing up downstream consumers.
+  const selector = newSelector(['a', 'b', 'c']);
+  selector.reorder(5, 0);
+  selector.reorder(0, 5);
+  selector.reorder(-1, 1);
+  selector.reorder(1, -1);
+  expect(selector.getValues()).toEqual(['a', 'b', 'c']);
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.test.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { OptionSelector } from './optionSelector';
+
+const newSelector = (values: string[]) => new OptionSelector({}, true, values);
+
+test('reorder moves an item across multiple positions without scrambling the rest', () => {
+  // Regression for #33951: a fast drag reorders across several indices in a
+  // single call. A swap would corrupt every position the cursor crossed, so
+  // moving the last item to the front must preserve the order of the others.
+  const selector = newSelector(['a', 'b', 'c', 'd', 'e']);
+  selector.reorder(4, 0);
+  expect(selector.getValues()).toEqual(['e', 'a', 'b', 'c', 'd']);
+});
+
+test('reorder moves an item from the front to the back', () => {
+  const selector = newSelector(['a', 'b', 'c', 'd', 'e']);
+  selector.reorder(0, 4);
+  expect(selector.getValues()).toEqual(['b', 'c', 'd', 'e', 'a']);
+});
+
+test('reorder to the same index leaves the order unchanged', () => {
+  const selector = newSelector(['a', 'b', 'c']);
+  selector.reorder(1, 1);
+  expect(selector.getValues()).toEqual(['a', 'b', 'c']);
+});

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -89,6 +89,11 @@ export class OptionSelector {
     [this.values[a], this.values[b]] = [this.values[b], this.values[a]];
   }
 
+  reorder(a: number, b: number) {
+    const [moved] = this.values.splice(a, 1);
+    this.values.splice(b, 0, moved);
+  }
+
   has(value: QueryFormColumn): boolean {
     return this.values.some(col => {
       if (isPhysicalColumn(value)) {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -89,6 +89,11 @@ export class OptionSelector {
     [this.values[a], this.values[b]] = [this.values[b], this.values[a]];
   }
 
+  reorder(from: number, to: number) {
+    const [moved] = this.values.splice(from, 1);
+    this.values.splice(to, 0, moved);
+  }
+
   has(value: QueryFormColumn): boolean {
     return this.values.some(col => {
       if (isPhysicalColumn(value)) {

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -90,6 +90,18 @@ export class OptionSelector {
   }
 
   reorder(from: number, to: number) {
+    // Guard against no-op and out-of-range indices. A fast drag can resolve to
+    // stale/identical endpoints; without this an out-of-range `from` splices
+    // `undefined` into the values and corrupts everything downstream.
+    if (
+      from === to ||
+      from < 0 ||
+      to < 0 ||
+      from >= this.values.length ||
+      to >= this.values.length
+    ) {
+      return;
+    }
     const [moved] = this.values.splice(from, 1);
     this.values.splice(to, 0, moved);
   }

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/utils/optionSelector.ts
@@ -89,6 +89,13 @@ export class OptionSelector {
     [this.values[a], this.values[b]] = [this.values[b], this.values[a]];
   }
 
+  /**
+   * Moves a value from one index to another, mutating `values` in place.
+   * No-ops on identical or out-of-range indices.
+   *
+   * @param from - original index
+   * @param to - destination index
+   */
   reorder(from: number, to: number) {
     // Guard against no-op and out-of-range indices. A fast drag can resolve to
     // stale/identical endpoints; without this an out-of-range `from` splices

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/AdhocFilterControl.test.tsx
@@ -18,9 +18,27 @@
  */
 import { render, screen } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
+import { useSortable } from '@dnd-kit/sortable';
 import AdhocFilterControl from '.';
 import AdhocFilter from '../AdhocFilter';
 import { Clauses, ExpressionTypes } from '../types';
+import {
+  CapturedSortables,
+  captureSortableData,
+  simulateReorder,
+} from '../../DndColumnSelectControl/dndTestUtils';
+
+jest.mock('@dnd-kit/sortable', () => ({
+  ...jest.requireActual('@dnd-kit/sortable'),
+  useSortable: jest.fn(),
+}));
+
+const sortables: CapturedSortables = { items: [] };
+
+beforeEach(() => {
+  sortables.items = [];
+  (useSortable as jest.Mock).mockImplementation(captureSortableData(sortables));
+});
 
 interface TestProps {
   name: string;
@@ -111,6 +129,40 @@ describe('AdhocFilterControl', () => {
     await userEvent.click(removeButton);
 
     expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  test('reorder commits the new filter order to onChange, not the stale order', () => {
+    // Pins the fast-drag persistence fix: resolveDragEnd fires the reorder
+    // callback and the drop-commit in the same tick. A drop-commit closing over
+    // the pre-drag `values` would re-commit the old order and revert the reorder
+    // on reload. Assert the COMMITTED array, not just the rendered order.
+    const filterA = new AdhocFilter({
+      expressionType: ExpressionTypes.Sql,
+      sqlExpression: 'expr_a',
+      clause: Clauses.Having,
+    });
+    const filterB = new AdhocFilter({
+      expressionType: ExpressionTypes.Sql,
+      sqlExpression: 'expr_b',
+      clause: Clauses.Having,
+    });
+    const filterC = new AdhocFilter({
+      expressionType: ExpressionTypes.Sql,
+      sqlExpression: 'expr_c',
+      clause: Clauses.Having,
+    });
+    const onChange = jest.fn();
+
+    renderComponent({ value: [filterA, filterB, filterC], onChange });
+
+    // Move the first filter to the end: a multi-index move a swap would corrupt.
+    simulateReorder(sortables, 0, 2);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const committed = (onChange.mock.calls[0][0] as AdhocFilter[]).map(
+      filter => filter.sqlExpression,
+    );
+    expect(committed).toEqual(['expr_b', 'expr_c', 'expr_a']);
   });
 
   test('should show add filter button when no filters exist', () => {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.jsx
@@ -285,14 +285,20 @@ class AdhocFilterControl extends Component {
   }
 
   moveLabel(dragIndex, hoverIndex) {
-    const { values } = this.state;
 
-    const newValues = [...values];
-    [newValues[hoverIndex], newValues[dragIndex]] = [
-      newValues[dragIndex],
-      newValues[hoverIndex],
-    ];
-    this.setState({ values: newValues });
+    const { values } = this.state;
+    if (
+      dragIndex === hoverIndex ||
+      dragIndex < 0 ||
+      hoverIndex < 0 ||
+      dragIndex >= values.length ||
+      hoverIndex >= values.length
+    ) {
+      return;
+    }
+    const [moved] = this.values.splice(dragIndex, 1);
+    this.values.splice(hoverIndex, 0, moved);
+    this.props.onChange(this.state.values);
   }
 
   mapOption(option) {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
@@ -321,27 +321,33 @@ function AdhocFilterControl({
     [values, onChange],
   );
 
-  const moveLabel = useCallback((dragIndex: number, hoverIndex: number) => {
-    setValues(prevValues => {
+  const moveLabel = useCallback(
+    (dragIndex: number, hoverIndex: number) => {
       if (
         dragIndex === hoverIndex ||
         dragIndex < 0 ||
         hoverIndex < 0 ||
-        dragIndex >= prevValues.length ||
-        hoverIndex >= prevValues.length
+        dragIndex >= values.length ||
+        hoverIndex >= values.length
       ) {
-        return prevValues;
+        return;
       }
-      const newValues = [...prevValues];
+      const newValues = [...values];
       const [moved] = newValues.splice(dragIndex, 1);
       newValues.splice(hoverIndex, 0, moved);
-      return newValues;
-    });
-  }, []);
+      setValues(newValues);
+      // Commit the freshly reordered array here rather than in onDropLabel.
+      // resolveDragEnd fires the reorder callback and the drop-commit in the
+      // same synchronous tick, so a drop-commit that closes over `values` would
+      // re-commit the stale pre-drag order and revert the reorder on reload.
+      onChange?.(newValues);
+    },
+    [onChange, values],
+  );
 
-  const onDropLabel = useCallback(() => {
-    onChange?.(values);
-  }, [onChange, values]);
+  // moveLabel already commits the reordered array. The drop event is a no-op so
+  // it cannot re-commit the stale pre-drag `values` its closure would capture.
+  const onDropLabel = useCallback(() => {}, []);
 
   const onNewFilter = useCallback(
     (newFilter: FilterOption | AdhocFilter) => {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterControl/index.tsx
@@ -323,11 +323,18 @@ function AdhocFilterControl({
 
   const moveLabel = useCallback((dragIndex: number, hoverIndex: number) => {
     setValues(prevValues => {
+      if (
+        dragIndex === hoverIndex ||
+        dragIndex < 0 ||
+        hoverIndex < 0 ||
+        dragIndex >= prevValues.length ||
+        hoverIndex >= prevValues.length
+      ) {
+        return prevValues;
+      }
       const newValues = [...prevValues];
-      [newValues[hoverIndex], newValues[dragIndex]] = [
-        newValues[dragIndex],
-        newValues[hoverIndex],
-      ];
+      const [moved] = newValues.splice(dragIndex, 1);
+      newValues.splice(hoverIndex, 0, moved);
       return newValues;
     });
   }, []);


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #33951
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
