### PR TITLE
feat(db): add dynamic schema support for athena

### DIFF
--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 
 from flask_babel import gettext as __
 from sqlalchemy import types
+from sqlalchemy.engine.url import URL
 
 from superset.constants import TimeGrain
 from superset.db_engine_specs.base import BaseEngineSpec
@@ -38,6 +39,7 @@ class AthenaEngineSpec(BaseEngineSpec):
     disable_ssh_tunneling = True
     # Athena doesn't support IS true/false syntax, use = true/false instead
     use_equality_for_boolean_filters = True
+    supports_dynamic_schema = True
 
     _time_grain_expressions = {
         None: "{col}",
@@ -92,3 +94,39 @@ class AthenaEngineSpec(BaseEngineSpec):
         :return: Conditionally mutated label
         """
         return label.lower()
+
+    @classmethod
+    def adjust_engine_params(
+        cls,
+        uri: URL,
+        connect_args: dict[str, Any],
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> tuple[URL, dict[str, Any]]:
+        """
+        Adjust the SQLAlchemy URI for Athena with a provided schema.
+
+        For AWS Athena the SQLAlchemy URI looks like this:
+
+            awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}&...
+        """
+        if not schema:
+            return uri, connect_args
+
+        uri = uri.set(database=schema)
+        return uri, connect_args
+
+    @classmethod
+    def get_schema_from_engine_params(
+        cls,
+        sqlalchemy_uri: URL,
+        connect_args: dict[str, Any],
+    ) -> str | None:
+        """
+        Return the configured schema.
+
+        For AWS Athena the SQLAlchemy URI looks like this:
+
+            awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}&...
+        """
+        return sqlalchemy_uri.database

--- a/superset/db_engine_specs/athena.py
+++ b/superset/db_engine_specs/athena.py
@@ -104,16 +104,18 @@ class AthenaEngineSpec(BaseEngineSpec):
         schema: str | None = None,
     ) -> tuple[URL, dict[str, Any]]:
         """
-        Adjust the SQLAlchemy URI for Athena with a provided schema.
+        Adjust the SQLAlchemy URI for Athena with a provided catalog and schema.
 
         For AWS Athena the SQLAlchemy URI looks like this:
 
-            awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}&...
+            awsathena+rest://athena.{region_name}.amazonaws.com:443/{schema_name}?catalog_name={catalog_name}&s3_staging_dir={s3_staging_dir}
         """
-        if not schema:
-            return uri, connect_args
+        if catalog:
+            uri = uri.update_query_dict({"catalog_name": catalog})
 
-        uri = uri.set(database=schema)
+        if schema:
+            uri = uri.set(database=schema)
+
         return uri, connect_args
 
     @classmethod
@@ -127,6 +129,6 @@ class AthenaEngineSpec(BaseEngineSpec):
 
         For AWS Athena the SQLAlchemy URI looks like this:
 
-            awsathena+rest://{aws_access_key_id}:{aws_secret_access_key}@athena.{region_name}.amazonaws.com:443/{schema_name}?s3_staging_dir={s3_staging_dir}&...
+            awsathena+rest://athena.{region_name}.amazonaws.com:443/{schema_name}?catalog_name={catalog_name}&s3_staging_dir={s3_staging_dir}
         """
         return sqlalchemy_uri.database

--- a/tests/unit_tests/db_engine_specs/test_athena.py
+++ b/tests/unit_tests/db_engine_specs/test_athena.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Optional
 
 import pytest
+from sqlalchemy.engine.url import make_url
 
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
@@ -119,4 +120,60 @@ def test_handle_boolean_filter() -> None:
     assert (
         str(result_false.compile(compile_kwargs={"literal_binds": True}))
         == "test_col = false"
+    )
+
+
+def test_adjust_engine_params() -> None:
+    """
+    Test `adjust_engine_params`.
+
+    The method can be used to adjust the schema dynamically.
+    """
+    from superset.db_engine_specs.athena import AthenaEngineSpec
+
+    url = make_url(
+        "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+    )
+
+    uri = AthenaEngineSpec.adjust_engine_params(url, {})[0]
+    assert (
+        str(uri)
+        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+    )
+
+    uri = AthenaEngineSpec.adjust_engine_params(
+        url,
+        {},
+        schema="new_schema",
+    )[0]
+    assert (
+        str(uri)
+        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/new_schema?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+    )
+
+
+def test_get_schema_from_engine_params() -> None:
+    """
+    Test the ``get_schema_from_engine_params`` method.
+    """
+    from superset.db_engine_specs.athena import AthenaEngineSpec
+
+    assert (
+        AthenaEngineSpec.get_schema_from_engine_params(
+            make_url(
+                "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+            ),
+            {},
+        )
+        == "default"
+    )
+
+    assert (
+        AthenaEngineSpec.get_schema_from_engine_params(
+            make_url(
+                "awsathena+rest://athena.us-east-1.amazonaws.com:443?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+            ),
+            {},
+        )
+        is None
     )

--- a/tests/unit_tests/db_engine_specs/test_athena.py
+++ b/tests/unit_tests/db_engine_specs/test_athena.py
@@ -131,24 +131,37 @@ def test_adjust_engine_params() -> None:
     """
     from superset.db_engine_specs.athena import AthenaEngineSpec
 
-    url = make_url(
-        "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?s3_staging_dir=s3%3A%2F%2Fathena-staging"
-    )
+    url = make_url("awsathena+rest://athena.us-east-1.amazonaws.com:443/default")
 
     uri = AthenaEngineSpec.adjust_engine_params(url, {})[0]
-    assert (
-        str(uri)
-        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?s3_staging_dir=s3%3A%2F%2Fathena-staging"
-    )
+    assert str(uri) == "awsathena+rest://athena.us-east-1.amazonaws.com:443/default"
 
     uri = AthenaEngineSpec.adjust_engine_params(
         url,
         {},
         schema="new_schema",
     )[0]
+    assert str(uri) == "awsathena+rest://athena.us-east-1.amazonaws.com:443/new_schema"
+
+    uri = AthenaEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+    )[0]
     assert (
         str(uri)
-        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/new_schema?s3_staging_dir=s3%3A%2F%2Fathena-staging"
+        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/default?catalog_name=new_catalog"
+    )
+
+    uri = AthenaEngineSpec.adjust_engine_params(
+        url,
+        {},
+        catalog="new_catalog",
+        schema="new_schema",
+    )[0]
+    assert (
+        str(uri)
+        == "awsathena+rest://athena.us-east-1.amazonaws.com:443/new_schema?catalog_name=new_catalog"
     )
 
 


### PR DESCRIPTION
### SUMMARY
This PR adds dynamic schema support to AWS Athena connection.

When Athena connection is configured to some schema selecting different schema in SQL Lab or Dataset configuration doesn't affect the query.
As a result it ends up looking for the table in the connection configured schema (not in selected) and fails with table not found error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="2230" height="1492" alt="Screenshot From 2025-11-05 15-42-28" src="https://github.com/user-attachments/assets/ff8b2b45-6a3d-4515-80e2-f42f02f97134" />


After:
<img width="2230" height="1492" alt="Screenshot From 2025-11-05 15-42-43" src="https://github.com/user-attachments/assets/1d461303-dfa1-45c6-bdcb-0dcf3f810023" />


### TESTING INSTRUCTIONS
Unit tests added.

To manually test:
- Install PyAthena module and connect to AWS Athena.
- Check you're able to run a SQL query without specifying the schema in the SQL statement as long as it's selected in the dropdown.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
