### PR TITLE
fix(controlPanel): add integer validation for rows per page setting

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -386,6 +386,7 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
+              validators: [legacyValidateInteger],
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -46,7 +46,7 @@ import {
   isAdhocColumn,
   isFeatureEnabled,
   isPhysicalColumn,
-  legacyValidateInteger,
+  validateInteger,
   QueryFormColumn,
   QueryMode,
   SMART_DATE_ID,
@@ -386,7 +386,7 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
-              validators: [legacyValidateInteger],
+              validators: [validateInteger],
             },
           },
         ],
@@ -405,7 +405,7 @@ const config: ControlPanelConfig = {
                   state?.common?.conf?.SQL_MAX_ROW,
               }),
               validators: [
-                legacyValidateInteger,
+                validateInteger,
                 (v, state) =>
                   validateMaxValue(
                     v,

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -45,7 +45,7 @@ import {
   ensureIsArray,
   isAdhocColumn,
   isPhysicalColumn,
-  legacyValidateInteger,
+  validateInteger,
   QueryFormColumn,
   QueryMode,
   SMART_DATE_ID,
@@ -407,7 +407,7 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
-              validators: [legacyValidateInteger],
+              validators: [validateInteger],
             },
           },
         ],
@@ -426,7 +426,7 @@ const config: ControlPanelConfig = {
                   state?.common?.conf?.SQL_MAX_ROW,
               }),
               validators: [
-                legacyValidateInteger,
+                validateInteger,
                 (v, state) =>
                   validateMaxValue(
                     v,

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -407,6 +407,7 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
+              validators: [legacyValidateInteger],
             },
           },
         ],


### PR DESCRIPTION
fixes #36258 

### Root Cause
The `server_page_length` control configuration lacked the `validators` array that the `row_limit` control had, specifically missing the `legacyValidateInteger` validator.

### Fix Applied
Added `[validators: [legacyValidateInteger]`  to the `server_page_length` 

**Before**
<img width="448" height="270" alt="Screenshot 2025-11-26 at 4 58 12 PM" src="https://github.com/user-attachments/assets/ff05b79b-6da2-460d-8715-f7a2b61b00ff" />


**After**
<img width="558" height="365" alt="Screenshot 2025-11-26 at 5 00 42 PM" src="https://github.com/user-attachments/assets/f15912c7-b318-4a2f-8ca7-12587bd4b064" />


### TESTING INSTRUCTIONS


### ADDITIONAL INFORMATION

- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
