### PR TITLE
docs: Improve the Quick Start to make it more AI-friendly

### DIFF
--- a/docs/developer_portal/extensions/contribution-types.md
+++ b/docs/developer_portal/extensions/contribution-types.md
@@ -35,14 +35,18 @@ Frontend contribution types allow extensions to extend Superset's user interface
 Extensions can add new views or panels to the host application, such as custom SQL Lab panels, dashboards, or other UI components. Each view is registered with a unique ID and can be activated or deactivated as needed. Contribution areas are uniquely identified (e.g., `sqllab.panels` for SQL Lab panels), enabling seamless integration into specific parts of the application.
 
 ``` json
-"views": {
-  "sqllab.panels": [
-    {
-      "id": "dataset_references.main",
-      "name": "Table references"
+"frontend": {
+  "contributions": {
+    "views": {
+      "sqllab.panels": [
+        {
+          "id": "my_extension.main",
+          "name": "My Panel Name"
+        }
+      ]
     }
-  ]
-},
+  }
+}
 ```
 
 ### Commands
@@ -50,14 +54,18 @@ Extensions can add new views or panels to the host application, such as custom S
 Extensions can define custom commands that can be executed within the host application, such as context-aware actions or menu options. Each command can specify properties like a unique command identifier, an icon, a title, and a description. These commands can be invoked by users through menus, keyboard shortcuts, or other UI elements, enabling extensions to add rich, interactive functionality to Superset.
 
 ``` json
-"commands": [
-  {
-    "command": "extension1.copy_query",
-    "icon": "CopyOutlined",
-    "title": "Copy Query",
-    "description": "Copy the current query to clipboard"
-  },
-]
+"frontend": {
+  "contributions": {
+    "commands": [
+      {
+        "command": "my_extension.copy_query",
+        "icon": "CopyOutlined",
+        "title": "Copy Query",
+        "description": "Copy the current query to clipboard"
+      }
+    ]
+  }
+}
 ```
 
 ### Menus
@@ -65,31 +73,31 @@ Extensions can define custom commands that can be executed within the host appli
 Extensions can contribute new menu items or context menus to the host application, providing users with additional actions and options. Each menu item can specify properties such as the target view, the command to execute, its placement (primary, secondary, or context), and conditions for when it should be displayed. Menu contribution areas are uniquely identified (e.g., `sqllab.editor` for the SQL Lab editor), allowing extensions to seamlessly integrate their functionality into specific menus and workflows within Superset.
 
 ``` json
-"menus": {
-  "sqllab.editor": {
-    "primary": [
-      {
-        "view": "builtin.editor",
-        "command": "extension1.copy_query"
+"frontend": {
+  "contributions": {
+    "menus": {
+      "sqllab.editor": {
+        "primary": [
+          {
+            "view": "builtin.editor",
+            "command": "my_extension.copy_query"
+          }
+        ],
+        "secondary": [
+          {
+            "view": "builtin.editor",
+            "command": "my_extension.prettify"
+          }
+        ],
+        "context": [
+          {
+            "view": "builtin.editor",
+            "command": "my_extension.clear"
+          }
+        ]
       }
-    ],
-    "secondary": [
-      {
-        "view": "builtin.editor",
-        "command": "extension1.prettify"
-      }
-    ],
-    "context": [
-      {
-        "view": "builtin.editor",
-        "command": "extension1.clear"
-      },
-      {
-        "view": "builtin.editor",
-     "command": "extension1.refresh"
-      }
-    ]
-  },
+    }
+  }
 }
 ```
 

--- a/docs/developer_portal/extensions/quick-start.md
+++ b/docs/developer_portal/extensions/quick-start.md
@@ -191,7 +191,125 @@ This registers your API with Superset when the extension loads.
 
 ## Step 5: Create Frontend Component
 
-The CLI generated boilerplate files. The webpack config and package.json are already properly configured with Module Federation.
+The CLI generates the frontend configuration files. Below are the key configurations that enable Module Federation integration with Superset.
+
+**`frontend/package.json`**
+
+The `@apache-superset/core` package must be listed in both `peerDependencies` (to declare runtime compatibility) and `devDependencies` (to provide TypeScript types during build):
+
+```json
+{
+  "name": "hello_world",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --stats-error-details --mode production"
+  },
+  "peerDependencies": {
+    "@apache-superset/core": "^x.x.x",
+    "react": "^x.x.x",
+    "react-dom": "^x.x.x"
+  },
+  "devDependencies": {
+    "@apache-superset/core": "^x.x.x",
+    "@types/react": "^x.x.x",
+    "ts-loader": "^x.x.x",
+    "typescript": "^x.x.x",
+    "webpack": "^5.x.x",
+    "webpack-cli": "^x.x.x",
+    "webpack-dev-server": "^x.x.x"
+  }
+}
+```
+
+**`frontend/webpack.config.js`**
+
+The webpack configuration requires specific settings for Module Federation:
+
+```javascript
+const path = require("path");
+const { ModuleFederationPlugin } = require("webpack").container;
+const packageConfig = require("./package.json");
+
+module.exports = (env, argv) => {
+  const isProd = argv.mode === "production";
+
+  return {
+    entry: isProd ? {} : "./src/index.tsx",
+    mode: isProd ? "production" : "development",
+    devServer: {
+      port: 3001,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    },
+    output: {
+      filename: isProd ? undefined : "[name].[contenthash].js",
+      chunkFilename: "[name].[contenthash].js",
+      clean: true,
+      path: path.resolve(__dirname, "dist"),
+      publicPath: `/api/v1/extensions/${packageConfig.name}/`,
+    },
+    resolve: {
+      extensions: [".ts", ".tsx", ".js", ".jsx"],
+    },
+    // Map @apache-superset/core imports to window.superset at runtime
+    externalsType: "window",
+    externals: {
+      "@apache-superset/core": "superset",
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: "ts-loader",
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    plugins: [
+      new ModuleFederationPlugin({
+        name: packageConfig.name,
+        filename: "remoteEntry.[contenthash].js",
+        exposes: {
+          "./index": "./src/index.tsx",
+        },
+        shared: {
+          react: {
+            singleton: true,
+            requiredVersion: packageConfig.peerDependencies.react,
+            import: false, // Use host's React, don't bundle
+          },
+          "react-dom": {
+            singleton: true,
+            requiredVersion: packageConfig.peerDependencies["react-dom"],
+            import: false,
+          },
+        },
+      }),
+    ],
+  };
+};
+```
+
+**`frontend/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}
+```
 
 **Create `frontend/src/HelloWorldPanel.tsx`**
 

--- a/docs/developer_portal/extensions/quick-start.md
+++ b/docs/developer_portal/extensions/quick-start.md
@@ -226,7 +226,7 @@ The `@apache-superset/core` package must be listed in both `peerDependencies` (t
 
 **`frontend/webpack.config.js`**
 
-The webpack configuration requires specific settings for Module Federation:
+The webpack configuration requires specific settings for Module Federation. Key settings include `externalsType: "window"` and `externals` to map `@apache-superset/core` to `window.superset` at runtime, `import: false` for shared modules to use the host's React instead of bundling a separate copy, and `remoteEntry.[contenthash].js` for cache busting:
 
 ```javascript
 const path = require("path");


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Improves the extension documentation to make it easier for AI assistants to help users build extensions from scratch.

- **quick-start.md**: Added complete configuration file examples (`package.json`, `webpack.config.js`, `tsconfig.json`) that were previously referenced but not shown
- **contribution-types.md**: Added `"frontend": { "contributions": { ... } }` wrapper to JSON snippets so AI understands the full schema path

These changes address gaps discovered when using AI to build an extension following the documentation.

### TESTING INSTRUCTIONS
Try to create an extension using the Quick Start guide and AI.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
