### PR TITLE
test: fix flaky MySQL integration test in test_update_v1_response

### DIFF
--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -406,6 +406,8 @@ class TestChartsUpdateCommand(SupersetTestCase):
         chart_to_update = db.session.query(Slice).get(pk)
         chart_to_update.last_saved_at = datetime.now()
         db.session.commit()
+        # Refresh to get the database value with MySQL's truncated microseconds
+        db.session.refresh(chart_to_update)
         last_saved_before = chart_to_update.last_saved_at
 
         command = UpdateChartCommand(

--- a/tests/integration_tests/charts/commands_tests.py
+++ b/tests/integration_tests/charts/commands_tests.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import time
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -370,22 +372,54 @@ class TestChartsUpdateCommand(SupersetTestCase):
     @patch("superset.utils.core.g")
     @patch("superset.security.manager.g")
     @pytest.mark.usefixtures("load_energy_table_with_slice")
-    def test_update_v1_response(self, mock_sm_g, mock_c_g, mock_u_g):
-        """Test that a chart command updates properties"""
+    def test_update_sets_last_saved_at(self, mock_sm_g, mock_c_g, mock_u_g):
+        """Test that update sets last_saved_at when previously unset"""
         pk = db.session.query(Slice).all()[0].id
         user = security_manager.find_user(username="admin")
         mock_u_g.user = mock_c_g.user = mock_sm_g.user = user
-        model_id = pk
-        json_obj = {
-            "description": "test for update",
-            "cache_timeout": None,
-            "owners": [user.id],
-        }
-        command = UpdateChartCommand(model_id, json_obj)
-        last_saved_before = db.session.query(Slice).get(pk).last_saved_at
+
+        # Explicitly set last_saved_at to None to test None -> datetime transition
+        chart_to_update = db.session.query(Slice).get(pk)
+        chart_to_update.last_saved_at = None
+        db.session.commit()
+
+        command = UpdateChartCommand(
+            pk,
+            {"description": "test", "owners": [user.id]},
+        )
         command.run()
+
         chart = db.session.query(Slice).get(pk)
-        assert chart.last_saved_at != last_saved_before
+        assert chart.last_saved_at is not None
+        assert chart.last_saved_by == user
+
+    @patch("superset.commands.chart.update.g")
+    @patch("superset.utils.core.g")
+    @patch("superset.security.manager.g")
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_update_changes_last_saved_at(self, mock_sm_g, mock_c_g, mock_u_g):
+        """Test that update changes last_saved_at when it already has a value"""
+        pk = db.session.query(Slice).all()[0].id
+        user = security_manager.find_user(username="admin")
+        mock_u_g.user = mock_c_g.user = mock_sm_g.user = user
+
+        chart_to_update = db.session.query(Slice).get(pk)
+        chart_to_update.last_saved_at = datetime.now()
+        db.session.commit()
+        last_saved_before = chart_to_update.last_saved_at
+
+        command = UpdateChartCommand(
+            pk,
+            {"description": "test", "owners": [user.id]},
+        )
+        # Sleep to ensure timestamp differs at MySQL's second precision (DATETIME(0))
+        time.sleep(1)
+        command.run()
+
+        chart = db.session.query(Slice).get(pk)
+        assert chart.last_saved_at.replace(microsecond=0) != last_saved_before.replace(
+            microsecond=0
+        )
         assert chart.last_saved_by == user
 
     @patch("superset.utils.core.g")


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes intermittent test failure in tests/integration_tests/charts/commands_tests.py::TestChartsUpdateCommand::test_update_v1_response that occurred on MySQL due to datetime precision handling with the error:

```
FAILED tests/integration_tests/charts/commands_tests.py::TestChartsUpdateCommand::test_update_v1_response - 
assert datetime.datetime(2025, 11, 17, 18, 27, 41) != datetime.datetime(2025, 11, 17, 18, 27, 41) + 
where datetime.datetime(2025, 11, 17, 18, 27, 41) = Average and Sum Trends.last_saved_at
 ```

  **Root Cause:**
  - MySQL's DATETIME type defaults to second-level precision, truncating microseconds from Python's datetime.now()
  - When the original test executed in under one second, timestamps appeared identical at second precision
  - Initial fix attempt added .replace(microsecond=0) for comparison, but failed when last_saved_at was None

  **Solution:**
  Split the original test into two focused, deterministic tests:

  1. test_update_sets_last_saved_at: Tests None → datetime transition
    - Explicitly sets last_saved_at = None before update
    - Verifies field gets populated after update
    - No sleep needed
  2. test_update_changes_last_saved_at: Tests datetime → datetime transition
    - Seeds last_saved_at = datetime.now() before update
    - Sleeps 1 second to guarantee crossing second boundary for MySQL
    - Uses .replace(microsecond=0) for database-agnostic comparison
    - Verifies timestamp actually changed

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
