### PR TITLE
fix: 'save and go to dashboard' option was disabled after changing the chart type

### DIFF
--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -217,6 +217,8 @@ describe('should collect control values and create SFD', () => {
     // advanced analytics - resample
     resample_rule: '1D',
     resample_method: 'zerofill',
+    // dashboard context
+    dashboardId: 123,
   };
   const sourceMockFormData: QueryFormData = {
     ...sharedControlsFormData,
@@ -240,12 +242,15 @@ describe('should collect control values and create SFD', () => {
   };
 
   beforeAll(() => {
+    // dashboardId is not a control, it's just context, so exclude it from control definitions
+    const publicControlFields = publicControls.filter(c => c !== 'dashboardId');
+
     getChartControlPanelRegistry().registerValue('source_viz', {
       controlPanelSections: [
         sections.advancedAnalyticsControls,
         {
           label: 'transform controls',
-          controlSetRows: publicControls.map(control => [control]),
+          controlSetRows: publicControlFields.map(control => [control]),
         },
         {
           label: 'axis column',
@@ -258,7 +263,7 @@ describe('should collect control values and create SFD', () => {
         sections.advancedAnalyticsControls,
         {
           label: 'transform controls',
-          controlSetRows: publicControls.map(control => [control]),
+          controlSetRows: publicControlFields.map(control => [control]),
         },
         {
           label: 'axis column',

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.test.ts
@@ -452,6 +452,83 @@ describe('should transform form_data between table and bigNumberTotal', () => {
     ]);
     expect(tblFormData.groupby).toEqual(['name', 'gender', adhocColumn]);
   });
+
+  test('preserves dashboardId when transforming between viz types', () => {
+    // Create form data with dashboardId (simulating opening explore from a dashboard)
+    const formDataWithDashboard = {
+      ...tableVizFormData,
+      dashboardId: 42,
+    };
+    const storeWithDashboard = {
+      ...tableVizStore,
+      form_data: formDataWithDashboard,
+    };
+
+    // Transform table -> bigNumberTotal
+    const sfd = new StandardizedFormData(formDataWithDashboard);
+    const { formData: bntFormData } = sfd.transform(
+      VizType.BigNumberTotal,
+      storeWithDashboard,
+    );
+
+    // Verify dashboardId is preserved after transformation
+    expect(bntFormData.dashboardId).toBe(42);
+
+    // Transform back bigNumberTotal -> table
+    const sfd2 = new StandardizedFormData(bntFormData);
+    const { formData: tblFormData } = sfd2.transform('table', {
+      ...storeWithDashboard,
+      form_data: bntFormData,
+      controls: {
+        ...tableVizStore.controls,
+      },
+    });
+
+    // Verify dashboardId is still preserved after second transformation
+    expect(tblFormData.dashboardId).toBe(42);
+  });
+
+  test('handles missing dashboardId gracefully', () => {
+    // Test with no dashboardId (exploring a chart not from a dashboard)
+    const formDataNoDashboard = {
+      ...tableVizFormData,
+      // dashboardId is undefined
+    };
+    const storeNoDashboard = {
+      ...tableVizStore,
+      form_data: formDataNoDashboard,
+    };
+
+    const sfd = new StandardizedFormData(formDataNoDashboard);
+    const { formData: bntFormData } = sfd.transform(
+      VizType.BigNumberTotal,
+      storeNoDashboard,
+    );
+
+    // dashboardId should not be present when it was never set
+    expect(bntFormData.dashboardId).toBeUndefined();
+  });
+
+  test('handles null dashboardId', () => {
+    // Test with explicit null dashboardId
+    const formDataNullDashboard = {
+      ...tableVizFormData,
+      dashboardId: null,
+    };
+    const storeNullDashboard = {
+      ...tableVizStore,
+      form_data: formDataNullDashboard,
+    };
+
+    const sfd = new StandardizedFormData(formDataNullDashboard);
+    const { formData: bntFormData } = sfd.transform(
+      VizType.BigNumberTotal,
+      storeNullDashboard,
+    );
+
+    // null is falsy, so dashboardId should not be added
+    expect(bntFormData.dashboardId).toBeUndefined();
+  });
 });
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -81,6 +81,8 @@ export const publicControls = [
   // advanced analytics - resample
   'resample_rule', // via sections.advancedAnalytics
   'resample_method', // via sections.advancedAnalytics
+  // dashboard context
+  'dashboardId', // preserve dashboard context when changing viz type
 ];
 
 export class StandardizedFormData {
@@ -216,6 +218,7 @@ export class StandardizedFormData {
     });
     const targetFormData = {
       ...getFormDataFromControls(targetControlsState),
+      ...publicFormData,
       standardizedFormData: this.serialize(),
     };
 

--- a/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
+++ b/superset-frontend/src/explore/controlUtils/standardizedFormData.ts
@@ -218,7 +218,10 @@ export class StandardizedFormData {
     });
     const targetFormData = {
       ...getFormDataFromControls(targetControlsState),
-      ...publicFormData,
+      // Preserve dashboard context when switching viz types.
+      ...(publicFormData.dashboardId && {
+        dashboardId: publicFormData.dashboardId,
+      }),
       standardizedFormData: this.serialize(),
     };
 

--- a/superset_text.yml
+++ b/superset_text.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 
-# To set the images of your preferred database, you may create a mapping here with engine and locations of the relevant images. The image can be hosted locally inside your static/file directory or online (e.g. S3)
+# To set the images of your preferred database, you may create a mapping here with engine and locations of the relevant images. The image can be hosted locally inside your static/file directory or online (e.g. S3).
 
 # DB_IMAGES:
 #   postgresql: "path/to/image/postgres.jpg"


### PR DESCRIPTION
### SUMMARY
  Fixes a bug where the "Save and go to dashboard" option becomes disabled after changing a chart's visualization type.

  **The Problem:**
  When a user opens a chart from a dashboard and changes its visualization type (e.g., Line Chart → Bar Chart), the dashboard context is lost. The Save modal then shows a placeholder "Select a dashboard OR create a new one" instead of the actual dashboard name, and the "Save & go to dashboard" option becomes disabled.

  **Root Cause:**
  The `dashboardId` field was being dropped during the form data transformation process when switching visualization types. This happened in `standardizedFormData.ts` where:
  - `dashboardId` is not a form control, it's just a regular field that stores the dashboard context
  - When `getFormDataFromControls()` builds the new form data, it only includes fields that have corresponding controls
  - The `dashboardId` wasn't in the `publicControls` array (fields that should be preserved across viz changes)
  - Even though public form data was collected, it was being overwritten instead of preserved

  **The Fix:**
  Two small changes to `superset-frontend/src/explore/controlUtils/standardizedFormData.ts`:
  1. Added `dashboardId` to the `publicControls` array so it gets collected during transformations
  2. Spread `publicFormData` after `getFormDataFromControls()` so the dashboard context is preserved and not overwritten

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
  **BEFORE:** After changing chart type, Save modal shows "Select a dashboard OR create a new one" and "Save & go to dashboard" is disabled and nothing shows on "Add to dashboard" field
<img width="1254" height="694" alt="Interactive Pivot Table 2025-11-12 22-38-23 (1)" src="https://github.com/user-attachments/assets/54eb7b7b-b832-41b4-b25c-236126d9f703" />

  **AFTER:** Save modal correctly displays the dashboard name and "Save & go to dashboard" remains enabled and "Add to dashboard" field shows the proper content
<img width="667" height="468" alt="Screenshot 2025-11-14 at 16 59 46" src="https://github.com/user-attachments/assets/cdf7b8ff-104f-4812-b377-7f9894b118b0" />


  ### TESTING INSTRUCTIONS
  1. Open a dashboard and click into one of its charts to open Explore view
  2. Click Save and verify the dashboard name appears with "Save & go to dashboard" enabled (don't actually save)
  3. Change the chart type to a different visualization (e.g., Line → Bar)
  4. Click Save again
  5. Verify the dashboard name still appears and "Save & go to dashboard" is still enabled

  ### ADDITIONAL INFORMATION
  - [x] Changes UI