### PR TITLE
fix(explore): Overwriting a chart updates the form_data_key

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -315,3 +315,33 @@ test('make sure slice_id in the URLSearchParams before the redirect', () => {
   );
   expect(result.get('slice_id')).toEqual('1');
 });
+
+test('removes form_data_key from URL parameters after save', () => {
+  const myProps = {
+    ...defaultProps,
+    slice: { slice_id: 1, slice_name: 'title', owners: [1] },
+    actions: {
+      setFormData: jest.fn(),
+      updateSlice: jest.fn(() => Promise.resolve({ id: 1 })),
+      getSliceDashboards: jest.fn(),
+    },
+    user: { userId: 1 },
+    history: {
+      replace: jest.fn(),
+    },
+    dispatch: jest.fn(),
+  };
+
+  const saveModal = new PureSaveModal(myProps);
+
+  // Test with form_data_key in the URL
+  const urlWithFormDataKey = '?form_data_key=12345&other_param=value';
+  const result = saveModal.handleRedirect(urlWithFormDataKey, { id: 1 });
+
+  // form_data_key should be removed
+  expect(result.has('form_data_key')).toBe(false);
+  // other parameters should remain
+  expect(result.get('other_param')).toEqual('value');
+  expect(result.get('slice_id')).toEqual('1');
+  expect(result.get('save_action')).toEqual('overwrite');
+});

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -169,9 +169,8 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
   handleRedirect = (windowLocationSearch: string, chart: any) => {
     const searchParams = new URLSearchParams(windowLocationSearch);
     searchParams.set('save_action', this.state.action);
-    if (this.state.action !== 'overwrite') {
-      searchParams.delete('form_data_key');
-    }
+
+    searchParams.delete('form_data_key');
 
     searchParams.set('slice_id', chart.id.toString());
     return searchParams;


### PR DESCRIPTION
### SUMMARY
Fixes a bug where overwriting a chart after changing its datasource would display the previous version instead of the updated chart.

**Root cause**: The `form_data_key` URL parameter caches form state. During chart overwrites, this cached data was preserved, causing the app to load stale data instead of the newly saved chart.

**Solution**: Always remove `form_data_key` from the URL after save operations (both "Save as" and "Overwrite"), ensuring fresh data is loaded from the database.

### TESTING INSTRUCTIONS
1. Open an existing chart in Explore view
2. Change the chart's datasource to a different one
3. Click "Save" and select "Save (Overwrite)"
4. Verify the chart displays with the new datasource data, not the old cached version
5. Check that the URL no longer contains `form_data_key` parameter after save

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API