### PR TITLE
fix(pivot-table): add bottom border to last grouped row

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/package.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/package.json
@@ -38,6 +38,10 @@
   },
   "devDependencies": {
     "@babel/types": "^7.29.7",
+    "@testing-library/dom": "^9.3.4",
+    "@testing-library/jest-dom": "*",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "*",
     "@types/jest": "^30.0.0",
     "jest": "^30.4.2"
   }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -122,6 +122,10 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       vertical-align: baseline;
     }
 
+    table.pvtTable tbody tr th.pvtRowLabel.pvtRowLabelLast {
+      border-bottom: 1px solid ${theme.colorSplit};
+    }
+
     .pvtTotal,
     .pvtGrandTotal {
       font-weight: ${theme.fontWeightStrong};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -132,6 +132,7 @@ interface PivotSettings {
   maxColVisible?: number;
   rowAttrSpans?: number[][];
   colAttrSpans?: number[][];
+  visibleRowCount?: number;
 }
 
 const parseLabel = (value: unknown): string | number => {
@@ -797,6 +798,7 @@ export function TableRenderer(props: TableRendererProps) {
     maxColVisible: Math.max(...visibleColKeys.map((k: string[]) => k.length)),
     rowAttrSpans: calcAttrSpans(visibleRowKeys, rowAttrs.length),
     colAttrSpans: calcAttrSpans(visibleColKeys, colAttrs.length),
+    visibleRowCount: visibleRowKeys.length + (colTotals ? 1 : 0),
     allowRenderHtml,
     ...basePivotSettings,
   };
@@ -1220,6 +1222,7 @@ export function TableRenderer(props: TableRendererProps) {
         rowTotalCallbacks,
         namesMapping,
         allowRenderHtml: settingsAllowRenderHtml,
+        visibleRowCount,
       } = settings;
 
       const {
@@ -1256,6 +1259,11 @@ export function TableRenderer(props: TableRendererProps) {
         }
         const rowSpan = rowAttrSpans![rowIdx][i];
         if (rowSpan > 0) {
+          const isLastRow = rowIdx + rowSpan === visibleRowCount;
+          let cellClassName = valueCellClassName;
+          if (isLastRow) {
+            cellClassName += ' pvtRowLabelLast';
+          }
           const flatRowKeySlice = flatKey(rowKey.slice(0, i + 1));
           const colSpan =
             1 + (i === settingsRowAttrs.length - 1 ? colIncrSpan : 0);
@@ -1290,7 +1298,7 @@ export function TableRenderer(props: TableRendererProps) {
           return (
             <th
               key={`rowKeyLabel-${i}`}
-              className={valueCellClassName}
+              className={cellClassName}
               style={rowHeaderStyle}
               rowSpan={rowSpan}
               colSpan={colSpan}

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/TableRenderer.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/TableRenderer.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import PivotTableChart from '../src/PivotTableChart';
+import transformProps from '../src/plugin/transformProps';
+import testData from './testData';
+import { ProviderWrapper } from './testHelpers';
+
+test('applies pvtRowLabelLast class to last data row when colTotals is disabled', () => {
+  const transformedProps = {
+    ...transformProps(testData.withoutColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  const tableBody = container.querySelector('tbody');
+  const dataRows = Array.from(tableBody?.querySelectorAll('tr') ?? []).filter(
+    row => !row.classList.contains('pvtRowTotals'),
+  );
+
+  // Get the last data row
+  const lastDataRow = dataRows[dataRows.length - 1];
+  expect(lastDataRow).toBeInTheDocument();
+
+  // Check if any cell in the last data row has pvtRowLabelLast class
+  const lastRowCells = lastDataRow.querySelectorAll('th.pvtRowLabel');
+  const hasLastClass = Array.from(lastRowCells).some(cell =>
+    cell.classList.contains('pvtRowLabelLast'),
+  );
+
+  expect(hasLastClass).toBe(true);
+});
+
+test('does not apply pvtRowLabelLast class to last data row when colTotals is enabled', () => {
+  const transformedProps = {
+    ...transformProps(testData.withColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  const tableBody = container.querySelector('tbody');
+  const dataRows = Array.from(tableBody?.querySelectorAll('tr') ?? []).filter(
+    row => !row.classList.contains('pvtRowTotals'),
+  );
+
+  // Get the last data row (before totals row)
+  const lastDataRow = dataRows[dataRows.length - 1];
+  expect(lastDataRow).toBeInTheDocument();
+
+  // Check if any cell in the last data row has pvtRowLabelLast class
+  const lastRowCells = lastDataRow.querySelectorAll('th.pvtRowLabel');
+  const hasLastClass = Array.from(lastRowCells).some(cell =>
+    cell.classList.contains('pvtRowLabelLast'),
+  );
+
+  // Should NOT have the class because totals row will have the border
+  expect(hasLastClass).toBe(false);
+
+  // Verify totals row exists
+  const totalsRow = container.querySelector('tr.pvtRowTotals');
+  expect(totalsRow).toBeInTheDocument();
+});

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/TableRenderer.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/TableRenderer.test.tsx
@@ -89,3 +89,70 @@ test('does not apply pvtRowLabelLast class to last data row when colTotals is en
   const totalsRow = container.querySelector('tr.pvtRowTotals');
   expect(totalsRow).toBeInTheDocument();
 });
+
+test('applies pvtRowLabelLast to the spanning outer <th> that bottoms out the table', () => {
+  // Two row dimensions ([country, city]) so the "Spain" outer <th> spans two
+  // data rows (rowSpan 2). This is the merged-cell case #36031 is about; the
+  // existing flat fixtures (every rowSpan 1) never exercise it.
+  const transformedProps = {
+    ...transformProps(testData.groupedRowsWithoutColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  // Find the outer row-label <th> that spans multiple data rows.
+  const spanningLabels = Array.from(
+    container.querySelectorAll('tbody th.pvtRowLabel'),
+  ).filter(cell => Number(cell.getAttribute('rowspan')) >= 2);
+
+  // Sanity check: the fixture actually produced a merged cell.
+  expect(spanningLabels.length).toBeGreaterThan(0);
+
+  const spanningCell = spanningLabels[spanningLabels.length - 1];
+  expect(spanningCell).toHaveTextContent('Spain');
+  expect(spanningCell.getAttribute('rowspan')).toBe('2');
+
+  // The spanning cell bottoms out the table (rowIdx + rowSpan === visibleRowCount)
+  // so it must carry the border class.
+  expect(spanningCell).toHaveClass('pvtRowLabelLast');
+});
+
+test('withholds pvtRowLabelLast from the spanning <th> when colTotals owns the bottom', () => {
+  const transformedProps = {
+    ...transformProps(testData.groupedRowsWithColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  const spanningLabels = Array.from(
+    container.querySelectorAll('tbody th.pvtRowLabel'),
+  ).filter(cell => Number(cell.getAttribute('rowspan')) >= 2);
+
+  expect(spanningLabels.length).toBeGreaterThan(0);
+
+  const spanningCell = spanningLabels[spanningLabels.length - 1];
+  expect(spanningCell).toHaveTextContent('Spain');
+
+  // The totals row now bottoms out the table, so no row-label <th> should get
+  // the border class.
+  const anyLabelHasLastClass = Array.from(
+    container.querySelectorAll('tbody th.pvtRowLabel'),
+  ).some(cell => cell.classList.contains('pvtRowLabelLast'));
+  expect(anyLabelHasLastClass).toBe(false);
+
+  // The totals row owns the bottom edge instead.
+  const totalsRow = container.querySelector('tr.pvtRowTotals');
+  expect(totalsRow).toBeInTheDocument();
+});

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  ChartDataResponseResult,
+  ChartProps,
+  DatasourceType,
+  VizType,
+  QueryFormData,
+} from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { GenericDataType } from '@apache-superset/core/common';
+
+const basicFormData: QueryFormData = {
+  datasource: '1__table',
+  viz_type: VizType.PivotTable,
+  groupbyRows: ['country'],
+  groupbyColumns: ['city'],
+  metrics: ['SUM(sales)'],
+  metricsLayout: 'COLUMNS',
+  rowOrder: 'key_a_to_z',
+  colOrder: 'key_a_to_z',
+  aggregateFunction: 'Sum',
+  rowSubTotals: false,
+  colTotals: true,
+  colSubTotals: false,
+  rowTotals: true,
+  valueFormat: 'SMART_NUMBER',
+  dateFormat: 'smart_date',
+  transposePivot: false,
+  combineMetric: false,
+  rowSubtotalPosition: false,
+  colSubtotalPosition: false,
+};
+
+const basicChartProps = {
+  width: 800,
+  height: 600,
+  datasource: {
+    id: 1,
+    name: 'test_dataset',
+    type: DatasourceType.Table,
+    columns: [],
+    metrics: [],
+    columnFormats: {},
+    verboseMap: {},
+  },
+  hooks: {},
+  initialValues: {},
+  queriesData: [
+    {
+      data: {
+        columns: [],
+        records: [],
+      },
+    },
+  ],
+  formData: basicFormData,
+  theme: supersetTheme,
+};
+
+const basicQueryResult: ChartDataResponseResult = {
+  annotation_data: null,
+  cache_key: null,
+  cached_dttm: null,
+  cache_timeout: null,
+  data: [],
+  colnames: [],
+  coltypes: [],
+  error: null,
+  is_cached: false,
+  query: 'SELECT ...',
+  rowcount: 100,
+  sql_rowcount: 100,
+  stacktrace: null,
+  status: 'success',
+  from_dttm: null,
+  to_dttm: null,
+};
+
+// Shared test data
+const pivotData = [
+  { country: 'France', city: 'Paris', 'SUM(sales)': 1000 },
+  { country: 'Germany', city: 'Berlin', 'SUM(sales)': 2000 },
+  { country: 'Spain', city: 'Madrid', 'SUM(sales)': 1500 },
+  { country: 'Italy', city: 'Rome', 'SUM(sales)': 3000 },
+  { country: 'UK', city: 'London', 'SUM(sales)': 2500 },
+];
+
+// Shared query result structure
+const basicQueriesData = [
+  {
+    ...basicQueryResult,
+    colnames: ['country', 'city', 'SUM(sales)'],
+    coltypes: [
+      GenericDataType.String,
+      GenericDataType.String,
+      GenericDataType.Numeric,
+    ],
+    data: pivotData,
+  },
+];
+
+/**
+ * Pivot table data with colTotals enabled
+ */
+const withColTotals = {
+  ...new ChartProps({
+    ...basicChartProps,
+    formData: {
+      ...basicFormData,
+      colTotals: true,
+      rowTotals: true,
+      rowSubTotals: false,
+      colSubTotals: false,
+    },
+  }),
+  queriesData: basicQueriesData,
+};
+
+/**
+ * Pivot table data without colTotals
+ */
+const withoutColTotals = {
+  ...new ChartProps({
+    ...basicChartProps,
+    formData: {
+      ...basicFormData,
+      colTotals: false,
+      rowTotals: false,
+      rowSubTotals: false,
+      colSubTotals: false,
+    },
+  }),
+  queriesData: basicQueriesData,
+};
+
+export default {
+  withColTotals,
+  withoutColTotals,
+};

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
@@ -151,7 +151,82 @@ const withoutColTotals = {
   queriesData: basicQueriesData,
 };
 
+/**
+ * Two-dimension rows data so an outer row-label <th> spans multiple data rows.
+ * Grouped by [country, city] with "Spain" (last alphabetically) owning two
+ * cities, so the "Spain" <th> has rowSpan >= 2 and bottoms out the table.
+ *
+ * visibleRowKeys order (rowOrder key_a_to_z):
+ *   0: [France, Paris]
+ *   1: [Germany, Berlin]
+ *   2: [Spain, Barcelona]
+ *   3: [Spain, Madrid]
+ */
+const groupedRowsData = [
+  { country: 'France', city: 'Paris', 'SUM(sales)': 1000 },
+  { country: 'Germany', city: 'Berlin', 'SUM(sales)': 2000 },
+  { country: 'Spain', city: 'Barcelona', 'SUM(sales)': 1200 },
+  { country: 'Spain', city: 'Madrid', 'SUM(sales)': 1500 },
+];
+
+const groupedRowsQueriesData = [
+  {
+    ...basicQueryResult,
+    colnames: ['country', 'city', 'SUM(sales)'],
+    coltypes: [
+      GenericDataType.String,
+      GenericDataType.String,
+      GenericDataType.Numeric,
+    ],
+    data: groupedRowsData,
+  },
+];
+
+const groupedRowsFormData: QueryFormData = {
+  ...basicFormData,
+  groupbyRows: ['country', 'city'],
+  groupbyColumns: [],
+};
+
+/**
+ * Two row dimensions, colTotals disabled: the bottom-most spanning <th>
+ * ("Spain", rowSpan 2) should own the bottom edge.
+ */
+const groupedRowsWithoutColTotals = {
+  ...new ChartProps({
+    ...basicChartProps,
+    formData: {
+      ...groupedRowsFormData,
+      colTotals: false,
+      rowTotals: false,
+      rowSubTotals: false,
+      colSubTotals: false,
+    },
+  }),
+  queriesData: groupedRowsQueriesData,
+};
+
+/**
+ * Two row dimensions, colTotals enabled: the totals row owns the bottom edge,
+ * so no row-label <th> (spanning or otherwise) gets pvtRowLabelLast.
+ */
+const groupedRowsWithColTotals = {
+  ...new ChartProps({
+    ...basicChartProps,
+    formData: {
+      ...groupedRowsFormData,
+      colTotals: true,
+      rowTotals: false,
+      rowSubTotals: false,
+      colSubTotals: false,
+    },
+  }),
+  queriesData: groupedRowsQueriesData,
+};
+
 export default {
   withColTotals,
   withoutColTotals,
+  groupedRowsWithoutColTotals,
+  groupedRowsWithColTotals,
 };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
@@ -91,6 +91,7 @@ const basicQueryResult: ChartDataResponseResult = {
   status: 'success',
   from_dttm: null,
   to_dttm: null,
+  queried_dttm: null,
 };
 
 // Shared test data

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/testHelpers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/testHelpers.tsx
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  supersetTheme,
+  ThemeProvider,
+  EmotionCacheProvider,
+  createEmotionCache,
+} from '@apache-superset/core/theme';
+
+const emotionCache = createEmotionCache({
+  key: 'test',
+});
+
+export function ProviderWrapper(props: any) {
+  const { children, theme = supersetTheme } = props;
+  return (
+    <EmotionCacheProvider value={emotionCache}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </EmotionCacheProvider>
+  );
+}

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "rootDir": "../../../"
+  },
+  "extends": "../../../tsconfig.json",
+  "include": ["**/*", "../types/**/*", "../../../types/**/*"]
+}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes missing bottom border on the last row label when grouping is expanded in Pivot Table visualization. 

Previously, when multiple groups were present and the last group was expanded, the bottom border was not rendered, creating a visual inconsistency. This PR adds logic to detect the last row and applies the `pvtRowLabelLast` CSS class, which adds the missing border-bottom style.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="995" height="443" alt="image" src="https://github.com/user-attachments/assets/f0630801-5053-4396-b1b3-460fbf5205c2" />

**After:**
<img width="767" height="280" alt="image" src="https://github.com/user-attachments/assets/88728a60-65a0-4d1b-8ec1-574bd8209731" />

### TESTING INSTRUCTIONS
1. Create a Pivot Table chart with multiple row groupings
2. Expand all groups to show nested data
3. Verify that the bottom border is now visible on the last row label
4. Check that the border appears correctly when:
   - Last group is collapsed
   - Last group is expanded
   - Column totals are enabled/disabled

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36031
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
