### PR TITLE
feat(embedded): add setThemeMode API for dynamic theme switching

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -81,6 +81,8 @@ export type ObserveDataMaskCallbackFn = (
     nativeFiltersChanged: boolean;
   },
 ) => void;
+export type ThemeMode = 'default' | 'dark' | 'system';
+
 export type EmbeddedDashboard = {
   getScrollSize: () => Promise<Size>;
   unmount: () => void;
@@ -92,6 +94,7 @@ export type EmbeddedDashboard = {
   getDataMask: () => Promise<Record<string, any>>;
   getChartStates: () => Promise<Record<string, any>>;
   setThemeConfig: (themeConfig: Record<string, any>) => void;
+  setThemeMode: (mode: ThemeMode) => void;
 };
 
 /**
@@ -265,6 +268,18 @@ export async function embedDashboard({
     }
   };
 
+  const setThemeMode = (mode: ThemeMode): void => {
+    try {
+      ourPort.emit('setThemeMode', { mode });
+      log(`Theme mode set to: ${mode}`);
+    } catch (error) {
+      log(
+        'Error sending theme mode. Ensure the iframe side implements the "setThemeMode" method.',
+      );
+      throw error;
+    }
+  };
+
   return {
     getScrollSize,
     unmount,
@@ -273,6 +288,7 @@ export async function embedDashboard({
     observeDataMask,
     getDataMask,
     getChartStates,
-    setThemeConfig
+    setThemeConfig,
+    setThemeMode,
   };
 }

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -22,7 +22,7 @@ import { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { makeApi, t, logging } from '@superset-ui/core';
-import { type SupersetThemeConfig } from '@apache-superset/core/ui';
+import { type SupersetThemeConfig, ThemeMode } from '@apache-superset/core/ui';
 import Switchboard from '@superset-ui/switchboard';
 import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import setupClient from 'src/setup/setupClient';
@@ -260,6 +260,39 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
         } catch (error) {
           logging.error('Failed to apply theme config:', error);
           throw new Error(`Failed to apply theme config: ${error.message}`);
+        }
+      },
+    );
+
+    Switchboard.defineMethod(
+      'setThemeMode',
+      (payload: { mode: 'default' | 'dark' | 'system' }) => {
+        const { mode } = payload;
+        log('Received setThemeMode request:', mode);
+
+        try {
+          const themeController = getThemeController();
+
+          const themeModeMap: Record<string, ThemeMode> = {
+            default: ThemeMode.DEFAULT,
+            dark: ThemeMode.DARK,
+            system: ThemeMode.SYSTEM,
+          };
+
+          const themeMode = themeModeMap[mode];
+          if (!themeMode) {
+            throw new Error(`Invalid theme mode: ${mode}`);
+          }
+
+          themeController.setThemeMode(themeMode);
+          return { success: true, message: `Theme mode set to ${mode}` };
+        } catch (error) {
+          logging.debug('Theme mode not changed:', error.message);
+          return {
+            success: false,
+            message: `Theme locked to current mode`,
+            silent: true,
+          };
         }
       },
     );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a new `setThemeMode()` method to the embedded SDK that allows host applications to dynamically control the theme mode (default/dark/system) of embedded dashboards.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Set up an embedded dashboard using the SDK
2. Configure a theme with both `theme_default` and `theme_dark`:
```typescript
const dashboard = await embedDashboard({ /* config */ });
dashboard.setThemeConfig({
  theme_default: { token: { colorPrimary: '#458588' } },
  theme_dark: { token: { colorPrimary: '#458588', colorBgBase: '#282828' }, algorithm: 'dark' }
});
```
3. Call `dashboard.setThemeMode('dark')` - verify dashboard switches to dark theme
4. Call `dashboard.setThemeMode('default')` - verify dashboard switches to default theme
5. Test theme locking: Configure a dashboard with only theme_default, verify `setThemeMode('dark')` is silently ignored (no errors, dashboard stays in default mode)