### PR TITLE
chore(DatabaseModal): simplify collapsible logic for extra extension section

### DIFF
--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.test.tsx
@@ -220,4 +220,21 @@ describe('ExtraOptions Component', () => {
     );
     expect(sqlLabTab).toHaveAttribute('aria-expanded', 'false');
   });
+
+  test('all collapse panels should expand when clicking anywhere on the header', () => {
+    renderComponent();
+    const allPanelTabs = screen.getAllByRole('tab');
+    expect(allPanelTabs.length).toBeGreaterThanOrEqual(4); // At least 4 main panels
+
+    allPanelTabs.forEach(panelTab => {
+      // Initially should be collapsed
+      expect(panelTab).toHaveAttribute('aria-expanded', 'false');
+      // Click on the panel tab (entire header should be clickable)
+      fireEvent.click(panelTab);
+      expect(panelTab).toHaveAttribute('aria-expanded', 'true');
+      fireEvent.click(panelTab);
+      // Panel should collapse back
+      expect(panelTab).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
 });

--- a/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
+++ b/superset-frontend/src/features/databases/DatabaseModal/ExtraOptions.tsx
@@ -613,9 +613,9 @@ const ExtraOptions = ({
           ? [
               {
                 key: extraExtension?.title,
-                collapsible: extraExtension.enabled?.()
-                  ? ('icon' as const)
-                  : ('disabled' as const),
+                ...(extraExtension.enabled?.()
+                  ? {}
+                  : { collapsible: 'disabled' as const }),
                 label: (
                   <CollapseLabelInModal
                     key={extraExtension?.title}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR refactors the collapsible logic used when rendering the extra extension section in the modal. Previously the component always set the collapsible property, using 'icon' when the extension was enabled and 'disabled' when it was not.
The new approach removes the explicit 'icon' case and applies collapsible: 'disabled' only when the extension is not enabled. When the extension is enabled, the default behavior is used by omitting the collapsible field entirely.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
