### PR TITLE
fix(utils): urls preserve query params

### DIFF
--- a/superset/utils/urls.py
+++ b/superset/utils/urls.py
@@ -54,15 +54,20 @@ def modify_url_query(url: str, **kwargs: Any) -> str:
     Replace or add parameters to a URL.
     """
     parts = list(urllib.parse.urlsplit(url))
-    params = urllib.parse.parse_qs(parts[3])
+    pairs = urllib.parse.parse_qsl(parts[3],keep_blank_values=True)
     for k, v in kwargs.items():
-        if not isinstance(v, list):
-            v = [v]
-        params[k] = v
-
-    parts[3] = "&".join(
-        f"{k}={urllib.parse.quote(str(v[0]))}" for k, v in params.items()
-    )
+        idxs = [i for i,(kk,_) in enumerate(pairs) if kk==k]
+        if idxs:
+            pos = min(idxs)
+            pairs = [(kk,vv) for (kk,vv) in pairs if kk!=k]
+            new=[(k,str(x)) for x in v] if isinstance(v, (list,tuple)) else [(k,str(v))]
+            pairs[pos:pos]=new
+        else:
+            if isinstance(v,(list,tuple)):
+                pairs.extend((k,str(x)) for x in v)
+            else:
+                pairs.append((k,str(v)))
+    parts[3]=urllib.parse.urlencode(pairs,doseq=True)
     return urllib.parse.urlunsplit(parts)
 
 

--- a/superset/utils/urls.py
+++ b/superset/utils/urls.py
@@ -54,20 +54,33 @@ def modify_url_query(url: str, **kwargs: Any) -> str:
     Replace or add parameters to a URL.
     """
     parts = list(urllib.parse.urlsplit(url))
-    pairs = urllib.parse.parse_qsl(parts[3],keep_blank_values=True)
-    for k, v in kwargs.items():
-        idxs = [i for i,(kk,_) in enumerate(pairs) if kk==k]
-        if idxs:
-            pos = min(idxs)
-            pairs = [(kk,vv) for (kk,vv) in pairs if kk!=k]
-            new=[(k,str(x)) for x in v] if isinstance(v, (list,tuple)) else [(k,str(v))]
-            pairs[pos:pos]=new
-        else:
-            if isinstance(v,(list,tuple)):
-                pairs.extend((k,str(x)) for x in v)
-            else:
-                pairs.append((k,str(v)))
-    parts[3]=urllib.parse.urlencode(pairs,doseq=True)
+    pairs = urllib.parse.parse_qsl(parts[3], keep_blank_values=True)
+    replacements = {
+        key: [(key, str(item)) for item in value]
+        if isinstance(value, list | tuple)
+        else [(key, str(value))]
+        for key, value in kwargs.items()
+    }
+    pending_keys = set(replacements)
+    updated_pairs: list[tuple[str, str]] = []
+
+    for key, value in pairs:
+        if key not in replacements:
+            updated_pairs.append((key, value))
+        elif key in pending_keys:
+            updated_pairs.extend(replacements[key])
+            pending_keys.remove(key)
+
+    for key in kwargs:
+        if key in pending_keys:
+            updated_pairs.extend(replacements[key])
+
+    parts[3] = urllib.parse.urlencode(
+        updated_pairs,
+        doseq=True,
+        quote_via=urllib.parse.quote,
+        safe="/",
+    )
     return urllib.parse.urlunsplit(parts)
 
 

--- a/tests/unit_tests/utils/urls_tests.py
+++ b/tests/unit_tests/utils/urls_tests.py
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from superset.utils.urls import modify_url_query
+from flask import current_app
+
+from superset.utils.urls import get_url_path, modify_url_query
 
 EXPLORE_CHART_LINK = "http://localhost:9000/explore/?form_data=%7B%22slice_id%22%3A+76%7D&standalone=true&force=false"
 
@@ -38,3 +40,49 @@ def test_convert_dashboard_link() -> None:
 def test_convert_dashboard_link_with_integer() -> None:
     test_url = modify_url_query(EXPLORE_DASHBOARD_LINK, standalone=0)
     assert test_url == "http://localhost:9000/superset/dashboard/3/?standalone=0"
+
+
+def test_modify_url_query_preserves_repeated_and_blank_params() -> None:
+    test_url = modify_url_query(
+        "http://localhost:9000/explore/?a=1&a=2&b=&c=3",
+        a=[4, 5],
+    )
+
+    assert test_url == "http://localhost:9000/explore/?a=4&a=5&b=&c=3"
+
+
+def test_modify_url_query_appends_new_params_after_existing_params() -> None:
+    test_url = modify_url_query(
+        "http://localhost:9000/explore/?a=1&a=2&b=&c=3",
+        d=7,
+    )
+
+    assert test_url == "http://localhost:9000/explore/?a=1&a=2&b=&c=3&d=7"
+
+
+def test_modify_url_query_preserves_standard_url_encoding_for_list_values() -> None:
+    test_url = modify_url_query(
+        "http://localhost:9000/explore/?existing=ok",
+        tag=["alpha value", "beta/value"],
+    )
+
+    assert (
+        test_url
+        == "http://localhost:9000/explore/?existing=ok&tag=alpha%20value&tag=beta/value"
+    )
+
+
+def test_get_url_path_preserves_query_params(app_context: None) -> None:
+    current_app.config["WEBDRIVER_BASEURL"] = "http://localhost:9000/"
+
+    test_url = get_url_path(
+        "static",
+        filename="assets/images/favicon.png",
+        standalone=1,
+        form_data='{"slice_id": 76}',
+    )
+
+    assert (
+        test_url
+        == "http://localhost:9000/static/assets/images/favicon.png?standalone=1&form_data=%7B%22slice_id%22:+76%7D"
+    )


### PR DESCRIPTION
### SUMMARY

> Reviewer context from [`#issuecomment-4663003094`](https://github.com/apache/superset/pull/35936#issuecomment-4663003094): rebase the branch, add coverage for query parameter preservation, and address the bot feedback on the URL helper implementation.

---

#### 1. Purpose

This PR fixes `modify_url_query` so URL query parameters are updated without losing:

- repeated keys, such as `a=1&a=2`
- blank values, such as `b=`
- the visible order of unrelated query parameters

The change is limited to Superset's Python URL helper and its unit coverage. It does **not** change route definitions, frontend behavior, report scheduling, dashboard permissions, database state, or any public REST API contract.

---

#### 2. Scope

| Area | Included | Reviewer notes |
| --- | ---: | --- |
| `modify_url_query` behavior | **Yes** | Preserves repeated query keys and blank values while replacing or appending requested parameters. |
| `get_url_path` coverage | **Yes** | Adds a regression test for query parameters generated through Flask routing. |
| Unit tests | **Yes** | Adds focused coverage for the reviewed URL behavior. |
| UI changes | **No** | No frontend files or visible UI behavior are changed. |
| Database changes | **No** | No model, migration, seed data, or persistence changes are included. |
| Public API changes | **No** | No endpoint, exported package, or function signature changes are included. |

---

#### 3. Implementation Details

`modify_url_query` now parses the query string as ordered pairs:

```python
urllib.parse.parse_qsl(parts[3], keep_blank_values=True)
```

This keeps duplicate keys and blank values visible to the replacement logic. The helper then builds replacement pairs from `kwargs`, processes the existing query pairs once, and serializes the result with:

```python
urllib.parse.urlencode(updated_pairs, doseq=True)
```

The replacement rules are explicit:

| Case | Behavior |
| --- | --- |
| Existing key with scalar replacement | Replace the first occurrence with one encoded pair and drop later occurrences of that same key. |
| Existing key with list or tuple replacement | Replace the first occurrence with one encoded pair per value. |
| Existing unrelated key | Keep the key and value in the same relative order. |
| New key | Append the new key after existing query parameters in `kwargs` order. |
| Blank existing value | Preserve it by parsing with `keep_blank_values=True`. |

This addresses the bot feedback by avoiding the prior repeated scan plus slice insertion pattern while preserving the behavior intended by the original PR.

---

#### 4. Changed Files and Areas

| Status | File or area | Why it changed | What changed |
| --- | --- | --- | --- |
| Updated | `superset/utils/urls.py` | The previous `parse_qs` based approach collapsed duplicate keys and did not preserve enough ordering information for repeated parameter updates. | Replaced dict based query handling with ordered pair handling, preserved blank values, and used one pass over existing pairs for replacements. |
| Updated | `tests/unit_tests/utils/urls_tests.py` | The reviewed behavior needed direct regression coverage before the PR could be reviewed safely. | Added tests for repeated parameter replacement, blank value preservation, appended parameters, and `get_url_path` query preservation. |

---

#### 5. Package and API Boundary

The public function signature remains unchanged:

```python
modify_url_query(url: str, **kwargs: Any) -> str
```

Existing callers can continue passing scalar values, lists, and tuples. The behavior change is limited to preserving query data that already exists in the input URL, specifically repeated query keys and blank values.

---

#### 6. User Experience

There is no direct UI change.

Generated links that pass through `modify_url_query` can now retain repeated query parameters and blank query values instead of dropping them during URL rewriting.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. This PR changes backend URL helper behavior and unit tests only.

---

### TESTING INSTRUCTIONS

#### 1. Local Verification

| Command or check | Result | Notes |
| --- | --- | --- |
| `python -m py_compile superset/utils/urls.py tests/unit_tests/utils/urls_tests.py` | **Passed** | Confirms both edited Python files compile. |
| Focused Flask harness for `modify_url_query` and `get_url_path` cases | **Passed** | Covered the URL behavior added in this PR without loading repository wide test fixtures. |
| `ruff format --check superset/utils/urls.py tests/unit_tests/utils/urls_tests.py` | **Passed** | Formatting check passed after applying `ruff format`. |
| `ruff check superset/utils/urls.py tests/unit_tests/utils/urls_tests.py` | **Passed** | Lint check passed for the changed files. |
| `pre-commit run` | **Partially passed** | All relevant hooks passed except `mypy`, which failed on existing Windows Python 3.14 `signal.SIGALRM` and `signal.alarm` references in `superset/utils/core.py`. The failure is outside this PR's changed files. |

#### 2. Local Test Environment Constraint

`pytest tests/unit_tests/utils/urls_tests.py` could not complete locally because repository wide `tests/conftest.py` imports dependencies such as `pandas` that were not installed in the available Python environment.

CI should still run the full test file in Superset's supported test environment. The focused Flask harness covered the behavior added by this PR.

#### 3. Behavior Cases Covered

| Input | Operation | Expected output |
| --- | --- | --- |
| `http://localhost:9000/explore/?a=1&a=2&b=&c=3` | `modify_url_query(url, a=[4, 5])` | `http://localhost:9000/explore/?a=4&a=5&b=&c=3` |
| `http://localhost:9000/explore/?a=1&a=2&b=&c=3` | `modify_url_query(url, d=7)` | `http://localhost:9000/explore/?a=1&a=2&b=&c=3&d=7` |
| Flask static route generated through `get_url_path(...)` | `standalone=1`, `form_data='{"slice_id": 76}'` | Query parameters remain present on the generated absolute URL. |

---

#### 4. Risk and Mitigation

| Risk | Mitigation |
| --- | --- |
| Existing callers rely on scalar query replacement. | Scalar replacement remains supported and is covered by existing URL tests. |
| Repeated query keys are reordered incorrectly. | Replacement occurs at the first occurrence of the key, and unrelated keys keep their original relative order. |
| Blank query values are dropped during parsing. | `keep_blank_values=True` is used and covered by the repeated parameter regression test. |
| CI surfaces checks that could not be reproduced locally. | The diff is limited to two files, local validation results are documented, and the known local `mypy` failure is identified as environment specific and outside the changed files. |

---

#### 5. Out of Scope

This PR does not change:

- report execution
- screenshot routing
- dashboard access control
- permalink storage
- frontend query parameter handling
- database schema or migrations
- public REST API behavior

---

#### 6. Rollout and Follow-up

No feature flag, deployment ordering, database migration, or configuration change is required.

The branch currently has two URL focused commits. It can be squashed before final review if maintainers prefer a single commit for this focused helper change.

---

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
