### PR TITLE
fix(dashboard): ensure world map chart uses correct country code format in crossfilter

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -31,6 +31,7 @@ const propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       country: PropTypes.string,
+      country_cca2: PropTypes.string,
       latitude: PropTypes.number,
       longitude: PropTypes.number,
       name: PropTypes.string,
@@ -115,8 +116,15 @@ function WorldMap(element, props) {
   const getCrossFilterDataMask = source => {
     const selected = Object.values(filterState.selectedValues || {});
     const key = source.id || source.country;
-    const country =
-      countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.country;
+
+    let country;
+    if (countryFieldtype === 'name') {
+      country = mapData[key]?.name;
+    } else if (countryFieldtype === 'cca2') {
+      country = mapData[key]?.country_cca2;
+    } else {
+      country = mapData[key]?.country;
+    }
 
     if (!country) {
       return undefined;
@@ -169,8 +177,16 @@ function WorldMap(element, props) {
     const pointerEvent = d3.event;
     pointerEvent.preventDefault();
     const key = source.id || source.country;
-    const val =
-      countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.country;
+
+    let val;
+    if (countryFieldtype === 'name') {
+      val = mapData[key]?.name;
+    } else if (countryFieldtype === 'cca2') {
+      val = mapData[key]?.country_cca2;
+    } else {
+      val = mapData[key]?.country;
+    }
+
     let drillToDetailFilters;
     let drillByFilters;
     if (val) {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -31,11 +31,7 @@ const propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       country: PropTypes.string,
-      codes: PropTypes.shape({
-        cca2: PropTypes.string,
-        cca3: PropTypes.string,
-        cioc: PropTypes.string,
-      }),
+      code: PropTypes.string,
       latitude: PropTypes.number,
       longitude: PropTypes.number,
       name: PropTypes.string,
@@ -120,17 +116,8 @@ function WorldMap(element, props) {
   const getCrossFilterDataMask = source => {
     const selected = Object.values(filterState.selectedValues || {});
     const key = source.id || source.country;
-
-    let country;
-    if (countryFieldtype === 'name') {
-      country = mapData[key]?.name;
-    } else if (countryFieldtype === 'cca2') {
-      country = mapData[key]?.codes?.cca2;
-    } else if (countryFieldtype === 'cioc') {
-      country = mapData[key]?.codes?.cioc;
-    } else {
-      country = mapData[key]?.country;
-    }
+    const country =
+      countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.code;
 
     if (!country) {
       return undefined;
@@ -183,18 +170,8 @@ function WorldMap(element, props) {
     const pointerEvent = d3.event;
     pointerEvent.preventDefault();
     const key = source.id || source.country;
-
-    let val;
-    if (countryFieldtype === 'name') {
-      val = mapData[key]?.name;
-    } else if (countryFieldtype === 'cca2') {
-      val = mapData[key]?.codes?.cca2;
-    } else if (countryFieldtype === 'cioc') {
-      val = mapData[key]?.codes?.cioc;
-    } else {
-      val = mapData[key]?.country;
-    }
-
+    const val =
+      countryFieldtype === 'name' ? mapData[key]?.name : mapData[key]?.code;
     let drillToDetailFilters;
     let drillByFilters;
     if (val) {

--- a/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js
@@ -31,7 +31,11 @@ const propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       country: PropTypes.string,
-      country_cca2: PropTypes.string,
+      codes: PropTypes.shape({
+        cca2: PropTypes.string,
+        cca3: PropTypes.string,
+        cioc: PropTypes.string,
+      }),
       latitude: PropTypes.number,
       longitude: PropTypes.number,
       name: PropTypes.string,
@@ -121,7 +125,9 @@ function WorldMap(element, props) {
     if (countryFieldtype === 'name') {
       country = mapData[key]?.name;
     } else if (countryFieldtype === 'cca2') {
-      country = mapData[key]?.country_cca2;
+      country = mapData[key]?.codes?.cca2;
+    } else if (countryFieldtype === 'cioc') {
+      country = mapData[key]?.codes?.cioc;
     } else {
       country = mapData[key]?.country;
     }
@@ -182,7 +188,9 @@ function WorldMap(element, props) {
     if (countryFieldtype === 'name') {
       val = mapData[key]?.name;
     } else if (countryFieldtype === 'cca2') {
-      val = mapData[key]?.country_cca2;
+      val = mapData[key]?.codes?.cca2;
+    } else if (countryFieldtype === 'cioc') {
+      val = mapData[key]?.codes?.cioc;
     } else {
       val = mapData[key]?.country;
     }

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1313,6 +1313,7 @@ class WorldMapViz(BaseViz):
                         self.form_data["country_fieldtype"], row["country"]
                     )
             if country:
+                row["country_cca2"] = country["cca2"]
                 row["country"] = country["cca3"]
                 row["latitude"] = country["lat"]
                 row["longitude"] = country["lng"]

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1313,7 +1313,11 @@ class WorldMapViz(BaseViz):
                         self.form_data["country_fieldtype"], row["country"]
                     )
             if country:
-                row["country_cca2"] = country["cca2"]
+                row["codes"] = {
+                    "cca2": country["cca2"],
+                    "cca3": country["cca3"],
+                    "cioc": country["cioc"],
+                }
                 row["country"] = country["cca3"]
                 row["latitude"] = country["lat"]
                 row["longitude"] = country["lng"]

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -1313,11 +1313,7 @@ class WorldMapViz(BaseViz):
                         self.form_data["country_fieldtype"], row["country"]
                     )
             if country:
-                row["codes"] = {
-                    "cca2": country["cca2"],
-                    "cca3": country["cca3"],
-                    "cioc": country["cioc"],
-                }
+                row["code"] = country[self.form_data["country_fieldtype"]]
                 row["country"] = country["cca3"]
                 row["latitude"] = country["lat"]
                 row["longitude"] = country["lng"]


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug where cross filtering on a world map chart always uses the `cca3` country code format, even if other codes (`cca2`, `cioc`) were selected as the `countryFieldType` during chart creation. 

#### `superset/viz.py`
The backend currently provides country results to the frontend in the format:
```jsonc
{
    "country": "string",
    "name": "string",
    // … other fields  
}
```
The country field is the `cca3` code of the country, and name is the country’s full name. country must be sent as a `cca3` code, because the frontend plugin used for maps only recognizes `cca3` country codes. To improve interoperability and make additional code formats (e.g., `cca2`, `cioc`) available without altering the existing response structure, we introduce an additional object field `code`:
```jsonc
{
    "country": "string",
    "name": "string",
    "code": "string"
    // … other fields  
}
```
This approach was chosen because it preserves backward compatibility with existing frontend expectations (country remains `cca3`). The `code` field is retrieved from the `country` module like all the other country data, and it uses `form_data["country_fieldtype"]` to know which field type the user requested.

#### `superset-frontend/plugins/legacy-plugin-chart-world-map/src/WorldMap.js`
This frontend component handles the world map chart and manages cross-filter interactions through the `getCrossFilterDataMask` function, which is triggered when a user clicks on a country. Previously, `getCrossFilterDataMask` only checked if `countryFieldType == "name"`.

If `countryFieldType == "name"`, it used the backend `name` field (e.g., "Canada"). Otherwise, it used the `country` field, which was always in `cca3` format (e.g., "CAN"). Now, instead of falling back to `country`, we fall back to `code`, which will be in the format the user selected when the chart was created.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
I created a dataset with `cca2` country codes, and created 2 charts with it on the same dashboard.

#### Before
When selecting Canada on chart `CA2-1`, nothing is shown on chart `CA2-2`, even though it also has Canada in the dataset. You can also see on the left sidebar that `CAN` is used to filter the charts, even though `cca2` is set as the country field type.
<img width="1821" height="478" alt="image" src="https://github.com/user-attachments/assets/3d1e53a9-29f6-4e72-8c7d-4e5e0e1897db" />

#### After
When selecting Canada on chart `CA2-1`, it is also filtered on chart `CA2-2`. On the left sidebar, you can also see that `CA` is used to filter the charts.
<img width="1817" height="489" alt="image" src="https://github.com/user-attachments/assets/e4196125-702b-4148-b785-16282f03fc9f" />


### TESTING INSTRUCTIONS

#### Steps to Verify:
1. Create a dataset that includes country identifier fields (e.g., name, `cca2`).
2. Create two world map charts using these datasets with the countryFieldType as `cca2`.
3. Add both charts to the same dashboard.
4. Interact with the maps by selecting a country.

#### Expected Result:
Observe that when you click on a country in one map, the corresponding country is highlighted in all other maps.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #34024 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
