### PR TITLE
fix(CountryMap): ISO updated for France overseas

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-country-map/scripts/Country Map GeoJSON Generator.ipynb
+++ b/superset-frontend/plugins/legacy-plugin-chart-country-map/scripts/Country Map GeoJSON Generator.ipynb
@@ -94,7 +94,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading ne_50m_admin_1_states_provinces.zip... \r",
+      "Downloading ne_50m_admin_1_states_provinces.zip... \r\n",
       "Done.                                                            \n"
      ]
     }
@@ -2746,12 +2746,14 @@
     "\n",
     "- Seien-et-Marne => Seine-et-Marne\n",
     "- Haute-Rhin => Haut-Rhin\n",
-    "- FR-IDF\\t => FR-IDF"
+    "- FR-IDF\\t => FR-IDF\n",
+    "- FR-GP, FR-GF, FR-RE, FR-YT, FR-MQ => Iso code 2021-11-25\n",
+    "- FR-COR, FR-GUA, FR-GUF, FR-LRE, FR-MAY, FR-MTQ => Iso code 2021-11-25"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2761,7 +2763,20 @@
     "        \n",
     "replace_column('name', france, 'Seien-et-Marne', 'Seine-et-Marne')\n",
     "replace_column('name', france, 'Haute-Rhin', 'Haut-Rhin')\n",
-    "replace_column('region_cod', france, 'FR-IDF\\t', 'FR-IDF')"
+    "\n",
+    "replace_column('iso_3166_2', france, 'FR-GP', 'FR-971')\n",
+    "replace_column('iso_3166_2', france, 'FR-GF', 'FR-973')\n",
+    "replace_column('iso_3166_2', france, 'FR-RE', 'FR-974')\n",
+    "replace_column('iso_3166_2', france, 'FR-YT', 'FR-976')\n",
+    "replace_column('iso_3166_2', france, 'FR-MQ', 'FR-972')\n",
+    "\n",
+    "replace_column('region_cod', france, 'FR-IDF\\t', 'FR-IDF')\n",
+    "replace_column('region_cod', france, 'FR-COR', 'FR-20R')\n",
+    "replace_column('region_cod', france, 'FR-GUA', 'FR-971')\n",
+    "replace_column('region_cod', france, 'FR-GUF', 'FR-973')\n",
+    "replace_column('region_cod', france, 'FR-LRE', 'FR-974')\n",
+    "replace_column('region_cod', france, 'FR-MAY', 'FR-976')\n",
+    "replace_column('region_cod', france, 'FR-MTQ', 'FR-972')"
    ]
   },
   {


### PR DESCRIPTION
The Jupyter notebook has been modified to incorporate corrections to the France overseas ISO codes.
Source : https://www.iso.org/obp/ui/en/#iso:code:3166:FR
Effective date of change : 2021-11-25