### PR TITLE
fix: set pandas 2.1 as requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "packaging",
     # --------------------------
     # pandas and related (wanting pandas[performance] without numba as it's 100+MB and not needed)
-    "pandas[excel]>=2.0.3, <2.2",
+    "pandas[excel]>=2.1.4, <2.2",
     "bottleneck", # recommended performance dependency for pandas, see https://pandas.pydata.org/docs/getting_started/install.html#performance-dependencies-recommended
     # --------------------------
     "parsedatetime",


### PR DESCRIPTION
### SUMMARY
Pandas 2.0.3 has a bug which removes `NULL` indexes which was fixed on the 2.1 branch. As we were already pinning to 2.1.4 as per #34999, also setting the lower bound to 2.1.4 only makes sense.

### BEFORE
On Pandas 2.0.3, a dataset with three rows, one of which has a null value that is used as the index is removed:
<img width="984" height="791" alt="image" src="https://github.com/user-attachments/assets/92c16978-ff7e-4ff5-9b53-862986d4cd08" />

### AFTER
On Pandas 2.1.4, the null column is preserved (3 rows):
<img width="1002" height="813" alt="image" src="https://github.com/user-attachments/assets/3cf244b7-2072-4708-83c4-518ca391fdf4" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
