### PR TITLE
feat(dashboard): implement boolean conditional formatting

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -490,7 +490,7 @@ export type ColorFormatters = {
   column: string;
   toAllRow?: boolean;
   toTextColor?: boolean;
-  getColorFromValue: (value: number | string | boolean) => string | undefined;
+  getColorFromValue: (value: number | string | boolean | null) => string | undefined;
 }[];
 
 export default {};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -462,6 +462,10 @@ export enum Comparator {
   EndsWith = 'ends with',
   Containing = 'containing',
   NotContaining = 'not containing',
+  IsTrue = 'is true',
+  IsFalse = 'is false',
+  IsNull = 'is null',
+  IsNotNull = 'is not null',
 }
 
 export const MultipleValueComparators = [
@@ -473,7 +477,7 @@ export const MultipleValueComparators = [
 
 export type ConditionalFormattingConfig = {
   operator?: Comparator;
-  targetValue?: number | string;
+  targetValue?: number | string | boolean;
   targetValueLeft?: number;
   targetValueRight?: number;
   column?: string;
@@ -486,7 +490,7 @@ export type ColorFormatters = {
   column: string;
   toAllRow?: boolean;
   toTextColor?: boolean;
-  getColorFromValue: (value: number | string) => string | undefined;
+  getColorFromValue: (value: number | string | boolean) => string | undefined;
 }[];
 
 export default {};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -490,7 +490,9 @@ export type ColorFormatters = {
   column: string;
   toAllRow?: boolean;
   toTextColor?: boolean;
-  getColorFromValue: (value: number | string | boolean | null) => string | undefined;
+  getColorFromValue: (
+    value: number | string | boolean | null,
+  ) => string | undefined;
 }[];
 
 export default {};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/types.ts
@@ -477,7 +477,7 @@ export const MultipleValueComparators = [
 
 export type ConditionalFormattingConfig = {
   operator?: Comparator;
-  targetValue?: number | string | boolean;
+  targetValue?: number | string;
   targetValueLeft?: number;
   targetValueRight?: number;
   column?: string;

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -33,17 +33,12 @@ const MIN_OPACITY_UNBOUNDED = 0;
 const MAX_OPACITY = 1;
 export const getOpacity = (
   value: number | string | boolean | null,
-  cutoffPoint: number | string | boolean,
-  extremeValue: number | string | boolean,
+  cutoffPoint: number | string,
+  extremeValue: number | string,
   minOpacity = MIN_OPACITY_BOUNDED,
   maxOpacity = MAX_OPACITY,
 ) => {
-  if (
-    extremeValue === cutoffPoint ||
-    typeof value !== 'number' ||
-    typeof cutoffPoint === 'boolean' ||
-    typeof extremeValue === 'boolean'
-  ) {
+  if (extremeValue === cutoffPoint || typeof value !== 'number') {
     return maxOpacity;
   }
   const numCutoffPoint =
@@ -84,12 +79,7 @@ export const getColorFunction = (
   let comparatorFunction: (
     value: number | string | boolean | null,
     allValues: number[] | string[] | (boolean | null)[],
-  ) =>
-    | false
-    | {
-        cutoffValue: number | string | boolean;
-        extremeValue: number | string | boolean;
-      };
+  ) => false | { cutoffValue: number | string; extremeValue: number | string };
   if (operator === undefined || colorScheme === undefined) {
     return () => undefined;
   }
@@ -109,10 +99,7 @@ export const getColorFunction = (
   switch (operator) {
     case Comparator.None:
       minOpacity = MIN_OPACITY_UNBOUNDED;
-      comparatorFunction = (
-        value: number | string | boolean | null,
-        allValues: number[],
-      ) => {
+      comparatorFunction = (value: number | string, allValues: number[]) => {
         if (typeof value !== 'number') {
           return { cutoffValue: value!, extremeValue: value! };
         }

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getColorFormatters.ts
@@ -32,7 +32,7 @@ const MIN_OPACITY_BOUNDED = 0.05;
 const MIN_OPACITY_UNBOUNDED = 0;
 const MAX_OPACITY = 1;
 export const getOpacity = (
-  value: number | string | boolean,
+  value: number | string | boolean | null,
   cutoffPoint: number | string | boolean,
   extremeValue: number | string | boolean,
   minOpacity = MIN_OPACITY_BOUNDED,
@@ -75,15 +75,15 @@ export const getColorFunction = (
     targetValueRight,
     colorScheme,
   }: ConditionalFormattingConfig,
-  columnValues: number[] | string[] | boolean[],
+  columnValues: number[] | string[] | (boolean | null)[],
   alpha?: boolean,
 ) => {
   let minOpacity = MIN_OPACITY_BOUNDED;
   const maxOpacity = MAX_OPACITY;
 
   let comparatorFunction: (
-    value: number | string | boolean,
-    allValues: number[] | string[] | boolean[],
+    value: number | string | boolean | null,
+    allValues: number[] | string[] | (boolean | null)[],
   ) =>
     | false
     | {
@@ -110,7 +110,7 @@ export const getColorFunction = (
     case Comparator.None:
       minOpacity = MIN_OPACITY_UNBOUNDED;
       comparatorFunction = (
-        value: number | string | boolean,
+        value: number | string | boolean | null,
         allValues: number[],
       ) => {
         if (typeof value !== 'number') {
@@ -237,25 +237,25 @@ export const getColorFunction = (
 
       break;
     case Comparator.IsTrue:
-      comparatorFunction = (value: boolean) =>
+      comparatorFunction = (value: boolean | null) =>
         isBoolean(value) && value
           ? { cutoffValue: targetValue!, extremeValue: targetValue! }
           : false;
       break;
     case Comparator.IsFalse:
-      comparatorFunction = (value: boolean) =>
+      comparatorFunction = (value: boolean | null) =>
         isBoolean(value) && !value
           ? { cutoffValue: targetValue!, extremeValue: targetValue! }
           : false;
       break;
     case Comparator.IsNull:
-      comparatorFunction = (value: boolean) =>
-        isBoolean(value) && value === null
+      comparatorFunction = (value: boolean | null) =>
+        value === null
           ? { cutoffValue: targetValue!, extremeValue: targetValue! }
           : false;
       break;
     case Comparator.IsNotNull:
-      comparatorFunction = (value: boolean) =>
+      comparatorFunction = (value: boolean | null) =>
         isBoolean(value) && value !== null
           ? { cutoffValue: targetValue!, extremeValue: targetValue! }
           : false;
@@ -265,7 +265,7 @@ export const getColorFunction = (
       break;
   }
 
-  return (value: number | string | boolean) => {
+  return (value: number | string | boolean | null) => {
     const compareResult = comparatorFunction(value, columnValues);
     if (compareResult === false) return undefined;
     const { cutoffValue, extremeValue } = compareResult;

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -450,7 +450,7 @@ test('getColorFunction IsTrue', () => {
   const colorFunction = getColorFunction(
     {
       operator: Comparator.IsTrue,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
@@ -465,7 +465,7 @@ test('getColorFunction IsFalse', () => {
   const colorFunction = getColorFunction(
     {
       operator: Comparator.IsFalse,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
@@ -480,7 +480,7 @@ test('getColorFunction IsNull', () => {
   const colorFunction = getColorFunction(
     {
       operator: Comparator.IsNull,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
@@ -495,7 +495,7 @@ test('getColorFunction IsNotNull', () => {
   const colorFunction = getColorFunction(
     {
       operator: Comparator.IsNotNull,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
@@ -600,25 +600,25 @@ test('correct column boolean config', () => {
   const columnConfigBoolean = [
     {
       operator: Comparator.IsTrue,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
     {
       operator: Comparator.IsFalse,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
     {
       operator: Comparator.IsNull,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },
     {
       operator: Comparator.IsNotNull,
-      targetValue: true,
+      targetValue: '',
       colorScheme: '#FF0000',
       column: 'isMember',
     },

--- a/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/utils/getColorFormatters.test.ts
@@ -35,6 +35,9 @@ const countValues = mockData.map(row => row.count);
 const strData = [{ name: 'Brian' }, { name: 'Carlos' }, { name: 'Diana' }];
 const strValues = strData.map(row => row.name);
 
+const boolData = [{ isMember: true }, { isMember: false }, { isMember: null }];
+const boolValues = boolData.map(row => row.isMember);
+
 test('round', () => {
   expect(round(1)).toEqual(1);
   expect(round(1, 2)).toEqual(1);
@@ -443,6 +446,66 @@ test('getColorFunction None', () => {
   expect(colorFunction('Brian')).toEqual('#FF0000FF');
 });
 
+test('getColorFunction IsTrue', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.IsTrue,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    boolValues,
+  );
+  expect(colorFunction(true)).toEqual('#FF0000FF');
+  expect(colorFunction(false)).toBeUndefined();
+  expect(colorFunction(null)).toBeUndefined();
+});
+
+test('getColorFunction IsFalse', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.IsFalse,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    boolValues,
+  );
+  expect(colorFunction(true)).toBeUndefined();
+  expect(colorFunction(false)).toEqual('#FF0000FF');
+  expect(colorFunction(null)).toBeUndefined();
+});
+
+test('getColorFunction IsNull', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.IsNull,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    boolValues,
+  );
+  expect(colorFunction(true)).toBeUndefined();
+  expect(colorFunction(false)).toBeUndefined();
+  expect(colorFunction(null)).toEqual('#FF0000FF');
+});
+
+test('getColorFunction IsNotNull', () => {
+  const colorFunction = getColorFunction(
+    {
+      operator: Comparator.IsNotNull,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    boolValues,
+  );
+  expect(colorFunction(true)).toEqual('#FF0000FF');
+  expect(colorFunction(false)).toEqual('#FF0000FF');
+  expect(colorFunction(null)).toBeUndefined();
+});
+
 test('correct column config', () => {
   const columnConfig = [
     {
@@ -531,4 +594,48 @@ test('correct column string config', () => {
 
   expect(colorFormatters[3].column).toEqual('name');
   expect(colorFormatters[3].getColorFromValue('Carlos')).toEqual('#FF0000FF');
+});
+
+test('correct column boolean config', () => {
+  const columnConfigBoolean = [
+    {
+      operator: Comparator.IsTrue,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    {
+      operator: Comparator.IsFalse,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    {
+      operator: Comparator.IsNull,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+    {
+      operator: Comparator.IsNotNull,
+      targetValue: true,
+      colorScheme: '#FF0000',
+      column: 'isMember',
+    },
+  ];
+  const colorFormatters = getColorFormatters(columnConfigBoolean, boolData);
+  expect(colorFormatters.length).toEqual(4);
+
+  expect(colorFormatters[0].column).toEqual('isMember');
+  expect(colorFormatters[0].getColorFromValue(true)).toEqual('#FF0000FF');
+
+  expect(colorFormatters[1].column).toEqual('isMember');
+  expect(colorFormatters[1].getColorFromValue(false)).toEqual('#FF0000FF');
+
+  expect(colorFormatters[2].column).toEqual('isMember');
+  expect(colorFormatters[2].getColorFromValue(null)).toEqual('#FF0000FF');
+
+  expect(colorFormatters[3].column).toEqual('isMember');
+  expect(colorFormatters[3].getColorFromValue(true)).toEqual('#FF0000FF');
+  expect(colorFormatters[3].getColorFromValue(false)).toEqual('#FF0000FF');
 });

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -907,10 +907,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
               formatter: ColorFormatters[number],
               valueToFormat: any,
             ) => {
-              const hasValue =
-                valueToFormat !== undefined && valueToFormat !== null;
-              if (!hasValue) return;
-
               const formatterResult =
                 formatter.getColorFromValue(valueToFormat);
               if (!formatterResult) return;

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -797,7 +797,8 @@ const config: ControlPanelConfig = {
                         if (
                           coltypes[index] === GenericDataType.Numeric ||
                           (!explore?.controls?.time_compare?.value &&
-                            coltypes[index] === GenericDataType.String)
+                            (coltypes[index] === GenericDataType.String ||
+                              coltypes[index] === GenericDataType.Boolean))
                         ) {
                           acc.push({
                             value: colname,

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -613,7 +613,9 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByTitle('2467063')).background).toBe(
           '',
         );
-        expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
+        expect(getComputedStyle(screen.getByText('N/A')).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
       });
       test('should display original label in grouped headers', () => {
         const props = transformProps(testData.comparison);
@@ -984,6 +986,128 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(screen.getByText('Maria')).background).toBe(
           'rgba(172, 225, 196, 1)',
         );
+      });
+
+      test('render color with boolean column color formatter (operator is true)', () => {
+        render(
+          ProviderWrapper({
+            children: (
+              <TableChart
+                {...transformProps({
+                  ...testData.nameAndBoolean,
+                  rawFormData: {
+                    ...testData.nameAndBoolean.rawFormData,
+                    conditional_formatting: [
+                      {
+                        colorScheme: '#ACE1C4',
+                        column: 'is_adult',
+                        operator: 'is true',
+                        targetValue: '',
+                      },
+                    ],
+                  },
+                })}
+              />
+            ),
+          }),
+        );
+        expect(getComputedStyle(screen.getByText('true')).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
+        expect(getComputedStyle(screen.getByText('false')).background).toBe('');
+      });
+
+      test('render color with boolean column color formatter (operator is false)', () => {
+        render(
+          ProviderWrapper({
+            children: (
+              <TableChart
+                {...transformProps({
+                  ...testData.nameAndBoolean,
+                  rawFormData: {
+                    ...testData.nameAndBoolean.rawFormData,
+                    conditional_formatting: [
+                      {
+                        colorScheme: '#ACE1C4',
+                        column: 'is_adult',
+                        operator: 'is false',
+                        targetValue: '',
+                      },
+                    ],
+                  },
+                })}
+              />
+            ),
+          }),
+        );
+        expect(getComputedStyle(screen.getByText('false')).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
+        expect(getComputedStyle(screen.getByText('true')).background).toBe('');
+      });
+
+      test('render color with boolean column color formatter (operator is null)', () => {
+        render(
+          ProviderWrapper({
+            children: (
+              <TableChart
+                {...transformProps({
+                  ...testData.nameAndBoolean,
+                  rawFormData: {
+                    ...testData.nameAndBoolean.rawFormData,
+                    conditional_formatting: [
+                      {
+                        colorScheme: '#ACE1C4',
+                        column: 'is_adult',
+                        operator: 'is null',
+                        targetValue: '',
+                      },
+                    ],
+                  },
+                })}
+              />
+            ),
+          }),
+        );
+        expect(getComputedStyle(screen.getByText('N/A')).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
+        expect(getComputedStyle(screen.getByText('true')).background).toBe('');
+        expect(getComputedStyle(screen.getByText('false')).background).toBe('');
+      });
+
+      test('render color with boolean column color formatter (operator is not null)', () => {
+        render(
+          ProviderWrapper({
+            children: (
+              <TableChart
+                {...transformProps({
+                  ...testData.nameAndBoolean,
+                  rawFormData: {
+                    ...testData.nameAndBoolean.rawFormData,
+                    conditional_formatting: [
+                      {
+                        colorScheme: '#ACE1C4',
+                        column: 'is_adult',
+                        operator: 'is not null',
+                        targetValue: '',
+                      },
+                    ],
+                  },
+                })}
+              />
+            ),
+          }),
+        );
+        const trueElements = screen.getAllByText('true');
+        const falseElements = screen.getAllByText('false');
+        expect(getComputedStyle(trueElements[0]).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
+        expect(getComputedStyle(falseElements[0]).background).toBe(
+          'rgba(172, 225, 196, 1)',
+        );
+        expect(getComputedStyle(screen.getByText('N/A')).background).toBe('');
       });
 
       test('render color with column color formatter to entire row', () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -370,6 +370,31 @@ const bigint = {
   ],
 };
 
+const nameAndBoolean: TableChartProps = {
+  ...new ChartProps(basicChartProps),
+  queriesData: [
+    {
+      ...basicQueryResult,
+      colnames: ['name', 'is_adult'],
+      coltypes: [GenericDataType.String, GenericDataType.Boolean],
+      data: [
+        {
+          name: 'Alice',
+          is_adult: true,
+        },
+        {
+          name: 'Bob',
+          is_adult: false,
+        },
+        {
+          name: 'Carl',
+          is_adult: null,
+        },
+      ],
+    },
+  ],
+};
+
 export default {
   basic,
   advanced,
@@ -379,4 +404,5 @@ export default {
   empty,
   raw,
   bigint,
+  nameAndBoolean,
 };

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.test.tsx
@@ -40,6 +40,11 @@ const columnsStringType = [
   { label: 'Column 2', value: 'column2', dataType: GenericDataType.String },
 ];
 
+const columnsBooleanType = [
+  { label: 'Column 1', value: 'column1', dataType: GenericDataType.Boolean },
+  { label: 'Column 2', value: 'column2', dataType: GenericDataType.Boolean },
+];
+
 const extraColorChoices = [
   {
     value: ColorSchemeEnum.Green,
@@ -146,6 +151,22 @@ test('displays the correct input fields based on the selected string type operat
   });
   fireEvent.click(await screen.findByTitle('begins with'));
   expect(await screen.findByLabelText('Target value')).toBeInTheDocument();
+});
+
+test('does not display the input fields when selected a boolean type operator', async () => {
+  render(
+    <FormattingPopoverContent
+      onChange={mockOnChange}
+      columns={columnsBooleanType}
+      extraColorChoices={extraColorChoices}
+    />,
+  );
+
+  fireEvent.change(screen.getAllByLabelText('Operator')[0], {
+    target: { value: Comparator.IsTrue },
+  });
+  fireEvent.click(await screen.findByTitle('is true'));
+  expect(await screen.queryByLabelText('Target value')).toBeNull();
 });
 
 test('displays the toAllRow and toTextColor flags based on the selected numeric type operator', () => {

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -205,7 +205,7 @@ const renderOperatorFields = (
             label={t('Target value')}
             initialValue={''}
             hidden
-           />
+          />
         </Col>
       </Row>
     );

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -197,7 +197,7 @@ const renderOperatorFields = (
 ) => {
   const columnTypeString = columnType === GenericDataType.String;
   const columnTypeBoolean = columnType === GenericDataType.Boolean;
-  const operatorColSpan = columnTypeString ? 8 : 6;
+  const operatorColSpan = columnTypeString || columnTypeBoolean ? 8 : 6;
   const valueColSpan = columnTypeString ? 16 : 18;
 
   if (columnTypeBoolean) {

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -91,6 +91,13 @@ const stringOperatorOptions = [
   { value: Comparator.NotContaining, label: t('not containing') },
 ];
 
+const booleanOperatorOptions = [
+  { value: Comparator.IsNull, label: t('is null') },
+  { value: Comparator.IsTrue, label: t('is true') },
+  { value: Comparator.IsFalse, label: t('is false') },
+  { value: Comparator.IsNotNull, label: t('is not null') },
+];
+
 const targetValueValidator =
   (
     compare: (targetValue: number, compareValue: number) => boolean,
@@ -160,7 +167,9 @@ const renderOperator = ({
   const options =
     columnType === GenericDataType.String
       ? stringOperatorOptions
-      : operatorOptions;
+      : columnType === GenericDataType.Boolean
+        ? booleanOperatorOptions
+        : operatorOptions;
 
   return (
     <FormItem
@@ -182,8 +191,25 @@ const renderOperatorFields = (
   columnType?: GenericDataType,
 ) => {
   const columnTypeString = columnType === GenericDataType.String;
+  const columnTypeBoolean = columnType === GenericDataType.Boolean;
   const operatorColSpan = columnTypeString ? 8 : 6;
   const valueColSpan = columnTypeString ? 16 : 18;
+
+  if (columnTypeBoolean) {
+    return (
+      <Row gutter={12}>
+        <Col span={operatorColSpan}>{renderOperator({ columnType })}</Col>
+        <Col span={valueColSpan}>
+          <FormItem
+            name="targetValue"
+            label={t('Target value')}
+            initialValue={''}
+            hidden
+           />
+        </Col>
+      </Row>
+    );
+  }
 
   return isOperatorNone(getFieldValue('operator')) ? (
     <Row gutter={12}>
@@ -307,7 +333,9 @@ export const FormattingPopoverContent = ({
       const defaultOperator =
         newColumnType === GenericDataType.String
           ? stringOperatorOptions[0].value
-          : operatorOptions[0].value;
+          : newColumnType === GenericDataType.Boolean
+            ? booleanOperatorOptions[0].value
+            : operatorOptions[0].value;
 
       form.setFieldsValue({
         operator: defaultOperator,

--- a/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
+++ b/superset-frontend/src/explore/components/controls/ConditionalFormattingControl/FormattingPopoverContent.tsx
@@ -164,12 +164,17 @@ const renderOperator = ({
   showOnlyNone,
   columnType,
 }: { showOnlyNone?: boolean; columnType?: GenericDataType } = {}) => {
-  const options =
-    columnType === GenericDataType.String
-      ? stringOperatorOptions
-      : columnType === GenericDataType.Boolean
-        ? booleanOperatorOptions
-        : operatorOptions;
+  let options;
+  switch (columnType) {
+    case GenericDataType.String:
+      options = stringOperatorOptions;
+      break;
+    case GenericDataType.Boolean:
+      options = booleanOperatorOptions;
+      break;
+    default:
+      options = operatorOptions;
+  }
 
   return (
     <FormItem
@@ -330,12 +335,20 @@ export const FormattingPopoverContent = ({
   const handleColumnChange = (value: string) => {
     const newColumnType = columns.find(item => item.value === value)?.dataType;
     if (newColumnType !== previousColumnType) {
-      const defaultOperator =
-        newColumnType === GenericDataType.String
-          ? stringOperatorOptions[0].value
-          : newColumnType === GenericDataType.Boolean
-            ? booleanOperatorOptions[0].value
-            : operatorOptions[0].value;
+      let defaultOperator: Comparator;
+
+      switch (newColumnType) {
+        case GenericDataType.String:
+          defaultOperator = stringOperatorOptions[0].value;
+          break;
+
+        case GenericDataType.Boolean:
+          defaultOperator = booleanOperatorOptions[0].value;
+          break;
+
+        default:
+          defaultOperator = operatorOptions[0].value;
+      }
 
       form.setFieldsValue({
         operator: defaultOperator,


### PR DESCRIPTION
## **User description**
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces **boolean conditional formatting** to the table chart’s conditional formatting configuration.

Until now, conditional formatting only worked for **numeric** and **string** columns. With this update, boolean columns are also supported through the following operators:

1. `isTrue`: highlight cells with a value of `true`
2. `isFalse`: highlight cell with a value of `false`
3. `isNull`: highlight empty or `null` cells
4. `isNull`: highlight non-empty cells

These enhancements would make conditional formatting more flexible and easier to use, especially for tables that include different data types.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/2574f720-519b-4ca2-94d0-83665986c3de

### TESTING INSTRUCTIONS

1. Manual Testing

   1. Create or open a Table chart that includes boolean columns.
   2. Add the boolean column you want to test.
   3. Open the custom conditional formatting panel and choose that column.
   4. Select the `isTrue` operator — cells with `true` should be highlighted.
   5. Select the `isFalse` operator — cells with `false` should be highlighted.
   6. Select the `isNull` operator — empty/null cells should be highlighted.
   7. Select the `isNotNull` operator — non-empty cells should be highlighted.
  
2. Automated Tests:

   - Run all tests:
```bash
cd superset-frontend
npm run test
```
   - Run specific unit tests added in this pr:
```bash
npm run test -- getColorFormatters
npm run test -- TableChart
npm run test -- FormattingPopoverContent
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add boolean-aware conditional formatting to table charts

### What Changed
- Table charts now support conditional formatting on boolean columns with operators for “is true”, “is false”, “is null”, and “is not null”
- Boolean columns appear in the conditional formatting panel with a simplified operator selector that does not require entering a target value
- Cells representing null or empty values (including those shown as “N/A”) can now be highlighted when they match the configured condition
- Added automated tests to cover boolean column formatting and the updated conditional formatting UI behavior

### Impact
`✅ Clearer true/false status in tables`
`✅ Easier highlighting of boolean columns`
`✅ Consistent styling of empty/null cells`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
