### PR TITLE
fix(storybook): import exampleThemes from correct package

### DIFF
--- a/superset-frontend/.storybook/preview.jsx
+++ b/superset-frontend/.storybook/preview.jsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 import { withJsx } from '@mihkeleidast/storybook-addon-source';
-import { exampleThemes } from '@superset-ui/core';
-import { themeObject, css } from '@apache-superset/core/ui';
+import { exampleThemes, themeObject, css } from '@apache-superset/core/ui';
 import { combineReducers, createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';


### PR DESCRIPTION

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Import exampleThemes from @apache-superset/core/ui instead of @superset-ui/core to fix webpack warnings during Storybook build.

The exampleThemes export is part of the new @apache-superset/core package and was causing 'export not found' warnings when imported from the legacy @superset-ui/core package.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1910" height="797" alt="Screenshot 2025-11-20 at 12 02 53" src="https://github.com/user-attachments/assets/80831974-c586-4d7e-8313-6592ef7fcd5b" />




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
