### PR TITLE
fix(ui): standardize kebab menu behavior across dashboard cards

### DIFF
--- a/superset-frontend/src/components/KebabMenuButton/KebabMenuButton.test.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/KebabMenuButton.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import type { MenuItemType } from '@superset-ui/core/components/Menu';
+import { KebabMenuButton, KebabMenuButtonProps } from './index';
+
+const mockMenuItems: MenuItemType[] = [
+  {
+    key: 'edit',
+    label: 'Edit',
+  },
+  {
+    key: 'delete',
+    label: 'Delete',
+  },
+  {
+    key: 'share',
+    label: 'Share',
+  },
+];
+
+const defaultProps: Partial<KebabMenuButtonProps> = {
+  menuItems: mockMenuItems,
+  dataTest: 'kebab-menu-button',
+};
+
+const setup = (props: Partial<KebabMenuButtonProps> = defaultProps) =>
+  render(<KebabMenuButton menuItems={mockMenuItems} {...props} />, {
+    useRouter: true,
+  });
+
+test('should render with default props', () => {
+  const { container } = setup();
+  expect(container).toBeInTheDocument();
+  expect(screen.getByRole('button')).toBeInTheDocument();
+});
+
+test('should render with horizontal icon orientation by default', () => {
+  setup();
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  // Check for horizontal three-dot icon (MoreOutlined)
+  const icon = button.querySelector('svg');
+  expect(icon).toBeInTheDocument();
+});
+
+test('should render with vertical icon orientation', () => {
+  setup({ ...defaultProps, iconOrientation: 'vertical' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  // Check for vertical three-dot icon (EllipsisOutlined with rotation)
+  const icon = button.querySelector('svg');
+  expect(icon).toBeInTheDocument();
+});
+
+test('should render custom icon when provided', () => {
+  const customIcon = <span data-test="custom-icon">★</span>;
+  setup({ ...defaultProps, icon: customIcon });
+  expect(screen.getByText('★')).toBeInTheDocument();
+});
+
+test('should have correct aria attributes for accessibility', () => {
+  setup({ ...defaultProps, ariaLabel: 'Menu Options' });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-label', 'Menu Options');
+  expect(button).toHaveAttribute('aria-haspopup', 'true');
+});
+
+test('should use default aria-label when not provided', () => {
+  setup();
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-label', 'More Options');
+});
+
+test('should have correct data-test attribute', () => {
+  setup({ ...defaultProps, dataTest: 'custom-test-id' });
+  const button = screen.getByTestId('custom-test-id');
+  expect(button).toBeInTheDocument();
+});
+
+test('should have correct button id when provided', () => {
+  setup({ ...defaultProps, buttonId: 'my-button-id' });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('id', 'my-button-id');
+});
+
+test('should open menu on click', async () => {
+  setup();
+  const button = screen.getByRole('button');
+
+  // Click the button to open menu
+  await userEvent.click(button);
+
+  // Check if menu items appear
+  expect(await screen.findByText('Edit')).toBeInTheDocument();
+  expect(screen.getByText('Delete')).toBeInTheDocument();
+  expect(screen.getByText('Share')).toBeInTheDocument();
+});
+
+test('should render menu items correctly', async () => {
+  setup();
+  const button = screen.getByRole('button');
+
+  // Open the menu
+  await userEvent.click(button);
+
+  // Verify all menu items are present
+  expect(screen.getByText('Edit')).toBeInTheDocument();
+  expect(screen.getByText('Delete')).toBeInTheDocument();
+  expect(screen.getByText('Share')).toBeInTheDocument();
+});
+
+test('should apply custom button size', () => {
+  setup({ ...defaultProps, buttonSize: 'small' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  // The button component applies size through classes/props
+});
+
+test('should apply custom button style', () => {
+  setup({ ...defaultProps, buttonStyle: 'primary' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+});
+
+test('should use link button style by default', () => {
+  setup();
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+});
+
+test('should apply custom placement', () => {
+  setup({ ...defaultProps, placement: 'topRight' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+});

--- a/superset-frontend/src/components/KebabMenuButton/index.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { css, useTheme } from '@apache-superset/core/ui';
+import { css } from '@apache-superset/core/ui';
 import { Dropdown, Button } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { MenuItem } from '@superset-ui/core/components/Menu';
@@ -60,7 +60,7 @@ export interface KebabMenuButtonProps {
    */
   overlayStyle?: React.CSSProperties;
   /**
-   * Optional: Dropdown placement
+   * Optional: Dropdown placement (defaults to Ant Design's 'bottomLeft' if not specified)
    */
   placement?:
     | 'bottomLeft'
@@ -94,33 +94,19 @@ export function KebabMenuButton({
   buttonStyle,
   buttonCss,
   overlayStyle,
-  placement = 'bottomRight',
+  placement,
   iconOrientation = 'horizontal',
 }: KebabMenuButtonProps) {
-  const theme = useTheme();
-
   const defaultIcon =
     iconOrientation === 'vertical' ? (
       <Icons.EllipsisOutlined
         css={css`
           transform: rotate(90deg);
-          &:hover {
-            cursor: pointer;
-          }
         `}
         iconSize="xl"
-        iconColor={theme.colorTextLabel}
       />
     ) : (
-      <Icons.MoreOutlined
-        iconSize="xl"
-        iconColor={theme.colorTextLabel}
-        css={css`
-          &:hover {
-            cursor: pointer;
-          }
-        `}
-      />
+      <Icons.MoreOutlined iconSize="xl" />
     );
 
   return (

--- a/superset-frontend/src/components/KebabMenuButton/index.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/index.tsx
@@ -17,10 +17,11 @@
  * under the License.
  */
 import { ReactNode } from 'react';
-import { css } from '@apache-superset/core/ui';
+import { css, useTheme } from '@apache-superset/core/ui';
 import { Dropdown, Button } from '@superset-ui/core/components';
 import { Icons } from '@superset-ui/core/components/Icons';
-import { MenuItem } from '@superset-ui/core/components/Menu';
+import type { MenuItem } from '@superset-ui/core/components/Menu';
+import type { ButtonProps } from '@superset-ui/core/components/Button';
 
 export interface KebabMenuButtonProps {
   /**
@@ -34,7 +35,7 @@ export interface KebabMenuButtonProps {
   /**
    * Optional: Button size (default: 'xsmall')
    */
-  buttonSize?: 'small' | 'xsmall';
+  buttonSize?: ButtonProps['buttonSize'];
   /**
    * Optional: aria-label for accessibility
    */
@@ -50,7 +51,7 @@ export interface KebabMenuButtonProps {
   /**
    * Optional: Button style (default: 'link')
    */
-  buttonStyle?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'link';
+  buttonStyle?: ButtonProps['buttonStyle'];
   /**
    * Optional: Additional CSS for the button
    */
@@ -97,16 +98,24 @@ export function KebabMenuButton({
   placement,
   iconOrientation = 'horizontal',
 }: KebabMenuButtonProps) {
+  const theme = useTheme();
+
   const defaultIcon =
     iconOrientation === 'vertical' ? (
       <Icons.EllipsisOutlined
         css={css`
+          color: ${theme.colorTextLabel};
           transform: rotate(90deg);
         `}
         iconSize="xl"
       />
     ) : (
-      <Icons.MoreOutlined iconSize="xl" />
+      <Icons.MoreOutlined
+        css={css`
+          color: ${theme.colorTextLabel};
+        `}
+        iconSize="xl"
+      />
     );
 
   return (

--- a/superset-frontend/src/components/KebabMenuButton/index.tsx
+++ b/superset-frontend/src/components/KebabMenuButton/index.tsx
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ReactNode } from 'react';
+import { css, useTheme } from '@apache-superset/core/ui';
+import { Dropdown, Button } from '@superset-ui/core/components';
+import { Icons } from '@superset-ui/core/components/Icons';
+import { MenuItem } from '@superset-ui/core/components/Menu';
+
+export interface KebabMenuButtonProps {
+  /**
+   * Menu items to display in the dropdown
+   */
+  menuItems: MenuItem[];
+  /**
+   * Optional: Custom icon to use instead of the default three-dot icon
+   */
+  icon?: ReactNode;
+  /**
+   * Optional: Button size (default: 'xsmall')
+   */
+  buttonSize?: 'small' | 'xsmall';
+  /**
+   * Optional: aria-label for accessibility
+   */
+  ariaLabel?: string;
+  /**
+   * Optional: data-test attribute for testing
+   */
+  dataTest?: string;
+  /**
+   * Optional: Button id attribute
+   */
+  buttonId?: string;
+  /**
+   * Optional: Button style (default: 'link')
+   */
+  buttonStyle?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'link';
+  /**
+   * Optional: Additional CSS for the button
+   */
+  buttonCss?: ReturnType<typeof css>;
+  /**
+   * Optional: Additional styles for the dropdown overlay
+   */
+  overlayStyle?: React.CSSProperties;
+  /**
+   * Optional: Dropdown placement
+   */
+  placement?:
+    | 'bottomLeft'
+    | 'bottomCenter'
+    | 'bottomRight'
+    | 'topLeft'
+    | 'topCenter'
+    | 'topRight';
+  /**
+   * Optional: IconOrientation - 'horizontal' for horizontal dots, 'vertical' for vertical dots
+   */
+  iconOrientation?: 'horizontal' | 'vertical';
+}
+
+/**
+ * Standardized kebab menu button component with consistent styling and behavior
+ * across Welcome page cards and Dashboard/Chart cards.
+ *
+ * Features:
+ * - Uses colorTextLabel for consistent icon color
+ * - Opens on click (not hover) for better UX consistency
+ * - Wraps Ant Design Dropdown with Superset conventions
+ */
+export function KebabMenuButton({
+  menuItems,
+  icon,
+  buttonSize = 'xsmall',
+  ariaLabel = 'More Options',
+  dataTest,
+  buttonId,
+  buttonStyle,
+  buttonCss,
+  overlayStyle,
+  placement = 'bottomRight',
+  iconOrientation = 'horizontal',
+}: KebabMenuButtonProps) {
+  const theme = useTheme();
+
+  const defaultIcon =
+    iconOrientation === 'vertical' ? (
+      <Icons.EllipsisOutlined
+        css={css`
+          transform: rotate(90deg);
+          &:hover {
+            cursor: pointer;
+          }
+        `}
+        iconSize="xl"
+        iconColor={theme.colorTextLabel}
+      />
+    ) : (
+      <Icons.MoreOutlined
+        iconSize="xl"
+        iconColor={theme.colorTextLabel}
+        css={css`
+          &:hover {
+            cursor: pointer;
+          }
+        `}
+      />
+    );
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems }}
+      trigger={['click']}
+      placement={placement}
+      overlayStyle={overlayStyle}
+    >
+      <Button
+        id={buttonId}
+        buttonSize={buttonSize}
+        buttonStyle={buttonStyle || 'link'}
+        aria-label={ariaLabel}
+        aria-haspopup="true"
+        data-test={dataTest}
+        css={buttonCss}
+      >
+        {icon || defaultIcon}
+      </Button>
+    </Dropdown>
+  );
+}

--- a/superset-frontend/src/components/index.ts
+++ b/superset-frontend/src/components/index.ts
@@ -49,3 +49,4 @@ export {
   type PluginContextType,
 } from './DynamicPlugins';
 export * from './FacePile';
+export { KebabMenuButton, type KebabMenuButtonProps } from './KebabMenuButton';

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -564,12 +564,8 @@ const SliceHeaderControls = (
           <Icons.EllipsisOutlined
             css={css`
               transform: rotate(90deg);
-              &:hover {
-                cursor: pointer;
-              }
             `}
             iconSize="xl"
-            iconColor={theme.colorTextLabel}
             className="dot"
           />
         </Button>

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -566,6 +566,7 @@ const SliceHeaderControls = (
               transform: rotate(90deg);
             `}
             iconSize="xl"
+            iconColor={theme.colorTextLabel}
             className="dot"
           />
         </Button>

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -78,23 +78,6 @@ const RefreshTooltip = styled.div`
 const getScreenshotNodeSelector = (chartId: string | number) =>
   `.dashboard-chart-id-${chartId}`;
 
-const VerticalDotsTrigger = () => {
-  const theme = useTheme();
-  return (
-    <Icons.EllipsisOutlined
-      css={css`
-        transform: rotate(90deg);
-        &:hover {
-          cursor: pointer;
-        }
-      `}
-      iconSize="xl"
-      iconColor={theme.colorTextLabel}
-      className="dot"
-    />
-  );
-};
-
 export interface SliceHeaderControlsProps {
   slice: {
     description: string;
@@ -578,7 +561,17 @@ const SliceHeaderControls = (
             padding-right: 0px;
           `}
         >
-          <VerticalDotsTrigger />
+          <Icons.EllipsisOutlined
+            css={css`
+              transform: rotate(90deg);
+              &:hover {
+                cursor: pointer;
+              }
+            `}
+            iconSize="xl"
+            iconColor={theme.colorTextLabel}
+            className="dot"
+          />
         </Button>
       </NoAnimationDropdown>
       <DrillDetailModal

--- a/superset-frontend/src/features/charts/ChartCard.tsx
+++ b/superset-frontend/src/features/charts/ChartCard.tsx
@@ -21,8 +21,6 @@ import { css } from '@apache-superset/core/ui';
 import { Link, useHistory } from 'react-router-dom';
 import {
   ConfirmStatusChange,
-  Button,
-  Dropdown,
   FaveStar,
   Label,
   ListViewCard,
@@ -30,7 +28,7 @@ import {
   MenuItem,
 } from '@superset-ui/core/components';
 import Chart from 'src/types/Chart';
-import { FacePile } from 'src/components';
+import { FacePile, KebabMenuButton } from 'src/components';
 import { handleChartDelete, CardStyles } from 'src/views/CRUD/utils';
 import { assetUrl } from 'src/utils/assetUrl';
 
@@ -201,11 +199,7 @@ export default function ChartCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown menu={{ items: menuItems }} trigger={['click', 'hover']}>
-              <Button buttonSize="xsmall" type="link" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
+            <KebabMenuButton menuItems={menuItems} dataTest="chart-card-menu" />
           </ListViewCard.Actions>
         }
       />

--- a/superset-frontend/src/features/dashboards/DashboardCard.tsx
+++ b/superset-frontend/src/features/dashboards/DashboardCard.tsx
@@ -26,8 +26,6 @@ import {
 } from '@superset-ui/core';
 import { CardStyles } from 'src/views/CRUD/utils';
 import {
-  Dropdown,
-  Button,
   FaveStar,
   PublishedLabel,
   ListViewCard,
@@ -36,7 +34,7 @@ import { MenuItem } from '@superset-ui/core/components/Menu';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { Dashboard } from 'src/views/CRUD/types';
 import { assetUrl } from 'src/utils/assetUrl';
-import { FacePile } from 'src/components';
+import { FacePile, KebabMenuButton } from 'src/components';
 
 interface DashboardCardProps {
   isChart?: boolean;
@@ -191,11 +189,10 @@ function DashboardCard({
                 isStarred={favoriteStatus}
               />
             )}
-            <Dropdown menu={{ items: menuItems }} trigger={['hover', 'click']}>
-              <Button buttonSize="xsmall" buttonStyle="link">
-                <Icons.MoreOutlined iconSize="xl" />
-              </Button>
-            </Dropdown>
+            <KebabMenuButton
+              menuItems={menuItems}
+              dataTest="dashboard-card-menu"
+            />
           </ListViewCard.Actions>
         }
       />


### PR DESCRIPTION
fixes #36324


I noticed that the three-dot (kebab) menu behaved a bit differently depending on where it appeared. Welcome page cards and Dashboard page cards were using different color tokens and different interaction patterns (hover vs click) for what is effectively the same control. This PR cleans that up by introducing a small shared KebabMenuButton component and using it consistently in DashboardCard, ChartCard, and SliceHeaderControls. The result is a uniform look and click based interaction across all card menus


https://github.com/user-attachments/assets/a74ea904-9ec5-471b-b370-cf94fc886b74



### TEST FIX

open Superset and check the three-dot menu on both Welcome page cards and Dashboard page cards (including chart cards). Confirm that the menu icon uses the same color in all contexts and that the menu opens on click (not on hover).

### ADDITIONAL INFORMATION
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
