### PR TITLE
fix: cache key generation

### DIFF
--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -1059,6 +1059,19 @@ class QueryContextProcessor:
 
         self.ensure_totals_available()
 
+        # Update cache_values to reflect modifications made by ensure_totals_available()
+        # This ensures cache keys are generated from the actual query state
+        # We merge the original query dict with the updated query dict to preserve
+        # any fields that might not be in to_dict() but were in the original request
+        self._query_context.cache_values["queries"] = [
+            {**cached_query, **query.to_dict()}
+            for cached_query, query in zip(
+                self._query_context.cache_values["queries"],
+                self._query_context.queries,
+                strict=True,
+            )
+        ]
+
         query_results = [
             get_query_results(
                 query_obj.result_type or self._query_context.result_type,

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -485,11 +485,12 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             cache_dict, default=json_int_dttm_ser, ignore_nan=True
         )
         # Log QueryObject cache key generation for debugging
-        logger.info(
-            "QueryObject CACHE KEY generated: %s from dict with keys: %s",
-            cache_key,
-            sorted(cache_dict.keys()),
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "QueryObject CACHE KEY generated: %s from dict with keys: %s",
+                cache_key,
+                sorted(cache_dict.keys()),
+            )
         return cache_key
 
     def exec_post_processing(self, df: DataFrame) -> DataFrame:

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -385,6 +385,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             "metrics": self.metrics,
             "order_desc": self.order_desc,
             "orderby": self.orderby,
+            "post_processing": self.post_processing,
             "row_limit": self.row_limit,
             "row_offset": self.row_offset,
             "series_columns": self.series_columns,
@@ -480,7 +481,16 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             # datasource or database do not exist
             pass
 
-        return md5_sha_from_dict(cache_dict, default=json_int_dttm_ser, ignore_nan=True)
+        cache_key = md5_sha_from_dict(
+            cache_dict, default=json_int_dttm_ser, ignore_nan=True
+        )
+        # Log QueryObject cache key generation for debugging
+        logger.info(
+            "QueryObject CACHE KEY generated: %s from dict with keys: %s",
+            cache_key,
+            sorted(cache_dict.keys()),
+        )
+        return cache_key
 
     def exec_post_processing(self, df: DataFrame) -> DataFrame:
         """

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -159,7 +159,7 @@ class QueryCacheManager:
         if cache_value := _cache[region].get(key):
             logger.debug("Cache key: %s", key)
             # Log cache hit for debugging
-            logger.info("CACHE GET - Key: %s, Region: %s", key, region)
+            logger.debug("CACHE GET - Key: %s, Region: %s", key, region)
             current_app.config["STATS_LOGGER"].incr("loading_from_cache")
             try:
                 query_cache.df = cache_value["df"]

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -158,6 +158,8 @@ class QueryCacheManager:
 
         if cache_value := _cache[region].get(key):
             logger.debug("Cache key: %s", key)
+            # Log cache hit for debugging
+            logger.info("CACHE GET - Key: %s, Region: %s", key, region)
             current_app.config["STATS_LOGGER"].incr("loading_from_cache")
             try:
                 query_cache.df = cache_value["df"]

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -181,6 +181,7 @@ class QueryObjectDict(TypedDict, total=False):
     group_others_when_limit_reached: bool
     to_dttm: datetime | None
     time_shift: str | None
+    post_processing: list[dict[str, Any]]
 
     # Additional fields used throughout the codebase
     time_range: str | None

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -40,12 +40,15 @@ logger = logging.getLogger(__name__)
 def generate_cache_key(values_dict: dict[str, Any], key_prefix: str = "") -> str:
     hash_str = md5_sha_from_dict(values_dict, default=json_int_dttm_ser)
     cache_key = f"{key_prefix}{hash_str}"
-    # Log cache key generation for debugging
-    logger.debug(
-        "Cache key generated: %s from dict keys: %s",
-        cache_key,
-        list(values_dict.keys()),
-    )
+
+    if logger.isEnabledFor(logging.DEBUG):
+        # Log cache key generation for debugging
+        logger.debug(
+            "Cache key generated: %s from dict keys: %s",
+            cache_key,
+            list(values_dict.keys()),
+        )
+
     return cache_key
 
 

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -39,7 +39,14 @@ logger = logging.getLogger(__name__)
 
 def generate_cache_key(values_dict: dict[str, Any], key_prefix: str = "") -> str:
     hash_str = md5_sha_from_dict(values_dict, default=json_int_dttm_ser)
-    return f"{key_prefix}{hash_str}"
+    cache_key = f"{key_prefix}{hash_str}"
+    # Log cache key generation for debugging
+    logger.debug(
+        "Cache key generated: %s from dict keys: %s",
+        cache_key,
+        list(values_dict.keys()),
+    )
+    return cache_key
 
 
 def set_and_log_cache(
@@ -67,6 +74,14 @@ def set_and_log_cache(
         cache_instance.set(cache_key, value, timeout=timeout)
         stats_logger = app.config["STATS_LOGGER"]
         stats_logger.incr("set_cache_key")
+
+        # Log cache key details for debugging
+        logger.info(
+            "CACHE SET - Key: %s, Datasource: %s, Timeout: %s",
+            cache_key,
+            datasource_uid,
+            timeout,
+        )
 
         if datasource_uid and app.config["STORE_CACHE_KEYS_IN_METADATA_DB"]:
             ck = CacheKey(

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -76,7 +76,7 @@ def set_and_log_cache(
         stats_logger.incr("set_cache_key")
 
         # Log cache key details for debugging
-        logger.info(
+        logger.debug(
             "CACHE SET - Key: %s, Datasource: %s, Timeout: %s",
             cache_key,
             datasource_uid,

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -626,6 +626,169 @@ def test_processing_time_offsets_date_range_enabled(processor):
                                 assert isinstance(result["cache_keys"], list)
 
 
+def test_ensure_totals_available_updates_cache_values():
+    """
+    Test that ensure_totals_available() updates the query objects AND
+    cache_values to keep them in sync.
+
+    The issue was that ensure_totals_available() modified QueryObject instances
+    (e.g., setting row_limit=None on totals queries and adding contribution_totals
+    to post_processing), but cache_values still contained the original queries.
+    This caused cache key mismatches between worker execution and cache fetch.
+    """
+    import pandas as pd
+
+    from superset.common.query_object import QueryObject
+
+    # Create a mock datasource
+    mock_datasource = MagicMock()
+    mock_datasource.uid = "test_datasource"
+    mock_datasource.database.db_engine_spec.engine = "postgresql"
+    mock_datasource.cache_timeout = None
+    mock_datasource.changed_on = None
+
+    # Create QueryObjects that would trigger ensure_totals_available logic
+    # Query 1: Main query with contribution post-processing (needs totals)
+    main_query = QueryObject(
+        datasource=mock_datasource,
+        columns=["brokerage"],
+        metrics=["Net Amount In", "Amount Out", "Amount In"],
+        row_limit=50000,
+        orderby=[["Net Amount In", False]],
+        post_processing=[
+            {
+                "operation": "contribution",
+                "options": {
+                    "columns": ["Amount In", "Amount Out"],
+                    "rename_columns": ["%Amount In", "%Amount Out"],
+                },
+            }
+        ],
+    )
+
+    # Query 2: Totals query (no columns, has metrics, no post-processing)
+    totals_query = QueryObject(
+        datasource=mock_datasource,
+        columns=[],  # No columns = totals query
+        metrics=["Net Amount In", "Amount Out", "Amount In"],
+        row_limit=50000,
+        post_processing=[],  # No post-processing
+    )
+
+    # Create mock query context
+    mock_query_context = MagicMock()
+    mock_query_context.force = False
+    mock_query_context.datasource = mock_datasource
+    mock_query_context.queries = [main_query, totals_query]
+    mock_query_context.result_type = "full"
+    mock_query_context.cache_values = {
+        "datasource": {"type": "table", "id": 1},
+        "queries": [
+            # These are the original queries as they would be stored in cache_values
+            {
+                "columns": ["brokerage"],
+                "metrics": ["Net Amount In", "Amount Out", "Amount In"],
+                "row_limit": 50000,
+                "orderby": [("Net Amount In", False)],
+                "post_processing": [
+                    {
+                        "operation": "contribution",
+                        "options": {
+                            "columns": ["Amount In", "Amount Out"],
+                            "rename_columns": ["%Amount In", "%Amount Out"],
+                        },
+                    }
+                ],
+            },
+            {
+                "columns": [],
+                "metrics": ["Net Amount In", "Amount Out", "Amount In"],
+                "row_limit": 50000,
+                "post_processing": [],
+            },
+        ],
+        "result_type": "full",
+        "result_format": "json",
+    }
+
+    # Create processor
+    processor = QueryContextProcessor(mock_query_context)
+    processor._qc_datasource = mock_datasource
+
+    # Mock the query execution result for totals query
+    mock_query_result = MagicMock()
+    mock_df = pd.DataFrame(
+        {
+            "Net Amount In": [20228060486.838825],
+            "Amount Out": [-20543489614.980007],
+            "Amount In": [40771550101.81883],
+        }
+    )
+    mock_query_result.df = mock_df
+
+    with patch.object(
+        mock_query_context, "get_query_result", return_value=mock_query_result
+    ):
+        # Call ensure_totals_available
+        processor.ensure_totals_available()
+
+        # Now call get_payload which should update cache_values
+        with patch(
+            "superset.common.query_context_processor.get_query_results"
+        ) as mock_get_query_results:
+            # Mock the query results
+            mock_query_results_response = [
+                {
+                    "data": [{"brokerage": "Test", "Net Amount In": 100}],
+                    "query": "SELECT ...",
+                }
+            ]
+            mock_get_query_results.return_value = mock_query_results_response
+
+            # Mock cache manager to avoid actual caching
+            with patch(
+                "superset.common.query_context_processor.QueryCacheManager"
+            ) as mock_cache_manager:
+                mock_cache = MagicMock()
+                mock_cache.is_loaded = True
+                mock_cache.df = pd.DataFrame(
+                    {"brokerage": ["Test"], "Net Amount In": [100]}
+                )
+                mock_cache.query = "SELECT ..."
+                mock_cache.error_message = None
+                mock_cache.status = "success"
+                mock_cache_manager.get.return_value = mock_cache
+
+                # This should update cache_values to match the modified queries
+                processor.get_payload(cache_query_context=False)
+
+    # Verify that cache_values has been updated to reflect the modifications
+    updated_cache_queries = mock_query_context.cache_values["queries"]
+
+    # Check that totals query has row_limit=None (modified by ensure_totals_available)
+    assert updated_cache_queries[1]["row_limit"] is None, (
+        "Expected totals query to have row_limit=None after ensure_totals_available, "
+        f"but got: {updated_cache_queries[1]['row_limit']}"
+    )
+
+    # Check that the main query has contribution_totals in post_processing
+    assert (
+        "contribution_totals"
+        in updated_cache_queries[0]["post_processing"][0]["options"]
+    ), "Expected main query post_processing to have contribution_totals added"
+
+    # Verify the contribution_totals match what we mocked
+    expected_totals = {
+        "Net Amount In": 20228060486.838825,
+        "Amount Out": -20543489614.980007,
+        "Amount In": 40771550101.81883,
+    }
+    assert (
+        updated_cache_queries[0]["post_processing"][0]["options"]["contribution_totals"]
+        == expected_totals
+    )
+
+
 def test_get_df_payload_validates_before_cache_key_generation():
     """
     Test that get_df_payload calls validate() before generating cache key.
@@ -701,3 +864,131 @@ def test_get_df_payload_validates_before_cache_key_generation():
         f"Expected validate to be called before cache_key, "
         f"but got call order: {call_order}"
     )
+
+
+def test_cache_values_sync_after_ensure_totals_available():
+    """
+    Test that cache_values is synchronized with QueryObject modifications
+    after ensure_totals_available() runs.
+
+    This is a focused regression test for the cache key mismatch issue.
+    It verifies that when ensure_totals_available() modifies QueryObject
+    instances, those changes are reflected in cache_values before the
+    QueryContext cache key is generated.
+    """
+    import pandas as pd
+
+    from superset.common.query_object import QueryObject
+
+    # Create a mock datasource
+    mock_datasource = MagicMock()
+    mock_datasource.uid = "test_datasource_456"
+    mock_datasource.database.db_engine_spec.engine = "pinot"
+    mock_datasource.cache_timeout = None
+    mock_datasource.changed_on = None
+
+    # Create two queries: one totals query and one main query with contribution
+    totals_query = QueryObject(
+        datasource=mock_datasource,
+        columns=[],
+        metrics=["sales"],
+        row_limit=1000,
+        post_processing=[],
+    )
+
+    main_query = QueryObject(
+        datasource=mock_datasource,
+        columns=["region"],
+        metrics=["sales"],
+        row_limit=1000,
+        post_processing=[{"operation": "contribution", "options": {}}],
+    )
+
+    # Create mock query context with initial cache_values
+    mock_query_context = MagicMock()
+    mock_query_context.force = False
+    mock_query_context.datasource = mock_datasource
+    mock_query_context.queries = [main_query, totals_query]
+    mock_query_context.result_type = "full"
+    mock_query_context.cache_values = {
+        "datasource": {"type": "table", "id": 20},
+        "queries": [
+            {
+                "columns": ["region"],
+                "metrics": ["sales"],
+                "row_limit": 1000,
+                "post_processing": [{"operation": "contribution", "options": {}}],
+            },
+            {
+                "columns": [],
+                "metrics": ["sales"],
+                "row_limit": 1000,
+                "post_processing": [],
+            },
+        ],
+        "result_type": "full",
+        "result_format": "json",
+    }
+
+    # Create processor
+    processor = QueryContextProcessor(mock_query_context)
+    processor._qc_datasource = mock_datasource
+
+    # Mock query execution result (totals query execution)
+    mock_query_result = MagicMock()
+    mock_df = pd.DataFrame({"sales": [1000.0]})
+    mock_query_result.df = mock_df
+
+    # Patch methods to isolate the test
+    with patch.object(
+        mock_query_context, "get_query_result", return_value=mock_query_result
+    ):
+        # Mock cache management to prevent actual caching
+        with patch(
+            "superset.common.query_context_processor.QueryCacheManager"
+        ) as mock_cache_manager:
+            mock_cache = MagicMock()
+            mock_cache.is_loaded = True
+            mock_cache.df = pd.DataFrame({"region": ["North"], "sales": [100]})
+            mock_cache.query = "SELECT region, SUM(sales) FROM table GROUP BY region"
+            mock_cache.error_message = None
+            mock_cache.status = "success"
+            mock_cache_manager.get.return_value = mock_cache
+
+            # Mock the query results
+            with patch(
+                "superset.common.query_context_processor.get_query_results"
+            ) as mock_get_query_results:
+                mock_query_results_response = [
+                    {
+                        "data": [{"region": "North", "sales": 100}],
+                        "query": "SELECT region, SUM(sales) FROM table GROUP BY region",
+                    }
+                ]
+                mock_get_query_results.return_value = mock_query_results_response
+
+                # Call get_payload - this internally calls ensure_totals_available()
+                # and then should update cache_values
+                processor.get_payload(cache_query_context=False)
+
+    # Verify the fix: cache_values should now reflect the modifications
+    updated_cache_queries = mock_query_context.cache_values["queries"]
+    updated_totals_row_limit = updated_cache_queries[1]["row_limit"]
+
+    # Before the fix: row_limit would remain 1000 in cache_values
+    # After the fix: row_limit should be None (modified by
+    # ensure_totals_available)
+    assert updated_totals_row_limit is None, (
+        "Expected row_limit to be None after ensure_totals_available, "
+        f"but got: {updated_totals_row_limit}"
+    )
+
+    # Verify that contribution_totals was added to the main query
+    assert (
+        "contribution_totals"
+        in updated_cache_queries[0]["post_processing"][0]["options"]
+    )
+
+    # Verify that the main query row_limit is still 1000 (only totals query
+    # should be modified)
+    assert updated_cache_queries[0]["row_limit"] == 1000

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -119,6 +119,8 @@ def test_cache_key_cache_query_by_user_on_no_user(logger_mock, feature_flag_mock
     When CACHE_QUERY_BY_USER flag is on and there is no user,
     cache key will be the same
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -134,7 +136,8 @@ def test_cache_key_cache_query_by_user_on_no_user(logger_mock, feature_flag_mock
     query_object = QueryObject(row_limit=1, datasource=datasource)
     cache_key = query_object.cache_key()
     assert query_object.cache_key() == cache_key
-    logger_mock.debug.assert_not_called()
+    # Should have cache key generation log
+    logger_mock.debug.assert_called()
 
 
 @patch("superset.common.query_object.feature_flag_manager")
@@ -144,6 +147,8 @@ def test_cache_key_cache_query_by_user_on_with_user(logger_mock, feature_flag_mo
     When the same user is requesting a cache key with CACHE_QUERY_BY_USER
     flag on, the key will be the same
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -162,8 +167,12 @@ def test_cache_key_cache_query_by_user_on_with_user(logger_mock, feature_flag_mo
         cache_key1 = query_object.cache_key()
         assert query_object.cache_key() == cache_key1
 
-    logger_mock.debug.assert_called_with(
-        "Adding impersonation key to QueryObject cache dict: %s", "test_user"
+    # Should have both impersonation and cache key generation logs
+    logger_mock.debug.assert_has_calls(
+        [
+            call("Adding impersonation key to QueryObject cache dict: %s", "test_user"),
+        ],
+        any_order=True,
     )
 
 
@@ -176,6 +185,8 @@ def test_cache_key_cache_query_by_user_on_with_different_user(
     When two different users are requesting a cache key with CACHE_QUERY_BY_USER
     flag on, the key will be different
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -198,6 +209,7 @@ def test_cache_key_cache_query_by_user_on_with_different_user(
 
     assert cache_key1 != cache_key2
 
+    # Should have both impersonation and cache key generation logs (any order)
     logger_mock.debug.assert_has_calls(
         [
             call(
@@ -206,7 +218,8 @@ def test_cache_key_cache_query_by_user_on_with_different_user(
             call(
                 "Adding impersonation key to QueryObject cache dict: %s", "test_user2"
             ),
-        ]
+        ],
+        any_order=True,
     )
 
 
@@ -217,6 +230,8 @@ def test_cache_key_cache_impersonation_on_no_user(logger_mock, feature_flag_mock
     When CACHE_IMPERSONATION flag is on and there is no user,
     cache key will be the same
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -232,7 +247,8 @@ def test_cache_key_cache_impersonation_on_no_user(logger_mock, feature_flag_mock
     query_object = QueryObject(row_limit=1, datasource=datasource)
     cache_key = query_object.cache_key()
     assert query_object.cache_key() == cache_key
-    logger_mock.debug.assert_not_called()
+    # Should have cache key generation log
+    logger_mock.debug.assert_called()
 
 
 @patch("superset.common.query_object.feature_flag_manager")
@@ -240,8 +256,11 @@ def test_cache_key_cache_impersonation_on_no_user(logger_mock, feature_flag_mock
 def test_cache_key_cache_impersonation_on_with_user(logger_mock, feature_flag_mock):
     """
     When the same user is requesting a cache key with CACHE_IMPERSONATION
-    flag on, the key will be the same
+    flag on, but the cache_impersonation is not enabled on the database,
+    the key will be the same and no impersonation logging should occur
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -260,7 +279,15 @@ def test_cache_key_cache_impersonation_on_with_user(logger_mock, feature_flag_mo
         cache_key1 = query_object.cache_key()
         assert query_object.cache_key() == cache_key1
 
-    logger_mock.debug.assert_not_called()
+    # Should have cache key generation log
+    logger_mock.debug.assert_called()
+    # But no impersonation key should be added without database impersonation enabled
+    impersonation_calls = [
+        call
+        for call in logger_mock.debug.call_args_list
+        if "Adding impersonation key" in str(call)
+    ]
+    assert len(impersonation_calls) == 0
 
 
 @patch("superset.common.query_object.feature_flag_manager")
@@ -273,6 +300,8 @@ def test_cache_key_cache_impersonation_on_with_different_user(
     flag on, but the cache_impersonation is not enabled on the database,
     the keys will be the same
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -295,19 +324,30 @@ def test_cache_key_cache_impersonation_on_with_different_user(
 
     assert cache_key1 == cache_key2
 
-    logger_mock.debug.assert_not_called()
+    # Should have cache key generation log
+    logger_mock.debug.assert_called()
+    # But no impersonation key should be added without database impersonation enabled
+    impersonation_calls = [
+        call
+        for call in logger_mock.debug.call_args_list
+        if "Adding impersonation key" in str(call)
+    ]
+    assert len(impersonation_calls) == 0
 
 
 @patch("superset.common.query_object.feature_flag_manager")
 @patch("superset.common.query_object.logger")
 def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonation(
-    logger_mock, feature_flag_mock
+    logger_mock,
+    feature_flag_mock,
 ):
     """
     When two different users are requesting a cache key with CACHE_IMPERSONATION
     flag on, and cache_impersonation is enabled on the database,
     the keys will be different
     """
+    # Configure logger to enable DEBUG level for isEnabledFor check
+    logger_mock.isEnabledFor.return_value = True
 
     datasource = SqlaTable(
         table_name="test_table",
@@ -334,6 +374,7 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
 
     assert cache_key1 != cache_key2
 
+    # Should have both impersonation and cache key generation logs (any order)
     logger_mock.debug.assert_has_calls(
         [
             call(
@@ -342,5 +383,6 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
             call(
                 "Adding impersonation key to QueryObject cache dict: %s", "test_user2"
             ),
-        ]
+        ],
+        any_order=True,
     )

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -52,6 +52,7 @@ def test_default_query_object_to_dict():
         "metrics": None,
         "order_desc": True,
         "orderby": [],
+        "post_processing": [],
         "row_limit": 1,
         "row_offset": 0,
         "series_columns": [],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes 422 errors caused by cache key mismatches between worker and cache fetch operations by ensuring `cache_values` preserves all original request fields while capturing runtime modifications. The issue occurred because `ensure_totals_available()` modified `QueryObjects` but `cache_values` was replaced with an incomplete `to_dict()` 
 output, losing fields like columns and causing mismatched MD5 hashes. The fix merges original request data with updated `QueryObject` data and adds `post_processing` to `to_dict()` to capture modifications.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
