### PR TITLE
feat(word-cloud): add React component controls (POC)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -5331,6 +5331,7 @@
       "resolved": "https://registry.npmjs.org/@fontsource/fira-code/-/fira-code-5.2.7.tgz",
       "integrity": "sha512-tnB9NNund9TwIym8/7DMJe573nlPEQb+fKUV5GL8TBYXjIhDvL0D7mgmNVNQUPhXp+R7RylQeiBdkA4EbOHPGQ==",
       "license": "OFL-1.1",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
@@ -5562,7 +5563,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
       "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.0",
@@ -5584,14 +5584,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
       "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
       "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10197,92 +10195,88 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
-      "dev": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
-      "dev": true,
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/graphql": "^5.0.0",
-        "@octokit/request": "^6.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
+    },
+    "node_modules/@octokit/core/node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@octokit/core/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
-      "dev": true,
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@octokit/endpoint/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/@octokit/graphql": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
-      "dev": true,
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/request": "^6.0.0",
-        "@octokit/types": "^9.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
+    "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    },
     "node_modules/@octokit/openapi-types": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-enterprise-rest": {
       "version": "6.0.1",
@@ -10292,114 +10286,126 @@
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-      "dev": true,
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
+        "@octokit/types": "^13.10.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=4"
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@octokit/core": ">=3"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
-      "dev": true,
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/types": "^10.0.0"
+        "@octokit/types": "^13.10.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=3"
+        "@octokit/core": ">=6"
       }
     },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
     "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "dev": true,
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
-      "dev": true,
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/endpoint": "^7.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
-      "dev": true,
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
+        "@octokit/types": "^14.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@octokit/request/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/@octokit/request/node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/@octokit/rest": {
       "version": "20.1.2",
@@ -10568,25 +10574,13 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
-    "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
-      "dev": true,
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
@@ -11824,12 +11818,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/@octokit/openapi-types": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
-      "license": "MIT"
-    },
     "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.0.1.tgz",
@@ -11904,15 +11892,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/types": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
@@ -13735,16 +13714,16 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.5.1.tgz",
-      "integrity": "sha512-4zxjclENpZYuNY1fZJE4a7hd8Ho/SiOSN2B57fsIi1qCpKax3JU3J59ZcAWT0iidy5qgM2qMcWbrl0Bl/tWamA==",
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.14.tgz",
+      "integrity": "sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/csf": "0.1.12",
+        "@storybook/theming": "8.6.14",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
         "esbuild-register": "^3.5.0",
         "jsdoc-type-pratt-parser": "^4.0.0",
         "process": "^0.11.10",
@@ -14308,14 +14287,45 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@storybook/core/node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
+    "node_modules/@storybook/core/node_modules/@storybook/theming": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.14.tgz",
+      "integrity": "sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/storybook": {
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.14.tgz",
+      "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "type-fest": "^2.19.0"
+        "@storybook/core": "8.6.14"
+      },
+      "bin": {
+        "getstorybook": "bin/index.cjs",
+        "sb": "bin/index.cjs",
+        "storybook": "bin/index.cjs"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/csf": {
@@ -20354,18 +20364,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -20432,9 +20430,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21383,18 +21381,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/buf-compare": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
@@ -21974,13 +21960,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/charenc": {
       "version": "0.0.2",
@@ -27440,47 +27419,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -27650,6 +27588,29 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
@@ -30063,39 +30024,33 @@
       "license": "ISC"
     },
     "node_modules/github-username": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-8.0.0.tgz",
-      "integrity": "sha512-zq6QMHQKeGfhvdLMyT/nskL8ClE3Y9DFDRv3CgpBAIR1lGiL9GFZcgpmF0nMzegfMMLG3TmsEgHoFf8DcD25Lw==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/github-username/-/github-username-9.0.0.tgz",
+      "integrity": "sha512-lY7+mymwQUEhRwWTLxieKkxcZkVNnUh8iAGnl30DMB1ZtYODHkMAckZk8Jx5dLQs1YKPYM2ibnzQu02aCLFcYQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/rest": "^19.0.13"
+        "@octokit/rest": "^21.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/github-username/node_modules/@octokit/rest": {
-      "version": "19.0.13",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
-      "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
-      "dev": true,
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/gl-matrix": {
@@ -31976,16 +31931,16 @@
       "license": "MIT"
     },
     "node_modules/inquirer": {
-      "version": "9.3.7",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.7.tgz",
-      "integrity": "sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==",
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.8.tgz",
+      "integrity": "sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@inquirer/external-editor": "^1.0.2",
         "@inquirer/figures": "^1.0.3",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
         "mute-stream": "1.0.0",
         "ora": "^5.4.1",
         "run-async": "^3.0.0",
@@ -32166,6 +32121,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -36842,9 +36803,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
+      "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -37186,14 +37147,13 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
-      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.7",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
@@ -40714,9 +40674,10 @@
       }
     },
     "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.1.tgz",
+      "integrity": "sha512-8lqe85PkqQJzIcs2iD7xW/WSxcncC3/DPVbTOafKNJDIMXwGfwXS350mH4SJslomntN2iYtFBuC0yNO3CEap6g==",
+      "license": "MIT",
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -45666,16 +45627,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ospath": {
@@ -59439,21 +59390,17 @@
       }
     },
     "node_modules/yeoman-generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-7.4.0.tgz",
-      "integrity": "sha512-9vkum9nQQ9bU37kH55SymKFsE/ndkUtyz8T+xTaWMOKhNCj5BbqLSrzy7cJbNQivs/7YlXuUU5HL58kQB2/9gA==",
-      "dev": true,
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-7.5.1.tgz",
+      "integrity": "sha512-MYncRvzSTd71BMwiUMAVhfX00sDD8DZDrmPzRxQkWuWQ0V1Qt4Rd0gS/Nee2QDTWvRjvCa+KBfiAVrtOySq+JA==",
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/lodash-es": "^4.17.9",
-        "@types/node": ">=18.18.5",
         "@yeoman/namespace": "^1.0.0",
         "chalk": "^5.3.0",
         "debug": "^4.1.1",
         "execa": "^8.0.1",
-        "github-username": "^8.0.0",
+        "github-username": "^9.0.0",
         "json-schema": "^0.4.0",
         "latest-version": "^9.0.0",
         "lodash-es": "^4.17.21",
@@ -59469,18 +59416,21 @@
         "node": "^18.17.0 || >=20.5.0"
       },
       "peerDependencies": {
+        "@types/node": ">=18.18.5",
         "@yeoman/types": "^1.1.1",
         "mem-fs": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/yeoman-generator/node_modules/chalk": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
       "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -59492,10 +59442,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
       "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -59518,10 +59465,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
       "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -59533,10 +59477,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=16.17.0"
       }
@@ -59545,10 +59486,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -59560,10 +59498,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -59575,10 +59510,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -59590,10 +59522,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
       "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -59608,10 +59537,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
       "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -59626,10 +59552,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
       "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -59641,10 +59564,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -59656,10 +59576,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
       "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "is-plain-obj": "^4.0.0"
       },
@@ -59674,10 +59591,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
       "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -60412,190 +60326,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "packages/generator-superset/node_modules/@octokit/auth-token": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
-      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/core": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
-      "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.2.2",
-        "@octokit/request": "^9.2.3",
-        "@octokit/request-error": "^6.1.8",
-        "@octokit/types": "^14.0.0",
-        "before-after-hook": "^3.0.2",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/endpoint": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^14.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/graphql": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
-      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^9.2.3",
-        "@octokit/types": "^14.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/openapi-types": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
-      "license": "MIT"
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
-      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.10.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "license": "MIT"
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-request-log": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
-      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
-      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.10.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "license": "MIT"
-    },
-    "packages/generator-superset/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/request": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^10.1.4",
-        "@octokit/request-error": "^6.1.8",
-        "@octokit/types": "^14.0.0",
-        "fast-content-type-parse": "^2.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/request-error": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^14.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/rest": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
-      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^6.1.4",
-        "@octokit/plugin-paginate-rest": "^11.4.2",
-        "@octokit/plugin-request-log": "^5.3.1",
-        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/generator-superset/node_modules/@octokit/types": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^25.1.0"
-      }
-    },
     "packages/generator-superset/node_modules/@sinclair/typebox": {
       "version": "0.34.38",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
@@ -60651,12 +60381,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "packages/generator-superset/node_modules/before-after-hook": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "license": "Apache-2.0"
     },
     "packages/generator-superset/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -60720,29 +60444,6 @@
         }
       }
     },
-    "packages/generator-superset/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "packages/generator-superset/node_modules/expect": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
@@ -60761,22 +60462,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "packages/generator-superset/node_modules/fast-content-type-parse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "packages/generator-superset/node_modules/fs-extra": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
@@ -60790,33 +60475,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "packages/generator-superset/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/github-username": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-9.0.0.tgz",
-      "integrity": "sha512-lY7+mymwQUEhRwWTLxieKkxcZkVNnUh8iAGnl30DMB1ZtYODHkMAckZk8Jx5dLQs1YKPYM2ibnzQu02aCLFcYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/rest": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/generator-superset/node_modules/glob": {
@@ -60838,39 +60496,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/generator-superset/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "packages/generator-superset/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/generator-superset/node_modules/istanbul-lib-source-maps": {
@@ -60928,132 +60553,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "packages/generator-superset/node_modules/jest-changed-files/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "packages/generator-superset/node_modules/jest-circus": {
@@ -61778,18 +61277,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "packages/generator-superset/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/generator-superset/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -61804,48 +61291,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/generator-superset/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/generator-superset/node_modules/picomatch": {
@@ -61893,24 +61338,13 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/generator-superset/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/generator-superset/node_modules/slash": {
@@ -61921,21 +61355,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/generator-superset/node_modules/sort-keys": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
-      "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/generator-superset/node_modules/source-map": {
@@ -61959,73 +61378,10 @@
         "source-map": "^0.6.0"
       }
     },
-    "packages/generator-superset/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/generator-superset/node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC"
-    },
-    "packages/generator-superset/node_modules/yeoman-generator": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-7.5.1.tgz",
-      "integrity": "sha512-MYncRvzSTd71BMwiUMAVhfX00sDD8DZDrmPzRxQkWuWQ0V1Qt4Rd0gS/Nee2QDTWvRjvCa+KBfiAVrtOySq+JA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@types/lodash-es": "^4.17.9",
-        "@yeoman/namespace": "^1.0.0",
-        "chalk": "^5.3.0",
-        "debug": "^4.1.1",
-        "execa": "^8.0.1",
-        "github-username": "^9.0.0",
-        "json-schema": "^0.4.0",
-        "latest-version": "^9.0.0",
-        "lodash-es": "^4.17.21",
-        "mem-fs-editor": "^11.0.1",
-        "minimist": "^1.2.8",
-        "read-package-up": "^11.0.0",
-        "semver": "^7.5.4",
-        "simple-git": "^3.20.0",
-        "sort-keys": "^5.0.0",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18.18.5",
-        "@yeoman/types": "^1.1.1",
-        "mem-fs": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "packages/superset-core": {
       "name": "@apache-superset/core",
       "version": "0.0.1-rc5",
       "license": "ISC",
-      "dependencies": {
-        "@emotion/cache": "^11.4.0",
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.1",
-        "@fontsource/fira-code": "^5.2.6",
-        "@fontsource/inter": "^5.2.6",
-        "lodash": "^4.17.21"
-      },
       "devDependencies": {
         "@babel/cli": "^7.28.3",
         "@babel/core": "^7.28.3",
@@ -62034,19 +61390,32 @@
         "@babel/preset-typescript": "^7.26.0",
         "@emotion/styled": "^11.14.1",
         "@testing-library/dom": "^8.20.1",
-        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/jest-dom": "*",
         "@testing-library/react": "^12.1.5",
-        "@testing-library/react-hooks": "^8.0.1",
-        "@testing-library/user-event": "^12.8.3",
+        "@testing-library/react-hooks": "*",
+        "@testing-library/user-event": "*",
         "@types/lodash": "^4.17.20",
-        "@types/react": "^17.0.83",
+        "@types/react": "*",
+        "@types/react-loadable": "*",
+        "@types/react-window": "^1.8.8",
+        "@types/tinycolor2": "*",
         "install": "^0.13.0",
         "npm": "^11.1.0",
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.14.1",
+        "@fontsource/fira-code": "^5.2.6",
+        "@fontsource/inter": "^5.2.6",
         "antd": "^5.26.0",
-        "react": "^17.0.2"
+        "lodash": "^4.17.21",
+        "nanoid": "^5.0.9",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-loadable": "^5.5.0",
+        "tinycolor2": "*"
       }
     },
     "packages/superset-core/node_modules/@types/lodash": {
@@ -65843,6 +65212,7 @@
         "typescript": "^5.7.2"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@encodable/color": "=1.1.1",
         "@superset-ui/core": "*",
         "@superset-ui/legacy-plugin-chart-calendar": "*",
@@ -66330,13 +65700,13 @@
       }
     },
     "packages/superset-ui-demo/node_modules/storybook": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.5.1.tgz",
-      "integrity": "sha512-HuaAFA97j2w4i/1EHKj6X4iDiVzPrXzQpmTEE1tLD1QXzqrQKKHse+Ggc8AGMuLTAzxA6xmrX9xibgMNWCgvRA==",
+      "version": "8.6.14",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.14.tgz",
+      "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/core": "8.5.1"
+        "@storybook/core": "8.6.14"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -66427,6 +65797,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@emotion/react": "^11.4.1",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
@@ -66452,6 +65823,7 @@
         "react": "^19.2.0"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*"
       }
@@ -66475,6 +65847,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66490,6 +65863,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66552,6 +65926,7 @@
         "supercluster": "^8.0.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
@@ -66568,6 +65943,7 @@
         "reactable": "^1.1.0"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66582,6 +65958,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66597,6 +65974,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "@testing-library/jest-dom": "*",
@@ -66615,6 +65993,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@emotion/react": "^11.4.1",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
@@ -66633,6 +66012,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66679,6 +66059,7 @@
         "@types/urijs": "^1.19.25"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "mapbox-gl": "*",
@@ -66810,6 +66191,7 @@
         "urijs": "^1.19.11"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "react": "^17.0.2"
@@ -66868,6 +66250,7 @@
       },
       "peerDependencies": {
         "@ant-design/icons": "^5.2.6",
+        "@apache-superset/core": "*",
         "@reduxjs/toolkit": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
@@ -66922,6 +66305,7 @@
         "jest": "^30.2.0"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "ace-builds": "^1.4.14",
@@ -69375,6 +68759,7 @@
         "@types/d3-cloud": "^1.2.9"
       },
       "peerDependencies": {
+        "@apache-superset/core": "*",
         "@superset-ui/chart-controls": "*",
         "@superset-ui/core": "*",
         "@types/lodash": "*",

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/components/types.ts
@@ -38,3 +38,25 @@ export interface ControlComponentProps<
   hovered?: boolean;
   onChange?: (value: ValueType) => void;
 }
+
+/**
+ * Extended ControlComponentProps that properly types the onChange callback
+ * to support validation errors as a second parameter.
+ *
+ * The actual Control component implementation (src/explore/components/Control.tsx)
+ * accepts onChange with signature (value: JsonValue, errors: string[]) => void,
+ * but the base ControlComponentProps interface only defines (value: JsonValue) => void.
+ *
+ * This interface extends the base props and overrides onChange to match the
+ * actual implementation, providing proper type safety.
+ */
+export interface ExtendedControlComponentProps<
+  ValueType extends JsonValue = JsonValue,
+> extends Omit<ControlComponentProps<ValueType>, 'onChange'> {
+  /**
+   * Callback invoked when the control value changes.
+   * @param value - The new value for the control
+   * @param errors - Array of validation error messages (empty array if no errors)
+   */
+  onChange?: (value: ValueType, errors?: string[]) => void;
+}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -17,7 +17,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactElement, ReactNode, ReactText, ComponentType } from 'react';
+import { ReactElement, ReactNode, ReactText, ComponentType, FunctionComponent } from 'react';
 
 import type {
   AdhocColumn,
@@ -380,7 +380,7 @@ export const isCustomControlItem = (obj: unknown): obj is CustomControlItem =>
 
 // use ReactElement instead of ReactNode because `string`, `number`, etc. may
 // interfere with other ControlSetItem types
-export type ExpandedControlItem = CustomControlItem | ReactElement | null;
+export type ExpandedControlItem = CustomControlItem | ReactElement | ComponentType<any> | FunctionComponent<any> | null;
 
 export type ControlSetItem =
   | SharedControlAlias

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -35,7 +35,10 @@ import type {
 import { sharedControls, sharedControlComponents } from './shared-controls';
 
 export type { Metric } from '@superset-ui/core';
-export type { ControlComponentProps } from './shared-controls/components/types';
+export type {
+  ControlComponentProps,
+  ExtendedControlComponentProps,
+} from './shared-controls/components/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDict = Record<string, any>;

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -17,7 +17,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactElement, ReactNode, ReactText, ComponentType, FunctionComponent } from 'react';
+import {
+  ReactElement,
+  ReactNode,
+  ReactText,
+  ComponentType,
+  FunctionComponent,
+} from 'react';
 
 import type {
   AdhocColumn,
@@ -383,7 +389,12 @@ export const isCustomControlItem = (obj: unknown): obj is CustomControlItem =>
 
 // use ReactElement instead of ReactNode because `string`, `number`, etc. may
 // interfere with other ControlSetItem types
-export type ExpandedControlItem = CustomControlItem | ReactElement | ComponentType<any> | FunctionComponent<any> | null;
+export type ExpandedControlItem =
+  | CustomControlItem
+  | ReactElement
+  | ComponentType<any>
+  | FunctionComponent<any>
+  | null;
 
 export type ControlSetItem =
   | SharedControlAlias

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/expandControlConfig.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isValidElement, ReactElement } from 'react';
+import { isValidElement, ReactElement, ComponentType } from 'react';
 import { sharedControls, sharedControlComponents } from '../shared-controls';
 import {
   ControlType,
@@ -62,9 +62,13 @@ export function expandControlConfig(
       },
     };
   }
-  // JSX/React element or NULL
+  // JSX/React element, function component, or NULL
   if (!control || typeof control === 'string' || isValidElement(control)) {
     return control as ReactElement;
+  }
+  // Function component (React component reference)
+  if (typeof control === 'function') {
+    return control as ComponentType<any>;
   }
   // already fully expanded control config, e.g.
   // {

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/__tests__/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/__tests__/controlPanel.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import controlPanelConfig from '../controlPanel';
+import {
+  RotationControl,
+  SizeFromControl,
+  SizeToControl,
+} from '../controls';
+
+test('should have required control panel structure', () => {
+  expect(controlPanelConfig).toBeDefined();
+  expect(controlPanelConfig.controlPanelSections).toBeDefined();
+  expect(Array.isArray(controlPanelConfig.controlPanelSections)).toBe(true);
+});
+
+test('should have Query section with required controls', () => {
+  const querySection = controlPanelConfig.controlPanelSections[0];
+  const { controlSetRows } = querySection!;
+
+  expect(querySection).toBeDefined();
+  expect(querySection!.label).toBe('Query');
+  expect(querySection!.expanded).toBe(true);
+  expect(querySection!.controlSetRows).toBeDefined();
+  expect(controlSetRows).toContainEqual(['series']);
+  expect(controlSetRows).toContainEqual(['metric']);
+  expect(controlSetRows).toContainEqual(['adhoc_filters']);
+  expect(controlSetRows).toContainEqual(['row_limit']);
+  expect(controlSetRows).toContainEqual(['sort_by_metric']);
+});
+
+test('should have Options section with React component controls', () => {
+  const optionsSection = controlPanelConfig.controlPanelSections[1];
+  const { controlSetRows } = optionsSection!;
+
+  expect(optionsSection).toBeDefined();
+  expect(optionsSection!.label).toBe('Options');
+  expect(optionsSection!.expanded).toBe(true);
+  expect(optionsSection!.controlSetRows).toBeDefined();
+
+  // Check that React components are present in controlSetRows
+  const hasSizeFromControl = controlSetRows.some((row: any) =>
+    Array.isArray(row) && row.includes(SizeFromControl),
+  );
+  const hasSizeToControl = controlSetRows.some((row: any) =>
+    Array.isArray(row) && row.includes(SizeToControl),
+  );
+  const hasRotationControl = controlSetRows.some((row: any) =>
+    Array.isArray(row) && row.includes(RotationControl),
+  );
+
+  expect(hasSizeFromControl).toBe(true);
+  expect(hasSizeToControl).toBe(true);
+  expect(hasRotationControl).toBe(true);
+});
+
+test('should have controlOverrides with defaults for React component controls', () => {
+  expect(controlPanelConfig.controlOverrides).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.size_from).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.size_from!.default).toBe(10);
+  expect(controlPanelConfig.controlOverrides!.size_to).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.size_to!.default).toBe(70);
+  expect(controlPanelConfig.controlOverrides!.rotation).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.rotation!.default).toBe('square');
+});
+
+test('should have controlOverrides for legacy controls', () => {
+  expect(controlPanelConfig.controlOverrides).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.series).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.row_limit).toBeDefined();
+  expect(controlPanelConfig.controlOverrides!.row_limit!.default).toBe(100);
+});
+
+test('should have formDataOverrides function', () => {
+  expect(controlPanelConfig.formDataOverrides).toBeDefined();
+  expect(typeof controlPanelConfig.formDataOverrides).toBe('function');
+});
+
+test('should mix React component controls with legacy string controls', () => {
+  const optionsSection = controlPanelConfig.controlPanelSections[1];
+  const { controlSetRows } = optionsSection!;
+
+  // Should have both React components and string-based controls
+  const hasReactComponents = controlSetRows.some((row: any) =>
+    Array.isArray(row) &&
+    (row.includes(SizeFromControl) ||
+      row.includes(SizeToControl) ||
+      row.includes(RotationControl)),
+  );
+  const hasLegacyControls = controlSetRows.some((row: any) =>
+    Array.isArray(row) && row.includes('color_scheme'),
+  );
+
+  expect(hasReactComponents).toBe(true);
+  expect(hasLegacyControls).toBe(true);
+});
+
+test('should have React components with correct defaultProps', () => {
+  // Verify that React components have defaultProps set for name extraction
+  expect(RotationControl.defaultProps).toBeDefined();
+  expect(RotationControl.defaultProps!.name).toBe('rotation');
+  expect(SizeFromControl.defaultProps).toBeDefined();
+  expect(SizeFromControl.defaultProps!.name).toBe('size_from');
+  expect(SizeToControl.defaultProps).toBeDefined();
+  expect(SizeToControl.defaultProps!.name).toBe('size_to');
+});
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/__tests__/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/__tests__/controlPanel.test.ts
@@ -17,11 +17,7 @@
  * under the License.
  */
 import controlPanelConfig from '../controlPanel';
-import {
-  RotationControl,
-  SizeFromControl,
-  SizeToControl,
-} from '../controls';
+import { RotationControl, SizeFromControl, SizeToControl } from '../controls';
 
 test('should have required control panel structure', () => {
   expect(controlPanelConfig).toBeDefined();
@@ -54,14 +50,14 @@ test('should have Options section with React component controls', () => {
   expect(optionsSection!.controlSetRows).toBeDefined();
 
   // Check that React components are present in controlSetRows
-  const hasSizeFromControl = controlSetRows.some((row: any) =>
-    Array.isArray(row) && row.includes(SizeFromControl),
+  const hasSizeFromControl = controlSetRows.some(
+    (row: any) => Array.isArray(row) && row.includes(SizeFromControl),
   );
-  const hasSizeToControl = controlSetRows.some((row: any) =>
-    Array.isArray(row) && row.includes(SizeToControl),
+  const hasSizeToControl = controlSetRows.some(
+    (row: any) => Array.isArray(row) && row.includes(SizeToControl),
   );
-  const hasRotationControl = controlSetRows.some((row: any) =>
-    Array.isArray(row) && row.includes(RotationControl),
+  const hasRotationControl = controlSetRows.some(
+    (row: any) => Array.isArray(row) && row.includes(RotationControl),
   );
 
   expect(hasSizeFromControl).toBe(true);
@@ -96,14 +92,15 @@ test('should mix React component controls with legacy string controls', () => {
   const { controlSetRows } = optionsSection!;
 
   // Should have both React components and string-based controls
-  const hasReactComponents = controlSetRows.some((row: any) =>
-    Array.isArray(row) &&
-    (row.includes(SizeFromControl) ||
-      row.includes(SizeToControl) ||
-      row.includes(RotationControl)),
+  const hasReactComponents = controlSetRows.some(
+    (row: any) =>
+      Array.isArray(row) &&
+      (row.includes(SizeFromControl) ||
+        row.includes(SizeToControl) ||
+        row.includes(RotationControl)),
   );
-  const hasLegacyControls = controlSetRows.some((row: any) =>
-    Array.isArray(row) && row.includes('color_scheme'),
+  const hasLegacyControls = controlSetRows.some(
+    (row: any) => Array.isArray(row) && row.includes('color_scheme'),
   );
 
   expect(hasReactComponents).toBe(true);
@@ -119,4 +116,3 @@ test('should have React components with correct defaultProps', () => {
   expect(SizeToControl.defaultProps).toBeDefined();
   expect(SizeToControl.defaultProps!.name).toBe('size_to');
 });
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
@@ -21,11 +21,7 @@ import {
   ControlPanelConfig,
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
-import {
-  RotationControl,
-  SizeFromControl,
-  SizeToControl,
-} from './controls';
+import { RotationControl, SizeFromControl, SizeToControl } from './controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -49,9 +45,7 @@ const config: ControlPanelConfig = {
           SizeFromControl,
           SizeToControl,
         ],
-        [
-          RotationControl,
-        ],
+        [RotationControl],
         // Legacy string-based control (still supported for backward compatibility)
         ['color_scheme'],
       ],

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controlPanel.ts
@@ -21,6 +21,11 @@ import {
   ControlPanelConfig,
   getStandardizedControls,
 } from '@superset-ui/chart-controls';
+import {
+  RotationControl,
+  SizeFromControl,
+  SizeToControl,
+} from './controls';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -40,47 +45,14 @@ const config: ControlPanelConfig = {
       expanded: true,
       controlSetRows: [
         [
-          {
-            name: 'size_from',
-            config: {
-              type: 'TextControl',
-              isInt: true,
-              label: t('Minimum Font Size'),
-              renderTrigger: true,
-              default: 10,
-              description: t('Font size for the smallest value in the list'),
-            },
-          },
-          {
-            name: 'size_to',
-            config: {
-              type: 'TextControl',
-              isInt: true,
-              label: t('Maximum Font Size'),
-              renderTrigger: true,
-              default: 70,
-              description: t('Font size for the biggest value in the list'),
-            },
-          },
+          // React component-based controls (modern approach)
+          SizeFromControl,
+          SizeToControl,
         ],
         [
-          {
-            name: 'rotation',
-            config: {
-              type: 'SelectControl',
-              label: t('Word Rotation'),
-              choices: [
-                ['random', t('random')],
-                ['flat', t('flat')],
-                ['square', t('square')],
-              ],
-              renderTrigger: true,
-              default: 'square',
-              clearable: false,
-              description: t('Rotation to apply to words in the cloud'),
-            },
-          },
+          RotationControl,
         ],
+        // Legacy string-based control (still supported for backward compatibility)
         ['color_scheme'],
       ],
     },
@@ -92,6 +64,16 @@ const config: ControlPanelConfig = {
     },
     row_limit: {
       default: 100,
+    },
+    // Ensure defaults are set even if controls are removed from UI
+    size_from: {
+      default: 10,
+    },
+    size_to: {
+      default: 70,
+    },
+    rotation: {
+      default: 'square',
     },
   },
   formDataOverrides: formData => ({

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/IntegerInputControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/IntegerInputControl.tsx
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { t, legacyValidateInteger } from '@superset-ui/core';
+import {
+  Input,
+  FormLabel,
+  Tooltip,
+  InfoTooltip,
+  Constants,
+} from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { debounce } from 'lodash';
+import { useTheme } from '@apache-superset/core/ui';
+import { ExtendedControlComponentProps } from './types';
+
+/**
+ * Configuration for IntegerInputControl component.
+ */
+export interface IntegerInputControlConfig {
+  /** Default control name */
+  defaultName: string;
+  /** Default label text */
+  defaultLabel: string;
+  /** Default description text */
+  defaultDescription: string;
+  /** Default numeric value */
+  defaultValue: number;
+}
+
+/**
+ * Props for IntegerInputControl component.
+ */
+export interface IntegerInputControlProps
+  extends ExtendedControlComponentProps {
+  /** Default numeric value */
+  default?: number;
+  /** Placeholder text for the input */
+  placeholder?: string;
+  /** Whether the input is disabled */
+  disabled?: boolean;
+  /** Configuration for default values (used when props are not provided) */
+  config?: IntegerInputControlConfig;
+}
+
+/**
+ * Reusable integer input control component with validation.
+ * This component handles integer input with debouncing, validation, and error display.
+ */
+export const IntegerInputControl: React.FC<IntegerInputControlProps> = ({
+  name,
+  label,
+  description,
+  value,
+  onChange,
+  validationErrors,
+  renderTrigger = true,
+  hovered,
+  default: defaultValue,
+  placeholder,
+  disabled,
+  config,
+}) => {
+  const safeStringify = (val?: string | number | null) =>
+    val == null ? '' : String(val);
+
+  const theme = useTheme();
+  const finalName = name || config?.defaultName || '';
+  const finalLabel = label || config?.defaultLabel || '';
+  const finalDescription = description || config?.defaultDescription || '';
+  const finalDefaultValue = defaultValue ?? config?.defaultValue ?? 0;
+  const labelText = typeof finalLabel === 'string' ? finalLabel : '';
+  const safeValue =
+    typeof value === 'number' || typeof value === 'string'
+      ? value
+      : finalDefaultValue;
+
+  const [inputValue, setInputValue] = useState(safeStringify(safeValue));
+
+  useEffect(() => {
+    if (
+      value !== undefined &&
+      value !== null &&
+      (typeof value === 'number' || typeof value === 'string')
+    ) {
+      setInputValue(safeStringify(value));
+    }
+  }, [value]);
+
+  const handleChange = useCallback(
+    (inputVal: string) => {
+      let parsedValue: string | number = inputVal;
+      const errors: string[] = [];
+
+      if (inputVal !== '') {
+        const error = legacyValidateInteger(inputVal);
+        if (error) {
+          errors.push(error);
+        } else {
+          parsedValue = parseInt(inputVal, 10);
+        }
+      }
+
+      onChange?.(parsedValue, errors);
+    },
+    [onChange],
+  );
+
+  const debouncedOnChange = useMemo(
+    () => debounce(handleChange, Constants.FAST_DEBOUNCE),
+    [handleChange],
+  );
+
+  const onChangeWrapper = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      setInputValue(newValue);
+      debouncedOnChange(newValue);
+    },
+    [debouncedOnChange],
+  );
+
+  return (
+    <div>
+      {finalLabel && (
+        <div className="ControlHeader" data-test={`${finalName}-header`}>
+          <FormLabel htmlFor={finalName}>
+            {labelText}
+            {finalDescription && hovered && (
+              <Tooltip
+                id={`${finalName}-tooltip`}
+                title={finalDescription}
+                placement="top"
+              >
+                <Icons.InfoCircleOutlined />
+              </Tooltip>
+            )}
+            {renderTrigger && hovered && (
+              <InfoTooltip
+                label={t('bolt')}
+                tooltip={t('Changing this control takes effect instantly')}
+                placement="top"
+                type="notice"
+              />
+            )}
+            {validationErrors && validationErrors.length > 0 && (
+              <Tooltip
+                id="error-tooltip"
+                placement="top"
+                title={
+                  Array.isArray(validationErrors)
+                    ? validationErrors.join(' ')
+                    : String(validationErrors)
+                }
+              >
+                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
+              </Tooltip>
+            )}
+          </FormLabel>
+        </div>
+      )}
+      <Input
+        type="text"
+        data-test="inline-name"
+        placeholder={placeholder}
+        onChange={onChangeWrapper}
+        value={inputValue}
+        disabled={disabled}
+        aria-label={labelText}
+      />
+    </div>
+  );
+};

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/RotationControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/RotationControl.tsx
@@ -18,17 +18,22 @@
  */
 import React, { useMemo } from 'react';
 import { t } from '@superset-ui/core';
-import { Select, FormLabel, Tooltip, InfoTooltip } from '@superset-ui/core/components';
-import { ControlComponentProps } from '@superset-ui/chart-controls';
+import {
+  Select,
+  FormLabel,
+  Tooltip,
+  InfoTooltip,
+} from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { useTheme } from '@apache-superset/core/ui';
+import { ExtendedControlComponentProps } from './types';
 
 /**
  * React component-based control for Word Cloud rotation setting.
  * This is a proper React functional component that renders actual UI,
  * replacing the legacy configuration object approach.
  */
-export const RotationControl: React.FC<ControlComponentProps> = ({
+export const RotationControl: React.FC<ExtendedControlComponentProps> = ({
   name = 'rotation',
   label = t('Word Rotation'),
   description = t('Rotation to apply to words in the cloud'),
@@ -63,10 +68,10 @@ export const RotationControl: React.FC<ControlComponentProps> = ({
   const labelText = typeof label === 'string' ? label : '';
 
   const handleChange = (selectedValue: string | string[]) => {
-    const value = Array.isArray(selectedValue) ? selectedValue[0] : selectedValue;
-    // ControlComponentProps onChange signature is (value: JsonValue) => void
-    // but we need to pass errors, so we use type assertion
-    (onChange as any)?.(value, []);
+    const value = Array.isArray(selectedValue)
+      ? selectedValue[0]
+      : selectedValue;
+    onChange?.(value, []);
   };
 
   return (
@@ -76,7 +81,11 @@ export const RotationControl: React.FC<ControlComponentProps> = ({
           <FormLabel htmlFor={name}>
             {labelText}
             {description && hovered && (
-              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
+              <Tooltip
+                id={`${name}-tooltip`}
+                title={description}
+                placement="top"
+              >
                 <Icons.InfoCircleOutlined />
               </Tooltip>
             )}
@@ -116,4 +125,3 @@ export const RotationControl: React.FC<ControlComponentProps> = ({
 RotationControl.defaultProps = {
   name: 'rotation',
 };
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/RotationControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/RotationControl.tsx
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useMemo } from 'react';
+import { t } from '@superset-ui/core';
+import { Select, FormLabel, Tooltip, InfoTooltip } from '@superset-ui/core/components';
+import { ControlComponentProps } from '@superset-ui/chart-controls';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { useTheme } from '@apache-superset/core/ui';
+
+/**
+ * React component-based control for Word Cloud rotation setting.
+ * This is a proper React functional component that renders actual UI,
+ * replacing the legacy configuration object approach.
+ */
+export const RotationControl: React.FC<ControlComponentProps> = ({
+  name = 'rotation',
+  label = t('Word Rotation'),
+  description = t('Rotation to apply to words in the cloud'),
+  value,
+  onChange,
+  validationErrors,
+  renderTrigger = true,
+  hovered,
+  ...restProps
+}) => {
+  const choices = useMemo(
+    () => [
+      ['random', t('random')],
+      ['flat', t('flat')],
+      ['square', t('square')],
+    ],
+    [],
+  );
+
+  const options = useMemo(
+    () =>
+      choices.map(([val, label]) => ({
+        label,
+        value: val,
+      })),
+    [choices],
+  );
+
+  const currentValue = value ?? 'square';
+
+  const theme = useTheme();
+  const labelText = typeof label === 'string' ? label : '';
+
+  const handleChange = (selectedValue: string | string[]) => {
+    const value = Array.isArray(selectedValue) ? selectedValue[0] : selectedValue;
+    // ControlComponentProps onChange signature is (value: JsonValue) => void
+    // but we need to pass errors, so we use type assertion
+    (onChange as any)?.(value, []);
+  };
+
+  return (
+    <div>
+      {label && (
+        <div className="ControlHeader" data-test={`${name}-header`}>
+          <FormLabel htmlFor={name}>
+            {labelText}
+            {description && hovered && (
+              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
+                <Icons.InfoCircleOutlined />
+              </Tooltip>
+            )}
+            {renderTrigger && hovered && (
+              <InfoTooltip
+                label={t('bolt')}
+                tooltip={t('Changing this control takes effect instantly')}
+                placement="top"
+                type="notice"
+              />
+            )}
+            {validationErrors && validationErrors.length > 0 && (
+              <Tooltip
+                id="error-tooltip"
+                placement="top"
+                title={validationErrors.join(' ')}
+              >
+                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
+              </Tooltip>
+            )}
+          </FormLabel>
+        </div>
+      )}
+      <Select
+        name={`select-${name}`}
+        options={options}
+        value={currentValue as string}
+        onChange={handleChange}
+        allowClear={false}
+        ariaLabel={labelText || t('Select ...')}
+      />
+    </div>
+  );
+};
+
+// Set default props for control name extraction
+RotationControl.defaultProps = {
+  name: 'rotation',
+};
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeFromControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeFromControl.tsx
@@ -16,123 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { t, legacyValidateInteger } from '@superset-ui/core';
-import { Input, FormLabel, Tooltip, InfoTooltip, Constants } from '@superset-ui/core/components';
-import { Icons } from '@superset-ui/core/components/Icons';
-import { debounce } from 'lodash';
-import { ControlComponentProps } from '@superset-ui/chart-controls';
-import { useTheme } from '@apache-superset/core/ui';
+import React from 'react';
+import { t } from '@superset-ui/core';
+import { IntegerInputControl } from './IntegerInputControl';
 
 /**
  * React component-based control for Word Cloud minimum font size.
  * This is a proper React functional component that renders actual UI,
  * replacing the legacy configuration object approach.
  */
-interface SizeFromControlProps extends ControlComponentProps {
-  default?: number;
-  placeholder?: string;
-  disabled?: boolean;
-}
-
-export const SizeFromControl: React.FC<SizeFromControlProps> = ({
-  name = 'size_from',
-  label = t('Minimum Font Size'),
-  description = t('Font size for the smallest value in the list'),
-  value,
-  onChange,
-  validationErrors,
-  renderTrigger = true,
-  hovered,
-  default: defaultValue = 10,
-  placeholder,
-  disabled,
-}) => {
-  const safeStringify = (val?: string | number | null) =>
-    val == null ? '' : String(val);
-
-  const theme = useTheme();
-  const labelText = typeof label === 'string' ? label : '';
-  const safeValue = typeof value === 'number' || typeof value === 'string' ? value : defaultValue;
-  
-  const [inputValue, setInputValue] = useState(safeStringify(safeValue));
-
-  useEffect(() => {
-    if (value !== undefined && value !== null && (typeof value === 'number' || typeof value === 'string')) {
-      setInputValue(safeStringify(value));
-    }
-  }, [value]);
-
-  const handleChange = useCallback((inputVal: string) => {
-    let parsedValue: string | number = inputVal;
-    const errors: any[] = [];
-
-    if (inputVal !== '') {
-      const error = legacyValidateInteger(inputVal);
-      if (error) {
-        errors.push(error);
-      } else {
-        parsedValue = parseInt(inputVal, 10);
-      }
-    }
-
-    // ControlComponentProps onChange signature is (value: JsonValue) => void
-    // but we need to pass errors, so we use type assertion
-    (onChange as any)?.(parsedValue, errors);
-  }, [onChange]);
-
-  const debouncedOnChange = useMemo(
-    () => debounce(handleChange, Constants.FAST_DEBOUNCE),
-    [handleChange],
-  );
-
-  const onChangeWrapper = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    setInputValue(newValue);
-    debouncedOnChange(newValue);
-  }, [debouncedOnChange]);
-
+export const SizeFromControl: React.FC<
+  React.ComponentProps<typeof IntegerInputControl>
+> = props => {
+  const {
+    name,
+    label,
+    description,
+    default: defaultValue,
+    ...restProps
+  } = props;
   return (
-    <div>
-      {label && (
-        <div className="ControlHeader" data-test={`${name}-header`}>
-          <FormLabel htmlFor={name}>
-            {labelText}
-            {description && hovered && (
-              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
-                <Icons.InfoCircleOutlined />
-              </Tooltip>
-            )}
-            {renderTrigger && hovered && (
-              <InfoTooltip
-                label={t('bolt')}
-                tooltip={t('Changing this control takes effect instantly')}
-                placement="top"
-                type="notice"
-              />
-            )}
-            {validationErrors && validationErrors.length > 0 && (
-              <Tooltip
-                id="error-tooltip"
-                placement="top"
-                title={Array.isArray(validationErrors) ? validationErrors.join(' ') : String(validationErrors)}
-              >
-                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
-              </Tooltip>
-            )}
-          </FormLabel>
-        </div>
-      )}
-      <Input
-        type="text"
-        data-test="inline-name"
-        placeholder={placeholder}
-        onChange={onChangeWrapper}
-        value={inputValue}
-        disabled={disabled}
-        aria-label={labelText}
-      />
-    </div>
+    <IntegerInputControl
+      name={name || 'size_from'}
+      label={label || t('Minimum Font Size')}
+      description={
+        description || t('Font size for the smallest value in the list')
+      }
+      default={defaultValue ?? 10}
+      config={{
+        defaultName: 'size_from',
+        defaultLabel: t('Minimum Font Size'),
+        defaultDescription: t('Font size for the smallest value in the list'),
+        defaultValue: 10,
+      }}
+      {...restProps}
+    />
   );
 };
 
@@ -140,4 +58,3 @@ export const SizeFromControl: React.FC<SizeFromControlProps> = ({
 SizeFromControl.defaultProps = {
   name: 'size_from',
 };
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeFromControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeFromControl.tsx
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { t, legacyValidateInteger } from '@superset-ui/core';
+import { Input, FormLabel, Tooltip, InfoTooltip, Constants } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { debounce } from 'lodash';
+import { ControlComponentProps } from '@superset-ui/chart-controls';
+import { useTheme } from '@apache-superset/core/ui';
+
+/**
+ * React component-based control for Word Cloud minimum font size.
+ * This is a proper React functional component that renders actual UI,
+ * replacing the legacy configuration object approach.
+ */
+interface SizeFromControlProps extends ControlComponentProps {
+  default?: number;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export const SizeFromControl: React.FC<SizeFromControlProps> = ({
+  name = 'size_from',
+  label = t('Minimum Font Size'),
+  description = t('Font size for the smallest value in the list'),
+  value,
+  onChange,
+  validationErrors,
+  renderTrigger = true,
+  hovered,
+  default: defaultValue = 10,
+  placeholder,
+  disabled,
+}) => {
+  const safeStringify = (val?: string | number | null) =>
+    val == null ? '' : String(val);
+
+  const theme = useTheme();
+  const labelText = typeof label === 'string' ? label : '';
+  const safeValue = typeof value === 'number' || typeof value === 'string' ? value : defaultValue;
+  
+  const [inputValue, setInputValue] = useState(safeStringify(safeValue));
+
+  useEffect(() => {
+    if (value !== undefined && value !== null && (typeof value === 'number' || typeof value === 'string')) {
+      setInputValue(safeStringify(value));
+    }
+  }, [value]);
+
+  const handleChange = useCallback((inputVal: string) => {
+    let parsedValue: string | number = inputVal;
+    const errors: any[] = [];
+
+    if (inputVal !== '') {
+      const error = legacyValidateInteger(inputVal);
+      if (error) {
+        errors.push(error);
+      } else {
+        parsedValue = parseInt(inputVal, 10);
+      }
+    }
+
+    // ControlComponentProps onChange signature is (value: JsonValue) => void
+    // but we need to pass errors, so we use type assertion
+    (onChange as any)?.(parsedValue, errors);
+  }, [onChange]);
+
+  const debouncedOnChange = useMemo(
+    () => debounce(handleChange, Constants.FAST_DEBOUNCE),
+    [handleChange],
+  );
+
+  const onChangeWrapper = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setInputValue(newValue);
+    debouncedOnChange(newValue);
+  }, [debouncedOnChange]);
+
+  return (
+    <div>
+      {label && (
+        <div className="ControlHeader" data-test={`${name}-header`}>
+          <FormLabel htmlFor={name}>
+            {labelText}
+            {description && hovered && (
+              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
+                <Icons.InfoCircleOutlined />
+              </Tooltip>
+            )}
+            {renderTrigger && hovered && (
+              <InfoTooltip
+                label={t('bolt')}
+                tooltip={t('Changing this control takes effect instantly')}
+                placement="top"
+                type="notice"
+              />
+            )}
+            {validationErrors && validationErrors.length > 0 && (
+              <Tooltip
+                id="error-tooltip"
+                placement="top"
+                title={Array.isArray(validationErrors) ? validationErrors.join(' ') : String(validationErrors)}
+              >
+                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
+              </Tooltip>
+            )}
+          </FormLabel>
+        </div>
+      )}
+      <Input
+        type="text"
+        data-test="inline-name"
+        placeholder={placeholder}
+        onChange={onChangeWrapper}
+        value={inputValue}
+        disabled={disabled}
+        aria-label={labelText}
+      />
+    </div>
+  );
+};
+
+// Set default props for control name extraction
+SizeFromControl.defaultProps = {
+  name: 'size_from',
+};
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
@@ -28,12 +28,20 @@ import { IntegerInputControl } from './IntegerInputControl';
 export const SizeToControl: React.FC<
   React.ComponentProps<typeof IntegerInputControl>
 > = props => {
-  const { name, label, description, default: defaultValue, ...restProps } = props;
+  const {
+    name,
+    label,
+    description,
+    default: defaultValue,
+    ...restProps
+  } = props;
   return (
     <IntegerInputControl
       name={name || 'size_to'}
       label={label || t('Maximum Font Size')}
-      description={description || t('Font size for the biggest value in the list')}
+      description={
+        description || t('Font size for the biggest value in the list')
+      }
       default={defaultValue ?? 70}
       config={{
         defaultName: 'size_to',

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { t, legacyValidateInteger } from '@superset-ui/core';
+import { Input, FormLabel, Tooltip, InfoTooltip, Constants } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { debounce } from 'lodash';
+import { ControlComponentProps } from '@superset-ui/chart-controls';
+import { useTheme } from '@apache-superset/core/ui';
+
+/**
+ * React component-based control for Word Cloud maximum font size.
+ * This is a proper React functional component that renders actual UI,
+ * replacing the legacy configuration object approach.
+ */
+interface SizeToControlProps extends ControlComponentProps {
+  default?: number;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export const SizeToControl: React.FC<SizeToControlProps> = ({
+  name = 'size_to',
+  label = t('Maximum Font Size'),
+  description = t('Font size for the biggest value in the list'),
+  value,
+  onChange,
+  validationErrors,
+  renderTrigger = true,
+  hovered,
+  default: defaultValue = 70,
+  placeholder,
+  disabled,
+}) => {
+  const safeStringify = (val?: string | number | null) =>
+    val == null ? '' : String(val);
+
+  const theme = useTheme();
+  const labelText = typeof label === 'string' ? label : '';
+  const safeValue = typeof value === 'number' || typeof value === 'string' ? value : defaultValue;
+  
+  const [inputValue, setInputValue] = useState(safeStringify(safeValue));
+
+  useEffect(() => {
+    if (value !== undefined && value !== null && (typeof value === 'number' || typeof value === 'string')) {
+      setInputValue(safeStringify(value));
+    }
+  }, [value]);
+
+  const handleChange = useCallback((inputVal: string) => {
+    let parsedValue: string | number = inputVal;
+    const errors: any[] = [];
+
+    if (inputVal !== '') {
+      const error = legacyValidateInteger(inputVal);
+      if (error) {
+        errors.push(error);
+      } else {
+        parsedValue = parseInt(inputVal, 10);
+      }
+    }
+
+    // ControlComponentProps onChange signature is (value: JsonValue) => void
+    // but we need to pass errors, so we use type assertion
+    (onChange as any)?.(parsedValue, errors);
+  }, [onChange]);
+
+  const debouncedOnChange = useMemo(
+    () => debounce(handleChange, Constants.FAST_DEBOUNCE),
+    [handleChange],
+  );
+
+  const onChangeWrapper = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setInputValue(newValue);
+    debouncedOnChange(newValue);
+  }, [debouncedOnChange]);
+
+  return (
+    <div>
+      {label && (
+        <div className="ControlHeader" data-test={`${name}-header`}>
+          <FormLabel htmlFor={name}>
+            {labelText}
+            {description && hovered && (
+              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
+                <Icons.InfoCircleOutlined />
+              </Tooltip>
+            )}
+            {renderTrigger && hovered && (
+              <InfoTooltip
+                label={t('bolt')}
+                tooltip={t('Changing this control takes effect instantly')}
+                placement="top"
+                type="notice"
+              />
+            )}
+            {validationErrors && validationErrors.length > 0 && (
+              <Tooltip
+                id="error-tooltip"
+                placement="top"
+                title={Array.isArray(validationErrors) ? validationErrors.join(' ') : String(validationErrors)}
+              >
+                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
+              </Tooltip>
+            )}
+          </FormLabel>
+        </div>
+      )}
+      <Input
+        type="text"
+        data-test="inline-name"
+        placeholder={placeholder}
+        onChange={onChangeWrapper}
+        value={inputValue}
+        disabled={disabled}
+        aria-label={labelText}
+      />
+    </div>
+  );
+};
+
+// Set default props for control name extraction
+SizeToControl.defaultProps = {
+  name: 'size_to',
+};
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/SizeToControl.tsx
@@ -16,123 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { t, legacyValidateInteger } from '@superset-ui/core';
-import { Input, FormLabel, Tooltip, InfoTooltip, Constants } from '@superset-ui/core/components';
-import { Icons } from '@superset-ui/core/components/Icons';
-import { debounce } from 'lodash';
-import { ControlComponentProps } from '@superset-ui/chart-controls';
-import { useTheme } from '@apache-superset/core/ui';
+import React from 'react';
+import { t } from '@superset-ui/core';
+import { IntegerInputControl } from './IntegerInputControl';
 
 /**
  * React component-based control for Word Cloud maximum font size.
  * This is a proper React functional component that renders actual UI,
  * replacing the legacy configuration object approach.
  */
-interface SizeToControlProps extends ControlComponentProps {
-  default?: number;
-  placeholder?: string;
-  disabled?: boolean;
-}
-
-export const SizeToControl: React.FC<SizeToControlProps> = ({
-  name = 'size_to',
-  label = t('Maximum Font Size'),
-  description = t('Font size for the biggest value in the list'),
-  value,
-  onChange,
-  validationErrors,
-  renderTrigger = true,
-  hovered,
-  default: defaultValue = 70,
-  placeholder,
-  disabled,
-}) => {
-  const safeStringify = (val?: string | number | null) =>
-    val == null ? '' : String(val);
-
-  const theme = useTheme();
-  const labelText = typeof label === 'string' ? label : '';
-  const safeValue = typeof value === 'number' || typeof value === 'string' ? value : defaultValue;
-  
-  const [inputValue, setInputValue] = useState(safeStringify(safeValue));
-
-  useEffect(() => {
-    if (value !== undefined && value !== null && (typeof value === 'number' || typeof value === 'string')) {
-      setInputValue(safeStringify(value));
-    }
-  }, [value]);
-
-  const handleChange = useCallback((inputVal: string) => {
-    let parsedValue: string | number = inputVal;
-    const errors: any[] = [];
-
-    if (inputVal !== '') {
-      const error = legacyValidateInteger(inputVal);
-      if (error) {
-        errors.push(error);
-      } else {
-        parsedValue = parseInt(inputVal, 10);
-      }
-    }
-
-    // ControlComponentProps onChange signature is (value: JsonValue) => void
-    // but we need to pass errors, so we use type assertion
-    (onChange as any)?.(parsedValue, errors);
-  }, [onChange]);
-
-  const debouncedOnChange = useMemo(
-    () => debounce(handleChange, Constants.FAST_DEBOUNCE),
-    [handleChange],
-  );
-
-  const onChangeWrapper = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    setInputValue(newValue);
-    debouncedOnChange(newValue);
-  }, [debouncedOnChange]);
-
+export const SizeToControl: React.FC<
+  React.ComponentProps<typeof IntegerInputControl>
+> = props => {
+  const { name, label, description, default: defaultValue, ...restProps } = props;
   return (
-    <div>
-      {label && (
-        <div className="ControlHeader" data-test={`${name}-header`}>
-          <FormLabel htmlFor={name}>
-            {labelText}
-            {description && hovered && (
-              <Tooltip id={`${name}-tooltip`} title={description} placement="top">
-                <Icons.InfoCircleOutlined />
-              </Tooltip>
-            )}
-            {renderTrigger && hovered && (
-              <InfoTooltip
-                label={t('bolt')}
-                tooltip={t('Changing this control takes effect instantly')}
-                placement="top"
-                type="notice"
-              />
-            )}
-            {validationErrors && validationErrors.length > 0 && (
-              <Tooltip
-                id="error-tooltip"
-                placement="top"
-                title={Array.isArray(validationErrors) ? validationErrors.join(' ') : String(validationErrors)}
-              >
-                <Icons.ExclamationCircleOutlined iconColor={theme.colorError} />
-              </Tooltip>
-            )}
-          </FormLabel>
-        </div>
-      )}
-      <Input
-        type="text"
-        data-test="inline-name"
-        placeholder={placeholder}
-        onChange={onChangeWrapper}
-        value={inputValue}
-        disabled={disabled}
-        aria-label={labelText}
-      />
-    </div>
+    <IntegerInputControl
+      name={name || 'size_to'}
+      label={label || t('Maximum Font Size')}
+      description={description || t('Font size for the biggest value in the list')}
+      default={defaultValue ?? 70}
+      config={{
+        defaultName: 'size_to',
+        defaultLabel: t('Maximum Font Size'),
+        defaultDescription: t('Font size for the biggest value in the list'),
+        defaultValue: 70,
+      }}
+      {...restProps}
+    />
   );
 };
 
@@ -140,4 +50,3 @@ export const SizeToControl: React.FC<SizeToControlProps> = ({
 SizeToControl.defaultProps = {
   name: 'size_to',
 };
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, userEvent, selectOption } from 'spec/helpers/testing-library';
+import { RotationControl } from '../RotationControl';
+
+const defaultProps = {
+  name: 'rotation',
+  label: 'Word Rotation',
+  description: 'Rotation to apply to words in the cloud',
+  onChange: jest.fn(),
+  value: 'square',
+  hovered: false,
+};
+
+const setup = (overrides = {}) => (
+  <RotationControl {...defaultProps} {...overrides} />
+);
+
+test('should render', () => {
+  const { container } = render(setup());
+  expect(container).toBeInTheDocument();
+});
+
+test('should render with label', () => {
+  render(setup());
+  expect(screen.getByText('Word Rotation')).toBeInTheDocument();
+});
+
+test('should render Select component', () => {
+  render(setup());
+  // The Select component should be rendered
+  const select = screen.getByRole('combobox');
+  expect(select).toBeInTheDocument();
+});
+
+test('should display current value', () => {
+  render(setup({ value: 'random' }));
+  // The Select component displays the label, not the value directly
+  // We check that the select is rendered (the actual value is internal)
+  const select = screen.getByRole('combobox');
+  expect(select).toBeInTheDocument();
+});
+
+test('should use default value when value is undefined', () => {
+  render(setup({ value: undefined }));
+  // The Select component uses default value internally
+  const select = screen.getByRole('combobox');
+  expect(select).toBeInTheDocument();
+});
+
+test('should call onChange when value changes', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange }));
+  
+  await selectOption('random');
+  
+  expect(onChange).toHaveBeenCalledWith('random', []);
+});
+
+test('should display description tooltip when hovered', () => {
+  render(setup({ hovered: true }));
+  // The tooltip icon should be present when hovered
+  const header = screen.getByTestId('rotation-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should not display description tooltip when not hovered', () => {
+  render(setup({ hovered: false }));
+  const header = screen.getByTestId('rotation-header');
+  expect(header).toBeInTheDocument();
+  // Tooltip should not be visible when not hovered
+});
+
+test('should display validation errors', () => {
+  const validationErrors = ['Invalid rotation value'];
+  render(setup({ validationErrors }));
+  // Error icon should be present
+  const header = screen.getByTestId('rotation-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should have correct default name prop', () => {
+  expect(RotationControl.defaultProps?.name).toBe('rotation');
+});
+
+test('should handle all rotation options', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange }));
+  
+  // Test 'random' option
+  await selectOption('random');
+  expect(onChange).toHaveBeenCalledWith('random', []);
+  
+  // Test 'flat' option
+  await selectOption('flat');
+  expect(onChange).toHaveBeenCalledWith('flat', []);
+  
+  // Test 'square' option
+  await selectOption('square');
+  expect(onChange).toHaveBeenCalledWith('square', []);
+});
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, userEvent, selectOption } from 'spec/helpers/testing-library';
+import { render, screen, selectOption } from 'spec/helpers/testing-library';
 import { RotationControl } from '../RotationControl';
 
 const defaultProps = {

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/RotationControl.test.tsx
@@ -67,9 +67,9 @@ test('should use default value when value is undefined', () => {
 test('should call onChange when value changes', async () => {
   const onChange = jest.fn();
   render(setup({ onChange }));
-  
+
   await selectOption('random');
-  
+
   expect(onChange).toHaveBeenCalledWith('random', []);
 });
 
@@ -102,17 +102,16 @@ test('should have correct default name prop', () => {
 test('should handle all rotation options', async () => {
   const onChange = jest.fn();
   render(setup({ onChange }));
-  
+
   // Test 'random' option
   await selectOption('random');
   expect(onChange).toHaveBeenCalledWith('random', []);
-  
+
   // Test 'flat' option
   await selectOption('flat');
   expect(onChange).toHaveBeenCalledWith('flat', []);
-  
+
   // Test 'square' option
   await selectOption('square');
   expect(onChange).toHaveBeenCalledWith('square', []);
 });
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeFromControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeFromControl.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import { SizeFromControl } from '../SizeFromControl';
+
+const defaultProps = {
+  name: 'size_from',
+  label: 'Minimum Font Size',
+  description: 'Font size for the smallest value in the list',
+  onChange: jest.fn(),
+  value: 10,
+  hovered: false,
+  default: 10,
+};
+
+const setup = (overrides = {}) => (
+  <SizeFromControl {...defaultProps} {...overrides} />
+);
+
+test('should render', () => {
+  const { container } = render(setup());
+  expect(container).toBeInTheDocument();
+});
+
+test('should render with label', () => {
+  render(setup());
+  expect(screen.getByText('Minimum Font Size')).toBeInTheDocument();
+});
+
+test('should render Input component', () => {
+  render(setup());
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+});
+
+test('should display current numeric value', () => {
+  render(setup({ value: 20 }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('20');
+});
+
+test('should display current string value', () => {
+  render(setup({ value: '15' }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('15');
+});
+
+test('should use default value when value is undefined', () => {
+  render(setup({ value: undefined }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('10');
+});
+
+test('should call onChange with parsed integer when valid number is entered', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  await userEvent.type(input, '25');
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Check that onChange was called with parsed integer
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[0]).toBe(25);
+  expect(lastCall[1]).toEqual([]); // No errors
+});
+
+test('should call onChange with errors when invalid input is entered', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  await userEvent.type(input, 'abc');
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Check that onChange was called with errors
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[1].length).toBeGreaterThan(0); // Has errors
+});
+
+test('should handle empty input', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: 10 }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Empty string should be passed without errors
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[0]).toBe('');
+  expect(lastCall[1]).toEqual([]);
+});
+
+test('should display placeholder when provided', () => {
+  render(setup({ placeholder: 'Enter minimum size' }));
+  const input = screen.getByPlaceholderText('Enter minimum size');
+  expect(input).toBeInTheDocument();
+});
+
+test('should be disabled when disabled prop is true', () => {
+  render(setup({ disabled: true }));
+  const input = screen.getByRole('textbox');
+  expect(input).toBeDisabled();
+});
+
+test('should update input value when value prop changes', () => {
+  const { rerender } = render(setup({ value: 10 }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('10');
+  
+  rerender(setup({ value: 30 }));
+  expect(input).toHaveValue('30');
+});
+
+test('should display description tooltip when hovered', () => {
+  render(setup({ hovered: true }));
+  const header = screen.getByTestId('size_from-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should display validation errors', () => {
+  const validationErrors = ['Value must be positive'];
+  render(setup({ validationErrors }));
+  const header = screen.getByTestId('size_from-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should have correct default name prop', () => {
+  expect(SizeFromControl.defaultProps?.name).toBe('size_from');
+});
+
+test('should debounce onChange calls', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  // Type multiple characters quickly
+  await userEvent.type(input, '123', { delay: 10 });
+  
+  // Should not have been called immediately
+  expect(onChange).not.toHaveBeenCalled();
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+});
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeFromControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeFromControl.test.tsx
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import { SizeFromControl } from '../SizeFromControl';
 
 const defaultProps = {
@@ -71,10 +76,10 @@ test('should call onChange with parsed integer when valid number is entered', as
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
   await userEvent.type(input, '25');
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -82,7 +87,7 @@ test('should call onChange with parsed integer when valid number is entered', as
     },
     { timeout: 500 },
   );
-  
+
   // Check that onChange was called with parsed integer
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -94,10 +99,10 @@ test('should call onChange with errors when invalid input is entered', async () 
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
   await userEvent.type(input, 'abc');
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -105,7 +110,7 @@ test('should call onChange with errors when invalid input is entered', async () 
     },
     { timeout: 500 },
   );
-  
+
   // Check that onChange was called with errors
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -116,9 +121,9 @@ test('should handle empty input', async () => {
   const onChange = jest.fn();
   render(setup({ onChange, value: 10 }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -126,7 +131,7 @@ test('should handle empty input', async () => {
     },
     { timeout: 500 },
   );
-  
+
   // Empty string should be passed without errors
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -150,7 +155,7 @@ test('should update input value when value prop changes', () => {
   const { rerender } = render(setup({ value: 10 }));
   const input = screen.getByRole('textbox');
   expect(input).toHaveValue('10');
-  
+
   rerender(setup({ value: 30 }));
   expect(input).toHaveValue('30');
 });
@@ -176,13 +181,13 @@ test('should debounce onChange calls', async () => {
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   // Type multiple characters quickly
   await userEvent.type(input, '123', { delay: 10 });
-  
+
   // Should not have been called immediately
   expect(onChange).not.toHaveBeenCalled();
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -191,4 +196,3 @@ test('should debounce onChange calls', async () => {
     { timeout: 500 },
   );
 });
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeToControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeToControl.test.tsx
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import { SizeToControl } from '../SizeToControl';
 
 const defaultProps = {
@@ -71,10 +76,10 @@ test('should call onChange with parsed integer when valid number is entered', as
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
   await userEvent.type(input, '100');
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -82,7 +87,7 @@ test('should call onChange with parsed integer when valid number is entered', as
     },
     { timeout: 500 },
   );
-  
+
   // Check that onChange was called with parsed integer
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -94,10 +99,10 @@ test('should call onChange with errors when invalid input is entered', async () 
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
   await userEvent.type(input, 'xyz');
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -105,7 +110,7 @@ test('should call onChange with errors when invalid input is entered', async () 
     },
     { timeout: 500 },
   );
-  
+
   // Check that onChange was called with errors
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -116,9 +121,9 @@ test('should handle empty input', async () => {
   const onChange = jest.fn();
   render(setup({ onChange, value: 70 }));
   const input = screen.getByRole('textbox');
-  
+
   await userEvent.clear(input);
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -126,7 +131,7 @@ test('should handle empty input', async () => {
     },
     { timeout: 500 },
   );
-  
+
   // Empty string should be passed without errors
   const calls = onChange.mock.calls;
   const lastCall = calls[calls.length - 1];
@@ -150,7 +155,7 @@ test('should update input value when value prop changes', () => {
   const { rerender } = render(setup({ value: 70 }));
   const input = screen.getByRole('textbox');
   expect(input).toHaveValue('70');
-  
+
   rerender(setup({ value: 120 }));
   expect(input).toHaveValue('120');
 });
@@ -176,13 +181,13 @@ test('should debounce onChange calls', async () => {
   const onChange = jest.fn();
   render(setup({ onChange, value: undefined }));
   const input = screen.getByRole('textbox');
-  
+
   // Type multiple characters quickly
   await userEvent.type(input, '999', { delay: 10 });
-  
+
   // Should not have been called immediately
   expect(onChange).not.toHaveBeenCalled();
-  
+
   // Wait for debounce
   await waitFor(
     () => {
@@ -191,4 +196,3 @@ test('should debounce onChange calls', async () => {
     { timeout: 500 },
   );
 });
-

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeToControl.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/__tests__/SizeToControl.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import { SizeToControl } from '../SizeToControl';
+
+const defaultProps = {
+  name: 'size_to',
+  label: 'Maximum Font Size',
+  description: 'Font size for the biggest value in the list',
+  onChange: jest.fn(),
+  value: 70,
+  hovered: false,
+  default: 70,
+};
+
+const setup = (overrides = {}) => (
+  <SizeToControl {...defaultProps} {...overrides} />
+);
+
+test('should render', () => {
+  const { container } = render(setup());
+  expect(container).toBeInTheDocument();
+});
+
+test('should render with label', () => {
+  render(setup());
+  expect(screen.getByText('Maximum Font Size')).toBeInTheDocument();
+});
+
+test('should render Input component', () => {
+  render(setup());
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+});
+
+test('should display current numeric value', () => {
+  render(setup({ value: 100 }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('100');
+});
+
+test('should display current string value', () => {
+  render(setup({ value: '80' }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('80');
+});
+
+test('should use default value when value is undefined', () => {
+  render(setup({ value: undefined }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('70');
+});
+
+test('should call onChange with parsed integer when valid number is entered', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  await userEvent.type(input, '100');
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Check that onChange was called with parsed integer
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[0]).toBe(100);
+  expect(lastCall[1]).toEqual([]); // No errors
+});
+
+test('should call onChange with errors when invalid input is entered', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  await userEvent.type(input, 'xyz');
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Check that onChange was called with errors
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[1].length).toBeGreaterThan(0); // Has errors
+});
+
+test('should handle empty input', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: 70 }));
+  const input = screen.getByRole('textbox');
+  
+  await userEvent.clear(input);
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+  
+  // Empty string should be passed without errors
+  const calls = onChange.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  expect(lastCall[0]).toBe('');
+  expect(lastCall[1]).toEqual([]);
+});
+
+test('should display placeholder when provided', () => {
+  render(setup({ placeholder: 'Enter maximum size' }));
+  const input = screen.getByPlaceholderText('Enter maximum size');
+  expect(input).toBeInTheDocument();
+});
+
+test('should be disabled when disabled prop is true', () => {
+  render(setup({ disabled: true }));
+  const input = screen.getByRole('textbox');
+  expect(input).toBeDisabled();
+});
+
+test('should update input value when value prop changes', () => {
+  const { rerender } = render(setup({ value: 70 }));
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('70');
+  
+  rerender(setup({ value: 120 }));
+  expect(input).toHaveValue('120');
+});
+
+test('should display description tooltip when hovered', () => {
+  render(setup({ hovered: true }));
+  const header = screen.getByTestId('size_to-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should display validation errors', () => {
+  const validationErrors = ['Value must be positive'];
+  render(setup({ validationErrors }));
+  const header = screen.getByTestId('size_to-header');
+  expect(header).toBeInTheDocument();
+});
+
+test('should have correct default name prop', () => {
+  expect(SizeToControl.defaultProps?.name).toBe('size_to');
+});
+
+test('should debounce onChange calls', async () => {
+  const onChange = jest.fn();
+  render(setup({ onChange, value: undefined }));
+  const input = screen.getByRole('textbox');
+  
+  // Type multiple characters quickly
+  await userEvent.type(input, '999', { delay: 10 });
+  
+  // Should not have been called immediately
+  expect(onChange).not.toHaveBeenCalled();
+  
+  // Wait for debounce
+  await waitFor(
+    () => {
+      expect(onChange).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+});
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export { RotationControl } from './RotationControl';
+export { SizeFromControl } from './SizeFromControl';
+export { SizeToControl } from './SizeToControl';
+

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
@@ -21,4 +21,7 @@ export { SizeFromControl } from './SizeFromControl';
 export { SizeToControl } from './SizeToControl';
 export { IntegerInputControl } from './IntegerInputControl';
 export type { ExtendedControlComponentProps } from './types';
-export type { IntegerInputControlConfig, IntegerInputControlProps } from './IntegerInputControl';
+export type {
+  IntegerInputControlConfig,
+  IntegerInputControlProps,
+} from './IntegerInputControl';

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/index.ts
@@ -19,4 +19,6 @@
 export { RotationControl } from './RotationControl';
 export { SizeFromControl } from './SizeFromControl';
 export { SizeToControl } from './SizeToControl';
-
+export { IntegerInputControl } from './IntegerInputControl';
+export type { ExtendedControlComponentProps } from './types';
+export type { IntegerInputControlConfig, IntegerInputControlProps } from './IntegerInputControl';

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/types.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/types.ts
@@ -16,27 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { JsonValue } from '@superset-ui/core';
-import { ControlComponentProps } from '@superset-ui/chart-controls';
 
 /**
- * Extended ControlComponentProps that properly types the onChange callback
- * to support validation errors as a second parameter.
+ * Re-export ExtendedControlComponentProps from the shared location.
  *
- * The actual Control component implementation (src/explore/components/Control.tsx)
- * accepts onChange with signature (value: any, errors: any[]) => void,
- * but the base ControlComponentProps interface only defines (value: JsonValue) => void.
- *
- * This interface extends the base props and overrides onChange to match the
- * actual implementation, providing proper type safety.
+ * This type has been moved to @superset-ui/chart-controls to avoid coupling
+ * core infrastructure to specific plugins. This file maintains backward
+ * compatibility for plugin-internal imports.
  */
-export interface ExtendedControlComponentProps<
-  ValueType extends JsonValue = JsonValue,
-> extends Omit<ControlComponentProps<ValueType>, 'onChange'> {
-  /**
-   * Callback invoked when the control value changes.
-   * @param value - The new value for the control
-   * @param errors - Array of validation error messages (empty array if no errors)
-   */
-  onChange?: (value: ValueType, errors?: string[]) => void;
-}
+export type { ExtendedControlComponentProps } from '@superset-ui/chart-controls';

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/types.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/controls/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { JsonValue } from '@superset-ui/core';
+import { ControlComponentProps } from '@superset-ui/chart-controls';
+
+/**
+ * Extended ControlComponentProps that properly types the onChange callback
+ * to support validation errors as a second parameter.
+ *
+ * The actual Control component implementation (src/explore/components/Control.tsx)
+ * accepts onChange with signature (value: any, errors: any[]) => void,
+ * but the base ControlComponentProps interface only defines (value: JsonValue) => void.
+ *
+ * This interface extends the base props and overrides onChange to match the
+ * actual implementation, providing proper type safety.
+ */
+export interface ExtendedControlComponentProps<
+  ValueType extends JsonValue = JsonValue,
+> extends Omit<ControlComponentProps<ValueType>, 'onChange'> {
+  /**
+   * Callback invoked when the control value changes.
+   * @param value - The new value for the control
+   * @param errors - Array of validation error messages (empty array if no errors)
+   */
+  onChange?: (value: ValueType, errors?: string[]) => void;
+}

--- a/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/src/plugin/transformProps.ts
@@ -41,8 +41,8 @@ export default function transformProps(chartProps: ChartProps): WordCloudProps {
     metric,
     rotation,
     series,
-    sizeFrom = 0,
-    sizeTo,
+    sizeFrom = 10,
+    sizeTo = 70, // Default value if control is removed
     sliceId,
   } = formData as WordCloudFormData;
 

--- a/superset-frontend/plugins/plugin-chart-word-cloud/tsconfig.json
+++ b/superset-frontend/plugins/plugin-chart-word-cloud/tsconfig.json
@@ -11,7 +11,12 @@
     "rootDir": "src",
     "declarationDir": "lib"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "types/**/*"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/plugin/controls/**/*.tsx",
+    "types/**/*"
+  ],
   "exclude": [
     "src/**/*.js",
     "src/**/*.jsx",

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -81,7 +81,7 @@ import { Operators } from '../constants';
 import { Clauses } from './controls/FilterControl/types';
 import { AdhocFilterType } from './controls/FilterControl/adhocFilterType';
 import StashFormDataContainer from './StashFormDataContainer';
-import { ExtendedControlComponentProps } from 'plugins/plugin-chart-word-cloud/src/plugin/controls/types';
+import { ExtendedControlComponentProps } from '@superset-ui/chart-controls';
 
 /**
  * Extended props that are passed to control components in ControlPanelsContainer.

--- a/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
+++ b/superset-frontend/src/explore/controlUtils/controlUtils.test.tsx
@@ -98,7 +98,19 @@ describe('controlUtils', () => {
   describe('getControlConfig', () => {
     test('returns a valid spatial controlConfig', () => {
       const spatialControl = getControlConfig('color_scheme', 'test-chart');
-      expect(spatialControl?.type).toEqual('ColorSchemeControl');
+      // Type guard: check if result is a BaseControlConfig with a string type property
+      if (
+        spatialControl &&
+        typeof spatialControl === 'object' &&
+        'type' in spatialControl &&
+        typeof spatialControl.type === 'string'
+      ) {
+        expect(spatialControl.type).toEqual('ColorSchemeControl');
+      } else {
+        throw new Error(
+          'Expected spatialControl to be a BaseControlConfig with string type',
+        );
+      }
     });
 
     test('overrides according to vizType', () => {

--- a/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from 'react';
-import { ExtendedControlComponentProps } from 'plugins/plugin-chart-word-cloud/src/plugin/controls/types';
+import { ExtendedControlComponentProps } from '@superset-ui/chart-controls';
 
 /**
  * Extracts the control name from a React component.

--- a/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
@@ -32,7 +32,9 @@ import { ExtendedControlComponentProps } from '@superset-ui/chart-controls';
  * @returns Control name string, or null if unable to determine
  */
 export function getControlNameFromComponent(
-  Component: React.ComponentType<ExtendedControlComponentProps> | React.ReactElement,
+  Component:
+    | React.ComponentType<ExtendedControlComponentProps>
+    | React.ReactElement,
   elementProps?: { name?: string },
 ): string | null {
   // First, check if there's a name in element props
@@ -52,9 +54,10 @@ export function getControlNameFromComponent(
 
   // Check defaultProps.name first (highest priority for explicit naming)
   // Type assertion needed because defaultProps is not always in the type definition
-  const componentWithDefaults = ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
-    defaultProps?: { name?: string };
-  };
+  const componentWithDefaults =
+    ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
+      defaultProps?: { name?: string };
+    };
   if (componentWithDefaults.defaultProps?.name) {
     return componentWithDefaults.defaultProps.name;
   }
@@ -62,11 +65,13 @@ export function getControlNameFromComponent(
   // Fall back to converting component name to control name
   // RotationControl -> rotation, SizeFromControl -> size_from
   // Type assertion needed because displayName is not always in the type definition
-  const componentWithDisplayName = ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
-    name?: string;
-    displayName?: string;
-  };
-  const componentName = componentWithDisplayName.name || componentWithDisplayName.displayName || '';
+  const componentWithDisplayName =
+    ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
+      name?: string;
+      displayName?: string;
+    };
+  const componentName =
+    componentWithDisplayName.name || componentWithDisplayName.displayName || '';
   if (componentName.endsWith('Control')) {
     const baseName = componentName.slice(0, -7); // Remove 'Control' suffix
     return baseName

--- a/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlNameFromComponent.ts
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { ExtendedControlComponentProps } from 'plugins/plugin-chart-word-cloud/src/plugin/controls/types';
+
+/**
+ * Extracts the control name from a React component.
+ *
+ * Priority order:
+ * 1. Component's defaultProps.name (if set)
+ * 2. Element props.name (if provided)
+ * 3. Convert component name to control name (e.g., RotationControl -> rotation)
+ *
+ * @param Component - React component type or React element
+ * @param elementProps - Optional props from a React element (if Component is an element)
+ * @returns Control name string, or null if unable to determine
+ */
+export function getControlNameFromComponent(
+  Component: React.ComponentType<ExtendedControlComponentProps> | React.ReactElement,
+  elementProps?: { name?: string },
+): string | null {
+  // First, check if there's a name in element props
+  if (elementProps?.name) {
+    return elementProps.name;
+  }
+
+  // Get the component type (handle both ComponentType and ReactElement)
+  const ComponentType =
+    typeof Component === 'function'
+      ? Component
+      : (Component as React.ReactElement).type;
+
+  if (typeof ComponentType !== 'function') {
+    return null;
+  }
+
+  // Check defaultProps.name first (highest priority for explicit naming)
+  // Type assertion needed because defaultProps is not always in the type definition
+  const componentWithDefaults = ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
+    defaultProps?: { name?: string };
+  };
+  if (componentWithDefaults.defaultProps?.name) {
+    return componentWithDefaults.defaultProps.name;
+  }
+
+  // Fall back to converting component name to control name
+  // RotationControl -> rotation, SizeFromControl -> size_from
+  // Type assertion needed because displayName is not always in the type definition
+  const componentWithDisplayName = ComponentType as React.ComponentType<ExtendedControlComponentProps> & {
+    name?: string;
+    displayName?: string;
+  };
+  const componentName = componentWithDisplayName.name || componentWithDisplayName.displayName || '';
+  if (componentName.endsWith('Control')) {
+    const baseName = componentName.slice(0, -7); // Remove 'Control' suffix
+    return baseName
+      .replace(/([A-Z])/g, '_$1') // Convert camelCase to snake_case
+      .toLowerCase()
+      .replace(/^_/, ''); // Remove leading underscore if present
+  }
+
+  return null;
+}

--- a/superset-frontend/src/explore/controlUtils/getControlState.ts
+++ b/superset-frontend/src/explore/controlUtils/getControlState.ts
@@ -34,7 +34,7 @@ import {
 import { getSectionsToRender } from './getSectionsToRender';
 import { getControlConfig } from './getControlConfig';
 import { getControlNameFromComponent } from './getControlNameFromComponent';
-import { ExtendedControlComponentProps } from 'plugins/plugin-chart-word-cloud/src/plugin/controls/types';
+import { ExtendedControlComponentProps } from '@superset-ui/chart-controls';
 
 type ValidationError = JsonValue;
 

--- a/superset-frontend/src/explore/controlUtils/getSectionsToRender.ts
+++ b/superset-frontend/src/explore/controlUtils/getSectionsToRender.ts
@@ -94,7 +94,14 @@ const getMemoizedSectionsToRender = memoizeOne(
                     typeof control !== 'string' ||
                     !invalidControls.includes(control),
                 )
-                .map(item => expandControlConfig(item, controlOverrides)),
+                .map(item => {
+                  // If it's a function component, pass it through as-is
+                  // (expandControlConfig will handle it)
+                  if (typeof item === 'function') {
+                    return item;
+                  }
+                  return expandControlConfig(item, controlOverrides);
+                }),
             ) || [],
         };
       })

--- a/superset-frontend/src/explore/controlUtils/index.ts
+++ b/superset-frontend/src/explore/controlUtils/index.ts
@@ -22,3 +22,5 @@ export * from './getControlState';
 export * from './getFormDataFromControls';
 export * from './getControlValuesCompatibleWithDatasource';
 export * from './standardizedFormData';
+export * from './getControlNameFromComponent';
+export { getControlConfigFromComponent } from './getControlState';

--- a/superset-frontend/src/utils/getControlsForVizType.ts
+++ b/superset-frontend/src/utils/getControlsForVizType.ts
@@ -27,7 +27,7 @@ import {
   getControlNameFromComponent,
   getControlConfigFromComponent,
 } from '../explore/controlUtils';
-import { ExtendedControlComponentProps } from 'plugins/plugin-chart-word-cloud/src/plugin/controls/types';
+import { ExtendedControlComponentProps } from '@superset-ui/chart-controls';
 
 const memoizedControls = memoizeOne(
   (vizType: string, controlPanel: JsonObject | undefined): ControlMap => {
@@ -90,8 +90,11 @@ const memoizedControls = memoizeOne(
                   controlsMap[controlObj.name] = controlObj.config;
                 } else if (
                   // Handle React elements (component-based controls)
+                  control !== null &&
+                  control !== undefined &&
                   typeof control === 'object' &&
-                  control != null &&
+                  !(control instanceof Date) &&
+                  !(control instanceof RegExp) &&
                   'type' in control
                 ) {
                   const element = control as React.ReactElement;


### PR DESCRIPTION
### SUMMARY

Related to #35655 

This PR introduces React functional components for Word Cloud chart controls, replacing legacy configuration objects. This is a proof of concept demonstrating the pattern for migrating control panels to React components, as discussed in the maintainer feedback.

**Changes:**
- Created 3 React component controls: `RotationControl`, `SizeFromControl`, and `SizeToControl`
- Updated control panel infrastructure to support React components in `controlSetRows`
- Added comprehensive test suite (51 tests) covering all new controls
- Maintained backward compatibility with legacy string-based controls

**Infrastructure Updates:**
- Modified `ControlPanelsContainer.tsx` to handle React function components
- Updated `getControlState.ts` and `getAllControlsState.ts` to extract control names from React components
- Updated `getControlsForVizType.ts` to map React components to control configurations
- Extended `ExpandedControlItem` type to include `ComponentType` and `FunctionComponent`

This PR demonstrates the pattern for future control panel modernization while keeping changes small and focused on a single chart type, as recommended by maintainers.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No visual changes - the controls render identically to the previous implementation, but are now React components instead of configuration objects.

### TESTING INSTRUCTIONS

1. **Run the test suite:**ash
   cd superset-frontend
   npm test -- plugins/plugin-chart-word-cloud
      Should show 51 tests passing across 4 test suites.

2. **Manual testing:**
   - Navigate to Explore view
   - Select Word Cloud chart type
   - Verify all controls render correctly:
     - Rotation control (dropdown with random/flat/square options)
     - Minimum Font Size (text input)
     - Maximum Font Size (text input)
   - Change values and verify they save correctly
   - Verify chart renders with the selected values
   - Verify legacy controls (series, metric, color_scheme) still work

3. **Integration testing:**
   - Create a new Word Cloud chart
   - Modify all React component controls
   - Save the chart
   - Reload the page and verify values persist
   - Edit the chart and verify controls show saved values

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No (POC/demonstration PR)

- [ ] Required feature flags: None

- [x] Changes UI: No visual changes, but changes control implementation

- [ ] Includes DB Migration: No

- [x] Introduces new feature or API: Yes - React component controls pattern

- [ ] Removes existing feature or API: No - maintains backward compatibility