### PR TITLE
fix(screenshots): Only cache thumbnails when image generation succeeds

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -160,6 +160,7 @@ greenlet==3.1.1
     # via
     #   apache-superset (pyproject.toml)
     #   shillelagh
+    #   sqlalchemy
 gunicorn==23.0.0
     # via apache-superset (pyproject.toml)
 h11==0.16.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -176,6 +176,7 @@ cryptography==44.0.3
     #   paramiko
     #   pyjwt
     #   pyopenssl
+    #   secretstorage
 cycler==0.12.1
     # via matplotlib
 cyclopts==3.24.0
@@ -367,6 +368,7 @@ greenlet==3.1.1
     #   apache-superset
     #   gevent
     #   shillelagh
+    #   sqlalchemy
 grpcio==1.71.0
     # via
     #   apache-superset
@@ -439,6 +441,10 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   -c requirements/base-constraint.txt
@@ -878,6 +884,8 @@ rsa==4.9.1
     #   google-auth
 ruff==0.8.0
     # via apache-superset
+secretstorage==3.4.1
+    # via keyring
 selenium==4.32.0
     # via
     #   -c requirements/base-constraint.txt

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -275,10 +275,7 @@ class BaseScreenshot:
         """
         cache_key = cache_key or self.get_cache_key(window_size, thumb_size)
         cache_payload = self.get_from_cache_key(cache_key) or ScreenshotCachePayload()
-        if (
-            cache_payload.status in [StatusValues.COMPUTING, StatusValues.UPDATED]
-            and not force
-        ):
+        if not cache_payload.should_trigger_task(force=force):
             logger.info(
                 "Skipping compute - already processed for thumbnail: %s", cache_key
             )

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -310,7 +310,9 @@ class BaseScreenshot:
             with event_logger.log_context(f"screenshot.cache.{self.thumbnail_type}"):
                 cache_payload.update(image)
             self.cache.set(cache_key, cache_payload.to_dict())
-            logger.info("Updated thumbnail cache; Status: %s", cache_payload.get_status())
+            logger.info(
+                "Updated thumbnail cache; Status: %s", cache_payload.get_status()
+            )
         return
 
     @classmethod

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -277,7 +277,6 @@ class BaseScreenshot:
         thumb_size = thumb_size or self.thumb_size
         logger.info("Processing url for thumbnail: %s", cache_key)
         cache_payload.computing()
-        self.cache.set(cache_key, cache_payload.to_dict())
         image = None
         # Assuming all sorts of things can go wrong with Selenium
         try:
@@ -299,8 +298,8 @@ class BaseScreenshot:
             logger.info("Caching thumbnail: %s", cache_key)
             with event_logger.log_context(f"screenshot.cache.{self.thumbnail_type}"):
                 cache_payload.update(image)
-        self.cache.set(cache_key, cache_payload.to_dict())
-        logger.info("Updated thumbnail cache; Status: %s", cache_payload.get_status())
+            self.cache.set(cache_key, cache_payload.to_dict())
+            logger.info("Updated thumbnail cache; Status: %s", cache_payload.get_status())
         return
 
     @classmethod

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -312,9 +312,7 @@ class BaseScreenshot:
 
         logger.info("Caching thumbnail: %s", cache_key)
         self.cache.set(cache_key, cache_payload.to_dict())
-        logger.info(
-            "Updated thumbnail cache; Status: %s", cache_payload.get_status()
-        )
+        logger.info("Updated thumbnail cache; Status: %s", cache_payload.get_status())
         return
 
     @classmethod

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -172,6 +172,10 @@ class TestCacheOnlyOnSuccess:
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=check_cache_during_screenshot,
         )
+        # Mock resize to avoid PIL errors with fake image data
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".resize_image", return_value=b"resized_image_data"
+        )
 
         # Execute compute_and_cache
         screenshot_obj.compute_and_cache(user=mock_user, force=True)

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -355,8 +355,7 @@ class TestIntegrationCacheBugFix:
 
         # Subsequent request should trigger new computation
         # (not return 404 from corrupted cache)
-        cached_payload = screenshot_obj.get_from_cache_key(cache_key)
-        if cached_payload:
+        if cached_payload := screenshot_obj.get_from_cache_key(cache_key):
             # If there was a cache entry, it should trigger recomputation
             assert cached_payload.should_trigger_task() is True
 

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -76,9 +76,7 @@ class TestCacheOnlyOnSuccess:
 
     def _setup_mocks(self, mocker: MockerFixture, screenshot_obj):
         """Helper method to set up common mocks."""
-        mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
-        )
+        mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         get_screenshot = mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"image_data"
         )
@@ -89,9 +87,7 @@ class TestCacheOnlyOnSuccess:
         self, mocker: MockerFixture, screenshot_obj, mock_user
     ):
         """Test that cache is not saved when screenshot generation fails."""
-        mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
-        )
+        mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         get_screenshot = mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=Exception("Screenshot failed"),
@@ -149,9 +145,7 @@ class TestCacheOnlyOnSuccess:
         self, mocker: MockerFixture, screenshot_obj, mock_user
     ):
         """Test that cache is not saved during COMPUTING state."""
-        mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
-        )
+        mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         BaseScreenshot.cache = MockCache()
 
         # Mock get_screenshot to check cache state during execution
@@ -161,9 +155,9 @@ class TestCacheOnlyOnSuccess:
             cache_key = screenshot_obj.get_cache_key()
             cached_value = BaseScreenshot.cache.get(cache_key)
             # Cache should be empty during screenshot generation
-            assert (
-                cached_value is None
-            ), "Cache should not be saved during COMPUTING state"
+            assert cached_value is None, (
+                "Cache should not be saved during COMPUTING state"
+            )
             return b"image_data"
 
         mocker.patch(
@@ -192,7 +186,9 @@ class TestShouldTriggerTask:
 
         # Create payload with COMPUTING status from 400 seconds ago (stale)
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=old_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=old_timestamp
+        )
 
         # Should trigger task because COMPUTING is stale
         assert payload.should_trigger_task(force=False) is True
@@ -205,7 +201,9 @@ class TestShouldTriggerTask:
 
         # Create payload with COMPUTING status from 100 seconds ago (fresh)
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=fresh_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=fresh_timestamp
+        )
 
         # Should NOT trigger task because COMPUTING is still fresh
         assert payload.should_trigger_task(force=False) is False
@@ -241,7 +239,9 @@ class TestShouldTriggerTask:
 
         # Create payload with ERROR status from 400 seconds ago (expired)
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.ERROR, timestamp=old_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.ERROR, timestamp=old_timestamp
+        )
 
         assert payload.should_trigger_task(force=False) is True
 
@@ -253,7 +253,9 @@ class TestShouldTriggerTask:
 
         # Create payload with ERROR status from 100 seconds ago (fresh)
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.ERROR, timestamp=fresh_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.ERROR, timestamp=fresh_timestamp
+        )
 
         assert payload.should_trigger_task(force=False) is False
 
@@ -278,7 +280,9 @@ class TestIsComputingStale:
 
         # Timestamp from 400 seconds ago
         old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=old_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=old_timestamp
+        )
 
         assert payload.is_computing_stale() is True
 
@@ -289,7 +293,9 @@ class TestIsComputingStale:
 
         # Timestamp from 100 seconds ago
         fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=fresh_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=fresh_timestamp
+        )
 
         assert payload.is_computing_stale() is False
 
@@ -300,7 +306,9 @@ class TestIsComputingStale:
 
         # Timestamp from exactly 300 seconds ago
         exact_timestamp = (datetime.now() - timedelta(seconds=300)).isoformat()
-        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=exact_timestamp)
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=exact_timestamp
+        )
 
         # At exactly TTL, should not be stale yet (needs to be > TTL)
         assert payload.is_computing_stale() is False
@@ -330,9 +338,7 @@ class TestIntegrationCacheBugFix:
         Integration test: Failed screenshot should not leave cache entry
         that triggers 404 errors.
         """
-        mocker.patch(
-            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
-        )
+        mocker.patch(BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None)
         mocker.patch(
             BASE_SCREENSHOT_PATH + ".get_screenshot",
             side_effect=Exception("Network error"),

--- a/tests/unit_tests/utils/test_screenshot_cache_fix.py
+++ b/tests/unit_tests/utils/test_screenshot_cache_fix.py
@@ -1,0 +1,392 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for screenshot cache bug fixes:
+1. Cache only saved when image generation succeeds
+2. Recompute stale COMPUTING tasks and UPDATED without image
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.utils.screenshots import (
+    BaseScreenshot,
+    ScreenshotCachePayload,
+    StatusValues,
+)
+
+BASE_SCREENSHOT_PATH = "superset.utils.screenshots.BaseScreenshot"
+
+
+class MockCache:
+    """A class to manage screenshot cache for testing."""
+
+    def __init__(self):
+        self._cache = {}
+
+    def set(self, key, value):
+        """Set the cache with a new value."""
+        self._cache[key] = value
+
+    def get(self, key):
+        """Get the cached value."""
+        return self._cache.get(key)
+
+    def clear(self):
+        """Clear all cached values."""
+        self._cache.clear()
+
+
+@pytest.fixture
+def mock_user():
+    """Fixture to create a mock user."""
+    user = MagicMock()
+    user.id = 1
+    return user
+
+
+@pytest.fixture
+def screenshot_obj():
+    """Fixture to create a BaseScreenshot object."""
+    url = "http://example.com"
+    digest = "sample_digest"
+    return BaseScreenshot(url, digest)
+
+
+class TestCacheOnlyOnSuccess:
+    """Test that cache is only saved when image generation succeeds."""
+
+    def _setup_mocks(self, mocker: MockerFixture, screenshot_obj):
+        """Helper method to set up common mocks."""
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
+        )
+        get_screenshot = mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"image_data"
+        )
+        BaseScreenshot.cache = MockCache()
+        return get_screenshot
+
+    def test_cache_not_saved_when_screenshot_fails(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """Test that cache is not saved when screenshot generation fails."""
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
+        )
+        get_screenshot = mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot",
+            side_effect=Exception("Screenshot failed"),
+        )
+        BaseScreenshot.cache = MockCache()
+
+        # Execute compute_and_cache
+        screenshot_obj.compute_and_cache(user=mock_user, force=True)
+
+        # Verify get_screenshot was called
+        get_screenshot.assert_called_once()
+
+        # Cache should not be set (no image was generated)
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is None
+
+    def test_cache_not_saved_when_resize_fails(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """Test that cache is not saved when image resize fails."""
+        self._setup_mocks(mocker, screenshot_obj)
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".resize_image",
+            side_effect=Exception("Resize failed"),
+        )
+
+        # Use different window and thumb sizes to trigger resize
+        screenshot_obj.compute_and_cache(
+            user=mock_user, force=True, window_size=(800, 600), thumb_size=(400, 300)
+        )
+
+        # Cache should not be set (resize failed, so image is None)
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is None
+
+    def test_cache_saved_only_when_image_generated(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """Test that cache is only saved when image is successfully generated."""
+        self._setup_mocks(mocker, screenshot_obj)
+
+        # Execute compute_and_cache
+        screenshot_obj.compute_and_cache(user=mock_user, force=True)
+
+        # Cache should be set with UPDATED status and image
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is not None
+        assert cached_value["status"] == "Updated"
+        assert cached_value["image"] is not None
+
+    def test_no_intermediate_cache_during_computing(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """Test that cache is not saved during COMPUTING state."""
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
+        )
+        BaseScreenshot.cache = MockCache()
+
+        # Mock get_screenshot to check cache state during execution
+        def check_cache_during_screenshot(*args, **kwargs):
+            # At this point, we're in COMPUTING state
+            # Cache should NOT be set yet
+            cache_key = screenshot_obj.get_cache_key()
+            cached_value = BaseScreenshot.cache.get(cache_key)
+            # Cache should be empty during screenshot generation
+            assert (
+                cached_value is None
+            ), "Cache should not be saved during COMPUTING state"
+            return b"image_data"
+
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot",
+            side_effect=check_cache_during_screenshot,
+        )
+
+        # Execute compute_and_cache
+        screenshot_obj.compute_and_cache(user=mock_user, force=True)
+
+        # After completion, cache should be set with UPDATED status
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is not None
+        assert cached_value["status"] == "Updated"
+
+
+class TestShouldTriggerTask:
+    """Test the should_trigger_task method improvements."""
+
+    @patch("superset.utils.screenshots.app")
+    def test_trigger_on_stale_computing_status(self, mock_app):
+        """Test that stale COMPUTING status triggers recomputation."""
+        # Set TTL to 300 seconds
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Create payload with COMPUTING status from 400 seconds ago (stale)
+        old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=old_timestamp)
+
+        # Should trigger task because COMPUTING is stale
+        assert payload.should_trigger_task(force=False) is True
+
+    @patch("superset.utils.screenshots.app")
+    def test_no_trigger_on_fresh_computing_status(self, mock_app):
+        """Test that fresh COMPUTING status does not trigger recomputation."""
+        # Set TTL to 300 seconds
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Create payload with COMPUTING status from 100 seconds ago (fresh)
+        fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=fresh_timestamp)
+
+        # Should NOT trigger task because COMPUTING is still fresh
+        assert payload.should_trigger_task(force=False) is False
+
+    def test_trigger_on_updated_without_image(self):
+        """Test that UPDATED status without image triggers recomputation."""
+        # Create payload with UPDATED status but no image
+        # This simulates the bug where cache was saved without an image
+        payload = ScreenshotCachePayload(image=None, status=StatusValues.UPDATED)
+
+        # Should trigger task because UPDATED but has no image
+        assert payload.should_trigger_task(force=False) is True
+
+    def test_no_trigger_on_updated_with_image(self):
+        """Test that UPDATED status with image does not trigger recomputation."""
+        # Create payload with UPDATED status and valid image
+        payload = ScreenshotCachePayload(image=b"valid_image_data")
+
+        # Should NOT trigger task because UPDATED with valid image
+        assert payload.should_trigger_task(force=False) is False
+
+    def test_trigger_on_pending_status(self):
+        """Test that PENDING status triggers task."""
+        payload = ScreenshotCachePayload(status=StatusValues.PENDING)
+
+        assert payload.should_trigger_task(force=False) is True
+
+    @patch("superset.utils.screenshots.app")
+    def test_trigger_on_expired_error(self, mock_app):
+        """Test that expired ERROR status triggers task."""
+        # Set TTL to 300 seconds
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Create payload with ERROR status from 400 seconds ago (expired)
+        old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.ERROR, timestamp=old_timestamp)
+
+        assert payload.should_trigger_task(force=False) is True
+
+    @patch("superset.utils.screenshots.app")
+    def test_no_trigger_on_fresh_error(self, mock_app):
+        """Test that fresh ERROR status does not trigger task."""
+        # Set TTL to 300 seconds
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Create payload with ERROR status from 100 seconds ago (fresh)
+        fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.ERROR, timestamp=fresh_timestamp)
+
+        assert payload.should_trigger_task(force=False) is False
+
+    def test_force_always_triggers(self):
+        """Test that force=True always triggers task regardless of status."""
+        # Test with UPDATED + image (normally wouldn't trigger)
+        payload_updated = ScreenshotCachePayload(image=b"image_data")
+        assert payload_updated.should_trigger_task(force=True) is True
+
+        # Test with fresh COMPUTING (normally wouldn't trigger)
+        payload_computing = ScreenshotCachePayload(status=StatusValues.COMPUTING)
+        assert payload_computing.should_trigger_task(force=True) is True
+
+
+class TestIsComputingStale:
+    """Test the is_computing_stale method."""
+
+    @patch("superset.utils.screenshots.app")
+    def test_computing_is_stale(self, mock_app):
+        """Test that old COMPUTING status is detected as stale."""
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Timestamp from 400 seconds ago
+        old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=old_timestamp)
+
+        assert payload.is_computing_stale() is True
+
+    @patch("superset.utils.screenshots.app")
+    def test_computing_is_not_stale(self, mock_app):
+        """Test that fresh COMPUTING status is not stale."""
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Timestamp from 100 seconds ago
+        fresh_timestamp = (datetime.now() - timedelta(seconds=100)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=fresh_timestamp)
+
+        assert payload.is_computing_stale() is False
+
+    @patch("superset.utils.screenshots.app")
+    def test_computing_exactly_at_ttl(self, mock_app):
+        """Test boundary condition at exactly TTL."""
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Timestamp from exactly 300 seconds ago
+        exact_timestamp = (datetime.now() - timedelta(seconds=300)).isoformat()
+        payload = ScreenshotCachePayload(status=StatusValues.COMPUTING, timestamp=exact_timestamp)
+
+        # At exactly TTL, should not be stale yet (needs to be > TTL)
+        assert payload.is_computing_stale() is False
+
+    @patch("superset.utils.screenshots.app")
+    def test_computing_just_past_ttl(self, mock_app):
+        """Test boundary condition just past TTL."""
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Timestamp from 301 seconds ago (just past TTL)
+        past_ttl_timestamp = (datetime.now() - timedelta(seconds=301)).isoformat()
+        payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=past_ttl_timestamp
+        )
+
+        # Just past TTL should be stale
+        assert payload.is_computing_stale() is True
+
+
+class TestIntegrationCacheBugFix:
+    """Integration tests combining both fixes."""
+
+    def test_failed_screenshot_does_not_pollute_cache(
+        self, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """
+        Integration test: Failed screenshot should not leave cache entry
+        that triggers 404 errors.
+        """
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_from_cache_key", return_value=None
+        )
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot",
+            side_effect=Exception("Network error"),
+        )
+        BaseScreenshot.cache = MockCache()
+
+        # First attempt fails
+        screenshot_obj.compute_and_cache(user=mock_user, force=True)
+
+        # Verify cache is empty (no corrupted entry)
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is None
+
+        # Subsequent request should trigger new computation
+        # (not return 404 from corrupted cache)
+        cached_payload = screenshot_obj.get_from_cache_key(cache_key)
+        if cached_payload:
+            # If there was a cache entry, it should trigger recomputation
+            assert cached_payload.should_trigger_task() is True
+
+    @patch("superset.utils.screenshots.app")
+    def test_stale_computing_triggers_retry(
+        self, mock_app, mocker: MockerFixture, screenshot_obj, mock_user
+    ):
+        """
+        Integration test: Stale COMPUTING status should trigger retry
+        to recover from stuck tasks.
+        """
+        mock_app.config = {"THUMBNAIL_ERROR_CACHE_TTL": 300}
+
+        # Create stale COMPUTING entry in cache
+        old_timestamp = (datetime.now() - timedelta(seconds=400)).isoformat()
+        stale_payload = ScreenshotCachePayload(
+            status=StatusValues.COMPUTING, timestamp=old_timestamp
+        )
+
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_from_cache_key",
+            return_value=stale_payload,
+        )
+        mocker.patch(
+            BASE_SCREENSHOT_PATH + ".get_screenshot", return_value=b"recovered_image"
+        )
+        BaseScreenshot.cache = MockCache()
+
+        # Should trigger task because COMPUTING is stale
+        assert stale_payload.should_trigger_task() is True
+
+        # Retry should succeed and update cache
+        screenshot_obj.compute_and_cache(user=mock_user, force=False)
+
+        cache_key = screenshot_obj.get_cache_key()
+        cached_value = BaseScreenshot.cache.get(cache_key)
+        assert cached_value is not None
+        assert cached_value["status"] == "Updated"
+        assert cached_value["image"] is not None


### PR DESCRIPTION
Previously, the cache was being saved in two problematic scenarios:
1. When entering COMPUTING state (line 280) - before image generation
2. Always after processing (line 302) - even when image generation failed

This caused issues where the /screenshot endpoint would find a cache key but without an actual image, resulting in 404 errors.

Changes:
- Removed cache.set() call after entering COMPUTING state
- Moved cache.set() and status logging inside the `if image:` block
- Cache is now only saved when image generation and processing succeed

This ensures that cache entries always contain valid image data.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
