### PR TITLE
fix(sqllab): align refresh buttons with select input fields

### DIFF
--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -56,7 +56,6 @@ const DatabaseSelectorWrapper = styled.div`
       align-items: center;
       width: 30px;
       margin-left: ${theme.sizeUnit}px;
-      margin-top: ${theme.sizeUnit * 5}px;
     }
 
     .section {
@@ -74,6 +73,12 @@ const DatabaseSelectorWrapper = styled.div`
       margin-bottom: ${theme.sizeUnit * 4}px;
     }
   `}
+`;
+
+const StyledFormLabel = styled(FormLabel)`
+  display: block;
+  font-size: ${({ theme }) => theme.fontSizeSM}px;
+  margin-bottom: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const LabelStyle = styled.div`
@@ -372,23 +377,27 @@ export function DatabaseSelector({
         tooltipContent={t('Force refresh catalog list')}
       />
     );
-    return renderSelectRow(
-      <Select
-        ariaLabel={t('Select catalog or type to search catalogs')}
-        disabled={!currentDb || readOnly}
-        header={<FormLabel>{t('Catalog')}</FormLabel>}
-        labelInValue
-        loading={loadingCatalogs}
-        name="select-catalog"
-        notFoundContent={t('No compatible catalog found')}
-        placeholder={t('Select catalog or type to search catalogs')}
-        onChange={item => changeCatalog(item as CatalogOption)}
-        options={catalogOptions}
-        showSearch
-        value={currentCatalog || undefined}
-        allowClear
-      />,
-      refreshIcon,
+    return (
+      <>
+        <StyledFormLabel>{t('Catalog')}</StyledFormLabel>
+        {renderSelectRow(
+          <Select
+            ariaLabel={t('Select catalog or type to search catalogs')}
+            disabled={!currentDb || readOnly}
+            labelInValue
+            loading={loadingCatalogs}
+            name="select-catalog"
+            notFoundContent={t('No compatible catalog found')}
+            placeholder={t('Select catalog or type to search catalogs')}
+            onChange={item => changeCatalog(item as CatalogOption)}
+            options={catalogOptions}
+            showSearch
+            value={currentCatalog || undefined}
+            allowClear
+          />,
+          refreshIcon,
+        )}
+      </>
     );
   }
 
@@ -399,23 +408,27 @@ export function DatabaseSelector({
         tooltipContent={t('Force refresh schema list')}
       />
     );
-    return renderSelectRow(
-      <Select
-        ariaLabel={t('Select schema or type to search schemas')}
-        disabled={!currentDb || readOnly}
-        header={<FormLabel>{t('Schema')}</FormLabel>}
-        labelInValue
-        loading={loadingSchemas}
-        name="select-schema"
-        notFoundContent={t('No compatible schema found')}
-        placeholder={t('Select schema or type to search schemas')}
-        onChange={item => changeSchema(item as SchemaOption)}
-        options={schemaOptions}
-        showSearch
-        value={currentSchema}
-        allowClear
-      />,
-      refreshIcon,
+    return (
+      <>
+        <StyledFormLabel>{t('Schema')}</StyledFormLabel>
+        {renderSelectRow(
+          <Select
+            ariaLabel={t('Select schema or type to search schemas')}
+            disabled={!currentDb || readOnly}
+            labelInValue
+            loading={loadingSchemas}
+            name="select-schema"
+            notFoundContent={t('No compatible schema found')}
+            placeholder={t('Select schema or type to search schemas')}
+            onChange={item => changeSchema(item as SchemaOption)}
+            options={schemaOptions}
+            showSearch
+            value={currentSchema}
+            allowClear
+          />,
+          refreshIcon,
+        )}
+      </>
     );
   }
 

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -48,6 +48,7 @@ import type {
   DatabaseValue,
   DatabaseObject,
 } from './types';
+import { StyledFormLabel } from './styles';
 
 const DatabaseSelectorWrapper = styled.div`
   ${({ theme }) => `
@@ -73,12 +74,6 @@ const DatabaseSelectorWrapper = styled.div`
       margin-bottom: ${theme.sizeUnit * 4}px;
     }
   `}
-`;
-
-const StyledFormLabel = styled(FormLabel)`
-  display: block;
-  font-size: ${({ theme }) => theme.fontSizeSM}px;
-  margin-bottom: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const LabelStyle = styled.div`

--- a/superset-frontend/src/components/DatabaseSelector/styles.ts
+++ b/superset-frontend/src/components/DatabaseSelector/styles.ts
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { styled } from '@superset-ui/core';
+import { FormLabel } from '@superset-ui/core/components';
+
+export const StyledFormLabel = styled(FormLabel)`
+  display: block;
+  font-size: ${({ theme }) => theme.fontSizeSM}px;
+  margin-bottom: ${({ theme }) => theme.sizeUnit}px;
+`;

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -53,7 +53,6 @@ const TableSelectorWrapper = styled.div`
       align-items: center;
       width: ${REFRESH_WIDTH}px;
       margin-left: ${theme.sizeUnit}px;
-      margin-top: ${theme.sizeUnit * 5}px;
     }
 
     .section {
@@ -76,6 +75,12 @@ const TableSelectorWrapper = styled.div`
       max-width: calc(100% - ${theme.sizeUnit + REFRESH_WIDTH}px)
     }
   `}
+`;
+
+const StyledFormLabel = styled(FormLabel)`
+  display: block;
+  font-size: ${({ theme }) => theme.fontSizeSM}px;
+  margin-bottom: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const TableLabel = styled.span`
@@ -314,18 +319,13 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
   function renderTableSelect() {
     const disabled = (currentSchema && !formMode && readOnly) || !currentSchema;
 
-    const header = sqlLabMode ? (
-      <FormLabel>{t('See table schema')}</FormLabel>
-    ) : (
-      <FormLabel>{t('Table')}</FormLabel>
-    );
+    const label = sqlLabMode ? t('See table schema') : t('Table');
 
     const select = (
       <Select
         ariaLabel={t('Select table or type to search tables')}
         disabled={disabled}
         filterOption={handleFilterOption}
-        header={header}
         labelInValue
         loading={loadingTables}
         name="select-table"
@@ -349,7 +349,12 @@ const TableSelector: FunctionComponent<TableSelectorProps> = ({
       />
     );
 
-    return renderSelectRow(select, refreshLabel);
+    return (
+      <>
+        <StyledFormLabel>{label}</StyledFormLabel>
+        {renderSelectRow(select, refreshLabel)}
+      </>
+    );
   }
 
   return (

--- a/superset-frontend/src/components/TableSelector/index.tsx
+++ b/superset-frontend/src/components/TableSelector/index.tsx
@@ -31,14 +31,11 @@ import {
   getClientErrorMessage,
   getClientErrorObject,
 } from '@superset-ui/core';
-import {
-  FormLabel,
-  CertifiedBadge,
-  Select,
-} from '@superset-ui/core/components';
+import { CertifiedBadge, Select } from '@superset-ui/core/components';
 import { DatabaseSelector } from 'src/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import type { DatabaseObject } from 'src/components/DatabaseSelector/types';
+import { StyledFormLabel } from 'src/components/DatabaseSelector/styles';
 import RefreshLabel from '@superset-ui/core/components/RefreshLabel';
 import WarningIconWithTooltip from '@superset-ui/core/components/WarningIconWithTooltip';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -75,12 +72,6 @@ const TableSelectorWrapper = styled.div`
       max-width: calc(100% - ${theme.sizeUnit + REFRESH_WIDTH}px)
     }
   `}
-`;
-
-const StyledFormLabel = styled(FormLabel)`
-  display: block;
-  font-size: ${({ theme }) => theme.fontSizeSM}px;
-  margin-bottom: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const TableLabel = styled.span`


### PR DESCRIPTION
### SUMMARY

This PR fixes the vertical alignment issue of refresh buttons next to the Schema and Table selector fields in SQL Lab and the Add Dataset interface.

**Problem:**
The refresh icons were vertically misaligned with their corresponding select input fields due to two issues:
1. A hardcoded `margin-top: 20px` was applied to the refresh button container
2. More fundamentally, the refresh buttons were aligned to the entire Select/AsyncSelect component (which includes the label + input field), causing them to align vertically centered against both elements rather than just the input field

**Root Cause:**
When using the `header` prop on Select/AsyncSelect components, the label becomes part of the component's internal structure. This caused the flex container holding the refresh button to align against the total height of the label + input, positioning the button between the label and input rather than horizontally aligned with just the input field.

**Solution:**
1. Removed the `margin-top: 20px` from the `.refresh` CSS class in both `DatabaseSelector` and `TableSelector` components
2. Extracted labels from the Select/AsyncSelect components by:
   - Removing the `header` prop from Select/AsyncSelect components
   - Creating a separate `StyledFormLabel` component positioned outside the select component
3. This allows refresh buttons to align horizontally with the input field only, achieving proper vertical alignment

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE:**
<img width="418" height="422" alt="sqllab refresh" src="https://github.com/user-attachments/assets/60663790-7ab9-4a0a-94eb-5ff89290a8f3" />

**AFTER:**
<img width="388" height="226" alt="Screenshot 2025-10-30 at 17 54 37" src="https://github.com/user-attachments/assets/6702c694-1875-4de2-a2e5-488af4aa46fa" />
<img width="392" height="70" alt="Screenshot 2025-10-30 at 18 41 54" src="https://github.com/user-attachments/assets/d8e518e1-fe0c-4801-bfd4-666bd089f6f6" />


### TESTING INSTRUCTIONS

**Test in SQL Lab:**
1. Navigate to **SQL Lab** → **SQL Editor**
2. Observe the **Schema** selector field
3. Verify the refresh icon is horizontally aligned with the schema select input (not the label)
4. Observe the **See table schema** selector field
5. Verify the refresh icon is horizontally aligned with the table select input (not the label)
6. Check that spacing to the left of refresh buttons is consistent (4px)

**Test in Add Dataset:**
1. Navigate to **Data** → **Datasets**
2. Click **+ Dataset** button
3. In the left panel, observe the **Schema** selector
4. Verify the refresh icon is horizontally aligned with the schema select input
5. Observe the **Table** selector (note: shows "Table" label instead of "See table schema" when `sqlLabMode={false}`)
6. Verify the refresh icon is horizontally aligned with the table select input

### ADDITIONAL INFORMATION
- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
