### PR TITLE
chore(deps): Update sqlachemy-utils to 0.42.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
     "simplejson>=3.15.0",
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
-    "sqlalchemy-utils>=0.38.3, <0.39",
+    "sqlalchemy-utils>=0.42.0, <0.43",
     "sqlglot>=28.10.0, <29",
     # newer pandas needs 0.9+
     "tabulate>=0.9.0, <1.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -399,7 +399,7 @@ sqlalchemy==1.4.54
     #   marshmallow-sqlalchemy
     #   shillelagh
     #   sqlalchemy-utils
-sqlalchemy-utils==0.38.3
+sqlalchemy-utils==0.42.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -990,7 +990,7 @@ sqlalchemy==1.4.54
     #   sqlalchemy-utils
 sqlalchemy-bigquery==1.15.0
     # via apache-superset
-sqlalchemy-utils==0.38.3
+sqlalchemy-utils==0.42.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "flask-appbuilder>=5.0.2,<6",
     "pydantic>=2.8.0",
     "sqlalchemy>=1.4.0,<2.0",
-    "sqlalchemy-utils>=0.38.0",
+    "sqlalchemy-utils>=0.42.0",
     "sqlglot>=28.10.0, <29",
     "typing-extensions>=4.0.0",
 ]


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates sqlalchemy-utils to latest version 0.42.0. Previous version 0.38.3 did not support Python 3.11 or 3.12. Some dialects are using version > 0.38.3 so was causing issue with local build. The upgrade looks fairly inconsequential from superset side, just use of some of the types e.g. UUID

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
