### PR TITLE
fix: adhoc column quoting

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1867,9 +1867,7 @@ class SqlaTable(
     def default_query(qry: Query) -> Query:
         return qry.filter_by(is_sqllab_view=False)
 
-    def has_extra_cache_key_calls(
-        self, query_obj: QueryObjectDict
-    ) -> bool:  # noqa: C901
+    def has_extra_cache_key_calls(self, query_obj: QueryObjectDict) -> bool:  # noqa: C901
         """
         Detects the presence of calls to `ExtraCache` methods in items in query_obj that
         can be templated. If any are present, the query must be evaluated to extract

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1529,9 +1529,10 @@ class SqlaTable(
             is_dttm = col_in_metadata.is_temporal
             pdf = col_in_metadata.python_date_format
         else:
-            # Column doesn't exist in metadata or is not a reference - treat as ad-hoc expression
-            # Note: If isColumnReference=true but column not found, we still quote it as a fallback
-            # for backwards compatibility, though this indicates the frontend sent incorrect metadata
+            # Column doesn't exist in metadata or is not a reference - treat as ad-hoc
+            # expression Note: If isColumnReference=true but column not found, we still
+            # quote it as a fallback for backwards compatibility, though this indicates
+            # the frontend sent incorrect metadata
             try:
                 # For column references, conditionally quote identifiers that need it
                 expression_to_process = sql_expression

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1509,33 +1509,34 @@ class SqlaTable(
         :rtype: sqlalchemy.sql.column
         """
         label = utils.get_column_name(col)
-        try:
-            sql_expression = col["sqlExpression"]
-
-            # For column references, conditionally quote identifiers that need it
-            if col.get("isColumnReference"):
-                sql_expression = self.database.quote_identifier(sql_expression)
-
-            expression = self._process_select_expression(
-                expression=sql_expression,
-                database_id=self.database_id,
-                engine=self.database.backend,
-                schema=self.schema,
-                template_processor=template_processor,
-            )
-        except SupersetSecurityException as ex:
-            raise QueryObjectValidationError(ex.message) from ex
+        sql_expression = col["sqlExpression"]
         time_grain = col.get("timeGrain")
         has_timegrain = col.get("columnType") == "BASE_AXIS" and time_grain
         is_dttm = False
         pdf = None
-        if col_in_metadata := self.get_column(expression):
+        if col.get("isColumnReference"):
+            col_in_metadata = self.get_column(sql_expression)
+            if col_in_metadata is None:
+                # should not happen
+                raise ColumnNotFoundException("Column not found")
+
             sqla_column = col_in_metadata.get_sqla_col(
                 template_processor=template_processor
             )
             is_dttm = col_in_metadata.is_temporal
             pdf = col_in_metadata.python_date_format
         else:
+            try:
+                expression = self._process_select_expression(
+                    expression=sql_expression,
+                    database_id=self.database_id,
+                    engine=self.database.backend,
+                    schema=self.schema,
+                    template_processor=template_processor,
+                )
+            except SupersetSecurityException as ex:
+                raise QueryObjectValidationError(ex.message) from ex
+
             sqla_column = literal_column(expression)
             if has_timegrain or force_type_check:
                 try:
@@ -1866,7 +1867,9 @@ class SqlaTable(
     def default_query(qry: Query) -> Query:
         return qry.filter_by(is_sqllab_view=False)
 
-    def has_extra_cache_key_calls(self, query_obj: QueryObjectDict) -> bool:  # noqa: C901
+    def has_extra_cache_key_calls(
+        self, query_obj: QueryObjectDict
+    ) -> bool:  # noqa: C901
         """
         Detects the presence of calls to `ExtraCache` methods in items in query_obj that
         can be templated. If any are present, the query must be evaluated to extract

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -408,8 +408,16 @@ class DBEventLogger(AbstractEventLogger):
             db.session.bulk_save_objects(logs)
             db.session.commit()  # pylint: disable=consider-using-transaction
         except SQLAlchemyError as ex:
+            # Log errors but don't raise - logging failures should not break the application
+            # Common in tests where the session may be in prepared state or db is locked
             logging.error("DBEventLogger failed to log event(s)")
             logging.exception(ex)
+            # Rollback to clean up the session state
+            try:
+                db.session.rollback()
+            except Exception:  # pylint: disable=broad-except
+                # If rollback also fails, just continue - don't let logging issues crash the app
+                pass
 
 
 class StdOutEventLogger(AbstractEventLogger):

--- a/superset/utils/log.py
+++ b/superset/utils/log.py
@@ -408,16 +408,19 @@ class DBEventLogger(AbstractEventLogger):
             db.session.bulk_save_objects(logs)
             db.session.commit()  # pylint: disable=consider-using-transaction
         except SQLAlchemyError as ex:
-            # Log errors but don't raise - logging failures should not break the application
-            # Common in tests where the session may be in prepared state or db is locked
+            # Log errors but don't raise - logging failures should not break the
+            # application. Common in tests where the session may be in prepared state or
+            # db is locked
             logging.error("DBEventLogger failed to log event(s)")
             logging.exception(ex)
             # Rollback to clean up the session state
             try:
                 db.session.rollback()
             except Exception:  # pylint: disable=broad-except
-                # If rollback also fails, just continue - don't let logging issues crash the app
-                pass
+                # If rollback also fails, just continue - don't let issues crash the app
+                logging.error(
+                    "DBEventLogger failed to rollback the session after failure"
+                )
 
 
 class StdOutEventLogger(AbstractEventLogger):

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -871,7 +871,7 @@ def test_time_column_with_time_grain(app_context, physical_dataset):
         "sqlExpression": "col6",
         "columnType": "BASE_AXIS",
         "timeGrain": "P1Y",
-        "isColumnReference": False,
+        "isColumnReference": True,
     }
     qc = QueryContextFactory().create(
         datasource={

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -864,12 +864,14 @@ def test_time_column_with_time_grain(app_context, physical_dataset):
         "label": "I_AM_AN_ORIGINAL_COLUMN",
         "sqlExpression": "col5",
         "timeGrain": "P1Y",
+        "isColumnReference": True,
     }
     adhoc_column: AdhocColumn = {
         "label": "I_AM_A_TRUNC_COLUMN",
         "sqlExpression": "col6",
         "columnType": "BASE_AXIS",
         "timeGrain": "P1Y",
+        "isColumnReference": False,
     }
     qc = QueryContextFactory().create(
         datasource={
@@ -1039,6 +1041,7 @@ def test_time_grain_and_time_offset_with_base_axis(app_context, physical_dataset
         "sqlExpression": "col6",
         "columnType": "BASE_AXIS",
         "timeGrain": "P3M",
+        "isColumnReference": True,
     }
     qc = QueryContextFactory().create(
         datasource={
@@ -1152,6 +1155,7 @@ def test_time_offset_with_temporal_range_filter(app_context, physical_dataset):
                         "sqlExpression": "col6",
                         "columnType": "BASE_AXIS",
                         "timeGrain": "P3M",
+                        "isColumnReference": True,
                     }
                 ],
                 "metrics": [

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -1641,5 +1641,3 @@ def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:
     # Verify SELECT and FROM clauses are present
     assert "SELECT" in sql
     assert "FROM" in sql
-
-    print(f"\nGenerated SQL:\n{sql}")  # This will show in test output with -v flag

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -1396,7 +1396,8 @@ def test_reapply_query_filters_with_empty_filters(database: Database) -> None:
 def test_adhoc_column_to_sqla_with_column_reference(database: Database) -> None:
     """
     Test that adhoc_column_to_sqla properly handles column references
-    by looking up the column in metadata instead of quoting and processing through SQLGlot.
+    by looking up the column in metadata instead of quoting and processing through
+    SQLGlot.
 
     This tests the fix for column names with spaces being properly handled
     without going through SQLGlot which could misinterpret "column AS alias" patterns.
@@ -1432,12 +1433,12 @@ def test_adhoc_column_to_sqla_preserves_column_type_for_time_grain(
     database: Database,
 ) -> None:
     """
-    Test that adhoc_column_to_sqla preserves column type information when using column references.
+    Test that adhoc_column_to_sqla preserves column type info in column references.
 
     This tests the fix where column references now look up metadata first, preserving
-    type information needed for time grain operations. Previously, quoting the column name
-    before metadata lookup would cause the column to not be found, resulting in NULL type
-    and failing to apply time grain transformations properly.
+    type information needed for time grain operations. Previously, quoting the column
+    name before metadata lookup would cause the column to not be found, resulting in
+    NULL type and failing to apply time grain transformations properly.
 
     The test verifies that:
     1. Column metadata is found by looking up the unquoted column name
@@ -1526,9 +1527,9 @@ def test_adhoc_column_with_spaces_generates_quoted_sql(database: Database) -> No
     Test that column names with spaces are properly quoted in the generated SQL.
 
     This verifies that even though we look up columns using unquoted names,
-    the final SQL still properly quotes column names that need quoting (like those with spaces).
+    the final SQL still properly quotes column names that need quoting (like those with
+    spaces).
     """
-    import sqlalchemy as sa
 
     from superset.connectors.sqla.models import SqlaTable, TableColumn
 
@@ -1578,7 +1579,9 @@ def test_adhoc_column_with_spaces_generates_quoted_sql(database: Database) -> No
             )
         )
 
-    assert '"Order Total"' in sql_numeric, f"Expected quoted column name in SQL: {sql_numeric}"
+    assert '"Order Total"' in sql_numeric, (
+        f"Expected quoted column name in SQL: {sql_numeric}"
+    )
 
 
 def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:
@@ -1586,7 +1589,8 @@ def test_adhoc_column_with_spaces_in_full_query(database: Database) -> None:
     Test that column names with spaces work correctly in a full SELECT query.
 
     This demonstrates that the fix properly handles column names with spaces
-    throughout the entire query generation process, with proper quoting in the final SQL.
+    throughout the entire query generation process, with proper quoting in the final
+    SQL.
     """
     import sqlalchemy as sa
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A fix for a change introduced in https://github.com/apache/superset/commit/306f4c14cf0#diff-af5e15a55ff9c81f441eb6b9b10dae13b2ee17fec614d3e3ad0057ed0dc814aeR1509. BigQuery stopped working because it always quote column names, turning foo into `foo`. This makes the check for a column to fail in:

```python
# here expression is quoted, so it doesn't match column names (`foo` vs foo).
if col_in_metadata := self.get_column(expression):
```

This makes it treat the column as an adhoc expression, which doesn't have types. For temporal columns with a time grain this means the time grain is not applied. See https://github.com/apache/superset/issues/36213.

I fixed it by not doing the quoting when we know it's a column, since we read the column using `self.get_column` and there's no need to quote.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #36213 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
