### PR TITLE
fix(deckgl): use DatasourceType enum in polygon transformProps test + some TS issues

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChartProps } from '@superset-ui/core';
+import { ChartProps, DatasourceType } from '@superset-ui/core';
 import transformProps from './transformProps';
 
 interface PolygonFeature {
@@ -55,7 +55,13 @@ describe('Polygon transformProps', () => {
         ],
       },
     ],
-    datasource: { type: 'table' as const, id: 1 },
+    datasource: {
+      type: DatasourceType.Table,
+      id: 1,
+      name: 'test_datasource',
+      columns: [],
+      metrics: [],
+    },
     height: 400,
     width: 600,
     hooks: {},


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes TypeScript error in the Polygon transformProps test introduced in [#35266](https://github.com/apache/superset/pull/35266)

<img width="710" height="250" alt="image" src="https://github.com/user-attachments/assets/4a33cfda-2de9-4c7f-b553-9581ef04100f" />

The test was using `'table' as const` for the datasource type, which TypeScript doesn't recognize as assignable to the `DatasourceType` enum. This PR:
- Imports `DatasourceType` from `@superset-ui/core`
- Uses `DatasourceType.Table` instead of the string literal
- Adds required `Datasource` interface properties (`name`, `columns`, `metrics`)

