### PR TITLE
fix: Use singlestoredb dialect for sqlglot

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -33,6 +33,7 @@ from sqlglot.dialects.dialect import (
     Dialect,
     Dialects,
 )
+from sqlglot.dialects.singlestore import SingleStore
 from sqlglot.errors import ParseError
 from sqlglot.optimizer.pushdown_predicates import (
     pushdown_predicates,
@@ -101,7 +102,7 @@ SQLGLOT_DIALECTS = {
     "redshift": Dialects.REDSHIFT,
     "risingwave": Dialects.RISINGWAVE,
     "shillelagh": Dialects.SQLITE,
-    "singlestore": Dialects.MYSQL,
+    "singlestoredb": SingleStore,
     "snowflake": Dialects.SNOWFLAKE,
     # "solr": ???
     "spark": Dialects.SPARK,

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2803,6 +2803,19 @@ def test_kqlstatement_is_select(kql: str, expected: bool) -> None:
     assert KustoKQLStatement(kql, "kustokql").is_select() == expected
 
 
+def test_singlestore_engine_mapping():
+    """
+    Test the `singlestoredb` dialect is properly used.
+    """
+    sql = "SELECT COUNT(*) AS `COUNT(*)`"
+    statement = SQLStatement(sql, engine="singlestoredb")
+    assert statement.is_select()
+
+    # Should parse without errors
+    formatted = statement.format()
+    assert "COUNT(*)" in formatted
+
+
 def test_remove_quotes() -> None:
     """
     Test the `remove_quotes` helper function.


### PR DESCRIPTION
### SUMMARY
The `sqlglot` dialect for Singlestore DB was set with `"singlestore"` (as opposed to `"singlestoredb"`) causing queries triggered from a `singlestoredb://` connection to use the generic parser, which would fail with parsing errors.

This PR fixes the issue by updating the reference, and also using the `Singlestore` dialect (as opposed to using MySQL).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**
<img width="3420" height="1028" alt="image" src="https://github.com/user-attachments/assets/00a5c57a-b38a-4779-9a51-f64856e6151c" />

**After**
<img width="3434" height="1056" alt="image" src="https://github.com/user-attachments/assets/d0c19903-e0e0-48fe-ac55-5b4933099baa" />

### TESTING INSTRUCTIONS
1. Create a `singlestoredb://` connection.
2. Create a dataset.
3. Create a chart, with a simple `MAX($column)` as the metric. Do not add a metric label.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
