### PR TITLE
fix(cal-heatmap): calendar heatmap rendering null month fix

### DIFF
--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -2722,7 +2722,9 @@ CalHeatMap.prototype = {
     var start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
     var stopExclusive;
     if (range instanceof Date) {
-      stopExclusive = new Date(Date.UTC(range.getUTCFullYear(), range.getUTCMonth(), 1));
+      stopExclusive = new Date(
+        Date.UTC(range.getUTCFullYear(), range.getUTCMonth(), 1),
+      );
     } else {
       stopExclusive = new Date(start);
       stopExclusive.setUTCMonth(stopExclusive.getUTCMonth() + range);

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -2717,18 +2717,17 @@ CalHeatMap.prototype = {
    * @return array  An array of months
    */
   getMonthDomain: function (d, range) {
-    'use strict';
-
-    var start = new Date(d.getFullYear(), d.getMonth());
-    var stop = null;
+    var start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+    var stopInclusive;
     if (range instanceof Date) {
-      stop = new Date(range.getFullYear(), range.getMonth());
+      stopInclusive = new Date(Date.UTC(range.getUTCFullYear(), range.getUTCMonth(), 1));
     } else {
-      stop = new Date(start);
-      stop = stop.setMonth(stop.getMonth() + range);
+      stopInclusive = new Date(start);
+      stopInclusive.setUTCMonth(stopInclusive.getUTCMonth() + (range - 1));
     }
-
-    return d3.time.months(Math.min(start, stop), Math.max(start, stop));
+    var stopExclusive = new Date(stopInclusive);
+    stopExclusive.setUTCMonth(stopExclusive.getUTCMonth() + 1);
+    return d3.time.months(start, stopExclusive);
   },
 
   /**

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -2717,6 +2717,8 @@ CalHeatMap.prototype = {
    * @return array  An array of months
    */
   getMonthDomain: function (d, range) {
+    'use strict';
+
     var start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
     var stopExclusive;
     if (range instanceof Date) {

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -2718,15 +2718,13 @@ CalHeatMap.prototype = {
    */
   getMonthDomain: function (d, range) {
     var start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
-    var stopInclusive;
+    var stopExclusive;
     if (range instanceof Date) {
-      stopInclusive = new Date(Date.UTC(range.getUTCFullYear(), range.getUTCMonth(), 1));
+      stopExclusive = new Date(Date.UTC(range.getUTCFullYear(), range.getUTCMonth(), 1));
     } else {
-      stopInclusive = new Date(start);
-      stopInclusive.setUTCMonth(stopInclusive.getUTCMonth() + (range - 1));
+      stopExclusive = new Date(start);
+      stopExclusive.setUTCMonth(stopExclusive.getUTCMonth() + range);
     }
-    var stopExclusive = new Date(stopInclusive);
-    stopExclusive.setUTCMonth(stopExclusive.getUTCMonth() + 1);
     return d3.time.months(start, stopExclusive);
   },
 

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/src/vendor/cal-heatmap.js
@@ -2710,7 +2710,7 @@ CalHeatMap.prototype = {
   },
 
   /**
-   * Return all the months between 2 dates
+   * Return all the months between 2 dates.
    *
    * @param  Date    d    A date
    * @param  int|date  range  Number of months in the range, or a stop date

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import CalendarChartPlugin from '../src/index';
+import CalHeatMap from '../src/vendor/cal-heatmap';
+
+/**
+ * The example tests in this file act as a starting point, and
+ * we encourage you to build more.
+ */
+describe('@superset-ui/legacy-plugin-chart-calendar', () => {
+  it('exists', () => {
+    expect(CalendarChartPlugin).toBeDefined();
+  });
+});
+
+/**
+ * This test tests that a reasonble starting date is selected given range
+ * and starting date. Since time offset is calculated, 2024-12-31 is also
+ * acceptable.
+ */
+describe('getMonthDomain filter month-day', () => {
+it('returns correct month domain for 2025-01-01 to 2025-02-31', () => {
+  const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
+  const d = new Date(Date.UTC(2025, 0, 1));
+  const range = 2;
+  const result = getMonthDomain(d, range);
+  expect(result[0].toISOString()).toContain('2025-01-01' || '2024-12-31');
+  });
+});

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -31,8 +31,8 @@ describe('@superset-ui/legacy-plugin-chart-calendar', () => {
 
 /**
  * This test tests that a reasonble starting date is selected given range
- * and starting date. Since time offset is calculated, 2024-12-31 is also
- * acceptable.
+ * and starting date. Since time offset is updated to be not considered,
+ * it would only be 1-1-2025
  */
 describe('getMonthDomain filter month-day', () => {
 it('returns correct month domain for 2025-01-01 to 2025-02-31', () => {
@@ -40,6 +40,6 @@ it('returns correct month domain for 2025-01-01 to 2025-02-31', () => {
   const d = new Date(Date.UTC(2025, 0, 1));
   const range = 2;
   const result = getMonthDomain(d, range);
-  expect(result[0].toISOString()).toContain('2025-01-01' || '2024-12-31');
+  expect(result[0].toISOString()).toContain('2025-01-01');
   });
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -30,16 +30,70 @@ describe('@superset-ui/legacy-plugin-chart-calendar', () => {
 });
 
 /**
- * This test tests that a reasonble starting date is selected given range
+ * This test tests that a reasonable starting date is selected given range
  * and starting date. Since time offset is updated to be not considered,
  * it would only be 1-1-2025
  */
 describe('getMonthDomain filter month-day', () => {
-it('returns correct month domain for 2025-01-01 to 2025-02-31', () => {
-  const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
-  const d = new Date(Date.UTC(2025, 0, 1));
-  const range = 2;
-  const result = getMonthDomain(d, range);
-  expect(result[0].toISOString()).toContain('2025-01-01');
+  it('returns correct month domain for 2025-03-01 to 2025-05-01', () => {
+    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
+    const d = new Date(Date.UTC(2025, 2, 1));
+    const range = 2;
+    const result = getMonthDomain(d, range);
+    expect(result[0].toISOString()).toContain('2025-03-01');
+    expect(result[1].toISOString()).toContain('2025-04-01');
+    expect(result.length).toBe(2);
+    });
+});
+
+/*
+ * This test checks if the getMonthDomain functions as intended during a
+ * leap year, when February has one extra day. Checks only February 2024, which 
+ * was a leap year. This works because if it is not a leap year, February won't have
+ * 29 days, and the method "Date.UTC" would return March 1st instead.
+*/
+describe('getMonthDomain leap year test', () => {
+  it('handles February 2024 leap year correctly', () => {
+    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain
+    const feb2024 = new Date(Date.UTC(2024, 1, 29));
+    const range = 2;
+    const result = getMonthDomain(feb2024, range);
+    expect(result[0].toISOString()).toContain('2024-02-01');
+    expect(result[1].toISOString()).toContain('2024-03-01');
+    expect(result.length).toBe(2);
+  });
+});
+
+/*
+ * This test case checks if getMonthDomain functions as intended if the range 
+ * is an actual Date object. From March 1st 2025 to May 1st 2025.
+*/
+describe('getMonthDomain with Date object range', () => {
+  it('uses Date object as range parameter', () => {
+    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
+    const startDate = new Date(Date.UTC(2025, 2, 1));
+    const endDate = new Date(Date.UTC(2025, 4, 1));
+    const result = getMonthDomain(startDate, endDate);
+    expect(result[0].toISOString()).toContain('2025-03-01');
+    expect(result[1].toISOString()).toContain('2025-04-01');
+    expect(result.length).toBe(2);
+  });
+});
+
+/*
+ * This test case checks if getMonthDomain functions as intended if the range
+ * goes across a year. From November 1st 2024 to February 1st 2025.
+*/
+describe('getMonthDomain multi-year UTC handling', () => {
+  it('handles multi-year ranges across year boundaries', () => {
+    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
+    const startDate = new Date(Date.UTC(2024, 10, 1));
+    const range = 4;
+    const result = getMonthDomain(startDate, range);
+    expect(result.length).toBe(4);
+    expect(result[0].toISOString()).toContain('2024-11-01');
+    expect(result[1].toISOString()).toContain('2024-12-01');
+    expect(result[2].toISOString()).toContain('2025-01-01');
+    expect(result[3].toISOString()).toContain('2025-02-01');
   });
 });

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -32,7 +32,7 @@ describe('@superset-ui/legacy-plugin-chart-calendar', () => {
 /*
  * This test checks if the getMonthDomain functions as intended in the case that
  * a time range has a "first day of the month" selected as an end date. This is an
- * example of the original issue found at https://github.com/apache/superset/issues/21870.
+ * example of the original issue found at https://github.com/apache/superset/issues/21870
  */
 describe('getMonthDomain filter month-day', () => {
   it('returns correct month domain for 2025-03-01 to 2025-05-01', () => {
@@ -43,7 +43,7 @@ describe('getMonthDomain filter month-day', () => {
     expect(result[0].toISOString()).toContain('2025-03-01');
     expect(result[1].toISOString()).toContain('2025-04-01');
     expect(result.length).toBe(2);
-    });
+  });
 });
 
 /*
@@ -51,10 +51,10 @@ describe('getMonthDomain filter month-day', () => {
  * leap year, when February has one extra day. Checks only February 2024, which
  * was a leap year. This works because if it is not a leap year, February won't have
  * 29 days, and the method "Date.UTC" would return March 1st instead.
-*/
+ */
 describe('getMonthDomain leap year test', () => {
   it('handles February 2024 leap year correctly', () => {
-    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain
+    const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
     const feb2024 = new Date(Date.UTC(2024, 1, 29));
     const range = 2;
     const result = getMonthDomain(feb2024, range);
@@ -67,7 +67,7 @@ describe('getMonthDomain leap year test', () => {
 /*
  * This test case checks if getMonthDomain functions as intended if the range
  * is an actual Date object. From March 1st 2025 to May 1st 2025.
-*/
+ */
 describe('getMonthDomain with Date object range', () => {
   it('uses Date object as range parameter', () => {
     const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;
@@ -83,7 +83,7 @@ describe('getMonthDomain with Date object range', () => {
 /*
  * This test case checks if getMonthDomain functions as intended if the range
  * goes across a year. From November 1st 2024 to February 1st 2025.
-*/
+ */
 describe('getMonthDomain multi-year UTC handling', () => {
   it('handles multi-year ranges across year boundaries', () => {
     const getMonthDomain = (CalHeatMap as any).prototype.getMonthDomain;

--- a/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/legacy-plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -29,10 +29,10 @@ describe('@superset-ui/legacy-plugin-chart-calendar', () => {
   });
 });
 
-/**
- * This test tests that a reasonable starting date is selected given range
- * and starting date. Since time offset is updated to be not considered,
- * it would only be 1-1-2025
+/*
+ * This test checks if the getMonthDomain functions as intended in the case that
+ * a time range has a "first day of the month" selected as an end date. This is an
+ * example of the original issue found at https://github.com/apache/superset/issues/21870.
  */
 describe('getMonthDomain filter month-day', () => {
   it('returns correct month domain for 2025-03-01 to 2025-05-01', () => {
@@ -48,7 +48,7 @@ describe('getMonthDomain filter month-day', () => {
 
 /*
  * This test checks if the getMonthDomain functions as intended during a
- * leap year, when February has one extra day. Checks only February 2024, which 
+ * leap year, when February has one extra day. Checks only February 2024, which
  * was a leap year. This works because if it is not a leap year, February won't have
  * 29 days, and the method "Date.UTC" would return March 1st instead.
 */
@@ -65,7 +65,7 @@ describe('getMonthDomain leap year test', () => {
 });
 
 /*
- * This test case checks if getMonthDomain functions as intended if the range 
+ * This test case checks if getMonthDomain functions as intended if the range
  * is an actual Date object. From March 1st 2025 to May 1st 2025.
 */
 describe('getMonthDomain with Date object range', () => {

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -799,6 +799,10 @@ class CalHeatmapViz(BaseViz):
         if domain == "year":
             range_ = end.year - start.year + 1
         elif domain == "month":
+            # extra day to exclude first day of the month
+            end = end - rdelta.relativedelta(days=1)
+            diff_delta = rdelta.relativedelta(end, start)
+            diff_secs = (end - start).total_seconds()
             range_ = diff_delta.years * 12 + diff_delta.months + 1
         elif domain == "week":
             range_ = diff_delta.years * 53 + diff_delta.weeks + 1

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -802,7 +802,6 @@ class CalHeatmapViz(BaseViz):
             # extra day to exclude first day of the month
             end = end - rdelta.relativedelta(days=1)
             diff_delta = rdelta.relativedelta(end, start)
-            diff_secs = (end - start).total_seconds()
             range_ = diff_delta.years * 12 + diff_delta.months + 1
         elif domain == "week":
             range_ = diff_delta.years * 53 + diff_delta.weeks + 1


### PR DESCRIPTION
## **User description**
### SUMMARY
This is a fix related to [issue#21870](https://github.com/apache/superset/issues/21870).

Unexpected Behaviour: In calendar heatmap, when the end date is the start day of the month, an extra null month is rendered, the null month is either rendered before or after based on local time offset compared to UTC.
Expected Behaviour: When rendering date, if first day of a month is selected as the end date, default going to 12AM, the month containing this date should not be rendered.
### IMPLEMENTATION DETAILS FOR REFERENCE
Modified logic related to plugin calendar-heatmap month-day rendering behaviour:
- cal-heatmaps.js contains a function named “getMonthDomain” responsible for returning time range for frontend render, replacing javascript Date methods with UTC equivalent to remove local time zone offset issue. Our rationale for this change is to preserve consistent time ranges between users in different time zones. We noticed our reproduction of the issue resulted in a null month prior to the time range of the chart, compared to the issuer’s example. This is because our time zone is in EST, which is 4-5 hours behind UTC depending on daylight savings. The issuer’s Superset image was in the Dutch language, so we assumed CET, an hour ahead of UTC. This is why the null month placement was different in our reproduction compared to theirs. 
- viz.py contains the backend class definition for “CalHeatmapViz”. Subtracted 1 day for end, when calculating range for first day of the month, to enforce exclusive end date, as desired for Superset’s Calendar Heatmap chart definition. This gets rid of null month rendering behaviour.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Setup steps, create a dataset using users:

Before any fix (Based in EST):
<img width="714" height="497" alt="Screenshot 2025-11-27 at 7 17 37 PM" src="https://github.com/user-attachments/assets/5a79f9aa-b963-4791-8f87-cb45907f40ea" />
After adding only UTC functions:
<img width="714" height="486" alt="Screenshot 2025-11-27 at 7 17 56 PM" src="https://github.com/user-attachments/assets/adfbd7a8-c2f0-448f-83bb-c3010f09263d" />
After both UTC and viz.py updates:
<img width="618" height="562" alt="Screenshot 2025-11-27 at 7 18 17 PM" src="https://github.com/user-attachments/assets/99e8196a-283d-4c54-922c-ebd9031f6f53" />


### TESTING INSTRUCTIONS
Testing this is normal usage of superset, for details:
1. Sync superset repo and start the application on localhost using `docker compose up --build` and login localhost.
2. Take any dataset on your Superset instance with date-value data points and open a Calendar Heatmap chart with it. (For the following test cases, our examples used superset’s preset dataset main.users with the MIN(# tz_offset) metrics)
3. Check what dates your data points occur.
4. Here are some cases to attempt:
a) Original issue case: 1st of a month to 1st of another month 2 months away, like March 1st to May 1st.
<img width="314" height="284" alt="Screenshot 2025-11-27 at 7 18 40 PM" src="https://github.com/user-attachments/assets/0738f625-761e-44ba-bb46-0db9fa8124ef" />

b) Within same month: when selecting March 1st to March 31st, make sure the same month range is possible with no repeat of the null month issue.
<img width="304" height="255" alt="Screenshot 2025-11-27 at 7 20 04 PM" src="https://github.com/user-attachments/assets/1f68c53c-366f-4f2e-8ec7-08285dd23864" />

c) >1 year case: like January 1st to January 1st of subsequent year, to make sure a range with years considered is displaying correctly.
<img width="523" height="273" alt="Screenshot 2025-11-27 at 7 20 13 PM" src="https://github.com/user-attachments/assets/db87fec0-d5ef-44b4-b260-c84aa22ffb86" />

### ADDITIONAL INFORMATION
- [x] Has associated issue: this pr is only related to and fixes #21870
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59] (https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix calendar heatmap extra empty month and make month ranges timezone-consistent

### What Changed
- Calendar heatmap no longer shows an extra empty/null month when the "Until" date is the first day of a month; that month is now excluded from the rendered range.
- Month boundaries are calculated using UTC so users in different time zones see the same month range and the null-month location no longer depends on local offset.
- Month sequences across leap years and year boundaries are handled correctly (e.g., Feb 29 on leap years and multi-year ranges).
- Added unit tests covering first-of-month end dates, leap-year February, Date-object ranges, and multi-year ranges to prevent regressions.

### Impact
 `✅ No extra blank month in calendar heatmap when "Until" is the first of a month`
 `✅ Consistent calendar heatmap month ranges across time zones`
 `✅ Correct month sequences for leap years and year-crossing selections`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
