### PR TITLE
fix(navbar): Minor fixes in navbar spacings

### DIFF
--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -65,7 +65,6 @@ const StyledBrandText = styled.div`
     color: ${theme.colorText};
     padding-left: ${theme.sizeUnit * 4}px;
     padding-right: ${theme.sizeUnit * 4}px;
-    margin-right: ${theme.sizeUnit * 6}px;
     font-size: ${theme.fontSizeLG}px;
     float: left;
     display: flex;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed excessive right margin from the navbar brand text component to improve visual balance and reduce unnecessary whitespace between the application name and navigation menu items.

### BEFORE/AFTER SCREENSHOTS
<!--- Skip this if not applicable -->

#### Before:
<img width="719" height="50" alt="before" src="https://github.com/user-attachments/assets/a2534f96-7147-4bf1-aaef-95ad96282e20" />

#### After:
<img width="692" height="50" alt="after" src="https://github.com/user-attachments/assets/978a87d9-1490-45ab-965e-1b27baa98c64" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Add the following to your `superset/config.py`:
```python
LOGO_RIGHT_TEXT = "Superset"
```
2. What to verify:
  - The brand text (e.g., "Superset") should now be visible in the navbar between the logo and menu items
  - Verify the spacing between the brand text and the first menu item is balanced and not excessive
  - The spacing should look natural, not too tight or too wide

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
