### PR TITLE
fix: CI failures caused by a ruff version mismatch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -71,7 +71,9 @@ jobs:
           GIT_DIFF_EXIT_CODE=$?
           if [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ] || [ "${GIT_DIFF_EXIT_CODE}" -ne 0 ]; then
             if [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ]; then
-              echo "❌ Pre-commit check failed (exit code: ${EXIT_CODE})."
+              echo "❌ Pre-commit check failed (exit code: ${PRE_COMMIT_EXIT_CODE})."
+              echo "🔍 Modified files:"
+              git diff --name-only
             else
               echo "❌ Git working directory is dirty."
               echo "📌 This likely means that pre-commit made changes that were not committed."

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -64,8 +64,11 @@ jobs:
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
+          echo "=== DEBUG: Git info ==="
+          git log --oneline -1
+          git ls-tree HEAD -- docker/pythonpath_dev/superset_config_docker_light.py
           echo "=== DEBUG: File content before pre-commit ==="
-          head -25 docker/pythonpath_dev/superset_config_docker_light.py
+          cat -n docker/pythonpath_dev/superset_config_docker_light.py | head -30
           echo "=== END DEBUG ==="
           export SKIP=eslint-frontend,type-checking-frontend
           pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -64,12 +64,6 @@ jobs:
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
-          echo "=== DEBUG: Git info ==="
-          git log --oneline -1
-          git ls-tree HEAD -- docker/pythonpath_dev/superset_config_docker_light.py
-          echo "=== DEBUG: File content before pre-commit ==="
-          cat -n docker/pythonpath_dev/superset_config_docker_light.py | head -30
-          echo "=== END DEBUG ==="
           export SKIP=eslint-frontend,type-checking-frontend
           pre-commit run --all-files
           PRE_COMMIT_EXIT_CODE=$?
@@ -80,8 +74,6 @@ jobs:
               echo "❌ Pre-commit check failed (exit code: ${PRE_COMMIT_EXIT_CODE})."
               echo "🔍 Modified files:"
               git diff --name-only
-              echo "🔍 Actual diff:"
-              git diff
             else
               echo "❌ Git working directory is dirty."
               echo "📌 This likely means that pre-commit made changes that were not committed."

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -80,6 +80,8 @@ jobs:
               echo "❌ Pre-commit check failed (exit code: ${PRE_COMMIT_EXIT_CODE})."
               echo "🔍 Modified files:"
               git diff --name-only
+              echo "🔍 Actual diff:"
+              git diff
             else
               echo "❌ Git working directory is dirty."
               echo "📌 This likely means that pre-commit made changes that were not committed."

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -64,6 +64,9 @@ jobs:
       - name: pre-commit
         run: |
           set +e  # Don't exit immediately on failure
+          echo "=== DEBUG: File content before pre-commit ==="
+          head -25 docker/pythonpath_dev/superset_config_docker_light.py
+          echo "=== END DEBUG ==="
           export SKIP=eslint-frontend,type-checking-frontend
           pre-commit run --all-files
           PRE_COMMIT_EXIT_CODE=$?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,12 +106,19 @@ repos:
         files: helm
         verbose: false
         args: ["--log-level", "error"]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.7
+  # Using local hooks ensures ruff version matches requirements/development.txt
+  - repo: local
     hooks:
       - id: ruff-format
+        name: ruff-format
+        entry: ruff format
+        language: system
+        types: [python]
       - id: ruff
-        args: [--fix]
+        name: ruff
+        entry: ruff check --fix
+        language: system
+        types: [python]
   - repo: local
     hooks:
       - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
         types: [python]
       - id: ruff
         name: ruff
-        entry: ruff check --fix
+        entry: ruff check --fix --show-fixes
         language: system
         types: [python]
   - repo: local

--- a/docker/pythonpath_dev/superset_config_docker_light.py
+++ b/docker/pythonpath_dev/superset_config_docker_light.py
@@ -19,6 +19,7 @@
 
 # Import all settings from the main config first
 from flask_caching.backends.filesystemcache import FileSystemCache
+
 from superset_config import *  # noqa: F403
 
 # Override caching to use simple in-memory cache instead of Redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,6 +352,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "superset/translations/utils.py" = ["TID251"]
 "superset/extensions/__init__.py" = ["TID251"]
 "superset/utils/json.py" = ["TID251"]
+"docker/*" = ["I"]  # Docker config files have non-standard imports that vary by environment
 
 [tool.ruff.lint.isort]
 case-sensitive = false

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -886,7 +886,7 @@ rsa==4.9.1
     # via
     #   -c requirements/base-constraint.txt
     #   google-auth
-ruff==0.8.0
+ruff==0.9.7
     # via apache-superset
 secretstorage==3.4.1
     # via keyring


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes CI failures caused by a ruff version mismatch between `requirements/development.txt` (0.8.0) and `.pre-commit-config.yaml` (0.9.7). The two versions format code differently, causing "files were modified by this hook" failures when CI runs pre-commit.

**Changes:**
- Switches ruff pre-commit hooks from external repo to local hooks that use the system-installed ruff
- Updates pinned ruff version in requirements from 0.8.0 to 0.9.7
 - Excludes `docker/*` from `isort` checks. These configuration files import `superset_config`, a local module in the same directory. Ruff's import classification varies by environment: locally it's classified as local-folder, while on CI (after dependencies are installed) it's classified as third-party. This causes ruff to want a blank line between imports locally but no blank line on CI, resulting in conflicting fixes. Excluding docker config files from `isort` avoids this environment-dependent inconsistency.

This ensures local development and CI always use the same ruff version, preventing future drift.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
