### PR TITLE
fix: Table chart types headers are offset from the columns in the table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -166,7 +166,7 @@ function StickyWrap({
   const scrollBodyRef = useRef<HTMLDivElement>(null); // main body
 
   const scrollBarSize = getScrollBarSize();
-  const { bodyHeight, columnWidths } = sticky;
+  const { bodyHeight, columnWidths, hasVerticalScroll } = sticky;
   const needSizer =
     !columnWidths ||
     sticky.width !== maxWidth ||
@@ -283,13 +283,18 @@ function StickyWrap({
       </colgroup>
     );
 
+    const headerContainerWidth = hasVerticalScroll
+      ? maxWidth - scrollBarSize
+      : maxWidth;
+
     headerTable = (
       <div
         key="header"
         ref={scrollHeaderRef}
         style={{
           overflow: 'hidden',
-          scrollbarGutter: 'stable',
+          width: headerContainerWidth,
+          boxSizing: 'border-box',
         }}
         role="presentation"
       >
@@ -309,7 +314,8 @@ function StickyWrap({
         ref={scrollFooterRef}
         style={{
           overflow: 'hidden',
-          scrollbarGutter: 'stable',
+          width: headerContainerWidth,
+          boxSizing: 'border-box',
         }}
         role="presentation"
       >
@@ -339,6 +345,8 @@ function StickyWrap({
           height: bodyHeight,
           overflow: 'auto',
           scrollbarGutter: 'stable',
+          width: maxWidth,
+          boxSizing: 'border-box',
         }}
         css={scrollBarStyles}
         onScroll={sticky.hasHorizontalScroll ? onScroll : undefined}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
When the body has a vertical scrollbar, scrollbarGutter: 'stable' reserves space for it, making the content area narrower. The header container had scrollbarGutter: 'stable' but no scrollbar, causing a width mismatch.
By: 
- Removing scrollbarGutter: 'stable' from the header container
- Setting the header width to maxWidth - scrollBarSize when a vertical scrollbar is present
- The header and body containers now have matching content widths, so the columns align correctly.

### BEFORE
<img width="1380" height="743" alt="Screenshot 2025-11-21 at 19 34 55" src="https://github.com/user-attachments/assets/6462c445-fd2a-4a16-b34c-05dc5cfa64eb" />

### AFTER

<img width="1375" height="702" alt="Screenshot 2025-11-21 at 19 35 12" src="https://github.com/user-attachments/assets/96a7a701-f068-4e33-999b-d8166ed6dd50" />


### TESTING INSTRUCTIONS
1. Open a Table viz and make sure columns are correctly aligned when a scroll bar is visible

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
