### PR TITLE
feat(mcp-service): implement FastMCP 2.13.0 response caching middleware [POC]

### DIFF
--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -18,7 +18,7 @@
 
 import logging
 import secrets
-from typing import Any, Dict, Optional
+from typing import Any
 
 from flask import Flask
 
@@ -34,7 +34,7 @@ WEBDRIVER_BASEURL = "http://localhost:9001/"
 WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 
 # Feature flags for MCP
-MCP_FEATURE_FLAGS: Dict[str, Any] = {
+MCP_FEATURE_FLAGS: dict[str, Any] = {
     "MCP_SERVICE": True,
 }
 
@@ -107,7 +107,7 @@ MCP_CACHE_CONFIG = {
 }
 
 
-def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
+def create_default_mcp_auth_factory(app: Flask) -> Any | None:
     """Default MCP auth factory using app.config values."""
     if not app.config.get("MCP_AUTH_ENABLED", False):
         return None
@@ -155,7 +155,7 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
         return None
 
 
-def default_user_resolver(app: Any, access_token: Any) -> Optional[str]:
+def default_user_resolver(app: Any, access_token: Any) -> str | None:
     """Extract username from JWT token claims."""
     logger.info(
         "Resolving user from token: type=%s, token=%s",
@@ -180,7 +180,7 @@ def generate_secret_key() -> str:
     return secrets.token_urlsafe(42)
 
 
-def get_mcp_config(app_config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def get_mcp_config(app_config: dict[str, Any] | None = None) -> dict[str, Any]:
     """
     Get complete MCP configuration dictionary.
 
@@ -208,8 +208,8 @@ def get_mcp_config(app_config: Dict[str, Any] | None = None) -> Dict[str, Any]:
 
 
 def get_mcp_config_with_overrides(
-    app_config: Dict[str, Any] | None = None,
-) -> Dict[str, Any]:
+    app_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """
     Alternative approach: Allow any app_config keys, not just predefined ones.
 
@@ -224,16 +224,16 @@ def get_mcp_config_with_overrides(
 
 
 def create_response_caching_middleware(
-    app_config: Dict[str, Any] | None = None,
-) -> Optional[Any]:
-    """
-    Create ResponseCachingMiddleware with configuration from app.config.
+    app_config: dict[str, Any] | None = None,
+) -> Any | None:
+    """Create ResponseCachingMiddleware with configuration from app.config.
 
     Args:
         app_config: Optional Flask app configuration dict
 
     Returns:
         ResponseCachingMiddleware instance or None if caching is disabled
+
     """
     app_config = app_config or {}
 
@@ -270,7 +270,7 @@ def create_response_caching_middleware(
         }
 
         # Tool caching with include/exclude lists
-        call_tool_settings: Dict[str, Any] = {
+        call_tool_settings: dict[str, Any] = {
             "ttl": cache_config.get("call_tool_ttl", 3600),
             "enabled": True,
         }
@@ -299,7 +299,8 @@ def create_response_caching_middleware(
 
         if cache_config.get("excluded_tools"):
             logger.info(
-                "Excluded tools from caching: %s", cache_config["excluded_tools"]
+                "Excluded tools from caching: %s",
+                cache_config["excluded_tools"],
             )
 
         return middleware
@@ -310,11 +311,11 @@ def create_response_caching_middleware(
         )
         return None
     except Exception as e:
-        logger.error("Failed to create response caching middleware: %s", e)
+        logger.exception("Failed to create response caching middleware: %s", e)
         return None
 
 
-def get_mcp_factory_config() -> Dict[str, Any]:
+def get_mcp_factory_config() -> dict[str, Any]:
     """
     Get FastMCP factory configuration.
 

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -104,9 +104,7 @@ def run_server(
 
         # Create middleware list - response caching is enabled by default
         middleware_list = []
-        caching_middleware = create_response_caching_middleware(
-            dict(flask_app.config)
-        )
+        caching_middleware = create_response_caching_middleware(dict(flask_app.config))
         if caching_middleware:
             middleware_list.append(caching_middleware)
             logging.info("Response caching middleware enabled")

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -85,6 +85,7 @@ def run_server(
         # Use default initialization with auth from Flask config
         logging.info("Creating MCP app with default configuration...")
         from superset.mcp_service.flask_singleton import get_flask_app
+        from superset.mcp_service.mcp_config import create_response_caching_middleware
 
         flask_app = get_flask_app()
 
@@ -101,7 +102,19 @@ def run_server(
             except Exception as e:
                 logging.error("Failed to create auth provider: %s", e)
 
-        mcp_instance = init_fastmcp_server(auth=auth_provider)
+        # Create middleware list - response caching is enabled by default
+        middleware_list = []
+        caching_middleware = create_response_caching_middleware(
+            dict(flask_app.config)
+        )
+        if caching_middleware:
+            middleware_list.append(caching_middleware)
+            logging.info("Response caching middleware enabled")
+
+        mcp_instance = init_fastmcp_server(
+            auth=auth_provider,
+            middleware=middleware_list or None,
+        )
 
     env_key = f"FASTMCP_RUNNING_{port}"
     if not os.environ.get(env_key):


### PR DESCRIPTION
## Summary

This PR implements FastMCP 2.13.0's response caching middleware for the Superset MCP service. The caching layer is **disabled by default** and requires Redis when enabled.

> **Note:** This is a proof of concept for review. Caching may not be needed for most use cases since MCP tools typically perform small OLTP queries that are fast enough without caching.

## Key Changes (Addressing Review Comments)

### Caching is DISABLED by Default

Based on review feedback:
- Most MCP tools perform small OLTP queries that are fast enough without caching
- Cache invalidation adds complexity without clear benefits for typical use cases
- Caching is now **opt-in** rather than opt-out

### Redis Required (No In-Memory Caching)

Addressed the multi-process/server/thread concern:
- When caching is enabled, **Redis is required**
- Uses Superset's existing Redis configuration (`REDIS_HOST`, `REDIS_PORT`)
- In-memory caching is NOT recommended and will log a warning
- Integrates with Superset's infrastructure rather than adding a new cache layer

### Clear Documentation

- Added comments explaining why caching is disabled by default
- Warning about cache invalidation limitations (no event-based invalidation)
- Example configuration for enabling caching

## Configuration

**Default behavior:** Caching disabled (no configuration needed)

**To enable caching (if needed):**

```python
# superset_config.py
MCP_CACHE_CONFIG = {
    "enabled": True,
    "use_redis": True,  # Uses REDIS_HOST/REDIS_PORT
}
```

**Required Redis configuration:**
```python
REDIS_HOST = "redis.example.com"
REDIS_PORT = 6379
REDIS_RESULTS_DB = 1  # Optional, defaults to 1
```

## Changes

### mcp_config.py
- Disabled caching by default (`enabled: False`)
- Added `use_redis` option (default: True) to require Redis when caching is enabled
- Added `_create_redis_cache_storage()` using `key_value.aio.stores.redis.RedisStore`
- Added extensive documentation about tradeoffs and configuration
- Logs warning if in-memory caching is used (not recommended)

### server.py
- Integrated with Flask app config for auth and caching
- Passes Flask config to middleware factory

### app.py
- Removed deprecated `stateless_http=True` parameter (FastMCP 2.13+)

## Addressing Review Comments

| Comment | Resolution |
|---------|------------|
| "reuses our Redis instance? in-mem cache?" | Now uses Superset's Redis config (`REDIS_HOST`/`REDIS_PORT`) |
| "in-mem is not great for multi-process setup" | Redis is now required when caching is enabled |
| "Superset uses flask-cache, easy to wire to Redis" | Uses `key_value.aio.stores.redis.RedisStore` with Superset's Redis config |
| "cache-invalidation is a concern" | Added warning in docs; TTL-based expiration only |
| "not worried about most tools" | Caching disabled by default |
| "more worried about context-bloat" | Separate concern - not addressed in this caching PR |

## Testing

- [ ] MCP instance creates successfully without caching (default)
- [ ] Redis caching works when explicitly enabled
- [ ] Warning logged for in-memory fallback
- [ ] Pre-commit hooks pass (mypy, ruff, pylint)

## Dependencies

Requires `key_value[redis]` package for Redis support. This is an optional dependency - if not installed, caching remains disabled with a warning.

---

**Status:** Draft - awaiting review of the updated approach