### PR TITLE
test: revert unrelated flaky test fix from MCP PR

### DIFF
--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -372,8 +372,6 @@ class TestChartsUpdateCommand(SupersetTestCase):
     @pytest.mark.usefixtures("load_energy_table_with_slice")
     def test_update_v1_response(self, mock_sm_g, mock_c_g, mock_u_g):
         """Test that a chart command updates properties"""
-        import time
-
         pk = db.session.query(Slice).all()[0].id
         user = security_manager.find_user(username="admin")
         mock_u_g.user = mock_c_g.user = mock_sm_g.user = user
@@ -385,7 +383,6 @@ class TestChartsUpdateCommand(SupersetTestCase):
         }
         command = UpdateChartCommand(model_id, json_obj)
         last_saved_before = db.session.query(Slice).get(pk).last_saved_at
-        time.sleep(0.01)  # Ensure timestamp will be different
         command.run()
         chart = db.session.query(Slice).get(pk)
         assert chart.last_saved_at != last_saved_before


### PR DESCRIPTION
### SUMMARY

Reverts an unrelated flaky test fix that was accidentally included in PR #35163 (MCP service infrastructure).

### ISSUE

The MCP service PR (#35163) included a `time.sleep(0.01)` workaround for a flaky test in `tests/integration_tests/charts/commands_tests.py`. As noted in the PR review, this change was unrelated to the MCP service and should have been in a separate PR.

### CHANGES

**Reverted**:
- Removed `import time` statement
- Removed `time.sleep(0.01)` line before timestamp comparison

**File**: `tests/integration_tests/charts/commands_tests.py`

### MOTIVATION

This flaky test fix deserves its own investigation and proper solution:
- The timestamp race condition needs proper analysis
- Solutions like mocking time with `freezegun` may be more appropriate
- The fix should be accompanied by explanation of the root cause

### NEXT STEPS

- [ ] Create GitHub issue to track proper flaky test investigation
- [ ] Investigate why `last_saved_at` timestamp comparison is flaky
- [ ] Implement proper fix (mock time, use freezegun, or fix UpdateChartCommand)
- [ ] Add test documentation explaining the timing sensitivity

### TESTING

✅ Reverted changes only
✅ No functional changes to test behavior
✅ Test may become flaky again (expected, needs proper fix)

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Will create after revert
- [x] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [x] Removes existing feature or API: Yes (removes workaround)

**References**:
- Original PR: #35163