### PR TITLE
test(dashboard): strengthen fontWeightStrong assertion for markdown bold

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Markdown/Markdown.test.tsx
@@ -426,10 +426,11 @@ test('should have fontWeightStrong in theme for bold markdown rendering', async 
     },
   });
 
-  // CRITICAL: Verify fontWeightStrong exists in the theme
+  // CRITICAL: Verify fontWeightStrong exists in the theme with adequate weight
   // If it's missing from allowedAntdTokens, GlobalStyles.tsx:66 will set
   // font-weight: undefined on <strong> tags, breaking bold markdown rendering
-  // Ant Design default is 600, backend config sets 500, either is acceptable
+  // Must be >= 600 (semibold) to show a true visual difference when bolded
+  // Values < 600 (like 500/medium) are too subtle and appear similar to normal (400)
   expect(supersetTheme.fontWeightStrong).toBeDefined();
-  expect(supersetTheme.fontWeightStrong).toBeGreaterThan(400);
+  expect(supersetTheme.fontWeightStrong).toBeGreaterThanOrEqual(600);
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow up to https://github.com/apache/superset/pull/35821, where the test was looking for anything greater than 400. Update test to require fontWeightStrong >= 600 (semibold) instead of > 400. This ensures the theme token has adequate weight to show a true visual difference when bold text is rendered.

Values < 600 (like 500/medium) are too subtle and appear similar to normal weight (400), making bold text barely distinguishable. The stricter assertion catches this inadequate configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
