### PR TITLE
fix(echarts): ensure last month label appears on time series x-axis

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -528,7 +528,7 @@ export default function transformProps(
     nameGap: convertInteger(xAxisTitleMargin),
     nameLocation: 'middle',
     axisLabel: {
-      hideOverlap: true,
+      hideOverlap: xAxisType !== AxisType.Time,
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -582,6 +582,16 @@ export default function transformProps(
     [padding.bottom, padding.left] = [padding.left, padding.bottom];
   }
 
+  // Ensure hideOverlap is false for temporal axes to show last temporal tick, true otherwise
+  // Do this after potential swap so that axis.type matches the final axis object
+  const setHideOverlap = (axis: any) => {
+    if (axis && axis.axisLabel) {
+      axis.axisLabel.hideOverlap = axis.type === AxisType.Time ? false : true;
+    }
+  };
+  setHideOverlap(xAxis);
+  setHideOverlap(yAxis);
+
   const echartOptions: EChartsCoreOption = {
     useUTC: true,
     grid: {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -27,6 +27,7 @@ import {
   SqlaFormData,
   TimeseriesAnnotationLayer,
 } from '@superset-ui/core';
+import { test } from '@jest/globals';
 import { supersetTheme } from '@apache-superset/core/ui';
 import { EchartsTimeseriesChartProps } from '../../src/types';
 import transformProps from '../../src/Timeseries/transformProps';
@@ -724,41 +725,39 @@ describe('legend sorting', () => {
   });
 });
 
-describe('x-axis label behavior', () => {
-  it('should set hideOverlap to false for time-based x-axis', () => {
-    const chartProps = new ChartProps(chartPropsConfig);
-    const transformed = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+test('x-axis label behavior - should set hideOverlap to false for time-based x-axis', () => {
+  const chartProps = new ChartProps(chartPropsConfig);
+  const transformed = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-    expect(transformed.echartOptions.xAxis).toEqual(
-      expect.objectContaining({
-        axisLabel: expect.objectContaining({
-          hideOverlap: false,
-        }),
+  expect(transformed.echartOptions.xAxis).toEqual(
+    expect.objectContaining({
+      axisLabel: expect.objectContaining({
+        hideOverlap: false,
       }),
-    );
+    }),
+  );
+});
+
+test('x-axis label behavior - should set hideOverlap to true for categorical x-axis', () => {
+  const categoricalFormData = {
+    ...formData,
+    xAxisForceCategorical: true,
+  };
+  const chartProps = new ChartProps({
+    ...chartPropsConfig,
+    formData: categoricalFormData,
   });
+  const transformed = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-  it('should set hideOverlap to true for categorical x-axis', () => {
-    const categoricalFormData = {
-      ...formData,
-      xAxisForceCategorical: true,
-    };
-    const chartProps = new ChartProps({
-      ...chartPropsConfig,
-      formData: categoricalFormData,
-    });
-    const transformed = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
-
-    expect(transformed.echartOptions.xAxis).toEqual(
-      expect.objectContaining({
-        axisLabel: expect.objectContaining({
-          hideOverlap: true,
-        }),
+  expect(transformed.echartOptions.xAxis).toEqual(
+    expect.objectContaining({
+      axisLabel: expect.objectContaining({
+        hideOverlap: true,
       }),
-    );
-  });
+    }),
+  );
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -726,18 +726,33 @@ describe('legend sorting', () => {
 });
 
 test('x-axis label behavior - should set hideOverlap to false for time-based x-axis', () => {
-  const chartProps = new ChartProps(chartPropsConfig);
-  const transformed = transformProps(
-    chartProps as EchartsTimeseriesChartProps,
-  );
-
-  expect(transformed.echartOptions.xAxis).toEqual(
-    expect.objectContaining({
-      axisLabel: expect.objectContaining({
-        hideOverlap: false,
-      }),
-    }),
-  );
+  // Create test data with proper temporal axis setup
+  const temporalFormData = {
+    ...formData,
+    granularity_sqla: '__timestamp',
+  };
+  const temporalQueriesData = [
+    {
+      data: [
+        { 'San Francisco': 1, 'New York': 2, __timestamp: 599616000000 },
+        { 'San Francisco': 3, 'New York': 4, __timestamp: 599916000000 },
+      ],
+      colnames: ['__timestamp', 'San Francisco', 'New York'],
+      coltypes: [2, 0, 0], // 2 = temporal, 0 = numeric
+    },
+  ];
+  const chartProps = new ChartProps({
+    ...chartPropsConfig,
+    formData: temporalFormData,
+    queriesData: temporalQueriesData,
+  });
+  const result = transformProps(chartProps as any);
+  const axis = Array.isArray(result.echartOptions.xAxis)
+    ? result.echartOptions.xAxis[0]
+    : result.echartOptions.xAxis;
+  expect(axis).toBeDefined();
+  // For temporal axis, hideOverlap should be false
+  expect(axis.axisLabel.hideOverlap).toBe(false);
 });
 
 test('x-axis label behavior - should set hideOverlap to true for categorical x-axis', () => {
@@ -745,19 +760,26 @@ test('x-axis label behavior - should set hideOverlap to true for categorical x-a
     ...formData,
     xAxisForceCategorical: true,
   };
+  const categoricalQueriesData = [
+    {
+      data: [
+        { category_col: 'A', 'San Francisco': 1, 'New York': 2 },
+        { category_col: 'B', 'San Francisco': 3, 'New York': 4 },
+      ],
+      colnames: ['category_col', 'San Francisco', 'New York'],
+      coltypes: [1, 0, 0], // 1 = string/categorical, 0 = numeric
+    },
+  ];
   const chartProps = new ChartProps({
     ...chartPropsConfig,
     formData: categoricalFormData,
+    queriesData: categoricalQueriesData,
   });
-  const transformed = transformProps(
-    chartProps as EchartsTimeseriesChartProps,
-  );
-
-  expect(transformed.echartOptions.xAxis).toEqual(
-    expect.objectContaining({
-      axisLabel: expect.objectContaining({
-        hideOverlap: true,
-      }),
-    }),
-  );
+  const result = transformProps(chartProps as any);
+  const axis = Array.isArray(result.echartOptions.xAxis)
+    ? result.echartOptions.xAxis[0]
+    : result.echartOptions.xAxis;
+  expect(axis).toBeDefined();
+  // For categorical axis, hideOverlap should be true
+  expect(axis.axisLabel.hideOverlap).toBe(true);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -723,3 +723,42 @@ describe('legend sorting', () => {
     ]);
   });
 });
+
+describe('x-axis label behavior', () => {
+  it('should set hideOverlap to false for time-based x-axis', () => {
+    const chartProps = new ChartProps(chartPropsConfig);
+    const transformed = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformed.echartOptions.xAxis).toEqual(
+      expect.objectContaining({
+        axisLabel: expect.objectContaining({
+          hideOverlap: false,
+        }),
+      }),
+    );
+  });
+
+  it('should set hideOverlap to true for categorical x-axis', () => {
+    const categoricalFormData = {
+      ...formData,
+      xAxisForceCategorical: true,
+    };
+    const chartProps = new ChartProps({
+      ...chartPropsConfig,
+      formData: categoricalFormData,
+    });
+    const transformed = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformed.echartOptions.xAxis).toEqual(
+      expect.objectContaining({
+        axisLabel: expect.objectContaining({
+          hideOverlap: true,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### SUMMARY
Fixes #33905 

This PR resolves an issue where the last month's label doesn't appear on the X-axis for Time Series Line Charts with monthly time grain.

### DESCRIPTION OF CHANGE
The issue was caused by the `hideOverlap: true` setting in the x-axis label configuration, which prevented the final label from displaying when ECharts detected potential overlap.

**Changes made:**
1. **Updated** `superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts`
   - Modified `axisLabel.hideOverlap` logic to set `false` for time-based axes (AxisType.Time)
   - Set `true` for categorical/value axes to maintain overlap prevention for non-time axes

2. **Added** tests in `superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts`
   - Test verifying `hideOverlap: false` for time-based x-axis
   - Test verifying `hideOverlap: true` for categorical x-axis (when `xAxisForceCategorical` is enabled)

### CHECKLIST
- [x] Has associated issue: #33905
- [ ] Required feature flags:
- [ ] Change will be tested in Cypress tests
- [ ] Code follows style guidelines
- [ ] Tests pass locally with my changes
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary
- [ ] Added an entry to UPDATING.md for any breaking changes or significant updates

### ADDITIONAL NOTES
This fix specifically targets time-based axes where showing all temporal labels (including the last one) is important for data interpretation. For categorical and value axes, overlap prevention remains enabled to maintain readability.