### PR TITLE
feat: added deterministic field generation to dashboard export

### DIFF
--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -50,6 +50,7 @@ DEFAULT_CHART_HEIGHT = 50
 DEFAULT_CHART_WIDTH = 4
 
 
+# No longer needed
 def suffix(length: int = 8) -> str:
     return "".join(
         random.SystemRandom().choice(string.ascii_uppercase + string.digits)
@@ -72,12 +73,12 @@ def get_default_position(title: str) -> dict[str, Any]:
 
 
 def append_charts(position: dict[str, Any], charts: set[Slice]) -> dict[str, Any]:
-    chart_hashes = [f"CHART-{suffix()}" for _ in charts]
+    chart_hashes = [f"CHART-{str(chart.uuid)}" for chart in charts]
 
     # if we have ROOT_ID/GRID_ID, append orphan charts to a new row inside the grid
     row_hash = None
     if "ROOT_ID" in position and "GRID_ID" in position["ROOT_ID"]["children"]:
-        row_hash = f"ROW-N-{suffix()}"
+        row_hash = f"ROW-N-{len(position['GRID_ID']['children'])}"
         position["GRID_ID"]["children"].append(row_hash)
         position[row_hash] = {
             "children": chart_hashes,

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -17,8 +17,6 @@
 # isort:skip_file
 
 import logging
-import random
-import string
 import uuid as uuid_module
 from typing import Any, Optional, Callable
 from collections.abc import Iterator
@@ -48,14 +46,6 @@ logger = logging.getLogger(__name__)
 JSON_KEYS = {"position_json": "position", "json_metadata": "metadata"}
 DEFAULT_CHART_HEIGHT = 50
 DEFAULT_CHART_WIDTH = 4
-
-
-# No longer needed
-def suffix(length: int = 8) -> str:
-    return "".join(
-        random.SystemRandom().choice(string.ascii_uppercase + string.digits)
-        for _ in range(length)
-    )
 
 
 def get_default_position(title: str) -> dict[str, Any]:

--- a/tests/integration_tests/dashboards/commands_tests.py
+++ b/tests/integration_tests/dashboards/commands_tests.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import itertools
 from unittest.mock import MagicMock, patch  # noqa: F401
 
 import pytest
@@ -348,22 +347,21 @@ class TestExportDashboardsCommand(SupersetTestCase):
         }
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
-    @patch("superset.commands.dashboard.export.suffix")
-    def test_append_charts(self, mock_suffix):
+    def test_append_charts(self):
         """Test that orphaned charts are added to the dashboard position"""
-        # return deterministic IDs
-        mock_suffix.side_effect = (str(i) for i in itertools.count(1))
-
+        # IDs are deterministic: charts are keyed by their UUID and rows are
+        # numbered by their position within the grid.
         position = get_default_position("example")
         chart_1 = (
             db.session.query(Slice).filter_by(slice_name="World's Population").one()
         )
+        chart_1_key = f"CHART-{chart_1.uuid}"
         new_position = append_charts(position, {chart_1})
         assert new_position == {
             "DASHBOARD_VERSION_KEY": "v2",
             "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT"},
             "GRID_ID": {
-                "children": ["ROW-N-2"],
+                "children": ["ROW-N-0"],
                 "id": "GRID_ID",
                 "parents": ["ROOT_ID"],
                 "type": "GRID",
@@ -373,16 +371,16 @@ class TestExportDashboardsCommand(SupersetTestCase):
                 "meta": {"text": "example"},
                 "type": "HEADER",
             },
-            "ROW-N-2": {
-                "children": ["CHART-1"],
-                "id": "ROW-N-2",
+            "ROW-N-0": {
+                "children": [chart_1_key],
+                "id": "ROW-N-0",
                 "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"},
                 "type": "ROW",
                 "parents": ["ROOT_ID", "GRID_ID"],
             },
-            "CHART-1": {
+            chart_1_key: {
                 "children": [],
-                "id": "CHART-1",
+                "id": chart_1_key,
                 "meta": {
                     "chartId": chart_1.id,
                     "height": 50,
@@ -391,19 +389,18 @@ class TestExportDashboardsCommand(SupersetTestCase):
                     "width": 4,
                 },
                 "type": "CHART",
-                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-2"],
+                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-0"],
             },
         }
 
-        chart_2 = (
-            db.session.query(Slice).filter_by(slice_name="World's Population").one()
-        )
+        chart_2 = db.session.query(Slice).filter_by(slice_name="Growth Rate").one()
+        chart_2_key = f"CHART-{chart_2.uuid}"
         new_position = append_charts(new_position, {chart_2})
         assert new_position == {
             "DASHBOARD_VERSION_KEY": "v2",
             "ROOT_ID": {"children": ["GRID_ID"], "id": "ROOT_ID", "type": "ROOT"},
             "GRID_ID": {
-                "children": ["ROW-N-2", "ROW-N-4"],
+                "children": ["ROW-N-0", "ROW-N-1"],
                 "id": "GRID_ID",
                 "parents": ["ROOT_ID"],
                 "type": "GRID",
@@ -413,23 +410,23 @@ class TestExportDashboardsCommand(SupersetTestCase):
                 "meta": {"text": "example"},
                 "type": "HEADER",
             },
-            "ROW-N-2": {
-                "children": ["CHART-1"],
-                "id": "ROW-N-2",
+            "ROW-N-0": {
+                "children": [chart_1_key],
+                "id": "ROW-N-0",
                 "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"},
                 "type": "ROW",
                 "parents": ["ROOT_ID", "GRID_ID"],
             },
-            "ROW-N-4": {
-                "children": ["CHART-3"],
-                "id": "ROW-N-4",
+            "ROW-N-1": {
+                "children": [chart_2_key],
+                "id": "ROW-N-1",
                 "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"},
                 "type": "ROW",
                 "parents": ["ROOT_ID", "GRID_ID"],
             },
-            "CHART-1": {
+            chart_1_key: {
                 "children": [],
-                "id": "CHART-1",
+                "id": chart_1_key,
                 "meta": {
                     "chartId": chart_1.id,
                     "height": 50,
@@ -438,29 +435,29 @@ class TestExportDashboardsCommand(SupersetTestCase):
                     "width": 4,
                 },
                 "type": "CHART",
-                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-2"],
+                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-0"],
             },
-            "CHART-3": {
+            chart_2_key: {
                 "children": [],
-                "id": "CHART-3",
+                "id": chart_2_key,
                 "meta": {
                     "chartId": chart_2.id,
                     "height": 50,
-                    "sliceName": "World's Population",
+                    "sliceName": "Growth Rate",
                     "uuid": str(chart_2.uuid),
                     "width": 4,
                 },
                 "type": "CHART",
-                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-4"],
+                "parents": ["ROOT_ID", "GRID_ID", "ROW-N-1"],
             },
         }
 
         position = {"DASHBOARD_VERSION_KEY": "v2"}
         new_position = append_charts(position, [chart_1, chart_2])
         assert new_position == {
-            "CHART-5": {
+            chart_1_key: {
                 "children": [],
-                "id": "CHART-5",
+                "id": chart_1_key,
                 "meta": {
                     "chartId": chart_1.id,
                     "height": 50,
@@ -470,13 +467,13 @@ class TestExportDashboardsCommand(SupersetTestCase):
                 },
                 "type": "CHART",
             },
-            "CHART-6": {
+            chart_2_key: {
                 "children": [],
-                "id": "CHART-6",
+                "id": chart_2_key,
                 "meta": {
                     "chartId": chart_2.id,
                     "height": 50,
-                    "sliceName": "World's Population",
+                    "sliceName": "Growth Rate",
                     "uuid": str(chart_2.uuid),
                     "width": 4,
                 },

--- a/tests/unit_tests/dashboards/export_append_charts_tests.py
+++ b/tests/unit_tests/dashboards/export_append_charts_tests.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import uuid
+
+from superset.commands.dashboard import export as export_module
+
+
+class DummySlice:
+    def __init__(self, id_: int, slice_uuid: uuid.UUID, slice_name: str = "chart"):
+        self.id = id_
+        self.uuid = slice_uuid
+        self.slice_name = slice_name
+
+
+def test_append_deterministic_fields():
+    # start with a default position (has ROOT_ID and GRID_ID)
+    position = export_module.get_default_position("test")
+
+    # create two dummy slices with known UUIDs
+    u1 = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    u2 = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    s1 = DummySlice(101, u1, "Chart One")
+    s2 = DummySlice(102, u2, "Chart Two")
+    charts = {s1, s2}
+
+    new_pos = export_module.append_charts(position, charts)
+
+    # chart keys should be CHART-<uuid>
+    expected_keys = {f"CHART-{str(u1)}", f"CHART-{str(u2)}"}
+
+    # row key should be ROW-N-<row number>
+    # expected row number is 0 since we started with only ROOT_ID and GRID_ID
+    expected_row = "ROW-N-0"
+
+    assert expected_row in new_pos, "expected row key in position"
+    for k in expected_keys:
+        assert k in new_pos, f"expected chart key {k} in position"
+
+    # Ensure meta.uuid equals the chart uuid and chartId equals id
+    for chart in (s1, s2):
+        key = f"CHART-{str(chart.uuid)}"
+        meta = new_pos[key]["meta"]
+        assert meta["uuid"] == str(chart.uuid)
+        assert meta["chartId"] == chart.id
+        assert meta["sliceName"] == chart.slice_name


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Instead of using randomly generated suffixes for rows and charts in export, now uses sequential row number for the row's id field and a chart's uuid for its id field (but not its chartId field).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Backend change, not applicable.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
`pytest -q tests/unit_tests/dashboards/export_append_charts_tests.py`


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/32987
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
