### PR TITLE
fix(formatting): improve small number formatting logic

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/formatValue.ts
@@ -67,15 +67,20 @@ export function formatColumnValue(
 ) {
   const { dataType, formatter, config = {} } = column;
   const isNumber = dataType === GenericDataType.Numeric;
-  const smallNumberFormatter =
-    config.d3SmallNumberFormat === undefined
-      ? formatter
-      : config.currencyFormat
-        ? new CurrencyFormatter({
-            d3Format: config.d3SmallNumberFormat,
-            currency: config.currencyFormat,
-          })
-        : getNumberFormatter(config.d3SmallNumberFormat);
+  // Use smallNumberFormat only if it's a non-empty string
+  // Empty strings or falsy values should fall back to the main formatter
+  const hasValidSmallNumberFormat =
+    config.d3SmallNumberFormat &&
+    typeof config.d3SmallNumberFormat === 'string' &&
+    config.d3SmallNumberFormat.trim() !== '';
+  const smallNumberFormatter = hasValidSmallNumberFormat
+    ? config.currencyFormat
+      ? new CurrencyFormatter({
+          d3Format: config.d3SmallNumberFormat,
+          currency: config.currencyFormat,
+        })
+      : getNumberFormatter(config.d3SmallNumberFormat)
+    : formatter;
   return formatValue(
     isNumber && typeof value === 'number' && Math.abs(value) < 1
       ? smallNumberFormatter

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/formatValue.ts
@@ -62,15 +62,20 @@ export function formatColumnValue(
 ) {
   const { dataType, formatter, config = {} } = column;
   const isNumber = dataType === GenericDataType.Numeric;
-  const smallNumberFormatter =
-    config.d3SmallNumberFormat === undefined
-      ? formatter
-      : config.currencyFormat
-        ? new CurrencyFormatter({
-            d3Format: config.d3SmallNumberFormat,
-            currency: config.currencyFormat,
-          })
-        : getNumberFormatter(config.d3SmallNumberFormat);
+  // Use smallNumberFormat only if it's a non-empty string
+  // Empty strings or falsy values should fall back to the main formatter
+  const hasValidSmallNumberFormat =
+    config.d3SmallNumberFormat &&
+    typeof config.d3SmallNumberFormat === 'string' &&
+    config.d3SmallNumberFormat.trim() !== '';
+  const smallNumberFormatter = hasValidSmallNumberFormat
+    ? config.currencyFormat
+      ? new CurrencyFormatter({
+          d3Format: config.d3SmallNumberFormat,
+          currency: config.currencyFormat,
+        })
+      : getNumberFormatter(config.d3SmallNumberFormat)
+    : formatter;
   return formatValue(
     isNumber && typeof value === 'number' && Math.abs(value) < 1
       ? smallNumberFormatter


### PR DESCRIPTION
fixes #36189 

### SUMMARY
**Root Cause**
Empty string in [d3SmallNumberFormat] config bypassed the undefined check, causing D3's to return an identity function that just stringified numbers without formatting.

**Solution Applied**
Added validation in both table plugins to check that [d3SmallNumberFormat] is a non-empty, non-whitespace string before using it. Falls back to main formatter when invalid.

**BEFORE**
<img width="532" height="503" alt="516380619-4c83bf30-f9e0-4eb5-89a3-78dc7cb00724" src="https://github.com/user-attachments/assets/d2c70c96-c732-4b1d-a2bc-6f4191058ab8" />


**AFTER**
<img width="1163" height="657" alt="Screenshot 2025-11-23 at 12 40 18 AM" src="https://github.com/user-attachments/assets/6ac34ee4-b4f5-4190-9931-03dde46959fb" />


### TESTING INSTRUCTIONS
1. Open Customize → Customize Columns → Select the column that contains the tiny values.
2. Set the number format to ".8%" or select "Small Number Format" that applies percentage.
3. Confirm that:
   - Tiny **positive** values are correctly formatted as percentages.
   - Tiny **negative** values are also correctly formatted (this was previously broken).
   - Larger values continue to be formatted correctly.
   - The column no longer falls back to raw numeric output.

### ADDITIONAL INFORMATION
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
