### PR TITLE
fix(dashboard): prevent validation error in properties modal when ope…

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -616,4 +616,115 @@ describe('PropertiesModal', () => {
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent('Superset Admin');
   }, 30000);
+
+  test('should not run validation while data is loading', async () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+
+    // Don't pass dashboardInfo to trigger fetch behavior
+    const { rerender } = render(<PropertiesModal {...props} show={false} />, {
+      useRedux: true,
+    });
+
+    const getSpy = jest.spyOn(SupersetCore.SupersetClient, 'get');
+    let resolveFetch: any;
+    const fetchPromise = new Promise(resolve => {
+      resolveFetch = resolve;
+    });
+
+    getSpy.mockReturnValue(fetchPromise as any);
+
+    rerender(<PropertiesModal {...props} show />);
+
+    // Allow time for validation hooks to run (they shouldn't during loading)
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(
+      screen.queryByTestId('dashboard-edit-properties-form'),
+    ).not.toBeInTheDocument();
+
+    resolveFetch({
+      json: {
+        result: { ...dashboardInfo, json_metadata: mockedJsonMetadata },
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('dashboard-edit-properties-form'),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+
+    getSpy.mockRestore();
+  });
+
+  test('should run validation when data is ready', async () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+
+    // Pass dashboardInfo to skip loading state - data is immediately ready
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('dashboard-edit-properties-form'),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  test('should trigger validation on field changes when data is ready', async () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    const props = createProps();
+
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        json_metadata: mockedJsonMetadata,
+      },
+    };
+
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('dashboard-edit-properties-form'),
+      ).toBeInTheDocument();
+    });
+
+    const titleInput = screen.getAllByRole('textbox')[0];
+
+    // Clear to trigger validation error
+    userEvent.clear(titleInput);
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+      },
+      { timeout: 1000 },
+    );
+
+    // Re-enter valid title to clear error
+    userEvent.type(titleInput, 'New Dashboard Title');
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+      },
+      { timeout: 1000 },
+    );
+  });
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -586,26 +586,28 @@ const PropertiesModal = ({
     sections: modalSections,
   });
 
+  const isDataReady = !isLoading && dashboardInfo;
+
   // Validate basic section when title changes or data loads
   useEffect(() => {
-    if (!isLoading && dashboardInfo) {
+    if (isDataReady) {
       validateSection('basic');
     }
-  }, [dashboardTitle, validateSection, isLoading, dashboardInfo]);
+  }, [dashboardTitle, validateSection, isDataReady]);
 
   // Validate advanced section when JSON changes or data loads
   useEffect(() => {
-    if (!isLoading && dashboardInfo) {
+    if (isDataReady) {
       validateSection('advanced');
     }
-  }, [jsonMetadata, validateSection, isLoading, dashboardInfo]);
+  }, [jsonMetadata, validateSection, isDataReady]);
 
   // Validate refresh section when frequency changes or data loads
   useEffect(() => {
-    if (!isLoading && dashboardInfo) {
+    if (isDataReady) {
       validateSection('refresh');
     }
-  }, [refreshFrequency, validateSection, isLoading, dashboardInfo]);
+  }, [refreshFrequency, validateSection, isDataReady]);
 
   return (
     <StandardModal
@@ -636,7 +638,7 @@ const PropertiesModal = ({
         onFinish={onFinish}
         onFieldsChange={() => {
           // Re-validate sections when form fields change
-          if (!isLoading && dashboardInfo) {
+          if (isDataReady) {
             validateSection('basic');
           }
         }}

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -588,18 +588,24 @@ const PropertiesModal = ({
 
   // Validate basic section when title changes
   useEffect(() => {
-    validateSection('basic');
-  }, [dashboardTitle, validateSection]);
+    if (!isLoading) {
+      validateSection('basic');
+    }
+  }, [dashboardTitle, validateSection, isLoading]);
 
   // Validate advanced section when JSON changes
   useEffect(() => {
-    validateSection('advanced');
-  }, [jsonMetadata, validateSection]);
+    if (!isLoading) {
+      validateSection('advanced');
+    }
+  }, [jsonMetadata, validateSection, isLoading]);
 
   // Validate refresh section when refresh frequency changes
   useEffect(() => {
-    validateSection('refresh');
-  }, [refreshFrequency, validateSection]);
+    if (!isLoading) {
+      validateSection('refresh');
+    }
+  }, [refreshFrequency, validateSection, isLoading]);
 
   return (
     <StandardModal
@@ -630,7 +636,9 @@ const PropertiesModal = ({
         onFinish={onFinish}
         onFieldsChange={() => {
           // Re-validate sections when form fields change
-          setTimeout(() => validateSection('basic'), 100);
+          if (!isLoading) {
+            setTimeout(() => validateSection('basic'), 100);
+          }
         }}
         data-test="dashboard-edit-properties-form"
         layout="vertical"

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -586,26 +586,26 @@ const PropertiesModal = ({
     sections: modalSections,
   });
 
-  // Validate basic section when title changes
+  // Validate basic section when title changes or data loads
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && dashboardInfo) {
       validateSection('basic');
     }
-  }, [dashboardTitle, validateSection, isLoading]);
+  }, [dashboardTitle, validateSection, isLoading, dashboardInfo]);
 
-  // Validate advanced section when JSON changes
+  // Validate advanced section when JSON changes or data loads
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && dashboardInfo) {
       validateSection('advanced');
     }
-  }, [jsonMetadata, validateSection, isLoading]);
+  }, [jsonMetadata, validateSection, isLoading, dashboardInfo]);
 
-  // Validate refresh section when refresh frequency changes
+  // Validate refresh section when frequency changes or data loads
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && dashboardInfo) {
       validateSection('refresh');
     }
-  }, [refreshFrequency, validateSection, isLoading]);
+  }, [refreshFrequency, validateSection, isLoading, dashboardInfo]);
 
   return (
     <StandardModal
@@ -636,8 +636,8 @@ const PropertiesModal = ({
         onFinish={onFinish}
         onFieldsChange={() => {
           // Re-validate sections when form fields change
-          if (!isLoading) {
-            setTimeout(() => validateSection('basic'), 100);
+          if (!isLoading && dashboardInfo) {
+            validateSection('basic');
           }
         }}
         data-test="dashboard-edit-properties-form"


### PR DESCRIPTION
### SUMMARY
  Fixes validation error icon appearing in Dashboard Properties modal when opened from dashboard list.

  **Problem**: When opening the Dashboard Properties modal by clicking "Edit" from the dashboard list, a validation error icon appears next to "General information" even though the required "Name" field is populated. The error persists until the user modifies and restores the name field.

  **Root Cause**: The modal has two entry points with different initialization patterns:
  1. **Dashboard List**: Passes only `dashboardId`, requiring asynchronous data fetch
  2. **Dashboard Edit Mode**: Passes pre-loaded `dashboardInfo` and `dashboardTitle`

  The validation `useEffect` hooks were executing immediately on modal open, before the asynchronous data fetch completed in the first scenario. This caused validation to run against empty form fields, triggering false validation errors.

  **Solution**:
  - Added `isLoading` and `dashboardInfo` guards to all validation effects to prevent validation from running before data is available
  - Included `dashboardInfo` as a dependency in validation effects, ensuring validation automatically runs when data loads (when `dashboardInfo` transitions from `undefined` to populated object)
  - Removed arbitrary `setTimeout` delay from field change validation handler for immediate, consistent validation feedback
  - Added clear comments explaining the validation timing logic

  This ensures validation only runs on populated form fields, eliminating false positives while guaranteeing validation occurs after data loads.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
  **Before**: Opening modal from dashboard list shows validation error icon next to "General information" despite name field being filled.
<img width="606" height="791" alt="92750" src="https://github.com/user-attachments/assets/2350af04-b8b2-4016-b906-ff2cb8e4bd6c" />


  **After**: No validation error appears when opening from dashboard list with properly filled fields.
<img width="573" height="241" alt="Screenshot 2025-11-07 at 19 54 06" src="https://github.com/user-attachments/assets/f9053b64-b833-46d4-8fa9-bdbe92a260c6" />

  ### TESTING INSTRUCTIONS
  1. Navigate to the Dashboard List page
  2. Click the "Edit" icon on any dashboard row
  3. Verify the Dashboard Properties modal opens without a validation error icon next to "General information"
  4. Verify the dashboard name is populated in the form
  5. Also test opening the modal from dashboard edit mode (click "Edit dashboard" → "Edit properties" from menu)
  6. Verify both entry points work correctly without false validation errors

  ### ADDITIONAL INFORMATION
  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API