### PR TITLE
test(table): remove conditionals from TableChart tests 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -655,6 +655,7 @@ describe('plugin-chart-table', () => {
         // Third assertion: ALL aria-labelledby values should be valid
         cellsWithLabels.forEach(cell => {
           const labelledBy = cell.getAttribute('aria-labelledby');
+          expect(labelledBy).not.toBeNull();
           expect(labelledBy).toEqual(expect.stringMatching(/\S/));
           const labelledByValue = labelledBy as string;
           // Check that the ID doesn't contain spaces (would be interpreted as multiple IDs)
@@ -754,6 +755,7 @@ describe('plugin-chart-table', () => {
         // Third assertion: ALL aria-labelledby values should be valid
         cellsWithLabels.forEach(cell => {
           const labelledBy = cell.getAttribute('aria-labelledby');
+          expect(labelledBy).not.toBeNull();
           expect(labelledBy).toEqual(expect.stringMatching(/\S/));
           const labelledByValue = labelledBy as string;
           // Verify no spaces (would be interpreted as multiple IDs)

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -655,8 +655,7 @@ describe('plugin-chart-table', () => {
         // Third assertion: ALL aria-labelledby values should be valid
         cellsWithLabels.forEach(cell => {
           const labelledBy = cell.getAttribute('aria-labelledby');
-          expect(labelledBy).not.toBeNull();
-          expect(labelledBy).not.toBe('');
+          expect(labelledBy).toEqual(expect.stringMatching(/\S/));
           const labelledByValue = labelledBy as string;
           // Check that the ID doesn't contain spaces (would be interpreted as multiple IDs)
           expect(labelledByValue).not.toMatch(/\s/);
@@ -755,8 +754,7 @@ describe('plugin-chart-table', () => {
         // Third assertion: ALL aria-labelledby values should be valid
         cellsWithLabels.forEach(cell => {
           const labelledBy = cell.getAttribute('aria-labelledby');
-          expect(labelledBy).not.toBeNull();
-          expect(labelledBy).not.toBe('');
+          expect(labelledBy).toEqual(expect.stringMatching(/\S/));
           const labelledByValue = labelledBy as string;
           // Verify no spaces (would be interpreted as multiple IDs)
           expect(labelledByValue).not.toMatch(/\s/);

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -25,6 +25,33 @@ import DateWithFormatter from '../src/utils/DateWithFormatter';
 import testData from './testData';
 import { ProviderWrapper } from './testHelpers';
 
+const expectValidAriaLabels = (container: HTMLElement) => {
+  const allCells = container.querySelectorAll('tbody td');
+  const cellsWithLabels = container.querySelectorAll(
+    'tbody td[aria-labelledby]',
+  );
+
+  // Table must render data cells (catch empty table regression)
+  expect(allCells.length).toBeGreaterThan(0);
+
+  // ALL data cells must have aria-labelledby (no unlabeled cells)
+  expect(cellsWithLabels.length).toBe(allCells.length);
+
+  // ALL aria-labelledby values should be valid
+  cellsWithLabels.forEach(cell => {
+    const labelledBy = cell.getAttribute('aria-labelledby');
+    expect(labelledBy).not.toBeNull();
+    expect(labelledBy).toEqual(expect.stringMatching(/\S/));
+    const labelledByValue = labelledBy as string;
+    expect(labelledByValue).not.toMatch(/\s/);
+    expect(labelledByValue).not.toMatch(/[%#△]/);
+    const referencedHeader = container.querySelector(
+      `#${CSS.escape(labelledByValue)}`,
+    );
+    expect(referencedHeader).toBeTruthy();
+  });
+};
+
 test('sanitizeHeaderId should sanitize percent sign', () => {
   expect(sanitizeHeaderId('%pct_nice')).toBe('percentpct_nice');
 });
@@ -641,33 +668,7 @@ describe('plugin-chart-table', () => {
 
         const { container } = render(<TableChart {...props} sticky={false} />);
 
-        const allCells = container.querySelectorAll('tbody td');
-        const cellsWithLabels = container.querySelectorAll(
-          'tbody td[aria-labelledby]',
-        );
-
-        // First assertion: Table must render data cells (catch empty table regression)
-        expect(allCells.length).toBeGreaterThan(0);
-
-        // Second assertion: ALL data cells must have aria-labelledby (no unlabeled cells)
-        expect(cellsWithLabels.length).toBe(allCells.length);
-
-        // Third assertion: ALL aria-labelledby values should be valid
-        cellsWithLabels.forEach(cell => {
-          const labelledBy = cell.getAttribute('aria-labelledby');
-          expect(labelledBy).not.toBeNull();
-          expect(labelledBy).toEqual(expect.stringMatching(/\S/));
-          const labelledByValue = labelledBy as string;
-          // Check that the ID doesn't contain spaces (would be interpreted as multiple IDs)
-          expect(labelledByValue).not.toMatch(/\s/);
-          // Check that the ID doesn't contain special characters
-          expect(labelledByValue).not.toMatch(/[%#△]/);
-          // Verify the referenced header actually exists
-          const referencedHeader = container.querySelector(
-            `#${CSS.escape(labelledByValue)}`,
-          );
-          expect(referencedHeader).toBeTruthy();
-        });
+        expectValidAriaLabels(container);
       });
 
       test('should set meaningful header IDs for regular table columns', () => {
@@ -741,33 +742,7 @@ describe('plugin-chart-table', () => {
           }),
         );
 
-        const allCells = container.querySelectorAll('tbody td');
-        const cellsWithLabels = container.querySelectorAll(
-          'tbody td[aria-labelledby]',
-        );
-
-        // First assertion: Table must render data cells (catch empty table regression)
-        expect(allCells.length).toBeGreaterThan(0);
-
-        // Second assertion: ALL data cells must have aria-labelledby (no unlabeled cells)
-        expect(cellsWithLabels.length).toBe(allCells.length);
-
-        // Third assertion: ALL aria-labelledby values should be valid
-        cellsWithLabels.forEach(cell => {
-          const labelledBy = cell.getAttribute('aria-labelledby');
-          expect(labelledBy).not.toBeNull();
-          expect(labelledBy).toEqual(expect.stringMatching(/\S/));
-          const labelledByValue = labelledBy as string;
-          // Verify no spaces (would be interpreted as multiple IDs)
-          expect(labelledByValue).not.toMatch(/\s/);
-          // Verify no special characters
-          expect(labelledByValue).not.toMatch(/[%#△]/);
-          // Verify the referenced header actually exists
-          const referencedHeader = container.querySelector(
-            `#${CSS.escape(labelledByValue)}`,
-          );
-          expect(referencedHeader).toBeTruthy();
-        });
+        expectValidAriaLabels(container);
       });
 
       test('render cell bars properly, and only when it is toggled on in both regular and percent metrics', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In #35968 I introduced tests with conditionals in it which could prevent parts of the validation to not run. This PR corrects this. Remove conditional logic from table tests following the testing best practice: "tests should not contain conditionals." Split 2 tests with `if` statements into 4 unconditional tests with explicit assertions, and significantly improve ARIA accessibility validation.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
