### PR TITLE
perf(docker): exclude unnecessary directories from Flask reloader watch

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -80,7 +80,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0
+    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*"
     ;;
   app-gunicorn)
     echo "Starting web app..."


### PR DESCRIPTION
### SUMMARY
This PR fixes Flask development server hanging/deadlocking in Docker environments by excluding unnecessary directories from the file watcher.

Adds `--exclude-patterns` to the Flask development server to prevent watching `node_modules`, `.venv`, `build`, and `__pycache__` directories. This reduces inotify watch usage from ~285k to ~9.4k files per instance (97% reduction).

**Problem:** The Flask reloader with watchdog was attempting to watch all ~285k files in the mounted volumes, exceeding typical inotify watch limits and causing the server to hang during initialization.

**Solution:** Exclude directories that don't need to be watched for Python code changes, dramatically reducing resource usage and preventing the deadlock.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend performance improvement

### TESTING INSTRUCTIONS
1. Start Superset in development mode using `docker-compose-light.yml`
2. Verify Flask starts successfully with `--reload` enabled
3. Verify health endpoint responds: `curl http://localhost:8088/health`
4. Optional: Monitor inotify usage to confirm reduction in watch count

### ADDITIONAL INFORMATION
- [ ] Has associated issue: Fixes hanging Flask dev server in Docker
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

**Benefits:**
- Enables running multiple Superset instances on same Docker host
- Reduces system resource usage (inotify watches)
- Faster Flask reloader initialization
- More stable development environment