### PR TITLE
fix: Drill-to-detail in TableChart not providing the correct dates b…

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -328,51 +328,34 @@ function getEndTimeFromGranularity(
 
   switch (granularity) {
     case TimeGranularity.SECOND:
-    case 'PT1S':
       return new Date(time + MS_IN_SECOND);
     case TimeGranularity.MINUTE:
-    case 'PT1M':
       return new Date(time + MS_IN_MINUTE);
     case TimeGranularity.FIVE_MINUTES:
-    case 'PT5M':
       return new Date(time + MS_IN_MINUTE * 5);
     case TimeGranularity.TEN_MINUTES:
-    case 'PT10M':
       return new Date(time + MS_IN_MINUTE * 10);
     case TimeGranularity.FIFTEEN_MINUTES:
-    case 'PT15M':
       return new Date(time + MS_IN_MINUTE * 15);
     case TimeGranularity.THIRTY_MINUTES:
-    case 'PT30M':
       return new Date(time + MS_IN_MINUTE * 30);
     case TimeGranularity.HOUR:
-    case 'PT1H':
       return new Date(time + MS_IN_HOUR);
     case TimeGranularity.DAY:
     case TimeGranularity.DATE:
-    case 'P1D':
-    case 'date':
       return new Date(Date.UTC(year, month, date + 1));
     case TimeGranularity.WEEK:
     case TimeGranularity.WEEK_STARTING_SUNDAY:
     case TimeGranularity.WEEK_STARTING_MONDAY:
-    case 'P1W':
-    case '1969-12-28T00:00:00Z/P1W':
-    case '1969-12-29T00:00:00Z/P1W':
       return new Date(Date.UTC(year, month, date + 7));
     case TimeGranularity.WEEK_ENDING_SATURDAY:
     case TimeGranularity.WEEK_ENDING_SUNDAY:
-    case 'P1W/1970-01-03T00:00:00Z':
-    case 'P1W/1970-01-04T00:00:00Z':
       return new Date(Date.UTC(year, month, date + 1));
     case TimeGranularity.MONTH:
-    case 'P1M':
       return new Date(Date.UTC(year, month + 1, 1));
     case TimeGranularity.QUARTER:
-    case 'P3M':
       return new Date(Date.UTC(year, Math.floor(month / 3) * 3 + 3, 1));
     case TimeGranularity.YEAR:
-    case 'P1Y':
       return new Date(Date.UTC(year + 1, 0, 1));
     default:
       return new Date(Date.UTC(year, month, date + 1));
@@ -626,23 +609,24 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         clientX: number,
         clientY: number,
       ) => {
-      const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+        const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
         filteredColumnsMeta.forEach(col => {
           if (!col.isMetric) {
             const dataRecordValue = value[col.key];
-            
+
             // Handle temporal columns differently to support time ranges
             if (col.dataType === GenericDataType.Temporal && timeGrain) {
               // Make sure the value is a Date
-              const startTime = dataRecordValue instanceof Date 
-                ? dataRecordValue 
-                : new Date(dataRecordValue as string | number);
-              
+              const startTime =
+                dataRecordValue instanceof Date
+                  ? dataRecordValue
+                  : new Date(dataRecordValue as string | number);
+
               // Calculate the end time based on the granularity
               const endTime = getEndTimeFromGranularity(startTime, timeGrain);
-              
+
               const timeRangeValue = `${startTime.toISOString()} : ${endTime.toISOString()}`;
-              
+
               drillToDetailFilters.push({
                 col: col.key,
                 op: 'TEMPORAL_RANGE',
@@ -652,11 +636,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               });
             } else {
               // Non-temporal columns use exact match
+              const sanitizedValue = extractTextFromHTML(dataRecordValue);
               drillToDetailFilters.push({
                 col: col.key,
                 op: '==',
-                val: dataRecordValue as string | number | boolean,
-                formattedVal: formatColumnValue(col, dataRecordValue)[1],
+                val: sanitizedValue as string | number | boolean,
+                formattedVal: formatColumnValue(col, sanitizedValue)[1],
               });
             }
           }
@@ -687,6 +672,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     isRawRecords,
     filteredColumnsMeta,
     getCrossFilterDataMask,
+    timeGrain,
   ]);
 
   const getHeaderColumns = useCallback(

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -48,6 +48,7 @@ import {
   getTimeFormatterForGranularity,
   BinaryQueryObjectFilterClause,
   extractTextFromHTML,
+  TimeGranularity,
 } from '@superset-ui/core';
 import {
   styled,
@@ -306,6 +307,78 @@ function SelectPageSize({
 const getNoResultsMessage = (filter: string) =>
   filter ? t('No matching records found') : t('No records found');
 
+//Calculates the end time based on the granularity
+function getEndTimeFromGranularity(
+  startTime: Date,
+  granularity?: TimeGranularity,
+): Date {
+  if (!granularity) {
+    return startTime;
+  }
+
+  const time = startTime.getTime();
+  const date = startTime.getUTCDate();
+  const month = startTime.getUTCMonth();
+  const year = startTime.getUTCFullYear();
+
+  // Constants for time calculations
+  const MS_IN_SECOND = 1000;
+  const MS_IN_MINUTE = 60 * MS_IN_SECOND;
+  const MS_IN_HOUR = 60 * MS_IN_MINUTE;
+
+  switch (granularity) {
+    case TimeGranularity.SECOND:
+    case 'PT1S':
+      return new Date(time + MS_IN_SECOND);
+    case TimeGranularity.MINUTE:
+    case 'PT1M':
+      return new Date(time + MS_IN_MINUTE);
+    case TimeGranularity.FIVE_MINUTES:
+    case 'PT5M':
+      return new Date(time + MS_IN_MINUTE * 5);
+    case TimeGranularity.TEN_MINUTES:
+    case 'PT10M':
+      return new Date(time + MS_IN_MINUTE * 10);
+    case TimeGranularity.FIFTEEN_MINUTES:
+    case 'PT15M':
+      return new Date(time + MS_IN_MINUTE * 15);
+    case TimeGranularity.THIRTY_MINUTES:
+    case 'PT30M':
+      return new Date(time + MS_IN_MINUTE * 30);
+    case TimeGranularity.HOUR:
+    case 'PT1H':
+      return new Date(time + MS_IN_HOUR);
+    case TimeGranularity.DAY:
+    case TimeGranularity.DATE:
+    case 'P1D':
+    case 'date':
+      return new Date(Date.UTC(year, month, date + 1));
+    case TimeGranularity.WEEK:
+    case TimeGranularity.WEEK_STARTING_SUNDAY:
+    case TimeGranularity.WEEK_STARTING_MONDAY:
+    case 'P1W':
+    case '1969-12-28T00:00:00Z/P1W':
+    case '1969-12-29T00:00:00Z/P1W':
+      return new Date(Date.UTC(year, month, date + 7));
+    case TimeGranularity.WEEK_ENDING_SATURDAY:
+    case TimeGranularity.WEEK_ENDING_SUNDAY:
+    case 'P1W/1970-01-03T00:00:00Z':
+    case 'P1W/1970-01-04T00:00:00Z':
+      return new Date(Date.UTC(year, month, date + 1));
+    case TimeGranularity.MONTH:
+    case 'P1M':
+      return new Date(Date.UTC(year, month + 1, 1));
+    case TimeGranularity.QUARTER:
+    case 'P3M':
+      return new Date(Date.UTC(year, Math.floor(month / 3) * 3 + 3, 1));
+    case TimeGranularity.YEAR:
+    case 'P1Y':
+      return new Date(Date.UTC(year + 1, 0, 1));
+    default:
+      return new Date(Date.UTC(year, month, date + 1));
+  }
+}
+
 export default function TableChart<D extends DataRecord = DataRecord>(
   props: TableChartTransformedProps<D> & {
     sticky?: DataTableProps<D>['sticky'];
@@ -553,18 +626,39 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         clientX: number,
         clientY: number,
       ) => {
-        const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
+      const drillToDetailFilters: BinaryQueryObjectFilterClause[] = [];
         filteredColumnsMeta.forEach(col => {
           if (!col.isMetric) {
-            let dataRecordValue = value[col.key];
-            dataRecordValue = extractTextFromHTML(dataRecordValue);
-
-            drillToDetailFilters.push({
-              col: col.key,
-              op: '==',
-              val: dataRecordValue as string | number | boolean,
-              formattedVal: formatColumnValue(col, dataRecordValue)[1],
-            });
+            const dataRecordValue = value[col.key];
+            
+            // Handle temporal columns differently to support time ranges
+            if (col.dataType === GenericDataType.Temporal && timeGrain) {
+              // Make sure the value is a Date
+              const startTime = dataRecordValue instanceof Date 
+                ? dataRecordValue 
+                : new Date(dataRecordValue as string | number);
+              
+              // Calculate the end time based on the granularity
+              const endTime = getEndTimeFromGranularity(startTime, timeGrain);
+              
+              const timeRangeValue = `${startTime.toISOString()} : ${endTime.toISOString()}`;
+              
+              drillToDetailFilters.push({
+                col: col.key,
+                op: 'TEMPORAL_RANGE',
+                val: timeRangeValue,
+                grain: timeGrain,
+                formattedVal: formatColumnValue(col, dataRecordValue)[1],
+              });
+            } else {
+              // Non-temporal columns use exact match
+              drillToDetailFilters.push({
+                col: col.key,
+                op: '==',
+                val: dataRecordValue as string | number | boolean,
+                formattedVal: formatColumnValue(col, dataRecordValue)[1],
+              });
+            }
           }
         });
         onContextMenu(clientX, clientY, {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -1572,3 +1572,115 @@ describe('plugin-chart-table', () => {
     });
   });
 });
+
+test('drill-to-detail uses TEMPORAL_RANGE for temporal columns when timeGrain is set', () => {
+  const onContextMenu = jest.fn();
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      time_grain_sqla: TimeGranularity.MONTH,
+    },
+    hooks: {
+      onAddFilter: jest.fn(),
+      setDataMask: jest.fn(),
+      onContextMenu,
+    },
+  });
+  render(<TableChart {...props} sticky={false} />);
+
+  const tbody = screen.getAllByRole('rowgroup')[1];
+  fireEvent.contextMenu(tbody.querySelectorAll('td')[0]);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const [, , { drillToDetail }] = onContextMenu.mock.calls[0];
+  const timestampFilter = drillToDetail.find(
+    (f: { col: string }) => f.col === '__timestamp',
+  );
+  expect(timestampFilter.op).toBe('TEMPORAL_RANGE');
+  expect(timestampFilter.grain).toBe(TimeGranularity.MONTH);
+  // Row value is 2020-01-01T12:34:56Z; month granularity end is start of next month
+  expect(timestampFilter.val).toBe(
+    '2020-01-01T12:34:56.000Z : 2020-02-01T00:00:00.000Z',
+  );
+});
+
+test('drill-to-detail TEMPORAL_RANGE range end matches granularity boundary for year grain', () => {
+  const onContextMenu = jest.fn();
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      time_grain_sqla: TimeGranularity.YEAR,
+    },
+    hooks: {
+      onAddFilter: jest.fn(),
+      setDataMask: jest.fn(),
+      onContextMenu,
+    },
+  });
+  render(<TableChart {...props} sticky={false} />);
+
+  const tbody = screen.getAllByRole('rowgroup')[1];
+  fireEvent.contextMenu(tbody.querySelectorAll('td')[0]);
+
+  const [, , { drillToDetail }] = onContextMenu.mock.calls[0];
+  const timestampFilter = drillToDetail.find(
+    (f: { col: string }) => f.col === '__timestamp',
+  );
+  expect(timestampFilter.op).toBe('TEMPORAL_RANGE');
+  // Row value is 2020-01-01T12:34:56Z; year granularity end is start of 2021
+  expect(timestampFilter.val).toBe(
+    '2020-01-01T12:34:56.000Z : 2021-01-01T00:00:00.000Z',
+  );
+});
+
+test('drill-to-detail uses == for non-temporal columns even when timeGrain is set', () => {
+  const onContextMenu = jest.fn();
+  const props = transformProps({
+    ...testData.basic,
+    rawFormData: {
+      ...testData.basic.rawFormData,
+      time_grain_sqla: TimeGranularity.MONTH,
+    },
+    hooks: {
+      onAddFilter: jest.fn(),
+      setDataMask: jest.fn(),
+      onContextMenu,
+    },
+  });
+  render(<TableChart {...props} sticky={false} />);
+
+  const tbody = screen.getAllByRole('rowgroup')[1];
+  fireEvent.contextMenu(tbody.querySelectorAll('td')[0]);
+
+  const [, , { drillToDetail }] = onContextMenu.mock.calls[0];
+  const nameFilter = drillToDetail.find(
+    (f: { col: string }) => f.col === 'name',
+  );
+  expect(nameFilter.op).toBe('==');
+  expect(nameFilter.val).toBe('Michael');
+});
+
+test('drill-to-detail uses == for temporal columns when no timeGrain is set', () => {
+  const onContextMenu = jest.fn();
+  const props = transformProps({
+    ...testData.basic,
+    hooks: {
+      onAddFilter: jest.fn(),
+      setDataMask: jest.fn(),
+      onContextMenu,
+    },
+  });
+  render(<TableChart {...props} sticky={false} />);
+
+  const tbody = screen.getAllByRole('rowgroup')[1];
+  fireEvent.contextMenu(tbody.querySelectorAll('td')[0]);
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1);
+  const [, , { drillToDetail }] = onContextMenu.mock.calls[0];
+  const timestampFilter = drillToDetail.find(
+    (f: { col: string }) => f.col === '__timestamp',
+  );
+  expect(timestampFilter.op).toBe('==');
+});


### PR DESCRIPTION
…y using a Time Range.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
fix(dashboard): Drill to detail on date-time columns returns correct range of values

### SUMMARY
Fix for Issue: [23847](https://github.com/apache/superset/issues/23847)

Unexpected Behaviour: For table charts with time grains (year, month, day, hour, etc): when the user drills down by a date-time column they do not get the expected records. For example, if the time grain is month, and the user selects “Drill to detail by month” the resulting table contains records for where the date-time column equals “yyyy-mm-01 00:00:00z”. So, only the records that have year, month, and first day yyyy-mm-01 with exactly the start of the first day 00:00:00z, are returned. In the expected output, we want to include all the records that have the same selected yyyy-mm regardless of the day and time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before Fix:
![Before Fix](https://github.com/user-attachments/assets/a3e3b369-90ae-4162-97cb-c80539d4c392)

After Fix:
![After Fix](https://github.com/user-attachments/assets/1c9d8e9d-c46e-4c68-af16-a2f32ea249e9)
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
How to verify the fix:
1. Create an aggregate table chart with a date-time variable as a dimension
2. Select a Time Grain
3. On dashboard, Drill to Detail by chosen Time Grain
4. All the values within the range of the Time grain should be displayed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/23847
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
