### PR TITLE
refactor: refactor `get_query_result`

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -24,7 +24,6 @@ import pandas as pd
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.common.query_context_processor import QueryContextProcessor
 from superset.common.query_object import QueryObject
-from superset.models.helpers import CachedTimeOffset
 from superset.models.slice import Slice
 from superset.utils.core import GenericDataType
 
@@ -125,36 +124,6 @@ class QueryContext:
 
     def get_query_result(self, query_object: QueryObject) -> QueryResult:
         return self._processor.get_query_result(query_object)
-
-    def processing_time_offsets(
-        self,
-        df: pd.DataFrame,
-        query_object: QueryObject,
-    ) -> CachedTimeOffset:
-        """
-        Process time offsets by delegating to datasource with caching support.
-        """
-
-        # Create cache key function that uses the processor's method
-        def cache_key_fn(
-            qo: QueryObject, time_offset: str, time_grain: Any
-        ) -> str | None:
-            return self._processor.query_cache_key(
-                qo, time_offset=time_offset, time_grain=time_grain
-            )
-
-        # Create cache timeout function
-        def cache_timeout_fn() -> int:
-            return self._processor.get_cache_timeout()
-
-        # Call datasource's processing_time_offsets with caching support
-        return self.datasource.processing_time_offsets(
-            df,
-            query_object,
-            cache_key_fn=cache_key_fn,
-            cache_timeout_fn=cache_timeout_fn,
-            force_cache=self.force,
-        )
 
     def raise_for_access(self) -> None:
         self._processor.raise_for_access()

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -38,7 +38,7 @@ from superset.exceptions import (
     SupersetException,
 )
 from superset.extensions import cache_manager, security_manager
-from superset.models.helpers import CachedTimeOffset, QueryResult
+from superset.models.helpers import QueryResult
 from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils import csv, excel
 from superset.utils.cache import generate_cache_key, set_and_log_cache
@@ -228,38 +228,6 @@ class QueryContextProcessor:
         post-processing.
         """
         return self._qc_datasource.get_query_result(query_object)
-
-    def processing_time_offsets(
-        self,
-        df: pd.DataFrame,
-        query_object: QueryObject,
-    ) -> CachedTimeOffset:
-        """
-        Process time offsets by delegating to datasource.
-
-        This method provides caching support via callback functions.
-        """
-
-        # Create cache key function
-        def cache_key_fn(
-            qo: QueryObject, time_offset: str, time_grain: Any
-        ) -> str | None:
-            return self.query_cache_key(
-                qo, time_offset=time_offset, time_grain=time_grain
-            )
-
-        # Create cache timeout function
-        def cache_timeout_fn() -> int:
-            return self.get_cache_timeout()
-
-        # Delegate to datasource with caching support
-        return self._qc_datasource.processing_time_offsets(
-            df,
-            query_object,
-            cache_key_fn=cache_key_fn,
-            cache_timeout_fn=cache_timeout_fn,
-            force_cache=self._query_context.force,
-        )
 
     def get_data(
         self, df: pd.DataFrame, coltypes: list[GenericDataType]

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -16,59 +16,42 @@
 # under the License.
 from __future__ import annotations
 
-import copy
 import logging
 import re
-from datetime import datetime
 from typing import Any, cast, ClassVar, TYPE_CHECKING, TypedDict
 
-import numpy as np
 import pandas as pd
 from flask import current_app
 from flask_babel import gettext as _
-from pandas import DateOffset
 
 from superset.common.chart_data import ChartDataResultFormat
 from superset.common.db_query_status import QueryStatus
 from superset.common.query_actions import get_query_results
-from superset.common.utils import dataframe_utils
 from superset.common.utils.query_cache_manager import QueryCacheManager
-from superset.common.utils.time_range_utils import (
-    get_since_until_from_query_object,
-    get_since_until_from_time_range,
-)
+from superset.common.utils.time_range_utils import get_since_until_from_time_range
 from superset.connectors.sqla.models import BaseDatasource
-from superset.constants import CACHE_DISABLED_TIMEOUT, CacheRegion, TimeGrain
+from superset.constants import CACHE_DISABLED_TIMEOUT, CacheRegion
 from superset.daos.annotation_layer import AnnotationLayerDAO
 from superset.daos.chart import ChartDAO
 from superset.exceptions import (
     QueryObjectValidationError,
     SupersetException,
 )
-from superset.extensions import cache_manager, feature_flag_manager, security_manager
+from superset.extensions import cache_manager, security_manager
 from superset.models.helpers import QueryResult
 from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils import csv, excel
 from superset.utils.cache import generate_cache_key, set_and_log_cache
 from superset.utils.core import (
     DatasourceType,
-    DateColumn,
     DTTM_ALIAS,
     error_msg_from_exception,
-    FilterOperator,
     GenericDataType,
-    get_base_axis_labels,
     get_column_names_from_columns,
     get_column_names_from_metrics,
-    get_metric_names,
-    get_x_axis_label,
     is_adhoc_column,
     is_adhoc_metric,
-    normalize_dttm_col,
-    QueryObjectFilterClause,
-    TIME_COMPARISON,
 )
-from superset.utils.date_parser import get_past_or_future, normalize_time_delta
 from superset.utils.pandas_postprocessing.utils import unescape_separator
 from superset.views.utils import get_viz
 from superset.viz import viz_types
@@ -78,27 +61,6 @@ if TYPE_CHECKING:
     from superset.common.query_object import QueryObject
 
 logger = logging.getLogger(__name__)
-
-# Offset join column suffix used for joining offset results
-OFFSET_JOIN_COLUMN_SUFFIX = "__offset_join_column_"
-
-# This only includes time grains that may influence
-# the temporal column used for joining offset results.
-# Given that we don't allow time shifts smaller than a day,
-# we don't need to include smaller time grains aggregations.
-AGGREGATED_JOIN_GRAINS = {
-    TimeGrain.WEEK,
-    TimeGrain.WEEK_STARTING_SUNDAY,
-    TimeGrain.WEEK_STARTING_MONDAY,
-    TimeGrain.WEEK_ENDING_SATURDAY,
-    TimeGrain.WEEK_ENDING_SUNDAY,
-    TimeGrain.MONTH,
-    TimeGrain.QUARTER,
-    TimeGrain.YEAR,
-}
-
-# Right suffix used for joining offset results
-R_SUFFIX = "__right_suffix"
 
 
 class CachedTimeOffset(TypedDict):
@@ -273,681 +235,37 @@ class QueryContextProcessor:
         """
         return self._qc_datasource.get_query_result(query_object)
 
-    def normalize_df(self, df: pd.DataFrame, query_object: QueryObject) -> pd.DataFrame:
-        # todo: should support "python_date_format" and "get_column" in each datasource
-        def _get_timestamp_format(
-            source: BaseDatasource, column: str | None
-        ) -> str | None:
-            column_obj = source.get_column(column)
-            if (
-                column_obj
-                # only sqla column was supported
-                and hasattr(column_obj, "python_date_format")
-                and (formatter := column_obj.python_date_format)
-            ):
-                return str(formatter)
-
-            return None
-
-        datasource = self._qc_datasource
-        labels = tuple(
-            label
-            for label in [
-                *get_base_axis_labels(query_object.columns),
-                query_object.granularity,
-            ]
-            if datasource
-            # Query datasource didn't support `get_column`
-            and hasattr(datasource, "get_column")
-            and (col := datasource.get_column(label))
-            # todo(hugh) standardize column object in Query datasource
-            and (col.get("is_dttm") if isinstance(col, dict) else col.is_dttm)
-        )
-        dttm_cols = [
-            DateColumn(
-                timestamp_format=_get_timestamp_format(datasource, label),
-                offset=datasource.offset,
-                time_shift=query_object.time_shift,
-                col_label=label,
-            )
-            for label in labels
-            if label
-        ]
-        if DTTM_ALIAS in df:
-            dttm_cols.append(
-                DateColumn.get_legacy_time_column(
-                    timestamp_format=_get_timestamp_format(
-                        datasource, query_object.granularity
-                    ),
-                    offset=datasource.offset,
-                    time_shift=query_object.time_shift,
-                )
-            )
-        normalize_dttm_col(
-            df=df,
-            dttm_cols=tuple(dttm_cols),
-        )
-
-        if self.enforce_numerical_metrics:
-            dataframe_utils.df_metrics_to_num(df, query_object)
-
-        df.replace([np.inf, -np.inf], np.nan, inplace=True)
-
-        return df
-
-    @staticmethod
-    def get_time_grain(query_object: QueryObject) -> Any | None:
-        if (
-            query_object.columns
-            and len(query_object.columns) > 0
-            and isinstance(query_object.columns[0], dict)
-        ):
-            # If the time grain is in the columns it will be the first one
-            # and it will be of AdhocColumn type
-            return query_object.columns[0].get("timeGrain")
-
-        return query_object.extras.get("time_grain_sqla")
-
-    # pylint: disable=too-many-arguments
-    def add_offset_join_column(
-        self,
-        df: pd.DataFrame,
-        name: str,
-        time_grain: str,
-        time_offset: str | None = None,
-        join_column_producer: Any = None,
-    ) -> None:
-        """
-        Adds an offset join column to the provided DataFrame.
-
-        The function modifies the DataFrame in-place.
-
-        :param df: pandas DataFrame to which the offset join column will be added.
-        :param name: The name of the new column to be added.
-        :param time_grain: The time grain used to calculate the new column.
-        :param time_offset: The time offset used to calculate the new column.
-        :param join_column_producer: A function to generate the join column.
-        """
-        if join_column_producer:
-            df[name] = df.apply(lambda row: join_column_producer(row, 0), axis=1)
-        else:
-            df[name] = df.apply(
-                lambda row: self.generate_join_column(row, 0, time_grain, time_offset),
-                axis=1,
-            )
-
-    def is_valid_date(self, date_string: str) -> bool:
-        try:
-            # Attempt to parse the string as a date in the format YYYY-MM-DD
-            datetime.strptime(date_string, "%Y-%m-%d")
-            return True
-        except ValueError:
-            # If parsing fails, it's not a valid date in the format YYYY-MM-DD
-            return False
-
-    def is_valid_date_range(self, date_range: str) -> bool:
-        try:
-            # Attempt to parse the string as a date range in the format
-            # YYYY-MM-DD:YYYY-MM-DD
-            start_date, end_date = date_range.split(":")
-            datetime.strptime(start_date.strip(), "%Y-%m-%d")
-            datetime.strptime(end_date.strip(), "%Y-%m-%d")
-            return True
-        except ValueError:
-            # If parsing fails, it's not a valid date range in the format
-            # YYYY-MM-DD:YYYY-MM-DD
-            return False
-
-    def get_offset_custom_or_inherit(
-        self,
-        offset: str,
-        outer_from_dttm: datetime,
-        outer_to_dttm: datetime,
-    ) -> str:
-        """
-        Get the time offset for custom or inherit.
-
-        :param offset: The offset string.
-        :param outer_from_dttm: The outer from datetime.
-        :param outer_to_dttm: The outer to datetime.
-        :returns: The time offset.
-        """
-        if offset == "inherit":
-            # return the difference in days between the from and the to dttm formatted as a string with the " days ago" suffix  # noqa: E501
-            return f"{(outer_to_dttm - outer_from_dttm).days} days ago"
-        if self.is_valid_date(offset):
-            # return the offset as the difference in days between the outer from dttm and the offset date (which is a YYYY-MM-DD string) formatted as a string with the " days ago" suffix  # noqa: E501
-            offset_date = datetime.strptime(offset, "%Y-%m-%d")
-            return f"{(outer_from_dttm - offset_date).days} days ago"
-        return ""
-
-    def processing_time_offsets(  # pylint: disable=too-many-locals,too-many-statements # noqa: C901
+    def processing_time_offsets(
         self,
         df: pd.DataFrame,
         query_object: QueryObject,
     ) -> CachedTimeOffset:
         """
-        Process time offsets for time comparison feature.
+        Process time offsets by delegating to datasource.
 
-        This method handles both relative time offsets (e.g., "1 week ago") and
-        absolute date range offsets (e.g., "2015-01-03 : 2015-01-04").
+        This method provides caching support via callback functions.
         """
-        query_context = self._query_context
-        # ensure query_object is immutable
-        query_object_clone = copy.copy(query_object)
-        queries: list[str] = []
-        cache_keys: list[str | None] = []
-        offset_dfs: dict[str, pd.DataFrame] = {}
 
-        outer_from_dttm, outer_to_dttm = get_since_until_from_query_object(query_object)
-        if not outer_from_dttm or not outer_to_dttm:
-            raise QueryObjectValidationError(
-                _(
-                    "An enclosed time range (both start and end) must be specified "
-                    "when using a Time Comparison."
-                )
+        # Create cache key function
+        def cache_key_fn(
+            qo: QueryObject, time_offset: str, time_grain: Any
+        ) -> str | None:
+            return self.query_cache_key(
+                qo, time_offset=time_offset, time_grain=time_grain
             )
 
-        time_grain = self.get_time_grain(query_object)
-        metric_names = get_metric_names(query_object.metrics)
-        # use columns that are not metrics as join keys
-        join_keys = [col for col in df.columns if col not in metric_names]
-
-        for offset in query_object.time_offsets:
-            try:
-                original_offset = offset
-                is_date_range_offset = self.is_valid_date_range(offset)
-
-                if is_date_range_offset and feature_flag_manager.is_feature_enabled(
-                    "DATE_RANGE_TIMESHIFTS_ENABLED"
-                ):
-                    # DATE RANGE OFFSET LOGIC (like "2015-01-03 : 2015-01-04")
-                    try:
-                        # Parse the specified range
-                        offset_from_dttm, offset_to_dttm = (
-                            get_since_until_from_time_range(time_range=offset)
-                        )
-                    except ValueError as ex:
-                        raise QueryObjectValidationError(str(ex)) from ex
-
-                    # Use the specified range directly
-                    query_object_clone.from_dttm = offset_from_dttm
-                    query_object_clone.to_dttm = offset_to_dttm
-
-                    # For date range offsets, we must NOT set inner bounds
-                    # These create additional WHERE clauses that conflict with our
-                    # date range
-                    query_object_clone.inner_from_dttm = None
-                    query_object_clone.inner_to_dttm = None
-
-                elif is_date_range_offset:
-                    # Date range timeshift feature is disabled
-                    raise QueryObjectValidationError(
-                        "Date range timeshifts are not enabled. "
-                        "Please contact your administrator to enable the "
-                        "DATE_RANGE_TIMESHIFTS_ENABLED feature flag."
-                    )
-
-                else:
-                    # RELATIVE OFFSET LOGIC (like "1 day ago")
-                    if self.is_valid_date(offset) or offset == "inherit":
-                        offset = self.get_offset_custom_or_inherit(
-                            offset,
-                            outer_from_dttm,
-                            outer_to_dttm,
-                        )
-                    query_object_clone.from_dttm = get_past_or_future(
-                        offset,
-                        outer_from_dttm,
-                    )
-                    query_object_clone.to_dttm = get_past_or_future(
-                        offset, outer_to_dttm
-                    )
-
-                    query_object_clone.inner_from_dttm = query_object_clone.from_dttm
-                    query_object_clone.inner_to_dttm = query_object_clone.to_dttm
-
-                x_axis_label = get_x_axis_label(query_object.columns)
-                query_object_clone.granularity = (
-                    query_object_clone.granularity or x_axis_label
-                )
-
-            except ValueError as ex:
-                raise QueryObjectValidationError(str(ex)) from ex
-
-            query_object_clone.time_offsets = []
-            query_object_clone.post_processing = []
-
-            # Get time offset index
-            index = (get_base_axis_labels(query_object.columns) or [DTTM_ALIAS])[0]
-
-            if is_date_range_offset and feature_flag_manager.is_feature_enabled(
-                "DATE_RANGE_TIMESHIFTS_ENABLED"
-            ):
-                # Create a completely new filter list to preserve original filters
-                query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
-
-                # Remove any existing temporal filters that might conflict
-                query_object_clone.filter = [
-                    flt
-                    for flt in query_object_clone.filter
-                    if not (flt.get("op") == FilterOperator.TEMPORAL_RANGE)
-                ]
-
-                # Determine the temporal column with multiple fallback strategies
-                temporal_col = self._get_temporal_column_for_filter(
-                    query_object_clone, x_axis_label
-                )
-
-                # Always add a temporal filter for date range offsets
-                if temporal_col:
-                    new_temporal_filter: QueryObjectFilterClause = {
-                        "col": temporal_col,
-                        "op": FilterOperator.TEMPORAL_RANGE,
-                        "val": (
-                            f"{query_object_clone.from_dttm} : "
-                            f"{query_object_clone.to_dttm}"
-                        ),
-                    }
-                    query_object_clone.filter.append(new_temporal_filter)
-
-                else:
-                    # This should rarely happen with proper fallbacks
-                    raise QueryObjectValidationError(
-                        _(
-                            "Unable to identify temporal column for date range time comparison."  # noqa: E501
-                            "Please ensure your dataset has a properly configured time column."  # noqa: E501
-                        )
-                    )
-
-            else:
-                # RELATIVE OFFSET: Original logic for non-date-range offsets
-                # The comparison is not using a temporal column so we need to modify
-                # the temporal filter so we run the query with the correct time range
-                if not dataframe_utils.is_datetime_series(df.get(index)):
-                    query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
-
-                    # Find and update temporal filters
-                    for flt in query_object_clone.filter:
-                        if flt.get(
-                            "op"
-                        ) == FilterOperator.TEMPORAL_RANGE and isinstance(
-                            flt.get("val"), str
-                        ):
-                            time_range = cast(str, flt.get("val"))
-                            (
-                                new_outer_from_dttm,
-                                new_outer_to_dttm,
-                            ) = get_since_until_from_time_range(
-                                time_range=time_range,
-                                time_shift=offset,
-                            )
-                            flt["val"] = f"{new_outer_from_dttm} : {new_outer_to_dttm}"
-                else:
-                    # If it IS a datetime series, we still need to clear conflicts
-                    query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
-
-                    # For relative offsets with datetime series, ensure the temporal
-                    # filter matches our range
-                    temporal_col = query_object_clone.granularity or x_axis_label
-
-                    # Update any existing temporal filters to match our shifted range
-                    for flt in query_object_clone.filter:
-                        if (
-                            flt.get("op") == FilterOperator.TEMPORAL_RANGE
-                            and flt.get("col") == temporal_col
-                        ):
-                            flt["val"] = (
-                                f"{query_object_clone.from_dttm} : "
-                                f"{query_object_clone.to_dttm}"
-                            )
-
-            # Remove non-temporal x-axis filters (but keep temporal ones)
-            query_object_clone.filter = [
-                flt
-                for flt in query_object_clone.filter
-                if not (
-                    flt.get("col") == x_axis_label
-                    and flt.get("op") != FilterOperator.TEMPORAL_RANGE
-                )
-            ]
-
-            # Continue with the rest of the method (caching, execution, etc.)
-            cached_time_offset_key = (
-                offset if offset == original_offset else f"{offset}_{original_offset}"
-            )
-
-            cache_key = self.query_cache_key(
-                query_object_clone,
-                time_offset=cached_time_offset_key,
-                time_grain=time_grain,
-            )
-            cache = QueryCacheManager.get(
-                cache_key, CacheRegion.DATA, query_context.force
-            )
-
-            if cache.is_loaded:
-                offset_dfs[offset] = cache.df
-                queries.append(cache.query)
-                cache_keys.append(cache_key)
-                continue
-
-            query_object_clone_dct = query_object_clone.to_dict()
-
-            # rename metrics: SUM(value) => SUM(value) 1 year ago
-            metrics_mapping = {
-                metric: TIME_COMPARISON.join([metric, original_offset])
-                for metric in metric_names
-            }
-
-            # When the original query has limit or offset we wont apply those
-            # to the subquery so we prevent data inconsistency due to missing records
-            # in the dataframes when performing the join
-            if query_object.row_limit or query_object.row_offset:
-                query_object_clone_dct["row_limit"] = current_app.config["ROW_LIMIT"]
-                query_object_clone_dct["row_offset"] = 0
-
-            # Call the unified query method on the datasource
-            result = self._qc_datasource.query(query_object_clone_dct)
-
-            queries.append(result.query)
-            cache_keys.append(None)
-
-            offset_metrics_df = result.df
-            if offset_metrics_df.empty:
-                offset_metrics_df = pd.DataFrame(
-                    {
-                        col: [np.NaN]
-                        for col in join_keys + list(metrics_mapping.values())
-                    }
-                )
-            else:
-                # 1. normalize df, set dttm column
-                offset_metrics_df = self.normalize_df(
-                    offset_metrics_df, query_object_clone
-                )
-
-                # 2. rename extra query columns
-                offset_metrics_df = offset_metrics_df.rename(columns=metrics_mapping)
-
-            # cache df and query
-            value = {
-                "df": offset_metrics_df,
-                "query": result.query,
-            }
-            cache.set(
-                key=cache_key,
-                value=value,
-                timeout=self.get_cache_timeout(),
-                datasource_uid=query_context.datasource.uid,
-                region=CacheRegion.DATA,
-            )
-            offset_dfs[offset] = offset_metrics_df
-
-        if offset_dfs:
-            df = self.join_offset_dfs(
-                df,
-                offset_dfs,
-                time_grain,
-                join_keys,
-            )
-
-        return CachedTimeOffset(df=df, queries=queries, cache_keys=cache_keys)
-
-    def _get_temporal_column_for_filter(  # noqa: C901
-        self, query_object: QueryObject, x_axis_label: str | None
-    ) -> str | None:
-        """
-        Helper method to reliably determine the temporal column for filtering.
-
-        This method tries multiple strategies to find the correct temporal column:
-        1. Use explicitly set granularity
-        2. Use x_axis_label if it's a temporal column
-        3. Find any datetime column in the datasource
-
-        :param query_object: The query object
-        :param x_axis_label: The x-axis label from the query
-        :return: The name of the temporal column, or None if not found
-        """
-        # Strategy 1: Use explicitly set granularity
-        if query_object.granularity:
-            return query_object.granularity
-
-        # Strategy 2: Use x_axis_label if it exists
-        if x_axis_label:
-            return x_axis_label
-
-        # Strategy 3: Find any datetime column in the datasource
-        if hasattr(self._qc_datasource, "columns"):
-            for col in self._qc_datasource.columns:
-                if hasattr(col, "is_dttm") and col.is_dttm:
-                    if hasattr(col, "column_name"):
-                        return col.column_name
-                    elif hasattr(col, "name"):
-                        return col.name
-
-        return None
-
-    def _process_date_range_offset(
-        self, offset_df: pd.DataFrame, join_keys: list[str]
-    ) -> tuple[pd.DataFrame, list[str]]:
-        """Process date range offset data and return modified DataFrame and keys."""
-        temporal_cols = ["ds", "__timestamp", "dttm"]
-        non_temporal_join_keys = [key for key in join_keys if key not in temporal_cols]
-
-        if non_temporal_join_keys:
-            return offset_df, non_temporal_join_keys
-
-        metric_columns = [col for col in offset_df.columns if col not in temporal_cols]
-
-        if metric_columns:
-            aggregated_values = {}
-            for col in metric_columns:
-                if pd.api.types.is_numeric_dtype(offset_df[col]):
-                    aggregated_values[col] = offset_df[col].sum()
-                else:
-                    aggregated_values[col] = (
-                        offset_df[col].iloc[0] if not offset_df.empty else None
-                    )
-
-            offset_df = pd.DataFrame([aggregated_values])
-
-        return offset_df, []
-
-    def _apply_cleanup_logic(
-        self,
-        df: pd.DataFrame,
-        offset: str,
-        time_grain: str | None,
-        join_keys: list[str],
-        is_date_range_offset: bool,
-    ) -> pd.DataFrame:
-        """Apply appropriate cleanup logic based on offset type."""
-        if time_grain and not is_date_range_offset:
-            if join_keys:
-                col = df.pop(join_keys[0])
-                df.insert(0, col.name, col)
-
-            df.drop(
-                list(df.filter(regex=f"{OFFSET_JOIN_COLUMN_SUFFIX}|{R_SUFFIX}")),
-                axis=1,
-                inplace=True,
-            )
-        elif is_date_range_offset:
-            df.drop(
-                list(df.filter(regex=f"{R_SUFFIX}")),
-                axis=1,
-                inplace=True,
-            )
-        else:
-            df.drop(
-                list(df.filter(regex=f"{R_SUFFIX}")),
-                axis=1,
-                inplace=True,
-            )
-
-        return df
-
-    def _determine_join_keys(
-        self,
-        df: pd.DataFrame,
-        offset_df: pd.DataFrame,
-        offset: str,
-        time_grain: str | None,
-        join_keys: list[str],
-        is_date_range_offset: bool,
-        join_column_producer: Any,
-    ) -> tuple[pd.DataFrame, list[str]]:
-        """Determine appropriate join keys and modify DataFrames if needed."""
-        if time_grain and not is_date_range_offset:
-            column_name = OFFSET_JOIN_COLUMN_SUFFIX + offset
-
-            # Add offset join columns for relative time offsets
-            self.add_offset_join_column(
-                df, column_name, time_grain, offset, join_column_producer
-            )
-            self.add_offset_join_column(
-                offset_df, column_name, time_grain, None, join_column_producer
-            )
-            return offset_df, [column_name, *join_keys[1:]]
-
-        elif is_date_range_offset:
-            return self._process_date_range_offset(offset_df, join_keys)
-
-        else:
-            return offset_df, join_keys
-
-    def _perform_join(
-        self, df: pd.DataFrame, offset_df: pd.DataFrame, actual_join_keys: list[str]
-    ) -> pd.DataFrame:
-        """Perform the appropriate join operation."""
-        if actual_join_keys:
-            return dataframe_utils.left_join_df(
-                left_df=df,
-                right_df=offset_df,
-                join_keys=actual_join_keys,
-                rsuffix=R_SUFFIX,
-            )
-        else:
-            temp_key = "__temp_join_key__"
-            df[temp_key] = 1
-            offset_df[temp_key] = 1
-
-            result_df = dataframe_utils.left_join_df(
-                left_df=df,
-                right_df=offset_df,
-                join_keys=[temp_key],
-                rsuffix=R_SUFFIX,
-            )
-
-            # Remove temporary join keys
-            result_df.drop(columns=[temp_key], inplace=True, errors="ignore")
-            result_df.drop(
-                columns=[f"{temp_key}{R_SUFFIX}"], inplace=True, errors="ignore"
-            )
-            return result_df
-
-    def join_offset_dfs(
-        self,
-        df: pd.DataFrame,
-        offset_dfs: dict[str, pd.DataFrame],
-        time_grain: str | None,
-        join_keys: list[str],
-    ) -> pd.DataFrame:
-        """
-        Join offset DataFrames with the main DataFrame.
-
-        :param df: The main DataFrame.
-        :param offset_dfs: A list of offset DataFrames.
-        :param time_grain: The time grain used to calculate the temporal join key.
-        :param join_keys: The keys to join on.
-        """
-        join_column_producer = current_app.config[
-            "TIME_GRAIN_JOIN_COLUMN_PRODUCERS"
-        ].get(time_grain)
-
-        if join_column_producer and not time_grain:
-            raise QueryObjectValidationError(
-                _("Time Grain must be specified when using Time Shift.")
-            )
-
-        for offset, offset_df in offset_dfs.items():
-            is_date_range_offset = self.is_valid_date_range(
-                offset
-            ) and feature_flag_manager.is_feature_enabled(
-                "DATE_RANGE_TIMESHIFTS_ENABLED"
-            )
-
-            offset_df, actual_join_keys = self._determine_join_keys(
-                df,
-                offset_df,
-                offset,
-                time_grain,
-                join_keys,
-                is_date_range_offset,
-                join_column_producer,
-            )
-
-            df = self._perform_join(df, offset_df, actual_join_keys)
-            df = self._apply_cleanup_logic(
-                df, offset, time_grain, join_keys, is_date_range_offset
-            )
-
-        return df
-
-    @staticmethod
-    def generate_join_column(
-        row: pd.Series,
-        column_index: int,
-        time_grain: str,
-        time_offset: str | None = None,
-    ) -> str:
-        value = row[column_index]
-
-        if hasattr(value, "strftime"):
-            if time_offset and not QueryContextProcessor.is_valid_date_range_static(
-                time_offset
-            ):
-                value = value + DateOffset(**normalize_time_delta(time_offset))
-
-            if time_grain in (
-                TimeGrain.WEEK_STARTING_SUNDAY,
-                TimeGrain.WEEK_ENDING_SATURDAY,
-            ):
-                return value.strftime("%Y-W%U")
-
-            if time_grain in (
-                TimeGrain.WEEK,
-                TimeGrain.WEEK_STARTING_MONDAY,
-                TimeGrain.WEEK_ENDING_SUNDAY,
-            ):
-                return value.strftime("%Y-W%W")
-
-            if time_grain == TimeGrain.MONTH:
-                return value.strftime("%Y-%m")
-
-            if time_grain == TimeGrain.QUARTER:
-                return value.strftime("%Y-Q") + str(value.quarter)
-
-            if time_grain == TimeGrain.YEAR:
-                return value.strftime("%Y")
-
-        return str(value)
-
-    @staticmethod
-    def is_valid_date_range_static(date_range: str) -> bool:
-        """Static version of is_valid_date_range for use in static methods"""
-        try:
-            # Attempt to parse the string as a date range in the format
-            # YYYY-MM-DD:YYYY-MM-DD
-            start_date, end_date = date_range.split(":")
-            datetime.strptime(start_date.strip(), "%Y-%m-%d")
-            datetime.strptime(end_date.strip(), "%Y-%m-%d")
-            return True
-        except ValueError:
-            # If parsing fails, it's not a valid date range in the format
-            # YYYY-MM-DD:YYYY-MM-DD
-            return False
+        # Create cache timeout function
+        def cache_timeout_fn() -> int:
+            return self.get_cache_timeout()
+
+        # Delegate to datasource with caching support
+        return self._qc_datasource.processing_time_offsets(
+            df,
+            query_object,
+            cache_key_fn=cache_key_fn,
+            cache_timeout_fn=cache_timeout_fn,
+            force_cache=self._query_context.force,
+        )
 
     def get_data(
         self, df: pd.DataFrame, coltypes: list[GenericDataType]

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, cast, ClassVar, TYPE_CHECKING, TypedDict
+from typing import Any, cast, ClassVar, TYPE_CHECKING
 
 import pandas as pd
 from flask import current_app
@@ -38,7 +38,7 @@ from superset.exceptions import (
     SupersetException,
 )
 from superset.extensions import cache_manager, security_manager
-from superset.models.helpers import QueryResult
+from superset.models.helpers import CachedTimeOffset, QueryResult
 from superset.superset_typing import AdhocColumn, AdhocMetric
 from superset.utils import csv, excel
 from superset.utils.cache import generate_cache_key, set_and_log_cache
@@ -61,12 +61,6 @@ if TYPE_CHECKING:
     from superset.common.query_object import QueryObject
 
 logger = logging.getLogger(__name__)
-
-
-class CachedTimeOffset(TypedDict):
-    df: pd.DataFrame
-    queries: list[str]
-    cache_keys: list[str | None]
 
 
 class QueryContextProcessor:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -18,12 +18,11 @@
 from __future__ import annotations
 
 import builtins
-import dataclasses
 import logging
 from collections import defaultdict
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Callable, cast, Optional, Union
 
 import pandas as pd
@@ -82,8 +81,6 @@ from superset.exceptions import (
     ColumnNotFoundException,
     DatasetInvalidPermissionEvaluationException,
     QueryObjectValidationError,
-    SupersetErrorException,
-    SupersetErrorsException,
     SupersetGenericDBErrorException,
     SupersetSecurityException,
     SupersetSyntaxErrorException,
@@ -1613,89 +1610,27 @@ class SqlaTable(
         return or_(*groups)
 
     def query(self, query_obj: QueryObjectDict) -> QueryResult:
-        qry_start_dttm = datetime.now()
-        query_str_ext = self.get_query_str_extended(query_obj)
-        sql = query_str_ext.sql
-        status = QueryStatus.SUCCESS
-        errors = None
-        error_message = None
+        """
+        Executes the query for SqlaTable with additional column ordering logic.
 
-        def assign_column_label(df: pd.DataFrame) -> pd.DataFrame | None:
-            """
-            Some engines change the case or generate bespoke column names, either by
-            default or due to lack of support for aliasing. This function ensures that
-            the column names in the DataFrame correspond to what is expected by
-            the viz components.
+        This overrides ExploreMixin.query() to add SqlaTable-specific behavior
+        for handling column_order from extras.
+        """
+        # Get the base result from parent
+        result = super().query(query_obj)
 
-            Sometimes a query may also contain only order by columns that are not used
-            as metrics or groupby columns, but need to present in the SQL `select`,
-            filtering by `labels_expected` make sure we only return columns users want.
-
-            :param df: Original DataFrame returned by the engine
-            :return: Mutated DataFrame
-            """
-            labels_expected = query_str_ext.labels_expected
-            if df is not None and not df.empty:
-                if len(df.columns) < len(labels_expected):
-                    raise QueryObjectValidationError(
-                        _("Db engine did not return all queried columns")
-                    )
-                if len(df.columns) > len(labels_expected):
-                    df = df.iloc[:, 0 : len(labels_expected)]
-                df.columns = labels_expected
-
-                extras = query_obj.get("extras", {})
-                column_order = extras.get("column_order")
-                if column_order and isinstance(column_order, list):
-                    existing_cols = [col for col in column_order if col in df.columns]
-                    remaining_cols = [
-                        col for col in df.columns if col not in existing_cols
-                    ]
-                    final_order = existing_cols + remaining_cols
-                    df = df[final_order]
-            return df
-
-        try:
-            df = self.database.get_df(
-                sql,
-                self.catalog,
-                self.schema or None,
-                mutator=assign_column_label,
-            )
-        except (SupersetErrorException, SupersetErrorsException):
-            # SupersetError(s) exception should not be captured; instead, they should
-            # bubble up to the Flask error handler so they are returned as proper SIP-40
-            # errors. This is particularly important for database OAuth2, see SIP-85.
-            raise
-        except Exception as ex:  # pylint: disable=broad-except
-            # TODO (betodealmeida): review exception handling while querying the external  # noqa: E501
-            # database. Ideally we'd expect and handle external database error, but
-            # everything else / the default should be to let things bubble up.
-            df = pd.DataFrame()
-            status = QueryStatus.FAILED
-            logger.warning(
-                "Query %s on schema %s failed", sql, self.schema, exc_info=True
-            )
-            db_engine_spec = self.db_engine_spec
-            errors = [
-                dataclasses.asdict(error)
-                for error in db_engine_spec.extract_errors(
-                    ex, database_name=self.database.unique_name
-                )
+        # Apply SqlaTable-specific column ordering
+        extras = query_obj.get("extras", {})
+        column_order = extras.get("column_order")
+        if column_order and isinstance(column_order, list) and not result.df.empty:
+            existing_cols = [col for col in column_order if col in result.df.columns]
+            remaining_cols = [
+                col for col in result.df.columns if col not in existing_cols
             ]
-            error_message = utils.error_msg_from_exception(ex)
+            final_order = existing_cols + remaining_cols
+            result.df = result.df[final_order]
 
-        return QueryResult(
-            applied_template_filters=query_str_ext.applied_template_filters,
-            applied_filter_columns=query_str_ext.applied_filter_columns,
-            rejected_filter_columns=query_str_ext.rejected_filter_columns,
-            status=status,
-            df=df,
-            duration=datetime.now() - qry_start_dttm,
-            query=sql,
-            errors=errors,
-            error_message=error_message,
-        )
+        return result
 
     def get_sqla_table_object(self) -> Table:
         return self.database.get_table(

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1616,8 +1616,9 @@ class SqlaTable(
         This overrides ExploreMixin.query() to add SqlaTable-specific behavior
         for handling column_order from extras.
         """
-        # Get the base result from parent
-        result = super().query(query_obj)
+        # Get the base result from ExploreMixin
+        # (explicitly, not super() which would hit BaseDatasource first)
+        result = ExploreMixin.query(self, query_obj)
 
         # Apply SqlaTable-specific column ordering
         extras = query_obj.get("extras", {})

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -153,6 +153,7 @@ class CachedTimeOffset(TypedDict):
     queries: list[str]
     cache_keys: list[str | None]
 
+
 # Keys used to filter QueryObjectDict for get_sqla_query parameters
 SQLA_QUERY_KEYS = {
     "apply_fetch_values_predicate",

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -80,6 +80,7 @@ from superset.exceptions import (
     InvalidPostProcessingError,
     QueryClauseValidationException,
     QueryObjectValidationError,
+    SupersetErrorException,
     SupersetSecurityException,
     SupersetSyntaxErrorException,
 )
@@ -1181,6 +1182,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                 mutator=assign_column_label,
             )
         except Exception as ex:  # pylint: disable=broad-except
+            # Re-raise SupersetErrorException (includes OAuth2RedirectError)
+            # to bubble up to API layer
+            if isinstance(ex, SupersetErrorException):
+                raise
             df = pd.DataFrame()
             status = QueryStatus.FAILED
             logger.warning(

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import builtins
+import copy
 import dataclasses
 import logging
 import re
@@ -52,6 +53,7 @@ from flask_appbuilder.security.sqla.models import User
 from flask_babel import get_locale, lazy_gettext as _
 from jinja2.exceptions import TemplateError
 from markupsafe import escape, Markup
+from pandas import DateOffset
 from sqlalchemy import and_, Column, or_, UniqueConstraint
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.ext.declarative import declared_attr
@@ -64,13 +66,18 @@ from sqlalchemy_utils import UUIDType
 from superset import db, is_feature_enabled
 from superset.advanced_data_type.types import AdvancedDataTypeResponse
 from superset.common.db_query_status import QueryStatus
-from superset.common.utils.time_range_utils import get_since_until_from_time_range
-from superset.constants import EMPTY_STRING, NULL_STRING
+from superset.common.utils import dataframe_utils
+from superset.common.utils.time_range_utils import (
+    get_since_until_from_query_object,
+    get_since_until_from_time_range,
+)
+from superset.constants import CacheRegion, EMPTY_STRING, NULL_STRING, TimeGrain
 from superset.db_engine_specs.base import TimestampExpression
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     AdvancedDataTypeResponseError,
     ColumnNotFoundException,
+    InvalidPostProcessingError,
     QueryClauseValidationException,
     QueryObjectValidationError,
     SupersetSecurityException,
@@ -90,15 +97,25 @@ from superset.superset_typing import (
 )
 from superset.utils import core as utils, json
 from superset.utils.core import (
+    DateColumn,
+    DTTM_ALIAS,
+    FilterOperator,
     GenericDataType,
+    get_base_axis_labels,
     get_column_name,
+    get_metric_names,
     get_non_base_axis_columns,
     get_user_id,
+    get_x_axis_label,
     is_adhoc_column,
     MediumText,
+    normalize_dttm_col,
+    QueryObjectFilterClause,
     remove_duplicates,
     SqlExpressionType,
+    TIME_COMPARISON,
 )
+from superset.utils.date_parser import get_past_or_future, normalize_time_delta
 from superset.utils.dates import datetime_to_epoch
 from superset.utils.rls import apply_rls
 
@@ -111,6 +128,7 @@ class ValidationResultDict(TypedDict):
 
 
 if TYPE_CHECKING:
+    from superset.common.query_object import QueryObject
     from superset.connectors.sqla.models import SqlMetric, TableColumn
     from superset.db_engine_specs import BaseEngineSpec
     from superset.models.core import Database
@@ -119,6 +137,20 @@ logger = logging.getLogger(__name__)
 
 VIRTUAL_TABLE_ALIAS = "virtual_table"
 SERIES_LIMIT_SUBQ_ALIAS = "series_limit"
+
+# Offset join column suffix used for joining offset results
+OFFSET_JOIN_COLUMN_SUFFIX = "__offset_join_column_"
+
+# Right suffix used for joining offset results
+R_SUFFIX = "__right_suffix"
+
+
+class CachedTimeOffset(TypedDict):
+    """Result type for time offset processing"""
+
+    df: pd.DataFrame
+    queries: list[str]
+    cache_keys: list[str | None]
 
 # Keys used to filter QueryObjectDict for get_sqla_query parameters
 SQLA_QUERY_KEYS = {
@@ -781,9 +813,6 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
     def db_extra(self) -> Optional[dict[str, Any]]:
         raise NotImplementedError()
 
-    def query(self, query_obj: QueryObjectDict) -> QueryResult:
-        raise NotImplementedError()
-
     @property
     def database_id(self) -> int:
         raise NotImplementedError()
@@ -1107,9 +1136,15 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             if is_alias_used_in_orderby(col):
                 col.name = f"{col.name}__"
 
-    def exc_query(self, qry: Any) -> QueryResult:
+    def query(self, query_obj: QueryObjectDict) -> QueryResult:
+        """
+        Executes the query and returns a dataframe.
+
+        This method is the unified entry point for query execution across all
+        datasource types (Query, SqlaTable, etc.).
+        """
         qry_start_dttm = datetime.now()
-        query_str_ext = self.get_query_str_extended(qry)
+        query_str_ext = self.get_query_str_extended(query_obj)
         sql = query_str_ext.sql
         status = QueryStatus.SUCCESS
         errors = None
@@ -1171,6 +1206,755 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             errors=errors,
             error_message=error_message,
         )
+
+    def exc_query(self, qry: Any) -> QueryResult:
+        """
+        Deprecated: Use query() instead.
+        This method is kept for backward compatibility.
+        """
+        return self.query(qry)
+
+    def normalize_df(self, df: pd.DataFrame, query_object: QueryObject) -> pd.DataFrame:
+        """
+        Normalize the dataframe by converting datetime columns and ensuring
+        numerical metrics.
+
+        :param df: The dataframe to normalize
+        :param query_object: The query object with metadata about columns
+        :return: Normalized dataframe
+        """
+
+        def _get_timestamp_format(column: str | None) -> str | None:
+            if not hasattr(self, "get_column"):
+                return None
+            column_obj = self.get_column(column)
+            if (
+                column_obj
+                and hasattr(column_obj, "python_date_format")
+                and (formatter := column_obj.python_date_format)
+            ):
+                return str(formatter)
+            return None
+
+        # Collect datetime columns
+        labels = tuple(
+            label
+            for label in [
+                *get_base_axis_labels(query_object.columns),
+                query_object.granularity,
+            ]
+            if hasattr(self, "get_column")
+            and (col := self.get_column(label))
+            and (col.get("is_dttm") if isinstance(col, dict) else col.is_dttm)
+        )
+
+        dttm_cols = [
+            DateColumn(
+                timestamp_format=_get_timestamp_format(label),
+                offset=self.offset,
+                time_shift=query_object.time_shift,
+                col_label=label,
+            )
+            for label in labels
+            if label
+        ]
+
+        if DTTM_ALIAS in df:
+            dttm_cols.append(
+                DateColumn.get_legacy_time_column(
+                    timestamp_format=_get_timestamp_format(query_object.granularity),
+                    offset=self.offset,
+                    time_shift=query_object.time_shift,
+                )
+            )
+
+        normalize_dttm_col(
+            df=df,
+            dttm_cols=tuple(dttm_cols),
+        )
+
+        # Convert metrics to numerical values if enforced
+        if getattr(self, "enforce_numerical_metrics", True):
+            dataframe_utils.df_metrics_to_num(df, query_object)
+
+        df.replace([np.inf, -np.inf], np.nan, inplace=True)
+
+        return df
+
+    def get_query_result(self, query_object: QueryObject) -> QueryResult:
+        """
+        Execute query and return results with full processing pipeline.
+
+        This method handles:
+        1. Query execution via self.query()
+        2. DataFrame normalization
+        3. Time offset processing (if applicable)
+        4. Post-processing operations
+
+        :param query_object: The query configuration
+        :return: QueryResult with processed dataframe
+        """
+        # Execute the base query
+        result = self.query(query_object.to_dict())
+        query = result.query + ";\n\n" if result.query else ""
+
+        # Process the dataframe if not empty
+        df = result.df
+        if not df.empty:
+            # Normalize datetime columns and metrics
+            df = self.normalize_df(df, query_object)
+
+            # Process time offsets if requested
+            if query_object.time_offsets:
+                # Process time offsets using the datasource's own method
+                # Note: caching is disabled here as we don't have query context
+                time_offsets = self.processing_time_offsets(
+                    df, query_object, cache_key_fn=None, cache_timeout_fn=None
+                )
+                df = time_offsets["df"]
+                queries = time_offsets["queries"]
+                query += ";\n\n".join(queries)
+                query += ";\n\n"
+
+            # Execute post-processing operations
+            try:
+                df = query_object.exec_post_processing(df)
+            except InvalidPostProcessingError as ex:
+                raise QueryObjectValidationError(ex.message) from ex
+
+        # Update result with processed data
+        result.df = df
+        result.query = query
+        result.from_dttm = query_object.from_dttm
+        result.to_dttm = query_object.to_dttm
+
+        return result
+
+    def processing_time_offsets(  # pylint: disable=too-many-locals,too-many-statements # noqa: C901
+        self,
+        df: pd.DataFrame,
+        query_object: QueryObject,
+        cache_key_fn: Callable[[QueryObject, str, Any], str | None] | None = None,
+        cache_timeout_fn: Callable[[], int] | None = None,
+        force_cache: bool = False,
+    ) -> CachedTimeOffset:
+        """
+        Process time offsets for time comparison feature.
+
+        This method handles both relative time offsets (e.g., "1 week ago") and
+        absolute date range offsets (e.g., "2015-01-03 : 2015-01-04").
+
+        :param df: The main dataframe
+        :param query_object: The query object with time offset configuration
+        :param cache_key_fn: Optional function to generate cache keys
+        :param cache_timeout_fn: Optional function to get cache timeout
+        :param force_cache: Whether to force cache refresh
+        :return: CachedTimeOffset with processed dataframe and queries
+        """
+        # Import here to avoid circular dependency
+        # pylint: disable=import-outside-toplevel
+        from superset.common.utils.query_cache_manager import QueryCacheManager
+
+        # ensure query_object is immutable
+        query_object_clone = copy.copy(query_object)
+        queries: list[str] = []
+        cache_keys: list[str | None] = []
+        offset_dfs: dict[str, pd.DataFrame] = {}
+
+        outer_from_dttm, outer_to_dttm = get_since_until_from_query_object(query_object)
+        if not outer_from_dttm or not outer_to_dttm:
+            raise QueryObjectValidationError(
+                _(
+                    "An enclosed time range (both start and end) must be specified "
+                    "when using a Time Comparison."
+                )
+            )
+
+        time_grain = self.get_time_grain(query_object)
+        metric_names = get_metric_names(query_object.metrics)
+        # use columns that are not metrics as join keys
+        join_keys = [col for col in df.columns if col not in metric_names]
+
+        for offset in query_object.time_offsets:
+            try:
+                original_offset = offset
+                is_date_range_offset = self.is_valid_date_range(offset)
+
+                if is_date_range_offset and feature_flag_manager.is_feature_enabled(
+                    "DATE_RANGE_TIMESHIFTS_ENABLED"
+                ):
+                    # DATE RANGE OFFSET LOGIC (like "2015-01-03 : 2015-01-04")
+                    try:
+                        # Parse the specified range
+                        offset_from_dttm, offset_to_dttm = (
+                            get_since_until_from_time_range(time_range=offset)
+                        )
+                    except ValueError as ex:
+                        raise QueryObjectValidationError(str(ex)) from ex
+
+                    # Use the specified range directly
+                    query_object_clone.from_dttm = offset_from_dttm
+                    query_object_clone.to_dttm = offset_to_dttm
+
+                    # For date range offsets, we must NOT set inner bounds
+                    # These create additional WHERE clauses that conflict with our
+                    # date range
+                    query_object_clone.inner_from_dttm = None
+                    query_object_clone.inner_to_dttm = None
+
+                elif is_date_range_offset:
+                    # Date range timeshift feature is disabled
+                    raise QueryObjectValidationError(
+                        "Date range timeshifts are not enabled. "
+                        "Please contact your administrator to enable the "
+                        "DATE_RANGE_TIMESHIFTS_ENABLED feature flag."
+                    )
+
+                else:
+                    # RELATIVE OFFSET LOGIC (like "1 day ago")
+                    if self.is_valid_date(offset) or offset == "inherit":
+                        offset = self.get_offset_custom_or_inherit(
+                            offset,
+                            outer_from_dttm,
+                            outer_to_dttm,
+                        )
+                    query_object_clone.from_dttm = get_past_or_future(
+                        offset,
+                        outer_from_dttm,
+                    )
+                    query_object_clone.to_dttm = get_past_or_future(
+                        offset, outer_to_dttm
+                    )
+
+                    query_object_clone.inner_from_dttm = query_object_clone.from_dttm
+                    query_object_clone.inner_to_dttm = query_object_clone.to_dttm
+
+                x_axis_label = get_x_axis_label(query_object.columns)
+                query_object_clone.granularity = (
+                    query_object_clone.granularity or x_axis_label
+                )
+
+            except ValueError as ex:
+                raise QueryObjectValidationError(str(ex)) from ex
+
+            query_object_clone.time_offsets = []
+            query_object_clone.post_processing = []
+
+            # Get time offset index
+            index = (get_base_axis_labels(query_object.columns) or [DTTM_ALIAS])[0]
+
+            if is_date_range_offset and feature_flag_manager.is_feature_enabled(
+                "DATE_RANGE_TIMESHIFTS_ENABLED"
+            ):
+                # Create a completely new filter list to preserve original filters
+                query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
+
+                # Remove any existing temporal filters that might conflict
+                query_object_clone.filter = [
+                    flt
+                    for flt in query_object_clone.filter
+                    if not (flt.get("op") == FilterOperator.TEMPORAL_RANGE)
+                ]
+
+                # Determine the temporal column with multiple fallback strategies
+                temporal_col = self._get_temporal_column_for_filter(
+                    query_object_clone, x_axis_label
+                )
+
+                # Always add a temporal filter for date range offsets
+                if temporal_col:
+                    new_temporal_filter: QueryObjectFilterClause = {
+                        "col": temporal_col,
+                        "op": FilterOperator.TEMPORAL_RANGE,
+                        "val": (
+                            f"{query_object_clone.from_dttm} : "
+                            f"{query_object_clone.to_dttm}"
+                        ),
+                    }
+                    query_object_clone.filter.append(new_temporal_filter)
+
+                else:
+                    # This should rarely happen with proper fallbacks
+                    raise QueryObjectValidationError(
+                        _(
+                            "Unable to identify temporal column for date range time comparison."  # noqa: E501
+                            "Please ensure your dataset has a properly configured time column."  # noqa: E501
+                        )
+                    )
+
+            else:
+                # RELATIVE OFFSET: Original logic for non-date-range offsets
+                # The comparison is not using a temporal column so we need to modify
+                # the temporal filter so we run the query with the correct time range
+                if not dataframe_utils.is_datetime_series(df.get(index)):
+                    query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
+
+                    # Find and update temporal filters
+                    for flt in query_object_clone.filter:
+                        if flt.get(
+                            "op"
+                        ) == FilterOperator.TEMPORAL_RANGE and isinstance(
+                            flt.get("val"), str
+                        ):
+                            time_range = cast(str, flt.get("val"))
+                            (
+                                new_outer_from_dttm,
+                                new_outer_to_dttm,
+                            ) = get_since_until_from_time_range(
+                                time_range=time_range,
+                                time_shift=offset,
+                            )
+                            flt["val"] = f"{new_outer_from_dttm} : {new_outer_to_dttm}"
+                else:
+                    # If it IS a datetime series, we still need to clear conflicts
+                    query_object_clone.filter = copy.deepcopy(query_object_clone.filter)
+
+                    # For relative offsets with datetime series, ensure the temporal
+                    # filter matches our range
+                    temporal_col = query_object_clone.granularity or x_axis_label
+
+                    # Update any existing temporal filters to match our shifted range
+                    for flt in query_object_clone.filter:
+                        if (
+                            flt.get("op") == FilterOperator.TEMPORAL_RANGE
+                            and flt.get("col") == temporal_col
+                        ):
+                            flt["val"] = (
+                                f"{query_object_clone.from_dttm} : "
+                                f"{query_object_clone.to_dttm}"
+                            )
+
+            # Remove non-temporal x-axis filters (but keep temporal ones)
+            query_object_clone.filter = [
+                flt
+                for flt in query_object_clone.filter
+                if not (
+                    flt.get("col") == x_axis_label
+                    and flt.get("op") != FilterOperator.TEMPORAL_RANGE
+                )
+            ]
+
+            # Continue with the rest of the method (caching, execution, etc.)
+            cached_time_offset_key = (
+                offset if offset == original_offset else f"{offset}_{original_offset}"
+            )
+
+            cache_key = None
+            if cache_key_fn:
+                cache_key = cache_key_fn(
+                    query_object_clone,
+                    cached_time_offset_key,
+                    time_grain,
+                )
+
+            cache = QueryCacheManager.get(cache_key, CacheRegion.DATA, force_cache)
+
+            if cache.is_loaded:
+                offset_dfs[offset] = cache.df
+                queries.append(cache.query)
+                cache_keys.append(cache_key)
+                continue
+
+            query_object_clone_dct = query_object_clone.to_dict()
+
+            # rename metrics: SUM(value) => SUM(value) 1 year ago
+            metrics_mapping = {
+                metric: TIME_COMPARISON.join([metric, original_offset])
+                for metric in metric_names
+            }
+
+            # When the original query has limit or offset we wont apply those
+            # to the subquery so we prevent data inconsistency due to missing records
+            # in the dataframes when performing the join
+            if query_object.row_limit or query_object.row_offset:
+                query_object_clone_dct["row_limit"] = app.config["ROW_LIMIT"]
+                query_object_clone_dct["row_offset"] = 0
+
+            # Call the unified query method on the datasource
+            result = self.query(query_object_clone_dct)
+
+            queries.append(result.query)
+            cache_keys.append(None)
+
+            offset_metrics_df = result.df
+            if offset_metrics_df.empty:
+                offset_metrics_df = pd.DataFrame(
+                    {
+                        col: [np.NaN]
+                        for col in join_keys + list(metrics_mapping.values())
+                    }
+                )
+            else:
+                # 1. normalize df, set dttm column
+                offset_metrics_df = self.normalize_df(
+                    offset_metrics_df, query_object_clone
+                )
+
+                # 2. rename extra query columns
+                offset_metrics_df = offset_metrics_df.rename(columns=metrics_mapping)
+
+            # cache df and query if caching is enabled
+            if cache_key and cache_timeout_fn:
+                value = {
+                    "df": offset_metrics_df,
+                    "query": result.query,
+                }
+                cache.set(
+                    key=cache_key,
+                    value=value,
+                    timeout=cache_timeout_fn(),
+                    datasource_uid=self.uid,
+                    region=CacheRegion.DATA,
+                )
+            offset_dfs[offset] = offset_metrics_df
+
+        if offset_dfs:
+            df = self.join_offset_dfs(
+                df,
+                offset_dfs,
+                time_grain,
+                join_keys,
+            )
+
+        return CachedTimeOffset(df=df, queries=queries, cache_keys=cache_keys)
+
+    @staticmethod
+    def get_time_grain(query_object: QueryObject) -> Any | None:
+        if (
+            query_object.columns
+            and len(query_object.columns) > 0
+            and isinstance(query_object.columns[0], dict)
+        ):
+            # If the time grain is in the columns it will be the first one
+            # and it will be of AdhocColumn type
+            return query_object.columns[0].get("timeGrain")
+
+        return query_object.extras.get("time_grain_sqla")
+
+    def is_valid_date(self, date_string: str) -> bool:
+        try:
+            # Attempt to parse the string as a date in the format YYYY-MM-DD
+            datetime.strptime(date_string, "%Y-%m-%d")
+            return True
+        except ValueError:
+            # If parsing fails, it's not a valid date in the format YYYY-MM-DD
+            return False
+
+    def is_valid_date_range(self, date_range: str) -> bool:
+        try:
+            # Attempt to parse the string as a date range in the format
+            # YYYY-MM-DD:YYYY-MM-DD
+            start_date, end_date = date_range.split(":")
+            datetime.strptime(start_date.strip(), "%Y-%m-%d")
+            datetime.strptime(end_date.strip(), "%Y-%m-%d")
+            return True
+        except ValueError:
+            # If parsing fails, it's not a valid date range in the format
+            # YYYY-MM-DD:YYYY-MM-DD
+            return False
+
+    def get_offset_custom_or_inherit(
+        self,
+        offset: str,
+        outer_from_dttm: datetime,
+        outer_to_dttm: datetime,
+    ) -> str:
+        """
+        Get the time offset for custom or inherit.
+
+        :param offset: The offset string.
+        :param outer_from_dttm: The outer from datetime.
+        :param outer_to_dttm: The outer to datetime.
+        :returns: The time offset.
+        """
+        if offset == "inherit":
+            # return the difference in days between the from and the to dttm formatted as a string with the " days ago" suffix  # noqa: E501
+            return f"{(outer_to_dttm - outer_from_dttm).days} days ago"
+        if self.is_valid_date(offset):
+            # return the offset as the difference in days between the outer from dttm and the offset date (which is a YYYY-MM-DD string) formatted as a string with the " days ago" suffix  # noqa: E501
+            offset_date = datetime.strptime(offset, "%Y-%m-%d")
+            return f"{(outer_from_dttm - offset_date).days} days ago"
+        return ""
+
+    def _get_temporal_column_for_filter(  # noqa: C901
+        self, query_object: QueryObject, x_axis_label: str | None
+    ) -> str | None:
+        """
+        Helper method to reliably determine the temporal column for filtering.
+
+        This method tries multiple strategies to find the correct temporal column:
+        1. Use explicitly set granularity
+        2. Use x_axis_label if it's a temporal column
+        3. Find any datetime column in the datasource
+
+        :param query_object: The query object
+        :param x_axis_label: The x-axis label from the query
+        :return: The name of the temporal column, or None if not found
+        """
+        # Strategy 1: Use explicitly set granularity
+        if query_object.granularity:
+            return query_object.granularity
+
+        # Strategy 2: Use x_axis_label if it exists
+        if x_axis_label:
+            return x_axis_label
+
+        # Strategy 3: Find any datetime column in the datasource
+        if hasattr(self, "columns"):
+            for col in self.columns:
+                if hasattr(col, "is_dttm") and col.is_dttm:
+                    if hasattr(col, "column_name"):
+                        return col.column_name
+                    elif hasattr(col, "name"):
+                        return col.name
+
+        return None
+
+    def _process_date_range_offset(
+        self, offset_df: pd.DataFrame, join_keys: list[str]
+    ) -> tuple[pd.DataFrame, list[str]]:
+        """Process date range offset data and return modified DataFrame and keys."""
+        temporal_cols = ["ds", "__timestamp", "dttm"]
+        non_temporal_join_keys = [key for key in join_keys if key not in temporal_cols]
+
+        if non_temporal_join_keys:
+            return offset_df, non_temporal_join_keys
+
+        metric_columns = [col for col in offset_df.columns if col not in temporal_cols]
+
+        if metric_columns:
+            aggregated_values = {}
+            for col in metric_columns:
+                if pd.api.types.is_numeric_dtype(offset_df[col]):
+                    aggregated_values[col] = offset_df[col].sum()
+                else:
+                    aggregated_values[col] = (
+                        offset_df[col].iloc[0] if not offset_df.empty else None
+                    )
+
+            offset_df = pd.DataFrame([aggregated_values])
+
+        return offset_df, []
+
+    def _apply_cleanup_logic(
+        self,
+        df: pd.DataFrame,
+        offset: str,
+        time_grain: str | None,
+        join_keys: list[str],
+        is_date_range_offset: bool,
+    ) -> pd.DataFrame:
+        """Apply appropriate cleanup logic based on offset type."""
+        if time_grain and not is_date_range_offset:
+            if join_keys:
+                col = df.pop(join_keys[0])
+                df.insert(0, col.name, col)
+
+            df.drop(
+                list(df.filter(regex=f"{OFFSET_JOIN_COLUMN_SUFFIX}|{R_SUFFIX}")),
+                axis=1,
+                inplace=True,
+            )
+        elif is_date_range_offset:
+            df.drop(
+                list(df.filter(regex=f"{R_SUFFIX}")),
+                axis=1,
+                inplace=True,
+            )
+        else:
+            df.drop(
+                list(df.filter(regex=f"{R_SUFFIX}")),
+                axis=1,
+                inplace=True,
+            )
+
+        return df
+
+    def _determine_join_keys(
+        self,
+        df: pd.DataFrame,
+        offset_df: pd.DataFrame,
+        offset: str,
+        time_grain: str | None,
+        join_keys: list[str],
+        is_date_range_offset: bool,
+        join_column_producer: Any,
+    ) -> tuple[pd.DataFrame, list[str]]:
+        """Determine appropriate join keys and modify DataFrames if needed."""
+        if time_grain and not is_date_range_offset:
+            column_name = OFFSET_JOIN_COLUMN_SUFFIX + offset
+
+            # Add offset join columns for relative time offsets
+            self.add_offset_join_column(
+                df, column_name, time_grain, offset, join_column_producer
+            )
+            self.add_offset_join_column(
+                offset_df, column_name, time_grain, None, join_column_producer
+            )
+            return offset_df, [column_name, *join_keys[1:]]
+
+        elif is_date_range_offset:
+            return self._process_date_range_offset(offset_df, join_keys)
+
+        else:
+            return offset_df, join_keys
+
+    def _perform_join(
+        self, df: pd.DataFrame, offset_df: pd.DataFrame, actual_join_keys: list[str]
+    ) -> pd.DataFrame:
+        """Perform the appropriate join operation."""
+        if actual_join_keys:
+            return dataframe_utils.left_join_df(
+                left_df=df,
+                right_df=offset_df,
+                join_keys=actual_join_keys,
+                rsuffix=R_SUFFIX,
+            )
+        else:
+            temp_key = "__temp_join_key__"
+            df[temp_key] = 1
+            offset_df[temp_key] = 1
+
+            result_df = dataframe_utils.left_join_df(
+                left_df=df,
+                right_df=offset_df,
+                join_keys=[temp_key],
+                rsuffix=R_SUFFIX,
+            )
+
+            # Remove temporary join keys
+            result_df.drop(columns=[temp_key], inplace=True, errors="ignore")
+            result_df.drop(
+                columns=[f"{temp_key}{R_SUFFIX}"], inplace=True, errors="ignore"
+            )
+            return result_df
+
+    def join_offset_dfs(
+        self,
+        df: pd.DataFrame,
+        offset_dfs: dict[str, pd.DataFrame],
+        time_grain: str | None,
+        join_keys: list[str],
+    ) -> pd.DataFrame:
+        """
+        Join offset DataFrames with the main DataFrame.
+
+        :param df: The main DataFrame.
+        :param offset_dfs: A list of offset DataFrames.
+        :param time_grain: The time grain used to calculate the temporal join key.
+        :param join_keys: The keys to join on.
+        """
+        join_column_producer = app.config["TIME_GRAIN_JOIN_COLUMN_PRODUCERS"].get(
+            time_grain
+        )
+
+        if join_column_producer and not time_grain:
+            raise QueryObjectValidationError(
+                _("Time Grain must be specified when using Time Shift.")
+            )
+
+        for offset, offset_df in offset_dfs.items():
+            is_date_range_offset = self.is_valid_date_range(
+                offset
+            ) and feature_flag_manager.is_feature_enabled(
+                "DATE_RANGE_TIMESHIFTS_ENABLED"
+            )
+
+            offset_df, actual_join_keys = self._determine_join_keys(
+                df,
+                offset_df,
+                offset,
+                time_grain,
+                join_keys,
+                is_date_range_offset,
+                join_column_producer,
+            )
+
+            df = self._perform_join(df, offset_df, actual_join_keys)
+            df = self._apply_cleanup_logic(
+                df, offset, time_grain, join_keys, is_date_range_offset
+            )
+
+        return df
+
+    def add_offset_join_column(
+        self,
+        df: pd.DataFrame,
+        name: str,
+        time_grain: str,
+        time_offset: str | None = None,
+        join_column_producer: Any = None,
+    ) -> None:
+        """
+        Adds an offset join column to the provided DataFrame.
+
+        The function modifies the DataFrame in-place.
+
+        :param df: pandas DataFrame to which the offset join column will be added.
+        :param name: The name of the new column to be added.
+        :param time_grain: The time grain used to calculate the new column.
+        :param time_offset: The time offset used to calculate the new column.
+        :param join_column_producer: A function to generate the join column.
+        """
+        if join_column_producer:
+            df[name] = df.apply(lambda row: join_column_producer(row, 0), axis=1)
+        else:
+            df[name] = df.apply(
+                lambda row: self.generate_join_column(row, 0, time_grain, time_offset),
+                axis=1,
+            )
+
+    @staticmethod
+    def generate_join_column(
+        row: pd.Series,
+        column_index: int,
+        time_grain: str,
+        time_offset: str | None = None,
+    ) -> str:
+        value = row[column_index]
+
+        if hasattr(value, "strftime"):
+            if time_offset and not ExploreMixin.is_valid_date_range_static(time_offset):
+                value = value + DateOffset(**normalize_time_delta(time_offset))
+
+            if time_grain in (
+                TimeGrain.WEEK_STARTING_SUNDAY,
+                TimeGrain.WEEK_ENDING_SATURDAY,
+            ):
+                return value.strftime("%Y-W%U")
+
+            if time_grain in (
+                TimeGrain.WEEK,
+                TimeGrain.WEEK_STARTING_MONDAY,
+                TimeGrain.WEEK_ENDING_SUNDAY,
+            ):
+                return value.strftime("%Y-W%W")
+
+            if time_grain == TimeGrain.MONTH:
+                return value.strftime("%Y-%m")
+
+            if time_grain == TimeGrain.QUARTER:
+                return value.strftime("%Y-Q") + str(value.quarter)
+
+            if time_grain == TimeGrain.YEAR:
+                return value.strftime("%Y")
+
+        return str(value)
+
+    @staticmethod
+    def is_valid_date_range_static(date_range: str) -> bool:
+        """Static version of is_valid_date_range for use in static methods"""
+        try:
+            # Attempt to parse the string as a date range in the format
+            # YYYY-MM-DD:YYYY-MM-DD
+            start_date, end_date = date_range.split(":")
+            datetime.strptime(start_date.strip(), "%Y-%m-%d")
+            datetime.strptime(end_date.strip(), "%Y-%m-%d")
+            return True
+        except ValueError:
+            # If parsing fails, it's not a valid date range in the format
+            # YYYY-MM-DD:YYYY-MM-DD
+            return False
 
     def get_rendered_sql(
         self,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -81,6 +81,7 @@ from superset.exceptions import (
     QueryClauseValidationException,
     QueryObjectValidationError,
     SupersetErrorException,
+    SupersetErrorsException,
     SupersetSecurityException,
     SupersetSyntaxErrorException,
 )
@@ -1185,7 +1186,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         except Exception as ex:  # pylint: disable=broad-except
             # Re-raise SupersetErrorException (includes OAuth2RedirectError)
             # to bubble up to API layer
-            if isinstance(ex, SupersetErrorException):
+            if isinstance(ex, (SupersetErrorException, SupersetErrorsException)):
                 raise
             df = pd.DataFrame()
             status = QueryStatus.FAILED

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -622,10 +622,24 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year ago", "1 year later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
+
+        # Create cache functions for testing
+        def cache_key_fn(qo, time_offset, time_grain):
+            return query_context._processor.query_cache_key(
+                qo, time_offset=time_offset, time_grain=time_grain
+            )
+
+        def cache_timeout_fn():
+            return query_context._processor.get_cache_timeout()
+
         # query without cache
-        query_context._processor.processing_time_offsets(df.copy(), query_object)
+        query_context.datasource.processing_time_offsets(
+            df.copy(), query_object, cache_key_fn, cache_timeout_fn, query_context.force
+        )
         # query with cache
-        rv = query_context._processor.processing_time_offsets(df.copy(), query_object)
+        rv = query_context.datasource.processing_time_offsets(
+            df.copy(), query_object, cache_key_fn, cache_timeout_fn, query_context.force
+        )
         cache_keys = rv["cache_keys"]
         cache_keys__1_year_ago = cache_keys[0]
         cache_keys__1_year_later = cache_keys[1]
@@ -637,7 +651,9 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year later", "1 year ago"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        rv = query_context._processor.processing_time_offsets(df.copy(), query_object)
+        rv = query_context.datasource.processing_time_offsets(
+            df.copy(), query_object, cache_key_fn, cache_timeout_fn, query_context.force
+        )
         cache_keys = rv["cache_keys"]
         assert cache_keys__1_year_ago == cache_keys[1]
         assert cache_keys__1_year_later == cache_keys[0]
@@ -646,9 +662,8 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = []
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        rv = query_context._processor.processing_time_offsets(
-            df.copy(),
-            query_object,
+        rv = query_context.datasource.processing_time_offsets(
+            df.copy(), query_object, cache_key_fn, cache_timeout_fn, query_context.force
         )
 
         assert rv["df"].shape == df.shape
@@ -676,8 +691,17 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context._processor.processing_time_offsets(
-            df, query_object
+
+        def cache_key_fn(qo, time_offset, time_grain):
+            return query_context._processor.query_cache_key(
+                qo, time_offset=time_offset, time_grain=time_grain
+            )
+
+        def cache_timeout_fn():
+            return query_context._processor.get_cache_timeout()
+
+        time_offsets_obj = query_context.datasource.processing_time_offsets(
+            df, query_object, cache_key_fn, cache_timeout_fn, query_context.force
         )
         query_from_1977_to_1988 = time_offsets_obj["queries"][0]
         query_from_1983_to_1994 = time_offsets_obj["queries"][1]
@@ -709,8 +733,17 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context._processor.processing_time_offsets(
-            df, query_object
+
+        def cache_key_fn(qo, time_offset, time_grain):
+            return query_context._processor.query_cache_key(
+                qo, time_offset=time_offset, time_grain=time_grain
+            )
+
+        def cache_timeout_fn():
+            return query_context._processor.get_cache_timeout()
+
+        time_offsets_obj = query_context.datasource.processing_time_offsets(
+            df, query_object, cache_key_fn, cache_timeout_fn, query_context.force
         )
         df_with_offsets = time_offsets_obj["df"]
         df_with_offsets = df_with_offsets.set_index(["__timestamp", "state"])
@@ -799,8 +832,17 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year ago", "1 year later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context._processor.processing_time_offsets(
-            df, query_object
+
+        def cache_key_fn(qo, time_offset, time_grain):
+            return query_context._processor.query_cache_key(
+                qo, time_offset=time_offset, time_grain=time_grain
+            )
+
+        def cache_timeout_fn():
+            return query_context._processor.get_cache_timeout()
+
+        time_offsets_obj = query_context.datasource.processing_time_offsets(
+            df, query_object, cache_key_fn, cache_timeout_fn, query_context.force
         )
         sqls = time_offsets_obj["queries"]
         row_limit_value = current_app.config["ROW_LIMIT"]

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -623,9 +623,9 @@ class TestQueryContext(SupersetTestCase):
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
         # query without cache
-        query_context.processing_time_offsets(df.copy(), query_object)
+        query_context._processor.processing_time_offsets(df.copy(), query_object)
         # query with cache
-        rv = query_context.processing_time_offsets(df.copy(), query_object)
+        rv = query_context._processor.processing_time_offsets(df.copy(), query_object)
         cache_keys = rv["cache_keys"]
         cache_keys__1_year_ago = cache_keys[0]
         cache_keys__1_year_later = cache_keys[1]
@@ -637,7 +637,7 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year later", "1 year ago"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        rv = query_context.processing_time_offsets(df.copy(), query_object)
+        rv = query_context._processor.processing_time_offsets(df.copy(), query_object)
         cache_keys = rv["cache_keys"]
         assert cache_keys__1_year_ago == cache_keys[1]
         assert cache_keys__1_year_later == cache_keys[0]
@@ -646,7 +646,7 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = []
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        rv = query_context.processing_time_offsets(
+        rv = query_context._processor.processing_time_offsets(
             df.copy(),
             query_object,
         )
@@ -676,7 +676,9 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context.processing_time_offsets(df, query_object)
+        time_offsets_obj = query_context._processor.processing_time_offsets(
+            df, query_object
+        )
         query_from_1977_to_1988 = time_offsets_obj["queries"][0]
         query_from_1983_to_1994 = time_offsets_obj["queries"][1]
 
@@ -707,7 +709,9 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["3 years ago", "3 years later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context.processing_time_offsets(df, query_object)
+        time_offsets_obj = query_context._processor.processing_time_offsets(
+            df, query_object
+        )
         df_with_offsets = time_offsets_obj["df"]
         df_with_offsets = df_with_offsets.set_index(["__timestamp", "state"])
 
@@ -795,7 +799,9 @@ class TestQueryContext(SupersetTestCase):
         payload["queries"][0]["time_offsets"] = ["1 year ago", "1 year later"]
         query_context = ChartDataQueryContextSchema().load(payload)
         query_object = query_context.queries[0]
-        time_offsets_obj = query_context.processing_time_offsets(df, query_object)
+        time_offsets_obj = query_context._processor.processing_time_offsets(
+            df, query_object
+        )
         sqls = time_offsets_obj["queries"]
         row_limit_value = current_app.config["ROW_LIMIT"]
         row_limit_pattern_with_config_value = r"LIMIT " + re.escape(

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -582,7 +582,9 @@ def test_processing_time_offsets_temporal_column_error(processor):
                         QueryObjectValidationError,
                         match="Unable to identify temporal column",
                     ):
-                        processor.processing_time_offsets(df, query_object)
+                        processor._qc_datasource.processing_time_offsets(
+                            df, query_object, None, None, False
+                        )
 
 
 def test_processing_time_offsets_date_range_enabled(processor):
@@ -682,8 +684,10 @@ def test_processing_time_offsets_date_range_enabled(processor):
                             "processing_time_offsets",
                             return_value=mock_cached_result,
                         ):
-                            # Test the method
-                            result = processor.processing_time_offsets(df, query_object)
+                            # Test the method (call datasource method directly)
+                            result = processor._qc_datasource.processing_time_offsets(
+                                df, query_object, None, None, False
+                            )
 
                             # Verify that the method completes successfully
                             assert "df" in result

--- a/tests/unit_tests/common/test_time_shifts.py
+++ b/tests/unit_tests/common/test_time_shifts.py
@@ -23,8 +23,10 @@ from superset.common.query_context import QueryContext
 from superset.common.query_context_processor import QueryContextProcessor
 from superset.connectors.sqla.models import BaseDatasource
 from superset.constants import TimeGrain
+from superset.models.helpers import ExploreMixin
 
-query_context_processor = QueryContextProcessor(
+# Create processor and bind ExploreMixin methods to datasource
+processor = QueryContextProcessor(
     QueryContext(
         datasource=BaseDatasource(),
         queries=[],
@@ -35,6 +37,34 @@ query_context_processor = QueryContextProcessor(
         cache_values={},
     )
 )
+
+# Bind ExploreMixin methods to datasource for testing
+processor._qc_datasource.add_offset_join_column = (
+    ExploreMixin.add_offset_join_column.__get__(processor._qc_datasource)
+)
+processor._qc_datasource.join_offset_dfs = ExploreMixin.join_offset_dfs.__get__(
+    processor._qc_datasource
+)
+processor._qc_datasource.is_valid_date_range = ExploreMixin.is_valid_date_range.__get__(
+    processor._qc_datasource
+)
+processor._qc_datasource._determine_join_keys = (
+    ExploreMixin._determine_join_keys.__get__(processor._qc_datasource)
+)
+processor._qc_datasource._perform_join = ExploreMixin._perform_join.__get__(
+    processor._qc_datasource
+)
+processor._qc_datasource._apply_cleanup_logic = (
+    ExploreMixin._apply_cleanup_logic.__get__(processor._qc_datasource)
+)
+# Static methods don't need binding - assign directly
+processor._qc_datasource.generate_join_column = ExploreMixin.generate_join_column
+processor._qc_datasource.is_valid_date_range_static = (
+    ExploreMixin.is_valid_date_range_static
+)
+
+# Convenience reference for backward compatibility in tests
+query_context_processor = processor._qc_datasource
 
 
 @fixture


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The current flow for generating visualization data based on a chart request looks like this:

```python
class QueryContextProcessor:
    ...
    def get_query_result(self, query_object: QueryObject) -> QueryResult:
        if isinstance(query_context.datasource, Query):
            result = query_context.datasource.exc_query(query_object.to_dict())
        else:
            result = query_context.datasource.query(query_object.to_dict())

    df = result.df
    # ... normalization and post-processing
    return result
```

The post-processing before `result` is returned has similar dispatching based on the type of `datasource`: 

```python
    def processing_time_offsets(  # pylint: disable=too-many-locals,too-many-statements # noqa: C901
        self,
        df: pd.DataFrame,
        query_object: QueryObject,
    ) -> CachedTimeOffset:
        ...
        for offset in query_object.time_offsets:
            ...
            if isinstance(self._qc_datasource, Query):
                result = self._qc_datasource.exc_query(query_object_clone_dct)
            else:
                result = self._qc_datasource.query(query_object_clone_dct)
```

This PR cleans up the logic by:

1. Getting rid of `exc_query`; and
2. Implementing a `query` method in `ExploreMixin` that's used by both datasource types (queries and datasets).

Additionally, the method `get_query_result` is moved from the query context processor into the datasource. Why? The method offers a very clean interface:

```python
def get_query_result(self, query_object: QueryObject) -> QueryResult:
```

Moving it into the datasource allows us to more easily introduce new datasources, like [semantic views](https://github.com/apache/superset/issues/35003).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

WIP

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
