### PR TITLE
fix(DatasourceControl): eliminate test flakiness and async race conditions

### DIFF
--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -26,7 +26,6 @@ import {
   act,
   userEvent,
   waitFor,
-  cleanup,
 } from 'spec/helpers/testing-library';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
 import type { DatasetObject } from 'src/features/datasets/types';
@@ -42,7 +41,6 @@ beforeEach(() => {
 
 afterEach(() => {
   window.location = originalLocation;
-  cleanup();
   fetchMock.reset();
   fetchMock.restore();
   jest.clearAllMocks(); // Clears mock history but keeps spy in place

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -81,6 +81,11 @@ const createProps = (overrides: JsonObject = {}) => ({
 });
 
 async function openAndSaveChanges(datasource: any) {
+  fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
+  );
   fetchMock.put(
     'glob:*/api/v1/dataset/*',
     {},
@@ -208,6 +213,11 @@ test('Click on Edit dataset', async () => {
   const props = createProps();
   SupersetClientGet.mockImplementationOnce(
     async () => ({ json: { result: [] } }) as any,
+  );
+  fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
   );
   render(<DatasourceControl {...props} />, {
     useRedux: true,
@@ -525,6 +535,12 @@ test('should allow creating new metrics in dataset editor', async () => {
 
   // Mock API calls for dataset editor
   fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
+  );
+
+  fetchMock.get(
     'glob:*/api/v1/dataset/*',
     { result: mockDatasourceWithMetrics },
     { overwriteRoutes: true },
@@ -605,6 +621,12 @@ test('should allow deleting metrics in dataset editor', async () => {
 
   // Mock API calls
   fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
+  );
+
+  fetchMock.get(
     'glob:*/api/v1/dataset/*',
     { result: mockDatasourceWithMetrics },
     { overwriteRoutes: true },
@@ -668,6 +690,12 @@ test('should handle metric save confirmation modal', async () => {
 
   // Mock API calls for dataset editor
   fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
+  );
+
+  fetchMock.get(
     'glob:*/api/v1/dataset/*',
     { result: mockDatasource },
     { overwriteRoutes: true },
@@ -724,6 +752,12 @@ test('should verify real DatasourceControl callback fires on save', async () => 
   });
 
   // Mock API calls with the same datasource (no changes needed for this test)
+  fetchMock.get(
+    'glob:*/api/v1/database/?q=*',
+    { result: [] },
+    { overwriteRoutes: true },
+  );
+
   fetchMock.get(
     'glob:*/api/v1/dataset/*',
     { result: mockDatasource },

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -95,10 +95,10 @@ async function openAndSaveChanges(datasource: any) {
       overwriteRoutes: true,
     },
   );
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
-  userEvent.click(await screen.findByTestId('edit-dataset'));
-  userEvent.click(await screen.findByTestId('datasource-modal-save'));
-  userEvent.click(await screen.findByText('OK'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(await screen.findByTestId('edit-dataset'));
+  await userEvent.click(await screen.findByTestId('datasource-modal-save'));
+  await userEvent.click(await screen.findByText('OK'));
 }
 
 test('Should render', async () => {
@@ -122,7 +122,7 @@ test('Should open a menu', async () => {
   expect(screen.queryByText('Swap dataset')).not.toBeInTheDocument();
   expect(screen.queryByText('View in SQL Lab')).not.toBeInTheDocument();
 
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByText('Edit dataset')).toBeInTheDocument();
   expect(screen.getByText('Swap dataset')).toBeInTheDocument();
@@ -145,7 +145,7 @@ test('Should not show SQL Lab for non sql_lab role', async () => {
   });
   render(<DatasourceControl {...props} />, { useRouter: true });
 
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByText('Edit dataset')).toBeInTheDocument();
   expect(screen.getByText('Swap dataset')).toBeInTheDocument();
@@ -168,7 +168,7 @@ test('Should show SQL Lab for sql_lab role', async () => {
   });
   render(<DatasourceControl {...props} />, { useRouter: true });
 
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByText('Edit dataset')).toBeInTheDocument();
   expect(screen.getByText('Swap dataset')).toBeInTheDocument();
@@ -192,10 +192,10 @@ test('Click on Swap dataset option', async () => {
     useRedux: true,
     useRouter: true,
   });
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   await act(async () => {
-    userEvent.click(screen.getByText('Swap dataset'));
+    await userEvent.click(screen.getByText('Swap dataset'));
   });
   expect(
     screen.getByText(
@@ -213,10 +213,10 @@ test('Click on Edit dataset', async () => {
     useRedux: true,
     useRouter: true,
   });
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   await act(async () => {
-    userEvent.click(screen.getByText('Edit dataset'));
+    await userEvent.click(screen.getByText('Edit dataset'));
   });
 
   expect(
@@ -240,7 +240,7 @@ test('Edit dataset should be disabled when user is not admin', async () => {
     useRouter: true,
   });
 
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByTestId('edit-dataset')).toHaveAttribute(
     'aria-disabled',
@@ -268,12 +268,12 @@ test('Click on View in SQL Lab', async () => {
       useRouter: true,
     },
   );
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(queryByTestId('mock-sqllab-route')).not.toBeInTheDocument();
 
   await act(async () => {
-    userEvent.click(screen.getByText('View in SQL Lab'));
+    await userEvent.click(screen.getByText('View in SQL Lab'));
   });
 
   expect(getByTestId('mock-sqllab-route')).toBeInTheDocument();
@@ -302,7 +302,7 @@ test('Should open a different menu when datasource=query', async () => {
   expect(screen.queryByText('View in SQL Lab')).not.toBeInTheDocument();
   expect(screen.queryByText('Save as dataset')).not.toBeInTheDocument();
 
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
 
   expect(await screen.findByText('Query preview')).toBeInTheDocument();
   expect(screen.getByText('View in SQL Lab')).toBeInTheDocument();
@@ -323,7 +323,7 @@ test('Click on Save as dataset', async () => {
     useRedux: true,
     useRouter: true,
   });
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
   expect(
     screen.queryByRole('button', { name: /save/i }),
   ).not.toBeInTheDocument();
@@ -333,7 +333,7 @@ test('Click on Save as dataset', async () => {
   expect(
     screen.queryByText(/select or type dataset name/i),
   ).not.toBeInTheDocument();
-  userEvent.click(screen.getByText('Save as dataset'));
+  await userEvent.click(screen.getByText('Save as dataset'));
 
   // Renders a save dataset modal
   const saveRadioBtn = await screen.findByRole('radio', {
@@ -551,39 +551,39 @@ test('should allow creating new metrics in dataset editor', async () => {
   });
 
   // Open datasource menu and click edit dataset
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
-  userEvent.click(await screen.findByTestId('edit-dataset'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(await screen.findByTestId('edit-dataset'));
 
   // Wait for modal to appear and navigate to Metrics tab
   await waitFor(() => {
     expect(screen.getByText('Metrics')).toBeInTheDocument();
   });
 
-  userEvent.click(screen.getByText('Metrics'));
+  await userEvent.click(screen.getByText('Metrics'));
 
   // Click add new metric button
-  await waitFor(() => {
+  await waitFor(async () => {
     const addButton = screen.getByTestId('crud-add-table-item');
     expect(addButton).toBeInTheDocument();
-    userEvent.click(addButton);
+    await userEvent.click(addButton);
   });
 
   // Find and fill in the metric name
-  await waitFor(() => {
+  await waitFor(async () => {
     const nameInput = screen.getByTestId('textarea-editable-title-input');
     expect(nameInput).toBeInTheDocument();
-    userEvent.clear(nameInput);
-    userEvent.type(nameInput, newMetricName);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, newMetricName);
   });
 
   // Save the modal
-  userEvent.click(screen.getByTestId('datasource-modal-save'));
+  await userEvent.click(screen.getByTestId('datasource-modal-save'));
 
   // Confirm the save
-  await waitFor(() => {
+  await waitFor(async () => {
     const okButton = screen.getByText('OK');
     expect(okButton).toBeInTheDocument();
-    userEvent.click(okButton);
+    await userEvent.click(okButton);
   });
 
   // Verify the onDatasourceSave callback was called
@@ -626,17 +626,17 @@ test('should allow deleting metrics in dataset editor', async () => {
   });
 
   // Open edit dataset modal
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
-  userEvent.click(await screen.findByTestId('edit-dataset'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(await screen.findByTestId('edit-dataset'));
 
   // Navigate to Metrics tab
   await waitFor(() => {
     expect(screen.getByText('Metrics')).toBeInTheDocument();
   });
-  userEvent.click(screen.getByText('Metrics'));
+  await userEvent.click(screen.getByText('Metrics'));
 
   // Find existing metric and delete it
-  await waitFor(() => {
+  await waitFor(async () => {
     const metricRow = screen.getByText(existingMetricName).closest('tr');
     expect(metricRow).toBeInTheDocument();
 
@@ -644,17 +644,17 @@ test('should allow deleting metrics in dataset editor', async () => {
       '[data-test="crud-delete-icon"]',
     );
     expect(deleteButton).toBeInTheDocument();
-    userEvent.click(deleteButton!);
+    await userEvent.click(deleteButton!);
   });
 
   // Save the changes
-  userEvent.click(screen.getByTestId('datasource-modal-save'));
+  await userEvent.click(screen.getByTestId('datasource-modal-save'));
 
   // Confirm the save
-  await waitFor(() => {
+  await waitFor(async () => {
     const okButton = screen.getByText('OK');
     expect(okButton).toBeInTheDocument();
-    userEvent.click(okButton);
+    await userEvent.click(okButton);
   });
 
   // Verify the onDatasourceSave callback was called
@@ -689,14 +689,14 @@ test('should handle metric save confirmation modal', async () => {
   });
 
   // Open edit dataset modal
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
-  userEvent.click(await screen.findByTestId('edit-dataset'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(await screen.findByTestId('edit-dataset'));
 
   // Save without making changes
-  await waitFor(() => {
+  await waitFor(async () => {
     const saveButton = screen.getByTestId('datasource-modal-save');
     expect(saveButton).toBeInTheDocument();
-    userEvent.click(saveButton);
+    await userEvent.click(saveButton);
   });
 
   // Verify confirmation modal appears
@@ -705,7 +705,7 @@ test('should handle metric save confirmation modal', async () => {
   });
 
   // Click OK to confirm
-  userEvent.click(screen.getByText('OK'));
+  await userEvent.click(screen.getByText('OK'));
 
   // Verify the save was processed
   await waitFor(() => {
@@ -750,8 +750,8 @@ test('should verify real DatasourceControl callback fires on save', async () => 
   expect(screen.getByTestId('datasource-control')).toBeInTheDocument();
 
   // Open dataset editor
-  userEvent.click(screen.getByTestId('datasource-menu-trigger'));
-  userEvent.click(await screen.findByTestId('edit-dataset'));
+  await userEvent.click(screen.getByTestId('datasource-menu-trigger'));
+  await userEvent.click(await screen.findByTestId('edit-dataset'));
 
   // Wait for modal to open
   await waitFor(() => {
@@ -759,11 +759,11 @@ test('should verify real DatasourceControl callback fires on save', async () => 
   });
 
   // Save without making changes (this should still trigger the callback)
-  userEvent.click(screen.getByTestId('datasource-modal-save'));
-  await waitFor(() => {
+  await userEvent.click(screen.getByTestId('datasource-modal-save'));
+  await waitFor(async () => {
     const okButton = screen.getByText('OK');
     expect(okButton).toBeInTheDocument();
-    userEvent.click(okButton);
+    await userEvent.click(okButton);
   });
 
   // Verify the REAL component called the callback

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -34,7 +34,14 @@ import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
 
+let originalLocation: Location;
+
+beforeEach(() => {
+  originalLocation = window.location;
+});
+
 afterEach(() => {
+  window.location = originalLocation;
   cleanup();
   fetchMock.reset();
   fetchMock.restore();

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -26,6 +26,7 @@ import {
   act,
   userEvent,
   waitFor,
+  cleanup,
 } from 'spec/helpers/testing-library';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
 import DatasourceControl from '.';
@@ -33,8 +34,10 @@ import DatasourceControl from '.';
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
 
 afterEach(() => {
+  cleanup();
   fetchMock.reset();
   fetchMock.restore();
+  jest.restoreAllMocks();
 });
 
 const mockDatasource = {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -91,25 +91,7 @@ const createProps = (overrides: JsonObject = {}) => ({
   ...overrides,
 });
 
-type TestDataset = {
-  id?: number;
-  name?: string;
-  type?: DatasetObject['type'] | string;
-  main_dttm_col?: string | null;
-  columns?: Array<{
-    column_name?: string;
-    is_dttm?: boolean;
-    [key: string]: unknown;
-  }>;
-  metrics?: Array<{
-    id?: number;
-    metric_name?: string;
-    [key: string]: unknown;
-  }>;
-  [key: string]: unknown;
-};
-
-async function openAndSaveChanges(datasource: TestDataset) {
+async function openAndSaveChanges(datasource: Partial<DatasetObject>) {
   fetchMock.get(
     'glob:*/api/v1/database/?q=*',
     { result: [] },
@@ -416,7 +398,7 @@ test('should set the default temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource);
+  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -452,7 +434,7 @@ test('should set the first available temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource);
+  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -488,7 +470,7 @@ test('should not set the temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource);
+  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -45,7 +45,7 @@ afterEach(() => {
   cleanup();
   fetchMock.reset();
   fetchMock.restore();
-  jest.restoreAllMocks();
+  jest.clearAllMocks(); // Clears mock history but keeps spy in place
 });
 
 const mockDatasource = {

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -29,6 +29,7 @@ import {
   cleanup,
 } from 'spec/helpers/testing-library';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
+import type { DatasetObject } from 'src/features/datasets/types';
 import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
@@ -83,7 +84,25 @@ const createProps = (overrides: JsonObject = {}) => ({
   ...overrides,
 });
 
-async function openAndSaveChanges(datasource: any) {
+type TestDataset = {
+  id?: number;
+  name?: string;
+  type?: DatasetObject['type'] | string;
+  main_dttm_col?: string | null;
+  columns?: Array<{
+    column_name?: string;
+    is_dttm?: boolean;
+    [key: string]: unknown;
+  }>;
+  metrics?: Array<{
+    id?: number;
+    metric_name?: string;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+async function openAndSaveChanges(datasource: TestDataset) {
   fetchMock.get(
     'glob:*/api/v1/database/?q=*',
     { result: [] },

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -46,13 +46,25 @@ afterEach(() => {
   jest.clearAllMocks(); // Clears mock history but keeps spy in place
 });
 
-const mockDatasource = {
+type TestDatasource = Omit<
+  Partial<DatasetObject>,
+  'columns' | 'main_dttm_col'
+> & {
+  name: string;
+  database: { name: string };
+  columns?: any[];
+  type?: DatasourceType;
+  main_dttm_col?: string | null;
+};
+
+const mockDatasource: TestDatasource = {
   id: 25,
   database: {
     name: 'examples',
   },
   name: 'channels',
-  type: 'table',
+  datasource_name: 'channels',
+  type: DatasourceType.Table,
   columns: [],
   owners: [{ first_name: 'john', last_name: 'doe', id: 1, username: 'jd' }],
   sql: 'SELECT * FROM mock_datasource_sql',
@@ -89,7 +101,7 @@ const createProps = (overrides: JsonObject = {}) => ({
   ...overrides,
 });
 
-async function openAndSaveChanges(datasource: Partial<DatasetObject>) {
+async function openAndSaveChanges(datasource: TestDatasource) {
   fetchMock.get(
     'glob:*/api/v1/database/?q=*',
     { result: [] },
@@ -396,9 +408,7 @@ test('should set the default temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(
-    overrideProps.datasource as unknown as Partial<DatasetObject>,
-  );
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -434,9 +444,7 @@ test('should set the first available temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(
-    overrideProps.datasource as unknown as Partial<DatasetObject>,
-  );
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -472,9 +480,7 @@ test('should not set the temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(
-    overrideProps.datasource as unknown as Partial<DatasetObject>,
-  );
+  await openAndSaveChanges(overrideProps.datasource);
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -28,7 +28,7 @@ import {
   waitFor,
 } from 'spec/helpers/testing-library';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
-import type { DatasetObject } from 'src/features/datasets/types';
+import type { DatasetObject, ColumnObject } from 'src/features/datasets/types';
 import DatasourceControl from '.';
 
 const SupersetClientGet = jest.spyOn(SupersetClient, 'get');
@@ -52,7 +52,7 @@ type TestDatasource = Omit<
 > & {
   name: string;
   database: { name: string };
-  columns?: any[];
+  columns?: Partial<ColumnObject>[];
   type?: DatasourceType;
   main_dttm_col?: string | null;
 };

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/DatasourceControl.test.tsx
@@ -398,7 +398,9 @@ test('should set the default temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
+  await openAndSaveChanges(
+    overrideProps.datasource as unknown as Partial<DatasetObject>,
+  );
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -434,7 +436,9 @@ test('should set the first available temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
+  await openAndSaveChanges(
+    overrideProps.datasource as unknown as Partial<DatasetObject>,
+  );
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -470,7 +474,9 @@ test('should not set the temporal column', async () => {
     useRouter: true,
   });
 
-  await openAndSaveChanges(overrideProps.datasource as unknown as Partial<DatasetObject>);
+  await openAndSaveChanges(
+    overrideProps.datasource as unknown as Partial<DatasetObject>,
+  );
   await waitFor(() => {
     expect(props.actions.setControlValue).toHaveBeenCalledWith(
       'granularity_sqla',
@@ -589,29 +595,20 @@ test('should allow creating new metrics in dataset editor', async () => {
   await userEvent.click(screen.getByText('Metrics'));
 
   // Click add new metric button
-  await waitFor(async () => {
-    const addButton = screen.getByTestId('crud-add-table-item');
-    expect(addButton).toBeInTheDocument();
-    await userEvent.click(addButton);
-  });
+  const addButton = await screen.findByTestId('crud-add-table-item');
+  await userEvent.click(addButton);
 
   // Find and fill in the metric name
-  await waitFor(async () => {
-    const nameInput = screen.getByTestId('textarea-editable-title-input');
-    expect(nameInput).toBeInTheDocument();
-    await userEvent.clear(nameInput);
-    await userEvent.type(nameInput, newMetricName);
-  });
+  const nameInput = await screen.findByTestId('textarea-editable-title-input');
+  await userEvent.clear(nameInput);
+  await userEvent.type(nameInput, newMetricName);
 
   // Save the modal
   await userEvent.click(screen.getByTestId('datasource-modal-save'));
 
   // Confirm the save
-  await waitFor(async () => {
-    const okButton = screen.getByText('OK');
-    expect(okButton).toBeInTheDocument();
-    await userEvent.click(okButton);
-  });
+  const okButton = await screen.findByText('OK');
+  await userEvent.click(okButton);
 
   // Verify the onDatasourceSave callback was called
   await waitFor(() => {
@@ -669,26 +666,21 @@ test('should allow deleting metrics in dataset editor', async () => {
   await userEvent.click(screen.getByText('Metrics'));
 
   // Find existing metric and delete it
-  await waitFor(async () => {
-    const metricRow = screen.getByText(existingMetricName).closest('tr');
-    expect(metricRow).toBeInTheDocument();
+  const metricRow = (await screen.findByText(existingMetricName)).closest('tr');
+  expect(metricRow).toBeInTheDocument();
 
-    const deleteButton = metricRow?.querySelector(
-      '[data-test="crud-delete-icon"]',
-    );
-    expect(deleteButton).toBeInTheDocument();
-    await userEvent.click(deleteButton!);
-  });
+  const deleteButton = metricRow?.querySelector(
+    '[data-test="crud-delete-icon"]',
+  );
+  expect(deleteButton).toBeInTheDocument();
+  await userEvent.click(deleteButton!);
 
   // Save the changes
   await userEvent.click(screen.getByTestId('datasource-modal-save'));
 
   // Confirm the save
-  await waitFor(async () => {
-    const okButton = screen.getByText('OK');
-    expect(okButton).toBeInTheDocument();
-    await userEvent.click(okButton);
-  });
+  const okButton = await screen.findByText('OK');
+  await userEvent.click(okButton);
 
   // Verify the onDatasourceSave callback was called
   await waitFor(() => {
@@ -732,11 +724,8 @@ test('should handle metric save confirmation modal', async () => {
   await userEvent.click(await screen.findByTestId('edit-dataset'));
 
   // Save without making changes
-  await waitFor(async () => {
-    const saveButton = screen.getByTestId('datasource-modal-save');
-    expect(saveButton).toBeInTheDocument();
-    await userEvent.click(saveButton);
-  });
+  const saveButton = await screen.findByTestId('datasource-modal-save');
+  await userEvent.click(saveButton);
 
   // Verify confirmation modal appears
   await waitFor(() => {
@@ -805,11 +794,8 @@ test('should verify real DatasourceControl callback fires on save', async () => 
 
   // Save without making changes (this should still trigger the callback)
   await userEvent.click(screen.getByTestId('datasource-modal-save'));
-  await waitFor(async () => {
-    const okButton = screen.getByText('OK');
-    expect(okButton).toBeInTheDocument();
-    await userEvent.click(okButton);
-  });
+  const okButton = await screen.findByText('OK');
+  await userEvent.click(okButton);
 
   // Verify the REAL component called the callback
   // This tests that the integration point works (regardless of what data is passed)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes flaky test failures and "Can't perform state update on unmounted component" warnings in `DatasourceControl.test.tsx` by addressing async race conditions, missing API mocks, and improper test cleanup.

  **Root causes fixed:**
  1. **Unawaited userEvent calls** - 30+ `userEvent` interactions were not awaited, causing tests to end while React was still processing state updates
  2. **Missing database API mock** - `DatasourceEditor` fetches `/api/v1/database/?q=*` on mount but the endpoint wasn't mocked, leaving background requests dangling
  3. **Incomplete test cleanup** - Module-level spy and global mutations (window.location) were never cleaned up between tests
  4. **Custom type drift** - Bespoke `TestDataset` type duplicated dataset shape, risking drift from the canonical `DatasetObject`
  5. **Spy lifecycle bug** - Using `jest.restoreAllMocks()` killed the module-level spy after the first test, causing subsequent tests to potentially make real HTTP calls

  **Related work:**
  - Follow up to https://github.com/apache/superset/pull/35810 to `fix-datasource-editor-async` branch which fixes the `DatasourceEditor` component tests
  - This PR fixes `DatasourceControl` component tests
  - No conflicts between branches (different test files)


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
