### PR TITLE
fix: add a fallback to chart state callback

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -114,6 +114,35 @@ const SliceContainer = styled.div`
 const EMPTY_OBJECT = {};
 const EMPTY_ARRAY = [];
 
+// Helper function to get chart state with fallback
+const getChartStateWithFallback = (chartState, formData, vizType) => {
+  if (!hasChartStateConverter(vizType)) {
+    return null;
+  }
+  
+  return (
+    chartState?.state ||
+    formData.table_state ||
+    formData.pivot_table_state
+  );
+};
+
+// Helper function to create own state with chart state conversion
+const createOwnStateWithChartState = (baseOwnState, chartState, vizType) => {
+  const state = getChartStateWithFallback(chartState, {}, vizType);
+  
+  if (!state) {
+    return baseOwnState;
+  }
+  
+  const convertedState = convertChartStateToOwnState(vizType, state);
+  return {
+    ...baseOwnState,
+    ...convertedState,
+    chartState: state,
+  };
+};
+
 const Chart = props => {
   const dispatch = useDispatch();
   const descriptionRef = useRef(null);
@@ -383,16 +412,7 @@ const Chart = props => {
 
   const ownState = useMemo(() => {
     const baseOwnState = dataMask[props.id]?.ownState || EMPTY_OBJECT;
-
-    if (hasChartStateConverter(slice.viz_type) && chartState?.state) {
-      return {
-        ...baseOwnState,
-        ...convertChartStateToOwnState(slice.viz_type, chartState.state),
-        chartState: chartState.state,
-      };
-    }
-
-    return baseOwnState;
+    return createOwnStateWithChartState(baseOwnState, chartState, slice.viz_type);
   }, [
     dataMask[props.id]?.ownState,
     props.id,
@@ -486,19 +506,15 @@ const Chart = props => {
         const safeChartName = chartName.replace(/[^a-zA-Z0-9_-]/g, '_');
         filename = `${safeChartName}${timestamp}.csv`;
       }
-      let ownState = dataMask[props.id]?.ownState || {};
-
-      // Convert chart-specific state to backend format using registered converter
-      if (hasChartStateConverter(slice.viz_type) && chartState?.state) {
-        const convertedState = convertChartStateToOwnState(
-          slice.viz_type,
-          chartState.state,
-        );
-        ownState = {
-          ...ownState,
-          ...convertedState,
-        };
-      }
+      const baseOwnState = dataMask[props.id]?.ownState || {};
+      const state = getChartStateWithFallback(chartState, formData, slice.viz_type);
+      
+      const ownState = state
+        ? {
+            ...baseOwnState,
+            ...convertChartStateToOwnState(slice.viz_type, state),
+          }
+        : baseOwnState;
 
       exportChart({
         formData: exportFormData,
@@ -671,7 +687,11 @@ const Chart = props => {
           formData={formData}
           labelsColor={labelsColor}
           labelsColorMap={labelsColorMap}
-          ownState={ownState}
+          ownState={createOwnStateWithChartState(
+            dataMask[props.id]?.ownState || EMPTY_OBJECT,
+            { state: getChartStateWithFallback(chartState, formData, slice.viz_type) },
+            slice.viz_type
+          )}
           filterState={dataMask[props.id]?.filterState}
           queriesResponse={chart.queriesResponse}
           timeout={timeout}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.jsx
@@ -119,22 +119,20 @@ const getChartStateWithFallback = (chartState, formData, vizType) => {
   if (!hasChartStateConverter(vizType)) {
     return null;
   }
-  
+
   return (
-    chartState?.state ||
-    formData.table_state ||
-    formData.pivot_table_state
+    chartState?.state || formData.table_state || formData.pivot_table_state
   );
 };
 
 // Helper function to create own state with chart state conversion
 const createOwnStateWithChartState = (baseOwnState, chartState, vizType) => {
   const state = getChartStateWithFallback(chartState, {}, vizType);
-  
+
   if (!state) {
     return baseOwnState;
   }
-  
+
   const convertedState = convertChartStateToOwnState(vizType, state);
   return {
     ...baseOwnState,
@@ -412,7 +410,11 @@ const Chart = props => {
 
   const ownState = useMemo(() => {
     const baseOwnState = dataMask[props.id]?.ownState || EMPTY_OBJECT;
-    return createOwnStateWithChartState(baseOwnState, chartState, slice.viz_type);
+    return createOwnStateWithChartState(
+      baseOwnState,
+      chartState,
+      slice.viz_type,
+    );
   }, [
     dataMask[props.id]?.ownState,
     props.id,
@@ -507,8 +509,12 @@ const Chart = props => {
         filename = `${safeChartName}${timestamp}.csv`;
       }
       const baseOwnState = dataMask[props.id]?.ownState || {};
-      const state = getChartStateWithFallback(chartState, formData, slice.viz_type);
-      
+      const state = getChartStateWithFallback(
+        chartState,
+        formData,
+        slice.viz_type,
+      );
+
       const ownState = state
         ? {
             ...baseOwnState,
@@ -689,8 +695,14 @@ const Chart = props => {
           labelsColorMap={labelsColorMap}
           ownState={createOwnStateWithChartState(
             dataMask[props.id]?.ownState || EMPTY_OBJECT,
-            { state: getChartStateWithFallback(chartState, formData, slice.viz_type) },
-            slice.viz_type
+            {
+              state: getChartStateWithFallback(
+                chartState,
+                formData,
+                slice.viz_type,
+              ),
+            },
+            slice.viz_type,
           )}
           filterState={dataMask[props.id]?.filterState}
           queriesResponse={chart.queriesResponse}

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
@@ -306,10 +306,14 @@ test('should re-render when cacheBusterProp changes', () => {
 test('should handle chart state conversion when converter exists', () => {
   const mockChartState = { sortColumn: 'column1', sortOrder: 'asc' };
   const mockConvertedState = { sort: [{ columnId: 'column1', order: 'asc' }] };
-  
-  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
-  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
-  
+
+  jest
+    .spyOn(chartStateConverter, 'hasChartStateConverter')
+    .mockReturnValue(true);
+  jest
+    .spyOn(chartStateConverter, 'convertChartStateToOwnState')
+    .mockReturnValue(mockConvertedState);
+
   const { getByTestId } = setup(
     {},
     {
@@ -322,18 +326,24 @@ test('should handle chart state conversion when converter exists', () => {
       },
     },
   );
-  
+
   expect(getByTestId('chart-container')).toBeInTheDocument();
-  expect(chartStateConverter.hasChartStateConverter).toHaveBeenCalledWith(VizType.Table);
+  expect(chartStateConverter.hasChartStateConverter).toHaveBeenCalledWith(
+    VizType.Table,
+  );
 });
 
 test('should fallback to formData state when runtime state not available', () => {
   const mockFormDataState = { sortColumn: 'column2', sortOrder: 'desc' };
   const mockConvertedState = { sort: [{ columnId: 'column2', order: 'desc' }] };
-  
-  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
-  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
-  
+
+  jest
+    .spyOn(chartStateConverter, 'hasChartStateConverter')
+    .mockReturnValue(true);
+  jest
+    .spyOn(chartStateConverter, 'convertChartStateToOwnState')
+    .mockReturnValue(mockConvertedState);
+
   const { getByTestId } = setup(
     {},
     {
@@ -350,14 +360,16 @@ test('should fallback to formData state when runtime state not available', () =>
       },
     },
   );
-  
+
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });
 
 test('should handle chart state when no converter exists', () => {
-  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(false);
+  jest
+    .spyOn(chartStateConverter, 'hasChartStateConverter')
+    .mockReturnValue(false);
   jest.spyOn(chartStateConverter, 'convertChartStateToOwnState');
-  
+
   const { getByTestId } = setup(
     {},
     {
@@ -370,19 +382,25 @@ test('should handle chart state when no converter exists', () => {
       },
     },
   );
-  
+
   expect(getByTestId('chart-container')).toBeInTheDocument();
-  expect(chartStateConverter.convertChartStateToOwnState).not.toHaveBeenCalled();
+  expect(
+    chartStateConverter.convertChartStateToOwnState,
+  ).not.toHaveBeenCalled();
 });
 
 test('should merge base ownState with converted chart state', () => {
   const baseOwnState = { existingProp: 'value' };
   const mockChartState = { sortColumn: 'column1', sortOrder: 'asc' };
   const mockConvertedState = { sort: [{ columnId: 'column1', order: 'asc' }] };
-  
-  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
-  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
-  
+
+  jest
+    .spyOn(chartStateConverter, 'hasChartStateConverter')
+    .mockReturnValue(true);
+  jest
+    .spyOn(chartStateConverter, 'convertChartStateToOwnState')
+    .mockReturnValue(mockConvertedState);
+
   const { getByTestId } = setup(
     {},
     {
@@ -400,6 +418,6 @@ test('should merge base ownState with converted chart state', () => {
       },
     },
   );
-  
+
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.test.jsx
@@ -21,6 +21,7 @@ import { FeatureFlag, VizType } from '@superset-ui/core';
 import * as redux from 'redux';
 
 import * as exploreUtils from 'src/explore/exploreUtils';
+import * as chartStateConverter from '../../../util/chartStateConverter';
 import { sliceEntitiesForChart as sliceEntities } from 'spec/fixtures/mockSliceEntities';
 import mockDatasource from 'spec/fixtures/mockDatasource';
 import chartQueries, {
@@ -114,6 +115,10 @@ beforeAll(() => {
     setFocusedFilterField,
     unsetFocusedFilterField,
   }));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
 });
 
 test('should render a SliceHeader', () => {
@@ -295,5 +300,106 @@ test('should re-render when cacheBusterProp changes', () => {
   expect(getByTestId('chart-container')).toBeInTheDocument();
 
   rerender(<Chart {...props} isComponentVisible cacheBusterProp="v2" />);
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+});
+
+test('should handle chart state conversion when converter exists', () => {
+  const mockChartState = { sortColumn: 'column1', sortOrder: 'asc' };
+  const mockConvertedState = { sort: [{ columnId: 'column1', order: 'asc' }] };
+  
+  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
+  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
+  
+  const { getByTestId } = setup(
+    {},
+    {
+      ...defaultState,
+      dashboardState: {
+        ...defaultState.dashboardState,
+        chartStates: {
+          [queryId]: { state: mockChartState },
+        },
+      },
+    },
+  );
+  
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+  expect(chartStateConverter.hasChartStateConverter).toHaveBeenCalledWith(VizType.Table);
+});
+
+test('should fallback to formData state when runtime state not available', () => {
+  const mockFormDataState = { sortColumn: 'column2', sortOrder: 'desc' };
+  const mockConvertedState = { sort: [{ columnId: 'column2', order: 'desc' }] };
+  
+  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
+  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
+  
+  const { getByTestId } = setup(
+    {},
+    {
+      ...defaultState,
+      charts: {
+        ...defaultState.charts,
+        [queryId]: {
+          ...defaultState.charts[queryId],
+          form_data: {
+            ...defaultState.charts[queryId].form_data,
+            table_state: mockFormDataState,
+          },
+        },
+      },
+    },
+  );
+  
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+});
+
+test('should handle chart state when no converter exists', () => {
+  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(false);
+  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState');
+  
+  const { getByTestId } = setup(
+    {},
+    {
+      ...defaultState,
+      dashboardState: {
+        ...defaultState.dashboardState,
+        chartStates: {
+          [queryId]: { state: { someState: 'value' } },
+        },
+      },
+    },
+  );
+  
+  expect(getByTestId('chart-container')).toBeInTheDocument();
+  expect(chartStateConverter.convertChartStateToOwnState).not.toHaveBeenCalled();
+});
+
+test('should merge base ownState with converted chart state', () => {
+  const baseOwnState = { existingProp: 'value' };
+  const mockChartState = { sortColumn: 'column1', sortOrder: 'asc' };
+  const mockConvertedState = { sort: [{ columnId: 'column1', order: 'asc' }] };
+  
+  jest.spyOn(chartStateConverter, 'hasChartStateConverter').mockReturnValue(true);
+  jest.spyOn(chartStateConverter, 'convertChartStateToOwnState').mockReturnValue(mockConvertedState);
+  
+  const { getByTestId } = setup(
+    {},
+    {
+      ...defaultState,
+      dataMask: {
+        [queryId]: {
+          ownState: baseOwnState,
+        },
+      },
+      dashboardState: {
+        ...defaultState.dashboardState,
+        chartStates: {
+          [queryId]: { state: mockChartState },
+        },
+      },
+    },
+  );
+  
   expect(getByTestId('chart-container')).toBeInTheDocument();
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow up from https://github.com/apache/superset/pull/35343 

Add a fallback mechanism to get chart state from form_data.
 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Testing suite should pass

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
