### PR TITLE
fix(datasets): prevent double time filter application in virtual datasets

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -840,9 +840,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_sqla_row_level_filters(
         self,
-        template_processor: Optional[
-            BaseTemplateProcessor
-        ] = None,  # pylint: disable=unused-argument
+        template_processor: Optional[BaseTemplateProcessor] = None,  # pylint: disable=unused-argument
     ) -> list[TextClause]:
         # TODO: We should refactor this mixin and remove this method
         # as it exists in the BaseDatasource and is not applicable
@@ -2213,9 +2211,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 )
 
                 # Get ADVANCED_DATA_TYPES from config when needed
-                ADVANCED_DATA_TYPES = app.config.get(
-                    "ADVANCED_DATA_TYPES", {}
-                )  # noqa: N806
+                ADVANCED_DATA_TYPES = app.config.get("ADVANCED_DATA_TYPES", {})  # noqa: N806
 
                 if (
                     col_advanced_data_type != ""
@@ -2383,9 +2379,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
         self.make_orderby_compatible(select_exprs, orderby_exprs)
 
-        for col, (_orig_col, ascending) in zip(
-            orderby_exprs, orderby, strict=False
-        ):  # noqa: B007
+        for col, (_orig_col, ascending) in zip(orderby_exprs, orderby, strict=False):  # noqa: B007
             if not db_engine_spec.allows_alias_in_orderby and isinstance(col, Label):
                 # if engine does not allow using SELECT alias in ORDER BY
                 # revert to the underlying column

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2145,7 +2145,17 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     is_metric_filter = True
             filter_grain = flt.get("grain")
 
-            if get_column_name(flt_col) in removed_filters:
+            # Check if this filter should be skipped because it was handled in
+            # template. Special handling for __timestamp alias: check both the
+            # alias and the actual column name
+            filter_col_name = get_column_name(flt_col)
+            should_skip_filter = filter_col_name in removed_filters
+            if not should_skip_filter and flt_col == utils.DTTM_ALIAS and col_obj:
+                # For __timestamp, also check if the actual datetime column was
+                # removed
+                should_skip_filter = col_obj.column_name in removed_filters
+
+            if should_skip_filter:
                 # Skip generating SQLA filter when the jinja template handles it.
                 continue
 

--- a/tests/unit_tests/models/test_time_filter_double_application.py
+++ b/tests/unit_tests/models/test_time_filter_double_application.py
@@ -1,0 +1,360 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test for double time filter application in virtual datasets (Issue #34894)"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from flask import Flask
+from freezegun import freeze_time
+from pytest_mock import MockerFixture
+
+from superset.connectors.sqla.models import SqlaTable, TableColumn
+from superset.models.core import Database
+
+
+def test_time_filter_applied_once_with_remove_filter_in_virtual_dataset(
+    mocker: MockerFixture, app: Flask
+) -> None:
+    """
+    Test that time filter is applied only once when using get_time_filter with
+    remove_filter=True in a virtual dataset.
+
+    This test reproduces the issue described in GitHub issue #34894 where time
+    filters are being applied twice - once in the inner query (virtual dataset)
+    and again in the outer query.
+
+    Expected behavior: When remove_filter=True is used in the virtual dataset,
+    the time filter should only be applied in the inner query, not in the outer query.
+
+    Actual behavior (bug): The filter is applied in both inner and outer queries.
+    """
+    # Mock the database connection
+    database = Database(
+        id=1,
+        database_name="test_db",
+        sqlalchemy_uri="postgresql://test",
+    )
+
+    # Create a virtual dataset that uses get_time_filter with
+    # remove_filter=True
+    virtual_dataset_sql = """
+    SELECT *
+    FROM my_table
+    WHERE
+        dttm >= {{
+            get_time_filter('dttm', remove_filter=True, target_type='DATE')
+                .from_expr
+        }}
+        AND dttm < {{
+            get_time_filter('dttm', remove_filter=True, target_type='DATE')
+                .to_expr
+        }}
+    """
+
+    columns = [
+        TableColumn(column_name="dttm", is_dttm=1, type="TIMESTAMP"),
+        TableColumn(column_name="value", type="INTEGER"),
+    ]
+
+    virtual_dataset = SqlaTable(
+        table_name="virtual_dataset",
+        sql=virtual_dataset_sql,
+        columns=columns,
+        main_dttm_col="dttm",
+        database=database,
+    )
+
+    # Mock the security manager to avoid RLS checks
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.get_guest_rls_filters",
+        return_value=[],
+    )
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.is_guest_user",
+        return_value=False,
+    )
+
+    # Create a query object with a time filter
+    query_obj = {
+        "granularity": "dttm",
+        "from_dttm": datetime(2024, 1, 1),
+        "to_dttm": datetime(2024, 1, 31),
+        "is_timeseries": False,
+        "filter": [
+            {
+                "col": "dttm",
+                "op": "TEMPORAL_RANGE",
+                "val": "2024-01-01 : 2024-01-31",
+            }
+        ],
+        "metrics": [],
+        "columns": ["value"],
+    }
+
+    with (
+        freeze_time("2024-01-15"),
+        app.test_request_context(
+            json={
+                "queries": [
+                    {
+                        "filters": [
+                            {
+                                "col": "dttm",
+                                "op": "TEMPORAL_RANGE",
+                                "val": "2024-01-01 : 2024-01-31",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+    ):
+        # Get the query SQL
+        sqla_query = virtual_dataset.get_query_str_extended(query_obj, mutate=False)
+        generated_sql = sqla_query.sql.lower()
+
+        print(f"\n\nGenerated SQL:\n{generated_sql}\n\n")
+
+        # Count how many times the date filter condition appears
+        # The filter should appear only ONCE (in the inner query from the
+        # virtual dataset). It should NOT appear in the outer query WHERE clause
+
+        # Check for patterns that indicate the filter is applied in the outer query
+        # This would be a bug - the filter should only be in the subquery
+        outer_where_pattern = (
+            "where" in generated_sql.split("from (")[1]
+            if "from (" in generated_sql
+            else False
+        )
+
+        # The assertion we want to pass: time filter should NOT be in outer query
+        # because remove_filter=True was used in the virtual dataset
+        # Currently this will FAIL because of bug #34894
+        assert (
+            not outer_where_pattern or "dttm" not in generated_sql.split("from (")[1]
+        ), (
+            "Time filter should only be applied in the inner query (virtual dataset), "
+            "not in the outer query when using remove_filter=True. "
+            "This indicates the filter is being applied twice."
+        )
+
+
+def test_time_filter_removed_from_outer_query_simple_case(
+    mocker: MockerFixture, app: Flask
+) -> None:
+    """
+    Test the basic mechanism: when a Jinja template uses get_time_filter with
+    remove_filter=True, the filter should be added to removed_filters list and
+    not be applied in the SQLAlchemy query generation.
+
+    This is a simpler test that verifies the core mechanism works at a single level.
+    """
+    database = Database(
+        id=1,
+        database_name="test_db",
+        sqlalchemy_uri="postgresql://test",
+    )
+
+    columns = [
+        TableColumn(column_name="dttm", is_dttm=1, type="TIMESTAMP"),
+        TableColumn(column_name="value", type="INTEGER"),
+    ]
+
+    # Simple query with Jinja template that removes the filter
+    simple_sql = """
+    SELECT *
+    FROM my_table
+    WHERE dttm >= {{
+        get_time_filter('dttm', remove_filter=True, target_type='DATE').from_expr
+    }}
+    """
+
+    dataset = SqlaTable(
+        table_name="test_table",
+        sql=simple_sql,
+        columns=columns,
+        main_dttm_col="dttm",
+        database=database,
+    )
+
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.get_guest_rls_filters",
+        return_value=[],
+    )
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.is_guest_user",
+        return_value=False,
+    )
+
+    query_obj = {
+        "granularity": "dttm",
+        "from_dttm": datetime(2024, 1, 1),
+        "to_dttm": datetime(2024, 1, 31),
+        "is_timeseries": False,
+        "filter": [
+            {
+                "col": "dttm",
+                "op": "TEMPORAL_RANGE",
+                "val": "2024-01-01 : 2024-01-31",
+            }
+        ],
+        "metrics": [],
+        "columns": ["value"],
+    }
+
+    with (
+        freeze_time("2024-01-15"),
+        app.test_request_context(
+            json={
+                "queries": [
+                    {
+                        "filters": [
+                            {
+                                "col": "dttm",
+                                "op": "TEMPORAL_RANGE",
+                                "val": "2024-01-01 : 2024-01-31",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+    ):
+        sqla_query = dataset.get_query_str_extended(query_obj, mutate=False)
+        generated_sql = sqla_query.sql.lower()
+
+        print(f"\n\nSimple case SQL:\n{generated_sql}\n\n")
+
+        # In this simple case, the filter should appear exactly once
+        # (in the template, not added by SQLAlchemy)
+        # Count occurrences of date filter patterns
+        dttm_count = generated_sql.count("dttm")
+
+        # We expect to see dttm in the SELECT and WHERE (from template only)
+        # But NOT duplicated by SQLAlchemy's filter application
+        assert dttm_count <= 3, (
+            f"Expected at most 3 occurrences of 'dttm' "
+            f"(SELECT, WHERE from template), but found {dttm_count}. "
+            f"This suggests the filter is being applied multiple times."
+        )
+
+
+def test_time_filter_with_timestamp_alias(mocker: MockerFixture, app: Flask) -> None:
+    """
+    Test that remove_filter works correctly when using __timestamp alias.
+
+    This test specifically addresses the issue where time filters use the __timestamp
+    alias in timeseries queries, but get_time_filter uses the actual column name.
+    The fix ensures both are recognized as the same column.
+    """
+    database = Database(
+        id=1,
+        database_name="test_db",
+        sqlalchemy_uri="postgresql://test",
+    )
+
+    columns = [
+        TableColumn(column_name="dttm", is_dttm=1, type="TIMESTAMP"),
+        TableColumn(column_name="value", type="INTEGER"),
+    ]
+
+    # Virtual dataset with Jinja template that removes the filter using
+    # actual column name
+    virtual_sql = """
+    SELECT *
+    FROM my_table
+    WHERE dttm >= {{
+        get_time_filter('dttm', remove_filter=True, target_type='DATE').from_expr
+    }}
+      AND dttm < {{
+        get_time_filter('dttm', remove_filter=True, target_type='DATE').to_expr
+    }}
+    """
+
+    dataset = SqlaTable(
+        table_name="test_table",
+        sql=virtual_sql,
+        columns=columns,
+        main_dttm_col="dttm",
+        database=database,
+    )
+
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.get_guest_rls_filters",
+        return_value=[],
+    )
+    mocker.patch(
+        "superset.connectors.sqla.models.security_manager.is_guest_user",
+        return_value=False,
+    )
+
+    # Query using __timestamp alias (as timeseries charts do)
+    query_obj = {
+        "granularity": "dttm",
+        "from_dttm": datetime(2024, 1, 1),
+        "to_dttm": datetime(2024, 1, 31),
+        "is_timeseries": True,  # This will cause __timestamp alias to be used
+        "filter": [
+            {
+                "col": "__timestamp",  # Using the special alias
+                "op": "TEMPORAL_RANGE",
+                "val": "2024-01-01 : 2024-01-31",
+            }
+        ],
+        "metrics": ["count"],
+        "columns": [],
+    }
+
+    with (
+        freeze_time("2024-01-15"),
+        app.test_request_context(
+            json={
+                "queries": [
+                    {
+                        "filters": [
+                            {
+                                "col": "__timestamp",
+                                "op": "TEMPORAL_RANGE",
+                                "val": "2024-01-01 : 2024-01-31",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+    ):
+        sqla_query = dataset.get_query_str_extended(query_obj, mutate=False)
+        generated_sql = sqla_query.sql.lower()
+
+        print(f"\n\nTimestamp alias case SQL:\n{generated_sql}\n\n")
+
+        # The filter should only appear in the inner query (virtual dataset)
+        # NOT in the outer query WHERE clause
+        # Check if there's a WHERE clause after the subquery
+        parts = generated_sql.split(")")
+        if len(parts) > 1:
+            outer_part = parts[-1]
+            # The outer part should not have additional date filter conditions
+            # (It may have GROUP BY, ORDER BY, LIMIT, but not WHERE with dttm)
+            if "where" in outer_part:
+                assert "dttm" not in outer_part or "to_date" not in outer_part, (
+                    "Time filter should not be applied in outer query when using "
+                    "remove_filter=True in virtual dataset. The __timestamp alias "
+                    "should be recognized as equivalent to the actual column name."
+                )

--- a/tests/unit_tests/models/test_time_filter_double_application.py
+++ b/tests/unit_tests/models/test_time_filter_double_application.py
@@ -24,7 +24,7 @@ from flask import Flask
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
 
-from superset.connectors.sqla.models import SqlaTable, TableColumn
+from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.models.core import Database
 
 
@@ -293,6 +293,7 @@ def test_time_filter_with_timestamp_alias(mocker: MockerFixture, app: Flask) -> 
         columns=columns,
         main_dttm_col="dttm",
         database=database,
+        metrics=[SqlMetric(metric_name="count", expression="COUNT(*)")],
     )
 
     mocker.patch(

--- a/tests/unit_tests/models/test_time_filter_double_application.py
+++ b/tests/unit_tests/models/test_time_filter_double_application.py
@@ -26,10 +26,12 @@ from pytest_mock import MockerFixture
 
 from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
 from superset.models.core import Database
+from superset.superset_typing import QueryObjectDict
 
 
 def test_time_filter_applied_once_with_remove_filter_in_virtual_dataset(
-    mocker: MockerFixture, app: Flask
+    mocker: MockerFixture,
+    app: Flask,
 ) -> None:
     """
     Test that time filter is applied only once when using get_time_filter with
@@ -42,11 +44,11 @@ def test_time_filter_applied_once_with_remove_filter_in_virtual_dataset(
     Expected behavior: When remove_filter=True is used in the virtual dataset,
     the time filter should only be applied in the inner query, not in the outer query.
     """
-    # Mock the database connection
+    # use a sqlite database just for the dttm conversion from its DB engine spec
     database = Database(
         id=1,
         database_name="test_db",
-        sqlalchemy_uri="postgresql://test",
+        sqlalchemy_uri="sqlite://",
     )
 
     # Create a virtual dataset that uses get_time_filter with
@@ -89,7 +91,7 @@ def test_time_filter_applied_once_with_remove_filter_in_virtual_dataset(
     )
 
     # Create a query object with a time filter
-    query_obj = {
+    query_obj: QueryObjectDict = {
         "granularity": "dttm",
         "from_dttm": datetime(2024, 1, 1),
         "to_dttm": datetime(2024, 1, 31),
@@ -173,10 +175,11 @@ def test_time_filter_removed_from_outer_query_simple_case(
 
     This is a simpler test that verifies the core mechanism works at a single level.
     """
+    # use a sqlite database just for the dttm conversion from its DB engine spec
     database = Database(
         id=1,
         database_name="test_db",
-        sqlalchemy_uri="postgresql://test",
+        sqlalchemy_uri="sqlite://",
     )
 
     columns = [
@@ -210,7 +213,7 @@ def test_time_filter_removed_from_outer_query_simple_case(
         return_value=False,
     )
 
-    query_obj = {
+    query_obj: QueryObjectDict = {
         "granularity": "dttm",
         "from_dttm": datetime(2024, 1, 1),
         "to_dttm": datetime(2024, 1, 31),
@@ -269,10 +272,11 @@ def test_time_filter_with_timestamp_alias(mocker: MockerFixture, app: Flask) -> 
     alias in timeseries queries, but get_time_filter uses the actual column name.
     The fix ensures both are recognized as the same column.
     """
+    # use a sqlite database just for the dttm conversion from its DB engine spec
     database = Database(
         id=1,
         database_name="test_db",
-        sqlalchemy_uri="postgresql://test",
+        sqlalchemy_uri="sqlite://",
     )
 
     columns = [
@@ -312,7 +316,7 @@ def test_time_filter_with_timestamp_alias(mocker: MockerFixture, app: Flask) -> 
     )
 
     # Query using __timestamp alias (as timeseries charts do)
-    query_obj = {
+    query_obj: QueryObjectDict = {
         "granularity": "dttm",
         "from_dttm": datetime(2024, 1, 1),
         "to_dttm": datetime(2024, 1, 31),


### PR DESCRIPTION
### SUMMARY

Fixes #34894

When using `get_time_filter(remove_filter=True)` in virtual datasets, time filters were incorrectly applied twice:
1. Once in the inner query (from the virtual dataset's Jinja template)
2. Again in the outer query WHERE clause (added by Superset's query generator)

**Root Cause**: Timeseries charts use the special `__timestamp` alias for time filters, but virtual dataset Jinja templates use actual column names (e.g., "dttm"). The `removed_filters` check didn't recognize these as referring to the same column, causing the filter to be re-applied in the outer query.

**Solution**: Enhanced the filter skip logic in `superset/models/helpers.py` to check both the `__timestamp` alias and the actual datetime column name when determining if a filter should be skipped.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE (Bug)**: Virtual dataset with `get_time_filter('dttm', remove_filter=True)` would generate SQL like:
```sql
SELECT * FROM (
  SELECT * FROM my_table WHERE dttm >= '2024-01-01' AND dttm < '2024-01-31'
) AS virtual_table
WHERE dttm >= '2024-01-01' AND dttm < '2024-01-31'  -- Filter applied again!
```

**AFTER (Fixed)**: The filter is only applied once in the inner query:
```sql
SELECT * FROM (
  SELECT * FROM my_table WHERE dttm >= '2024-01-01' AND dttm < '2024-01-31'
) AS virtual_table
-- No duplicate filter in outer query
```

### TESTING INSTRUCTIONS

1. Run the new unit tests to verify the fix:
   ```bash
   pytest tests/unit_tests/models/test_time_filter_double_application.py -v
   ```

2. Run existing time filter tests to ensure no regressions:
   ```bash
   pytest tests/unit_tests/jinja_context_test.py -k test_get_time_filter -v
   ```

3. Manual test (optional):
   - Create a virtual dataset with SQL using `get_time_filter('your_time_col', remove_filter=True, target_type='DATE')`
   - Create a timeseries chart from this virtual dataset
   - Add the chart to a dashboard with a time filter applied
   - Inspect the generated SQL (via query inspector or logs) - the time filter should only appear in the subquery, not duplicated in the outer query

### ADDITIONAL INFORMATION

- [x] Has associated issue: #34894
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Code Changes**:
- `superset/models/helpers.py`: Added logic to handle `__timestamp` alias when checking removed_filters (10 lines)
- `tests/unit_tests/models/test_time_filter_double_application.py`: Added comprehensive unit tests (360 lines)

**Testing Coverage**:
- Test for basic virtual dataset with `remove_filter=True`
- Test for `__timestamp` alias handling in timeseries queries
- Test for simple non-nested cases

All pre-commit checks pass (mypy, ruff, pylint).