### PR TITLE
fix(explore): show validation errors in View Query modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { screen, render, waitFor } from 'spec/helpers/testing-library';
+import fetchMock from 'fetch-mock';
+import ViewQueryModal from './ViewQueryModal';
+
+const mockFormData = {
+  datasource: '1__table',
+  viz_type: 'table',
+};
+
+const chartDataEndpoint = 'glob:*/api/v1/chart/data*';
+
+afterEach(() => {
+  jest.resetAllMocks();
+  fetchMock.restore();
+});
+
+test('renders Alert component when query result contains validation error', async () => {
+  /**
+   * Regression test for issue #35492
+   * Verifies that validation errors from the backend are displayed in an Alert
+   * component instead of showing a blank panel
+   */
+  // Mock API response with validation error
+  fetchMock.post(chartDataEndpoint, {
+    result: [
+      {
+        error: 'Missing temporal column',
+        language: 'sql',
+      },
+    ],
+  });
+
+  render(<ViewQueryModal latestQueryFormData={mockFormData} />);
+
+  // Wait for API call to complete
+  await waitFor(() =>
+    expect(fetchMock.calls(chartDataEndpoint)).toHaveLength(1),
+  );
+
+  // Assert Alert component is rendered with error message
+  expect(screen.getByRole('alert')).toBeInTheDocument();
+  expect(screen.getByText('Missing temporal column')).toBeInTheDocument();
+});

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -24,8 +24,8 @@ import {
   getClientErrorObject,
   QueryFormData,
 } from '@superset-ui/core';
-import { styled } from '@apache-superset/core/ui';
-import { Loading, Alert } from '@superset-ui/core/components';
+import { styled, Alert } from '@apache-superset/core/ui';
+import { Loading } from '@superset-ui/core/components';
 import { SupportedLanguage } from '@superset-ui/core/components/CodeSyntaxHighlighter';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
@@ -89,26 +89,24 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData }) => {
 
   return (
     <ViewQueryModalContainer>
-      {result.map((item, index) => (
-        <Fragment key={index}>
-          {item.error && (
-            <Alert
-              key={`error-${index}`}
-              type="error"
-              message={item.error}
-              closable={false}
-            />
-          )}
-          {item.query && (
-            <ViewQuery
-              key={`query-${index}`}
-              datasource={latestQueryFormData.datasource}
-              sql={item.query}
-              language={item.language}
-            />
-          )}
-        </Fragment>
-      ))}
+      {result.map((item, index) => {
+        // Use content-based key when available, fall back to index
+        const key = item.query || item.error || `result-${index}`;
+        return (
+          <Fragment key={key}>
+            {item.error && (
+              <Alert type="error" message={item.error} closable={false} />
+            )}
+            {item.query && (
+              <ViewQuery
+                datasource={latestQueryFormData.datasource}
+                sql={item.query}
+                language={item.language}
+              />
+            )}
+          </Fragment>
+        );
+      })}
     </ViewQueryModalContainer>
   );
 };

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -89,24 +89,21 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData }) => {
 
   return (
     <ViewQueryModalContainer>
-      {result.map((item, index) => {
-        // Use content-based key when available, fall back to index
-        const key = item.query || item.error || `result-${index}`;
-        return (
-          <Fragment key={key}>
-            {item.error && (
-              <Alert type="error" message={item.error} closable={false} />
-            )}
-            {item.query && (
-              <ViewQuery
-                datasource={latestQueryFormData.datasource}
-                sql={item.query}
-                language={item.language}
-              />
-            )}
-          </Fragment>
-        );
-      })}
+      {result.map((item, index) => (
+        // Static API response data - index is appropriate for keys
+        <Fragment key={index}>
+          {item.error && (
+            <Alert type="error" message={item.error} closable={false} />
+          )}
+          {item.query && (
+            <ViewQuery
+              datasource={latestQueryFormData.datasource}
+              sql={item.query}
+              language={item.language}
+            />
+          )}
+        </Fragment>
+      ))}
     </ViewQueryModalContainer>
   );
 };

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, useEffect, useState } from 'react';
+import { FC, Fragment, useEffect, useState } from 'react';
 
 import {
   ensureIsArray,
@@ -89,23 +89,26 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData }) => {
 
   return (
     <ViewQueryModalContainer>
-      {result.map((item, index) =>
-        item.error ? (
-          <Alert
-            key={`error-${index}`}
-            type="error"
-            message={item.error}
-            closable={false}
-          />
-        ) : item.query ? (
-          <ViewQuery
-            key={`query-${index}`}
-            datasource={latestQueryFormData.datasource}
-            sql={item.query}
-            language={item.language}
-          />
-        ) : null,
-      )}
+      {result.map((item, index) => (
+        <Fragment key={index}>
+          {item.error && (
+            <Alert
+              key={`error-${index}`}
+              type="error"
+              message={item.error}
+              closable={false}
+            />
+          )}
+          {item.query && (
+            <ViewQuery
+              key={`query-${index}`}
+              datasource={latestQueryFormData.datasource}
+              sql={item.query}
+              language={item.language}
+            />
+          )}
+        </Fragment>
+      ))}
     </ViewQueryModalContainer>
   );
 };

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -25,7 +25,8 @@ import {
   QueryFormData,
 } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/ui';
-import { Loading } from '@superset-ui/core/components';
+import { Loading, Alert } from '@superset-ui/core/components';
+import { SupportedLanguage } from '@superset-ui/core/components/CodeSyntaxHighlighter';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
 
@@ -34,8 +35,9 @@ interface Props {
 }
 
 type Result = {
-  query: string;
-  language: string;
+  query?: string;
+  language: SupportedLanguage;
+  error?: string;
 };
 
 const ViewQueryModalContainer = styled.div`
@@ -88,12 +90,19 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData }) => {
   return (
     <ViewQueryModalContainer>
       {result.map((item, index) =>
-        item.query ? (
+        item.error ? (
+          <Alert
+            key={`error-${index}`}
+            type="error"
+            message={item.error}
+            closable={false}
+          />
+        ) : item.query ? (
           <ViewQuery
             key={`query-${index}`}
             datasource={latestQueryFormData.datasource}
             sql={item.query}
-            language="sql"
+            language={item.language}
           />
         ) : null,
       )}

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1482,9 +1482,12 @@ class ChartDataResponseResult(Schema):
         allow_none=None,
     )
     query = fields.String(
-        metadata={"description": "The executed query statement"},
-        required=True,
-        allow_none=False,
+        metadata={
+            "description": "The executed query statement. May be absent when "
+            "validation errors occur."
+        },
+        required=False,
+        allow_none=True,
     )
     status = fields.String(
         metadata={"description": "Status of the query"},

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -92,8 +92,8 @@ def _get_query(
     except SupersetParseError as err:
         # Parsing errors (SQL optimization/parsing failed)
         # SQL was generated but couldn't be optimized - show both
-        if err.error.extra:
-            result["query"] = err.error.extra.get("sql")
+        if err.error.extra and (sql := err.error.extra.get("sql")) is not None:
+            result["query"] = sql
         result["error"] = err.error.message
     return result
 

--- a/superset/common/query_actions.py
+++ b/superset/common/query_actions.py
@@ -24,7 +24,7 @@ from flask_babel import _
 from superset.common.chart_data import ChartDataResultType
 from superset.common.db_query_status import QueryStatus
 from superset.connectors.sqla.models import BaseDatasource
-from superset.exceptions import QueryObjectValidationError
+from superset.exceptions import QueryObjectValidationError, SupersetParseError
 from superset.utils.core import (
     extract_column_dtype,
     extract_dataframe_dtypes,
@@ -86,7 +86,15 @@ def _get_query(
     try:
         result["query"] = datasource.get_query_str(query_obj.to_dict())
     except QueryObjectValidationError as err:
+        # Validation errors (missing required fields, invalid config)
+        # No SQL was generated
         result["error"] = err.message
+    except SupersetParseError as err:
+        # Parsing errors (SQL optimization/parsing failed)
+        # SQL was generated but couldn't be optimized - show both
+        if err.error.extra:
+            result["query"] = err.error.extra.get("sql")
+        result["error"] = err.error.message
     return result
 
 

--- a/tests/unit_tests/charts/commands/data/__init__.py
+++ b/tests/unit_tests/charts/commands/data/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/charts/commands/data/test_get_data_command.py
+++ b/tests/unit_tests/charts/commands/data/test_get_data_command.py
@@ -1,0 +1,209 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from superset.commands.chart.data.get_data_command import ChartDataCommand
+from superset.commands.chart.exceptions import ChartDataQueryFailedError
+from superset.common.chart_data import ChartDataResultType
+from superset.common.query_context import QueryContext
+
+
+def test_query_result_type_allows_validation_error_payload() -> None:
+    """
+    Regression test: Ensure result_type='query' with error payload returns
+    the error instead of raising ChartDataQueryFailedError.
+
+    This locks in the behavior where validation errors are passed through
+    to the frontend for display in ViewQueryModal.
+
+    Context:
+    - GitHub Issue #35492
+    - Superset 4.1.3 allowed errors to pass through
+    - Command reorganization in 2023 broke this behavior
+    - This test ensures errors pass through for query-only requests
+    """
+    # Mock QueryContext with result_type=QUERY
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.QUERY
+    mock_query_context.get_payload.return_value = {
+        "queries": [{"error": "Missing temporal column", "language": "sql"}]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should NOT raise - this is the key assertion for the regression test
+    result = command.run()
+
+    # Verify error is passed through in the response
+    assert result["queries"][0]["error"] == "Missing temporal column"
+    assert result["queries"][0]["language"] == "sql"
+    assert "query" not in result["queries"][0]  # No SQL for validation errors
+
+
+def test_full_result_type_raises_on_error() -> None:
+    """
+    Test that result_type='full' with error raises ChartDataQueryFailedError.
+
+    This ensures data requests continue to fail fast when errors occur,
+    maintaining existing behavior for non-query requests.
+    """
+    # Mock QueryContext with result_type=FULL
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.FULL
+    mock_query_context.get_payload.return_value = {
+        "queries": [{"error": "Invalid column name"}]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should raise exception for data requests
+    with pytest.raises(ChartDataQueryFailedError) as exc_info:
+        command.run()
+
+    assert "Invalid column name" in str(exc_info.value)
+
+
+def test_results_result_type_raises_on_error() -> None:
+    """
+    Test that result_type='results' with error raises ChartDataQueryFailedError.
+
+    Ensures fail-fast behavior is preserved for results-only requests.
+    """
+    # Mock QueryContext with result_type=RESULTS
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.RESULTS
+    mock_query_context.get_payload.return_value = {
+        "queries": [{"error": "Database connection failed"}]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should raise exception for results requests
+    with pytest.raises(ChartDataQueryFailedError) as exc_info:
+        command.run()
+
+    assert "Database connection failed" in str(exc_info.value)
+
+
+def test_query_result_type_returns_successful_query() -> None:
+    """
+    Test that result_type='query' without error returns query successfully.
+
+    Ensures no regression for successful query requests.
+    """
+    # Mock QueryContext with result_type=QUERY and successful query
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.QUERY
+    mock_query_context.get_payload.return_value = {
+        "queries": [{"query": "SELECT * FROM table", "language": "sql"}]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should return query successfully
+    result = command.run()
+
+    assert result["queries"][0]["query"] == "SELECT * FROM table"
+    assert result["queries"][0]["language"] == "sql"
+    assert "error" not in result["queries"][0]
+
+
+def test_full_result_type_returns_successful_data() -> None:
+    """
+    Test that result_type='full' without error returns data successfully.
+
+    Ensures no regression for successful data requests.
+    """
+    # Mock QueryContext with result_type=FULL and successful data
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.FULL
+    mock_query_context.get_payload.return_value = {
+        "queries": [{"data": [{"col1": "value1"}], "colnames": ["col1"]}]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should return data successfully
+    result = command.run()
+
+    assert result["queries"][0]["data"] == [{"col1": "value1"}]
+    assert result["queries"][0]["colnames"] == ["col1"]
+    assert "error" not in result["queries"][0]
+
+
+def test_query_result_type_with_multiple_queries_and_mixed_results() -> None:
+    """
+    Test that result_type='query' handles multiple queries with mixed results.
+
+    Some queries may succeed while others have validation errors.
+    All should be returned without raising exceptions.
+    """
+    # Mock QueryContext with multiple queries
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.QUERY
+    mock_query_context.get_payload.return_value = {
+        "queries": [
+            {"query": "SELECT * FROM table1", "language": "sql"},
+            {"error": "Missing required field", "language": "sql"},
+            {"query": "SELECT * FROM table2", "language": "sql"},
+        ]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should return all queries without raising
+    result = command.run()
+
+    # Verify first query succeeded
+    assert result["queries"][0]["query"] == "SELECT * FROM table1"
+    assert "error" not in result["queries"][0]
+
+    # Verify second query has error
+    assert result["queries"][1]["error"] == "Missing required field"
+    assert "query" not in result["queries"][1]
+
+    # Verify third query succeeded
+    assert result["queries"][2]["query"] == "SELECT * FROM table2"
+    assert "error" not in result["queries"][2]
+
+
+def test_full_result_type_fails_fast_on_first_error_in_multiple_queries() -> None:
+    """
+    Test that result_type='full' raises on first error even with multiple queries.
+
+    Ensures fail-fast behavior when multiple queries are present.
+    """
+    # Mock QueryContext with multiple queries where first has error
+    mock_query_context = Mock(spec=QueryContext)
+    mock_query_context.result_type = ChartDataResultType.FULL
+    mock_query_context.get_payload.return_value = {
+        "queries": [
+            {"error": "First query failed"},
+            {"data": [{"col1": "value1"}]},
+        ]
+    }
+
+    command = ChartDataCommand(mock_query_context)
+
+    # Should raise on first error without processing remaining queries
+    with pytest.raises(ChartDataQueryFailedError) as exc_info:
+        command.run()
+
+    assert "First query failed" in str(exc_info.value)

--- a/tests/unit_tests/charts/commands/data/test_get_data_command.py
+++ b/tests/unit_tests/charts/commands/data/test_get_data_command.py
@@ -217,10 +217,6 @@ def test_get_query_catches_parsing_error() -> None:
     - SQL has already been compiled (stored in error.extra['sql'])
     - Error message describes the parsing failure
     - Both should be returned to the frontend for display
-
-    This is Phase 2 of the fix for GitHub Issue #35492.
-    Phase 1 fixed validation errors (before SQL generation).
-    Phase 2 fixes parsing errors (after SQL generation, during optimization).
     """
     from superset.common.query_actions import _get_query
     from superset.common.query_object import QueryObject
@@ -252,4 +248,78 @@ def test_get_query_catches_parsing_error() -> None:
         # Should return both query (from error.extra['sql']) and error message
         assert result["query"] == "SELECT SUM ( Open"
         assert result["error"] == "Error parsing near 'Open' at line 1:17"
+        assert result["language"] == "sql"
+
+
+def test_get_query_handles_parsing_error_with_missing_sql_key() -> None:
+    """
+    Test _get_query() when error.extra exists but 'sql' key is missing.
+
+    Edge case: error.extra = {"other_field": "value"} with no 'sql' key.
+    Should NOT set result["query"] - prevents null from reaching TypeScript.
+    Should still return error message for display.
+
+    Ensures defensive programming when extracting SQL from exception extra data.
+    """
+    from superset.common.query_actions import _get_query
+    from superset.common.query_object import QueryObject
+    from superset.exceptions import SupersetParseError
+
+    mock_query_context = Mock()
+    mock_query_obj = Mock(spec=QueryObject)
+
+    parse_error = SupersetParseError(
+        sql="SELECT * FROM table",
+        message="Parsing error occurred",
+    )
+    # Mock error.extra to NOT have sql key
+    parse_error.error.extra = {"other_field": "some_value"}
+
+    with patch("superset.common.query_actions._get_datasource") as mock_get_ds:
+        mock_datasource = Mock()
+        mock_datasource.query_language = "sql"
+        mock_datasource.get_query_str.side_effect = parse_error
+        mock_get_ds.return_value = mock_datasource
+
+        result = _get_query(mock_query_context, mock_query_obj, False)
+
+        assert "query" not in result
+        assert result["error"] == "Parsing error occurred"
+        assert result["language"] == "sql"
+
+
+def test_get_query_handles_parsing_error_with_null_sql_value() -> None:
+    """
+    Test _get_query() when error.extra has 'sql': None explicitly set.
+
+    Edge case: error.extra = {"sql": None} with sql key present but value is None.
+    Should NOT set result["query"] - prevents null from reaching TypeScript.
+    Should still return error message for display.
+
+    Ensures defensive programming when extracting SQL from exception extra data.
+    """
+    from superset.common.query_actions import _get_query
+    from superset.common.query_object import QueryObject
+    from superset.exceptions import SupersetParseError
+
+    mock_query_context = Mock()
+    mock_query_obj = Mock(spec=QueryObject)
+
+    parse_error = SupersetParseError(
+        sql="SELECT * FROM table",
+        message="Parsing error occurred",
+    )
+    # Mock error.extra to have sql key with None value
+    parse_error.error.extra = {"sql": None}
+
+    with patch("superset.common.query_actions._get_datasource") as mock_get_ds:
+        mock_datasource = Mock()
+        mock_datasource.query_language = "sql"
+        mock_datasource.get_query_str.side_effect = parse_error
+        mock_get_ds.return_value = mock_datasource
+
+        result = _get_query(mock_query_context, mock_query_obj, False)
+
+        assert "query" not in result
+        assert result["error"] == "Parsing error occurred"
         assert result["language"] == "sql"


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes #35492 - Restores the ability to view helpful information in the "View Query" modal when chart queries fail.

This PR addresses a regression introduced during the 2023 command reorganization (commit 07bcfa9b5f) that broke error handling for the View Query feature. Previously in Superset 4.1.3, when charts failed, users could view either SQL or error messages. The reorganization caused all errors to return 400 status codes, making the frontend unable to display any helpful information.

  Two types of errors are now properly handled:

  1. Validation errors (Phase 1): Occur before SQL generation (e.g., missing required fields, invalid metrics)
    - Before: Blank modal or generic "Sorry, An error occurred" message
    - After: Clear error message displayed in Alert component
  2. Parsing errors (Phase 2): Occur after SQL generation during optimization (e.g., SQL syntax issues)
    - Before: 500 error, SQL lost completely
    - After: Both error message AND SQL displayed together

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

**After**
<img width="2074" height="784" alt="Screenshot 2025-11-05 at 4 46 10 PM" src="https://github.com/user-attachments/assets/88c05770-ee52-468e-a35e-fd6b280288eb" />


<img width="1501" height="889" alt="Screenshot 2025-11-06 at 7 58 29 PM" src="https://github.com/user-attachments/assets/f1b93ce4-c80d-4740-a0d3-6bc88f494fd7" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

   #### Automated Tests
   ```bash
   # Backend unit tests
   pytest tests/unit_tests/charts/commands/data/test_get_data_command.py -v

   # Frontend component test
   npm run test -- ViewQueryModal.test.tsx
   ```

   #### Manual Testing

   **Test Case 1: Validation Error (The Fix)**
   1. Create a chart in Explore view
   2. Add duplicate metric labels (e.g., add "sum__num" twice)
   3. Click "View Query" button
   4. **Expected**: Red Alert shows "Duplicate column/metric labels: sum__num"
   5. **Before fix**: Blank panel or generic error

   **Test Case 2: Valid Chart (No Regression)**
   1. Create a valid chart
   2. Click "View Query"
   3. **Expected**: SQL query displayed normally
   4. **Verify**: No regression on happy path

   **Test Case 3: Database Error (No Regression)**
   1. Create a chart with invalid column in database
   2. Click "View Query"
   3. **Expected**: Shows SQL query (generated before execution error)
   4. **Verify**: Database errors still work

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35492 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
