### PR TITLE
docs: fix formatting of BaseCache import statement in docs

### DIFF
--- a/docs/docs/configuration/async-queries-celery.mdx
+++ b/docs/docs/configuration/async-queries-celery.mdx
@@ -52,11 +52,11 @@ To start a job which schedules periodic background jobs, run the following comma
 celery --app=superset.tasks.celery_app:app beat
 ```
 
-To setup a result backend, you need to pass an instance of a derivative of from
-from flask_caching.backends.base import BaseCache to the RESULTS_BACKEND configuration key in your superset_config.py. You can
-use Memcached, Redis, S3 (https://pypi.python.org/pypi/s3werkzeugcache), memory or the file system
-(in a single server-type setup or for testing), or to write your own caching interface. Your
-`superset_config.py` may look something like:
+To setup a result backend, you need to pass an instance of a derivative of `BaseCache` (`from
+flask_caching.backends.base import BaseCache`) to the RESULTS_BACKEND configuration key in your
+superset_config.py. You can use Memcached, Redis, S3 (https://pypi.python.org/pypi/s3werkzeugcache),
+memory or the file system (in a single server-type setup or for testing), or to write your own
+caching interface. Your `superset_config.py` may look something like:
 
 ```python
 # On S3


### PR DESCRIPTION
### SUMMARY

An unformatted line of Python code made part of the docs look bad and have grammar problems. This fixes it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS

Just a docs change; ensure that the paragraph that changed looks good.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
