### PR TITLE
fix(sqllab): preserve multiple whitespaces in query result cells

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ThemedAgGridReact/index.tsx
@@ -144,6 +144,7 @@ export const ThemedAgGridReact = forwardRef<
         height: 100%;
         .ag-cell {
           -webkit-font-smoothing: antialiased;
+          white-space: pre-wrap;
         }
       `}
       data-themed-ag-grid="true"

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -393,3 +393,44 @@ describe('FilterableTable sorting - RTL', () => {
     );
   });
 });
+
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+describe('FilterableTable whitespace preservation', () => {
+  beforeAll(() => {
+    setupAGGridModules();
+  });
+
+  test('renders table with data containing multiple consecutive whitespaces', () => {
+    const whitespaceProps = {
+      orderedColumnKeys: ['text'],
+      data: [
+        { text: 'single space' },
+        { text: 'double  space' },
+        { text: 'triple   space' },
+        { text: 'multiple    spaces     here' },
+      ],
+      height: 500,
+    };
+
+    const { container } = render(<FilterableTable {...whitespaceProps} />);
+
+    // Verify the grid renders with the whitespace data
+    const grid = container.querySelector('[role="grid"]');
+    expect(grid).toBeInTheDocument();
+
+    // Find all cells and verify whitespace data is in the DOM
+    // Note: This test verifies that data with multiple spaces is present in the DOM,
+    // but does NOT verify visual rendering (JSDOM doesn't compute CSS).
+    // The white-space: pre-wrap CSS ensures spaces are displayed in real browsers.
+    // Visual verification requires manual testing or E2E tests with Playwright.
+    const cells = container.querySelectorAll(
+      '[role="gridcell"] .ag-cell-value',
+    );
+    const cellTexts = Array.from(cells).map(cell => cell.textContent);
+
+    // Check that cells with multiple spaces are in the DOM
+    expect(cellTexts).toContain('double  space'); // Two spaces
+    expect(cellTexts).toContain('triple   space'); // Three spaces
+    expect(cellTexts).toContain('multiple    spaces     here'); // Multiple groups of spaces
+  });
+});


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes #36042
<!--- Describe the change below, including rationale and design decisions -->


Add `white-space: pre-wrap` CSS to AG Grid cells to preserve multiple consecutive whitespaces in SQL Lab query results. Previously, HTML default behavior collapsed multiple spaces into single spaces, causing issues with financial data like option symbols that require exact whitespace preservation.

Changes:
- Add `white-space: pre-wrap` to `.ag-cell` in ThemedAgGridReact
- Add test to verify table renders with whitespace data

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="839" height="699" alt="image" src="https://github.com/user-attachments/assets/caf05aac-bfbd-4c92-9f5c-1589eb2acede" />

After:
<img width="869" height="708" alt="image" src="https://github.com/user-attachments/assets/0a464f7d-d58b-44ac-86d0-8e92169fcb6a" />


### TESTING INSTRUCTIONS
1. Go to SQL Lab
2. Run a query with multiple spaces:

```
SELECT 'double  space' as text
   UNION ALL
   SELECT 'triple   space'
   UNION ALL
   SELECT 'multiple    spaces     here'
```

   3. Verify the result table preserves the multiple spaces (not collapsed)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #36042
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
