### PR TITLE
fix(mcp): avoid mutating global SENSITIVE_FIELDS in field permissions

### DIFF
--- a/superset/mcp_service/utils/permissions_utils.py
+++ b/superset/mcp_service/utils/permissions_utils.py
@@ -142,9 +142,9 @@ def get_allowed_fields(
     if not user:
         user = get_current_user()
 
-    # Get sensitive fields for this object type
-    sensitive_fields = SENSITIVE_FIELDS.get(object_type, set())
-    sensitive_fields.update(SENSITIVE_FIELDS.get("common", set()))
+    base=SENSITIVE_FIELDS.get(object_type, set())
+    common=SENSITIVE_FIELDS.get("common", set())
+    sensitive_fields= set(base)|set(common)
 
     # If no user, only allow non-sensitive fields
     if not user:


### PR DESCRIPTION
Build sensitive_fields from copies to prevent bleed-through across requests/tests

SUMMARY
Build a local union set (set(base)|set(common)) in get_allowed_fields instead of updating SENSITIVE_FIELDS, preventing cross-request/type bleed-through and stabilizing MCP dataset/chart/dashboard filtering.

Call get_allowed_fields(...) and confirm SENSITIVE_FIELDS remains unchanged before/after.


•  No UI changes; No DB migration; No new APIs...