### PR TITLE
fix: remove unwanted info from tags REST API

### DIFF
--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -109,7 +109,6 @@ class TagRestApi(BaseSupersetModelRestApi):
         "created_on_delta_humanized",
         "created_by.first_name",
         "created_by.last_name",
-        "created_by",
     ]
 
     base_related_field_filters = {

--- a/tests/integration_tests/tags/api_tests.py
+++ b/tests/integration_tests/tags/api_tests.py
@@ -148,6 +148,46 @@ class TestTagApi(InsertChartMixin, SupersetTestCase):
         db.session.delete(tag)
         db.session.commit()
 
+    def test_get_tag_user_fields(self):
+        """
+        Query API: Test get tag only returns first_name and last_name for
+        created_by and changed_by fields
+        """
+        self.login(ADMIN_USERNAME)
+        # Create tag via API to ensure created_by is set
+        uri = "api/v1/tag/"
+        rv = self.client.post(
+            uri,
+            json={"name": "test_user_fields_tag", "objects_to_tag": []},
+        )
+        assert rv.status_code == 201
+
+        # Get the created tag
+        tag = db.session.query(Tag).filter(Tag.name == "test_user_fields_tag").first()
+        assert tag is not None
+
+        # Fetch the tag via GET API
+        uri = f"api/v1/tag/{tag.id}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+
+        # Verify created_by only contains first_name and last_name
+        assert result["created_by"] is not None
+        assert set(result["created_by"].keys()) == {"first_name", "last_name"}
+        assert result["created_by"]["first_name"] is not None
+        assert result["created_by"]["last_name"] is not None
+
+        # Verify changed_by only contains first_name and last_name (or is None)
+        if result["changed_by"] is not None:
+            assert set(result["changed_by"].keys()) == {"first_name", "last_name"}
+
+        # Cleanup
+        db.session.delete(tag)
+        db.session.commit()
+
     def test_get_tag_not_found(self):
         """
         Query API: Test get query not found


### PR DESCRIPTION
### SUMMARY
Remove unnecessary info from the tags API. Specifically for /api/v1/tag/<id>


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
