### PR TITLE
fix(alerts): wrong alert trigger with custom query

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -120,11 +120,17 @@ class AlertCommand(BaseCommand):
 
     def _validate_operator(self, rows: np.recarray[Any, Any]) -> None:
         self._validate_result(rows)
-        if rows[0][1] in (0, None, np.nan):
+
+        if rows[0][1] is None or (
+            isinstance(rows[0][1], float) and np.isnan(rows[0][1])
+        ):
+            self._result = None
+            return
+
+        if rows[0][1] == 0:
             self._result = 0.0
             return
         try:
-            # Check if it's float or if we can convert it
             self._result = float(rows[0][1])
             return
         except (AssertionError, TypeError, ValueError) as ex:

--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -32,7 +32,6 @@ from superset import jinja_context, security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.report.exceptions import (
     AlertQueryError,
-    AlertQueryInfoException,
     AlertQueryInvalidTypeError,
     AlertQueryMultipleColumnsError,
     AlertQueryMultipleRowsError,
@@ -60,14 +59,17 @@ class AlertCommand(BaseCommand):
         self._report_schedule = report_schedule
         self._execution_id = execution_id
         self._result: float | None = None
+        self._info_message: str | None = None
 
-    def run(self) -> bool:
+    def run(self) -> tuple[bool, str | None]:
         """
         Executes an alert SQL query and validates it.
         Will set the report_schedule.last_value or last_value_row_json
         with the query result
 
-        :return: bool, if the alert triggered or not
+        :return: tuple[bool, str | None] - (triggered, message)
+            - triggered: True if alert condition was met
+            - message: Optional info message explaining why alert didn't trigger
         :raises AlertQueryError: SQL query is not valid
         :raises AlertQueryInvalidTypeError: The output from the SQL query
         is not an allowed type
@@ -80,23 +82,47 @@ class AlertCommand(BaseCommand):
 
         if self._is_validator_not_null:
             self._report_schedule.last_value_row_json = str(self._result)
-            return self._result not in (0, None, np.nan)
+            is_null_or_nan = self._result is None or pd.isna(self._result)
+            triggered = bool(self._result != 0 and not is_null_or_nan)
+            if not triggered:
+                logger.debug(
+                    "Alert not triggered for report_schedule_id=%s, "
+                    "execution_id=%s, result=%s, message=%s",
+                    self._report_schedule.id,
+                    self._execution_id,
+                    self._result,
+                    self._info_message,
+                )
+            return (triggered, self._info_message)
         self._report_schedule.last_value = self._result
         try:
-            operator = json.loads(self._report_schedule.validator_config_json)["op"]
-            threshold = json.loads(self._report_schedule.validator_config_json)[
-                "threshold"
-            ]
+            config = json.loads(self._report_schedule.validator_config_json)
+            operator = config["op"]
+            threshold = config["threshold"]
             # Return False for None results to prevent false alert triggers
             if self._result is None:
-                return False
-            return OPERATOR_FUNCTIONS[operator](self._result, threshold)
+                logger.debug(
+                    "Alert not triggered (NULL result) for report_schedule_id=%s, "
+                    "execution_id=%s, message=%s",
+                    self._report_schedule.id,
+                    self._execution_id,
+                    self._info_message,
+                )
+                return (False, self._info_message)
+            triggered = OPERATOR_FUNCTIONS[operator](self._result, threshold)
+            return (triggered, None)
         except (KeyError, json.JSONDecodeError) as ex:
             raise AlertValidatorConfigError() from ex
 
     def _validate_not_null(self, rows: np.recarray[Any, Any]) -> None:
         self._validate_result(rows)
-        self._result = rows[0][1]
+        value = rows[0][1]
+        # Normalize NULL/NaN to None for consistency with _validate_operator
+        if value is None or pd.isna(value):
+            self._result = None
+            self._info_message = "Query returned NULL value"
+            return
+        self._result = value
 
     @staticmethod
     def _validate_result(rows: np.recarray[Any, Any]) -> None:
@@ -122,11 +148,10 @@ class AlertCommand(BaseCommand):
     def _validate_operator(self, rows: np.recarray[Any, Any]) -> None:
         self._validate_result(rows)
 
-        if rows[0][1] is None or (
-            isinstance(rows[0][1], float) and np.isnan(rows[0][1])
-        ):
+        if rows[0][1] is None or pd.isna(rows[0][1]):
             self._result = None
-            raise AlertQueryInfoException("Query returned NULL value")
+            self._info_message = "Query returned NULL value"
+            return
 
         if rows[0][1] == 0:
             self._result = 0.0
@@ -222,15 +247,15 @@ class AlertCommand(BaseCommand):
             self._result = None
             return
         if df.empty and self._is_validator_operator:
-            logger.info(
+            logger.debug(
                 "Alert query returned empty result for report_schedule_id=%s, "
                 "execution_id=%s.",
                 self._report_schedule.id,
                 self._execution_id,
             )
-
             self._result = None
-            raise AlertQueryInfoException("Query returned no rows (empty result set)")
+            self._info_message = "Query returned no rows (empty result set)"
+            return
         rows = df.to_records()
         if self._is_validator_not_null:
             self._validate_not_null(rows)

--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -32,6 +32,7 @@ from superset import jinja_context, security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.report.exceptions import (
     AlertQueryError,
+    AlertQueryInfoException,
     AlertQueryInvalidTypeError,
     AlertQueryMultipleColumnsError,
     AlertQueryMultipleRowsError,
@@ -125,7 +126,7 @@ class AlertCommand(BaseCommand):
             isinstance(rows[0][1], float) and np.isnan(rows[0][1])
         ):
             self._result = None
-            return
+            raise AlertQueryInfoException("Query returned NULL value")
 
         if rows[0][1] == 0:
             self._result = 0.0
@@ -229,7 +230,7 @@ class AlertCommand(BaseCommand):
             )
 
             self._result = None
-            return
+            raise AlertQueryInfoException("Query returned no rows (empty result set)")
         rows = df.to_records()
         if self._is_validator_not_null:
             self._validate_not_null(rows)

--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -212,8 +212,22 @@ class AlertCommand(BaseCommand):
             self._result = None
             return
         if df.empty and self._is_validator_operator:
-            self._result = 0.0
-            return
+            logger.error(
+                "Alert query returned empty result for report_schedule_id=%s, "
+                "execution_id=%s. This may indicate a query error or no data "
+                "matching the WHERE conditions. Query: %s",
+                self._report_schedule.id,
+                self._execution_id,
+                self._report_schedule.sql[:500],
+            )
+            raise AlertQueryError(
+                message=_(
+                    (
+                        "Alert query returned no results. Please verify your query "
+                        "is correct and returns data."
+                    )
+                )
+            )
         rows = df.to_records()
         if self._is_validator_not_null:
             self._validate_not_null(rows)

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -253,18 +253,6 @@ class AlertQueryTimeout(CommandException):
     message = _("A timeout occurred while executing the query.")
 
 
-class AlertQueryInfoException(CommandException):
-    """
-    Informational exception for alert query results that don't trigger alerts.
-    """
-
-    status = 200
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-        self.message = message
-
-
 class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
     message = _("A timeout occurred while taking a screenshot.")

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -253,6 +253,18 @@ class AlertQueryTimeout(CommandException):
     message = _("A timeout occurred while executing the query.")
 
 
+class AlertQueryInfoException(CommandException):
+    """
+    Informational exception for alert query results that don't trigger alerts.
+    """
+
+    status = 200
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
 class ReportScheduleScreenshotTimeout(CommandException):
     status = 408
     message = _("A timeout occurred while taking a screenshot.")

--- a/tests/integration_tests/reports/alert_tests.py
+++ b/tests/integration_tests/reports/alert_tests.py
@@ -131,7 +131,9 @@ def test_execute_query_mutate_query_enabled(
         database=mock_database,
         validator_config_json='{"op": "==", "threshold": 1}',
     )
-    AlertCommand(report_schedule=report_schedule, execution_id=uuid.uuid4()).run()
+    triggered, message = AlertCommand(
+        report_schedule=report_schedule, execution_id=uuid.uuid4()
+    ).run()
 
     mock_mutate_call.assert_called_once_with(mock_limited_sql.return_value)
     mock_get_df.assert_called_once_with(sql=mock_mutate_call.return_value)
@@ -166,7 +168,9 @@ def test_execute_query_mutate_query_disabled(
         database=mock_database,
         validator_config_json='{"op": "==", "threshold": 1}',
     )
-    AlertCommand(report_schedule=report_schedule, execution_id=uuid.uuid4()).run()
+    triggered, message = AlertCommand(
+        report_schedule=report_schedule, execution_id=uuid.uuid4()
+    ).run()
 
     mock_database.mutate_sql_based_on_config.assert_not_called()
     mock_database.get_df.assert_called_once_with(

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -17,6 +17,7 @@
 
 from uuid import uuid4
 
+import numpy as np
 import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
@@ -165,3 +166,149 @@ def test_malformed_config_raises_error_even_with_empty_result(
 
     with pytest.raises(AlertValidatorConfigError):
         command.run()
+
+
+def test_query_returning_null_value_sets_result_to_none(
+    mocker: MockerFixture,
+) -> None:
+    """Test that query returning NULL value sets result to None (not 0)"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame({"value": [None]}),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": "<", "threshold": 0.75}'
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    command.validate()
+    assert command._result is None, "Query returning NULL should set result to None"
+
+    triggered = command.run()
+    assert triggered is False, "NULL value should not trigger alert"
+    assert report_schedule_mock.last_value is None
+
+
+def test_query_returning_zero_value_sets_result_to_zero(
+    mocker: MockerFixture,
+) -> None:
+    """Test that query returning 0 value sets result to 0.0 (not None)"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame({"value": [0]}),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": "<", "threshold": 0.75}'
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    command.validate()
+    assert command._result == 0.0, "Query returning 0 should set result to 0.0"
+
+    triggered = command.run()
+    assert triggered is True, "0 < 0.75 should trigger alert"
+    assert report_schedule_mock.last_value == 0.0
+
+
+def test_query_returning_nan_value_sets_result_to_none(
+    mocker: MockerFixture,
+) -> None:
+    """Test that query returning NaN value sets result to None (not 0)"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame({"value": [np.nan]}),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": ">", "threshold": 5}'
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    command.validate()
+    assert command._result is None, "Query returning NaN should set result to None"
+
+    triggered = command.run()
+    assert triggered is False, "NaN value should not trigger alert"
+    assert report_schedule_mock.last_value is None
+
+
+@pytest.mark.parametrize(
+    "value,expected_result,operator,threshold,should_trigger",
+    [
+        (None, None, "<", 0.75, False),
+        (0, 0.0, "<", 0.75, True),
+        (0.5, 0.5, "<", 0.75, True),
+        (1.0, 1.0, "<", 0.75, False),
+        (np.nan, None, ">", 5, False),
+        (0, 0.0, ">=", 0, True),
+        (None, None, "==", 0, False),
+    ],
+)
+def test_value_handling_comprehensive(
+    mocker: MockerFixture,
+    value: float | None,
+    expected_result: float | None,
+    operator: str,
+    threshold: float,
+    should_trigger: bool,
+) -> None:
+    """Comprehensive test for proper handling of 0, NULL, and NaN values"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame({"value": [value]}),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = (
+        f'{{"op": "{operator}", "threshold": {threshold}}}'
+    )
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    triggered = command.run()
+    assert command._result == expected_result, (
+        f"Value {value} should result in {expected_result}, got {command._result}"
+    )
+    assert triggered is should_trigger, (
+        f"Value {value} with {operator} {threshold} should "
+        f"{'trigger' if should_trigger else 'not trigger'} alert"
+    )
+    assert report_schedule_mock.last_value == expected_result

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from uuid import uuid4
+
+import pandas as pd
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.commands.report.alert import AlertCommand
+from superset.commands.report.exceptions import AlertQueryError
+from superset.reports.models import ReportScheduleValidatorType
+
+
+def test_empty_query_result_with_operator_validator_raises_error(
+    mocker: MockerFixture,
+) -> None:
+    """Test that empty results with operator validator raise AlertQueryError"""
+    # Mock the retry_call to directly call the function without backoff
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+
+    # Mock _execute_query to return empty DataFrame
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame(),
+    )
+
+    # Create mock report schedule with operator validator
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.id = 1
+    report_schedule_mock.sql = "SELECT value FROM metrics WHERE value < 0.75"
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    # Verify AlertQueryError is raised with correct message
+    with pytest.raises(AlertQueryError, match="Alert query returned no results"):
+        command.validate()

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -23,14 +23,17 @@ import pytest
 from pytest_mock import MockerFixture
 
 from superset.commands.report.alert import AlertCommand
-from superset.commands.report.exceptions import AlertValidatorConfigError
+from superset.commands.report.exceptions import (
+    AlertQueryInfoException,
+    AlertValidatorConfigError,
+)
 from superset.reports.models import ReportScheduleValidatorType, ReportState
 
 
-def test_empty_query_result_with_operator_validator_sets_none(
+def test_empty_query_result_with_operator_validator_raises_info_exception(
     mocker: MockerFixture,
 ) -> None:
-    """Test that empty results with operator validator set result to None"""
+    """Test that empty results with operator validator raises info exception"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
@@ -51,12 +54,11 @@ def test_empty_query_result_with_operator_validator_sets_none(
         execution_id=uuid4(),
     )
 
-    command.validate()
-    assert command._result is None
+    with pytest.raises(AlertQueryInfoException) as exc_info:
+        command.validate()
 
-    triggered = command.run()
-    assert triggered is False
-    assert report_schedule_mock.last_value is None
+    assert command._result is None
+    assert str(exc_info.value) == "Query returned no rows (empty result set)"
 
 
 @pytest.mark.parametrize(
@@ -75,7 +77,7 @@ def test_empty_result_prevents_false_alerts_for_all_operators(
     operator: str,
     threshold: float,
 ) -> None:
-    """Test that empty results don't trigger false alerts for any operator type"""
+    """Test that empty results raise info exception for any operator type"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
@@ -97,14 +99,16 @@ def test_empty_result_prevents_false_alerts_for_all_operators(
         execution_id=uuid4(),
     )
 
-    triggered = command.run()
-    assert triggered is False, (
-        f"Alert with operator '{operator}' should not trigger on empty results"
+    with pytest.raises(AlertQueryInfoException) as exc_info:
+        command.run()
+
+    assert str(exc_info.value) == "Query returned no rows (empty result set)", (
+        f"Alert with operator '{operator}' should raise info exception on empty results"
     )
 
 
 def test_empty_result_flow_sets_noop_state(mocker: MockerFixture) -> None:
-    """Test that empty results lead to NOOP state and no notification is sent"""
+    """Test that empty results lead to NOOP state with info message"""
     from superset.commands.report.execute import ReportNotTriggeredErrorState
 
     mocker.patch(
@@ -134,21 +138,23 @@ def test_empty_result_flow_sets_noop_state(mocker: MockerFixture) -> None:
 
     state.next()
 
-    update_mock.assert_any_call(ReportState.NOOP)
+    update_mock.assert_any_call(
+        ReportState.NOOP, error_message="Query returned no rows (empty result set)"
+    )
     send_mock.assert_not_called()
 
 
-def test_malformed_config_raises_error_even_with_empty_result(
+def test_malformed_config_raises_error_with_valid_result(
     mocker: MockerFixture,
 ) -> None:
-    """Test that malformed config is detected even when result is None"""
+    """Test that malformed config is detected when result is valid"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
     )
     mocker.patch(
         "superset.commands.report.alert.AlertCommand._execute_query",
-        return_value=pd.DataFrame(),
+        return_value=pd.DataFrame({"value": [0.5]}),
     )
 
     report_schedule_mock = mocker.Mock()
@@ -161,17 +167,14 @@ def test_malformed_config_raises_error_even_with_empty_result(
         execution_id=uuid4(),
     )
 
-    command.validate()
-    assert command._result is None
-
     with pytest.raises(AlertValidatorConfigError):
         command.run()
 
 
-def test_query_returning_null_value_sets_result_to_none(
+def test_query_returning_null_value_raises_info_exception(
     mocker: MockerFixture,
 ) -> None:
-    """Test that query returning NULL value sets result to None (not 0)"""
+    """Test that query returning NULL value raises info exception"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
@@ -191,12 +194,11 @@ def test_query_returning_null_value_sets_result_to_none(
         execution_id=uuid4(),
     )
 
-    command.validate()
-    assert command._result is None, "Query returning NULL should set result to None"
+    with pytest.raises(AlertQueryInfoException) as exc_info:
+        command.validate()
 
-    triggered = command.run()
-    assert triggered is False, "NULL value should not trigger alert"
-    assert report_schedule_mock.last_value is None
+    assert command._result is None, "Query returning NULL should set result to None"
+    assert str(exc_info.value) == "Query returned NULL value"
 
 
 def test_query_returning_zero_value_sets_result_to_zero(
@@ -230,10 +232,10 @@ def test_query_returning_zero_value_sets_result_to_zero(
     assert report_schedule_mock.last_value == 0.0
 
 
-def test_query_returning_nan_value_sets_result_to_none(
+def test_query_returning_nan_value_raises_info_exception(
     mocker: MockerFixture,
 ) -> None:
-    """Test that query returning NaN value sets result to None (not 0)"""
+    """Test that query returning NaN value raises info exception"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
@@ -253,35 +255,31 @@ def test_query_returning_nan_value_sets_result_to_none(
         execution_id=uuid4(),
     )
 
-    command.validate()
-    assert command._result is None, "Query returning NaN should set result to None"
+    with pytest.raises(AlertQueryInfoException) as exc_info:
+        command.validate()
 
-    triggered = command.run()
-    assert triggered is False, "NaN value should not trigger alert"
-    assert report_schedule_mock.last_value is None
+    assert command._result is None, "Query returning NaN should set result to None"
+    assert str(exc_info.value) == "Query returned NULL value"
 
 
 @pytest.mark.parametrize(
     "value,expected_result,operator,threshold,should_trigger",
     [
-        (None, None, "<", 0.75, False),
         (0, 0.0, "<", 0.75, True),
         (0.5, 0.5, "<", 0.75, True),
         (1.0, 1.0, "<", 0.75, False),
-        (np.nan, None, ">", 5, False),
         (0, 0.0, ">=", 0, True),
-        (None, None, "==", 0, False),
     ],
 )
-def test_value_handling_comprehensive(
+def test_value_handling_with_valid_numbers(
     mocker: MockerFixture,
-    value: float | None,
-    expected_result: float | None,
+    value: float,
+    expected_result: float,
     operator: str,
     threshold: float,
     should_trigger: bool,
 ) -> None:
-    """Comprehensive test for proper handling of 0, NULL, and NaN values"""
+    """Test proper handling of valid numeric values including 0"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
@@ -312,3 +310,42 @@ def test_value_handling_comprehensive(
         f"{'trigger' if should_trigger else 'not trigger'} alert"
     )
     assert report_schedule_mock.last_value == expected_result
+
+
+@pytest.mark.parametrize(
+    "value,expected_message",
+    [
+        (None, "Query returned NULL value"),
+        (np.nan, "Query returned NULL value"),
+    ],
+)
+def test_value_handling_with_null_and_nan(
+    mocker: MockerFixture,
+    value: float | None,
+    expected_message: str,
+) -> None:
+    """Test that NULL and NaN values raise info exceptions"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame({"value": [value]}),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": "<", "threshold": 0.75}'
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    with pytest.raises(AlertQueryInfoException) as exc_info:
+        command.run()
+
+    assert str(exc_info.value) == expected_message
+    assert command._result is None

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -22,29 +22,26 @@ import pytest
 from pytest_mock import MockerFixture
 
 from superset.commands.report.alert import AlertCommand
-from superset.commands.report.exceptions import AlertQueryError
-from superset.reports.models import ReportScheduleValidatorType
+from superset.commands.report.exceptions import AlertValidatorConfigError
+from superset.reports.models import ReportScheduleValidatorType, ReportState
 
 
-def test_empty_query_result_with_operator_validator_raises_error(
+def test_empty_query_result_with_operator_validator_sets_none(
     mocker: MockerFixture,
 ) -> None:
-    """Test that empty results with operator validator raise AlertQueryError"""
-    # Mock the retry_call to directly call the function without backoff
+    """Test that empty results with operator validator set result to None"""
     mocker.patch(
         "superset.commands.report.alert.retry_call",
         side_effect=lambda func, **kwargs: func(),
     )
-
-    # Mock _execute_query to return empty DataFrame
     mocker.patch(
         "superset.commands.report.alert.AlertCommand._execute_query",
         return_value=pd.DataFrame(),
     )
 
-    # Create mock report schedule with operator validator
     report_schedule_mock = mocker.Mock()
     report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": "<", "threshold": 0.75}'
     report_schedule_mock.id = 1
     report_schedule_mock.sql = "SELECT value FROM metrics WHERE value < 0.75"
 
@@ -53,6 +50,118 @@ def test_empty_query_result_with_operator_validator_raises_error(
         execution_id=uuid4(),
     )
 
-    # Verify AlertQueryError is raised with correct message
-    with pytest.raises(AlertQueryError, match="Alert query returned no results"):
-        command.validate()
+    command.validate()
+    assert command._result is None
+
+    triggered = command.run()
+    assert triggered is False
+    assert report_schedule_mock.last_value is None
+
+
+@pytest.mark.parametrize(
+    "operator,threshold",
+    [
+        ("<", 0.75),
+        ("<=", 100),
+        (">", 50),
+        (">=", 0),
+        ("==", 42),
+        ("!=", 0),
+    ],
+)
+def test_empty_result_prevents_false_alerts_for_all_operators(
+    mocker: MockerFixture,
+    operator: str,
+    threshold: float,
+) -> None:
+    """Test that empty results don't trigger false alerts for any operator type"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame(),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = (
+        f'{{"op": "{operator}", "threshold": {threshold}}}'
+    )
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    triggered = command.run()
+    assert triggered is False, (
+        f"Alert with operator '{operator}' should not trigger on empty results"
+    )
+
+
+def test_empty_result_flow_sets_noop_state(mocker: MockerFixture) -> None:
+    """Test that empty results lead to NOOP state and no notification is sent"""
+    from superset.commands.report.execute import ReportNotTriggeredErrorState
+
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame(),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.type = "Alert"
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = '{"op": "<", "threshold": 0.75}'
+    report_schedule_mock.id = 1
+    report_schedule_mock.last_state = ReportState.NOOP
+
+    state = ReportNotTriggeredErrorState(
+        report_schedule=report_schedule_mock,
+        scheduled_dttm=mocker.Mock(),
+        execution_id=uuid4(),
+    )
+
+    send_mock = mocker.patch.object(state, "send")
+    update_mock = mocker.patch.object(state, "update_report_schedule_and_log")
+
+    state.next()
+
+    update_mock.assert_any_call(ReportState.NOOP)
+    send_mock.assert_not_called()
+
+
+def test_malformed_config_raises_error_even_with_empty_result(
+    mocker: MockerFixture,
+) -> None:
+    """Test that malformed config is detected even when result is None"""
+    mocker.patch(
+        "superset.commands.report.alert.retry_call",
+        side_effect=lambda func, **kwargs: func(),
+    )
+    mocker.patch(
+        "superset.commands.report.alert.AlertCommand._execute_query",
+        return_value=pd.DataFrame(),
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.validator_type = ReportScheduleValidatorType.OPERATOR
+    report_schedule_mock.validator_config_json = "invalid json"
+    report_schedule_mock.id = 1
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    command.validate()
+    assert command._result is None
+
+    with pytest.raises(AlertValidatorConfigError):
+        command.run()


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Alerts configured with operator validators (>, <, >=, <=, !=) were silently defaulting to a value of `0.0` when their custom SQL queries returned no results. This behavior could cause alerts to trigger incorrectly, as the system would evaluate the threshold condition against this default value instead of recognizing that the query produced no data.

This change addresses the issue by raising an explicit AlertQueryError when operator validator queries return empty results. Instead of silently defaulting to 0.0, the system now logs detailed diagnostic information (including the report_schedule_id, execution_id, and the query itself) and presents users with a clear, actionable error message

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a test alert:
    - Go to Alerts & Reports --> Create Alert
    - Select a database and configure a query that returns no results:
     `SELECT value FROM some_table WHERE 1 = 0`
    - Set validator type to OPERATOR (e.g., >)
    - Set threshold to any value (e.g., 10)
    - Save the alert
2. Trigger the alert:
    - Manually trigger the alert or wait for scheduled execution
3. Verify the error:
    - Alert should fail with error message: "Alert query returned no results. Please verify your query is correct and returns data."
    - Check logs for detailed error with report_schedule_id and query details
    - Verify alert does not trigger incorrectly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Fix alerts triggering on empty or NULL query results**

### What Changed
- Alerts no longer treat empty query results or NULL/NaN as numeric zero; empty results and NULL/NaN now prevent alerts from triggering and return an explanatory message instead.
- Zero values are preserved as 0.0 and can still trigger alerts when they meet the operator condition.
- When an operator validator query returns no rows, the system logs diagnostic info and sets the alert state to NOOP with a clear "Query returned no rows (empty result set)" message; malformed validator configs raise a validation error.
- Added unit tests covering empty results, NULL/NaN, zero handling, malformed config, and operator behavior to verify correct outcomes.

### Impact
`✅ Fewer false alerts from empty query results`
`✅ Clearer alert failure messages for empty/NULL results`
`✅ Accurate last_value recording for zero vs NULL`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
