### PR TITLE
feat: Floating Point Formatting for Scatter Point Chart

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -342,28 +342,30 @@ const x_axis_time_format: SharedControlConfig<
     option.label.includes(search) || option.value.includes(search),
 };
 
-const x_axis_number_format: SharedControlConfig<'SelectControl', SelectDefaultOption> =
-  {
-    type: 'SelectControl',
-    freeForm: true,
-    label: t('X Axis Number Format'),
-    renderTrigger: true,
-    default: DEFAULT_NUMBER_FORMAT,
-    choices: D3_FORMAT_OPTIONS,
-    description: D3_FORMAT_DOCS,
-    tokenSeparators: ['\n', '\t', ';'],
-    filterOption: ({ data: option }, search) =>
-      option.label.includes(search) || option.value.includes(search),
-    mapStateToProps: state => {
-      const isPercentage =
-        state.controls?.comparison_type?.value === ComparisonType.Percentage;
-      return {
-        choices: isPercentage
-          ? D3_FORMAT_OPTIONS.filter(option => option[0].includes('%'))
-          : D3_FORMAT_OPTIONS,
-      };
-    },
-  };
+const x_axis_number_format: SharedControlConfig<
+  'SelectControl',
+  SelectDefaultOption
+> = {
+  type: 'SelectControl',
+  freeForm: true,
+  label: t('X Axis Number Format'),
+  renderTrigger: true,
+  default: DEFAULT_NUMBER_FORMAT,
+  choices: D3_FORMAT_OPTIONS,
+  description: D3_FORMAT_DOCS,
+  tokenSeparators: ['\n', '\t', ';'],
+  filterOption: ({ data: option }, search) =>
+    option.label.includes(search) || option.value.includes(search),
+  mapStateToProps: state => {
+    const isPercentage =
+      state.controls?.comparison_type?.value === ComparisonType.Percentage;
+    return {
+      choices: isPercentage
+        ? D3_FORMAT_OPTIONS.filter(option => option[0].includes('%'))
+        : D3_FORMAT_OPTIONS,
+    };
+  },
+};
 
 const color_scheme: SharedControlConfig<'ColorSchemeControl'> = {
   type: 'ColorSchemeControl',

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/sharedControls.tsx
@@ -342,6 +342,29 @@ const x_axis_time_format: SharedControlConfig<
     option.label.includes(search) || option.value.includes(search),
 };
 
+const x_axis_number_format: SharedControlConfig<'SelectControl', SelectDefaultOption> =
+  {
+    type: 'SelectControl',
+    freeForm: true,
+    label: t('X Axis Number Format'),
+    renderTrigger: true,
+    default: DEFAULT_NUMBER_FORMAT,
+    choices: D3_FORMAT_OPTIONS,
+    description: D3_FORMAT_DOCS,
+    tokenSeparators: ['\n', '\t', ';'],
+    filterOption: ({ data: option }, search) =>
+      option.label.includes(search) || option.value.includes(search),
+    mapStateToProps: state => {
+      const isPercentage =
+        state.controls?.comparison_type?.value === ComparisonType.Percentage;
+      return {
+        choices: isPercentage
+          ? D3_FORMAT_OPTIONS.filter(option => option[0].includes('%'))
+          : D3_FORMAT_OPTIONS,
+      };
+    },
+  };
+
 const color_scheme: SharedControlConfig<'ColorSchemeControl'> = {
   type: 'ColorSchemeControl',
   label: t('Color Scheme'),
@@ -456,6 +479,7 @@ const sharedControls: Record<string, SharedControlConfig<any>> = {
   size: dndSizeControl,
   y_axis_format,
   x_axis_time_format,
+  x_axis_number_format,
   adhoc_filters: dndAdhocFilterControl,
   color_scheme,
   time_shift_color,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -143,7 +143,6 @@ const config: ControlPanelConfig = {
                 }
                 
                 const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
-                console.log('xAxisType', xAxisType);
 
                 if (typeof xAxisType !== 'string')
                 {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -117,14 +117,18 @@ const config: ControlPanelConfig = {
                 const xAxisColumn = controls?.x_axis?.value;
                 const xAxisOptions = controls?.x_axis?.options;
 
-                if (!xAxisColumn || !Array.isArray(xAxisOptions))
-                {
+                if (!xAxisColumn || !Array.isArray(xAxisOptions)) {
                   return false;
                 }
 
-                const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
+                const xAxisType = xAxisOptions.find(
+                  option => option.column_name === xAxisColumn,
+                )?.type;
 
-                return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('TIME');
+                return (
+                  typeof xAxisType === 'string' &&
+                  xAxisType.toUpperCase().includes('TIME')
+                );
               },
             },
           },
@@ -137,24 +141,26 @@ const config: ControlPanelConfig = {
                 const xAxisColumn = controls?.x_axis?.value;
                 const xAxisOptions = controls?.x_axis?.options;
 
-                if (!xAxisColumn || !Array.isArray(xAxisOptions))
-                {
+                if (!xAxisColumn || !Array.isArray(xAxisOptions)) {
                   return false;
                 }
 
-                const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
+                const xAxisType = xAxisOptions.find(
+                  option => option.column_name === xAxisColumn,
+                )?.type;
 
-                if (typeof xAxisType !== 'string')
-                {
+                if (typeof xAxisType !== 'string') {
                   return false;
                 }
 
                 const typeUpper = xAxisType.toUpperCase();
 
-                return ['FLOAT', 'DOUBLE', 'REAL', 'NUMERIC', 'DECIMAL'].some(t => typeUpper.includes(t));
+                return ['FLOAT', 'DOUBLE', 'REAL', 'NUMERIC', 'DECIMAL'].some(
+                  t => typeUpper.includes(t),
+                );
               },
             },
-          }
+          },
         ],
         [xAxisLabelRotation],
         [xAxisLabelInterval],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -112,8 +112,40 @@ const config: ControlPanelConfig = {
               ...sharedControls.x_axis_time_format,
               default: 'smart_date',
               description: `${D3_TIME_FORMAT_DOCS}. ${TIME_SERIES_DESCRIPTION_TEXT}`,
+              visibility: ({ controls }: ControlPanelsContainerProps) => {
+                const xAxisColumn = controls?.x_axis?.value;
+                const xAxisOptions = controls?.x_axis?.options;
+
+                if (!xAxisColumn || !Array.isArray(xAxisOptions))
+                {
+                  return false;
+                }
+
+                const xAxisType = Array.isArray(xAxisOptions) ? xAxisOptions.find(option => option.column_name === xAxisColumn)?.type : null;
+                
+                return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('TIME');
+              },
             },
           },
+          {
+            name: 'x_axis_format',
+            config: {
+              ...sharedControls.x_axis_number_format,
+              visibility: ({ controls }: ControlPanelsContainerProps) => {
+                const xAxisColumn = controls?.x_axis?.value;
+                const xAxisOptions = controls?.x_axis?.options;
+
+                if (!xAxisColumn || !Array.isArray(xAxisOptions))
+                {
+                  return false;
+                }
+                
+                const xAxisType = Array.isArray(xAxisOptions) ? xAxisOptions.find(option => option.column_name === xAxisColumn)?.type : null;
+                
+                return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('FLOAT');
+              },
+            },
+          }
         ],
         [xAxisLabelRotation],
         [xAxisLabelInterval],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -113,6 +113,7 @@ const config: ControlPanelConfig = {
               default: 'smart_date',
               description: `${D3_TIME_FORMAT_DOCS}. ${TIME_SERIES_DESCRIPTION_TEXT}`,
               visibility: ({ controls }: ControlPanelsContainerProps) => {
+                // check if x axis is a time column
                 const xAxisColumn = controls?.x_axis?.value;
                 const xAxisOptions = controls?.x_axis?.options;
 
@@ -121,17 +122,18 @@ const config: ControlPanelConfig = {
                   return false;
                 }
 
-                const xAxisType = Array.isArray(xAxisOptions) ? xAxisOptions.find(option => option.column_name === xAxisColumn)?.type : null;
+                const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
                 
                 return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('TIME');
               },
             },
           },
           {
-            name: 'x_axis_format',
+            name: 'x_axis_number_format',
             config: {
               ...sharedControls.x_axis_number_format,
               visibility: ({ controls }: ControlPanelsContainerProps) => {
+                // check if x axis is a floating-point column
                 const xAxisColumn = controls?.x_axis?.value;
                 const xAxisOptions = controls?.x_axis?.options;
 
@@ -140,9 +142,17 @@ const config: ControlPanelConfig = {
                   return false;
                 }
                 
-                const xAxisType = Array.isArray(xAxisOptions) ? xAxisOptions.find(option => option.column_name === xAxisColumn)?.type : null;
+                const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
+                console.log('xAxisType', xAxisType);
+
+                if (typeof xAxisType !== 'string')
+                {
+                  return false;
+                }
+
+                const typeUpper = xAxisType.toUpperCase();
                 
-                return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('FLOAT');
+                return ['FLOAT', 'DOUBLE', 'REAL', 'NUMERIC', 'DECIMAL'].some(t => typeUpper.includes(t));
               },
             },
           }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -123,7 +123,7 @@ const config: ControlPanelConfig = {
                 }
 
                 const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
-                
+
                 return typeof xAxisType === 'string' && xAxisType.toUpperCase().includes('TIME');
               },
             },
@@ -141,7 +141,7 @@ const config: ControlPanelConfig = {
                 {
                   return false;
                 }
-                
+
                 const xAxisType = xAxisOptions.find(option => option.column_name === xAxisColumn)?.type;
 
                 if (typeof xAxisType !== 'string')
@@ -150,7 +150,7 @@ const config: ControlPanelConfig = {
                 }
 
                 const typeUpper = xAxisType.toUpperCase();
-                
+
                 return ['FLOAT', 'DOUBLE', 'REAL', 'NUMERIC', 'DECIMAL'].some(t => typeUpper.includes(t));
               },
             },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -72,6 +72,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   stack: false,
   tooltipTimeFormat: 'smart_date',
   xAxisTimeFormat: 'smart_date',
+  xAxisNumberFormat: 'SMART_NUMBER',
   truncateXAxis: true,
   truncateYAxis: false,
   yAxisBounds: [null, null],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -487,8 +487,8 @@ export default function transformProps(
     xAxisDataType === GenericDataType.Temporal
       ? getXAxisFormatter(xAxisTimeFormat)
       : xAxisDataType === GenericDataType.Numeric
-      ? getNumberFormatter(xAxisNumberFormat)
-      : String;
+        ? getNumberFormatter(xAxisNumberFormat)
+        : String;
 
   const {
     setDataMask = () => {},

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -189,6 +189,7 @@ export default function transformProps(
     xAxisSort,
     xAxisSortAsc,
     xAxisTimeFormat,
+    xAxisNumberFormat,
     xAxisTitle,
     xAxisTitleMargin,
     yAxisBounds,
@@ -485,6 +486,8 @@ export default function transformProps(
   const xAxisFormatter =
     xAxisDataType === GenericDataType.Temporal
       ? getXAxisFormatter(xAxisTimeFormat)
+      : xAxisDataType === GenericDataType.Numeric
+      ? getNumberFormatter(xAxisNumberFormat)
       : String;
 
   const {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -84,6 +84,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   yAxisFormat?: string;
   xAxisForceCategorical?: boolean;
   xAxisTimeFormat?: string;
+  xAxisNumberFormat?: string;
   timeGrainSqla?: TimeGranularity;
   forceMaxInterval?: boolean;
   xAxisBounds: [number | undefined | null, number | undefined | null];

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
@@ -41,21 +41,26 @@ describe('Scatter Chart Control Panel', () => {
     }
 
     return null;
-  }
+  };
 
-  const mockControls = (xAxisColumn: string | null, xAxisType: string | null): ControlPanelsContainerProps => {
-        const options = xAxisType ? [{ column_name: xAxisColumn, type: xAxisType }] : [];
+  const mockControls = (
+    xAxisColumn: string | null,
+    xAxisType: string | null,
+  ): ControlPanelsContainerProps => {
+    const options = xAxisType
+      ? [{ column_name: xAxisColumn, type: xAxisType }]
+      : [];
 
-        return {
-          controls: {
-            // @ts-ignore
-            x_axis: {
-              value: xAxisColumn,
-              options: options,
-            },
-          },
-        };
-      };
+    return {
+      controls: {
+        // @ts-ignore
+        x_axis: {
+          value: xAxisColumn,
+          options: options,
+        },
+      },
+    };
+  };
 
   describe('x_axis_time_format control', () => {
     const timeFormatControl: any = getControl('x_axis_time_format');
@@ -80,23 +85,28 @@ describe('Scatter Chart Control Panel', () => {
     });
 
     describe('x_axis_time_format control visibility', () => {
-      const isVisible = (xAxisColumn: string | null, xAxisType: string | null): boolean => {
+      const isVisible = (
+        xAxisColumn: string | null,
+        xAxisType: string | null,
+      ): boolean => {
         const props = mockControls(xAxisColumn, xAxisType);
         const visibilityFn = timeFormatControl?.config?.visibility;
         return visibilityFn ? visibilityFn(props) : false;
       };
 
       it('should be visible for any data types include TIME', () => {
-        expect(isVisible("time_column", "TIME")).toBe(true);
-        expect(isVisible("time_column", "TIME WITH TIME ZONE")).toBe(true);
-        expect(isVisible("time_column", "TIMESTAMP WITH TIME ZONE")).toBe(true);
-        expect(isVisible("time_column", "TIMESTAMP WITHOUT TIME ZONE")).toBe(true);
+        expect(isVisible('time_column', 'TIME')).toBe(true);
+        expect(isVisible('time_column', 'TIME WITH TIME ZONE')).toBe(true);
+        expect(isVisible('time_column', 'TIMESTAMP WITH TIME ZONE')).toBe(true);
+        expect(isVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
+          true,
+        );
       });
 
       it('should be hidden for any data types include TIME', () => {
-        expect(isVisible("null", "null")).toBe(false);
+        expect(isVisible('null', 'null')).toBe(false);
         expect(isVisible(null, null)).toBe(false);
-        expect(isVisible("float_column", "FLOAT")).toBe(false);
+        expect(isVisible('float_column', 'FLOAT')).toBe(false);
       });
     });
   });
@@ -124,25 +134,30 @@ describe('Scatter Chart Control Panel', () => {
     });
 
     describe('x_axis_number_format control visibility', () => {
-      const isVisible = (xAxisColumn: string | null, xAxisType: string | null): boolean => {
+      const isVisible = (
+        xAxisColumn: string | null,
+        xAxisType: string | null,
+      ): boolean => {
         const props = mockControls(xAxisColumn, xAxisType);
         const visibilityFn = numberFormatControl?.config?.visibility;
         return visibilityFn ? visibilityFn(props) : false;
       };
 
       it('should be visible for any floating-point data types', () => {
-        expect(isVisible("float_column", 'FLOAT')).toBe(true);
-        expect(isVisible("double_column", "DOUBLE")).toBe(true);
-        expect(isVisible("real_column", "REAL")).toBe(true);
-        expect(isVisible("numeric_column", "NUMERIC")).toBe(true);
-        expect(isVisible("decimal_column", "DECIMAL")).toBe(true);
+        expect(isVisible('float_column', 'FLOAT')).toBe(true);
+        expect(isVisible('double_column', 'DOUBLE')).toBe(true);
+        expect(isVisible('real_column', 'REAL')).toBe(true);
+        expect(isVisible('numeric_column', 'NUMERIC')).toBe(true);
+        expect(isVisible('decimal_column', 'DECIMAL')).toBe(true);
       });
 
       it('should be hidden for any non-floating-point data types', () => {
-        expect(isVisible("string_column", "VARCHAR")).toBe(false);
-        expect(isVisible("null", "null")).toBe(false);
+        expect(isVisible('string_column', 'VARCHAR')).toBe(false);
+        expect(isVisible('null', 'null')).toBe(false);
         expect(isVisible(null, null)).toBe(false);
-        expect(isVisible("time_column", "TIMESTAMP WITHOUT TIME ZONE")).toBe(false);
+        expect(isVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
+          false,
+        );
       });
     });
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ControlPanelsContainerProps } from '@superset-ui/chart-controls/types';
+import controlPanel from '../../../src/Timeseries/Regular/Scatter/controlPanel';
+
+const config = controlPanel;
+
+describe('Scatter Chart Control Panel', () => {
+  const getControl = (controlName: string) => {
+    for (const section of config.controlPanelSections) {
+      if (section && section.controlSetRows) {
+        for (const row of section.controlSetRows) {
+          for (const control of row) {
+            if (
+              typeof control === 'object' &&
+              control !== null &&
+              'name' in control &&
+              control.name === controlName
+            ) {
+              return control;
+            }
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  const mockControls = (xAxisColumn: string | null, xAxisType: string | null): ControlPanelsContainerProps => {
+        const options = xAxisType ? [{ column_name: xAxisColumn, type: xAxisType }] : [];
+
+        return {
+          controls: {
+            // @ts-ignore
+            x_axis: {
+              value: xAxisColumn,
+              options: options,
+            },
+          },
+        };
+      };
+
+  describe('x_axis_time_format control', () => {
+    const timeFormatControl: any = getControl('x_axis_time_format');
+
+    it('should include x_axis_time_format control in the panel', () => {
+      expect(timeFormatControl).toBeDefined();
+    });
+
+    it('should have correct default value for x_axis_time_format', () => {
+      expect(timeFormatControl).toBeDefined();
+      expect(timeFormatControl.config).toBeDefined();
+      expect(timeFormatControl.config.default).toBe('smart_date');
+    });
+
+    it('should have visibility function for x_axis_time_format', () => {
+      expect(timeFormatControl).toBeDefined();
+      expect(timeFormatControl.config.visibility).toBeDefined();
+      expect(typeof timeFormatControl.config.visibility).toBe('function');
+
+      // The visibility function exists - the exact logic is tested implicitly through UI behavior
+      // The important part is that the control has proper visibility configuration
+    });
+
+    describe('x_axis_time_format control visibility', () => {
+      const isVisible = (xAxisColumn: string | null, xAxisType: string | null): boolean => {
+        const props = mockControls(xAxisColumn, xAxisType);
+        const visibilityFn = timeFormatControl?.config?.visibility;
+        return visibilityFn ? visibilityFn(props) : false;
+      };
+
+      it('should be visible for any data types include TIME', () => {
+        expect(isVisible("time_column", "TIME")).toBe(true);
+        expect(isVisible("time_column", "TIME WITH TIME ZONE")).toBe(true);
+        expect(isVisible("time_column", "TIMESTAMP WITH TIME ZONE")).toBe(true);
+        expect(isVisible("time_column", "TIMESTAMP WITHOUT TIME ZONE")).toBe(true);
+      });
+
+      it('should be hidden for any data types include TIME', () => {
+        expect(isVisible("null", "null")).toBe(false);
+        expect(isVisible(null, null)).toBe(false);
+        expect(isVisible("float_column", "FLOAT")).toBe(false);
+      });
+    });
+  });
+
+  describe('x_axis_number_format control', () => {
+    const numberFormatControl: any = getControl('x_axis_number_format');
+
+    it('should include x_axis_number_format control in the panel', () => {
+      expect(numberFormatControl).toBeDefined();
+    });
+
+    it('should have correct default value for x_axis_number_format', () => {
+      expect(numberFormatControl).toBeDefined();
+      expect(numberFormatControl.config).toBeDefined();
+      expect(numberFormatControl.config.default).toBe('SMART_NUMBER');
+    });
+
+    it('should have visibility function for x_axis_number_format', () => {
+      expect(numberFormatControl).toBeDefined();
+      expect(numberFormatControl.config.visibility).toBeDefined();
+      expect(typeof numberFormatControl.config.visibility).toBe('function');
+
+      // The visibility function exists - the exact logic is tested implicitly through UI behavior
+      // The important part is that the control has proper visibility configuration
+    });
+
+    describe('x_axis_number_format control visibility', () => {
+      const isVisible = (xAxisColumn: string | null, xAxisType: string | null): boolean => {
+        const props = mockControls(xAxisColumn, xAxisType);
+        const visibilityFn = numberFormatControl?.config?.visibility;
+        return visibilityFn ? visibilityFn(props) : false;
+      };
+
+      it('should be visible for any floating-point data types', () => {
+        expect(isVisible("float_column", 'FLOAT')).toBe(true);
+        expect(isVisible("double_column", "DOUBLE")).toBe(true);
+        expect(isVisible("real_column", "REAL")).toBe(true);
+        expect(isVisible("numeric_column", "NUMERIC")).toBe(true);
+        expect(isVisible("decimal_column", "DECIMAL")).toBe(true);
+      });
+
+      it('should be hidden for any non-floating-point data types', () => {
+        expect(isVisible("string_column", "VARCHAR")).toBe(false);
+        expect(isVisible("null", "null")).toBe(false);
+        expect(isVisible(null, null)).toBe(false);
+        expect(isVisible("time_column", "TIMESTAMP WITHOUT TIME ZONE")).toBe(false);
+      });
+    });
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
@@ -101,7 +101,7 @@ test('x_axis_time_format control should be visible for any data types include TI
   );
 });
 
-test('x_axis_time_format control should be hidden for any data types include TIME', () => {
+test('x_axis_time_format control should be hidden for data types that do NOT include TIME', () => {
   expect(isTimeVisible('null', 'null')).toBe(false);
   expect(isTimeVisible(null, null)).toBe(false);
   expect(isTimeVisible('float_column', 'FLOAT')).toBe(false);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/controlPanel.test.ts
@@ -21,144 +21,136 @@ import controlPanel from '../../../src/Timeseries/Regular/Scatter/controlPanel';
 
 const config = controlPanel;
 
-describe('Scatter Chart Control Panel', () => {
-  const getControl = (controlName: string) => {
-    for (const section of config.controlPanelSections) {
-      if (section && section.controlSetRows) {
-        for (const row of section.controlSetRows) {
-          for (const control of row) {
-            if (
-              typeof control === 'object' &&
-              control !== null &&
-              'name' in control &&
-              control.name === controlName
-            ) {
-              return control;
-            }
+const getControl = (controlName: string) => {
+  for (const section of config.controlPanelSections) {
+    if (section && section.controlSetRows) {
+      for (const row of section.controlSetRows) {
+        for (const control of row) {
+          if (
+            typeof control === 'object' &&
+            control !== null &&
+            'name' in control &&
+            control.name === controlName
+          ) {
+            return control;
           }
         }
       }
     }
+  }
 
-    return null;
-  };
+  return null;
+};
 
-  const mockControls = (
-    xAxisColumn: string | null,
-    xAxisType: string | null,
-  ): ControlPanelsContainerProps => {
-    const options = xAxisType
-      ? [{ column_name: xAxisColumn, type: xAxisType }]
-      : [];
+const mockControls = (
+  xAxisColumn: string | null,
+  xAxisType: string | null,
+): ControlPanelsContainerProps => {
+  const options = xAxisType
+    ? [{ column_name: xAxisColumn, type: xAxisType }]
+    : [];
 
-    return {
-      controls: {
-        // @ts-ignore
-        x_axis: {
-          value: xAxisColumn,
-          options: options,
-        },
+  return {
+    controls: {
+      // @ts-ignore
+      x_axis: {
+        value: xAxisColumn,
+        options: options,
       },
-    };
+    },
   };
+};
 
-  describe('x_axis_time_format control', () => {
-    const timeFormatControl: any = getControl('x_axis_time_format');
+// tests for x_axis_time_format control
+const timeFormatControl: any = getControl('x_axis_time_format');
 
-    it('should include x_axis_time_format control in the panel', () => {
-      expect(timeFormatControl).toBeDefined();
-    });
+test('scatter chart control panel should include x_axis_time_format control in the panel', () => {
+  expect(timeFormatControl).toBeDefined();
+});
 
-    it('should have correct default value for x_axis_time_format', () => {
-      expect(timeFormatControl).toBeDefined();
-      expect(timeFormatControl.config).toBeDefined();
-      expect(timeFormatControl.config.default).toBe('smart_date');
-    });
+test('scatter chart control panel should have correct default value for x_axis_time_format', () => {
+  expect(timeFormatControl).toBeDefined();
+  expect(timeFormatControl.config).toBeDefined();
+  expect(timeFormatControl.config.default).toBe('smart_date');
+});
 
-    it('should have visibility function for x_axis_time_format', () => {
-      expect(timeFormatControl).toBeDefined();
-      expect(timeFormatControl.config.visibility).toBeDefined();
-      expect(typeof timeFormatControl.config.visibility).toBe('function');
+test('scatter chart control panel should have visibility function for x_axis_time_format', () => {
+  expect(timeFormatControl).toBeDefined();
+  expect(timeFormatControl.config.visibility).toBeDefined();
+  expect(typeof timeFormatControl.config.visibility).toBe('function');
 
-      // The visibility function exists - the exact logic is tested implicitly through UI behavior
-      // The important part is that the control has proper visibility configuration
-    });
+  // The visibility function exists - the exact logic is tested implicitly through UI behavior
+  // The important part is that the control has proper visibility configuration
+});
 
-    describe('x_axis_time_format control visibility', () => {
-      const isVisible = (
-        xAxisColumn: string | null,
-        xAxisType: string | null,
-      ): boolean => {
-        const props = mockControls(xAxisColumn, xAxisType);
-        const visibilityFn = timeFormatControl?.config?.visibility;
-        return visibilityFn ? visibilityFn(props) : false;
-      };
+const isTimeVisible = (
+  xAxisColumn: string | null,
+  xAxisType: string | null,
+): boolean => {
+  const props = mockControls(xAxisColumn, xAxisType);
+  const visibilityFn = timeFormatControl?.config?.visibility;
+  return visibilityFn ? visibilityFn(props) : false;
+};
 
-      it('should be visible for any data types include TIME', () => {
-        expect(isVisible('time_column', 'TIME')).toBe(true);
-        expect(isVisible('time_column', 'TIME WITH TIME ZONE')).toBe(true);
-        expect(isVisible('time_column', 'TIMESTAMP WITH TIME ZONE')).toBe(true);
-        expect(isVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
-          true,
-        );
-      });
+test('x_axis_time_format control should be visible for any data types include TIME', () => {
+  expect(isTimeVisible('time_column', 'TIME')).toBe(true);
+  expect(isTimeVisible('time_column', 'TIME WITH TIME ZONE')).toBe(true);
+  expect(isTimeVisible('time_column', 'TIMESTAMP WITH TIME ZONE')).toBe(true);
+  expect(isTimeVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
+    true,
+  );
+});
 
-      it('should be hidden for any data types include TIME', () => {
-        expect(isVisible('null', 'null')).toBe(false);
-        expect(isVisible(null, null)).toBe(false);
-        expect(isVisible('float_column', 'FLOAT')).toBe(false);
-      });
-    });
-  });
+test('x_axis_time_format control should be hidden for any data types include TIME', () => {
+  expect(isTimeVisible('null', 'null')).toBe(false);
+  expect(isTimeVisible(null, null)).toBe(false);
+  expect(isTimeVisible('float_column', 'FLOAT')).toBe(false);
+});
 
-  describe('x_axis_number_format control', () => {
-    const numberFormatControl: any = getControl('x_axis_number_format');
+// tests for x_axis_number_format control
+const numberFormatControl: any = getControl('x_axis_number_format');
 
-    it('should include x_axis_number_format control in the panel', () => {
-      expect(numberFormatControl).toBeDefined();
-    });
+test('scatter chart control panel should include x_axis_number_format control in the panel', () => {
+  expect(numberFormatControl).toBeDefined();
+});
 
-    it('should have correct default value for x_axis_number_format', () => {
-      expect(numberFormatControl).toBeDefined();
-      expect(numberFormatControl.config).toBeDefined();
-      expect(numberFormatControl.config.default).toBe('SMART_NUMBER');
-    });
+test('scatter chart control panel should have correct default value for x_axis_number_format', () => {
+  expect(numberFormatControl).toBeDefined();
+  expect(numberFormatControl.config).toBeDefined();
+  expect(numberFormatControl.config.default).toBe('SMART_NUMBER');
+});
 
-    it('should have visibility function for x_axis_number_format', () => {
-      expect(numberFormatControl).toBeDefined();
-      expect(numberFormatControl.config.visibility).toBeDefined();
-      expect(typeof numberFormatControl.config.visibility).toBe('function');
+test('scatter chart control panel should have visibility function for x_axis_number_format', () => {
+  expect(numberFormatControl).toBeDefined();
+  expect(numberFormatControl.config.visibility).toBeDefined();
+  expect(typeof numberFormatControl.config.visibility).toBe('function');
 
-      // The visibility function exists - the exact logic is tested implicitly through UI behavior
-      // The important part is that the control has proper visibility configuration
-    });
+  // The visibility function exists - the exact logic is tested implicitly through UI behavior
+  // The important part is that the control has proper visibility configuration
+});
 
-    describe('x_axis_number_format control visibility', () => {
-      const isVisible = (
-        xAxisColumn: string | null,
-        xAxisType: string | null,
-      ): boolean => {
-        const props = mockControls(xAxisColumn, xAxisType);
-        const visibilityFn = numberFormatControl?.config?.visibility;
-        return visibilityFn ? visibilityFn(props) : false;
-      };
+const isNumberVisible = (
+  xAxisColumn: string | null,
+  xAxisType: string | null,
+): boolean => {
+  const props = mockControls(xAxisColumn, xAxisType);
+  const visibilityFn = numberFormatControl?.config?.visibility;
+  return visibilityFn ? visibilityFn(props) : false;
+};
 
-      it('should be visible for any floating-point data types', () => {
-        expect(isVisible('float_column', 'FLOAT')).toBe(true);
-        expect(isVisible('double_column', 'DOUBLE')).toBe(true);
-        expect(isVisible('real_column', 'REAL')).toBe(true);
-        expect(isVisible('numeric_column', 'NUMERIC')).toBe(true);
-        expect(isVisible('decimal_column', 'DECIMAL')).toBe(true);
-      });
+test('x_axis_number_format control should be visible for any floating-point data types', () => {
+  expect(isNumberVisible('float_column', 'FLOAT')).toBe(true);
+  expect(isNumberVisible('double_column', 'DOUBLE')).toBe(true);
+  expect(isNumberVisible('real_column', 'REAL')).toBe(true);
+  expect(isNumberVisible('numeric_column', 'NUMERIC')).toBe(true);
+  expect(isNumberVisible('decimal_column', 'DECIMAL')).toBe(true);
+});
 
-      it('should be hidden for any non-floating-point data types', () => {
-        expect(isVisible('string_column', 'VARCHAR')).toBe(false);
-        expect(isVisible('null', 'null')).toBe(false);
-        expect(isVisible(null, null)).toBe(false);
-        expect(isVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
-          false,
-        );
-      });
-    });
-  });
+test('x_axis_number_format control should be hidden for any non-floating-point data types', () => {
+  expect(isNumberVisible('string_column', 'VARCHAR')).toBe(false);
+  expect(isNumberVisible('null', 'null')).toBe(false);
+  expect(isNumberVisible(null, null)).toBe(false);
+  expect(isNumberVisible('time_column', 'TIMESTAMP WITHOUT TIME ZONE')).toBe(
+    false,
+  );
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChartProps, SMART_DATE_ID, supersetTheme } from '@superset-ui/core';
+import transformProps from '../../../src/Timeseries/transformProps';
+import { DEFAULT_FORM_DATA } from '../../../src/Timeseries/constants';
+import { EchartsTimeseriesSeriesType, EchartsTimeseriesFormData, EchartsTimeseriesChartProps } from '../../../src/Timeseries/types';
+import { GenericDataType } from '@apache-superset/core/api/core';
+import { D3_FORMAT_OPTIONS, D3_TIME_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+
+describe('Scatter Chart X-axis Time Formatting', () => {
+  const baseFormData: EchartsTimeseriesFormData = {
+    ...DEFAULT_FORM_DATA,
+    colorScheme: 'supersetColors',
+    datasource: '1__table',
+    granularity_sqla: '__timestamp',
+    metric: ['column 1'],
+    groupby: [],
+    viz_type: 'echarts_timeseries_scatter',
+    seriesType: EchartsTimeseriesSeriesType.Scatter,
+  };
+
+  const timeseriesData = [
+    {
+      data: [
+        { column_1: 0.72099, __timestamp: 1609459200000 },
+        { column_1: 0.77954, __timestamp: 1612137600000 },
+        { column_1: 2.83434, __timestamp: 1614556800000 },
+      ],
+      colnames: ['column_1', '__timestamp'],
+      coltypes: [GenericDataType.Numeric, GenericDataType.Temporal],
+    },
+  ];
+
+  const baseChartPropsConfig = {
+    width: 800,
+    height: 600,
+    queriesData: timeseriesData,
+    theme: supersetTheme,
+  };
+
+  it('xAxisTimeFormat has no default formatter', () => {
+    const chartProps = new ChartProps({
+      ...baseChartPropsConfig,
+      formData: baseFormData,
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.xAxis).toHaveProperty('axisLabel');
+    const xAxis = transformedProps.echartOptions.xAxis as any;
+    expect(xAxis.axisLabel).toHaveProperty('formatter');
+    expect(xAxis.axisLabel.formatter).toBeUndefined();
+  });
+
+  it.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', (format) => {
+    const chartProps = new ChartProps({
+      ...baseChartPropsConfig,
+      formData: {
+        ...baseFormData,
+        xAxisTimeFormat: format,
+      },
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    const xAxis = transformedProps.echartOptions.xAxis as any;
+    expect(xAxis.axisLabel).toHaveProperty('formatter');
+    if (format === SMART_DATE_ID) {
+      expect(xAxis.axisLabel.formatter).toBeUndefined();
+    }
+    else {
+      expect(typeof xAxis.axisLabel.formatter).toBe('function');
+      expect(xAxis.axisLabel.formatter.id).toBe(format);
+    }
+  });
+});
+
+describe('Scatter Chart X-axis Number Formatting', () => {
+  const baseFormData: EchartsTimeseriesFormData = {
+    ...DEFAULT_FORM_DATA,
+    colorScheme: 'supersetColors',
+    datasource: '1__table',
+    metric: ['column_1'],
+    x_axis: 'column_2',
+    groupby: [],
+    viz_type: 'echarts_timeseries_scatter',
+    seriesType: EchartsTimeseriesSeriesType.Scatter,
+  };
+
+  const timeseriesData = [
+    {
+      data: [
+        { column_1: 0.72099, column_2: 3.01699 },
+        { column_1: 0.77954, column_2: 3.44802 },
+        { column_1: 2.83434, column_2: 3.58095 },
+      ],
+      colnames: ['column_1', 'column_2'],
+      coltypes: [GenericDataType.Numeric, GenericDataType.Numeric],
+    },
+  ];
+
+  const baseChartPropsConfig = {
+    width: 800,
+    height: 600,
+    queriesData: timeseriesData,
+    theme: supersetTheme,
+  };
+
+  it('should use SMART_NUMBER as default xAxisNumberFormat', () => {
+    const chartProps = new ChartProps({
+      ...baseChartPropsConfig,
+      formData: baseFormData,
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.xAxis).toHaveProperty('axisLabel');
+    const xAxis = transformedProps.echartOptions.xAxis as any;
+    expect(xAxis.axisLabel).toHaveProperty('formatter');
+    expect(typeof xAxis.axisLabel.formatter).toBe('function');
+    expect(xAxis.axisLabel.formatter.id).toBe('SMART_NUMBER');
+  });
+
+  it.each(D3_FORMAT_OPTIONS)('should handle %s format', (format) => {
+    const chartProps = new ChartProps({
+      ...baseChartPropsConfig,
+      formData: {
+        ...baseFormData,
+        xAxisNumberFormat: format,
+      },
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.xAxis).toHaveProperty('axisLabel');
+    const xAxis = transformedProps.echartOptions.xAxis as any;
+    expect(xAxis.axisLabel).toHaveProperty('formatter');
+    expect(typeof xAxis.axisLabel.formatter).toBe('function');
+    expect(xAxis.axisLabel.formatter.id).toBe(format);
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
@@ -62,7 +62,7 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     theme: supersetTheme,
   };
 
-  it('xAxisTimeFormat has no default formatter', () => {
+  test('xAxisTimeFormat has no default formatter', () => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: baseFormData,
@@ -78,7 +78,7 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     expect(xAxis.axisLabel.formatter).toBeUndefined();
   });
 
-  it.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', format => {
+  test.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', format => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: {
@@ -133,7 +133,7 @@ describe('Scatter Chart X-axis Number Formatting', () => {
     theme: supersetTheme,
   };
 
-  it('should use SMART_NUMBER as default xAxisNumberFormat', () => {
+  test('should use SMART_NUMBER as default xAxisNumberFormat', () => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: baseFormData,
@@ -150,7 +150,7 @@ describe('Scatter Chart X-axis Number Formatting', () => {
     expect(xAxis.axisLabel.formatter.id).toBe('SMART_NUMBER');
   });
 
-  it.each(D3_FORMAT_OPTIONS)('should handle %s format', format => {
+  test.each(D3_FORMAT_OPTIONS)('should handle %s format', format => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
@@ -20,9 +20,16 @@
 import { ChartProps, SMART_DATE_ID, supersetTheme } from '@superset-ui/core';
 import transformProps from '../../../src/Timeseries/transformProps';
 import { DEFAULT_FORM_DATA } from '../../../src/Timeseries/constants';
-import { EchartsTimeseriesSeriesType, EchartsTimeseriesFormData, EchartsTimeseriesChartProps } from '../../../src/Timeseries/types';
+import {
+  EchartsTimeseriesSeriesType,
+  EchartsTimeseriesFormData,
+  EchartsTimeseriesChartProps,
+} from '../../../src/Timeseries/types';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { D3_FORMAT_OPTIONS, D3_TIME_FORMAT_OPTIONS } from '@superset-ui/chart-controls';
+import {
+  D3_FORMAT_OPTIONS,
+  D3_TIME_FORMAT_OPTIONS,
+} from '@superset-ui/chart-controls';
 
 describe('Scatter Chart X-axis Time Formatting', () => {
   const baseFormData: EchartsTimeseriesFormData = {
@@ -71,7 +78,7 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     expect(xAxis.axisLabel.formatter).toBeUndefined();
   });
 
-  it.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', (format) => {
+  it.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', format => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: {
@@ -88,8 +95,7 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     expect(xAxis.axisLabel).toHaveProperty('formatter');
     if (format === SMART_DATE_ID) {
       expect(xAxis.axisLabel.formatter).toBeUndefined();
-    }
-    else {
+    } else {
       expect(typeof xAxis.axisLabel.formatter).toBe('function');
       expect(xAxis.axisLabel.formatter.id).toBe(format);
     }
@@ -144,7 +150,7 @@ describe('Scatter Chart X-axis Number Formatting', () => {
     expect(xAxis.axisLabel.formatter.id).toBe('SMART_NUMBER');
   });
 
-  it.each(D3_FORMAT_OPTIONS)('should handle %s format', (format) => {
+  it.each(D3_FORMAT_OPTIONS)('should handle %s format', format => {
     const chartProps = new ChartProps({
       ...baseChartPropsConfig,
       formData: {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/Scatter/transformProps.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartProps, SMART_DATE_ID, supersetTheme } from '@superset-ui/core';
+import { ChartProps, SMART_DATE_ID } from '@superset-ui/core';
 import transformProps from '../../../src/Timeseries/transformProps';
 import { DEFAULT_FORM_DATA } from '../../../src/Timeseries/constants';
 import {
@@ -30,6 +30,7 @@ import {
   D3_FORMAT_OPTIONS,
   D3_TIME_FORMAT_OPTIONS,
 } from '@superset-ui/chart-controls';
+import { supersetTheme } from '@apache-superset/core/ui';
 
 describe('Scatter Chart X-axis Time Formatting', () => {
   const baseFormData: EchartsTimeseriesFormData = {
@@ -69,6 +70,7 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     });
 
     const transformedProps = transformProps(
+      // @ts-ignore
       chartProps as EchartsTimeseriesChartProps,
     );
 
@@ -78,28 +80,32 @@ describe('Scatter Chart X-axis Time Formatting', () => {
     expect(xAxis.axisLabel.formatter).toBeUndefined();
   });
 
-  test.each(D3_TIME_FORMAT_OPTIONS)('should handle %s format', format => {
-    const chartProps = new ChartProps({
-      ...baseChartPropsConfig,
-      formData: {
-        ...baseFormData,
-        xAxisTimeFormat: format,
-      },
-    });
+  test.each(D3_TIME_FORMAT_OPTIONS.map(([id]) => id))(
+    'should handle %s format',
+    format => {
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        formData: {
+          ...baseFormData,
+          xAxisTimeFormat: format,
+        },
+      });
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+      const transformedProps = transformProps(
+        // @ts-ignore
+        chartProps as EchartsTimeseriesChartProps,
+      );
 
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    expect(xAxis.axisLabel).toHaveProperty('formatter');
-    if (format === SMART_DATE_ID) {
-      expect(xAxis.axisLabel.formatter).toBeUndefined();
-    } else {
-      expect(typeof xAxis.axisLabel.formatter).toBe('function');
-      expect(xAxis.axisLabel.formatter.id).toBe(format);
-    }
-  });
+      const xAxis = transformedProps.echartOptions.xAxis as any;
+      expect(xAxis.axisLabel).toHaveProperty('formatter');
+      if (format === SMART_DATE_ID) {
+        expect(xAxis.axisLabel.formatter).toBeUndefined();
+      } else {
+        expect(typeof xAxis.axisLabel.formatter).toBe('function');
+        expect(xAxis.axisLabel.formatter.id).toBe(format);
+      }
+    },
+  );
 });
 
 describe('Scatter Chart X-axis Number Formatting', () => {
@@ -140,6 +146,7 @@ describe('Scatter Chart X-axis Number Formatting', () => {
     });
 
     const transformedProps = transformProps(
+      // @ts-ignore
       chartProps as EchartsTimeseriesChartProps,
     );
 
@@ -150,23 +157,27 @@ describe('Scatter Chart X-axis Number Formatting', () => {
     expect(xAxis.axisLabel.formatter.id).toBe('SMART_NUMBER');
   });
 
-  test.each(D3_FORMAT_OPTIONS)('should handle %s format', format => {
-    const chartProps = new ChartProps({
-      ...baseChartPropsConfig,
-      formData: {
-        ...baseFormData,
-        xAxisNumberFormat: format,
-      },
-    });
+  test.each(D3_FORMAT_OPTIONS.map(([id]) => id))(
+    'should handle %s format',
+    format => {
+      const chartProps = new ChartProps({
+        ...baseChartPropsConfig,
+        formData: {
+          ...baseFormData,
+          xAxisNumberFormat: format,
+        },
+      });
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+      const transformedProps = transformProps(
+        // @ts-ignore
+        chartProps as EchartsTimeseriesChartProps,
+      );
 
-    expect(transformedProps.echartOptions.xAxis).toHaveProperty('axisLabel');
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    expect(xAxis.axisLabel).toHaveProperty('formatter');
-    expect(typeof xAxis.axisLabel.formatter).toBe('function');
-    expect(xAxis.axisLabel.formatter.id).toBe(format);
-  });
+      expect(transformedProps.echartOptions.xAxis).toHaveProperty('axisLabel');
+      const xAxis = transformedProps.echartOptions.xAxis as any;
+      expect(xAxis.axisLabel).toHaveProperty('formatter');
+      expect(typeof xAxis.axisLabel.formatter).toBe('function');
+      expect(xAxis.axisLabel.formatter.id).toBe(format);
+    },
+  );
 });


### PR DESCRIPTION
### SUMMARY
According to the issue https://github.com/apache/superset/issues/32902, the scatter point charts lack of generic axes, which means the scatter point charts only allow x-axis to be formatted with time formats. So, to fix the problem mentioned in this issue, our team adds a new floating-point formats for x-axis.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The before screenshot can be checked in issue https://github.com/apache/superset/issues/32902

The after screenshot:
<img width="319" height="476" alt="Screenshot 2025-10-30 at 13 24 10" src="https://github.com/user-attachments/assets/26086241-58da-4c57-8ab4-156f1c4ab74d" />

### TESTING INSTRUCTIONS
1. Create a scatter point chart or open an existing scatter point chart.
2. Select an "X-axis" in "Data" tab.
3. Check and select the format of "X-axis" in "Customize" tab. If the x-axis has a floating point data type (e.g. FLOAT, DOUBLE, REAL, NUMERIC, DECIMAL), the user interface will show "X Axis Number Format" and you can select formats for floating point numbers. If the x-axis has a time data type (e.g. TIMESTAMP WITHOUT TIME ZONE, TIMESTAMP WITH TIME ZONE), the user interface will show "Time Format" and you can select formats for time. The floating point formats are new features for x-axis, but the time formats are old features.
 
### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #32902
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
