### PR TITLE
fix(SearchFilter): prevent unintended autocomplete on search input

### DIFF
--- a/superset-frontend/src/components/ListView/Filters/Search.test.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.test.tsx
@@ -35,6 +35,7 @@ const defaultProps = {
   initialValue: '',
   toolTipDescription: undefined,
   onSubmit: mockOnSubmit,
+  autoComplete: undefined,
 };
 
 const setup = (props = {}) =>
@@ -171,27 +172,16 @@ test('uses custom name attribute when provided', () => {
   expect(input.name).toBe('custom-search-name');
 });
 
-test('generates random name when name is "name"', () => {
-  setup({ name: 'name' });
+test('sets autocomplete to off by default', () => {
+  setup();
   const input = screen.getByTestId('filters-search') as HTMLInputElement;
-  expect(input.name).toMatch(/^search-filter-[a-z0-9]{6}$/);
+  expect(input.autocomplete).toBe('off');
 });
 
-test('generates different random names for multiple instances', () => {
-  const { rerender } = render(
-    <SearchFilter {...defaultProps} name="name" />,
-  );
-  const firstInput = screen.getByTestId('filters-search') as HTMLInputElement;
-  const firstName = firstInput.name;
-
-  rerender(<SearchFilter {...defaultProps} name="name" />);
-  const secondInput = screen.getByTestId('filters-search') as HTMLInputElement;
-  const secondName = secondInput.name;
-
-  // Names should be different (though there's a tiny chance they could be the same)
-  // At minimum, they should match the pattern
-  expect(firstName).toMatch(/^search-filter-[a-z0-9]{6}$/);
-  expect(secondName).toMatch(/^search-filter-[a-z0-9]{6}$/);
+test('uses custom autocomplete value when provided', () => {
+  setup({ autoComplete: 'new-password' });
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.autocomplete).toBe('new-password');
 });
 
 test('renders with allowClear prop', () => {

--- a/superset-frontend/src/components/ListView/Filters/Search.test.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import SearchFilter from './Search';
+import type { FilterHandler } from './types';
+
+const mockOnSubmit = jest.fn();
+
+const defaultProps = {
+  Header: 'Search Header',
+  name: 'search-input',
+  initialValue: '',
+  toolTipDescription: undefined,
+  onSubmit: mockOnSubmit,
+};
+
+const setup = (props = {}) =>
+  render(<SearchFilter {...defaultProps} {...props} />);
+
+beforeEach(() => {
+  mockOnSubmit.mockClear();
+});
+
+test('renders search filter with header', () => {
+  setup();
+  expect(screen.getByText('Search Header')).toBeInTheDocument();
+});
+
+test('renders input with placeholder', () => {
+  setup();
+  expect(screen.getByPlaceholderText('Type a value')).toBeInTheDocument();
+});
+
+test('renders search icon', () => {
+  setup();
+  expect(screen.getByTestId('filters-search')).toBeInTheDocument();
+  // The icon should be present as a prefix
+  const input = screen.getByTestId('filters-search');
+  expect(input.parentElement?.querySelector('.anticon-search')).toBeTruthy();
+});
+
+test('renders with initial value', () => {
+  setup({ initialValue: 'initial search term' });
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.value).toBe('initial search term');
+});
+
+test('renders tooltip when toolTipDescription is provided', () => {
+  setup({ toolTipDescription: 'This is a helpful tooltip' });
+  const tooltip = screen.getByRole('img', { name: /info-circle/i });
+  expect(tooltip).toBeInTheDocument();
+});
+
+test('does not render tooltip when toolTipDescription is undefined', () => {
+  setup({ toolTipDescription: undefined });
+  const tooltip = screen.queryByRole('img', { name: /info-circle/i });
+  expect(tooltip).not.toBeInTheDocument();
+});
+
+test('updates input value on change', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+
+  await userEvent.type(input, 'test query');
+
+  expect(input.value).toBe('test query');
+});
+
+test('calls onSubmit with trimmed value on blur', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.type(input, '  search term  ');
+  await userEvent.tab(); // Trigger blur
+
+  await waitFor(() => {
+    expect(mockOnSubmit).toHaveBeenCalledWith('search term');
+  });
+});
+
+test('calls onSubmit with trimmed value on Enter key', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.type(input, '  another search  ');
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+  await waitFor(() => {
+    expect(mockOnSubmit).toHaveBeenCalledWith('another search');
+  });
+});
+
+test('calls onSubmit with empty string when input is cleared', async () => {
+  setup({ initialValue: 'initial value' });
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.clear(input);
+
+  await waitFor(() => {
+    expect(mockOnSubmit).toHaveBeenCalledWith('');
+  });
+});
+
+test('does not call onSubmit when empty value is submitted on blur', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.click(input);
+  await userEvent.tab(); // Trigger blur without typing
+
+  // onSubmit should not be called for empty value on blur/enter
+  expect(mockOnSubmit).not.toHaveBeenCalled();
+});
+
+test('calls onSubmit with empty string when only whitespace is entered and cleared', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.type(input, '   ');
+
+  // When cleared (which happens when the value becomes empty), onSubmit is called with ''
+  await userEvent.clear(input);
+
+  await waitFor(() => {
+    expect(mockOnSubmit).toHaveBeenCalledWith('');
+  });
+});
+
+test('clearFilter resets value and calls onSubmit with empty string', async () => {
+  const ref = createRef<FilterHandler>();
+  render(<SearchFilter {...defaultProps} initialValue="test" ref={ref} />);
+
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.value).toBe('test');
+
+  // Call clearFilter via ref
+  ref.current?.clearFilter();
+
+  await waitFor(() => {
+    expect(input.value).toBe('');
+    expect(mockOnSubmit).toHaveBeenCalledWith('');
+  });
+});
+
+test('uses custom name attribute when provided', () => {
+  setup({ name: 'custom-search-name' });
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.name).toBe('custom-search-name');
+});
+
+test('generates random name when name is "name"', () => {
+  setup({ name: 'name' });
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.name).toMatch(/^search-filter-[a-z0-9]{6}$/);
+});
+
+test('generates different random names for multiple instances', () => {
+  const { rerender } = render(
+    <SearchFilter {...defaultProps} name="name" />,
+  );
+  const firstInput = screen.getByTestId('filters-search') as HTMLInputElement;
+  const firstName = firstInput.name;
+
+  rerender(<SearchFilter {...defaultProps} name="name" />);
+  const secondInput = screen.getByTestId('filters-search') as HTMLInputElement;
+  const secondName = secondInput.name;
+
+  // Names should be different (though there's a tiny chance they could be the same)
+  // At minimum, they should match the pattern
+  expect(firstName).toMatch(/^search-filter-[a-z0-9]{6}$/);
+  expect(secondName).toMatch(/^search-filter-[a-z0-9]{6}$/);
+});
+
+test('renders with allowClear prop', () => {
+  setup({ initialValue: 'test value' });
+  const input = screen.getByTestId('filters-search');
+  // Ant Design Input with allowClear should have a clear button when there's a value
+  expect(input).toBeInTheDocument();
+});
+
+test('multiple rapid changes only submit the final value', async () => {
+  setup();
+  const input = screen.getByTestId('filters-search');
+
+  await userEvent.type(input, 'first');
+  await userEvent.type(input, ' second');
+  await userEvent.type(input, ' third');
+  await userEvent.tab();
+
+  await waitFor(() => {
+    expect(mockOnSubmit).toHaveBeenCalledWith('first second third');
+    // Should only be called once on blur, not for each keystroke
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('handles programmatic value changes through clearFilter', async () => {
+  const ref = createRef<FilterHandler>();
+  render(
+    <SearchFilter {...defaultProps} initialValue="initial value" ref={ref} />,
+  );
+
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+
+  // Type something new
+  await userEvent.clear(input);
+  await userEvent.type(input, 'new value');
+  expect(input.value).toBe('new value');
+
+  // Clear using ref
+  ref.current?.clearFilter();
+
+  await waitFor(() => {
+    expect(input.value).toBe('');
+    expect(mockOnSubmit).toHaveBeenCalledWith('');
+  });
+});

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -42,6 +42,7 @@ interface SearchHeaderProps extends BaseFilter {
   onSubmit: (val: string) => void;
   name: string;
   toolTipDescription: string | undefined;
+  autoComplete?: string;
 }
 
 function SearchFilter(
@@ -51,6 +52,7 @@ function SearchFilter(
     initialValue,
     toolTipDescription,
     onSubmit,
+    autoComplete = 'off',
   }: SearchHeaderProps,
   ref: RefObject<FilterHandler>,
 ) {
@@ -75,13 +77,6 @@ function SearchFilter(
     },
   }));
 
-  // if name is equal to 'name', use 'search-filter-' concatenated with a
-  // random string of 6 chars to avoid auto-fill issues with the browser.
-  let searchName = name;
-  if (name === 'name') {
-    searchName = `search-filter-${Math.random().toString(36).substring(2, 8)}`;
-  }
-
   return (
     <FilterContainer
       data-test="search-filter-container"
@@ -98,7 +93,8 @@ function SearchFilter(
         allowClear
         data-test="filters-search"
         placeholder={t('Type a value')}
-        name={searchName}
+        autoComplete={autoComplete || 'off'}
+        name={name}
         value={value}
         onChange={handleChange}
         onPressEnter={handleSubmit}

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -75,6 +75,13 @@ function SearchFilter(
     },
   }));
 
+  // if name is equal to 'name', use 'search-filter-' concatenated with a
+  // random string of 6 chars to avoid auto-fill issues with the browser.
+  let searchName = name;
+  if (name === 'name') {
+    searchName = `search-filter-${Math.random().toString(36).substring(2, 8)}`;
+  }
+
   return (
     <FilterContainer
       data-test="search-filter-container"
@@ -91,12 +98,11 @@ function SearchFilter(
         allowClear
         data-test="filters-search"
         placeholder={t('Type a value')}
-        name={name}
+        name={searchName}
         value={value}
         onChange={handleChange}
         onPressEnter={handleSubmit}
         onBlur={handleSubmit}
-        data-1p-ignore
         prefix={
           <Icons.SearchOutlined iconColor={theme.colorIcon} iconSize="l" />
         }

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -93,7 +93,7 @@ function SearchFilter(
         allowClear
         data-test="filters-search"
         placeholder={t('Type a value')}
-        autoComplete={autoComplete || 'off'}
+        autoComplete={autoComplete}
         name={name}
         value={value}
         onChange={handleChange}

--- a/superset-frontend/src/components/ListView/Filters/Search.tsx
+++ b/superset-frontend/src/components/ListView/Filters/Search.tsx
@@ -96,6 +96,7 @@ function SearchFilter(
         onChange={handleChange}
         onPressEnter={handleSubmit}
         onBlur={handleSubmit}
+        data-1p-ignore
         prefix={
           <Icons.SearchOutlined iconColor={theme.colorIcon} iconSize="l" />
         }

--- a/superset-frontend/src/components/ListView/Filters/index.test.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from 'spec/helpers/testing-library';
+import { ListViewFilterOperator } from '../types';
+import UIFilters from './index';
+
+const mockUpdateFilterValue = jest.fn();
+
+beforeEach(() => {
+  mockUpdateFilterValue.mockClear();
+});
+
+test('search filter uses id as input name when inputName is not provided', () => {
+  const filters = [
+    {
+      Header: 'Name',
+      key: 'name',
+      id: 'name',
+      input: 'search' as const,
+      operator: ListViewFilterOperator.Contains,
+    },
+  ];
+
+  render(
+    <UIFilters
+      filters={filters}
+      internalFilters={[]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.name).toBe('name');
+});
+
+test('search filter uses inputName when provided instead of id', () => {
+  const filters = [
+    {
+      Header: 'Name',
+      key: 'name',
+      id: 'name',
+      input: 'search' as const,
+      operator: ListViewFilterOperator.Contains,
+      inputName: 'custom_search_name',
+    },
+  ];
+
+  render(
+    <UIFilters
+      filters={filters}
+      internalFilters={[]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.name).toBe('custom_search_name');
+});
+
+test('search filter passes autoComplete prop correctly', () => {
+  const filters = [
+    {
+      Header: 'Name',
+      key: 'name',
+      id: 'name',
+      input: 'search' as const,
+      operator: ListViewFilterOperator.Contains,
+      autoComplete: 'new-password',
+    },
+  ];
+
+  render(
+    <UIFilters
+      filters={filters}
+      internalFilters={[]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  const input = screen.getByTestId('filters-search') as HTMLInputElement;
+  expect(input.autocomplete).toBe('new-password');
+});
+
+test('renders multiple search filters with different inputName values', () => {
+  const filters = [
+    {
+      Header: 'Name',
+      key: 'name',
+      id: 'name',
+      input: 'search' as const,
+      operator: ListViewFilterOperator.Contains,
+      inputName: 'filter_name_search',
+    },
+    {
+      Header: 'Description',
+      key: 'description',
+      id: 'description',
+      input: 'search' as const,
+      operator: ListViewFilterOperator.Contains,
+      // No inputName - should use id
+    },
+  ];
+
+  render(
+    <UIFilters
+      filters={filters}
+      internalFilters={[]}
+      updateFilterValue={mockUpdateFilterValue}
+    />,
+  );
+
+  const inputs = screen.getAllByTestId('filters-search') as HTMLInputElement[];
+  expect(inputs).toHaveLength(2);
+  expect(inputs[0].name).toBe('filter_name_search');
+  expect(inputs[1].name).toBe('description');
+});

--- a/superset-frontend/src/components/ListView/Filters/index.tsx
+++ b/superset-frontend/src/components/ListView/Filters/index.tsx
@@ -81,6 +81,8 @@ function UIFilters(
             min,
             max,
             dropdownStyle,
+            autoComplete,
+            inputName,
           },
           index,
         ) => {
@@ -121,7 +123,7 @@ function UIFilters(
                 Header={Header}
                 initialValue={initialValue}
                 key={key}
-                name={id}
+                name={inputName ?? id}
                 toolTipDescription={toolTipDescription}
                 onSubmit={(value: string) => {
                   if (onFilterUpdate) {
@@ -130,6 +132,7 @@ function UIFilters(
 
                   updateFilterValue(index, value);
                 }}
+                autoComplete={autoComplete}
               />
             );
           }

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -65,6 +65,8 @@ export interface ListViewFilter {
   min?: number;
   max?: number;
   dropdownStyle?: React.CSSProperties;
+  autoComplete?: string;
+  inputName?: string;
 }
 
 export type ListViewFilters = ListViewFilter[];

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -471,6 +471,7 @@ function AlertList({
         id: 'name',
         input: 'search',
         operator: FilterOperator.Contains,
+        inputName: 'alert_report_list_search',
       },
       {
         Header: t('Owner'),

--- a/superset-frontend/src/pages/AnnotationLayerList/index.tsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/index.tsx
@@ -255,6 +255,7 @@ function AnnotationLayersList({
         id: 'name',
         input: 'search',
         operator: FilterOperator.Contains,
+        inputName: 'annotation_layer_list_search',
       },
       {
         Header: t('Changed by'),

--- a/superset-frontend/src/pages/GroupsList/index.tsx
+++ b/superset-frontend/src/pages/GroupsList/index.tsx
@@ -299,6 +299,7 @@ function GroupsList({ user }: GroupsListProps) {
         id: 'name',
         input: 'search',
         operator: ListViewFilterOperator.Contains,
+        inputName: 'group_list_search',
       },
       {
         Header: t('Label'),

--- a/superset-frontend/src/pages/RolesList/index.tsx
+++ b/superset-frontend/src/pages/RolesList/index.tsx
@@ -300,6 +300,7 @@ function RolesList({ addDangerToast, addSuccessToast, user }: RolesListProps) {
         id: 'name',
         input: 'search',
         operator: FilterOperator.Contains,
+        inputName: 'role_list_search',
       },
       {
         Header: t('Users'),

--- a/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
@@ -266,6 +266,7 @@ function RowLevelSecurityList(props: RLSProps) {
         id: 'name',
         input: 'search',
         operator: FilterOperator.StartsWith,
+        inputName: 'rls_list_search',
       },
       {
         Header: t('Filter Type'),

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -266,6 +266,7 @@ function TagList(props: TagListProps) {
         id: 'name',
         input: 'search',
         operator: FilterOperator.Contains,
+        inputName: 'tag_list_search',
       },
       {
         Header: t('Modified by'),


### PR DESCRIPTION
## **User description**
### SUMMARY

Password managers like 1Password ignore `autocomplete="off"` when the input has `name="name"` because they recognize common field name patterns (like "name", "email", "password", etc.).
The happens only if the `ListViewFilters` has `id: 'name'` and `input: 'search'`.

Solution:
Added a new `inputName` property to the `ListViewFilter` type that allows you to set a custom name for the input element that password managers won't recognize:

1. **types.ts** - Added `inputName?: string;` to the `ListViewFilter` interface.
2. **Filters/index.tsx** - Updated to use `inputName ?? id` when passing the name prop to `SearchFilter`
3. **GroupsList/index.tsx** - Changed the `Name` filter to use `inputName: 'group_list_search'`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
## Before:
A 1password auto-fill icon was shown for some search components when the name was not passed correctly.
Resulting in an attr like the following:
```javascript
name="name"
```
<img width="718" height="552" alt="image" src="https://github.com/user-attachments/assets/48fe7200-3888-4b6b-ac66-f15b5f574935" />

## After:
#### Example of the pages failing
Annotation Layer, Alert Report List, Groups List, Roles List, Row Level Security List and Tags.

```javascript
name="annotation_layer_list_search"
```
<img width="721" height="309" alt="image" src="https://github.com/user-attachments/assets/1a0115ba-2c81-4c81-9752-f451fdb11cc4" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Login.
2. Enter user settings that has a search input box, for example **Annotations Layers**.
3. Try typing on the search box, the 1password icon **must not** appear.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Make ListView search inputs use a configurable name and autocomplete to avoid unwanted autofill

### What Changed
- Search input elements now use a provided inputName instead of the filter id when present, so each search field can have a custom name attribute
- Search inputs default autocomplete to "off" and accept a configurable autocomplete value (e.g., "new-password") to prevent password managers or browsers from showing autofill UI
- Several list pages (Alerts, Groups, Roles, RLS, Tags, Annotation Layers) set custom inputName values to avoid common field-name autofill triggers
- Unit tests added for search behavior: name handling, autocomplete handling, submit-on-blur/enter, clear behavior, and programmatic clearing

### Impact
`✅ Fewer unwanted password-manager autofill prompts`
`✅ Consistent search input names across list pages`
`✅ Clearer control over autocomplete behavior in search fields`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
