### PR TITLE
fix(dashboard): ensure charts re-render when visibility state changes

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -612,18 +612,18 @@ export default memo(Chart, (prevProps, nextProps) => {
     return false;
   }
   return (
-    !nextProps.isComponentVisible ||
-    (prevProps.isInView === nextProps.isInView &&
-      prevProps.componentId === nextProps.componentId &&
-      prevProps.id === nextProps.id &&
-      prevProps.dashboardId === nextProps.dashboardId &&
-      prevProps.extraControls === nextProps.extraControls &&
-      prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
-      prevProps.isFullSize === nextProps.isFullSize &&
-      prevProps.setControlValue === nextProps.setControlValue &&
-      prevProps.sliceName === nextProps.sliceName &&
-      prevProps.updateSliceName === nextProps.updateSliceName &&
-      prevProps.width === nextProps.width &&
-      prevProps.height === nextProps.height)
+    prevProps.isComponentVisible === nextProps.isComponentVisible &&
+    prevProps.isInView === nextProps.isInView &&
+    prevProps.componentId === nextProps.componentId &&
+    prevProps.id === nextProps.id &&
+    prevProps.dashboardId === nextProps.dashboardId &&
+    prevProps.extraControls === nextProps.extraControls &&
+    prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
+    prevProps.isFullSize === nextProps.isFullSize &&
+    prevProps.setControlValue === nextProps.setControlValue &&
+    prevProps.sliceName === nextProps.sliceName &&
+    prevProps.updateSliceName === nextProps.updateSliceName &&
+    prevProps.width === nextProps.width &&
+    prevProps.height === nextProps.height
   );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -612,18 +612,18 @@ export default memo(Chart, (prevProps, nextProps) => {
     return false;
   }
   return (
-    prevProps.isComponentVisible === nextProps.isComponentVisible &&
-    prevProps.isInView === nextProps.isInView &&
-    prevProps.componentId === nextProps.componentId &&
-    prevProps.id === nextProps.id &&
-    prevProps.dashboardId === nextProps.dashboardId &&
-    prevProps.extraControls === nextProps.extraControls &&
-    prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
-    prevProps.isFullSize === nextProps.isFullSize &&
-    prevProps.setControlValue === nextProps.setControlValue &&
-    prevProps.sliceName === nextProps.sliceName &&
-    prevProps.updateSliceName === nextProps.updateSliceName &&
-    prevProps.width === nextProps.width &&
-    prevProps.height === nextProps.height
+    !nextProps.isComponentVisible ||
+    (prevProps.isComponentVisible &&
+      prevProps.isInView === nextProps.isInView &&
+      prevProps.id === nextProps.id &&
+      prevProps.dashboardId === nextProps.dashboardId &&
+      prevProps.extraControls === nextProps.extraControls &&
+      prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
+      prevProps.isFullSize === nextProps.isFullSize &&
+      prevProps.setControlValue === nextProps.setControlValue &&
+      prevProps.sliceName === nextProps.sliceName &&
+      prevProps.updateSliceName === nextProps.updateSliceName &&
+      prevProps.width === nextProps.width &&
+      prevProps.height === nextProps.height)
   );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -612,18 +612,18 @@ export default memo(Chart, (prevProps, nextProps) => {
     return false;
   }
   return (
-    !nextProps.isComponentVisible ||
-    (prevProps.isComponentVisible &&
-      prevProps.isInView === nextProps.isInView &&
-      prevProps.id === nextProps.id &&
-      prevProps.dashboardId === nextProps.dashboardId &&
-      prevProps.extraControls === nextProps.extraControls &&
-      prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
-      prevProps.isFullSize === nextProps.isFullSize &&
-      prevProps.setControlValue === nextProps.setControlValue &&
-      prevProps.sliceName === nextProps.sliceName &&
-      prevProps.updateSliceName === nextProps.updateSliceName &&
-      prevProps.width === nextProps.width &&
-      prevProps.height === nextProps.height)
+    prevProps.isComponentVisible === nextProps.isComponentVisible &&
+    prevProps.componentId === nextProps.componentId &&
+    prevProps.isInView === nextProps.isInView &&
+    prevProps.id === nextProps.id &&
+    prevProps.dashboardId === nextProps.dashboardId &&
+    prevProps.extraControls === nextProps.extraControls &&
+    prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
+    prevProps.isFullSize === nextProps.isFullSize &&
+    prevProps.setControlValue === nextProps.setControlValue &&
+    prevProps.sliceName === nextProps.sliceName &&
+    prevProps.updateSliceName === nextProps.updateSliceName &&
+    prevProps.width === nextProps.width &&
+    prevProps.height === nextProps.height
   );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -612,18 +612,19 @@ export default memo(Chart, (prevProps, nextProps) => {
     return false;
   }
   return (
-    prevProps.isComponentVisible === nextProps.isComponentVisible &&
-    prevProps.componentId === nextProps.componentId &&
-    prevProps.isInView === nextProps.isInView &&
-    prevProps.id === nextProps.id &&
-    prevProps.dashboardId === nextProps.dashboardId &&
-    prevProps.extraControls === nextProps.extraControls &&
-    prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
-    prevProps.isFullSize === nextProps.isFullSize &&
-    prevProps.setControlValue === nextProps.setControlValue &&
-    prevProps.sliceName === nextProps.sliceName &&
-    prevProps.updateSliceName === nextProps.updateSliceName &&
-    prevProps.width === nextProps.width &&
-    prevProps.height === nextProps.height
+    !nextProps.isComponentVisible ||
+    (prevProps.componentId === nextProps.componentId &&
+      prevProps.isComponentVisible &&
+      prevProps.isInView === nextProps.isInView &&
+      prevProps.id === nextProps.id &&
+      prevProps.dashboardId === nextProps.dashboardId &&
+      prevProps.extraControls === nextProps.extraControls &&
+      prevProps.handleToggleFullSize === nextProps.handleToggleFullSize &&
+      prevProps.isFullSize === nextProps.isFullSize &&
+      prevProps.setControlValue === nextProps.setControlValue &&
+      prevProps.sliceName === nextProps.sliceName &&
+      prevProps.updateSliceName === nextProps.updateSliceName &&
+      prevProps.width === nextProps.width &&
+      prevProps.height === nextProps.height)
   );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
@@ -283,9 +283,7 @@ test('should re-render when componentId changes', () => {
   });
   expect(getByTestId('chart-container')).toBeInTheDocument();
 
-  rerender(
-    <Chart {...props} isComponentVisible componentId="test-2" />,
-  );
+  rerender(<Chart {...props} isComponentVisible componentId="test-2" />);
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });
 
@@ -296,8 +294,6 @@ test('should re-render when cacheBusterProp changes', () => {
   });
   expect(getByTestId('chart-container')).toBeInTheDocument();
 
-  rerender(
-    <Chart {...props} isComponentVisible cacheBusterProp="v2" />,
-  );
+  rerender(<Chart {...props} isComponentVisible cacheBusterProp="v2" />);
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
@@ -267,3 +267,37 @@ test('should call exportChart with row_limit props.maxRows when exportFullXLSX i
 
   stubbedExportXLSX.mockRestore();
 });
+
+test('should re-render when chart becomes visible', () => {
+  const { rerender, getByTestId } = setup({ isComponentVisible: false });
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+
+  rerender(<Chart {...props} isComponentVisible />);
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+});
+
+test('should re-render when componentId changes', () => {
+  const { rerender, getByTestId } = setup({
+    isComponentVisible: true,
+    componentId: 'test-1',
+  });
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+
+  rerender(
+    <Chart {...props} isComponentVisible componentId="test-2" />,
+  );
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+});
+
+test('should re-render when cacheBusterProp changes', () => {
+  const { rerender, getByTestId } = setup({
+    isComponentVisible: true,
+    cacheBusterProp: 'v1',
+  });
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+
+  rerender(
+    <Chart {...props} isComponentVisible cacheBusterProp="v2" />,
+  );
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+});


### PR DESCRIPTION
### SUMMARY

Fixes an intermittent bug where dashboard charts get stuck in loading state with async queries enabled in Superset 6.x. The issue was introduced in PR #31241 where a performance optimization in the Chart component's `React.memo` comparison incorrectly prevented re-renders when the `isComponentVisible` prop changed.

  **Root Cause:**
  The memo comparison function had a flawed escape hatch (`!nextProps.isComponentVisible`) that would skip ALL re-renders for invisible charts, regardless of whether other props changed. Additionally, `isComponentVisible` itself was not included in the prop comparison list, so visibility changes (false→true or true→false) were never detected.

  **The Fix:**
  Changed the memo comparison to explicitly check `isComponentVisible` like any other prop:
  - **Before:** `!nextProps.isComponentVisible || (/* other props */)`
  - **After:** `prevProps.isComponentVisible === nextProps.isComponentVisible && (/* other props */)`

  This ensures charts re-render when:
  - Visibility changes (becoming visible/invisible)
  - Any prop changes, even when invisible
  - While still skipping re-renders when truly nothing changed