### PR TITLE
fix(table-chart): fix missing table header IDs

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -144,6 +144,10 @@ function cellWidth({
 /**
  * Sanitize a column identifier for use in HTML id attributes and CSS selectors.
  * Replaces characters that are invalid in CSS selectors with safe alternatives.
+ *
+ * Note: The returned value should be prefixed with a string (e.g., "header-")
+ * to ensure it forms a valid HTML ID (IDs cannot start with a digit).
+ *
  * Exported for testing.
  */
 export function sanitizeHeaderId(columnId: string): string {
@@ -152,7 +156,8 @@ export function sanitizeHeaderId(columnId: string): string {
     .replace(/#/g, 'hash')
     .replace(/△/g, 'delta')
     .replace(/\s+/g, '_')
-    .replace(/[^a-zA-Z0-9_-]/g, '_');
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .replace(/_+/g, '_'); // Collapse consecutive underscores
 }
 
 /**
@@ -859,7 +864,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       }
 
       // Cache sanitized header ID to avoid recomputing it multiple times
-      const headerId = sanitizeHeaderId(column.originalLabel || column.key);
+      const headerId = sanitizeHeaderId(column.originalLabel ?? column.key);
 
       return {
         id: String(i), // to allow duplicate column keys

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -144,8 +144,9 @@ function cellWidth({
 /**
  * Sanitize a column identifier for use in HTML id attributes and CSS selectors.
  * Replaces characters that are invalid in CSS selectors with safe alternatives.
+ * Exported for testing.
  */
-function sanitizeHeaderId(columnId: string): string {
+export function sanitizeHeaderId(columnId: string): string {
   return columnId
     .replace(/%/g, 'percent')
     .replace(/#/g, 'hash')
@@ -857,6 +858,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         }
       }
 
+      // Cache sanitized header ID to avoid recomputing it multiple times
+      const headerId = sanitizeHeaderId(column.originalLabel || column.key);
+
       return {
         id: String(i), // to allow duplicate column keys
         // must use custom accessor to allow `.` in column names
@@ -982,7 +986,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           }
 
           const cellProps = {
-            'aria-labelledby': `header-${sanitizeHeaderId(column.originalLabel || column.key)}`,
+            'aria-labelledby': `header-${headerId}`,
             role: 'cell',
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,
@@ -1069,7 +1073,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         },
         Header: ({ column: col, onClick, style, onDragStart, onDrop }) => (
           <th
-            id={`header-${sanitizeHeaderId(column.originalLabel || column.key)}`}
+            id={`header-${headerId}`}
             title={t('Shift + Click to sort by multiple columns')}
             className={[className, col.isSorted ? 'is-sorted' : ''].join(' ')}
             style={{

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -142,6 +142,19 @@ function cellWidth({
 }
 
 /**
+ * Sanitize a column identifier for use in HTML id attributes and CSS selectors.
+ * Replaces characters that are invalid in CSS selectors with safe alternatives.
+ */
+function sanitizeHeaderId(columnId: string): string {
+  return columnId
+    .replace(/%/g, 'percent')
+    .replace(/#/g, 'hash')
+    .replace(/△/g, 'delta')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+/**
  * Cell left margin (offset) calculation for horizontal bar chart elements
  * when alignPositiveNegative is not set
  */
@@ -969,7 +982,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
           }
 
           const cellProps = {
-            'aria-labelledby': `header-${column.key}`,
+            'aria-labelledby': `header-${sanitizeHeaderId(column.originalLabel || column.key)}`,
             role: 'cell',
             // show raw number in title in case of numeric values
             title: typeof value === 'number' ? String(value) : undefined,
@@ -1056,7 +1069,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         },
         Header: ({ column: col, onClick, style, onDragStart, onDrop }) => (
           <th
-            id={`header-${column.originalLabel}`}
+            id={`header-${sanitizeHeaderId(column.originalLabel || column.key)}`}
             title={t('Shift + Click to sort by multiple columns')}
             className={[className, col.isSorted ? 'is-sorted' : ''].join(' ')}
             style={{

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -154,7 +154,7 @@ export function sanitizeHeaderId(columnId: string): string {
   return (
     columnId
       // Semantic replacements first: preserve meaning in IDs for readability
-      // (e.g., 'percentpct_nice' instead of '_pct_nice')
+      // (e.g., '%pct_nice' → 'percentpct_nice' instead of '_pct_nice')
       .replace(/%/g, 'percent')
       .replace(/#/g, 'hash')
       .replace(/△/g, 'delta')

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -151,13 +151,19 @@ function cellWidth({
  * Exported for testing.
  */
 export function sanitizeHeaderId(columnId: string): string {
-  return columnId
-    .replace(/%/g, 'percent')
-    .replace(/#/g, 'hash')
-    .replace(/△/g, 'delta')
-    .replace(/\s+/g, '_')
-    .replace(/[^a-zA-Z0-9_-]/g, '_')
-    .replace(/_+/g, '_'); // Collapse consecutive underscores
+  return (
+    columnId
+      // Semantic replacements first: preserve meaning in IDs for readability
+      // (e.g., 'percentpct_nice' instead of '_pct_nice')
+      .replace(/%/g, 'percent')
+      .replace(/#/g, 'hash')
+      .replace(/△/g, 'delta')
+      // Generic sanitization for remaining special characters
+      .replace(/\s+/g, '_')
+      .replace(/[^a-zA-Z0-9_-]/g, '_')
+      .replace(/_+/g, '_') // Collapse consecutive underscores
+      .replace(/^_+|_+$/g, '') // Trim leading/trailing underscores
+  );
 }
 
 /**

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -25,42 +25,47 @@ import DateWithFormatter from '../src/utils/DateWithFormatter';
 import testData from './testData';
 import { ProviderWrapper } from './testHelpers';
 
-describe('sanitizeHeaderId', () => {
-  test('should sanitize percent sign', () => {
-    expect(sanitizeHeaderId('%pct_nice')).toBe('percentpct_nice');
-  });
+test('sanitizeHeaderId should sanitize percent sign', () => {
+  expect(sanitizeHeaderId('%pct_nice')).toBe('percentpct_nice');
+});
 
-  test('should sanitize hash/pound sign', () => {
-    expect(sanitizeHeaderId('# metric_1')).toBe('hash_metric_1');
-  });
+test('sanitizeHeaderId should sanitize hash/pound sign', () => {
+  expect(sanitizeHeaderId('# metric_1')).toBe('hash_metric_1');
+});
 
-  test('should sanitize delta symbol', () => {
-    expect(sanitizeHeaderId('△ delta')).toBe('delta_delta');
-  });
+test('sanitizeHeaderId should sanitize delta symbol', () => {
+  expect(sanitizeHeaderId('△ delta')).toBe('delta_delta');
+});
 
-  test('should replace spaces with underscores', () => {
-    expect(sanitizeHeaderId('Main metric_1')).toBe('Main_metric_1');
-    expect(sanitizeHeaderId('multiple  spaces')).toBe('multiple_spaces');
-  });
+test('sanitizeHeaderId should replace spaces with underscores', () => {
+  expect(sanitizeHeaderId('Main metric_1')).toBe('Main_metric_1');
+  expect(sanitizeHeaderId('multiple  spaces')).toBe('multiple_spaces');
+});
 
-  test('should handle multiple special characters', () => {
-    expect(sanitizeHeaderId('% #△ test')).toBe('percent_hashdelta_test');
-    expect(sanitizeHeaderId('% # △ test')).toBe('percent_hash_delta_test');
-  });
+test('sanitizeHeaderId should handle multiple special characters', () => {
+  expect(sanitizeHeaderId('% #△ test')).toBe('percent_hashdelta_test');
+  expect(sanitizeHeaderId('% # △ test')).toBe('percent_hash_delta_test');
+});
 
-  test('should preserve alphanumeric, underscore, and hyphen', () => {
-    expect(sanitizeHeaderId('valid-name_123')).toBe('valid-name_123');
-  });
+test('sanitizeHeaderId should preserve alphanumeric, underscore, and hyphen', () => {
+  expect(sanitizeHeaderId('valid-name_123')).toBe('valid-name_123');
+});
 
-  test('should replace other special characters with underscore', () => {
-    expect(sanitizeHeaderId('col@name!test')).toBe('col_name_test');
-    expect(sanitizeHeaderId('test.column')).toBe('test_column');
-  });
+test('sanitizeHeaderId should replace other special characters with underscore', () => {
+  expect(sanitizeHeaderId('col@name!test')).toBe('col_name_test');
+  expect(sanitizeHeaderId('test.column')).toBe('test_column');
+});
 
-  test('should handle edge cases', () => {
-    expect(sanitizeHeaderId('')).toBe('');
-    expect(sanitizeHeaderId('simple')).toBe('simple');
-  });
+test('sanitizeHeaderId should handle edge cases', () => {
+  expect(sanitizeHeaderId('')).toBe('');
+  expect(sanitizeHeaderId('simple')).toBe('simple');
+});
+
+test('sanitizeHeaderId should collapse consecutive underscores', () => {
+  expect(sanitizeHeaderId('test @@ space')).toBe('test_space');
+  expect(sanitizeHeaderId('col___name')).toBe('col_name');
+  expect(sanitizeHeaderId('a  b  c')).toBe('a_b_c');
+  expect(sanitizeHeaderId('test@@name')).toBe('test_name');
 });
 
 describe('plugin-chart-table', () => {
@@ -645,11 +650,11 @@ describe('plugin-chart-table', () => {
           header.textContent?.includes('Sum of Num'),
         );
         expect(sumHeader).toBeDefined();
-        expect(sumHeader?.id).toBe('header-sum__num'); // Falls back to column.key, not verbose label
+        expect(sumHeader?.id).toBe('header-sum_num'); // Falls back to column.key, consecutive underscores collapsed
 
         // Verify cells reference this header correctly
         const sumCells = container.querySelectorAll(
-          'td[aria-labelledby="header-sum__num"]',
+          'td[aria-labelledby="header-sum_num"]',
         );
         expect(sumCells.length).toBeGreaterThan(0);
 

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -94,8 +94,8 @@ test('sanitizeHeaderId should handle inputs with only special characters', () =>
   expect(sanitizeHeaderId('@@')).toBe('');
   expect(sanitizeHeaderId('   ')).toBe('');
   expect(sanitizeHeaderId('!@$')).toBe('');
-  expect(sanitizeHeaderId('!@#$')).toBe('hash'); // # → 'hash' is preserved (semantic replacement)
-  // Semantic replacements should be preserved even when alone
+  expect(sanitizeHeaderId('!@#$')).toBe('hash'); // # is replaced with 'hash' (semantic replacement)
+  // Semantic replacements produce readable output even when alone
   expect(sanitizeHeaderId('%')).toBe('percent');
   expect(sanitizeHeaderId('#')).toBe('hash');
   expect(sanitizeHeaderId('△')).toBe('delta');
@@ -104,7 +104,7 @@ test('sanitizeHeaderId should handle inputs with only special characters', () =>
 
 describe('plugin-chart-table', () => {
   describe('transformProps', () => {
-    it('should parse pageLength to pageSize', () => {
+    test('should parse pageLength to pageSize', () => {
       expect(transformProps(testData.basic).pageSize).toBe(20);
       expect(
         transformProps({
@@ -120,13 +120,13 @@ describe('plugin-chart-table', () => {
       ).toBe(0);
     });
 
-    it('should memoize data records', () => {
+    test('should memoize data records', () => {
       expect(transformProps(testData.basic).data).toBe(
         transformProps(testData.basic).data,
       );
     });
 
-    it('should memoize columns meta', () => {
+    test('should memoize columns meta', () => {
       expect(transformProps(testData.basic).columns).toBe(
         transformProps({
           ...testData.basic,
@@ -135,14 +135,14 @@ describe('plugin-chart-table', () => {
       );
     });
 
-    it('should format timestamp', () => {
+    test('should format timestamp', () => {
       // eslint-disable-next-line no-underscore-dangle
       const parsedDate = transformProps(testData.basic).data[0]
         .__timestamp as DateWithFormatter;
       expect(String(parsedDate)).toBe('2020-01-01 12:34:56');
       expect(parsedDate.getTime()).toBe(1577882096000);
     });
-    it('should process comparison columns when time_compare and comparison_type are set', () => {
+    test('should process comparison columns when time_compare and comparison_type are set', () => {
       const transformedProps = transformProps(testData.comparison);
       const comparisonColumns = transformedProps.columns.filter(
         col =>
@@ -164,7 +164,7 @@ describe('plugin-chart-table', () => {
       expect(comparisonColumns.some(col => col.label === '%')).toBe(true);
     });
 
-    it('should not process comparison columns when time_compare is empty', () => {
+    test('should not process comparison columns when time_compare is empty', () => {
       const propsWithoutTimeCompare = {
         ...testData.comparison,
         rawFormData: {
@@ -187,7 +187,7 @@ describe('plugin-chart-table', () => {
       expect(comparisonColumns.length).toBe(0);
     });
 
-    it('should correctly apply column configuration for comparison columns', () => {
+    test('should correctly apply column configuration for comparison columns', () => {
       const transformedProps = transformProps(testData.comparisonWithConfig);
 
       const comparisonColumns = transformedProps.columns.filter(
@@ -225,7 +225,7 @@ describe('plugin-chart-table', () => {
       expect(percentMetricConfig?.config).toEqual({ d3NumberFormat: '.3f' });
     });
 
-    it('should correctly format comparison columns using getComparisonColFormatter', () => {
+    test('should correctly format comparison columns using getComparisonColFormatter', () => {
       const transformedProps = transformProps(testData.comparisonWithConfig);
       const comparisonColumns = transformedProps.columns.filter(
         col =>
@@ -256,7 +256,7 @@ describe('plugin-chart-table', () => {
       expect(formattedPercentMetric).toBe('0.123');
     });
 
-    it('should set originalLabel for comparison columns when time_compare and comparison_type are set', () => {
+    test('should set originalLabel for comparison columns when time_compare and comparison_type are set', () => {
       const transformedProps = transformProps(testData.comparison);
 
       // Check if comparison columns are processed
@@ -343,7 +343,7 @@ describe('plugin-chart-table', () => {
     });
 
     describe('TableChart', () => {
-      it('render basic data', () => {
+      test('render basic data', () => {
         render(
           <TableChart {...transformProps(testData.basic)} sticky={false} />,
         );
@@ -362,7 +362,7 @@ describe('plugin-chart-table', () => {
         expect(cells[8]).toHaveTextContent('N/A');
       });
 
-      it('render advanced data', () => {
+      test('render advanced data', () => {
         render(
           <TableChart {...transformProps(testData.advanced)} sticky={false} />,
         );
@@ -379,7 +379,7 @@ describe('plugin-chart-table', () => {
         expect(cells[4]).toHaveTextContent('2.47k');
       });
 
-      it('render advanced data with currencies', () => {
+      test('render advanced data with currencies', () => {
         render(
           ProviderWrapper({
             children: (
@@ -399,7 +399,7 @@ describe('plugin-chart-table', () => {
         expect(cells[4]).toHaveTextContent('$ 2.47k');
       });
 
-      it('render data with a bigint value in a raw record mode', () => {
+      test('render data with a bigint value in a raw record mode', () => {
         render(
           ProviderWrapper({
             children: (
@@ -420,7 +420,7 @@ describe('plugin-chart-table', () => {
         expect(cells[3]).toHaveTextContent('1234567890123456789');
       });
 
-      it('render raw data', () => {
+      test('render raw data', () => {
         const props = transformProps({
           ...testData.raw,
           rawFormData: { ...testData.raw.rawFormData },
@@ -437,7 +437,7 @@ describe('plugin-chart-table', () => {
         expect(cells[1]).toHaveTextContent('0');
       });
 
-      it('render raw data with currencies', () => {
+      test('render raw data with currencies', () => {
         const props = transformProps({
           ...testData.raw,
           rawFormData: {
@@ -462,7 +462,7 @@ describe('plugin-chart-table', () => {
         expect(cells[2]).toHaveTextContent('$ 0');
       });
 
-      it('render small formatted data with currencies', () => {
+      test('render small formatted data with currencies', () => {
         const props = transformProps({
           ...testData.raw,
           rawFormData: {
@@ -504,14 +504,14 @@ describe('plugin-chart-table', () => {
         expect(cells[2]).toHaveTextContent('$ 0.61');
       });
 
-      it('render empty data', () => {
+      test('render empty data', () => {
         render(
           <TableChart {...transformProps(testData.empty)} sticky={false} />,
         );
         expect(screen.getByText('No records found')).toBeInTheDocument();
       });
 
-      it('render color with column color formatter', () => {
+      test('render color with column color formatter', () => {
         render(
           ProviderWrapper({
             children: (
@@ -541,7 +541,7 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByTitle('2467')).background).toBe('');
       });
 
-      it('render cell without color', () => {
+      test('render cell without color', () => {
         const dataWithEmptyCell = cloneDeep(testData.advanced.queriesData[0]);
         dataWithEmptyCell.data.push({
           __timestamp: null,
@@ -582,7 +582,7 @@ describe('plugin-chart-table', () => {
         );
         expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
       });
-      it('should display original label in grouped headers', () => {
+      test('should display original label in grouped headers', () => {
         const props = transformProps(testData.comparison);
 
         render(<TableChart {...props} sticky={false} />);
@@ -597,7 +597,7 @@ describe('plugin-chart-table', () => {
         expect(hasMetricHeaders).toBe(true);
       });
 
-      it('should set meaningful header IDs for time-comparison columns', () => {
+      test('should set meaningful header IDs for time-comparison columns', () => {
         // Test time-comparison columns have proper IDs
         // Uses originalLabel (e.g., "metric_1") which is sanitized for CSS safety
         const props = transformProps(testData.comparison);
@@ -653,7 +653,7 @@ describe('plugin-chart-table', () => {
         });
       });
 
-      it('should set meaningful header IDs for regular table columns', () => {
+      test('should set meaningful header IDs for regular table columns', () => {
         // Test regular (non-time-comparison) columns have proper IDs
         // Uses fallback to column.key since originalLabel is undefined
         const props = transformProps(testData.advanced);
@@ -732,7 +732,7 @@ describe('plugin-chart-table', () => {
         });
       });
 
-      it('render cell bars properly, and only when it is toggled on in both regular and percent metrics', () => {
+      test('render cell bars properly, and only when it is toggled on in both regular and percent metrics', () => {
         const props = transformProps({
           ...testData.raw,
           rawFormData: { ...testData.raw.rawFormData },
@@ -782,7 +782,7 @@ describe('plugin-chart-table', () => {
         cells = document.querySelectorAll('td');
       });
 
-      it('render color with string column color formatter(operator begins with)', () => {
+      test('render color with string column color formatter(operator begins with)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -814,7 +814,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('render color with string column color formatter (operator ends with)', () => {
+      test('render color with string column color formatter (operator ends with)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -843,7 +843,7 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByText('Joe')).background).toBe('');
       });
 
-      it('render color with string column color formatter (operator containing)', () => {
+      test('render color with string column color formatter (operator containing)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -872,7 +872,7 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByText('Joe')).background).toBe('');
       });
 
-      it('render color with string column color formatter (operator not containing)', () => {
+      test('render color with string column color formatter (operator not containing)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -903,7 +903,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('render color with string column color formatter (operator =)', () => {
+      test('render color with string column color formatter (operator =)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -934,7 +934,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('render color with string column color formatter (operator None)', () => {
+      test('render color with string column color formatter (operator None)', () => {
         render(
           ProviderWrapper({
             children: (
@@ -967,7 +967,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('render color with column color formatter to entire row', () => {
+      test('render color with column color formatter to entire row', () => {
         render(
           ProviderWrapper({
             children: (
@@ -1003,7 +1003,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('display text color using column color formatter', () => {
+      test('display text color using column color formatter', () => {
         render(
           ProviderWrapper({
             children: (
@@ -1036,7 +1036,7 @@ describe('plugin-chart-table', () => {
         );
       });
 
-      it('display text color using column color formatter for entire row', () => {
+      test('display text color using column color formatter for entire row', () => {
         render(
           ProviderWrapper({
             children: (

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -19,11 +19,49 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@superset-ui/core/spec';
 import { cloneDeep } from 'lodash';
-import TableChart from '../src/TableChart';
+import TableChart, { sanitizeHeaderId } from '../src/TableChart';
 import transformProps from '../src/transformProps';
 import DateWithFormatter from '../src/utils/DateWithFormatter';
 import testData from './testData';
 import { ProviderWrapper } from './testHelpers';
+
+describe('sanitizeHeaderId', () => {
+  test('should sanitize percent sign', () => {
+    expect(sanitizeHeaderId('%pct_nice')).toBe('percentpct_nice');
+  });
+
+  test('should sanitize hash/pound sign', () => {
+    expect(sanitizeHeaderId('# metric_1')).toBe('hash_metric_1');
+  });
+
+  test('should sanitize delta symbol', () => {
+    expect(sanitizeHeaderId('△ delta')).toBe('delta_delta');
+  });
+
+  test('should replace spaces with underscores', () => {
+    expect(sanitizeHeaderId('Main metric_1')).toBe('Main_metric_1');
+    expect(sanitizeHeaderId('multiple  spaces')).toBe('multiple_spaces');
+  });
+
+  test('should handle multiple special characters', () => {
+    expect(sanitizeHeaderId('% #△ test')).toBe('percent_hashdelta_test');
+    expect(sanitizeHeaderId('% # △ test')).toBe('percent_hash_delta_test');
+  });
+
+  test('should preserve alphanumeric, underscore, and hyphen', () => {
+    expect(sanitizeHeaderId('valid-name_123')).toBe('valid-name_123');
+  });
+
+  test('should replace other special characters with underscore', () => {
+    expect(sanitizeHeaderId('col@name!test')).toBe('col_name_test');
+    expect(sanitizeHeaderId('test.column')).toBe('test_column');
+  });
+
+  test('should handle edge cases', () => {
+    expect(sanitizeHeaderId('')).toBe('');
+    expect(sanitizeHeaderId('simple')).toBe('simple');
+  });
+});
 
 describe('plugin-chart-table', () => {
   describe('transformProps', () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -68,6 +68,40 @@ test('sanitizeHeaderId should collapse consecutive underscores', () => {
   expect(sanitizeHeaderId('test@@name')).toBe('test_name');
 });
 
+test('sanitizeHeaderId should remove leading underscores', () => {
+  expect(sanitizeHeaderId('@col')).toBe('col');
+  expect(sanitizeHeaderId('!revenue')).toBe('revenue');
+  expect(sanitizeHeaderId('@@test')).toBe('test');
+  expect(sanitizeHeaderId('   leading_spaces')).toBe('leading_spaces');
+});
+
+test('sanitizeHeaderId should remove trailing underscores', () => {
+  expect(sanitizeHeaderId('col@')).toBe('col');
+  expect(sanitizeHeaderId('revenue!')).toBe('revenue');
+  expect(sanitizeHeaderId('test@@')).toBe('test');
+  expect(sanitizeHeaderId('trailing_spaces   ')).toBe('trailing_spaces');
+});
+
+test('sanitizeHeaderId should remove leading and trailing underscores', () => {
+  expect(sanitizeHeaderId('@col@')).toBe('col');
+  expect(sanitizeHeaderId('!test!')).toBe('test');
+  expect(sanitizeHeaderId('  spaced  ')).toBe('spaced');
+  expect(sanitizeHeaderId('@@multiple@@')).toBe('multiple');
+});
+
+test('sanitizeHeaderId should handle inputs with only special characters', () => {
+  expect(sanitizeHeaderId('@')).toBe('');
+  expect(sanitizeHeaderId('@@')).toBe('');
+  expect(sanitizeHeaderId('   ')).toBe('');
+  expect(sanitizeHeaderId('!@$')).toBe('');
+  expect(sanitizeHeaderId('!@#$')).toBe('hash'); // # → 'hash' is preserved (semantic replacement)
+  // Semantic replacements should be preserved even when alone
+  expect(sanitizeHeaderId('%')).toBe('percent');
+  expect(sanitizeHeaderId('#')).toBe('hash');
+  expect(sanitizeHeaderId('△')).toBe('delta');
+  expect(sanitizeHeaderId('% # △')).toBe('percent_hash_delta');
+});
+
 describe('plugin-chart-table', () => {
   describe('transformProps', () => {
     it('should parse pageLength to pageSize', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Table chart column headers were rendering with `id="header-undefined"` instead of meaningful IDs, breaking CSS customization and ARIA accessibility that worked in Superset 4.1.1.

   **Root Cause:**
   PR #31590 (Ant Design v5 migration) changed header IDs from `column.key` to `column.originalLabel`, but `originalLabel` is only set for time-comparison columns (added in PR #32665), leaving regular columns with undefined values.

   **Solution:**
   Implemented defensive fallback with sanitization:
   - Headers: `id="header-${sanitizeHeaderId(column.originalLabel || column.key)}"`
   - Cells: `aria-labelledby="header-${sanitizeHeaderId(column.originalLabel || column.key)}"`

   Column identifiers can contain CSS-unsafe characters (%, #, △, spaces), so added `sanitizeHeaderId()` helper to ensure valid CSS selectors and ARIA references.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:**
<img width="2558" height="746" alt="Screenshot 2025-11-06 at 12 36 14 PM" src="https://github.com/user-attachments/assets/639b1a84-c93f-4938-9511-223749f27376" />

**After:**
<img width="2375" height="886" alt="Screenshot 2025-11-06 at 12 35 13 PM" src="https://github.com/user-attachments/assets/8ebb1060-4393-42f5-8984-9ef51e4ec0d0" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

   **Manual Testing:**

   1. **Test regular table chart:**
      ```
      - Create a table chart with regular columns (non-time-comparison)
      - Inspect the DOM (browser dev tools)
      - Verify column headers have meaningful IDs like id="header-column_name"
      - Verify NO headers have id="header-undefined"
      - Verify table cells have matching aria-labelledby attributes
      ```

   2. **Test time-comparison table chart:**
      ```
      - Create a table chart with time comparison enabled
      - Add metrics and enable comparison type
      - Inspect the DOM
      - Verify comparison columns have IDs like id="header-metric_1"
      - Verify NO headers have id="header-undefined"
      ```

   3. **Test special characters:**
      ```
      - Create columns with special characters: %pct_nice, #count, etc.
      - Verify IDs are sanitized: id="header-percentpct_nice", id="header-hashcount"
      - Verify no spaces or invalid CSS characters in IDs
      ```

   4. **Test CSS customization (issue reporter's use case):**
      ```css
      /* Should now work */
      #header-column_name {
        background-color: red;
      }
      ```

   **Automated Testing:**
   ```bash
   # Run table chart tests
   npm test -- plugins/plugin-chart-table/test/TableChart.test.tsx

   # Run pre-commit validation
   pre-commit run --files plugins/plugin-chart-table/src/TableChart.tsx plugins/plugin-chart-table/test/TableChart.test.tsx
   ```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35783
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
