### PR TITLE
refactor(mcp): migrate to Flask config system for MCP settings

### DIFF
--- a/superset/mcp_service/__main__.py
+++ b/superset/mcp_service/__main__.py
@@ -123,7 +123,7 @@ def main() -> None:
         if transport == "streamable-http":
             host = os.environ.get("FASTMCP_HOST", "127.0.0.1")
             port = int(os.environ.get("FASTMCP_PORT", "5008"))
-            mcp.run(transport=transport, host=host, port=port)
+            mcp.run(transport=transport, host=host, port=port, stateless_http=True)
         else:
             mcp.run(transport=transport)
 

--- a/superset/mcp_service/__main__.py
+++ b/superset/mcp_service/__main__.py
@@ -117,15 +117,16 @@ def main() -> None:
                 sys.exit(0)
     else:
         # For other transports, use normal initialization
+        from superset.mcp_service.flask_singleton import get_flask_app
+
+        flask_app = get_flask_app()
         init_fastmcp_server()
 
         # Run with specified transport
         if transport == "streamable-http":
             host = os.environ.get("FASTMCP_HOST", "127.0.0.1")
             port = int(os.environ.get("FASTMCP_PORT", "5008"))
-            stateless = (
-                os.environ.get("FASTMCP_STATELESS_HTTP", "true").lower() == "true"
-            )
+            stateless = flask_app.config.get("MCP_FASTMCP_STATELESS_HTTP", True)
             mcp.run(transport=transport, host=host, port=port, stateless_http=stateless)
         else:
             mcp.run(transport=transport)

--- a/superset/mcp_service/__main__.py
+++ b/superset/mcp_service/__main__.py
@@ -123,7 +123,10 @@ def main() -> None:
         if transport == "streamable-http":
             host = os.environ.get("FASTMCP_HOST", "127.0.0.1")
             port = int(os.environ.get("FASTMCP_PORT", "5008"))
-            mcp.run(transport=transport, host=host, port=port, stateless_http=True)
+            stateless = (
+                os.environ.get("FASTMCP_STATELESS_HTTP", "true").lower() == "true"
+            )
+            mcp.run(transport=transport, host=host, port=port, stateless_http=stateless)
         else:
             mcp.run(transport=transport)
 

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -236,7 +236,7 @@ def create_mcp_app(
 
 # Create default MCP instance for backward compatibility
 # Tool modules can import this and use @mcp.tool decorators
-mcp = create_mcp_app(stateless_http=True)
+mcp = create_mcp_app()
 
 # Import all MCP tools to register them with the mcp instance
 # NOTE: Always add new tool imports here when creating new MCP tools.

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -45,6 +45,14 @@ MCP_SERVICE_PORT = 5008
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 
+# FastMCP stateless HTTP mode (True for stateless, False for stateful sessions)
+# Can be overridden in superset_config.py
+MCP_FASTMCP_STATELESS_HTTP = True
+
+# SQLAlchemy debug logging for MCP service
+# Can be overridden in superset_config.py
+MCP_SQLALCHEMY_DEBUG = False
+
 # Session configuration for local development
 MCP_SESSION_CONFIG = {
     "SESSION_COOKIE_HTTPONLY": True,

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -91,8 +91,15 @@ def run_server(
         os.environ[env_key] = "1"
         try:
             logging.info("Starting FastMCP on %s:%s", host, port)
+            # Configurable via FASTMCP_STATELESS_HTTP env var (default: true)
+            stateless = (
+                os.environ.get("FASTMCP_STATELESS_HTTP", "true").lower() == "true"
+            )
             mcp_instance.run(
-                transport="streamable-http", host=host, port=port, stateless_http=True
+                transport="streamable-http",
+                host=host,
+                port=port,
+                stateless_http=stateless,
             )
         except Exception as e:
             logging.error("FastMCP failed: %s", e)

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -91,7 +91,9 @@ def run_server(
         os.environ[env_key] = "1"
         try:
             logging.info("Starting FastMCP on %s:%s", host, port)
-            mcp_instance.run(transport="streamable-http", host=host, port=port)
+            mcp_instance.run(
+                transport="streamable-http", host=host, port=port, stateless_http=True
+            )
         except Exception as e:
             logging.error("FastMCP failed: %s", e)
             os.environ.pop(env_key, None)

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -23,14 +23,18 @@ import logging
 import os
 
 from superset.mcp_service.app import create_mcp_app, init_fastmcp_server
-from superset.mcp_service.mcp_config import get_mcp_factory_config
+from superset.mcp_service.mcp_config import (
+    get_mcp_factory_config,
+    MCP_FASTMCP_STATELESS_HTTP,
+    MCP_SQLALCHEMY_DEBUG,
+)
 
 
 def configure_logging(debug: bool = False) -> None:
     """Configure logging for the MCP service."""
     import sys
 
-    if debug or os.environ.get("SQLALCHEMY_DEBUG"):
+    if debug or MCP_SQLALCHEMY_DEBUG:
         # Only configure basic logging if no handlers exist (respects logging.ini)
         root_logger = logging.getLogger()
         if not root_logger.handlers:
@@ -91,15 +95,11 @@ def run_server(
         os.environ[env_key] = "1"
         try:
             logging.info("Starting FastMCP on %s:%s", host, port)
-            # Configurable via FASTMCP_STATELESS_HTTP env var (default: true)
-            stateless = (
-                os.environ.get("FASTMCP_STATELESS_HTTP", "true").lower() == "true"
-            )
             mcp_instance.run(
                 transport="streamable-http",
                 host=host,
                 port=port,
-                stateless_http=stateless,
+                stateless_http=MCP_FASTMCP_STATELESS_HTTP,
             )
         except Exception as e:
             logging.error("FastMCP failed: %s", e)


### PR DESCRIPTION
### SUMMARY
Refactors MCP service configuration to use Flask's config system instead of environment variables, improving consistency with Superset patterns and making configuration more discoverable.

This PR addresses the FastMCP deprecation warning and refactors configuration management:

1. **Fixes deprecation warning** by moving `stateless_http` parameter from server creation to `.run()` call
2. **Adds Flask config support** for MCP settings (`MCP_FASTMCP_STATELESS_HTTP`, `MCP_SQLALCHEMY_DEBUG`)
3. **Removes environment variable parsing** in favor of Flask config values

**Changes:**
- Removed `stateless_http=True` from `create_mcp_app()` call in `app.py`
- Added `MCP_FASTMCP_STATELESS_HTTP` and `MCP_SQLALCHEMY_DEBUG` to `mcp_config.py`
- Updated `server.py` and `__main__.py` to use Flask config values directly
- Simplified code by removing environment variable parsing logic

**Benefits:**
- ✅ Consistent with Superset configuration patterns
- ✅ Configuration discoverable in `mcp_config.py`
- ✅ Easy to override in `superset_config.py`
- ✅ Cleaner, simpler code without env var checks
- ✅ No deprecation warnings from FastMCP

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - internal API change

### TESTING INSTRUCTIONS
1. Start the MCP service in HTTP mode: `superset mcp run --port 5008`
2. Verify no deprecation warning appears
3. Verify the service functions normally
4. (Optional) Override config in `superset_config.py`:
   ```python
   MCP_FASTMCP_STATELESS_HTTP = False
   MCP_SQLALCHEMY_DEBUG = True
   ```
5. Restart and verify new settings are applied

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API