### PR TITLE
fix: Columns bleeding into other cells

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -61,7 +61,6 @@ export const Styles = styled.div`
     table.pvtTable tbody tr.pvtRowTotals th,
     table.pvtTable tbody tr.pvtRowTotals td {
       background-color: ${theme.colorBgBase};
-      z-index: 1;
     }
 
     table.pvtTable thead tr:last-of-type th,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -28,6 +28,7 @@ export const Styles = styled.div`
       text-align: left;
       margin: ${theme.sizeUnit}px;
       border-collapse: separate;
+      border-spacing: 0;
       font-family: ${theme.fontFamily};
       line-height: 1.4;
     }
@@ -54,6 +55,13 @@ export const Styles = styled.div`
     table.pvtTable tbody tr.pvtRowTotals {
       position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
       bottom: 0;
+      background-color: ${theme.colorBgBase};
+    }
+
+    table.pvtTable tbody tr.pvtRowTotals th,
+    table.pvtTable tbody tr.pvtRowTotals td {
+      background-color: ${theme.colorBgBase};
+      z-index: 1;
     }
 
     table.pvtTable thead tr:last-of-type th,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adjusted the Pivot Table styling so the sticky header/total areas no longer show underlying rows by zeroing out border-spacing, keeping the header row sticky, and relying on the theme background to cover the frozen cells. Restored sticky positioning on the header row while keeping it fully opaque with themed background colors.Applied the same background treatment to the sticky totals row so columns beneath it remain hidden during scroll.

### BEFORE
<img width="1469" height="724" alt="Screenshot 2025-11-19 at 18 24 54" src="https://github.com/user-attachments/assets/0b7c2dd2-d485-4a9d-bcb4-87f185b74daf" />

### AFTER
<img width="1465" height="723" alt="Screenshot 2025-11-19 at 18 25 13" src="https://github.com/user-attachments/assets/70fa41e8-4125-41dd-98cc-fbec7d13fc14" />

### TESTING INSTRUCTIONS
- Navigate to Charts
- Create new Pivot chart based on Video Game Sales
- Set Columns: name
- Set Rows: genre
- Set Metrics: COUNT(*)
- Run
- When the table is displayed, try scrolling down through the rows
- The data behind the frozen columns is now entirely hidden

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
