### PR TITLE
style(sqllab): restore Template Parameters modal styling

### DIFF
--- a/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/TemplateParamsEditor/index.tsx
@@ -35,6 +35,14 @@ const StyledConfigEditor = styled(ConfigEditor)`
   }
 `;
 
+const StyledParagraph = styled.p`
+  margin-top: 0;
+`;
+
+const Code = styled.code`
+  color: ${({ theme }) => theme.colorPrimary};
+`;
+
 export type TemplateParamsEditorProps = {
   queryEditorId: string;
   language: 'yaml' | 'json';
@@ -64,13 +72,11 @@ const TemplateParamsEditor = ({
 
   const modalBody = (
     <div>
-      <p>
-        {t('Assign a set of parameters as')}
-        <code>JSON</code>
-        {t('below (example:')}
-        <code>{'{"my_table": "foo"}'}</code>
-        {t('), and they become available in your SQL (example:')}
-        <code>SELECT * FROM {'{{ my_table }}'} </code>) {t('by using')}&nbsp;
+      <StyledParagraph>
+        {t('Assign a set of parameters as')} <Code>JSON</Code>{' '}
+        {t('below (example:')} <Code>{'{"my_table": "foo"}'}</Code>
+        {t('), and they become available in your SQL (example:')}{' '}
+        <Code>SELECT * FROM {'{{ my_table }}'} </Code>) {t('by using')}&nbsp;
         <a
           href="https://superset.apache.org/sqllab.html#templating-with-jinja"
           target="_blank"
@@ -79,7 +85,7 @@ const TemplateParamsEditor = ({
           {t('Jinja templating')}
         </a>{' '}
         {t('syntax.')}
-      </p>
+      </StyledParagraph>
       <StyledConfigEditor
         mode={language}
         minLines={25}


### PR DESCRIPTION
 ### SUMMARY
  Fixes styling issues in the SQL Lab Template Parameters modal that were causing poor readability and inconsistent
  appearance:

  1. **Removed excessive margin** between modal title and content by creating a `StyledParagraph` component with
  `margin-top: 0`
  2. **Fixed missing spaces** between words in the instructional text by adding proper spacing between translated
  strings and code elements
  3. **Restored blue styling** for code elements (`JSON`, `{"my_table": "foo"}`, `SELECT * FROM {{ my_table }}`) by
  creating a styled `Code` component using `theme.colorPrimary`

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **BEFORE:**
<img width="1446" height="767" alt="Screenshot 2025-10-23 at 10 26 28 (2)" src="https://github.com/user-attachments/assets/ec62dd68-16cd-462f-abb1-250d1f1f576f" />

  - Large gap between modal title and content
  - Words running together without spaces (e.g., "asJSONbelow")
  - Code elements appear in default black color instead of blue

  **AFTER:**
<img width="720" height="616" alt="Screenshot 2025-11-03 at 21 51 11" src="https://github.com/user-attachments/assets/bf306c12-7b7e-41f7-b146-23e66e45b9eb" />

  - Proper spacing between title and content
  - Correct spacing between all words
  - Code elements display in blue (primary theme color) for better visual hierarchy

  ### TESTING INSTRUCTIONS
  1. Start the Superset development environment
  2. Navigate to SQL Lab
  3. Click the **⋯** (ellipsis) button in the SQL Editor toolbar
  4. Click **Parameters** from the dropdown menu
  5. Verify:
     - The instructional text appears immediately below the modal title without excessive spacing
     - All words are properly spaced (e.g., "Assign a set of parameters as JSON below...")
     - Code elements (`JSON`, `{"my_table": "foo"}`, `SELECT * FROM {{ my_table }}`) appear in blue
     - The link to "Jinja templating" documentation works correctly

  ### ADDITIONAL INFORMATION
  - [x] Changes UI
  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API