### PR TITLE
fix(datasets): prevent viewport overflow in dataset creation page

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -331,7 +331,7 @@ const DatasetPanel = ({
             }
             title={tableName || ''}
           >
-            <Icons.InsertRowAboveOutlined />
+            <Icons.InsertRowAboveOutlined iconSize="xxl" />
             {tableName}
           </StyledHeader>
         </>

--- a/superset-frontend/src/features/datasets/styles.ts
+++ b/superset-frontend/src/features/datasets/styles.ts
@@ -46,7 +46,8 @@ const Row = styled.div`
 `;
 
 export const OuterRow = styled(Row)`
-  flex: 1 0 auto;
+  flex: 1 0 0;
+  min-height: 0;
   position: relative;
 `;
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**PROBLEM**
When selecting a dataset source in the dataset creation page, if the table had many columns, the column list would expand beyond the viewport height. 
This pushed the footer buttons ("Cancel" and "Create and explore dataset") below the fold, making them inaccessible without scrolling. 
The root cause was that the OuterRow container had `flex: 1 0 auto`, which allowed it to grow infinitely but prevented it from shrinking to fit within the viewport. 
Both the left panel (table selector) and right panel (column list) could expand the entire row beyond viewport boundaries. Additionally, the table icon in the dataset panel header was too small and difficult to see.

**SOLUTION**

`Layout Fix:`
Updated OuterRow flex properties in styles.ts:
Changed `flex: 1 0 auto` to `flex: 1 0 0` (flex-basis: 0 instead of auto)
Added `min-height: 0` to enable proper flex shrinking behavior
These changes allow the container to respect viewport constraints while the nested panels handle overflow with their existing overflow: auto styles

`Icon Enhancement:`
Increased the InsertRowAboveOutlined icon size to xxl for better visibility in the dataset panel header

`Testing:`
Added test to verify OuterRow has correct flex constraints (flex-grow: 1, min-height: 0)
Added regression test with 100 columns to ensure footer remains in DOM with large content

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

- Before
<img width="1735" height="1241" alt="before-1" src="https://github.com/user-attachments/assets/c4930fb7-47fd-4b2a-893a-e83e613f4530" />

- After
<img width="1654" height="1255" alt="after-1" src="https://github.com/user-attachments/assets/a7c77494-aef2-4fcf-bc60-2ecc69bd5eba" />

- Before 
<img width="1732" height="1247" alt="before-2" src="https://github.com/user-attachments/assets/b71cdea1-c60e-4e21-955a-fd89d3c9d68e" />

- After
<img width="1654" height="1258" alt="after-2" src="https://github.com/user-attachments/assets/dc1ac12f-be7b-46a5-8e6f-1e94223a67d0" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Navigate to the dataset creation page (Data → Datasets → + Dataset)
2. Select a database and schema
3. Select a table with many columns
4. Verify the column list scrolls within its container
5. Verify the "Cancel" and "Create and explore dataset" buttons remain visible at the bottom of the viewport without scrolling

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
