### PR TITLE
fix(dashboard): abort previous chart queries when filters change to p…

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -408,6 +408,13 @@ export function exploreJSON(
 ) {
   return async (dispatch, getState) => {
     const logStart = Logger.getTimestamp();
+
+    // Abort previous query if one exists
+    const { charts } = getState();
+    if (charts[key]?.queryController) {
+      charts[key].queryController.abort();
+    }
+
     const controller = new AbortController();
     const queryTimeout =
       timeout || getState().common.conf.SUPERSET_WEBSERVER_TIMEOUT;

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -67,6 +67,10 @@ export default function chartReducer(
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {
+      if (state.queryController) {
+        state.queryController.abort();
+      }
+
       return {
         ...state,
         chartStatus: 'loading',

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -67,10 +67,6 @@ export default function chartReducer(
       };
     },
     [actions.CHART_UPDATE_STARTED](state) {
-      if (state.queryController) {
-        state.queryController.abort();
-      }
-
       return {
         ...state,
         chartStatus: 'loading',


### PR DESCRIPTION
### SUMMARY

  Fixes cross-filter persistence bug where removing filters before charts finish loading leaves charts displaying stale
  filtered data despite filters being cleared from the UI.

  **Root Cause:** The `CHART_UPDATE_STARTED` reducer replaces the previous query's `AbortController` without calling
  `.abort()`, allowing in-flight requests to complete with outdated filter values.

  **The Fix:** Abort previous `AbortController` before replacing it (3-line change), matching the pattern already used
  for annotation queries.

  **Impact:**
  - Fixes data inconsistency where UI shows cleared filters but charts display filtered data
  - Prevents race conditions when filters change rapidly
  - Ensures latest filter state always wins

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **BEFORE:**
  In this case "Planes" was the cross-filter selected and then removed, but the charts did not rehydrate back:
<img width="1443" height="719" alt="Screenshot 2025-11-12 at 21 09 16" src="https://github.com/user-attachments/assets/3269f712-e706-4644-b30b-ddcd08f48160" />

  **AFTER:**
No filters are applied when cross-filter is cleared:
<img width="1253" height="985" alt="Screenshot 2025-11-12 at 21 22 31" src="https://github.com/user-attachments/assets/5aa965df-4bc6-4795-b290-f463fb198e59" />


  ### TESTING INSTRUCTIONS
  1. Configure async mode
  2. Open Sales Dashboard (or any dashboard with cross-filtering enabled)
  3. Click a chart element (bar/segment) to create a cross-filter
  4. Immediately click the X icon to remove the cross-filter
  5. **Expected:** All charts reload without the cross-filter applied

  ### ADDITIONAL INFORMATION

  - [x] Has associated issue: Fixes #35623
  - [ ] Required feature flags:
  - [ ] Changes UI
  - [ ] Includes DB Migration
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API