### PR TITLE
fix: Flakiness around scrolling during taking tiled screenshots with Playwright

### DIFF
--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -148,7 +148,7 @@ def take_tiled_screenshot(
 
             # Skip tile if dimensions are invalid (width or height <= 0)
             # This can happen if element is completely scrolled out of viewport
-            if clip_height <= 0:
+            if clip_height <= 0 or clip_y < 0:
                 logger.warning(
                     "Skipping tile %s/%s due to invalid clip dimensions: "
                     "x=%s, y=%s, width=%s, height=%s "

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -239,11 +239,13 @@ class WebDriverPlaywright(WebDriverProxy):
             browser_args = app.config["WEBDRIVER_OPTION_ARGS"]
             browser = playwright.chromium.launch(args=browser_args)
             pixel_density = app.config["WEBDRIVER_WINDOW"].get("pixel_density", 1)
+            viewport_height = self._window[1]
+            viewport_width = self._window[0]
             context = browser.new_context(
                 bypass_csp=True,
                 viewport={
-                    "height": self._window[1],
-                    "width": self._window[0],
+                    "height": viewport_height,
+                    "width": viewport_width,
                 },
                 device_scale_factor=pixel_density,
             )
@@ -343,15 +345,15 @@ class WebDriverPlaywright(WebDriverProxy):
                     height_threshold = app.config.get(
                         "SCREENSHOT_TILED_HEIGHT_THRESHOLD", 5000
                     )
-                    viewport_height = app.config.get(
-                        "SCREENSHOT_TILED_VIEWPORT_HEIGHT", self._window[1]
+                    tile_height = app.config.get(
+                        "SCREENSHOT_TILED_VIEWPORT_HEIGHT", viewport_height
                     )
 
                     # Use tiled screenshots for large dashboards
                     use_tiled = (
                         chart_count >= chart_threshold
                         or dashboard_height > height_threshold
-                    )
+                    ) and dashboard_height > tile_height
 
                     if use_tiled:
                         logger.info(
@@ -360,9 +362,11 @@ class WebDriverPlaywright(WebDriverProxy):
                             chart_count,
                             dashboard_height,
                         )
-                        img = take_tiled_screenshot(
-                            page, element_name, viewport_height=viewport_height
+                        # set viewport height to tile height for easier calculations
+                        page.set_viewport_size(
+                            {"height": tile_height, "width": viewport_width}
                         )
+                        img = take_tiled_screenshot(page, element_name, tile_height)
                         if img is None:
                             logger.warning(
                                 (

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -114,22 +114,11 @@ class TestTakeTiledScreenshot:
         element = MagicMock()
         page.locator.return_value = element
 
-        # Mock element info - simulating a 5000px tall dashboard
+        # Mock element info - simulating a 5000px tall dashboard at position 100
         element_info = {"height": 5000, "top": 100, "left": 50, "width": 800}
-        element_box = {"x": 50, "y": 200, "width": 800, "height": 600}
 
-        # For 3 tiles (5000px / 2000px = 2.5, rounded up to 3):
-        # 1 initial call + 3 scroll + 3 element box + 1 reset scroll = 8 calls
-        page.evaluate.side_effect = [
-            element_info,  # Initial call for dashboard dimensions
-            None,  # First scroll call
-            element_box,  # First element box call
-            None,  # Second scroll call
-            element_box,  # Second element box call
-            None,  # Third scroll call
-            element_box,  # Third element box call
-            None,  # Final reset scroll call
-        ]
+        # Only one evaluate call needed for dashboard dimensions
+        page.evaluate.return_value = element_info
 
         # Mock screenshot method
         fake_screenshot = b"fake_screenshot_data"
@@ -171,18 +160,9 @@ class TestTakeTiledScreenshot:
         """Test that tiles are calculated correctly."""
         # Mock dashboard height of 3500px with viewport of 2000px
         element_info = {"height": 3500, "top": 100, "left": 50, "width": 800}
-        element_box = {"x": 50, "y": 200, "width": 800, "height": 600}
 
-        # For 2 tiles (3500px / 2000px = 1.75, rounded up to 2):
-        # 1 initial call + 2 scroll + 2 element box + 1 reset scroll = 6 calls
-        mock_page.evaluate.side_effect = [
-            element_info,
-            None,  # First scroll call
-            element_box,  # First element box call
-            None,  # Second scroll call
-            element_box,  # Second element box call
-            None,  # Reset scroll call
-        ]
+        # Override the fixture's evaluate return for this test
+        mock_page.evaluate.return_value = element_info
 
         with patch(
             "superset.utils.screenshot_utils.combine_screenshot_tiles"
@@ -193,69 +173,6 @@ class TestTakeTiledScreenshot:
 
             # Should take 2 screenshots (3500px / 2000px = 1.75, rounded up to 2)
             assert mock_page.screenshot.call_count == 2
-
-    def test_scroll_positions_calculated_correctly(self, mock_page):
-        """Test that scroll positions are calculated correctly."""
-        # Override the fixture's side_effect for this specific test
-        element_info = {"height": 5000, "top": 100, "left": 50, "width": 800}
-        element_box = {"x": 50, "y": 200, "width": 800, "height": 600}
-
-        mock_page.evaluate.side_effect = [
-            element_info,  # Initial call for dashboard dimensions
-            None,  # First scroll call
-            element_box,  # First element box call
-            None,  # Second scroll call
-            element_box,  # Second element box call
-            None,  # Third scroll call
-            element_box,  # Third element box call
-            None,  # Reset scroll call
-        ]
-
-        with patch("superset.utils.screenshot_utils.combine_screenshot_tiles"):
-            take_tiled_screenshot(mock_page, "dashboard", viewport_height=2000)
-
-            # Check scroll positions (dashboard_top = 100)
-            scroll_calls = [
-                call
-                for call in mock_page.evaluate.call_args_list
-                if "scrollTo" in str(call)
-            ]
-
-            # Should have scrolled to positions: 100, 2100, 4100
-            expected_scrolls = [
-                "window.scrollTo(0, 100)",
-                "window.scrollTo(0, 2100)",
-                "window.scrollTo(0, 4100)",
-            ]
-            actual_scrolls = [call[0][0] for call in scroll_calls]
-
-            assert len(actual_scrolls) == 4  # 3 tile scrolls + 1 reset
-            for expected in expected_scrolls:
-                assert expected in actual_scrolls
-
-    def test_reset_scroll_position(self, mock_page):
-        """Test that scroll position is reset after screenshot."""
-        # Override the fixture's side_effect for this specific test
-        element_info = {"height": 5000, "top": 100, "left": 50, "width": 800}
-        element_box = {"x": 50, "y": 200, "width": 800, "height": 600}
-
-        mock_page.evaluate.side_effect = [
-            element_info,  # Initial call for dashboard dimensions
-            None,  # First scroll call
-            element_box,  # First element box call
-            None,  # Second scroll call
-            element_box,  # Second element box call
-            None,  # Third scroll call
-            element_box,  # Third element box call
-            None,  # Reset scroll call
-        ]
-
-        with patch("superset.utils.screenshot_utils.combine_screenshot_tiles"):
-            take_tiled_screenshot(mock_page, "dashboard", viewport_height=2000)
-
-            # Check that final call resets scroll to top
-            final_call = mock_page.evaluate.call_args_list[-1]
-            assert "window.scrollTo(0, 0)" in str(final_call)
 
     def test_logs_dashboard_info(self, mock_page):
         """Test that dashboard info is logged."""
@@ -284,18 +201,6 @@ class TestTakeTiledScreenshot:
             assert call_args[0][0] == "Tiled screenshot failed: %s"
             assert str(call_args[0][1]) == "Unexpected error"
 
-    def test_wait_timeouts_between_tiles(self, mock_page):
-        """Test that there are appropriate waits between tiles."""
-        with patch("superset.utils.screenshot_utils.combine_screenshot_tiles"):
-            take_tiled_screenshot(mock_page, "dashboard", viewport_height=2000)
-
-            # Should have called wait_for_timeout for each tile (3 tiles)
-            assert mock_page.wait_for_timeout.call_count == 3
-
-            # Each wait should be 2000ms (2 seconds)
-            for call in mock_page.wait_for_timeout.call_args_list:
-                assert call[0][0] == 2000
-
     def test_screenshot_clip_parameters(self, mock_page):
         """Test that screenshot clipping parameters are correct."""
         with patch("superset.utils.screenshot_utils.combine_screenshot_tiles"):
@@ -304,47 +209,36 @@ class TestTakeTiledScreenshot:
             # Check screenshot calls have correct clip parameters
             screenshot_calls = mock_page.screenshot.call_args_list
 
-            for call in screenshot_calls:
+            # Should have 3 tiles (5000px / 2000px = 2.5, rounded up to 3)
+            assert len(screenshot_calls) == 3
+
+            # All tiles use absolute coordinates
+            for _, call in enumerate(screenshot_calls):
                 kwargs = call[1]
                 assert kwargs["type"] == "png"
-                assert "clip" in kwargs
+                assert kwargs["clip"]["x"] == 0
+                assert kwargs["clip"]["width"] == 800
 
-                clip = kwargs["clip"]
-                assert clip["x"] == 50
-                assert clip["y"] == 200
-                assert clip["width"] == 800
-                # Height should be min of viewport_height and remaining content
-                assert clip["height"] <= 600  # Element height from mock
+            # Check y positions and heights for each tile
+            # Tile 1: y=100 (dashboard_top), height=2000
+            assert screenshot_calls[0][1]["clip"]["y"] == 100
+            assert screenshot_calls[0][1]["clip"]["height"] == 2000
 
-    def test_skips_tiles_with_zero_height(self):
-        """Test that tiles with zero height are skipped."""
-        mock_page = MagicMock()
+            # Tile 2: y=2100 (dashboard_top + viewport_height), height=2000
+            assert screenshot_calls[1][1]["clip"]["y"] == 2100
+            assert screenshot_calls[1][1]["clip"]["height"] == 2000
 
-        # Mock element locator
-        element = MagicMock()
-        mock_page.locator.return_value = element
+            # Tile 3: y=4100 (dashboard_top + 2*viewport_height)
+            # height=1000 (remaining)
+            assert screenshot_calls[2][1]["clip"]["y"] == 4100
+            assert screenshot_calls[2][1]["clip"]["height"] == 1000
 
-        # Mock element info - 4000px tall dashboard
+    def test_handles_invalid_tile_dimensions(self, mock_page):
+        """Test that tiles with invalid dimensions are skipped."""
+        # Mock a dashboard where the last tile would have 0 or negative height
+        # This simulates edge cases in height calculations
         element_info = {"height": 4000, "top": 100, "left": 50, "width": 800}
-
-        # First tile: valid clip region
-        valid_element_box = {"x": 50, "y": 200, "width": 800, "height": 600}
-
-        # Second tile: element scrolled completely out (zero height)
-        invalid_element_box = {"x": 50, "y": -100, "width": 800, "height": 0}
-
-        # For 2 tiles (4000px / 2000px = 2):
-        # 1 initial + 2 scroll + 2 element box + 1 reset = 6 calls
-        mock_page.evaluate.side_effect = [
-            element_info,  # Initial call for dashboard dimensions
-            None,  # First scroll call
-            valid_element_box,  # First element box (valid)
-            None,  # Second scroll call
-            invalid_element_box,  # Second element box (zero height)
-            None,  # Reset scroll call
-        ]
-
-        mock_page.screenshot.return_value = b"fake_screenshot"
+        mock_page.evaluate.return_value = element_info
 
         with patch("superset.utils.screenshot_utils.logger") as mock_logger:
             with patch(
@@ -352,21 +246,41 @@ class TestTakeTiledScreenshot:
             ) as mock_combine:
                 mock_combine.return_value = b"combined"
 
+                # Use exact viewport height that divides evenly
                 result = take_tiled_screenshot(
                     mock_page, "dashboard", viewport_height=2000
                 )
 
-                # Should still succeed with partial tiles
+                # Should succeed
                 assert result == b"combined"
 
-                # Should only take 1 screenshot (second tile skipped)
-                assert mock_page.screenshot.call_count == 1
+                # Should take 2 screenshots (4000px / 2000px = 2)
+                assert mock_page.screenshot.call_count == 2
 
-                # Should log warning about skipped tile
-                mock_logger.warning.assert_called_once()
-                warning_call = mock_logger.warning.call_args
-                # Check the format string
-                assert "invalid clip dimensions" in warning_call[0][0]
-                # Check the arguments (tile 2/2)
-                assert warning_call[0][1] == 2  # tile number (i + 1)
-                assert warning_call[0][2] == 2  # num_tiles
+                # Should not log any warnings about invalid dimensions
+                warning_calls = [
+                    call
+                    for call in mock_logger.warning.call_args_list
+                    if "invalid clip dimensions" in str(call)
+                ]
+                assert len(warning_calls) == 0
+
+    def test_skips_tile_with_zero_height(self, mock_page):
+        """Test that a tile with zero or negative height is skipped."""
+        # This test verifies the clip_height <= 0 check
+        # We'll manually test the logic by creating a scenario where
+        # remaining_content becomes <= 0
+        element_info = {"height": 2000, "top": 100, "left": 50, "width": 800}
+        mock_page.evaluate.return_value = element_info
+
+        with patch(
+            "superset.utils.screenshot_utils.combine_screenshot_tiles"
+        ) as mock_combine:
+            mock_combine.return_value = b"combined"
+
+            # Use viewport height equal to element height
+            result = take_tiled_screenshot(mock_page, "dashboard", viewport_height=2000)
+
+            # Should succeed with 1 tile
+            assert result == b"combined"
+            assert mock_page.screenshot.call_count == 1

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -23,6 +23,7 @@ from PIL import Image
 
 from superset.utils.screenshot_utils import (
     combine_screenshot_tiles,
+    SCROLL_SETTLE_TIMEOUT_MS,
     take_tiled_screenshot,
 )
 
@@ -313,9 +314,9 @@ class TestTakeTiledScreenshot:
         with patch("superset.utils.screenshot_utils.combine_screenshot_tiles"):
             take_tiled_screenshot(mock_page, "dashboard", tile_height=2000)
 
-            # Should call wait_for_timeout 3 times (once per tile for scroll settling)
+            # Should call wait_for_timeout 3 times (once per tile)
             assert mock_page.wait_for_timeout.call_count == 3
 
-            # Each wait should be 1000ms
+            # Each wait should use the scroll settle timeout constant
             for call in mock_page.wait_for_timeout.call_args_list:
-                assert call[0][0] == 1000
+                assert call[0][0] == SCROLL_SETTLE_TIMEOUT_MS

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -216,7 +216,7 @@ class TestTakeTiledScreenshot:
             for _, call in enumerate(screenshot_calls):
                 kwargs = call[1]
                 assert kwargs["type"] == "png"
-                assert kwargs["clip"]["x"] == 0
+                assert kwargs["clip"]["x"] == 50
                 assert kwargs["clip"]["width"] == 800
 
             # Check y positions and heights for each tile


### PR DESCRIPTION
### SUMMARY
Supplement of https://github.com/apache/superset/pull/36027

Simplify the logic around taking tile screenshots with playwright.
This PR removes calculations based on `getBoundingClientRect`. Instead, we take tile screenshots by simply calculating the (x,y) coordinates of the clip window based on tile index and viewport height.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
Unit tests should pass. For manual testing, create a large dashboard (longer than `SCREENSHOT_TILED_HEIGHT_THRESHOLD` from config.py) and run a report.
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
