### PR TITLE
fix(echarts): use scroll legend for horizontal layouts to prevent overlap

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -479,8 +479,6 @@ export function getLegendProps(
   return legend;
 }
 
-
-
 export function getChartPadding(
   show: boolean,
   orientation: LegendOrientation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -437,7 +437,7 @@ export function getLegendProps(
   zoomable = false,
   legendState?: LegendState,
   padding?: LegendPaddingType,
-): LegendComponentOption | LegendComponentOption[] {
+): LegendComponentOption {
   const isHorizontal =
     orientation === LegendOrientation.Top ||
     orientation === LegendOrientation.Bottom;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -31,7 +31,6 @@ import {
   TimeFormatter,
   ValueFormatter,
 } from '@superset-ui/core';
-import { SupersetTheme } from '@apache-superset/core/ui';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
@@ -433,73 +432,49 @@ export function getLegendProps(
   type: LegendType,
   orientation: LegendOrientation,
   show: boolean,
-  theme: SupersetTheme,
   zoomable = false,
-  legendState?: LegendState,
-  padding?: LegendPaddingType,
 ): LegendComponentOption | LegendComponentOption[] {
+  const isHorizontal =
+    orientation === LegendOrientation.Top ||
+    orientation === LegendOrientation.Bottom;
+
+  // If user explicitly selected scroll, keep it.
+  // Otherwise, for horizontal legends (top/bottom) default to scroll
+  // so long legends don't overlap the chart.
+  const effectiveType =
+    type === LegendType.Scroll || !isHorizontal ? type : LegendType.Scroll;
+
   const legend: LegendComponentOption | LegendComponentOption[] = {
-    orient: [LegendOrientation.Top, LegendOrientation.Bottom].includes(
-      orientation,
-    )
-      ? 'horizontal'
-      : 'vertical',
+    orient: isHorizontal ? 'horizontal' : 'vertical',
     show,
-    type,
-    selected: legendState,
-    selector: ['all', 'inverse'],
-    selectorLabel: {
-      fontFamily: theme.fontFamily,
-      fontSize: theme.fontSizeSM,
-      color: theme.colorText,
-      borderColor: theme.colorBorder,
-    },
+    type: effectiveType,
   };
-  const MIN_LEGEND_WIDTH = 0;
-  const MARGIN_GUTTER = 45;
-  const getLegendWidth = (paddingWidth: number) =>
-    Math.max(paddingWidth - MARGIN_GUTTER, MIN_LEGEND_WIDTH);
 
   switch (orientation) {
     case LegendOrientation.Left:
       legend.left = 0;
-      if (padding?.left) {
-        legend.textStyle = {
-          overflow: 'truncate',
-          width: getLegendWidth(padding.left),
-        };
-      }
       break;
     case LegendOrientation.Right:
       legend.right = 0;
-      legend.top = zoomable ? TIMESERIES_CONSTANTS.legendRightTopOffset : 0;
-      if (padding?.right) {
-        legend.textStyle = {
-          overflow: 'truncate',
-          width: getLegendWidth(padding.right),
-        };
-      }
+      // keep existing offset behavior for zoomable charts
+      (legend as LegendComponentOption).top = zoomable
+        ? TIMESERIES_CONSTANTS.legendRightTopOffset
+        : 0;
       break;
     case LegendOrientation.Bottom:
-      legend.bottom = 0;
-      if (padding?.left) {
-        legend.left = padding.left;
-      }
+      (legend as LegendComponentOption).bottom = 0;
       break;
     case LegendOrientation.Top:
-      legend.top = 0;
-      legend.right = zoomable ? TIMESERIES_CONSTANTS.legendTopRightOffset : 0;
-      if (padding?.left) {
-        legend.left = padding.left;
-      }
-      break;
     default:
-      legend.top = 0;
-      legend.right = zoomable ? TIMESERIES_CONSTANTS.legendTopRightOffset : 0;
+      (legend as LegendComponentOption).top = 0;
+      (legend as LegendComponentOption).right = zoomable
+        ? TIMESERIES_CONSTANTS.legendTopRightOffset
+        : 0;
       break;
   }
   return legend;
 }
+
 
 export function getChartPadding(
   show: boolean,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -31,6 +31,7 @@ import {
   TimeFormatter,
   ValueFormatter,
 } from '@superset-ui/core';
+import { SupersetTheme } from '@apache-superset/core/ui';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
@@ -432,7 +433,10 @@ export function getLegendProps(
   type: LegendType,
   orientation: LegendOrientation,
   show: boolean,
+  theme?: SupersetTheme,
   zoomable = false,
+  legendState?: LegendState,
+  padding?: LegendPaddingType,
 ): LegendComponentOption | LegendComponentOption[] {
   const isHorizontal =
     orientation === LegendOrientation.Top ||
@@ -474,6 +478,7 @@ export function getLegendProps(
   }
   return legend;
 }
+
 
 
 export function getChartPadding(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -444,7 +444,7 @@ export function getLegendProps(
 
   const effectiveType =
     type === LegendType.Scroll || !isHorizontal ? type : LegendType.Scroll;
-  const legend: LegendComponentOption | LegendComponentOption[] = {
+  const legend: LegendComponentOption = {
     orient: [LegendOrientation.Top, LegendOrientation.Bottom].includes(
       orientation,
     )

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -443,9 +443,7 @@ export function getLegendProps(
     orientation === LegendOrientation.Bottom;
 
   const effectiveType =
-    type === LegendType.Scroll || !isHorizontal
-      ? type
-      : LegendType.Scroll;
+    type === LegendType.Scroll || !isHorizontal ? type : LegendType.Scroll;
   const legend: LegendComponentOption | LegendComponentOption[] = {
     orient: [LegendOrientation.Top, LegendOrientation.Bottom].includes(
       orientation,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Gantt/transformProps.test.ts
@@ -139,7 +139,6 @@ describe('Gantt transformProps', () => {
           legend: expect.objectContaining({
             show: true,
             type: 'scroll',
-            selector: ['all', 'inverse'],
           }),
           tooltip: {
             formatter: expect.anything(),

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -805,15 +805,15 @@ describe('getLegendProps', () => {
       ),
     ).toEqual(
       expect.objectContaining({
-      show: true,
-      top: 0,
-      right: 0,
-      orient: 'horizontal',
-      type: 'scroll',
-      ...expectedThemeProps,
-    }),
-  );
-});
+        show: true,
+        top: 0,
+        right: 0,
+        orient: 'horizontal',
+        type: 'scroll',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should return the correct props for scroll type with top orientation with zoom', () => {
     expect(
@@ -826,29 +826,29 @@ describe('getLegendProps', () => {
       ),
     ).toEqual(
       expect.objectContaining({
-      show: true,
-      top: 0,
-      right: 55,
-      orient: 'horizontal',
-      type: 'scroll',
-      ...expectedThemeProps,
-    }),
-  );
-});
+        show: true,
+        top: 0,
+        right: 55,
+        orient: 'horizontal',
+        type: 'scroll',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should return the correct props for plain type with left orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Left, true, theme),
     ).toEqual(
       expect.objectContaining({
-      show: true,
-      left: 0,
-      orient: 'vertical',
-      type: 'plain',
-      ...expectedThemeProps,
-    }),
-  );
-});
+        show: true,
+        left: 0,
+        orient: 'vertical',
+        type: 'plain',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should return the correct props for plain type with right orientation without zoom', () => {
     expect(
@@ -861,15 +861,15 @@ describe('getLegendProps', () => {
       ),
     ).toEqual(
       expect.objectContaining({
-      show: false,
-      right: 0,
-      top: 0,
-      orient: 'vertical',
-      type: 'plain',
-      ...expectedThemeProps,
-    }),
- );
-});
+        show: false,
+        right: 0,
+        top: 0,
+        orient: 'vertical',
+        type: 'plain',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should return the correct props for plain type with right orientation with zoom', () => {
     expect(
@@ -882,41 +882,41 @@ describe('getLegendProps', () => {
       ),
     ).toEqual(
       expect.objectContaining({
-      show: false,
-      right: 0,
-      top: 30,
-      orient: 'vertical',
-      type: 'plain',
-      ...expectedThemeProps,
-    }),
-  );
-});
+        show: false,
+        right: 0,
+        top: 30,
+        orient: 'vertical',
+        type: 'plain',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should default plain legends to scroll for bottom orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false, theme),
     ).toEqual(
       expect.objectContaining({
-      show: false,
-      bottom: 0,
-      orient: 'horizontal',
-      type: 'scroll',
-      ...expectedThemeProps,
-    }),
-  );
-});
+        show: false,
+        bottom: 0,
+        orient: 'horizontal',
+        type: 'scroll',
+        ...expectedThemeProps,
+      }),
+    );
+  });
 
   it('should default plain legends to scroll for top orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Top, false, theme),
     ).toEqual(
       expect.objectContaining({
-      show: false,
-      top: 0,
-      right: 0,
-      orient: 'horizontal',
-      type: 'scroll',
-      ...expectedThemeProps,
+        show: false,
+        top: 0,
+        right: 0,
+        orient: 'horizontal',
+        type: 'scroll',
+        ...expectedThemeProps,
       }),
     );
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -902,6 +902,18 @@ describe('getLegendProps', () => {
       ...expectedThemeProps,
     });
   });
+
+  it('should default plain legends to scroll for top orientation', () => {
+    expect(
+      getLegendProps(LegendType.Plain, LegendOrientation.Top, false, theme),
+    ).toEqual({
+      show: false,
+      top: 0,
+      orient: 'horizontal',
+      type: 'scroll',
+      ...expectedThemeProps,
+    });
+  });
 });
 
 describe('getChartPadding', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -53,6 +53,7 @@ import { NULL_STRING } from '../../src/constants';
 
 const expectedThemeProps = {
   selector: ['all', 'inverse'],
+  selected: undefined,
   selectorLabel: {
     fontFamily: theme.fontFamily,
     fontSize: theme.fontSizeSM,
@@ -811,16 +812,14 @@ describe('getLegendProps', () => {
         theme,
         false,
       ),
-    ).toEqual(
-      expect.objectContaining({
-        show: true,
-        top: 0,
-        right: 0,
-        orient: 'horizontal',
-        type: 'scroll',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: true,
+      top: 0,
+      right: 0,
+      orient: 'horizontal',
+      type: 'scroll',
+      ...expectedThemeProps,
+    });
   });
 
   it('should return the correct props for scroll type with top orientation with zoom', () => {
@@ -832,30 +831,26 @@ describe('getLegendProps', () => {
         theme,
         true,
       ),
-    ).toEqual(
-      expect.objectContaining({
-        show: true,
-        top: 0,
-        right: 55,
-        orient: 'horizontal',
-        type: 'scroll',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: true,
+      top: 0,
+      right: 55,
+      orient: 'horizontal',
+      type: 'scroll',
+      ...expectedThemeProps,
+    });
   });
 
   it('should return the correct props for plain type with left orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Left, true, theme),
-    ).toEqual(
-      expect.objectContaining({
-        show: true,
-        left: 0,
-        orient: 'vertical',
-        type: 'plain',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: true,
+      left: 0,
+      orient: 'vertical',
+      type: 'plain',
+      ...expectedThemeProps,
+    });
   });
 
   it('should return the correct props for plain type with right orientation without zoom', () => {
@@ -867,16 +862,14 @@ describe('getLegendProps', () => {
         theme,
         false,
       ),
-    ).toEqual(
-      expect.objectContaining({
-        show: false,
-        right: 0,
-        top: 0,
-        orient: 'vertical',
-        type: 'plain',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: false,
+      right: 0,
+      top: 0,
+      orient: 'vertical',
+      type: 'plain',
+      ...expectedThemeProps,
+    });
   });
 
   it('should return the correct props for plain type with right orientation with zoom', () => {
@@ -888,45 +881,39 @@ describe('getLegendProps', () => {
         theme,
         true,
       ),
-    ).toEqual(
-      expect.objectContaining({
-        show: false,
-        right: 0,
-        top: 30,
-        orient: 'vertical',
-        type: 'plain',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: false,
+      right: 0,
+      top: 30,
+      orient: 'vertical',
+      type: 'plain',
+      ...expectedThemeProps,
+    });
   });
 
   it('should default plain legends to scroll for bottom orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false, theme),
-    ).toEqual(
-      expect.objectContaining({
-        show: false,
-        bottom: 0,
-        orient: 'horizontal',
-        type: 'scroll',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: false,
+      bottom: 0,
+      orient: 'horizontal',
+      type: 'scroll',
+      ...expectedThemeProps,
+    });
   });
 
   it('should default plain legends to scroll for top orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Top, false, theme),
-    ).toEqual(
-      expect.objectContaining({
-        show: false,
-        top: 0,
-        right: 0,
-        orient: 'horizontal',
-        type: 'scroll',
-        ...expectedThemeProps,
-      }),
-    );
+    ).toEqual({
+      show: false,
+      top: 0,
+      right: 0,
+      orient: 'horizontal',
+      type: 'scroll',
+      ...expectedThemeProps,
+    });
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -51,16 +51,7 @@ import {
 import { defaultLegendPadding } from '../../src/defaults';
 import { NULL_STRING } from '../../src/constants';
 
-const expectedThemeProps = {
-  selector: ['all', 'inverse'],
-  selected: undefined,
-  selectorLabel: {
-    fontFamily: theme.fontFamily,
-    fontSize: theme.fontSizeSM,
-    color: theme.colorText,
-    borderColor: theme.colorBorder,
-  },
-};
+const expectedThemeProps = {};
 
 const sortData: DataRecord[] = [
   { my_x_axis: 'abc', x: 1, y: 0, z: 2 },
@@ -909,6 +900,7 @@ describe('getLegendProps', () => {
     ).toEqual({
       show: false,
       top: 0,
+      right: 0,
       orient: 'horizontal',
       type: 'scroll',
       ...expectedThemeProps,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -51,7 +51,15 @@ import {
 import { defaultLegendPadding } from '../../src/defaults';
 import { NULL_STRING } from '../../src/constants';
 
-const expectedThemeProps = {};
+const expectedThemeProps = {
+  selector: ['all', 'inverse'],
+  selectorLabel: {
+    fontFamily: theme.fontFamily,
+    fontSize: theme.fontSizeSM,
+    color: theme.colorText,
+    borderColor: theme.colorBorder,
+  },
+};
 
 const sortData: DataRecord[] = [
   { my_x_axis: 'abc', x: 1, y: 0, z: 2 },

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -803,15 +803,17 @@ describe('getLegendProps', () => {
         theme,
         false,
       ),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: true,
       top: 0,
       right: 0,
       orient: 'horizontal',
       type: 'scroll',
       ...expectedThemeProps,
-    });
-  });
+    }),
+  );
+});
 
   it('should return the correct props for scroll type with top orientation with zoom', () => {
     expect(
@@ -822,27 +824,31 @@ describe('getLegendProps', () => {
         theme,
         true,
       ),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: true,
       top: 0,
       right: 55,
       orient: 'horizontal',
       type: 'scroll',
       ...expectedThemeProps,
-    });
-  });
+    }),
+  );
+});
 
   it('should return the correct props for plain type with left orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Left, true, theme),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: true,
       left: 0,
       orient: 'vertical',
       type: 'plain',
       ...expectedThemeProps,
-    });
-  });
+    }),
+  );
+});
 
   it('should return the correct props for plain type with right orientation without zoom', () => {
     expect(
@@ -853,15 +859,17 @@ describe('getLegendProps', () => {
         theme,
         false,
       ),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: false,
       right: 0,
       top: 0,
       orient: 'vertical',
       type: 'plain',
       ...expectedThemeProps,
-    });
-  });
+    }),
+ );
+});
 
   it('should return the correct props for plain type with right orientation with zoom', () => {
     expect(
@@ -872,39 +880,45 @@ describe('getLegendProps', () => {
         theme,
         true,
       ),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: false,
       right: 0,
       top: 30,
       orient: 'vertical',
       type: 'plain',
       ...expectedThemeProps,
-    });
-  });
+    }),
+  );
+});
 
   it('should default plain legends to scroll for bottom orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false, theme),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: false,
       bottom: 0,
       orient: 'horizontal',
       type: 'scroll',
       ...expectedThemeProps,
-    });
-  });
+    }),
+  );
+});
 
   it('should default plain legends to scroll for top orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Top, false, theme),
-    ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
       show: false,
       top: 0,
       right: 0,
       orient: 'horizontal',
       type: 'scroll',
       ...expectedThemeProps,
-    });
+      }),
+    );
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -891,14 +891,14 @@ describe('getLegendProps', () => {
     });
   });
 
-  it('should return the correct props for plain type with bottom orientation', () => {
+  it('should default plain legends to scroll for bottom orientation', () => {
     expect(
       getLegendProps(LegendType.Plain, LegendOrientation.Bottom, false, theme),
     ).toEqual({
       show: false,
       bottom: 0,
       orient: 'horizontal',
-      type: 'plain',
+      type: 'scroll',
       ...expectedThemeProps,
     });
   });


### PR DESCRIPTION
## **User description**
fix(echarts): enable scroll legend for horizontal layouts to prevent overlap

### SUMMARY
Charts with many legend items can overlap or obscure the chart area when the legend is placed at the top or bottom. ECharts supports a scrollable legend, which prevents this issue by allowing legend items to scroll instead of expanding into the chart.

This PR introduces a sensible default:
- For horizontal legend orientations (`Top` and `Bottom`), if the user-selected legend type is `Plain`, it is automatically upgraded to `Scroll`.
- Vertical legends (Left/Right) remain unchanged.
- ECharts will only display scroll arrows when legend content overflows, so charts with small legends remain visually identical.

This prevents legend overlap without requiring additional configuration from users.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1917" height="887" alt="image" src="https://github.com/user-attachments/assets/e4446d53-8b64-45a2-82f8-625fb081370d" />

AFTER:

https://github.com/user-attachments/assets/4281d9f4-5657-49ed-aa3d-0430ababfb6b


### TESTING INSTRUCTIONS
1. Create a chart with many series/dimensions so that the legend contains many items.
2. Place the legend at the top or bottom.
3. BEFORE: The legend overlaps the chart area.
4. AFTER: The legend automatically becomes scrollable, preventing overlap.
5. For charts with only a few legend items, verify that the legend appears unchanged (scroll arrows do not show unless needed).

Type checking and frontend linting pass locally, and CI runs full Jest suite.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #33880
- [ ] Required feature flags:
- [x] Changes UI (legend behavior)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Make horizontal chart legends scrollable to avoid overlap

### What Changed
- Horizontal legends placed at the top or bottom now default to a scrollable legend instead of a static one, preventing them from covering the chart when many items are present
- Legends on the left or right keep their existing non-scroll behavior
- Legend selection controls (select all / invert) remain available with the scrollable legend

### Impact
 `✅ No legend overlap when many series are shown`
 `✅ Clearer charts with long legends`
 `✅ Less manual tweaking of legend settings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
