### PR TITLE
feat(ListView): add pagination to card view and center row count display

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Pagination/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Pagination/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Pagination as AntdPagination } from 'antd';
+import type { PaginationProps as AntdPaginationProps } from 'antd';
+
+export type PaginationProps = AntdPaginationProps;
+
+export const Pagination = AntdPagination;

--- a/superset-frontend/packages/superset-ui-core/src/components/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/index.ts
@@ -147,6 +147,8 @@ export { Loading, type LoadingProps } from './Loading';
 
 export { Progress, type ProgressProps } from './Progress';
 
+export { Pagination, type PaginationProps } from './Pagination';
+
 export { Skeleton, type SkeletonProps } from './Skeleton';
 
 export { Switch, type SwitchProps } from './Switch';

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -30,6 +30,7 @@ import {
   Loading,
   type EmptyStateProps,
 } from '@superset-ui/core/components';
+import { Pagination } from 'antd';
 import CardCollection from './CardCollection';
 import FilterControls from './Filters';
 import { CardSortSelect } from './CardSortSelect';
@@ -91,6 +92,7 @@ const ListViewStyles = styled.div`
     .row-count-container {
       margin-top: ${theme.sizeUnit * 2}px;
       color: ${theme.colorText};
+      text-align: center;
     }
   `}
 `;
@@ -446,14 +448,39 @@ export function ListView<T extends object = any>({
             />
           )}
           {viewMode === 'card' && (
-            <CardCollection
-              bulkSelectEnabled={bulkSelectEnabled}
-              prepareRow={prepareRow}
-              renderCard={renderCard}
-              rows={rows}
-              loading={loading}
-              showThumbnails={showThumbnails}
-            />
+            <>
+              <CardCollection
+                bulkSelectEnabled={bulkSelectEnabled}
+                prepareRow={prepareRow}
+                renderCard={renderCard}
+                rows={rows}
+                loading={loading}
+                showThumbnails={showThumbnails}
+              />
+              {count > 0 && (
+                <div className="pagination-container">
+                  <Pagination
+                    current={pageIndex + 1}
+                    pageSize={pageSize}
+                    total={count}
+                    onChange={page => {
+                      gotoPage(page - 1);
+                    }}
+                    size="default"
+                    showSizeChanger={false}
+                    showQuickJumper={false}
+                    hideOnSinglePage
+                    align="center"
+                  />
+                  <div className="row-count-container">
+                    {`${pageIndex * pageSize + 1}-${Math.min(
+                      (pageIndex + 1) * pageSize,
+                      count,
+                    )} of ${count}`}
+                  </div>
+                </div>
+              )}
+            </>
           )}
           {viewMode === 'table' && (
             <>

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -28,9 +28,9 @@ import {
   Icons,
   EmptyState,
   Loading,
+  Pagination,
   type EmptyStateProps,
 } from '@superset-ui/core/components';
-import { Pagination } from 'antd';
 import CardCollection from './CardCollection';
 import FilterControls from './Filters';
 import { CardSortSelect } from './CardSortSelect';


### PR DESCRIPTION
fixes #36235 

### The Problem
In Apache Superset's dashboard list page `/dashboard/list/` pagination controls were visible and working correctly in List View, but in `Thumbnail/Card` View, only the first 25 dashboards were displayed with no pagination controls visible, even when more dashboards existed in the database.

### Root Cause
The [ListView] component renders two different sub-components based on view mode:

**Table View:** Uses [TableCollection] component, which internally includes pagination controls

**Card View:** Uses [CardCollection] component, which only renders cards without any pagination
The pagination state` [pageIndex] [pageSize] [count] [gotoPage]` existed in both views via the [useListViewState] hook, but the UI controls to navigate pages were never rendered in card view.


### The Fix
Added pagination controls after the [CardCollection] component in card view, reusing the existing pagination state


**Normal  list view (Working Correctly)**
<img width="1417" height="793" alt="Screenshot 2025-11-26 at 4 24 50 PM" src="https://github.com/user-attachments/assets/8615650b-4757-42cb-a725-606e32525630" />

**tile/ thumbnail (No Pagination)**
<img width="1425" height="810" alt="Screenshot 2025-11-26 at 4 24 39 PM" src="https://github.com/user-attachments/assets/6ed4c5e9-e86d-4898-9cd2-b23373ac7203" />

**After Applying Fix**
<img width="1431" height="839" alt="Screenshot 2025-11-26 at 4 34 04 PM" src="https://github.com/user-attachments/assets/0227f8b4-3276-4d0a-bcbb-c94f5ed63026" />
<img width="1424" height="665" alt="Screenshot 2025-11-26 at 4 34 10 PM" src="https://github.com/user-attachments/assets/cfbe3fea-e8d1-40e1-96a0-31a8e25d3df5" />

### TESTING INSTRUCTIONS
Have >25 dashboards
Switch between:
      List view 
     Thumbnail view 
Confirm missing pagination

### ADDITIONAL INFORMATION
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
