### PR TITLE
docs: Add minimal set of permissions required for public dashboards

### DIFF
--- a/docs/docs/configuration/networking-settings.mdx
+++ b/docs/docs/configuration/networking-settings.mdx
@@ -54,6 +54,22 @@ Restart Superset for this configuration change to take effect.
 1. Add the `'DASHBOARD_RBAC': True` [Feature Flag](https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md) to `superset_config.py`
 2. Add the `Public` role to your dashboard as described [here](https://superset.apache.org/docs/using-superset/creating-your-first-dashboard/#manage-access-to-dashboards)
 
+For security purposes, you will want to limit what public users can do on your superset instance.
+The minimal set of permissions to enable viewing dashboards with the public user is as follows:
+
+- can read on Chart
+- can read on Dashboard
+- can read on DashboardPermalinkRestApi
+- can dashboard permalink on Superset
+- can slice on Superset
+- can explore json on Superset
+- can dashboard on Superset
+
+Optionally if you want users to be able to download your chart data:
+
+- can export on Chart
+- can csv on Superset
+
 #### Embedding a Public Dashboard
 
 Now anybody can directly access the dashboard's URL. You can embed it in an iframe like so:


### PR DESCRIPTION
### SUMMARY
Updates the superset documentation on public dashboards to list the minimal set of requirements needed
to make public dashboards work.

Prior to this change, the suggestion is to initialize your superset instance with `PUBLIC_ROLE_LIKE = "Gamma"` but
Gamma permissions are too permissive, with things like write and delete permissions, for a public role.

This is purely a documentation change. I found this set of permissions by starting with all Gamma permissions and deleting permissions until I found the minimal permissions required to have a functional public dashboard without granting excess permissions.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
