### PR TITLE
style(database-modal): vertically align the button and the InfoTooltip icon

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
@@ -102,7 +102,7 @@ const SqlAlchemyTab = ({
         loading={testInProgress}
         cta
         buttonStyle="link"
-        css={(theme: SupersetTheme) => ([wideButton(theme), marginBottom(theme)])}
+        css={(theme: SupersetTheme) => [wideButton(theme), marginBottom(theme)]}
       >
         {t('Test connection')}
       </Button>

--- a/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
@@ -97,17 +97,15 @@ const SqlAlchemyTab = ({
         </div>
       </StyledInputContainer>
       {children}
-      <div css={(theme: SupersetTheme) => marginBottom(theme)}>
-        <Button
-          onClick={testConnection}
-          loading={testInProgress}
-          cta
-          buttonStyle="link"
-          css={(theme: SupersetTheme) => wideButton(theme)}
-        >
-          {t('Test connection')}
-        </Button>
-      </div>
+      <Button
+        onClick={testConnection}
+        loading={testInProgress}
+        cta
+        buttonStyle="link"
+        css={(theme: SupersetTheme) => ([wideButton(theme), marginBottom(theme)])}
+      >
+        {t('Test connection')}
+      </Button>
     </>
   );
 };

--- a/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/SqlAlchemyForm.tsx
@@ -21,7 +21,7 @@ import { t } from '@superset-ui/core';
 import { SupersetTheme } from '@apache-superset/core/ui';
 import SupersetText from 'src/utils/textUtils';
 import { Input, Button } from '@superset-ui/core/components';
-import { StyledInputContainer, wideButton } from './styles';
+import { StyledInputContainer, wideButton, marginBottom } from './styles';
 import { DatabaseObject } from '../types';
 
 const SqlAlchemyTab = ({
@@ -97,15 +97,17 @@ const SqlAlchemyTab = ({
         </div>
       </StyledInputContainer>
       {children}
-      <Button
-        onClick={testConnection}
-        loading={testInProgress}
-        cta
-        buttonStyle="link"
-        css={(theme: SupersetTheme) => wideButton(theme)}
-      >
-        {t('Test connection')}
-      </Button>
+      <div css={(theme: SupersetTheme) => marginBottom(theme)}>
+        <Button
+          onClick={testConnection}
+          loading={testInProgress}
+          cta
+          buttonStyle="link"
+          css={(theme: SupersetTheme) => wideButton(theme)}
+        >
+          {t('Test connection')}
+        </Button>
+      </div>
     </>
   );
 };

--- a/superset-frontend/src/features/databases/DatabaseModal/styles.ts
+++ b/superset-frontend/src/features/databases/DatabaseModal/styles.ts
@@ -106,6 +106,7 @@ export const infoTooltip = (theme: SupersetTheme) => css`
     margin-bottom: ${theme.sizeUnit * 0.25}px;
   }
   display: flex;
+  align-items: center;
 `;
 
 export const toggleStyle = (theme: SupersetTheme) => css`
@@ -324,6 +325,7 @@ export const StyledAlignment = styled.div`
 
 export const buttonLinkStyles = (theme: SupersetTheme) => css`
   text-transform: initial;
+  padding: 0 ${theme.sizeUnit * 4}px;
   padding-right: ${theme.sizeUnit * 2}px;
 `;
 
@@ -335,8 +337,8 @@ export const importDbButtonLinkStyles = (theme: SupersetTheme) => css`
 
 export const alchemyButtonLinkStyles = (theme: SupersetTheme) => css`
   text-transform: initial;
-  padding: ${theme.sizeUnit * 8}px 0 0;
   margin-left: 0px;
+  padding: 0 ${theme.sizeUnit * 2}px 0 0;
 `;
 
 export const TabHeader = styled.div`


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes alignment issues with the "Connect this database using the dynamic form instead" link in the database connection modal:

## BEFORE

- Link text was missing right padding, not aligned with form content
- InfoTooltip icon was vertically misaligned with the button text

## AFTER

- Link properly aligned with form's left/right edges
- InfoTooltip icon vertically centered with button text
- Consistent spacing between text and icon
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before 
<img width="754" height="977" alt="before-1" src="https://github.com/user-attachments/assets/5231bf1c-2315-4fcc-bcb1-669369b0a26e" />

- After
<img width="734" height="978" alt="after-1" src="https://github.com/user-attachments/assets/bd6fb520-6b89-41be-8ac5-062c18b5541c" />

- Before
<img width="679" height="996" alt="before-2" src="https://github.com/user-attachments/assets/ad4d03a1-e0ac-473d-9c44-f5f2fe62b769" />

- After
<img width="874" height="1058" alt="after-2" src="https://github.com/user-attachments/assets/de38972a-ccb0-47b5-80ed-f994834e040a" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- All tests should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
