### PR TITLE
fix(explore): formatting the SQL in "View Query" pop-up doesn't format

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.test.tsx
@@ -265,3 +265,29 @@ test('uses exploreBackend from Redux state when available', async () => {
   expect(formatCallBody.engine).toBe('postgresql');
   expect(fetchMock.calls(datasetApiEndpoint)).toHaveLength(0);
 });
+
+test('sends engine as string (not object) when fetched from dataset API', async () => {
+  const stateWithoutBackend = {
+    ...mockState(),
+    explore: undefined,
+  };
+
+  setup(mockProps, stateWithoutBackend);
+
+  await waitFor(() => {
+    expect(fetchMock.calls(datasetApiEndpoint)).toHaveLength(1);
+  });
+
+  await waitFor(() => {
+    expect(fetchMock.calls(formatSqlEndpoint)).toHaveLength(1);
+  });
+
+  const formatCallBody = JSON.parse(
+    fetchMock.lastCall(formatSqlEndpoint)?.[1]?.body as string,
+  );
+
+  expect(formatCallBody).toEqual({
+    sql: mockProps.sql,
+    engine: 'sqlite',
+  });
+});

--- a/superset-frontend/src/explore/components/controls/ViewQuery.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQuery.tsx
@@ -106,7 +106,8 @@ const ViewQuery: FC<ViewQueryProps> = props => {
         const response = await SupersetClient.get({
           endpoint: `/api/v1/dataset/${datasetId}?q=${queryParams}`,
         });
-        backend = response.json.result.database;
+        const { backend: datasetBackend } = response.json.result.database;
+        backend = datasetBackend;
       }
 
       // Format the SQL query


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes the SQL formatting toggle in the View Query modal which was returning a 400 Bad Request error.

  **The Problem:**
  When users clicked the format toggle in the View Query modal, the request to `/api/v1/sqllab/format_sql/` was sending the `engine` parameter as an object `{backend: "postgresql"}` instead of a string `"postgresql"`. The backend schema expects a string, causing validation to fail with `"Not a valid string."` error.

  **Root Cause:**
  When the backend engine is not available in Redux state, the code fetches it from the dataset API. The bug occurred during this extraction - the entire database object was being assigned instead of extracting just the `backend` property string.

  **The Fix:**
  - Use object destructuring to properly extract the backend string: `const { backend: datasetBackend } =
  response.json.result.database;`
  - Added comprehensive test to validate the complete API payload structure (both `sql` and `engine` fields)
  - Test ensures `engine` is sent as a string, not an object, preventing regression

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

After:

https://github.com/user-attachments/assets/e3dc44e0-b005-48f4-be00-1b7ca949b6d5



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  **Automated Testing:**
  ```bash
  npm run test -- ViewQuery.test.tsx
  All 12 tests should pass, including the new test: 'sends engine as string (not object) when fetched from dataset API'
   ```
  Manual Testing (Optional):
  1. Open SQL Lab or Explore view
  2. Write a SQL query (e.g., SELECT * FROM table)
  3. Click "View Query" button to open the modal
  4. Click the format toggle switch
  5. Verify: SQL is formatted successfully without errors
  6. Toggle back to original - should work without errors


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #35682
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
