### PR TITLE
feat(dashboard): Edit dashboard description from ui (and api) and show tooltip on dashboard list view

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -489,6 +489,7 @@ export function saveDashboardRequest(
       owners,
       roles,
       slug,
+      description,
       tags,
     } = data;
 
@@ -521,6 +522,7 @@ export function saveDashboardRequest(
             hasId(r) ? r.id : r,
           ),
       slug: slug || null,
+      description: description || null,
       tags: !isFeatureEnabled(FeatureFlag.TaggingSystem)
         ? undefined
         : ensureIsArray((tags || []) as JsonObject[]).map((r: JsonObject) =>
@@ -672,6 +674,7 @@ export function saveDashboardRequest(
               css: cleanedData.css,
               dashboard_title: cleanedData.dashboard_title,
               slug: cleanedData.slug,
+              description: cleanedData.description,
               owners: cleanedData.owners,
               roles: cleanedData.roles,
               tags: cleanedData.tags || [],

--- a/superset-frontend/src/dashboard/components/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/index.tsx
@@ -101,6 +101,7 @@ import { RefreshButton } from '../RefreshButton';
 
 type DashboardPropertiesUpdate = {
   slug?: string;
+  description?: string;
   jsonMetadata?: string;
   certifiedBy?: string;
   certificationDetails?: string;
@@ -122,6 +123,7 @@ type DashboardInfoState = RootState['dashboardInfo'] & {
   dash_share_perm?: boolean;
   is_managed_externally?: boolean;
   slug?: string;
+  description?: string;
   last_modified_time?: number;
   certified_by?: string;
   certification_details?: string;
@@ -442,6 +444,7 @@ const Header = (): JSX.Element => {
       owners: dashboardInfo.owners,
       roles: dashboardInfo.roles,
       slug,
+      description: dashboardInfo.description,
       tags: (dashboardInfo.tags || []).filter(
         item => item.type === TagTypeEnum.Custom || !item.type,
       ),
@@ -497,6 +500,7 @@ const Header = (): JSX.Element => {
     shouldPersistRefreshFrequency,
     slug,
     themeId,
+    dashboardInfo.description,
   ]);
 
   const {
@@ -555,6 +559,7 @@ const Header = (): JSX.Element => {
     (updates: DashboardPropertiesUpdate) => {
       boundActionCreators.dashboardInfoChanged({
         slug: updates.slug,
+        description: updates.description,
         metadata: JSON.parse(updates.jsonMetadata || '{}'),
         certified_by: updates.certifiedBy,
         certification_details: updates.certificationDetails,

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -212,7 +212,7 @@ describe('PropertiesModal', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
 
     // Only General information section is expanded by default
-    expect(screen.getAllByRole('textbox')).toHaveLength(2); // Name and Slug
+    expect(screen.getAllByRole('textbox')).toHaveLength(3); // Name, Slug and Description
 
     // Expand Styling section to see the ColorSchemeControlWrapper
     const stylingHeaderText = screen.getByText('Styling');
@@ -257,7 +257,7 @@ describe('PropertiesModal', () => {
     expect(screen.getByText('Certification')).toBeInTheDocument();
 
     // General information section is expanded by default
-    expect(screen.getAllByRole('textbox')).toHaveLength(2); // Name and Slug are visible
+    expect(screen.getAllByRole('textbox')).toHaveLength(3); // Name, Slug and Description are visible
 
     // Expand Access & ownership to see Tags
     const accessPanel = screen
@@ -302,7 +302,7 @@ describe('PropertiesModal', () => {
       await screen.findByTestId('dashboard-edit-properties-form'),
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(2); // Only Name and Slug visible initially
+    expect(screen.getAllByRole('textbox')).toHaveLength(3); // Only Name, Slug and Description visible initially
 
     // Click on the Advanced settings collapse panel to expand it
     const advancedHeaderText = screen.getByText('Advanced settings');

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -178,10 +178,12 @@ const PropertiesModal = ({
         is_managed_externally,
         theme,
         css,
+        description,
       } = dashboardData;
       const dashboardInfo = {
         id,
         title: dashboard_title,
+        description: description || '',
         slug: slug || '',
         certifiedBy: certified_by || '',
         certificationDetails: certification_details || '',
@@ -309,8 +311,13 @@ const PropertiesModal = ({
   };
 
   const onFinish = () => {
-    const { title, slug, certifiedBy, certificationDetails } =
-      form.getFieldsValue();
+    const {
+      title,
+      description = '',
+      slug,
+      certifiedBy,
+      certificationDetails,
+    } = form.getFieldsValue();
     let currentJsonMetadata = jsonMetadata;
 
     // validate currentJsonMetadata
@@ -389,6 +396,7 @@ const PropertiesModal = ({
     const onSubmitProps = {
       id: dashboardId,
       title,
+      description,
       slug,
       jsonMetadata: currentJsonMetadata,
       owners,
@@ -416,6 +424,7 @@ const PropertiesModal = ({
     } else {
       const saveData = {
         dashboard_title: title,
+        description: description || null,
         slug: slug || null,
         json_metadata: currentJsonMetadata || null,
         owners: (owners || []).map(o => o.id),

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.test.tsx
@@ -29,7 +29,7 @@ const defaultProps = {
   },
 };
 
-test('renders name and slug fields', () => {
+test('renders name, description and slug fields', () => {
   render(
     <Form>
       <BasicInfoSection {...defaultProps} />
@@ -38,6 +38,7 @@ test('renders name and slug fields', () => {
 
   expect(screen.getByTestId('dashboard-name-field')).toBeInTheDocument();
   expect(screen.getByTestId('dashboard-slug-field')).toBeInTheDocument();
+  expect(screen.getByTestId('dashboard-description-field')).toBeInTheDocument();
   expect(screen.getByTestId('dashboard-title-input')).toBeInTheDocument();
 });
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/BasicInfoSection.tsx
@@ -74,6 +74,18 @@ const BasicInfoSection = ({
           />
         </FormItem>
       </ModalFormField>
+      <ModalFormField
+        label={t('Description')}
+        testId="dashboard-description-field"
+        bottomSpacing={false}
+      >
+        <FormItem name="description" noStyle>
+          <Input.TextArea
+            placeholder={t('A description for your dashboard')}
+            data-test="dashboard-description-input"
+          />
+        </FormItem>
+      </ModalFormField>
     </>
   );
 };

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -212,6 +212,7 @@ export type DashboardInfo = {
   } | null;
   css?: string;
   slug?: string;
+  description?: string;
   last_modified_time: number;
   certified_by?: string;
   certification_details?: string;

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -95,6 +95,7 @@ const FlexRowContainer = styled.div`
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: 1.2;
+    min-width: 0;
   }
 
   svg {

--- a/superset-frontend/src/pages/DashboardList/DashboardList.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.test.tsx
@@ -88,7 +88,7 @@ test('fetches data', async () => {
 
   const calls = fetchMock.callHistory.calls(/dashboard\/\?q/);
   expect(calls[0].url).toMatchInlineSnapshot(
-    `"http://localhost/api/v1/dashboard/?q=(order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25,select_columns:!(id,dashboard_title,published,url,slug,changed_by,changed_by.id,changed_by.first_name,changed_by.last_name,changed_on_delta_humanized,owners,owners.id,owners.first_name,owners.last_name,tags.id,tags.name,tags.type,status,certified_by,certification_details,changed_on))"`,
+    `"http://localhost/api/v1/dashboard/?q=(order_column:changed_on_delta_humanized,order_direction:desc,page:0,page_size:25,select_columns:!(id,dashboard_title,published,url,slug,description,changed_by,changed_by.id,changed_by.first_name,changed_by.last_name,changed_on_delta_humanized,owners,owners.id,owners.first_name,owners.last_name,tags.id,tags.name,tags.type,status,certified_by,certification_details,changed_on))"`,
   );
 });
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -40,6 +40,7 @@ import {
   ConfirmStatusChange,
   DeleteModal,
   FaveStar,
+  InfoTooltip,
   Loading,
   PublishedLabel,
   Tooltip,
@@ -120,12 +121,31 @@ const Actions = styled.div`
   color: ${({ theme }) => theme.colorIcon};
 `;
 
+const FlexRowContainer = styled.div`
+  align-items: center;
+  display: flex;
+  gap: ${({ theme }) => theme.sizeUnit}px;
+
+  a {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.2;
+    min-width: 0;
+  }
+
+  svg {
+    margin-right: ${({ theme }) => theme.sizeUnit}px;
+  }
+`;
+
 const DASHBOARD_COLUMNS_TO_FETCH = [
   'id',
   'dashboard_title',
   'published',
   'url',
   'slug',
+  'description',
   'changed_by',
   'changed_by.id',
   'changed_by.first_name',
@@ -241,6 +261,7 @@ function DashboardList(props: DashboardListProps) {
                 changed_by: changedBy,
                 dashboard_title: dashboardTitle = '',
                 slug = '',
+                description = '',
                 json_metadata: jsonMetadata = '',
                 changed_on_delta_humanized: changedOnDeltaHumanized,
                 url = '',
@@ -255,6 +276,7 @@ function DashboardList(props: DashboardListProps) {
                 changed_by: changedBy,
                 dashboard_title: dashboardTitle,
                 slug,
+                description,
                 json_metadata: jsonMetadata,
                 changed_on_delta_humanized: changedOnDeltaHumanized,
                 url,
@@ -341,20 +363,24 @@ function DashboardList(props: DashboardListProps) {
               dashboard_title: dashboardTitle,
               certified_by: certifiedBy,
               certification_details: certificationDetails,
+              description,
             },
           },
         }: any) => (
-          <Link to={url} title={dashboardTitle}>
-            {certifiedBy && (
-              <>
-                <CertifiedBadge
-                  certifiedBy={certifiedBy}
-                  details={certificationDetails}
-                />{' '}
-              </>
-            )}
-            {dashboardTitle}
-          </Link>
+          <FlexRowContainer>
+            <Link to={url} title={dashboardTitle}>
+              {certifiedBy && (
+                <>
+                  <CertifiedBadge
+                    certifiedBy={certifiedBy}
+                    details={certificationDetails}
+                  />{' '}
+                </>
+              )}
+              {dashboardTitle}
+            </Link>
+            {description && <InfoTooltip tooltip={description} />}
+          </FlexRowContainer>
         ),
         Header: t('Name'),
         accessor: 'dashboard_title',

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -186,6 +186,7 @@ BASE_LIST_COLUMNS = [
     "published",
     "status",
     "slug",
+    "description",
     "url",
     "certified_by",
     "certification_details",
@@ -351,6 +352,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
         "certification_details",
         "dashboard_title",
         "slug",
+        "description",
         "owners",
         "roles",
         "position_json",
@@ -371,6 +373,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
         "published",
         "roles",
         "slug",
+        "description",
         "tags",
         "uuid",
     )

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -46,6 +46,7 @@ screenshot_query_schema = {
     },
 }
 dashboard_title_description = "A title for the dashboard."
+description_description = "A description for the dashboard."
 slug_description = "Unique identifying part for the web address of the dashboard."
 owners_description = (
     "Owner are users ids allowed to delete or change this dashboard. "
@@ -289,6 +290,7 @@ class DashboardGetResponseSchema(Schema):
     created_on_humanized = fields.String(data_key="created_on_delta_humanized")
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     uuid = fields.UUID(allow_none=True)
+    description = fields.String(allow_none=True)
 
     # pylint: disable=unused-argument
     @post_dump()
@@ -412,6 +414,10 @@ class DashboardPostSchema(BaseDashboardSchema):
         allow_none=True,
         validate=[Length(1, 255)],
     )
+    description = fields.String(
+        metadata={"description": description_description},
+        allow_none=True,
+    )
     owners = fields.List(fields.Integer(metadata={"description": owners_description}))
     roles = fields.List(fields.Integer(metadata={"description": roles_description}))
     position_json = fields.String(
@@ -465,6 +471,10 @@ class DashboardPutSchema(BaseDashboardSchema):
         metadata={"description": dashboard_title_description},
         allow_none=True,
         validate=Length(0, 500),
+    )
+    description = fields.String(
+        metadata={"description": description_description},
+        allow_none=True,
     )
     slug = fields.String(
         metadata={"description": slug_description},

--- a/tests/integration_tests/base_tests.py
+++ b/tests/integration_tests/base_tests.py
@@ -583,6 +583,7 @@ class SupersetTestCase(TestCase):
         published: bool = False,
         certified_by: Optional[str] = None,
         certification_details: Optional[str] = None,
+        desc: Optional[str] = None,
     ) -> Dashboard:
         obj_owners = list()  # noqa: C408
         obj_roles = list()  # noqa: C408
@@ -606,6 +607,7 @@ class SupersetTestCase(TestCase):
         dashboard = Dashboard(
             dashboard_title=dashboard_title,
             slug=slug,
+            description=desc,
             owners=obj_owners,
             roles=obj_roles,
             position_json=position_json,

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -81,6 +81,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
     dashboard_data = {
         "dashboard_title": "title1_changed",
         "slug": "slug1_changed",
+        "description": "desc_changed",
         "position_json": '{"b": "B"}',
         "css": "css_changed",
         "json_metadata": '{"refresh_frequency": 30, "timed_refresh_immune_slices": [], "expanded_slices": {}, "color_scheme": "", "label_colors": {}, "shared_label_colors": [], "map_label_colors": {}, "color_scheme_domain": [], "cross_filters_enabled": false}',  # noqa: E501
@@ -538,7 +539,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         """
         admin = self.get_user("admin")
         dashboard = self.insert_dashboard(
-            "title", "slug1", [admin.id], created_by=admin
+            "title", "slug1", [admin.id], created_by=admin, desc="description"
         )
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
@@ -578,6 +579,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
                 "thumbnail_url": dashboard.thumbnail_url,
                 "is_managed_externally": False,
                 "theme": None,
+                "description": "description",
             }
         data = json.loads(rv.data.decode("utf-8"))
         assert "changed_on" in data["result"]


### PR DESCRIPTION
## **User description**
feat(dashboard): Edit dashboard description from ui (and api) and show tooltip on dashboard list view

### SUMMARY
Similar to the description field on charts, this PR adds a text area field in the dashboard properties modal to update the description. Works from the list and from the dashboard header edit mode as well.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
**Edit modal**
<img width="503" height="298" alt="Screenshot 2025-11-11 at 11 00 52" src="https://github.com/user-attachments/assets/72394838-8100-4d5a-9090-9f5e1557a92f" />

**List view**
<img width="431" height="53" alt="Screenshot 2025-11-11 at 11 00 46" src="https://github.com/user-attachments/assets/2bfdc09e-bc59-48b6-940d-5d2176d27694" />

#### After
**Edit modal**
<img width="501" height="709" alt="Screenshot 2025-11-11 at 10 52 56" src="https://github.com/user-attachments/assets/29c11d8d-6bf6-42fe-98c8-022bd7f5b5f4" />

**List view with tooltip**
<img width="418" height="52" alt="Screenshot 2025-11-11 at 10 53 03" src="https://github.com/user-attachments/assets/ca940c7c-abb8-4d5a-a627-ebef8a82cbd1" />

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #27410
- [x] Changes UI
- [x] Introduces new feature or API


___

## **CodeAnt-AI Description**
Add editable dashboard description and display it as tooltip in dashboard list

### What Changed
- Users can add or edit a dashboard description from the dashboard properties modal and header save flow; the description is included when saving a dashboard.
- Dashboard list rows show an info tooltip next to the dashboard title when a description exists so users can read the description on hover.
- Backend API and schemas now include the dashboard description in list and get responses; integration and frontend tests updated to cover the new field.

### Impact
`✅ Clearer dashboard descriptions`
`✅ Easier to add or update dashboard purpose`
`✅ Faster dashboard discovery from the list view`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
