### PR TITLE
fix(dashboard): fix dashboard header overflow issue

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -96,14 +96,19 @@ const StickyPanel = styled.div<{ width: number }>`
 `;
 
 // @z-index-above-dashboard-popovers (99) + 1 = 100
-const StyledHeader = styled.div`
-  ${({ theme }) => css`
+const StyledHeader = styled.div<{
+  filterBarWidth: number;
+  showVerticalFilterBar: boolean;
+}>`
+  ${({ theme, filterBarWidth, showVerticalFilterBar }) => css`
     grid-column: 2;
     grid-row: 1;
     position: sticky;
     top: 0;
     z-index: 99;
-    max-width: 100vw;
+    max-width: ${showVerticalFilterBar
+      ? `calc(100vw - ${filterBarWidth}px)`
+      : '100vw'};
 
     .empty-droptarget:before {
       position: absolute;
@@ -561,6 +566,15 @@ const DashboardBuilder = () => {
     ? theme.sizeUnit * 4
     : theme.sizeUnit * 8;
 
+  // Calculate filter bar width for header max-width
+  const showVerticalFilterBar =
+    showFilterBar && filterBarOrientation === FilterBarOrientation.Vertical;
+  const headerFilterBarWidth = showVerticalFilterBar
+    ? dashboardFiltersOpen
+      ? OPEN_FILTER_BAR_WIDTH // Use default open width for header calculation
+      : CLOSED_FILTER_BAR_WIDTH
+    : 0;
+
   const renderChild = useCallback(
     adjustedWidth => {
       const filterBarWidth = dashboardFiltersOpen
@@ -614,7 +628,11 @@ const DashboardBuilder = () => {
             </ResizableSidebar>
           </>
         )}
-      <StyledHeader ref={headerRef}>
+      <StyledHeader
+        ref={headerRef}
+        filterBarWidth={headerFilterBarWidth}
+        showVerticalFilterBar={showVerticalFilterBar}
+      >
         {/* @ts-ignore */}
         <Droppable
           data-test="top-level-tabs"


### PR DESCRIPTION
### SUMMARY

Fixed horizontal overflow issue in dashboard headers when the vertical native filter bar is open or closed. Previously, the dashboard header used a fixed `max-width: 100vw` which didn't account for the filter bar width, causing tab content and other header elements to extend beyond the viewport and create horizontal scrollbars.

**Key Changes:**
- Updated `StyledHeader` component to dynamically calculate `max-width` based on filter bar state
- Uses existing constants (`OPEN_FILTER_BAR_WIDTH: 260px`, `CLOSED_FILTER_BAR_WIDTH: 32px`) for consistency

**Behavior:**
- **Vertical filter bar open**: `max-width: calc(100vw - 260px)`
- **Vertical filter bar closed**: `max-width: calc(100vw - 32px)` 
- **Horizontal filter bar or no filters**: `max-width: 100vw` (unchanged)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Dashboard header tabs overflow horizontally when vertical filter bar is present, creating unwanted scrollbars

https://github.com/user-attachments/assets/52395930-99a5-4279-8200-6eb98c8110fe

**After:** Dashboard header content properly constrains within available viewport width, accounting for filter bar space

https://github.com/user-attachments/assets/c1a2c5df-d30d-464e-84c8-2f3fdc232576



### TESTING INSTRUCTIONS

1. **Setup**: Navigate to a dashboard with native filters enabled
2. **Test vertical filter bar closed**:
   - Ensure vertical filter bar is in collapsed state (32px width)
   - Verify dashboard header/tabs don't overflow horizontally
   - Check that long tab names wrap or truncate appropriately
3. **Test vertical filter bar open**:
   - Expand the vertical filter bar (260px width)
   - Verify header content adjusts and stays within viewport bounds
   - Toggle filter bar open/closed and confirm smooth layout transitions
4. **Test horizontal filter bar**:
   - Switch to horizontal filter bar orientation 
   - Verify `max-width: 100vw` behavior is preserved (no regression)
5. **Test responsive behavior**:
   - Test at various screen sizes (mobile, tablet, desktop)
   - Ensure layout remains stable across different viewport widths
6. **Test edge cases**:
   - Dashboards with many long tab names
   - Dashboards with no native filters (should be unchanged)
   - Edit mode with builder panel open

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
