### PR TITLE
fix: pin setuptools <81 to prevent pkg_resources removal

### DIFF
--- a/docs/docs/contributing/pkg-resources-migration.md
+++ b/docs/docs/contributing/pkg-resources-migration.md
@@ -1,0 +1,101 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# pkg_resources Deprecation and Migration Guide
+
+## Background
+
+As of setuptools 81.0.0 (scheduled for removal around 2025-11-30), the `pkg_resources` API is deprecated and will be removed. This affects several packages in the Python ecosystem.
+
+## Current Status
+
+### Superset Codebase ✅
+The Superset codebase has already migrated away from `pkg_resources` to the modern `importlib.metadata` API:
+
+- `superset/db_engine_specs/__init__.py:36` - Uses `from importlib.metadata import entry_points`
+- All entry point loading uses the modern API
+
+### Production Dependencies ⚠️
+Some third-party dependencies may still use `pkg_resources`:
+
+- **`clients` package** (Preset-specific): Uses `pkg_resources` in `const.py`
+- Error path: `/usr/local/lib/python3.10/site-packages/clients/const.py:1`
+
+## Migration Path
+
+### Short-term Solution (Current)
+Pin setuptools to version 80.x to prevent breaking changes:
+
+```python
+# requirements/base.in
+setuptools<81
+```
+
+This prevents the removal of `pkg_resources` while dependent packages are updated.
+
+### Long-term Solution
+Update all dependencies to use `importlib.metadata` instead of `pkg_resources`:
+
+#### Migration Example
+**Old (deprecated):**
+```python
+import pkg_resources
+
+version = pkg_resources.get_distribution("package_name").version
+entry_points = pkg_resources.iter_entry_points("group_name")
+```
+
+**New (recommended):**
+```python
+from importlib.metadata import version, entry_points
+
+pkg_version = version("package_name")
+eps = entry_points(group="group_name")
+```
+
+## Action Items
+
+### For Preset Team
+1. **Update `clients` package** to use `importlib.metadata` instead of `pkg_resources`
+2. **Review other internal packages** for `pkg_resources` usage
+3. **Test with setuptools >= 81.0.0** once all packages are migrated
+4. **Monitor Datadog logs** for similar deprecation warnings
+
+### For Superset Maintainers
+1. ✅ Already using `importlib.metadata`
+2. Monitor third-party dependencies for updates
+3. Update setuptools pin once ecosystem is ready
+
+## Timeline
+
+- **2025-11-30**: Expected removal of `pkg_resources` from setuptools
+- **Before then**: All dependencies must migrate to `importlib.metadata`
+
+## References
+
+- [setuptools pkg_resources deprecation notice](https://setuptools.pypa.io/en/latest/pkg_resources.html)
+- [importlib.metadata documentation](https://docs.python.org/3/library/importlib.metadata.html)
+- [Migration guide](https://setuptools.pypa.io/en/latest/deprecated/pkg_resources.html)
+
+## Monitoring
+
+Track this issue in production using Datadog:
+- Warning pattern: `pkg_resources is deprecated as an API`
+- Component: `@component:app`
+- Environment: `environment:production`

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -36,3 +36,9 @@ marshmallow-sqlalchemy>=1.3.0,<1.4.1
 
 # needed for python 3.12 support
 openapi-schema-validator>=0.6.3
+
+# Pin setuptools <81 until all dependencies migrate from pkg_resources to importlib.metadata
+# pkg_resources is deprecated and will be removed in setuptools 81+ (around 2025-11-30)
+# Known affected packages: Preset's 'clients' package
+# See docs/docs/contributing/pkg-resources-migration.md for details
+setuptools<81

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -160,7 +160,6 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
-    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0
@@ -364,6 +363,8 @@ rsa==4.9.1
     # via google-auth
 selenium==4.32.0
     # via apache-superset (pyproject.toml)
+setuptools==80.9.0
+    # via -r requirements/base.in
 shillelagh==1.4.3
     # via apache-superset (pyproject.toml)
 simplejson==3.20.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -368,7 +368,6 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
-    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -884,7 +883,7 @@ rsa==4.9.1
     #   google-auth
 ruff==0.8.0
     # via apache-superset
-secretstorage==3.4.0
+secretstorage==3.4.1
     # via keyring
 selenium==4.32.0
     # via
@@ -892,8 +891,9 @@ selenium==4.32.0
     #   apache-superset
 semver==3.0.4
     # via apache-superset-extensions-cli
-setuptools==80.7.1
+setuptools==80.9.0
     # via
+    #   -c requirements/base-constraint.txt
     #   nodeenv
     #   pandas-gbq
     #   pydata-google-auth


### PR DESCRIPTION
### SUMMARY

Pin setuptools to version <81 to prevent breaking changes when pkg_resources is removed. The pkg_resources API is deprecated and scheduled for removal in setuptools 81+ (around 2025-11-30).

**Problem:**
- pkg_resources deprecation warnings appearing in production logs (Datadog)
- setuptools will remove pkg_resources API in version 81+ 
- Some dependencies still use the deprecated API

**Solution:**
- Add setuptools<81 constraint to requirements/base.in
- This prevents runtime errors while dependencies migrate
- Superset's codebase already uses the modern importlib.metadata API

**Status:**
- ✅ Superset codebase: Already migrated to importlib.metadata (superset/db_engine_specs/__init__.py:36)
- ⚠️ Third-party dependencies: Some still use pkg_resources (e.g., Preset's 'clients' package)
- 📚 Documentation: Added migration guide at docs/docs/contributing/pkg-resources-migration.md

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend dependency management only

### TESTING INSTRUCTIONS

1. Verify setuptools version constraint:
   ```bash
   grep "setuptools" requirements/base.txt
   # Should show: setuptools==80.9.0 (or similar <81)
   ```

2. Verify requirements regeneration:
   ```bash
   uv pip compile requirements/base.in -o /tmp/test-base.txt
   diff requirements/base.txt /tmp/test-base.txt
   # Should show no meaningful differences
   ```

3. Check that Superset uses modern API:
   ```bash
   grep -r "from importlib.metadata import" superset/
   # Should find: superset/db_engine_specs/__init__.py:from importlib.metadata import entry_points
   
   grep -r "import pkg_resources" superset/
   # Should find: no results (good!)
   ```

4. Review migration documentation:
   ```bash
   cat docs/docs/contributing/pkg-resources-migration.md
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue: Fixes production Datadog warnings for pkg_resources deprecation
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

**Timeline:**
- pkg_resources removal date: ~2025-11-30
- This pin provides time for ecosystem migration
- Can be removed once all dependencies update

**References:**
- [setuptools pkg_resources deprecation](https://setuptools.pypa.io/en/latest/pkg_resources.html)
- [importlib.metadata documentation](https://docs.python.org/3/library/importlib.metadata.html)