### PR TITLE
chore(ts): Migrate Tab.jsx to Tab.tsx [SIP-36]

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -28,8 +28,9 @@ import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import { EditableTitle } from '@superset-ui/core/components';
 import { setEditMode, onRefresh } from 'src/dashboard/actions/dashboardState';
 
-import Tab from './Tab';
+import Tab, { RENDER_TAB, RENDER_TAB_CONTENT } from './Tab';
 import Markdown from '../Markdown';
+import { LayoutItem } from 'src/dashboard/types';
 
 jest.mock('src/dashboard/util/getChartIdsFromComponent', () =>
   jest.fn(() => []),
@@ -52,9 +53,9 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
   Droppable: jest.fn(props => {
     const childProps = props.editMode
       ? {
-          dragSourceRef: props.dragSourceRef,
-          dropIndicatorProps: props.dropIndicatorProps,
-        }
+        dragSourceRef: props.dragSourceRef,
+        dropIndicatorProps: props.dropIndicatorProps,
+      }
       : {};
     const handleClick = () => {
       if (props.onDrop) {
@@ -103,7 +104,7 @@ const createProps = () => ({
   parentId: 'TABS-L-d9eyOE-b',
   depth: 2,
   index: 1,
-  renderType: 'RENDER_TAB_CONTENT',
+  renderType: RENDER_TAB_CONTENT as typeof RENDER_TAB | typeof RENDER_TAB_CONTENT,
   availableColumnCount: 12,
   columnWidth: 120,
   isFocused: false,
@@ -113,14 +114,14 @@ const createProps = () => ({
     meta: { text: '🚀 Aspiring Developers' },
     parents: ['ROOT_ID', 'GRID_ID', 'TABS-L-d9eyOE-b'],
     type: 'TAB',
-  },
+  } as LayoutItem,
   parentComponent: {
     children: ['TAB-AsMaxdYL_t', 'TAB-YT6eNksV-', 'TAB-l_9I0aNYZ'],
     id: 'TABS-L-d9eyOE-b',
     meta: {},
     parents: ['ROOT_ID', 'GRID_ID'],
     type: 'TABS',
-  },
+  } as LayoutItem,
   editMode: false,
   embeddedMode: false,
   undoLength: 0,
@@ -143,7 +144,7 @@ beforeEach(() => {
 
 test('Render tab (no content)', () => {
   const props = createProps();
-  props.renderType = 'RENDER_TAB';
+  props.renderType = RENDER_TAB;
   const { getByTestId } = render(<Tab {...props} />, {
     useRedux: true,
     useDnd: true,

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -53,9 +53,9 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
   Droppable: jest.fn(props => {
     const childProps = props.editMode
       ? {
-        dragSourceRef: props.dragSourceRef,
-        dropIndicatorProps: props.dropIndicatorProps,
-      }
+          dragSourceRef: props.dragSourceRef,
+          dropIndicatorProps: props.dropIndicatorProps,
+        }
       : {};
     const handleClick = () => {
       if (props.onDrop) {
@@ -104,7 +104,9 @@ const createProps = () => ({
   parentId: 'TABS-L-d9eyOE-b',
   depth: 2,
   index: 1,
-  renderType: RENDER_TAB_CONTENT as typeof RENDER_TAB | typeof RENDER_TAB_CONTENT,
+  renderType: RENDER_TAB_CONTENT as
+    | typeof RENDER_TAB
+    | typeof RENDER_TAB_CONTENT,
   availableColumnCount: 12,
   columnWidth: 120,
   isFocused: false,

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -53,9 +53,9 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
   Droppable: jest.fn(props => {
     const childProps = props.editMode
       ? {
-          dragSourceRef: props.dragSourceRef,
-          dropIndicatorProps: props.dropIndicatorProps,
-        }
+        dragSourceRef: props.dragSourceRef,
+        dropIndicatorProps: props.dropIndicatorProps,
+      }
       : {};
     const handleClick = () => {
       if (props.onDrop) {
@@ -104,9 +104,7 @@ const createProps = () => ({
   parentId: 'TABS-L-d9eyOE-b',
   depth: 2,
   index: 1,
-  renderType: RENDER_TAB_CONTENT as
-    | typeof RENDER_TAB
-    | typeof RENDER_TAB_CONTENT,
+  renderType: RENDER_TAB_CONTENT as typeof RENDER_TAB | typeof RENDER_TAB_CONTENT,
   availableColumnCount: 12,
   columnWidth: 120,
   isFocused: false,

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Fragment, useCallback, memo, useEffect, useRef, FC } from 'react';
+import { ResizeCallback, ResizeStartCallback } from 're-resizable';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { t, styled } from '@apache-superset/core/ui';
@@ -32,8 +33,7 @@ import {
   Droppable,
 } from 'src/dashboard/components/dnd/DragDroppable';
 import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
-import { Link } from 'react-router-dom';
-import { LayoutItem, RootState } from 'src/dashboard/types';
+import type { LayoutItem, RootState } from 'src/dashboard/types';
 
 export const RENDER_TAB = 'RENDER_TAB' as const;
 export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT' as const;
@@ -63,9 +63,9 @@ interface TabProps {
   // grid related
   availableColumnCount?: number;
   columnWidth?: number;
-  onResizeStart?: (...args: unknown[]) => void;
-  onResize?: (...args: unknown[]) => void;
-  onResizeStop?: (...args: unknown[]) => void;
+  onResizeStart?: ResizeStartCallback;
+  onResizeStop?: ResizeCallback;
+  onResize?: ResizeCallback;
 
   // redux
   handleComponentDrop: (...args: unknown[]) => unknown;
@@ -139,7 +139,7 @@ const Tab: FC<TabProps> = props => {
   const dashboardInfo = useSelector((state: RootState) => state.dashboardInfo);
 
   // Track which refresh we've already handled to prevent duplicates
-  const handledRefreshRef = useRef(null);
+  const handledRefreshRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (props.renderType === RENDER_TAB_CONTENT && props.isComponentVisible) {

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Fragment, useCallback, memo, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
+import { Fragment, useCallback, memo, useEffect, useRef, FC } from 'react';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { t, styled } from '@apache-superset/core/ui';
@@ -32,46 +31,48 @@ import {
   DragDroppable,
   Droppable,
 } from 'src/dashboard/components/dnd/DragDroppable';
-import { componentShape } from 'src/dashboard/util/propShapes';
 import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
 import { Link } from 'react-router-dom';
+import { LayoutItem, RootState } from 'src/dashboard/types';
 
-export const RENDER_TAB = 'RENDER_TAB';
-export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT';
+export const RENDER_TAB = 'RENDER_TAB' as const;
+export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT' as const;
 
 // Delay before refreshing charts to ensure they are fully mounted
 const CHART_MOUNT_DELAY = 100;
 
-const propTypes = {
-  dashboardId: PropTypes.number.isRequired,
-  id: PropTypes.string.isRequired,
-  parentId: PropTypes.string.isRequired,
-  component: componentShape.isRequired,
-  parentComponent: componentShape.isRequired,
-  index: PropTypes.number.isRequired,
-  depth: PropTypes.number.isRequired,
-  renderType: PropTypes.oneOf([RENDER_TAB, RENDER_TAB_CONTENT]).isRequired,
-  onDropOnTab: PropTypes.func,
-  onDropPositionChange: PropTypes.func,
-  onDragTab: PropTypes.func,
-  onHoverTab: PropTypes.func,
-  editMode: PropTypes.bool.isRequired,
-  embeddedMode: PropTypes.bool,
-  onTabTitleEditingChange: PropTypes.func,
+interface TabProps {
+  dashboardId: number;
+  id: string;
+  parentId: string;
+  component: LayoutItem;
+  parentComponent: LayoutItem;
+  index: number;
+  depth: number;
+  renderType: typeof RENDER_TAB | typeof RENDER_TAB_CONTENT;
+  onDropOnTab: (...args: unknown[]) => unknown;
+  onDropPositionChange?: Function;
+  onDragTab?: Function;
+  onHoverTab?: () => void;
+  editMode: boolean;
+  embeddedMode?: boolean;
+  onTabTitleEditingChange?: (IsEditing: boolean) => void;
+  isFocused?: boolean;
+  isHighlighted?: boolean;
 
   // grid related
-  availableColumnCount: PropTypes.number,
-  columnWidth: PropTypes.number,
-  onResizeStart: PropTypes.func,
-  onResize: PropTypes.func,
-  onResizeStop: PropTypes.func,
+  availableColumnCount?: number;
+  columnWidth?: number;
+  onResizeStart?: (...args: unknown[]) => void;
+  onResize?: (...args: unknown[]) => void;
+  onResizeStop?: (...args: unknown[]) => void;
 
   // redux
-  handleComponentDrop: PropTypes.func.isRequired,
-  updateComponents: PropTypes.func.isRequired,
-  setDirectPathToChild: PropTypes.func.isRequired,
-  isComponentVisible: PropTypes.bool,
-};
+  handleComponentDrop: (...args: unknown[]) => unknown;
+  updateComponents: Function;
+  setDirectPathToChild: (pathToTabIndex: string[]) => void;
+  isComponentVisible?: boolean;
+}
 
 const defaultProps = {
   availableColumnCount: 0,
@@ -86,7 +87,7 @@ const defaultProps = {
   onTabTitleEditingChange() {},
 };
 
-const TabTitleContainer = styled.div`
+const TabTitleContainer = styled.div<{ isHighlighted: boolean }>`
   ${({ isHighlighted, theme: { sizeUnit, colorPrimaryBg } }) => `
     display: inline-flex;
     position: relative;
@@ -116,20 +117,26 @@ const TitleDropIndicator = styled.div`
   }
 `;
 
-const renderDraggableContent = dropProps =>
-  dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />;
+const renderDraggableContent = (dropProps: {
+  dropIndicatorProps?: React.HTMLAttributes<HTMLDivElement>;
+}) => dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />;
 
-const Tab = props => {
+const Tab: FC<TabProps> = props => {
   const dispatch = useDispatch();
-  const canEdit = useSelector(state => state.dashboardInfo.dash_edit_perm);
-  const dashboardLayout = useSelector(state => state.dashboardLayout.present);
+  const canEdit = useSelector(
+    (state: RootState) => state.dashboardInfo.dash_edit_perm,
+  );
+  const dashboardLayout = useSelector(
+    (state: RootState) => state.dashboardLayout.present,
+  );
   const lastRefreshTime = useSelector(
-    state => state.dashboardState.lastRefreshTime,
+    (state: RootState) => state.dashboardState.lastRefreshTime,
   );
   const tabActivationTime = useSelector(
-    state => state.dashboardState.tabActivationTimes?.[props.id] || 0,
+    (state: RootState) =>
+      state.dashboardState.tabActivationTimes?.[props.id] || 0,
   );
-  const dashboardInfo = useSelector(state => state.dashboardInfo);
+  const dashboardInfo = useSelector((state: RootState) => state.dashboardInfo);
 
   // Track which refresh we've already handled to prevent duplicates
   const handledRefreshRef = useRef(null);
@@ -170,14 +177,14 @@ const Tab = props => {
   ]);
 
   const handleChangeTab = useCallback(
-    ({ pathToTabIndex }) => {
+    ({ pathToTabIndex }: { pathToTabIndex: string[] }) => {
       props.setDirectPathToChild(pathToTabIndex);
     },
     [props.setDirectPathToChild],
   );
 
   const handleChangeText = useCallback(
-    nextTabText => {
+    (nextTabText: string) => {
       const { updateComponents, component } = props;
       if (nextTabText && nextTabText !== component.meta.text) {
         updateComponents({
@@ -222,7 +229,10 @@ const Tab = props => {
     [props.handleComponentDrop],
   );
 
-  const shouldDropToChild = useCallback(item => item.type !== TAB_TYPE, []);
+  const shouldDropToChild = useCallback(
+    (item: { type: string }) => item.type !== TAB_TYPE,
+    [],
+  );
 
   const renderTabContent = useCallback(() => {
     const {
@@ -388,7 +398,7 @@ const Tab = props => {
       } = props;
       return (
         <TabTitleContainer
-          isHighlighted={isHighlighted}
+          isHighlighted={!!isHighlighted}
           className="dragdroppable-tab"
           ref={dragSourceRef}
         >
@@ -465,6 +475,7 @@ const Tab = props => {
     props.index,
     props.depth,
     props.editMode,
+    props.onDropOnTab,
     handleDrop,
     handleHoverTab,
     shouldDropToChild,
@@ -474,7 +485,6 @@ const Tab = props => {
   return props.renderType === RENDER_TAB ? renderTab() : renderTabContent();
 };
 
-Tab.propTypes = propTypes;
 Tab.defaultProps = defaultProps;
 
 export default memo(Tab);

--- a/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
+++ b/superset-frontend/src/dashboard/containers/DashboardComponent.jsx
@@ -49,6 +49,8 @@ const propTypes = {
   directPathToChild: PropTypes.arrayOf(PropTypes.string),
   directPathLastUpdated: PropTypes.number,
   isComponentVisible: PropTypes.bool,
+  onDrop: PropTypes.func,
+  onHover: PropTypes.func,
   availableColumnCount: PropTypes.number,
   columnWidth: PropTypes.number,
   onResizeStart: PropTypes.func,

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -127,6 +127,8 @@ export type DashboardState = {
     data: JsonObject;
   };
   chartStates?: Record<string, any>;
+  lastRefreshTime: number | null;
+  tabActivationTimes?: Record<string, number>;
 };
 export type DashboardInfo = {
   id: number;
@@ -207,15 +209,15 @@ type ComponentTypesKeys = keyof typeof componentTypes;
 export type ComponentType = (typeof componentTypes)[ComponentTypesKeys];
 
 export type LayoutItemMeta = {
-  chartId: number;
+  chartId?: number;
   defaultText?: string;
-  height: number;
+  height?: number;
   placeholder?: string;
   sliceName?: string;
   sliceNameOverride?: string;
   text?: string;
-  uuid: string;
-  width: number;
+  uuid?: string;
+  width?: number;
 };
 
 /** State of dashboardLayout item in redux */

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -127,7 +127,7 @@ export type DashboardState = {
     data: JsonObject;
   };
   chartStates?: Record<string, any>;
-  lastRefreshTime: number | null;
+  lastRefreshTime: number;
   tabActivationTimes?: Record<string, number>;
 };
 export type DashboardInfo = {
@@ -209,15 +209,15 @@ type ComponentTypesKeys = keyof typeof componentTypes;
 export type ComponentType = (typeof componentTypes)[ComponentTypesKeys];
 
 export type LayoutItemMeta = {
-  chartId?: number;
+  chartId: number;
   defaultText?: string;
-  height?: number;
+  height: number;
   placeholder?: string;
   sliceName?: string;
   sliceNameOverride?: string;
   text?: string;
-  uuid?: string;
-  width?: number;
+  uuid: string;
+  width: number;
 };
 
 /** State of dashboardLayout item in redux */

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -127,7 +127,7 @@ export type DashboardState = {
     data: JsonObject;
   };
   chartStates?: Record<string, any>;
-  lastRefreshTime: number;
+  lastRefreshTime?: number;
   tabActivationTimes?: Record<string, number>;
 };
 export type DashboardInfo = {


### PR DESCRIPTION
## **User description**
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

To migrate the Tab component, the following steps were performed:

1. Renamed the index file from `index.js` => `index.ts`
2. Renamed the component file from `Tab.jsx` => `Tab.tsx`
3. In `Tab.tsx`
    - Replaced the `propTypes` const with an `interface TabProps` definition
    - Typed callbacks and handlers to their expected values
4. In `Tab.test.tsx`,
    - Imported `RENDER_TAB` and `RENDER_TAB_CONTENT` from `Tab.tsx` 
    - In `createProps` function, casted `component` and `parentComponent` properties to `LayoutItem` type
5. In `DashboardComponent.jsx`,
    - Added missing properties to `propTypes` const
6. In `types.ts`,
    - Added missing properties to the `DashboardState` and `LayoutItemMeta` types
7. Resolved type errors

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="587" height="111" alt="image" src="https://github.com/user-attachments/assets/015bdc40-0bd4-4a41-b0eb-3b810ba133af" />
<img width="364" height="92" alt="image" src="https://github.com/user-attachments/assets/df399728-4d8e-4a99-a443-ab39c5a87faf" />

After:
<img width="531" height="107" alt="image" src="https://github.com/user-attachments/assets/a7d68af2-efb5-4959-8d2d-c547c0038278" />
<img width="339" height="97" alt="image" src="https://github.com/user-attachments/assets/296e8e6f-d8a9-4bde-b625-6abfb118fe12" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

CI and unit tests. Add a Tabs layout element to a dashboard and confirm that adding/editing/removing a tab works as expected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/9101
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
to: @rusackas @msyavuz @justinpark @sadpandajoe @geido


___

## **CodeAnt-AI Description**
**Migrate Tab component to TypeScript and expose tab render constants**

### What Changed
- Tab component rewritten in TypeScript: runtime PropTypes removed and inputs are statically typed, keeping UI behavior the same
- RENDER_TAB and RENDER_TAB_CONTENT are now exported from the Tab module and an index file so tests and other modules import these constants directly
- Unit tests updated to import the render constants and cast layout objects to the typed LayoutItem shape
- Dashboard container accepts onDrop and onHover props and dashboard types now include lastRefreshTime and tabActivationTimes so selectors used by the Tab component are present

### Impact
`✅ Fewer runtime type errors when rendering dashboard tabs`
`✅ Clearer, stable imports for tab render modes in tests`
`✅ Reduced test fragility around tab rendering and dashboard state`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
