### PR TITLE
fix(mcp): remove hardcoded admin username fallbacks

### DIFF
--- a/superset/mcp_service/README.md
+++ b/superset/mcp_service/README.md
@@ -110,7 +110,8 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_TIME_LIMIT = None
 
 # MCP Service Configuration
-MCP_ADMIN_USERNAME = 'admin'
+# REQUIRED: Set this to your actual Superset username
+# The service will fail if not configured
 MCP_DEV_USERNAME = 'admin'
 SUPERSET_WEBSERVER_ADDRESS = 'http://localhost:9001'
 
@@ -203,12 +204,13 @@ Then restart Claude Desktop. That's it! ✨
       "args": ["/absolute/path/to/your/superset/superset/mcp_service", "--stdio"],
       "env": {
         "PYTHONPATH": "/absolute/path/to/your/superset",
-        "MCP_ADMIN_USERNAME": "admin"
+        "MCP_DEV_USERNAME": "admin"
       }
     }
   }
 }
 ```
+Note: Replace "admin" with your actual Superset username. These environment variables override the values in superset_config.py.
 </details>
 
 <details>

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -45,22 +45,27 @@ def get_user_from_request() -> User:
 
     TODO (future PR): Add JWT token extraction and validation.
     TODO (future PR): Add user impersonation support.
-    TODO (future PR): Add fallback user configuration.
 
-    For now, this returns the admin user for development.
+    For now, this uses MCP_DEV_USERNAME from configuration for development.
+
+    Raises:
+        ValueError: If MCP_DEV_USERNAME is not configured or user doesn't exist
     """
+    from flask import current_app
+
     from superset import security_manager
 
     # TODO: Extract from JWT token once authentication is implemented
-    # For now, use a simple admin user fallback for development
-    username = "admin"
+    # For now, use MCP_DEV_USERNAME from configuration
+    username = current_app.config.get("MCP_DEV_USERNAME")
+
+    if not username:
+        raise ValueError("Username not configured")
+
     user = security_manager.find_user(username)
 
     if not user:
-        raise ValueError(
-            f"User '{username}' not found. "
-            f"Please create admin user with: superset fab create-admin"
-        )
+        raise ValueError(f"User '{username}' not found")
 
     return user
 

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -19,8 +19,8 @@
 from typing import Any, Dict
 
 # MCP Service Configuration
-MCP_ADMIN_USERNAME = "admin"
-MCP_DEV_USERNAME = "admin"
+# Note: MCP_DEV_USERNAME MUST be configured in superset_config.py
+# There is no default value - the service will fail if not set
 SUPERSET_WEBSERVER_ADDRESS = "http://localhost:9001"
 
 # WebDriver Configuration for screenshots
@@ -80,8 +80,6 @@ def get_mcp_config(app_config: Dict[str, Any] | None = None) -> Dict[str, Any]:
 
     # Default MCP configuration
     defaults = {
-        "MCP_ADMIN_USERNAME": MCP_ADMIN_USERNAME,
-        "MCP_DEV_USERNAME": MCP_DEV_USERNAME,
         "SUPERSET_WEBSERVER_ADDRESS": SUPERSET_WEBSERVER_ADDRESS,
         "WEBDRIVER_BASEURL": WEBDRIVER_BASEURL,
         "WEBDRIVER_BASEURL_USER_FRIENDLY": WEBDRIVER_BASEURL_USER_FRIENDLY,


### PR DESCRIPTION
### SUMMARY

Remove all hardcoded "admin" username fallbacks from the MCP service to improve security and configuration clarity.

**Changes:**
- Remove `MCP_ADMIN_USERNAME` config (unused, consolidated into `MCP_DEV_USERNAME`)
- Remove "admin" fallback from `auth.py` config lookups
- Simplify error messages to be concise (no config variable spam in logs)
- Update `README.md` and `mcp_config.py` documentation

**Why:**
- Hardcoded "admin" fallbacks are a security risk
- Service should fail fast with clear errors when misconfigured
- No need for separate admin/dev username configs

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend configuration change only

### TESTING INSTRUCTIONS

1. Start Superset with MCP service
2. Verify service fails with clear error if `MCP_DEV_USERNAME` not configured
3. Set `MCP_DEV_USERNAME` in `superset_config.py` and verify service works
4. Check error messages are concise (no config variable spam)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API