### PR TITLE
feat: Adds a right sidebar to SQL Lab

### DIFF
--- a/superset-frontend/src/SqlLab/components/App/index.tsx
+++ b/superset-frontend/src/SqlLab/components/App/index.tsx
@@ -37,6 +37,7 @@ import {
 } from 'src/logger/LogUtils';
 import TabbedSqlEditors from '../TabbedSqlEditors';
 import QueryAutoRefresh from '../QueryAutoRefresh';
+import RightSidebar from '../RightSidebar';
 
 const SqlLabStyles = styled.div`
   ${({ theme }) => css`
@@ -47,6 +48,18 @@ const SqlLabStyles = styled.div`
       bottom: 0;
       left: 0;
       padding: 0 ${theme.sizeUnit * 2}px;
+
+      .SqlLab-main {
+        display: flex;
+        flex-direction: row;
+        height: 100%;
+        width: 100%;
+
+        > *:first-child {
+          flex: 1;
+          min-width: 0;
+        }
+      }
 
       pre:not(.code) {
         padding: 0 !important;
@@ -216,7 +229,10 @@ class App extends PureComponent<AppProps, AppState> {
           queries={queries}
           queriesLastUpdate={queriesLastUpdate}
         />
-        <TabbedSqlEditors />
+        <div className="SqlLab-main">
+          <TabbedSqlEditors />
+          <RightSidebar />
+        </div>
       </SqlLabStyles>
     );
   }

--- a/superset-frontend/src/SqlLab/components/RightSidebar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RightSidebar/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Resizable } from 're-resizable';
+import { css, styled, useTheme } from '@apache-superset/core/ui';
+import { useExtensionsContext } from 'src/extensions/ExtensionsContext';
+import ExtensionsManager from 'src/extensions/ExtensionsManager';
+import useStoredSidebarWidth from 'src/components/ResizableSidebar/useStoredSidebarWidth';
+
+export const RIGHT_SIDEBAR_VIEW_ID = 'sqllab.rightSidebar';
+
+const getDefaultWidth = () => Math.round(window.innerWidth * 0.25);
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 600;
+
+const RightSidebarContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    border-left: 1px solid ${theme.colorBorderSecondary};
+    overflow: hidden;
+  `}
+`;
+
+const ContentWrapper = styled.div`
+  flex: 1;
+  overflow: auto;
+`;
+
+const RightSidebar = () => {
+  const theme = useTheme();
+  const [width, setWidth] = useStoredSidebarWidth(
+    'sqllab.rightSidebar',
+    getDefaultWidth(),
+  );
+  const contributions =
+    ExtensionsManager.getInstance().getViewContributions(RIGHT_SIDEBAR_VIEW_ID) ||
+    [];
+  const { getView } = useExtensionsContext();
+
+  if (contributions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Resizable
+      enable={{ left: true }}
+      size={{ width, height: '100%' }}
+      minWidth={MIN_WIDTH}
+      maxWidth={MAX_WIDTH}
+      onResizeStop={(e, direction, ref, d) => setWidth(width + d.width)}
+      handleStyles={{
+        left: {
+          width: '4px',
+          left: 0,
+        },
+      }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: theme.colorBgContainer,
+      }}
+      handleComponent={{
+        left: (
+          <div
+            css={css`
+              width: 4px;
+              height: 100%;
+              cursor: col-resize;
+              transition: background-color 0.2s;
+              &:hover {
+                background-color: ${theme.colorPrimary};
+              }
+            `}
+          />
+        ),
+      }}
+    >
+      <RightSidebarContainer data-test="sql-lab-right-sidebar">
+        <ContentWrapper>
+          {contributions.map(contribution => getView(contribution.id))}
+        </ContentWrapper>
+      </RightSidebarContainer>
+    </Resizable>
+  );
+};
+
+export default RightSidebar;

--- a/superset-frontend/src/SqlLab/components/RightSidebar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RightSidebar/index.tsx
@@ -51,8 +51,9 @@ const RightSidebar = () => {
     getDefaultWidth(),
   );
   const contributions =
-    ExtensionsManager.getInstance().getViewContributions(RIGHT_SIDEBAR_VIEW_ID) ||
-    [];
+    ExtensionsManager.getInstance().getViewContributions(
+      RIGHT_SIDEBAR_VIEW_ID,
+    ) || [];
   const { getView } = useExtensionsContext();
 
   if (contributions.length === 0) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Adds a right sidebar to SQL Lab that only appears when there's an extension registered to that area.

See [[SIP-177] Proposal for SQL Lab Extensions](https://github.com/apache/superset/issues/34162)

The extension shown in the video below is not included in this pull request.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
https://github.com/user-attachments/assets/0fc0a030-0f6f-41b3-9642-9e04bf0d2b49

### TESTING INSTRUCTIONS
1. Register an extension to the right side bar using `sqllab.rightSideBar`.
2. Check that the extension appears

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
