### PR TITLE
fix: Use total count to filter datasets

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
@@ -37,70 +37,73 @@ interface DatasetSelectProps {
   excludeDatasetIds?: number[];
 }
 
+const getErrorMessage = ({ error, message }: ClientErrorObject) => {
+  let errorText = message || error || t('An error has occurred');
+  if (message === 'Forbidden') {
+    errorText = t('You do not have permission to edit this dashboard');
+  }
+  return errorText;
+};
+
+export const loadDatasetOptions = async (
+  search: string,
+  page: number,
+  pageSize: number,
+  excludeDatasetIds: number[] = [],
+) => {
+  const query = rison.encode({
+    columns: ['id', 'table_name', 'database.database_name', 'schema'],
+    filters: [{ col: 'table_name', opr: 'ct', value: search }],
+    page,
+    page_size: pageSize,
+    order_column: 'table_name',
+    order_direction: 'asc',
+  });
+  return cachedSupersetGet({
+    endpoint: `/api/v1/dataset/?q=${query}`,
+  })
+    .then((response: JsonResponse) => {
+      const filteredResult = response.json.result.filter(
+        (item: Dataset) => !excludeDatasetIds.includes(item.id),
+      );
+
+      const list: {
+        label: string | ReactNode;
+        value: string | number;
+        table_name: string;
+      }[] = filteredResult.map((item: Dataset) => ({
+        ...item,
+        label: DatasetSelectLabel(item),
+        value: item.id,
+        table_name: item.table_name,
+      }));
+      return {
+        data: list,
+        totalCount: response.json.count ?? 0,
+      };
+    })
+    .catch(async error => {
+      const errorMessage = getErrorMessage(await getClientErrorObject(error));
+      throw new Error(errorMessage);
+    });
+};
+
 const DatasetSelect = ({
   onChange,
   value,
   excludeDatasetIds = [],
 }: DatasetSelectProps) => {
-  const getErrorMessage = useCallback(
-    ({ error, message }: ClientErrorObject) => {
-      let errorText = message || error || t('An error has occurred');
-      if (message === 'Forbidden') {
-        errorText = t('You do not have permission to edit this dashboard');
-      }
-      return errorText;
-    },
-    [],
-  );
-
-  const loadDatasetOptions = useCallback(
-    async (search: string, page: number, pageSize: number) => {
-      const query = rison.encode({
-        columns: ['id', 'table_name', 'database.database_name', 'schema'],
-        filters: [{ col: 'table_name', opr: 'ct', value: search }],
-        page,
-        page_size: pageSize,
-        order_column: 'table_name',
-        order_direction: 'asc',
-      });
-      return cachedSupersetGet({
-        endpoint: `/api/v1/dataset/?q=${query}`,
-      })
-        .then((response: JsonResponse) => {
-          const filteredResult = response.json.result.filter(
-            (item: Dataset) => !excludeDatasetIds.includes(item.id),
-          );
-
-          const list: {
-            label: string | ReactNode;
-            value: string | number;
-            table_name: string;
-          }[] = filteredResult.map((item: Dataset) => ({
-            ...item,
-            label: DatasetSelectLabel(item),
-            value: item.id,
-            table_name: item.table_name,
-          }));
-          return {
-            data: list,
-            totalCount: filteredResult.length,
-          };
-        })
-        .catch(async error => {
-          const errorMessage = getErrorMessage(
-            await getClientErrorObject(error),
-          );
-          throw new Error(errorMessage);
-        });
-    },
-    [excludeDatasetIds, getErrorMessage],
+  const loadDatasetOptionsCallback = useCallback(
+    (search: string, page: number, pageSize: number) =>
+      loadDatasetOptions(search, page, pageSize, excludeDatasetIds),
+    [excludeDatasetIds],
   );
 
   return (
     <AsyncSelect
       ariaLabel={t('Dataset')}
       value={value}
-      options={loadDatasetOptions}
+      options={loadDatasetOptionsCallback}
       onChange={onChange}
       optionFilterProps={['table_name']}
       notFoundContent={t('No compatible datasets found')}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The component was setting totalCount to filteredResult.length (the current page size) instead of response.json.count (the total count from the API).

### BEFORE


https://github.com/user-attachments/assets/1c50fc5b-ca3f-43fa-bd4c-55b0ddf772ca

### AFTER

https://github.com/user-attachments/assets/f3a2851d-baa4-4010-8077-48c985b9b643


### TESTING INSTRUCTIONS
Start in an instance with 100+ datasets created
1. Create a new dataset (I created a physical dataset)
2. Go to a dashboard
3. Go to add/edit a filter
4. Pick a filter type (I used a value filter)
5. In the dataset list, search for your new dataset

Current behavior:
New dataset SHOULD appear in the list

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #36124
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
