### PR TITLE
fix: Last Month Label Missing on X-Axis in Time Series Line Charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -525,7 +525,7 @@ export default function transformProps(
     nameGap: convertInteger(xAxisTitleMargin),
     nameLocation: 'middle',
     axisLabel: {
-      hideOverlap: true,
+      hideOverlap: xAxisType !== AxisType.Time,
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -722,4 +722,41 @@ describe('legend sorting', () => {
       'Boston',
     ]);
   });
+
+  it('should set hideOverlap to false for time-based x-axis', () => {
+    const chartProps = new ChartProps(chartPropsConfig);
+    const transformed = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformed.echartOptions.xAxis).toEqual(
+      expect.objectContaining({
+        axisLabel: expect.objectContaining({
+          hideOverlap: false,
+        }),
+      }),
+    );
+  });
+
+  it('should set hideOverlap to true for categorical x-axis', () => {
+    const categoricalFormData = {
+      ...formData,
+      xAxisForceCategorical: true,
+    };
+    const chartProps = new ChartProps({
+      ...chartPropsConfig,
+      formData: categoricalFormData,
+    });
+    const transformed = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformed.echartOptions.xAxis).toEqual(
+      expect.objectContaining({
+        axisLabel: expect.objectContaining({
+          hideOverlap: true,
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
#### Summary
Fixes #33905

- **File Updated:** `plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts`  
- **Change Description:**  
  Updated logic to set `axisLabel.hideOverlap` based on the axis type:
  - **Time axes:** `hideOverlap = false` (always show final labels)
  - **Categorical/Value axes:** `hideOverlap = true` (suppress overlapping labels)

#### Regression Coverage
- **Test File:** `plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts`  
- **New Tests Added:**
  - Assert that `hideOverlap` is **false** for time-based axes.
  - Assert that `hideOverlap` is **true** when the x-axis is forced to be categorical.
