### PR TITLE
fix(mcp-service): improve MCP tool parameter clarity and validation

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -589,7 +589,9 @@ class FilterConfig(BaseModel):
 
 # Actual chart types
 class TableChartConfig(BaseModel):
-    chart_type: Literal["table"] = Field("table", description="Chart type")
+    chart_type: Literal["table"] = Field(
+        ..., description="Chart type (REQUIRED: must be 'table')"
+    )
     columns: List[ColumnRef] = Field(
         ...,
         min_length=1,
@@ -632,7 +634,9 @@ class TableChartConfig(BaseModel):
 
 
 class XYChartConfig(BaseModel):
-    chart_type: Literal["xy"] = Field("xy", description="Chart type")
+    chart_type: Literal["xy"] = Field(
+        ..., description="Chart type (REQUIRED: must be 'xy')"
+    )
     x: ColumnRef = Field(..., description="X-axis column")
     y: List[ColumnRef] = Field(
         ...,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -635,6 +635,12 @@ class TableChartConfig(BaseModel):
 
 class XYChartConfig(BaseModel):
     chart_type: Literal["xy"] = Field(
+        ...,
+        description=(
+            "Chart type discriminator - MUST be 'xy' for XY charts (line, bar, area, scatter). "
+            "This field is REQUIRED and tells Superset which chart configuration schema to use."
+        )
+    )
         ..., description="Chart type (REQUIRED: must be 'xy')"
     )
     x: ColumnRef = Field(..., description="X-axis column")

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -637,11 +637,11 @@ class XYChartConfig(BaseModel):
     chart_type: Literal["xy"] = Field(
         ...,
         description=(
-            "Chart type discriminator - MUST be 'xy' for XY charts (line, bar, area, scatter). "
-            "This field is REQUIRED and tells Superset which chart configuration schema to use."
-        )
-    )
-        ..., description="Chart type (REQUIRED: must be 'xy')"
+            "Chart type discriminator - MUST be 'xy' for XY charts "
+            "(line, bar, area, scatter). "
+            "This field is REQUIRED and tells Superset which chart "
+            "configuration schema to use."
+        ),
     )
     x: ColumnRef = Field(..., description="X-axis column")
     y: List[ColumnRef] = Field(

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -61,7 +61,17 @@ async def generate_chart(  # noqa: C901
     - Embed preview_url as image: ![Chart Preview](preview_url)
     - Use numeric dataset ID or UUID (NOT schema.table_name format)
     - MUST include chart_type in config (either 'xy' or 'table')
+ """
+ IMPORTANT: The 'chart_type' field in the config is a DISCRIMINATOR that determines
+    which chart configuration schema to use. It MUST be included and MUST match the
+    other fields in your configuration:
 
+    - Use chart_type='xy' for charts with x and y axes (line, bar, area, scatter)
+      Required fields: x, y
+
+    - Use chart_type='table' for tabular visualizations
+      Required fields: columns
+ """
     Example usage for XY chart:
     ```json
     {

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -61,8 +61,8 @@ async def generate_chart(  # noqa: C901
     - Embed preview_url as image: ![Chart Preview](preview_url)
     - Use numeric dataset ID or UUID (NOT schema.table_name format)
     - MUST include chart_type in config (either 'xy' or 'table')
- """
- IMPORTANT: The 'chart_type' field in the config is a DISCRIMINATOR that determines
+
+    IMPORTANT: The 'chart_type' field in the config is a DISCRIMINATOR that determines
     which chart configuration schema to use. It MUST be included and MUST match the
     other fields in your configuration:
 
@@ -71,7 +71,7 @@ async def generate_chart(  # noqa: C901
 
     - Use chart_type='table' for tabular visualizations
       Required fields: columns
- """
+
     Example usage for XY chart:
     ```json
     {

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -59,6 +59,36 @@ async def generate_chart(  # noqa: C901
     - Set save_chart=False for temporary preview only
     - LLM clients MUST display returned chart URL to users
     - Embed preview_url as image: ![Chart Preview](preview_url)
+    - Use numeric dataset ID or UUID (NOT schema.table_name format)
+    - MUST include chart_type in config (either 'xy' or 'table')
+
+    Example usage for XY chart:
+    ```json
+    {
+        "dataset_id": 123,
+        "config": {
+            "chart_type": "xy",
+            "x": {"name": "order_date"},
+            "y": [{"name": "revenue", "aggregate": "SUM"}],
+            "kind": "line"
+        }
+    }
+    ```
+
+    Example usage for Table chart:
+    ```json
+    {
+        "dataset_id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+        "config": {
+            "chart_type": "table",
+            "columns": [
+                {"name": "product_name"},
+                {"name": "quantity", "aggregate": "SUM"},
+                {"name": "revenue", "aggregate": "SUM", "label": "Total Revenue"}
+            ]
+        }
+    }
+    ```
 
     VALIDATION:
     - 5-layer pipeline: Schema, business logic, dataset, Superset compatibility, runtime

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -46,10 +46,22 @@ async def get_chart_info(
     IMPORTANT FOR LLM CLIENTS:
     - ALWAYS display the chart URL when returned
     - URL field contains chart's screenshot URL for preview
+    - Use numeric ID or UUID string (NOT chart name)
+    - To find a chart ID, use the list_charts tool first
 
-    Supports:
-    - Numeric ID (e.g., 123)
-    - UUID string (e.g., "a1b2c3d4-...")
+    Example usage:
+    ```json
+    {
+        "identifier": 123
+    }
+    ```
+
+    Or with UUID:
+    ```json
+    {
+        "identifier": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+    }
+    ```
 
     Returns chart details including name, type, and URL.
     """

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -58,6 +58,35 @@ async def update_chart(
     - Chart must already be saved (from generate_chart with save_chart=True)
     - LLM clients MUST display updated chart URL to users
     - Embed preview_url as image: ![Updated Chart](preview_url)
+    - Use numeric ID or UUID string to identify the chart (NOT chart name)
+    - MUST include chart_type in config (either 'xy' or 'table')
+
+    Example usage:
+    ```json
+    {
+        "identifier": 123,
+        "config": {
+            "chart_type": "xy",
+            "x": {"name": "date"},
+            "y": [{"name": "sales", "aggregate": "SUM"}],
+            "kind": "line"
+        }
+    }
+    ```
+
+    Or with UUID:
+    ```json
+    {
+        "identifier": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+        "config": {
+            "chart_type": "table",
+            "columns": [
+                {"name": "product_name"},
+                {"name": "revenue", "aggregate": "SUM"}
+            ]
+        }
+    }
+    ```
 
     Use when:
     - Modifying existing saved chart

--- a/superset/mcp_service/dataset/tool/get_dataset_info.py
+++ b/superset/mcp_service/dataset/tool/get_dataset_info.py
@@ -48,6 +48,25 @@ async def get_dataset_info(
     """Get dataset metadata by ID or UUID.
 
     Returns columns, metrics, and schema details.
+
+    IMPORTANT FOR LLM CLIENTS:
+    - Use numeric ID (e.g., 123) or UUID string (e.g., "a1b2c3d4-...")
+    - DO NOT use schema.table_name format (e.g., "public.customers")
+    - To find a dataset ID, use the list_datasets tool first
+
+    Example usage:
+    ```json
+    {
+        "identifier": 123
+    }
+    ```
+
+    Or with UUID:
+    ```json
+    {
+        "identifier": "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+    }
+    ```
     """
     await ctx.info(
         "Retrieving dataset information: identifier=%s" % (request.identifier,)

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -52,6 +52,23 @@ async def generate_explore_link(
     - General data exploration
     - When user wants to SEE data visually
 
+    IMPORTANT:
+    - Use numeric dataset ID or UUID (NOT schema.table_name format)
+    - MUST include chart_type in config (either 'xy' or 'table')
+
+    Example usage:
+    ```json
+    {
+        "dataset_id": 123,
+        "config": {
+            "chart_type": "xy",
+            "x": {"name": "date"},
+            "y": [{"name": "sales", "aggregate": "SUM"}],
+            "kind": "bar"
+        }
+    }
+    ```
+
     Better UX because:
     - Users can interact with chart before saving
     - Easy to modify parameters instantly

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -36,19 +36,21 @@ class TestTableChartConfig:
         """Test that TableChartConfig rejects duplicate labels."""
         with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
             TableChartConfig(
+                chart_type="table",
                 columns=[
                     ColumnRef(name="product_line", label="product_line"),
                     ColumnRef(name="sales", aggregate="SUM", label="product_line"),
-                ]
+                ],
             )
 
     def test_unique_labels_accepted(self) -> None:
         """Test that TableChartConfig accepts unique labels."""
         config = TableChartConfig(
+            chart_type="table",
             columns=[
                 ColumnRef(name="product_line", label="Product Line"),
                 ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
-            ]
+            ],
         )
         assert len(config.columns) == 2
 
@@ -59,6 +61,7 @@ class TestXYChartConfig:
     def test_different_labels_accepted(self) -> None:
         """Test that different labels for x and y are accepted."""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="product_line"),  # Label: "product_line"
             y=[
                 ColumnRef(
@@ -73,6 +76,7 @@ class TestXYChartConfig:
         """Test that explicit duplicate labels are rejected."""
         with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
             XYChartConfig(
+                chart_type="xy",
                 x=ColumnRef(name="product_line"),
                 y=[ColumnRef(name="sales", label="product_line")],
             )
@@ -81,6 +85,7 @@ class TestXYChartConfig:
         """Test that duplicate y-axis labels are rejected."""
         with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
             XYChartConfig(
+                chart_type="xy",
                 x=ColumnRef(name="date"),
                 y=[
                     ColumnRef(name="sales", aggregate="SUM"),
@@ -91,6 +96,7 @@ class TestXYChartConfig:
     def test_unique_labels_accepted(self) -> None:
         """Test that unique labels are accepted."""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date", label="Order Date"),
             y=[
                 ColumnRef(name="sales", aggregate="SUM", label="Total Sales"),
@@ -103,6 +109,7 @@ class TestXYChartConfig:
         """Test that group_by conflicts with x are rejected."""
         with pytest.raises(ValidationError, match="Duplicate column/metric labels"):
             XYChartConfig(
+                chart_type="xy",
                 x=ColumnRef(name="region"),
                 y=[ColumnRef(name="sales", aggregate="SUM")],
                 group_by=ColumnRef(name="category", label="region"),
@@ -112,6 +119,7 @@ class TestXYChartConfig:
         """Test realistic chart configurations."""
         # This should work - COUNT(product_line) != product_line
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="product_line"),
             y=[
                 ColumnRef(name="product_line", aggregate="COUNT"),

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -88,10 +88,11 @@ class TestMapTableConfig:
     def test_map_table_config_basic(self) -> None:
         """Test basic table config mapping with aggregated columns"""
         config = TableChartConfig(
+            chart_type="table",
             columns=[
                 ColumnRef(name="product", aggregate="COUNT"),
                 ColumnRef(name="revenue", aggregate="SUM"),
-            ]
+            ],
         )
 
         result = map_table_config(config)
@@ -107,10 +108,11 @@ class TestMapTableConfig:
     def test_map_table_config_raw_columns(self) -> None:
         """Test table config mapping with raw columns (no aggregates)"""
         config = TableChartConfig(
+            chart_type="table",
             columns=[
                 ColumnRef(name="product"),
                 ColumnRef(name="category"),
-            ]
+            ],
         )
 
         result = map_table_config(config)
@@ -124,6 +126,7 @@ class TestMapTableConfig:
     def test_map_table_config_with_filters(self) -> None:
         """Test table config mapping with filters"""
         config = TableChartConfig(
+            chart_type="table",
             columns=[ColumnRef(name="product")],
             filters=[FilterConfig(column="status", op="=", value="active")],
         )
@@ -141,7 +144,9 @@ class TestMapTableConfig:
     def test_map_table_config_with_sort(self) -> None:
         """Test table config mapping with sort"""
         config = TableChartConfig(
-            columns=[ColumnRef(name="product")], sort_by=["product", "revenue"]
+            chart_type="table",
+            columns=[ColumnRef(name="product")],
+            sort_by=["product", "revenue"],
         )
 
         result = map_table_config(config)
@@ -154,6 +159,7 @@ class TestMapXYConfig:
     def test_map_xy_config_line_chart(self) -> None:
         """Test XY config mapping for line chart"""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date"),
             y=[ColumnRef(name="revenue", aggregate="SUM")],
             kind="line",
@@ -169,6 +175,7 @@ class TestMapXYConfig:
     def test_map_xy_config_with_groupby(self) -> None:
         """Test XY config mapping with group by"""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date"),
             y=[ColumnRef(name="revenue")],
             kind="bar",
@@ -183,6 +190,7 @@ class TestMapXYConfig:
     def test_map_xy_config_with_axes(self) -> None:
         """Test XY config mapping with axis configurations"""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date"),
             y=[ColumnRef(name="revenue")],
             kind="area",
@@ -202,6 +210,7 @@ class TestMapXYConfig:
     def test_map_xy_config_with_legend(self) -> None:
         """Test XY config mapping with legend configuration"""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date"),
             y=[ColumnRef(name="revenue")],
             kind="scatter",
@@ -220,14 +229,17 @@ class TestMapConfigToFormData:
 
     def test_map_table_config_type(self) -> None:
         """Test mapping table config type"""
-        config = TableChartConfig(columns=[ColumnRef(name="test")])
+        config = TableChartConfig(chart_type="table", columns=[ColumnRef(name="test")])
         result = map_config_to_form_data(config)
         assert result["viz_type"] == "table"
 
     def test_map_xy_config_type(self) -> None:
         """Test mapping XY config type"""
         config = XYChartConfig(
-            x=ColumnRef(name="date"), y=[ColumnRef(name="revenue")], kind="line"
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="revenue")],
+            kind="line",
         )
         result = map_config_to_form_data(config)
         assert result["viz_type"] == "echarts_timeseries_line"
@@ -244,10 +256,11 @@ class TestGenerateChartName:
     def test_generate_table_chart_name(self) -> None:
         """Test generating name for table chart"""
         config = TableChartConfig(
+            chart_type="table",
             columns=[
                 ColumnRef(name="product"),
                 ColumnRef(name="revenue"),
-            ]
+            ],
         )
 
         result = generate_chart_name(config)
@@ -256,6 +269,7 @@ class TestGenerateChartName:
     def test_generate_xy_chart_name(self) -> None:
         """Test generating name for XY chart"""
         config = XYChartConfig(
+            chart_type="xy",
             x=ColumnRef(name="date"),
             y=[ColumnRef(name="revenue"), ColumnRef(name="orders")],
             kind="line",


### PR DESCRIPTION
## Summary

This PR fixes identifier ambiguity and validation issues in MCP tools that were causing LLMs to make incorrect API calls.

### Issues Fixed

1. **Identifier Ambiguity**: LLMs were sometimes using `'public.datasetName'` format instead of numeric IDs or UUIDs for tools like `get_dataset_info`, `get_chart_info`, and `update_chart`

2. **chartType Validation Errors**: When generating XY charts, LLMs would get `ValidationError: Unable to extract tag using discriminator 'chart_type'` because `chart_type` was marked as optional (had a default value), so LLMs would omit it

### Changes Made

1. **Made `chart_type` required** in `XYChartConfig` and `TableChartConfig` schemas
   - Changed from `Field("xy", description="...")` to `Field(..., description="REQUIRED: must be 'xy'")`
   - Changed from `Field("table", description="...")` to `Field(..., description="REQUIRED: must be 'table'")`
   - This forces LLMs to explicitly specify the chart type, preventing discriminator errors

2. **Added JSON examples to tool docstrings** for better LLM guidance:
   - `get_dataset_info`: Shows correct ID/UUID usage with examples
   - `get_chart_info`: Shows correct ID/UUID usage with examples
   - `update_chart`: Shows complete request structure including required `chart_type`
   - `generate_chart`: Shows both XY chart and Table chart examples
   - `generate_explore_link`: Shows chart_type requirement

3. **Clarified identifier parameter usage** across all affected tools:
   - Explicitly state to use numeric ID or UUID string
   - Warn against using `schema.table_name` format (e.g., `"public.customers"`)
   - Direct users to `list_datasets`/`list_charts` tools to find correct IDs

### Impact

These changes help LLM clients understand:
- `chart_type` is always required (not optional)
- Identifiers must be numeric IDs or UUIDs (not names or schema.table patterns)
- Proper request structure through concrete JSON examples

This resolves the following LLM behavior issues:
- Omitting `chart_type`, causing discriminator validation errors
- Using `"public.datasetName"` instead of numeric IDs
- Struggling with parameter format without concrete examples

## Testing Instructions

1. Test with an LLM client (e.g., Claude Desktop with MCP):
   - Ask to create an XY chart - verify LLM includes `chart_type: "xy"`
   - Ask to create a Table chart - verify LLM includes `chart_type: "table"`
   - Ask to get dataset info - verify LLM uses numeric ID or UUID (not schema.table format)
   - Verify JSON examples appear in tool schema introspection

2. Verify existing functionality:
   - MCP tools should work as before
   - Schema validation should properly reject missing `chart_type`
   - Identifier lookup should work with both numeric IDs and UUIDs

## Additional Information

- No breaking changes to API contracts
- Only improves LLM client usability through better documentation and stricter validation
- Aligns with FastMCP best practices for tool documentation