### PR TITLE
feat(theming): add per-theme custom font URL support

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -146,6 +146,31 @@ Note: Pillow is now a required dependency (previously optional) to support image
 - [32432](https://github.com/apache/superset/pull/31260) Moves the List Roles FAB view to the frontend and requires `FAB_ADD_SECURITY_API` to be enabled in the configuration and `superset init` to be executed.
 - [34319](https://github.com/apache/superset/pull/34319) Drill to Detail and Drill By is now supported in Embedded mode, and also with the `DASHBOARD_RBAC` FF. If you don't want to expose these features in Embedded / `DASHBOARD_RBAC`, make sure the roles used for Embedded / `DASHBOARD_RBAC`don't have the required permissions to perform D2D actions.
 
+### Breaking Changes
+
+#### CUSTOM_FONT_URLS removed
+
+The `CUSTOM_FONT_URLS` configuration option has been removed. Use the new per-theme `fontUrls` token in `THEME_DEFAULT` or database-managed themes instead.
+
+**Before (5.x):**
+```python
+CUSTOM_FONT_URLS = [
+    "https://fonts.example.com/myfont.css",
+]
+```
+
+**After (6.0):**
+```python
+THEME_DEFAULT = {
+    "token": {
+        "fontUrls": [
+            "https://fonts.example.com/myfont.css",
+        ],
+        # ... other tokens
+    }
+}
+```
+
 ## 5.0.0
 
 - [31976](https://github.com/apache/superset/pull/31976) Removed the `DISABLE_LEGACY_DATASOURCE_EDITOR` feature flag. The previous value of the feature flag was `True` and now the feature is permanently removed.

--- a/docs/docs/configuration/theming.mdx
+++ b/docs/docs/configuration/theming.mdx
@@ -110,18 +110,30 @@ To export a theme for use in configuration files or another instance:
 
 ## Custom Fonts
 
-Superset supports custom fonts through runtime configuration, allowing you to use branded or custom typefaces without rebuilding the application.
+Superset supports custom fonts through the theme configuration, allowing you to use branded or custom typefaces without rebuilding the application.
+
+### Default Fonts
+
+By default, Superset uses Inter and Fira Code fonts which are bundled with the application via `@fontsource` packages. These fonts work offline and require no external network calls.
 
 ### Configuring Custom Fonts
 
-Add font URLs to your `superset_config.py`:
+To use custom fonts, add font URLs to your theme configuration using the `fontUrls` token:
 
 ```python
-# Load fonts from Google Fonts, Adobe Fonts, or self-hosted sources
-CUSTOM_FONT_URLS = [
-    "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap",
-]
+THEME_DEFAULT = {
+    "token": {
+        # Load fonts from external sources (e.g., Google Fonts, Adobe Fonts)
+        "fontUrls": [
+            "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap",
+        ],
+        # Reference the loaded fonts
+        "fontFamily": "Roboto, -apple-system, BlinkMacSystemFont, sans-serif",
+        "fontFamilyCode": "JetBrains Mono, Monaco, monospace",
+        # ... other theme tokens
+    }
+}
 
 # Update CSP to allow font sources
 TALISMAN_CONFIG = {
@@ -132,30 +144,23 @@ TALISMAN_CONFIG = {
 }
 ```
 
-### Using Custom Fonts in Themes
-
-Once configured, reference the fonts in your theme configuration:
-
-```python
-THEME_DEFAULT = {
-    "token": {
-        "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
-        "fontFamilyCode": "JetBrains Mono, Monaco, monospace",
-        # ... other theme tokens
-    }
-}
-```
-
 Or in the CRUD interface theme JSON:
 
 ```json
 {
   "token": {
-    "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+    "fontUrls": [
+      "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap"
+    ],
+    "fontFamily": "Roboto, -apple-system, BlinkMacSystemFont, sans-serif",
     "fontFamilyCode": "JetBrains Mono, Monaco, monospace"
   }
 }
 ```
+
+:::note
+Font URLs are validated against a configurable allowlist. By default, fonts from `fonts.googleapis.com`, `fonts.gstatic.com`, and `use.typekit.net` are allowed. Configure `THEME_FONT_URL_ALLOWED_DOMAINS` to customize the allowed domains.
+:::
 
 ### Font Sources
 

--- a/docs/versioned_docs/version-6.0.0/configuration/theming.mdx
+++ b/docs/versioned_docs/version-6.0.0/configuration/theming.mdx
@@ -110,18 +110,30 @@ To export a theme for use in configuration files or another instance:
 
 ## Custom Fonts
 
-Superset supports custom fonts through runtime configuration, allowing you to use branded or custom typefaces without rebuilding the application.
+Superset supports custom fonts through the theme configuration, allowing you to use branded or custom typefaces without rebuilding the application.
+
+### Default Fonts
+
+By default, Superset uses Inter and Fira Code fonts which are bundled with the application via `@fontsource` packages. These fonts work offline and require no external network calls.
 
 ### Configuring Custom Fonts
 
-Add font URLs to your `superset_config.py`:
+To use custom fonts, add font URLs to your theme configuration using the `fontUrls` token:
 
 ```python
-# Load fonts from Google Fonts, Adobe Fonts, or self-hosted sources
-CUSTOM_FONT_URLS = [
-    "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap",
-]
+THEME_DEFAULT = {
+    "token": {
+        # Load fonts from external sources (e.g., Google Fonts, Adobe Fonts)
+        "fontUrls": [
+            "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap",
+            "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap",
+        ],
+        # Reference the loaded fonts
+        "fontFamily": "Roboto, -apple-system, BlinkMacSystemFont, sans-serif",
+        "fontFamilyCode": "JetBrains Mono, Monaco, monospace",
+        # ... other theme tokens
+    }
+}
 
 # Update CSP to allow font sources
 TALISMAN_CONFIG = {
@@ -132,30 +144,23 @@ TALISMAN_CONFIG = {
 }
 ```
 
-### Using Custom Fonts in Themes
-
-Once configured, reference the fonts in your theme configuration:
-
-```python
-THEME_DEFAULT = {
-    "token": {
-        "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
-        "fontFamilyCode": "JetBrains Mono, Monaco, monospace",
-        # ... other theme tokens
-    }
-}
-```
-
 Or in the CRUD interface theme JSON:
 
 ```json
 {
   "token": {
-    "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+    "fontUrls": [
+      "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap"
+    ],
+    "fontFamily": "Roboto, -apple-system, BlinkMacSystemFont, sans-serif",
     "fontFamilyCode": "JetBrains Mono, Monaco, monospace"
   }
 }
 ```
+
+:::note
+Font URLs are validated against a configurable allowlist. By default, fonts from `fonts.googleapis.com`, `fonts.gstatic.com`, and `use.typekit.net` are allowed. Configure `THEME_FONT_URL_ALLOWED_DOMAINS` to customize the allowed domains.
+:::
 
 ### Font Sources
 

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -5344,6 +5344,7 @@
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
       "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
       "license": "OFL-1.1",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
@@ -64789,8 +64790,6 @@
         "@ant-design/icons": "^5.2.6",
         "@apache-superset/core": "*",
         "@babel/runtime": "^7.28.4",
-        "@fontsource/fira-code": "^5.2.7",
-        "@fontsource/inter": "^5.2.6",
         "@types/json-bigint": "^1.0.4",
         "@visx/responsive": "^3.12.0",
         "ace-builds": "^1.43.4",
@@ -64871,15 +64870,6 @@
         "react-dom": "^17.0.2",
         "react-loadable": "^5.5.0",
         "tinycolor2": "*"
-      }
-    },
-    "packages/superset-ui-core/node_modules/@fontsource/fira-code": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource/fira-code/-/fira-code-5.2.6.tgz",
-      "integrity": "sha512-wCkIpPm0BqlkCPLYeY4Vui96ODmVUV0/GpEe3OfJ4v8EJn/BF2SlyxvarFsTs1CKiGjrO2cXlIZbBrKi9F+hUQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "packages/superset-ui-core/node_modules/@types/lodash": {

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -35,6 +35,8 @@
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/fira-code": "^5.2.6",
+    "@fontsource/inter": "^5.2.6",
     "nanoid": "^5.0.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/superset-frontend/packages/superset-core/package.json
+++ b/superset-frontend/packages/superset-core/package.json
@@ -40,8 +40,6 @@
     "react-dom": "^17.0.2",
     "react-loadable": "^5.5.0",
     "tinycolor2": "*",
-    "@fontsource/fira-code": "^5.2.6",
-    "@fontsource/inter": "^5.2.6",
     "lodash": "^4.17.21",
     "antd": "^5.26.0"
   },

--- a/superset-frontend/packages/superset-core/src/ui/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/ui/theme/GlobalStyles.tsx
@@ -16,6 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+// @fontsource/* v5.1+ doesn't play nice with eslint-import plugin v2.31+
+/* eslint-disable import/extensions */
+import '@fontsource/inter/200.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/fira-code/400.css';
+import '@fontsource/fira-code/500.css';
+import '@fontsource/fira-code/600.css';
+/* eslint-enable import/extensions */
+
 import { css, useTheme, Global } from '@emotion/react';
 
 export const GlobalStyles = () => {

--- a/superset-frontend/packages/superset-core/src/ui/theme/GlobalStyles.tsx
+++ b/superset-frontend/packages/superset-core/src/ui/theme/GlobalStyles.tsx
@@ -16,18 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-// @fontsource/* v5.1+ doesn't play nice with eslint-import plugin v2.31+
-/* eslint-disable import/extensions */
-import '@fontsource/inter/200.css';
-import '@fontsource/inter/400.css';
-import '@fontsource/inter/500.css';
-import '@fontsource/inter/600.css';
-import '@fontsource/fira-code/400.css';
-import '@fontsource/fira-code/500.css';
-import '@fontsource/fira-code/600.css';
-/* eslint-enable import/extensions */
-
 import { css, useTheme, Global } from '@emotion/react';
 
 export const GlobalStyles = () => {

--- a/superset-frontend/packages/superset-core/src/ui/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/ui/theme/types.ts
@@ -130,7 +130,25 @@ export interface SupersetSpecificTokens {
   brandSpinnerSvg?: string;
 
   // Font loading
-  /** Array of font URLs to load for this theme (Google Fonts, Adobe Fonts, etc.) */
+  /**
+   * Array of font URLs to load for this theme.
+   * Supports multiple URLs for loading different font families or mixing providers.
+   * Each URL is injected as a CSS @import when the theme is applied.
+   *
+   * @example
+   * Multiple font families from Google Fonts
+   * fontUrls: [
+   *   "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap",
+   *   "https://fonts.googleapis.com/css2?family=Fira+Code&display=swap"
+   * ]
+   *
+   * @example
+   * Mix Google Fonts and Adobe Fonts
+   * fontUrls: [
+   *   "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap",
+   *   "https://use.typekit.net/abc123.css"
+   * ]
+   */
   fontUrls?: string[];
 
   // ECharts-related

--- a/superset-frontend/packages/superset-core/src/ui/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/ui/theme/types.ts
@@ -129,6 +129,10 @@ export interface SupersetSpecificTokens {
   brandSpinnerUrl?: string;
   brandSpinnerSvg?: string;
 
+  // Font loading
+  /** Array of font URLs to load for this theme (Google Fonts, Adobe Fonts, etc.) */
+  fontUrls?: string[];
+
   // ECharts-related
   /** Global ECharts configuration overrides applied to all chart types */
   echartsOptionsOverrides?: any;

--- a/superset-frontend/packages/superset-ui-core/package.json
+++ b/superset-frontend/packages/superset-ui-core/package.json
@@ -27,8 +27,6 @@
     "@apache-superset/core": "*",
     "@ant-design/icons": "^5.2.6",
     "@babel/runtime": "^7.28.4",
-    "@fontsource/fira-code": "^5.2.7",
-    "@fontsource/inter": "^5.2.6",
     "@types/json-bigint": "^1.0.4",
     "ace-builds": "^1.43.4",
     "ag-grid-community": "34.2.0",

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -813,7 +813,10 @@ export class ThemeController {
     if (newUrls.length === 0) return;
 
     // Use CSS @import for font loading
-    const css = newUrls.map(url => `@import url("${url}");`).join('\n');
+    // JSON.stringify provides safe escaping to prevent CSS injection attacks
+    const css = newUrls
+      .map(url => `@import url(${JSON.stringify(url)});`)
+      .join('\n');
 
     const style = document.createElement('style');
     style.setAttribute('data-superset-fonts', 'true');

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -99,6 +99,9 @@ export class ThemeController {
 
   private dashboardCrudTheme: AnyThemeConfig | null = null;
 
+  // Track loaded font URLs to avoid duplicate injections
+  private loadedFontUrls: Set<string> = new Set();
+
   constructor({
     storage = new LocalStorageAdapter(),
     modeStorageKey = STORAGE_KEYS.THEME_MODE,
@@ -248,6 +251,11 @@ export class ThemeController {
           normalizedConfig,
           baseTheme || undefined,
         );
+
+        // Load custom fonts if specified in dashboard theme config
+        const fontUrls = (normalizedConfig?.token as Record<string, unknown>)
+          ?.fontUrls as string[] | undefined;
+        this.loadFonts(fontUrls);
 
         // Cache the theme for reuse
         this.dashboardThemes.set(themeId, dashboardTheme);
@@ -781,10 +789,39 @@ export class ThemeController {
       // The merging with base theme happens in getThemeForMode() and other methods
       // that prepare themes before passing them to applyTheme()
       this.globalTheme.setConfig(normalizedConfig);
+
+      // Load custom fonts if specified in theme config
+      const fontUrls = (normalizedConfig?.token as Record<string, unknown>)
+        ?.fontUrls as string[] | undefined;
+      this.loadFonts(fontUrls);
     } catch (error) {
       console.error('Failed to apply theme:', error);
       this.fallbackToDefaultMode();
     }
+  }
+
+  /**
+   * Loads custom fonts from theme configuration.
+   * Injects CSS @import statements for font URLs that haven't been loaded yet.
+   * @param fontUrls - Array of font URLs to load (e.g., Google Fonts, Adobe Fonts)
+   */
+  private loadFonts(fontUrls?: string[]): void {
+    if (!fontUrls?.length) return;
+
+    // Filter out already loaded fonts
+    const newUrls = fontUrls.filter(url => !this.loadedFontUrls.has(url));
+    if (newUrls.length === 0) return;
+
+    // Use CSS @import for font loading
+    const css = newUrls.map(url => `@import url("${url}");`).join('\n');
+
+    const style = document.createElement('style');
+    style.setAttribute('data-superset-fonts', 'true');
+    style.textContent = css;
+    document.head.appendChild(style);
+
+    // Track loaded fonts to avoid duplicates
+    newUrls.forEach(url => this.loadedFontUrls.add(url));
   }
 
   /**

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -102,1272 +102,1391 @@ const mockThemeObject = {
   theme: DEFAULT_THEME,
 } as unknown as Theme;
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('LocalStorageAdapter', () => {
-  let adapter: LocalStorageAdapter;
-  const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-  beforeEach(() => {
-    adapter = new LocalStorageAdapter();
-    jest.clearAllMocks();
-    Object.defineProperty(window, 'localStorage', {
-      value: mockLocalStorage,
-      writable: true,
-    });
+// Helper to create a fresh ThemeController with common setup
+const createController = (
+  options: Partial<ConstructorParameters<typeof ThemeController>[0]> = {},
+) =>
+  new ThemeController({
+    themeObject: mockThemeObject,
+    ...options,
   });
 
-  afterAll(() => {
-    consoleSpy.mockRestore();
+// Shared console spies
+const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Setup DOM environment
+  Object.defineProperty(window, 'localStorage', {
+    value: mockLocalStorage,
+    writable: true,
   });
 
-  test('should return item from localStorage', () => {
-    mockLocalStorage.getItem.mockReturnValue('test-value');
-
-    const result = adapter.getItem('test-key');
-
-    expect(mockLocalStorage.getItem).toHaveBeenCalledTimes(1);
-    expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key');
-    expect(result).toBe('test-value');
+  Object.defineProperty(window, 'matchMedia', {
+    value: mockMatchMedia,
+    writable: true,
   });
 
-  test('should set item in localStorage', () => {
-    adapter.setItem('test-key', 'test-value');
-
-    expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-      'test-key',
-      'test-value',
-    );
+  mockMatchMedia.mockReturnValue({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
   });
 
-  test('should handle localStorage errors while setting an item', () => {
-    mockLocalStorage.setItem.mockImplementation(() => {
-      throw new Error('Storage error');
-    });
+  mockSetConfig.mockImplementation(() => {});
+  mockThemeFromConfig.mockReturnValue(mockThemeObject);
 
-    adapter.setItem('test-key', 'test-value');
+  // Mock Theme constructor
+  (Theme as any).fromConfig = mockThemeFromConfig;
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Failed to write to localStorage:',
-      expect.any(Error),
-    );
-  });
+  // Reset localStorage mocks
+  mockLocalStorage.getItem.mockReturnValue(null);
+  mockLocalStorage.setItem.mockImplementation(() => {});
+  mockLocalStorage.removeItem.mockImplementation(() => {});
 
-  test('should remove item from localStorage', () => {
-    adapter.removeItem('test-key');
-
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(1);
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test-key');
-  });
-
-  test('should handle localStorage errors while removing an item', () => {
-    mockLocalStorage.removeItem.mockImplementation(() => {
-      throw new Error('Storage error');
-    });
-
-    adapter.removeItem('test-key');
-
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Failed to remove from localStorage:',
-      expect.any(Error),
-    );
-  });
+  // Default BootstrapData
+  mockGetBootstrapData.mockReturnValue(createMockBootstrapData());
 });
 
-// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-describe('ThemeController', () => {
-  let controller: ThemeController;
-  const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+afterAll(() => {
+  consoleSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+// LocalStorageAdapter tests
+test('LocalStorageAdapter returns item from localStorage', () => {
+  const adapter = new LocalStorageAdapter();
+  mockLocalStorage.getItem.mockReturnValue('test-value');
 
-    // Setup DOM environment
-    Object.defineProperty(window, 'localStorage', {
-      value: mockLocalStorage,
-      writable: true,
-    });
+  const result = adapter.getItem('test-key');
 
-    Object.defineProperty(window, 'matchMedia', {
-      value: mockMatchMedia,
-      writable: true,
-    });
+  expect(mockLocalStorage.getItem).toHaveBeenCalledTimes(1);
+  expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key');
+  expect(result).toBe('test-value');
+});
 
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    });
+test('LocalStorageAdapter sets item in localStorage', () => {
+  const adapter = new LocalStorageAdapter();
 
-    mockSetConfig.mockImplementation(() => {});
-    mockThemeFromConfig.mockReturnValue(mockThemeObject);
+  adapter.setItem('test-key', 'test-value');
 
-    // Mock Theme constructor
-    (Theme as any).fromConfig = mockThemeFromConfig;
+  expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+  expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+    'test-key',
+    'test-value',
+  );
+});
 
-    // Reset localStorage mocks
-    mockLocalStorage.getItem.mockReturnValue(null);
-    mockLocalStorage.setItem.mockImplementation(() => {});
-    mockLocalStorage.removeItem.mockImplementation(() => {});
-
-    // Default BootstrapData
-    mockGetBootstrapData.mockReturnValue(createMockBootstrapData());
+test('LocalStorageAdapter handles localStorage errors while setting an item', () => {
+  const adapter = new LocalStorageAdapter();
+  mockLocalStorage.setItem.mockImplementation(() => {
+    throw new Error('Storage error');
   });
 
-  afterAll(() => {
-    consoleSpy.mockRestore();
-    consoleErrorSpy.mockRestore();
+  adapter.setItem('test-key', 'test-value');
+
+  expect(consoleSpy).toHaveBeenCalledTimes(1);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'Failed to write to localStorage:',
+    expect.any(Error),
+  );
+});
+
+test('LocalStorageAdapter removes item from localStorage', () => {
+  const adapter = new LocalStorageAdapter();
+
+  adapter.removeItem('test-key');
+
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledTimes(1);
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('test-key');
+});
+
+test('LocalStorageAdapter handles localStorage errors while removing an item', () => {
+  const adapter = new LocalStorageAdapter();
+  mockLocalStorage.removeItem.mockImplementation(() => {
+    throw new Error('Storage error');
   });
 
-  test('should initialize with default options', () => {
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-    });
+  adapter.removeItem('test-key');
 
-    expect(controller.getTheme()).toBe(mockThemeObject);
-  });
+  expect(consoleSpy).toHaveBeenCalledTimes(1);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'Failed to remove from localStorage:',
+    expect.any(Error),
+  );
+});
 
-  test('should use BootstrapData themes when available', () => {
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-    });
+// ThemeController initialization tests
+test('ThemeController initializes with default options', () => {
+  const controller = createController();
 
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
-    expect(mockSetConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({
-          colorBgBase: '#ededed',
-          colorPrimary: '#c96f0f',
-        }),
+  expect(controller.getTheme()).toBe(mockThemeObject);
+});
+
+test('ThemeController uses BootstrapData themes when available', () => {
+  createController();
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorBgBase: '#ededed',
+        colorPrimary: '#c96f0f',
       }),
-    );
-  });
+    }),
+  );
+});
 
-  test('should fallback to Superset default theme when BootstrapData themes are empty', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: {},
-        dark: {},
-      }),
-    );
+test('ThemeController fallbacks to Superset default theme when BootstrapData themes are empty', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-    const fallbackTheme = {
-      token: {
+  const fallbackTheme = {
+    token: {
+      colorBgBase: '#ffffff',
+      colorPrimary: '#1890ff',
+    },
+  };
+
+  createController({ defaultTheme: fallbackTheme });
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...fallbackTheme,
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
+});
+
+test('ThemeController handles system theme preference', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+});
+
+test('ThemeController handles only default theme', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: {},
+    }),
+  );
+
+  const controller = createController();
+
+  jest.clearAllMocks();
+
+  expect(() => controller.setThemeMode(ThemeMode.DARK)).toThrow(
+    'Theme mode changes are not allowed when only one theme is available',
+  );
+
+  expect(mockSetConfig).not.toHaveBeenCalled();
+});
+
+test('ThemeController handles only dark theme', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: DARK_THEME,
+    }),
+  );
+
+  const lightThemeFallback = {
+    token: {
+      colorBgBase: '#fff',
+      colorTextBase: '#000',
+      colorPrimary: '#1890ff',
+    },
+  };
+
+  const controller = createController({ defaultTheme: lightThemeFallback });
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+
+  const calledWith = mockSetConfig.mock.calls[0][0];
+
+  expect(calledWith.token.colorBgBase).toBe('#fff');
+  expect(calledWith.token.colorTextBase).toBe('#000');
+
+  expect(controller.canSetMode()).toBe(true);
+
+  jest.clearAllMocks();
+  controller.setThemeMode(ThemeMode.DARK);
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+});
+
+test('ThemeController handles completely empty BootstrapData', () => {
+  const fallbackTheme = {
+    token: {
+      colorBgBase: '#ffffff',
+      colorPrimary: '#1890ff',
+    },
+  };
+
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
+
+  createController({ defaultTheme: fallbackTheme });
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
         colorBgBase: '#ffffff',
         colorPrimary: '#1890ff',
-      },
-    };
-
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-      defaultTheme: fallbackTheme,
-    });
-
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
-    expect(mockSetConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...fallbackTheme,
-        algorithm: antdThemeImport.defaultAlgorithm,
       }),
-    );
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
+});
+
+test('ThemeController handles missing theme object', () => {
+  const fallbackTheme = { token: { colorPrimary: '#fallback' } };
+
+  mockGetBootstrapData.mockReturnValue({
+    common: {
+      application_root: '/',
+      static_assets_prefix: '/static/assets/',
+      conf: {},
+      locale: 'en',
+      feature_flags: {},
+      language_pack: {},
+      extra_categorical_color_schemes: [],
+      extra_sequential_color_schemes: [],
+      menu_data: {},
+      d3_format: {},
+      d3_time_format: {},
+    } as any,
   });
 
-  test('should handle system theme preference', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
+  createController({ defaultTheme: fallbackTheme });
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorPrimary: '#fallback',
       }),
-    );
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
+});
 
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-    });
+// Theme Management tests
 
-    expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
-  });
+test('ThemeController updates theme when allowed', () => {
+  const controller = createController();
 
-  test('should handle only default theme', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: {},
+  const newTheme = {
+    token: {
+      colorBgBase: '#000000',
+      colorPrimary: '#ff0000',
+    },
+  };
+
+  controller.setTheme(newTheme);
+
+  expect(mockSetConfig).toHaveBeenCalledWith(expect.objectContaining(newTheme));
+});
+
+test('ThemeController changes theme mode when allowed', () => {
+  const controller = createController();
+
+  jest.clearAllMocks();
+
+  controller.setThemeMode(ThemeMode.DARK);
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+  expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+  expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+    'superset-theme-mode',
+    ThemeMode.DARK,
+  );
+});
+
+test('ThemeController handles missing theme gracefully', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: {},
+    }),
+  );
+
+  const controller = createController();
+
+  expect(() => controller.setThemeMode(ThemeMode.DARK)).toThrow(
+    'Theme mode changes are not allowed when only one theme is available',
+  );
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+  expect(consoleSpy).not.toHaveBeenCalled();
+});
+
+test('ThemeController does not change mode if already set', () => {
+  const controller = createController();
+
+  jest.clearAllMocks();
+
+  controller.setThemeMode(ThemeMode.SYSTEM);
+
+  expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+});
+
+test('ThemeController resets to default theme', () => {
+  const controller = createController();
+
+  controller.setThemeMode(ThemeMode.DARK);
+  controller.resetTheme();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorBgBase: '#141118',
+        colorTextBase: '#fdc7c7',
       }),
-    );
+    }),
+  );
+});
 
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-    });
+// System Theme Changes tests
+test('ThemeController listens to system theme changes', () => {
+  const mockMediaQuery = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQuery);
 
-    // Clear the call from initialization
-    jest.clearAllMocks();
+  createController();
 
-    // Should throw when trying to change mode with only one theme
-    expect(() => controller.setThemeMode(ThemeMode.DARK)).toThrow(
-      'Theme mode changes are not allowed when only one theme is available',
-    );
+  expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+  expect(mockMediaQuery.addEventListener).toHaveBeenCalledWith(
+    'change',
+    expect.any(Function),
+  );
+});
 
-    // Config should not have been called since the error was thrown
-    expect(mockSetConfig).not.toHaveBeenCalled();
-  });
+test('ThemeController updates theme when system preference changes and mode is SYSTEM', () => {
+  const mockMediaQuery = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQuery);
 
-  test('should handle only dark theme', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: {},
-        dark: DARK_THEME,
+  const controller = createController();
+  controller.setThemeMode(ThemeMode.SYSTEM);
+
+  mockMediaQuery.matches = true;
+  const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
+
+  changeHandler();
+
+  expect(mockSetConfig).toHaveBeenCalled();
+});
+
+test('ThemeController does not update theme when mode is not SYSTEM', () => {
+  const mockMediaQuery = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQuery);
+
+  const controller = createController();
+  controller.setThemeMode(ThemeMode.DEFAULT);
+
+  const initialCallCount = mockSetConfig.mock.calls.length;
+
+  mockMediaQuery.matches = true;
+  const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
+
+  changeHandler();
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(initialCallCount);
+});
+
+test('ThemeController switches to dark theme when system is dark and mode is SYSTEM', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const mockMediaQueryDark = {
+    matches: true,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQueryDark);
+
+  const controller = createController();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
+
+  expect(mockSetConfig).toHaveBeenCalled();
+  const lastCall =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastCall.token.colorBgBase).toBe(DARK_THEME.token!.colorBgBase);
+  expect(lastCall.token.colorTextBase).toBe(DARK_THEME.token!.colorTextBase);
+});
+
+// Persistence tests
+
+test('ThemeController saves theme mode to localStorage', () => {
+  const controller = createController();
+
+  jest.clearAllMocks();
+
+  controller.setThemeMode(ThemeMode.DARK);
+
+  expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+  expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+    'superset-theme-mode',
+    ThemeMode.DARK,
+  );
+});
+
+test('ThemeController loads saved theme mode from localStorage', () => {
+  mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
+
+  const controller = createController();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
+});
+
+test('ThemeController handles invalid saved theme mode', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
+
+  mockLocalStorage.getItem.mockReturnValue('invalid-mode' as any);
+
+  const controller = createController();
+
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+});
+
+// Theme Structure tests
+
+test('ThemeController handles theme with token structure', () => {
+  const controller = createController();
+
+  const customTheme = {
+    token: {
+      colorBgBase: '#ff0000',
+      colorTextBase: '#ffffff',
+      colorPrimary: '#00ff00',
+    },
+  };
+
+  jest.clearAllMocks();
+
+  controller.setTheme(customTheme);
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorBgBase: '#ff0000',
+        colorTextBase: '#ffffff',
+        colorPrimary: '#00ff00',
       }),
-    );
+    }),
+  );
+});
 
-    // Provide an explicit light theme fallback for this test
-    const lightThemeFallback = {
-      token: {
-        colorBgBase: '#fff',
-        colorTextBase: '#000',
-        colorPrimary: '#1890ff',
-      },
-    };
+test('ThemeController preserves algorithm property from dark theme', () => {
+  const controller = createController();
 
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-      defaultTheme: lightThemeFallback,
-    });
+  jest.clearAllMocks();
 
-    // When only dark theme is available, controller uses the default fallback theme initially
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  controller.setThemeMode(ThemeMode.DARK);
 
-    const calledWith = mockSetConfig.mock.calls[0][0];
-
-    // Should use the default theme fallback (not dark) for initial load
-    expect(calledWith.token.colorBgBase).toBe('#fff');
-    expect(calledWith.token.colorTextBase).toBe('#000');
-
-    // Should allow mode changes since dark theme exists
-    expect(controller.canSetMode()).toBe(true);
-
-    // Should be able to switch to dark mode
-    jest.clearAllMocks();
-    controller.setThemeMode(ThemeMode.DARK);
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
-  });
-
-  test('should handle completely empty BootstrapData', () => {
-    const fallbackTheme = {
-      token: {
-        colorBgBase: '#ffffff',
-        colorPrimary: '#1890ff',
-      },
-    };
-
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: {},
-        dark: {},
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      algorithm: antdThemeImport.darkAlgorithm,
+      token: expect.objectContaining({
+        colorBgBase: '#141118',
+        colorTextBase: '#fdc7c7',
       }),
-    );
+    }),
+  );
+});
 
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-      defaultTheme: fallbackTheme,
-    });
+test('ThemeController handles theme without algorithm property', () => {
+  const controller = createController();
 
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
-    expect(mockSetConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({
-          colorBgBase: '#ffffff',
-          colorPrimary: '#1890ff',
-        }),
-        algorithm: antdThemeImport.defaultAlgorithm,
+  jest.clearAllMocks();
+
+  controller.setThemeMode(ThemeMode.DEFAULT);
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorBgBase: '#ededed',
+        colorTextBase: '#120f0f',
       }),
-    );
-  });
+    }),
+  );
 
-  test('should handle missing theme object', () => {
-    const fallbackTheme = { token: { colorPrimary: '#fallback' } };
+  const lastCall =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
 
-    mockGetBootstrapData.mockReturnValue({
-      common: {
-        application_root: '/',
-        static_assets_prefix: '/static/assets/',
-        conf: {},
-        locale: 'en',
-        feature_flags: {},
-        language_pack: {},
-        extra_categorical_color_schemes: [],
-        extra_sequential_color_schemes: [],
-        menu_data: {},
-        d3_format: {},
-        d3_time_format: {},
-      } as any,
-    });
+  expect(lastCall.algorithm).toBe(antdThemeImport.defaultAlgorithm);
+});
 
-    controller = new ThemeController({
-      themeObject: mockThemeObject,
-      defaultTheme: fallbackTheme,
-    });
+test('ThemeController handles color tokens correctly in theme switching', () => {
+  const controller = createController();
 
-    expect(mockSetConfig).toHaveBeenCalledTimes(1);
-    expect(mockSetConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({
-          colorPrimary: '#fallback',
-        }),
-        algorithm: antdThemeImport.defaultAlgorithm,
-      }),
-    );
-  });
+  controller.setThemeMode(ThemeMode.DEFAULT);
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Theme Management', () => {
-    beforeEach(() => {
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
+  let lastCall =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
 
-    test('should update theme when allowed', () => {
-      const newTheme = {
-        token: {
-          colorBgBase: '#000000',
-          colorPrimary: '#ff0000',
-        },
-      };
+  expect(lastCall.token.colorBgBase).toBe('#ededed');
+  expect(lastCall.token.colorTextBase).toBe('#120f0f');
 
-      controller.setTheme(newTheme);
+  controller.setThemeMode(ThemeMode.DARK);
 
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining(newTheme),
-      );
-    });
+  lastCall = mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
 
-    test('should change theme mode when allowed', () => {
-      // Clear initialization calls
-      jest.clearAllMocks();
+  expect(lastCall.token.colorBgBase).toBe('#141118');
+  expect(lastCall.token.colorTextBase).toBe('#fdc7c7');
+});
 
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
-      expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        'superset-theme-mode',
-        ThemeMode.DARK,
-      );
-    });
-
-    test('should handle missing theme gracefully', () => {
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: DEFAULT_THEME,
-          dark: {},
-        }),
-      );
-
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-
-      // Should throw when trying to set mode with only one theme
-      expect(() => controller.setThemeMode(ThemeMode.DARK)).toThrow(
-        'Theme mode changes are not allowed when only one theme is available',
-      );
-
-      // Mode should remain unchanged
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
-      expect(consoleSpy).not.toHaveBeenCalled();
-    });
-
-    test('should not change mode if already set', () => {
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-
-      jest.clearAllMocks();
-
-      // Try to change to the same mode (DEFAULT)
-      controller.setThemeMode(ThemeMode.SYSTEM);
-
-      // Should not call setItem since mode didn't change
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
-    });
-
-    test('should reset to default theme', () => {
-      controller.setThemeMode(ThemeMode.DARK);
-      controller.resetTheme();
-
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining({
-            colorBgBase: '#141118',
-            colorTextBase: '#fdc7c7',
-          }),
-        }),
-      );
-    });
-  });
-
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('System Theme Changes', () => {
-    let mockMediaQuery: any;
-
-    beforeEach(() => {
-      mockMediaQuery = {
-        matches: false,
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      };
-
-      mockMatchMedia.mockReturnValue(mockMediaQuery);
-
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
-
-    test('should listen to system theme changes', () => {
-      expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
-      expect(mockMediaQuery.addEventListener).toHaveBeenCalledWith(
-        'change',
-        expect.any(Function),
-      );
-    });
-
-    test('should update theme when system preference changes and mode is SYSTEM', () => {
-      controller.setThemeMode(ThemeMode.SYSTEM);
-
-      // Simulate system theme change
-      mockMediaQuery.matches = true;
-      const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
-
-      changeHandler();
-
-      expect(mockSetConfig).toHaveBeenCalled();
-    });
-
-    test('should not update theme when mode is not SYSTEM', () => {
-      controller.setThemeMode(ThemeMode.DEFAULT);
-
-      const initialCallCount = mockSetConfig.mock.calls.length;
-
-      // Simulate system theme change
-      mockMediaQuery.matches = true;
-      const changeHandler = mockMediaQuery.addEventListener.mock.calls[0][1];
-
-      changeHandler();
-
-      expect(mockSetConfig).toHaveBeenCalledTimes(initialCallCount);
-    });
-
-    test('should switch to dark theme when system is dark and mode is SYSTEM', () => {
-      // Setup with both light and dark themes available
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: DEFAULT_THEME,
-          dark: DARK_THEME,
-        }),
-      );
-
-      // Setup mock media query to return dark mode preference
-      const mockMediaQueryDark = {
-        matches: true, // System is in dark mode
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      };
-      mockMatchMedia.mockReturnValue(mockMediaQueryDark);
-
-      // Create fresh controller instance with dark system preference
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-
-      // Verify system mode is set by default
-      expect(controller.getCurrentMode()).toBe(ThemeMode.SYSTEM);
-
-      // Verify that dark theme was applied during initialization
-      expect(mockSetConfig).toHaveBeenCalled();
-      const lastCall =
-        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
-      expect(lastCall.token.colorBgBase).toBe(DARK_THEME.token!.colorBgBase);
-      expect(lastCall.token.colorTextBase).toBe(
-        DARK_THEME.token!.colorTextBase,
-      );
-    });
-  });
-
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Persistence', () => {
-    beforeEach(() => {
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
-
-    test('should save theme mode to localStorage', () => {
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
-
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        'superset-theme-mode',
-        ThemeMode.DARK,
-      );
-    });
-
-    test('should load saved theme mode from localStorage', () => {
-      mockLocalStorage.getItem.mockReturnValue(ThemeMode.DARK);
-
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DARK);
-    });
-
-    test('should handle invalid saved theme mode', () => {
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: {},
-          dark: {},
-        }),
-      );
-
-      mockLocalStorage.getItem.mockReturnValue('invalid-mode' as any);
-
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
-    });
-  });
-
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Theme Structure', () => {
-    beforeEach(() => {
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
-
-    test('should handle theme with token structure', () => {
-      const customTheme = {
-        token: {
-          colorBgBase: '#ff0000',
-          colorTextBase: '#ffffff',
-          colorPrimary: '#00ff00',
-        },
-      };
-
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
-
-      controller.setTheme(customTheme);
-
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining({
-            colorBgBase: '#ff0000',
-            colorTextBase: '#ffffff',
-            colorPrimary: '#00ff00',
-          }),
-        }),
-      );
-    });
-
-    test('should preserve algorithm property from dark theme', () => {
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
-
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          algorithm: antdThemeImport.darkAlgorithm,
-          token: expect.objectContaining({
-            colorBgBase: '#141118',
-            colorTextBase: '#fdc7c7',
-          }),
-        }),
-      );
-    });
-
-    test('should handle theme without algorithm property', () => {
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
-
-      controller.setThemeMode(ThemeMode.DEFAULT);
-
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining({
-            colorBgBase: '#ededed',
-            colorTextBase: '#120f0f',
-          }),
-        }),
-      );
-
-      // Should not have algorithm property or should be overridden
-      const lastCall =
-        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
-
-      expect(lastCall.algorithm).toBe(antdThemeImport.defaultAlgorithm);
-    });
-
-    test('should handle color tokens correctly in theme switching', () => {
-      // Start with default theme
-      controller.setThemeMode(ThemeMode.DEFAULT);
-
-      let lastCall =
-        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
-
-      expect(lastCall.token.colorBgBase).toBe('#ededed');
-      expect(lastCall.token.colorTextBase).toBe('#120f0f');
-
-      // Switch to dark theme
-      controller.setThemeMode(ThemeMode.DARK);
-
-      lastCall =
-        mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
-
-      expect(lastCall.token.colorBgBase).toBe('#141118');
-      expect(lastCall.token.colorTextBase).toBe('#fdc7c7');
-    });
-  });
-
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Algorithm Combinations', () => {
-    beforeEach(() => {
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: {
-            ...DEFAULT_THEME,
-            algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
-          },
-          dark: DARK_THEME,
-        }),
-      );
-
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
-
-    test('should handle valid algorithm combinations', () => {
-      const themeWithAlgorithm = {
+// Algorithm Combinations tests
+test('ThemeController handles valid algorithm combinations', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {
         ...DEFAULT_THEME,
-        algorithm: [
-          ThemeAlgorithm.DARK,
-          ThemeAlgorithm.COMPACT,
-        ] as ThemeAlgorithm[],
-      };
+        algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
+      },
+      dark: DARK_THEME,
+    }),
+  );
 
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
+  const controller = createController();
 
-      controller.setTheme(themeWithAlgorithm);
+  const themeWithAlgorithm = {
+    ...DEFAULT_THEME,
+    algorithm: [
+      ThemeAlgorithm.DARK,
+      ThemeAlgorithm.COMPACT,
+    ] as ThemeAlgorithm[],
+  };
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining({
-            colorBgBase: '#ededed',
-            colorPrimary: '#c96f0f',
-          }),
-          algorithm: [
-            antdThemeImport.darkAlgorithm,
-            antdThemeImport.compactAlgorithm,
-          ],
-        }),
-      );
-    });
+  jest.clearAllMocks();
 
-    test('should handle invalid algorithm combinations', () => {
-      const themeWithInvalidAlgorithm = {
+  controller.setTheme(themeWithAlgorithm);
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorBgBase: '#ededed',
+        colorPrimary: '#c96f0f',
+      }),
+      algorithm: [
+        antdThemeImport.darkAlgorithm,
+        antdThemeImport.compactAlgorithm,
+      ],
+    }),
+  );
+});
+
+test('ThemeController handles invalid algorithm combinations', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {
         ...DEFAULT_THEME,
-        algorithm: ['invalid', 'combination'] as any as ThemeAlgorithm[],
-      };
+        algorithm: [ThemeAlgorithm.DARK, ThemeAlgorithm.COMPACT],
+      },
+      dark: DARK_THEME,
+    }),
+  );
 
-      // Clear the call from controller initialization
-      jest.clearAllMocks();
+  const controller = createController();
 
-      controller.setTheme(themeWithInvalidAlgorithm);
+  const themeWithInvalidAlgorithm = {
+    ...DEFAULT_THEME,
+    algorithm: ['invalid', 'combination'] as any as ThemeAlgorithm[],
+  };
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          algorithm: antdThemeImport.defaultAlgorithm,
-        }),
-      );
-    });
+  jest.clearAllMocks();
+
+  controller.setTheme(themeWithInvalidAlgorithm);
+
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
+});
+
+// Change Callbacks tests
+test('ThemeController calls callback on theme change', () => {
+  const callback = jest.fn();
+  const controller = createController({ onChange: callback });
+
+  controller.setThemeMode(ThemeMode.DARK);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(mockThemeObject);
+});
+
+test('ThemeController registers additional callbacks', () => {
+  const callback = jest.fn();
+  const controller = createController({ onChange: callback });
+
+  const additionalCallback = jest.fn();
+  controller.onChange(additionalCallback);
+
+  controller.setThemeMode(ThemeMode.DARK);
+
+  expect(callback).toHaveBeenCalled();
+  expect(additionalCallback).toHaveBeenCalled();
+});
+
+test('ThemeController unsubscribes callbacks', () => {
+  const callback = jest.fn();
+  const controller = createController({ onChange: callback });
+
+  const additionalCallback = jest.fn();
+  const unsubscribe = controller.onChange(additionalCallback);
+
+  unsubscribe();
+  controller.setThemeMode(ThemeMode.DARK);
+
+  expect(additionalCallback).not.toHaveBeenCalled();
+});
+
+test('ThemeController handles callback errors', () => {
+  const callback = jest.fn();
+  const controller = createController({ onChange: callback });
+
+  const errorCallback = jest.fn().mockImplementation(() => {
+    throw new Error('Callback error');
   });
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Change Callbacks', () => {
-    let callback: jest.Mock;
-    let unsubscribe: () => void;
+  controller.onChange(errorCallback);
+  controller.setThemeMode(ThemeMode.DARK);
 
-    beforeEach(() => {
-      callback = jest.fn();
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-        onChange: callback,
-      });
-    });
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    'Error in theme change callback:',
+    expect.any(Error),
+  );
+});
 
-    test('should call callback on theme change', () => {
-      controller.setThemeMode(ThemeMode.DARK);
+// Error Handling tests
 
-      expect(callback).toHaveBeenCalledTimes(1);
-      expect(callback).toHaveBeenCalledWith(mockThemeObject);
-    });
+test('ThemeController handles theme application errors', () => {
+  const controller = createController();
 
-    test('should register additional callbacks', () => {
-      const additionalCallback = jest.fn();
-      unsubscribe = controller.onChange(additionalCallback);
-
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(callback).toHaveBeenCalled();
-      expect(additionalCallback).toHaveBeenCalled();
-    });
-
-    test('should unsubscribe callbacks', () => {
-      const additionalCallback = jest.fn();
-      unsubscribe = controller.onChange(additionalCallback);
-
-      unsubscribe();
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(additionalCallback).not.toHaveBeenCalled();
-    });
-
-    test('should handle callback errors', () => {
-      const errorCallback = jest.fn().mockImplementation(() => {
-        throw new Error('Callback error');
-      });
-
-      controller.onChange(errorCallback);
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error in theme change callback:',
-        expect.any(Error),
-      );
-    });
+  mockSetConfig.mockImplementationOnce(() => {
+    throw new Error('Theme application error');
   });
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Error Handling', () => {
-    beforeEach(() => {
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
-
-    test('should handle theme application errors', () => {
-      // Mock setConfig to throw an error
-      mockSetConfig.mockImplementationOnce(() => {
-        throw new Error('Theme application error');
-      });
-
-      // Mock fallbackToDefaultMode to avoid infinite recursion
-      const fallbackSpy = jest.spyOn(
-        controller as any,
-        'fallbackToDefaultMode',
-      );
-      fallbackSpy.mockImplementation(() => {
-        // Just set basic properties without calling updateTheme
-        (controller as any).customizations = DEFAULT_THEME;
-        (controller as any).currentMode = ThemeMode.DEFAULT;
-      });
-
-      controller.setThemeMode(ThemeMode.DARK);
-
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to apply theme:',
-        expect.any(Error),
-      );
-      expect(fallbackSpy).toHaveBeenCalled();
-
-      fallbackSpy.mockRestore();
-    });
+  const fallbackSpy = jest.spyOn(controller as any, 'fallbackToDefaultMode');
+  fallbackSpy.mockImplementation(() => {
+    (controller as any).customizations = DEFAULT_THEME;
+    (controller as any).currentMode = ThemeMode.DEFAULT;
   });
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('Cleanup', () => {
-    let mockMediaQueryInstance: any;
+  controller.setThemeMode(ThemeMode.DARK);
 
-    beforeEach(() => {
-      mockMediaQueryInstance = {
-        matches: false,
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      };
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    'Failed to apply theme:',
+    expect.any(Error),
+  );
+  expect(fallbackSpy).toHaveBeenCalled();
 
-      mockMatchMedia.mockReturnValue(mockMediaQueryInstance);
+  fallbackSpy.mockRestore();
+});
 
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
-    });
+// Cleanup tests
+test('ThemeController cleans up listeners on destroy', () => {
+  const mockMediaQueryInstance = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQueryInstance);
 
-    test('should clean up listeners on destroy', () => {
-      controller.destroy();
+  const controller = createController();
 
-      expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledWith(
-        'change',
-        expect.any(Function),
-      );
-    });
-  });
+  controller.destroy();
 
-  // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
-  describe('setThemeConfig', () => {
-    beforeEach(() => {
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: {},
-          dark: {},
-        }),
-      );
+  expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledTimes(1);
+  expect(mockMediaQueryInstance.removeEventListener).toHaveBeenCalledWith(
+    'change',
+    expect.any(Function),
+  );
+});
 
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-        defaultTheme: { token: {} },
-      });
+// setThemeConfig tests
+test('setThemeConfig sets complete theme configuration', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-      jest.clearAllMocks();
-    });
+  const controller = createController({ defaultTheme: { token: {} } });
 
-    test('should set complete theme configuration', () => {
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-        theme_dark: DARK_THEME,
-      };
+  jest.clearAllMocks();
 
-      controller.setThemeConfig(themeConfig);
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  };
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining(DEFAULT_THEME.token),
-          algorithm: antdThemeImport.defaultAlgorithm,
-        }),
-      );
+  controller.setThemeConfig(themeConfig);
 
-      expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
-      expect(controller.canSetTheme()).toBe(true);
-      expect(controller.canSetMode()).toBe(true);
-    });
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining(DEFAULT_THEME.token),
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
 
-    test('should handle theme_default only', () => {
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-      };
+  expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+  expect(controller.canSetTheme()).toBe(true);
+  expect(controller.canSetMode()).toBe(true);
+});
 
-      controller.setThemeConfig(themeConfig);
+test('setThemeConfig handles theme_default only', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining(DEFAULT_THEME.token),
-          algorithm: antdThemeImport.defaultAlgorithm,
-        }),
-      );
+  const controller = createController({ defaultTheme: { token: {} } });
 
-      expect(controller.canSetTheme()).toBe(true);
-      expect(controller.canSetMode()).toBe(false);
-    });
+  jest.clearAllMocks();
 
-    test('should handle theme_default and theme_dark without settings', () => {
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-        theme_dark: DARK_THEME,
-      };
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+  };
 
-      controller.setThemeConfig(themeConfig);
+  controller.setThemeConfig(themeConfig);
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining(DEFAULT_THEME.token),
-        }),
-      );
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining(DEFAULT_THEME.token),
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
 
-      jest.clearAllMocks();
-      controller.setThemeMode(ThemeMode.DARK);
+  expect(controller.canSetTheme()).toBe(true);
+  expect(controller.canSetMode()).toBe(false);
+});
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining(DARK_THEME.token),
-          algorithm: antdThemeImport.darkAlgorithm,
-        }),
-      );
-    });
+test('setThemeConfig handles theme_default and theme_dark without settings', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-    test('should apply appropriate theme after configuration', () => {
-      jest.clearAllMocks();
+  const controller = createController({ defaultTheme: { token: {} } });
 
-      const themeConfig = {
-        theme_default: {
-          token: {
-            colorPrimary: '#00ff00',
-          },
-        },
-        theme_dark: {
-          token: {
-            colorPrimary: '#ff0000',
-            colorBgBase: '#000000',
-          },
-          algorithm: 'dark',
-        },
-      };
+  jest.clearAllMocks();
 
-      controller.setThemeConfig(themeConfig as SupersetThemeConfig);
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  };
 
-      expect(mockSetConfig).toHaveBeenCalledTimes(1);
-      expect(mockSetConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          token: expect.objectContaining({
-            colorPrimary: '#00ff00',
-          }),
-          algorithm: antdThemeImport.defaultAlgorithm,
-        }),
-      );
-    });
+  controller.setThemeConfig(themeConfig);
 
-    test('should handle missing theme_dark gracefully', () => {
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-      };
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining(DEFAULT_THEME.token),
+    }),
+  );
 
-      controller.setThemeConfig(themeConfig);
+  jest.clearAllMocks();
+  controller.setThemeMode(ThemeMode.DARK);
 
-      // Can't set dark mode when there's no dark theme
-      expect(controller.canSetMode()).toBe(false);
-    });
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining(DARK_THEME.token),
+      algorithm: antdThemeImport.darkAlgorithm,
+    }),
+  );
+});
 
-    test('should preserve existing theme mode when possible', () => {
-      // First create controller with dark theme available
-      mockGetBootstrapData.mockReturnValue(
-        createMockBootstrapData({
-          default: DEFAULT_THEME,
-          dark: DARK_THEME,
-        }),
-      );
+test('setThemeConfig applies appropriate theme after configuration', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-      controller = new ThemeController({
-        themeObject: mockThemeObject,
-      });
+  const controller = createController({ defaultTheme: { token: {} } });
 
-      controller.setThemeMode(ThemeMode.DARK);
-      const initialMode = controller.getCurrentMode();
+  jest.clearAllMocks();
 
-      jest.clearAllMocks();
+  const themeConfig = {
+    theme_default: {
+      token: {
+        colorPrimary: '#00ff00',
+      },
+    },
+    theme_dark: {
+      token: {
+        colorPrimary: '#ff0000',
+        colorBgBase: '#000000',
+      },
+      algorithm: 'dark',
+    },
+  };
 
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-        theme_dark: DARK_THEME,
-      };
+  controller.setThemeConfig(themeConfig as SupersetThemeConfig);
 
-      controller.setThemeConfig(themeConfig);
-
-      expect(controller.getCurrentMode()).toBe(initialMode);
-    });
-
-    test('should trigger onChange callbacks', () => {
-      const changeCallback = jest.fn();
-      controller.onChange(changeCallback);
-
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-        theme_dark: DARK_THEME,
-      };
-
-      controller.setThemeConfig(themeConfig);
-
-      expect(changeCallback).toHaveBeenCalledTimes(1);
-      expect(changeCallback).toHaveBeenCalledWith(mockThemeObject);
-    });
-
-    test('should handle error in theme application', () => {
-      mockSetConfig.mockImplementationOnce(() => {
-        throw new Error('Theme application error');
-      });
-
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-      };
-
-      expect(() => {
-        controller.setThemeConfig(themeConfig);
-      }).not.toThrow();
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to apply theme:',
-        expect.any(Error),
-      );
-    });
-
-    test('should update stored theme mode', () => {
-      const themeConfig = {
-        theme_default: DEFAULT_THEME,
-        theme_dark: DARK_THEME,
-      };
-
-      controller.setThemeConfig(themeConfig);
-
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        'superset-theme-mode',
-        expect.any(String),
-      );
-    });
-  });
-
-  test('setThemeMode clears dev override and crud theme from storage', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
+  expect(mockSetConfig).toHaveBeenCalledTimes(1);
+  expect(mockSetConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      token: expect.objectContaining({
+        colorPrimary: '#00ff00',
       }),
-    );
+      algorithm: antdThemeImport.defaultAlgorithm,
+    }),
+  );
+});
 
-    mockLocalStorage.getItem.mockReturnValue(null);
+test('setThemeConfig handles missing theme_dark gracefully', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  const controller = createController({ defaultTheme: { token: {} } });
 
-    // Simulate having overrides after initialization using Reflect to access private properties
-    Reflect.set(controller, 'devThemeOverride', {
-      token: { colorPrimary: '#ff0000' },
-    });
-    Reflect.set(controller, 'crudThemeId', '123');
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+  };
 
-    jest.clearAllMocks();
+  controller.setThemeConfig(themeConfig);
 
-    // Change theme mode - should clear the overrides
-    controller.setThemeMode(ThemeMode.DARK);
+  expect(controller.canSetMode()).toBe(false);
+});
 
-    // Verify both storage keys were removed
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-dev-theme-override',
-    );
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-crud-theme-id',
-    );
+test('setThemeConfig preserves existing theme mode when possible', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = createController();
+
+  controller.setThemeMode(ThemeMode.DARK);
+  const initialMode = controller.getCurrentMode();
+
+  jest.clearAllMocks();
+
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  };
+
+  controller.setThemeConfig(themeConfig);
+
+  expect(controller.getCurrentMode()).toBe(initialMode);
+});
+
+test('setThemeConfig triggers onChange callbacks', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
+
+  const controller = createController({ defaultTheme: { token: {} } });
+
+  const changeCallback = jest.fn();
+  controller.onChange(changeCallback);
+
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  };
+
+  controller.setThemeConfig(themeConfig);
+
+  expect(changeCallback).toHaveBeenCalledTimes(1);
+  expect(changeCallback).toHaveBeenCalledWith(mockThemeObject);
+});
+
+test('setThemeConfig handles error in theme application', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
+
+  const controller = createController({ defaultTheme: { token: {} } });
+
+  mockSetConfig.mockImplementationOnce(() => {
+    throw new Error('Theme application error');
   });
 
-  test('setThemeMode can be called with same mode when overrides exist', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
-      }),
-    );
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+  };
 
-    mockLocalStorage.getItem.mockReturnValue(null);
+  expect(() => {
+    controller.setThemeConfig(themeConfig);
+  }).not.toThrow();
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    'Failed to apply theme:',
+    expect.any(Error),
+  );
+});
 
-    jest.clearAllMocks();
+test('setThemeConfig updates stored theme mode', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: {},
+      dark: {},
+    }),
+  );
 
-    // Simulate having dev override after initialization using Reflect
-    Reflect.set(controller, 'devThemeOverride', {
-      token: { colorPrimary: '#ff0000' },
-    });
+  const controller = createController({ defaultTheme: { token: {} } });
 
-    // Call setThemeMode with DEFAULT mode - should clear override
-    controller.setThemeMode(ThemeMode.DEFAULT);
+  const themeConfig = {
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  };
 
-    // Verify override was removed even though mode is the same
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-dev-theme-override',
-    );
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-crud-theme-id',
-    );
+  controller.setThemeConfig(themeConfig);
 
-    // Theme should still be updated to clear the override
-    expect(mockSetConfig).toHaveBeenCalled();
+  expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+    'superset-theme-mode',
+    expect.any(String),
+  );
+});
+
+// Override and applied theme ID tests
+test('setThemeMode clears dev override and crud theme from storage', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  mockLocalStorage.getItem.mockReturnValue(null);
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('setThemeMode with no override and same mode does not trigger update', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
-      }),
-    );
+  Reflect.set(controller, 'devThemeOverride', {
+    token: { colorPrimary: '#ff0000' },
+  });
+  Reflect.set(controller, 'crudThemeId', '123');
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  jest.clearAllMocks();
 
-    // Set mode to DEFAULT
-    controller.setThemeMode(ThemeMode.DEFAULT);
+  controller.setThemeMode(ThemeMode.DARK);
 
-    jest.clearAllMocks();
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-dev-theme-override',
+  );
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-crud-theme-id',
+  );
+});
 
-    // Call again with same mode and no override - should skip
-    controller.setThemeMode(ThemeMode.DEFAULT);
+test('setThemeMode can be called with same mode when overrides exist', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
 
-    // Should not trigger any updates
-    expect(mockSetConfig).not.toHaveBeenCalled();
-    expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
+  mockLocalStorage.getItem.mockReturnValue(null);
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('hasDevOverride returns true when dev override is set', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
-      }),
-    );
+  jest.clearAllMocks();
 
-    mockLocalStorage.getItem.mockReturnValue(null);
-
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
-
-    // Simulate dev override after initialization using Reflect
-    Reflect.set(controller, 'devThemeOverride', {
-      token: { colorPrimary: '#ff0000' },
-    });
-
-    expect(controller.hasDevOverride()).toBe(true);
+  Reflect.set(controller, 'devThemeOverride', {
+    token: { colorPrimary: '#ff0000' },
   });
 
-  test('hasDevOverride returns false when no dev override in storage', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
-      }),
-    );
+  controller.setThemeMode(ThemeMode.DEFAULT);
 
-    mockLocalStorage.getItem.mockReturnValue(null);
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-dev-theme-override',
+  );
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-crud-theme-id',
+  );
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  expect(mockSetConfig).toHaveBeenCalled();
+});
 
-    expect(controller.hasDevOverride()).toBe(false);
+test('setThemeMode with no override and same mode does not trigger update', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('clearLocalOverrides removes dev override, crud theme, and applied theme ID', () => {
-    mockGetBootstrapData.mockReturnValue(
-      createMockBootstrapData({
-        default: DEFAULT_THEME,
-        dark: DARK_THEME,
-      }),
-    );
+  controller.setThemeMode(ThemeMode.DEFAULT);
 
-    mockLocalStorage.getItem.mockReturnValue(null);
+  jest.clearAllMocks();
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  controller.setThemeMode(ThemeMode.DEFAULT);
 
-    jest.clearAllMocks();
+  expect(mockSetConfig).not.toHaveBeenCalled();
+  expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
+});
 
-    // Clear overrides
-    controller.clearLocalOverrides();
+test('hasDevOverride returns true when dev override is set', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
 
-    // Verify all storage keys are removed
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-dev-theme-override',
-    );
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-crud-theme-id',
-    );
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-applied-theme-id',
-    );
+  mockLocalStorage.getItem.mockReturnValue(null);
 
-    // Should reset to default theme
-    expect(mockSetConfig).toHaveBeenCalled();
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('getAppliedThemeId returns stored theme ID', () => {
-    mockLocalStorage.getItem.mockImplementation((key: string) => {
-      if (key === 'superset-applied-theme-id') {
-        return '42';
-      }
-      return null;
-    });
-
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
-
-    expect(controller.getAppliedThemeId()).toBe(42);
+  Reflect.set(controller, 'devThemeOverride', {
+    token: { colorPrimary: '#ff0000' },
   });
 
-  test('getAppliedThemeId returns null when no theme ID is stored', () => {
-    mockLocalStorage.getItem.mockReturnValue(null);
+  expect(controller.hasDevOverride()).toBe(true);
+});
 
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+test('hasDevOverride returns false when no dev override in storage', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
 
-    expect(controller.getAppliedThemeId()).toBeNull();
+  mockLocalStorage.getItem.mockReturnValue(null);
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('setAppliedThemeId stores theme ID in storage', () => {
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  expect(controller.hasDevOverride()).toBe(false);
+});
 
-    jest.clearAllMocks();
+test('clearLocalOverrides removes dev override, crud theme, and applied theme ID', () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({
+      default: DEFAULT_THEME,
+      dark: DARK_THEME,
+    }),
+  );
 
-    controller.setAppliedThemeId(123);
+  mockLocalStorage.getItem.mockReturnValue(null);
 
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-      'superset-applied-theme-id',
-      '123',
-    );
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
   });
 
-  test('setAppliedThemeId removes theme ID when null is passed', () => {
-    const controller = new ThemeController({
-      storage: mockLocalStorage,
-      themeObject: mockThemeObject,
-    });
+  jest.clearAllMocks();
 
-    jest.clearAllMocks();
+  controller.clearLocalOverrides();
 
-    controller.setAppliedThemeId(null);
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-dev-theme-override',
+  );
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-crud-theme-id',
+  );
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-applied-theme-id',
+  );
 
-    expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
-      'superset-applied-theme-id',
-    );
+  expect(mockSetConfig).toHaveBeenCalled();
+});
+
+test('getAppliedThemeId returns stored theme ID', () => {
+  mockLocalStorage.getItem.mockImplementation((key: string) => {
+    if (key === 'superset-applied-theme-id') {
+      return '42';
+    }
+    return null;
   });
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
+  });
+
+  expect(controller.getAppliedThemeId()).toBe(42);
+});
+
+test('getAppliedThemeId returns null when no theme ID is stored', () => {
+  mockLocalStorage.getItem.mockReturnValue(null);
+
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
+  });
+
+  expect(controller.getAppliedThemeId()).toBeNull();
+});
+
+test('setAppliedThemeId stores theme ID in storage', () => {
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
+  });
+
+  jest.clearAllMocks();
+
+  controller.setAppliedThemeId(123);
+
+  expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+    'superset-applied-theme-id',
+    '123',
+  );
+});
+
+test('setAppliedThemeId removes theme ID when null is passed', () => {
+  const controller = new ThemeController({
+    storage: mockLocalStorage,
+    themeObject: mockThemeObject,
+  });
+
+  jest.clearAllMocks();
+
+  controller.setAppliedThemeId(null);
+
+  expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(
+    'superset-applied-theme-id',
+  );
+});
+
+// Font loading tests
+test('font loading: injects font URLs as CSS @import when theme has fontUrls', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const themeWithFonts = {
+    token: {
+      colorPrimary: '#ff0000',
+      fontUrls: ['https://fonts.googleapis.com/css2?family=Roboto'],
+    },
+  };
+  fontController.setTheme(themeWithFonts);
+
+  const style = document.querySelector('style[data-superset-fonts]');
+  expect(style).toBeTruthy();
+  expect(style?.textContent).toContain(
+    '@import url("https://fonts.googleapis.com/css2?family=Roboto")',
+  );
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+});
+
+test('font loading: injects multiple font URLs', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const themeWithFonts = {
+    token: {
+      colorPrimary: '#ff0000',
+      fontUrls: [
+        'https://fonts.googleapis.com/css2?family=Roboto',
+        'https://fonts.googleapis.com/css2?family=Open+Sans',
+      ],
+    },
+  };
+  fontController.setTheme(themeWithFonts);
+
+  const style = document.querySelector('style[data-superset-fonts]');
+  expect(style).toBeTruthy();
+  expect(style?.textContent).toContain(
+    '@import url("https://fonts.googleapis.com/css2?family=Roboto")',
+  );
+  expect(style?.textContent).toContain(
+    '@import url("https://fonts.googleapis.com/css2?family=Open+Sans")',
+  );
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+});
+
+test('font loading: does not duplicate font URLs when same theme applied twice', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const themeWithFonts = {
+    token: {
+      colorPrimary: '#ff0000',
+      fontUrls: ['https://fonts.googleapis.com/css2?family=Roboto'],
+    },
+  };
+  fontController.setTheme(themeWithFonts);
+  fontController.setTheme(themeWithFonts);
+
+  const styles = document.querySelectorAll('style[data-superset-fonts]');
+  expect(styles.length).toBe(1);
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+});
+
+test('font loading: does not inject styles when fontUrls is empty array', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const themeWithEmptyFonts = {
+    token: {
+      colorPrimary: '#ff0000',
+      fontUrls: [],
+    },
+  };
+  fontController.setTheme(themeWithEmptyFonts);
+
+  const style = document.querySelector('style[data-superset-fonts]');
+  expect(style).toBeNull();
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+});
+
+test('font loading: does not inject styles when fontUrls is undefined', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const themeWithoutFonts = {
+    token: {
+      colorPrimary: '#ff0000',
+    },
+  };
+  fontController.setTheme(themeWithoutFonts);
+
+  const style = document.querySelector('style[data-superset-fonts]');
+  expect(style).toBeNull();
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+});
+
+test('font loading: adds new font URLs when switching themes', () => {
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
+  const fontController = new ThemeController({ themeObject: mockThemeObject });
+
+  const theme1 = {
+    token: {
+      colorPrimary: '#ff0000',
+      fontUrls: ['https://fonts.googleapis.com/css2?family=Roboto'],
+    },
+  };
+  const theme2 = {
+    token: {
+      colorPrimary: '#00ff00',
+      fontUrls: ['https://fonts.googleapis.com/css2?family=Open+Sans'],
+    },
+  };
+
+  fontController.setTheme(theme1);
+  fontController.setTheme(theme2);
+
+  const styles = document.querySelectorAll('style[data-superset-fonts]');
+  expect(styles.length).toBe(2);
+
+  const allContent = Array.from(styles)
+    .map(s => s.textContent)
+    .join('');
+  expect(allContent).toContain('Roboto');
+  expect(allContent).toContain('Open+Sans');
+
+  document
+    .querySelectorAll('style[data-superset-fonts]')
+    .forEach(el => el.remove());
 });

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -460,8 +460,8 @@ test('ThemeController resets to default theme', () => {
   expect(mockSetConfig).toHaveBeenCalledWith(
     expect.objectContaining({
       token: expect.objectContaining({
-        colorBgBase: '#141118',
-        colorTextBase: '#fdc7c7',
+        colorBgBase: '#ededed',
+        colorTextBase: '#120f0f',
       }),
     }),
   );

--- a/superset/config.py
+++ b/superset/config.py
@@ -766,6 +766,10 @@ THEME_DEFAULT: Theme = {
         "colorSuccess": "#5ac189",
         "colorInfo": "#66bcfe",
         # Fonts
+        "fontUrls": [
+            "https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;600&display=swap",
+            "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap",
+        ],
         "fontFamily": "Inter, Helvetica, Arial",
         "fontFamilyCode": "'Fira Code', 'Courier New', monospace",
         # Extra tokens
@@ -797,28 +801,16 @@ THEME_DARK: Optional[Theme] = {
 # Enable UI-based theme administration for admins
 ENABLE_UI_THEME_ADMINISTRATION = True  # Allows admins to set system themes via UI
 
-# Custom font configuration
-# Load external fonts at runtime without rebuilding the application
-# Example:
-# CUSTOM_FONT_URLS = [
-#     "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-#     "https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500&display=swap",
-# ]
-CUSTOM_FONT_URLS: list[str] = []
-
-# Per-Theme Font URL Configuration
-# These settings control font loading via the theme's fontUrls token
-# Maximum number of font URLs allowed per theme
-# Limits prevent performance degradation from excessive font requests
+# Maximum number of font URLs allowed per theme.
 THEME_FONTS_MAX_URLS: int = 15
 
-# Domains allowed for loading fonts via theme fontUrls token
-# Only HTTPS URLs from these domains will be accepted
+# Domains allowed for loading fonts via theme fontUrls token.
+# Only HTTPS URLs from these domains will be accepted.
 THEME_FONT_URL_ALLOWED_DOMAINS: list[str] = [
-    "fonts.googleapis.com",  # Google Fonts API
-    "fonts.gstatic.com",  # Google Fonts CDN
-    "use.typekit.net",  # Adobe Fonts
-    "use.typekit.com",  # Adobe Fonts alternate
+    "fonts.googleapis.com",  # Google Fonts API (serves CSS)
+    "fonts.gstatic.com",  # Google Fonts CDN (serves font files)
+    "use.typekit.net",  # Adobe Fonts (serves both CSS and fonts)
+    "use.typekit.com",  # Adobe Fonts alternate (serves both CSS and fonts)
 ]
 
 # ---------------------------------------------------
@@ -1331,8 +1323,8 @@ SQLLAB_CTAS_NO_LIMIT = False
 #         else:
 #             return f'tmp_{schema}'
 # Function accepts database object, user object, schema name and sql that will be run.
-SQLLAB_CTAS_SCHEMA_NAME_FUNC: None | (
-    Callable[[Database, models.User, str, str], str]
+SQLLAB_CTAS_SCHEMA_NAME_FUNC: (
+    None | (Callable[[Database, models.User, str, str], str])
 ) = None
 
 # If enabled, it can be used to store the results of long-running queries
@@ -1935,6 +1927,11 @@ TALISMAN_CONFIG = {
         "style-src": [
             "'self'",
             "'unsafe-inline'",
+            *[f"https://{d}" for d in THEME_FONT_URL_ALLOWED_DOMAINS],
+        ],
+        "font-src": [
+            "'self'",
+            *[f"https://{d}" for d in THEME_FONT_URL_ALLOWED_DOMAINS],
         ],
         "script-src": ["'self'", "'strict-dynamic'"],
     },
@@ -1970,6 +1967,11 @@ TALISMAN_DEV_CONFIG = {
         "style-src": [
             "'self'",
             "'unsafe-inline'",
+            *[f"https://{d}" for d in THEME_FONT_URL_ALLOWED_DOMAINS],
+        ],
+        "font-src": [
+            "'self'",
+            *[f"https://{d}" for d in THEME_FONT_URL_ALLOWED_DOMAINS],
         ],
         "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
     },

--- a/superset/config.py
+++ b/superset/config.py
@@ -806,6 +806,21 @@ ENABLE_UI_THEME_ADMINISTRATION = True  # Allows admins to set system themes via 
 # ]
 CUSTOM_FONT_URLS: list[str] = []
 
+# Per-Theme Font URL Configuration
+# These settings control font loading via the theme's fontUrls token
+# Maximum number of font URLs allowed per theme
+# Limits prevent performance degradation from excessive font requests
+THEME_FONTS_MAX_URLS: int = 15
+
+# Domains allowed for loading fonts via theme fontUrls token
+# Only HTTPS URLs from these domains will be accepted
+THEME_FONT_URL_ALLOWED_DOMAINS: list[str] = [
+    "fonts.googleapis.com",  # Google Fonts API
+    "fonts.gstatic.com",  # Google Fonts CDN
+    "use.typekit.net",  # Adobe Fonts
+    "use.typekit.com",  # Adobe Fonts alternate
+]
+
 # ---------------------------------------------------
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES is used for adding custom sequential color schemes
 # EXTRA_SEQUENTIAL_COLOR_SCHEMES =  [
@@ -1316,8 +1331,8 @@ SQLLAB_CTAS_NO_LIMIT = False
 #         else:
 #             return f'tmp_{schema}'
 # Function accepts database object, user object, schema name and sql that will be run.
-SQLLAB_CTAS_SCHEMA_NAME_FUNC: (
-    None | (Callable[[Database, models.User, str, str], str])
+SQLLAB_CTAS_SCHEMA_NAME_FUNC: None | (
+    Callable[[Database, models.User, str, str], str]
 ) = None
 
 # If enabled, it can be used to store the results of long-running queries

--- a/superset/config.py
+++ b/superset/config.py
@@ -766,10 +766,7 @@ THEME_DEFAULT: Theme = {
         "colorSuccess": "#5ac189",
         "colorInfo": "#66bcfe",
         # Fonts
-        "fontUrls": [
-            "https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;600&display=swap",
-            "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap",
-        ],
+        "fontUrls": [],
         "fontFamily": "Inter, Helvetica, Arial",
         "fontFamilyCode": "'Fira Code', 'Courier New', monospace",
         # Extra tokens

--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -61,13 +61,6 @@
         as="style"
       />
 
-      {# Load custom fonts from configuration #}
-      {% if appbuilder.app.config.get('CUSTOM_FONT_URLS') %}
-        {% for font_url in appbuilder.app.config['CUSTOM_FONT_URLS'] %}
-          <link rel="stylesheet" href="{{ font_url }}" />
-        {% endfor %}
-      {% endif %}
-
     {% endblock %}
 
     {{ js_bundle(assets_prefix, 'theme') }}

--- a/superset/themes/schemas.py
+++ b/superset/themes/schemas.py
@@ -18,7 +18,11 @@ from typing import Any
 
 from marshmallow import fields, Schema, validates, ValidationError
 
-from superset.themes.utils import is_valid_theme, sanitize_theme_tokens
+from superset.themes.utils import (
+    is_valid_theme,
+    sanitize_theme_tokens,
+    validate_font_urls,
+)
 from superset.utils import json
 
 
@@ -44,6 +48,12 @@ class ImportV1ThemeSchema(Schema):
 
         # Sanitize theme tokens (including SVG content)
         sanitized_config = sanitize_theme_tokens(theme_config)
+
+        # Validate and sanitize fontUrls if present
+        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
+            font_urls = sanitized_config["token"].get("fontUrls")
+            if font_urls is not None:
+                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
 
         # Validate theme structure
         if not is_valid_theme(sanitized_config):
@@ -79,6 +89,12 @@ class ThemePostSchema(Schema):
         # Sanitize theme tokens (including SVG content)
         sanitized_config = sanitize_theme_tokens(theme_config)
 
+        # Validate and sanitize fontUrls if present
+        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
+            font_urls = sanitized_config["token"].get("fontUrls")
+            if font_urls is not None:
+                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
+
         # Validate theme structure
         if not is_valid_theme(sanitized_config):
             raise ValidationError("Invalid theme configuration structure")
@@ -109,6 +125,12 @@ class ThemePutSchema(Schema):
 
         # Sanitize theme tokens (including SVG content)
         sanitized_config = sanitize_theme_tokens(theme_config)
+
+        # Validate and sanitize fontUrls if present
+        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
+            font_urls = sanitized_config["token"].get("fontUrls")
+            if font_urls is not None:
+                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
 
         # Validate theme structure
         if not is_valid_theme(sanitized_config):

--- a/superset/themes/schemas.py
+++ b/superset/themes/schemas.py
@@ -26,6 +26,27 @@ from superset.themes.utils import (
 from superset.utils import json
 
 
+def _sanitize_and_validate_theme_config(theme_config: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize and validate theme configuration.
+
+    Applies token sanitization and font URL validation.
+    Returns the sanitized configuration.
+    """
+    sanitized_config = sanitize_theme_tokens(theme_config)
+
+    # Validate and sanitize fontUrls if present
+    if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
+        font_urls = sanitized_config["token"].get("fontUrls")
+        if font_urls is not None:
+            sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
+
+    # Validate theme structure
+    if not is_valid_theme(sanitized_config):
+        raise ValidationError("Invalid theme configuration structure")
+
+    return sanitized_config
+
+
 class ImportV1ThemeSchema(Schema):
     theme_name = fields.String(required=True)
     json_data = fields.Raw(required=True)
@@ -46,18 +67,8 @@ class ImportV1ThemeSchema(Schema):
         except (TypeError, json.JSONDecodeError) as ex:
             raise ValidationError("Invalid JSON configuration") from ex
 
-        # Sanitize theme tokens (including SVG content)
-        sanitized_config = sanitize_theme_tokens(theme_config)
-
-        # Validate and sanitize fontUrls if present
-        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
-            font_urls = sanitized_config["token"].get("fontUrls")
-            if font_urls is not None:
-                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
-
-        # Validate theme structure
-        if not is_valid_theme(sanitized_config):
-            raise ValidationError("Invalid theme configuration structure")
+        # Sanitize and validate the theme configuration
+        sanitized_config = _sanitize_and_validate_theme_config(theme_config)
 
         # Update the field with sanitized content for import
         if sanitized_config != theme_config:
@@ -86,18 +97,8 @@ class ThemePostSchema(Schema):
         except (TypeError, json.JSONDecodeError) as ex:
             raise ValidationError("Invalid JSON configuration") from ex
 
-        # Sanitize theme tokens (including SVG content)
-        sanitized_config = sanitize_theme_tokens(theme_config)
-
-        # Validate and sanitize fontUrls if present
-        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
-            font_urls = sanitized_config["token"].get("fontUrls")
-            if font_urls is not None:
-                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
-
-        # Validate theme structure
-        if not is_valid_theme(sanitized_config):
-            raise ValidationError("Invalid theme configuration structure")
+        # Sanitize and validate the theme configuration
+        sanitized_config = _sanitize_and_validate_theme_config(theme_config)
 
         # Update the field with sanitized content
         # Note: This modifies the input data to ensure sanitized content is stored
@@ -123,18 +124,8 @@ class ThemePutSchema(Schema):
         except (TypeError, json.JSONDecodeError) as ex:
             raise ValidationError("Invalid JSON configuration") from ex
 
-        # Sanitize theme tokens (including SVG content)
-        sanitized_config = sanitize_theme_tokens(theme_config)
-
-        # Validate and sanitize fontUrls if present
-        if "token" in sanitized_config and isinstance(sanitized_config["token"], dict):
-            font_urls = sanitized_config["token"].get("fontUrls")
-            if font_urls is not None:
-                sanitized_config["token"]["fontUrls"] = validate_font_urls(font_urls)
-
-        # Validate theme structure
-        if not is_valid_theme(sanitized_config):
-            raise ValidationError("Invalid theme configuration structure")
+        # Sanitize and validate the theme configuration
+        sanitized_config = _sanitize_and_validate_theme_config(theme_config)
 
         # Update the field with sanitized content
         # Note: This modifies the input data to ensure sanitized content is stored

--- a/superset/themes/utils.py
+++ b/superset/themes/utils.py
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import Any, Dict
+from urllib.parse import urlparse
+
+from flask import current_app
+from marshmallow import ValidationError
 
 from superset.themes.types import ThemeMode
 from superset.utils.core import sanitize_svg_content, sanitize_url
@@ -120,3 +124,64 @@ def sanitize_theme_tokens(theme_config: Dict[str, Any]) -> Dict[str, Any]:
         sanitized_config["token"] = tokens
 
     return sanitized_config
+
+
+def _validate_single_font_url(
+    index: int, url: Any, allowed_domains: list[str]
+) -> str:
+    """
+    Validate a single font URL
+    """
+    if not isinstance(url, str):
+        raise ValidationError(f"fontUrls[{index}] must be a string")
+
+    # Reuse existing sanitize_url (blocks javascript:, data:, etc.)
+    sanitized = sanitize_url(url.strip())
+    if not sanitized:
+        raise ValidationError(f"fontUrls[{index}] contains invalid URL")
+
+    # Enforce HTTPS and validate domain
+    try:
+        parsed = urlparse(sanitized)
+        if parsed.scheme != "https":
+            raise ValidationError(f"fontUrls[{index}] must use HTTPS")
+        if parsed.netloc.lower() not in [d.lower() for d in allowed_domains]:
+            raise ValidationError(
+                f"fontUrls[{index}] domain '{parsed.netloc}' not in allowed list"
+            )
+    except ValidationError:
+        raise
+    except Exception as e:
+        raise ValidationError(f"fontUrls[{index}] is malformed: {e}") from e
+
+    return sanitized
+
+
+def validate_font_urls(font_urls: Any) -> list[str]:
+    """
+    Validate fontUrls array in theme token configuration
+    """
+    if font_urls is None:
+        return []
+
+    if not isinstance(font_urls, list):
+        raise ValidationError("fontUrls must be an array")
+
+    max_urls = current_app.config.get("THEME_FONTS_MAX_URLS", 15)
+    if len(font_urls) > max_urls:
+        raise ValidationError(f"Maximum {max_urls} font URLs allowed per theme")
+
+    allowed_domains = current_app.config.get(
+        "THEME_FONT_URL_ALLOWED_DOMAINS",
+        [
+            "fonts.googleapis.com",
+            "fonts.gstatic.com",
+            "use.typekit.net",
+            "use.typekit.com",
+        ],
+    )
+
+    return [
+        _validate_single_font_url(i, url, allowed_domains)
+        for i, url in enumerate(font_urls)
+    ]

--- a/superset/themes/utils.py
+++ b/superset/themes/utils.py
@@ -126,9 +126,7 @@ def sanitize_theme_tokens(theme_config: Dict[str, Any]) -> Dict[str, Any]:
     return sanitized_config
 
 
-def _validate_single_font_url(
-    index: int, url: Any, allowed_domains: list[str]
-) -> str:
+def _validate_single_font_url(index: int, url: Any, allowed_domains: list[str]) -> str:
     """
     Validate a single font URL
     """

--- a/tests/unit_tests/themes/test_utils.py
+++ b/tests/unit_tests/themes/test_utils.py
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from unittest.mock import MagicMock, patch
 
 import pytest
+from marshmallow import ValidationError
 
 from superset.themes.types import ThemeMode
 from superset.themes.utils import (
@@ -24,6 +26,7 @@ from superset.themes.utils import (
     _is_valid_theme_mode,
     is_valid_theme,
     sanitize_theme_tokens,
+    validate_font_urls,
 )
 
 
@@ -113,3 +116,166 @@ def test_sanitize_theme_tokens_no_spinner_tokens():
     theme_config = {"token": {"colorPrimary": "#ff0000", "fontFamily": "Arial"}}
     result = sanitize_theme_tokens(theme_config)
     assert result == theme_config
+
+
+@pytest.fixture
+def mock_app_config():
+    """Create a mock Flask app with default config values."""
+    mock_app = MagicMock()
+    mock_app.config.get.side_effect = lambda k, d=None: {
+        "THEME_FONTS_MAX_URLS": 15,
+        "THEME_FONT_URL_ALLOWED_DOMAINS": [
+            "fonts.googleapis.com",
+            "fonts.gstatic.com",
+            "use.typekit.net",
+            "use.typekit.com",
+        ],
+    }.get(k, d)
+    return mock_app
+
+
+def test_validate_font_urls_none_returns_empty_list():
+    """Test that None input returns an empty list."""
+    result = validate_font_urls(None)
+    assert result == []
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_valid_google_fonts(mock_current_app, mock_app_config):
+    """Test that valid Google Fonts URL passes validation."""
+    mock_current_app.config = mock_app_config.config
+
+    urls = ["https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap"]
+    result = validate_font_urls(urls)
+
+    assert len(result) == 1
+    assert result[0] == urls[0]
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_valid_typekit(mock_current_app, mock_app_config):
+    """Test that valid Adobe Fonts (Typekit) URL passes validation."""
+    mock_current_app.config = mock_app_config.config
+
+    urls = ["https://use.typekit.net/abc123.css"]
+    result = validate_font_urls(urls)
+
+    assert len(result) == 1
+    assert result[0] == urls[0]
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_multiple_valid_urls(mock_current_app, mock_app_config):
+    """Test that multiple valid font URLs pass validation."""
+    mock_current_app.config = mock_app_config.config
+
+    urls = [
+        "https://fonts.googleapis.com/css2?family=Roboto",
+        "https://fonts.googleapis.com/css2?family=Open+Sans",
+        "https://use.typekit.net/xyz789.css",
+    ]
+    result = validate_font_urls(urls)
+
+    assert len(result) == 3
+    assert result == urls
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_rejects_http(mock_current_app, mock_app_config):
+    """Test that HTTP URLs are rejected (HTTPS required)."""
+    mock_current_app.config = mock_app_config.config
+
+    with pytest.raises(ValidationError, match="must use HTTPS"):
+        validate_font_urls(["http://fonts.googleapis.com/css2?family=Roboto"])
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_rejects_unlisted_domain(mock_current_app, mock_app_config):
+    """Test that URLs from non-whitelisted domains are rejected."""
+    mock_current_app.config = mock_app_config.config
+
+    with pytest.raises(ValidationError, match="not in allowed list"):
+        validate_font_urls(["https://evil.com/malicious-font.css"])
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_rejects_javascript_scheme(
+    mock_current_app, mock_app_config
+):
+    """Test that javascript: URLs are rejected."""
+    mock_current_app.config = mock_app_config.config
+
+    with pytest.raises(ValidationError, match="invalid URL"):
+        validate_font_urls(["javascript:alert('xss')"])
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_rejects_data_scheme(mock_current_app, mock_app_config):
+    """Test that data: URLs are rejected."""
+    mock_current_app.config = mock_app_config.config
+
+    with pytest.raises(ValidationError, match="invalid URL"):
+        validate_font_urls(["data:text/css,body{color:red}"])
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_max_urls_enforced(mock_current_app):
+    """Test that maximum URL count is enforced."""
+    # Create a fresh config mock with max_urls set to 3
+    config_mock = MagicMock()
+    config_mock.get.side_effect = lambda k, d=None: {
+        "THEME_FONTS_MAX_URLS": 3,
+        "THEME_FONT_URL_ALLOWED_DOMAINS": ["fonts.googleapis.com"],
+    }.get(k, d)
+    mock_current_app.config = config_mock
+
+    urls = [f"https://fonts.googleapis.com/font{i}" for i in range(5)]
+
+    with pytest.raises(ValidationError, match="Maximum 3 font URLs"):
+        validate_font_urls(urls)
+
+
+def test_validate_font_urls_rejects_non_array():
+    """Test that non-array input is rejected."""
+    with pytest.raises(ValidationError, match="must be an array"):
+        validate_font_urls("not-an-array")
+
+
+def test_validate_font_urls_rejects_non_string_elements():
+    """Test that non-string elements in the array are rejected."""
+    with pytest.raises(ValidationError, match="must be a string"):
+        validate_font_urls([123, "https://fonts.googleapis.com/css"])
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_strips_whitespace(mock_current_app, mock_app_config):
+    """Test that whitespace is stripped from URLs."""
+    mock_current_app.config = mock_app_config.config
+
+    urls = ["  https://fonts.googleapis.com/css2?family=Roboto  "]
+    result = validate_font_urls(urls)
+
+    assert len(result) == 1
+    assert result[0] == "https://fonts.googleapis.com/css2?family=Roboto"
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_empty_array_returns_empty(
+    mock_current_app, mock_app_config
+):
+    """Test that empty array returns empty list."""
+    mock_current_app.config = mock_app_config.config
+
+    result = validate_font_urls([])
+    assert result == []
+
+
+@patch("superset.themes.utils.current_app")
+def test_validate_font_urls_case_insensitive_domain(mock_current_app, mock_app_config):
+    """Test that domain matching is case-insensitive."""
+    mock_current_app.config = mock_app_config.config
+
+    urls = ["https://FONTS.GOOGLEAPIS.COM/css2?family=Roboto"]
+    result = validate_font_urls(urls)
+
+    assert len(result) == 1


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds support for custom font URLs in theme configurations and migrates default fonts from bundled packages to CDN loading. Now we can specify a `fontUrls` array in theme tokens to load external fonts (Google Fonts, Adobe Fonts) that are automatically injected when the theme is applied.

- Removes bundled @fontsource packages in favor of loading Inter and Fira Code via Google Fonts
- Removes `CUSTOM_FONT_URLS` config in favor of per-theme `fontUrls` in theme tokens
- Configures CSP to dynamically allow font domains from `THEME_FONT_URL_ALLOWED_DOMAINS`

### AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
![theme-custom-fonts](https://github.com/user-attachments/assets/6300e3d4-35a6-4231-a338-fe0653f036ed)

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create/update a theme with `fontFamily` and `fontUrls` in the token configuration:
```json
{
  "token": {
    "fontFamily": "Science Gothic, sans-serif",
    "fontUrls": ["https://fonts.googleapis.com/css2?family=Science+Gothic:wght@100..900&display=swap"]
  },
  "algorithm": "dark"
}
```
2. Apply the theme and verify the font loads correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
