### PR TITLE
fix(SQLLab): most recent queries at the top in Query History without refreshing the page

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
@@ -211,7 +211,7 @@ test('displays multiple queries with newest query first', async () => {
   const editorQueryApiRoute = `glob:*/api/v1/query/?q=*`;
   fetchMock.get(editorQueryApiRoute, multipleQueriesApiResult);
   const { container } = render(setup(), { useRedux: true, initialState });
-  
+
   await waitFor(() =>
     expect(fetchMock.calls(editorQueryApiRoute).length).toBe(1),
   );

--- a/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/QueryHistory.test.tsx
@@ -133,3 +133,112 @@ test('fetches the query history by the tabViewId', async () => {
   expect(queryResultText).toBeInTheDocument();
   isFeatureEnabledMock.mockClear();
 });
+
+test('displays multiple queries with newest query first', async () => {
+  const isFeatureEnabledMock = mockedIsFeatureEnabled.mockImplementation(
+    featureFlag => featureFlag === FeatureFlag.SqllabBackendPersistence,
+  );
+
+  const multipleQueriesApiResult = {
+    count: 2,
+    ids: [694, 693],
+    result: [
+      {
+        changed_on: '2024-03-12T20:10:02.497775',
+        client_id: 'd2ZDzRYzn',
+        database: {
+          database_name: 'examples',
+          id: 1,
+        },
+        end_time: '1710274202496.047852',
+        error_message: null,
+        executed_sql: 'SELECT COUNT(*) from "FCC 2018 Survey"\nLIMIT 1001',
+        id: 694,
+        limit: 1000,
+        limiting_factor: 'DROPDOWN',
+        progress: 100,
+        results_key: null,
+        rows: 1,
+        schema: 'main',
+        select_as_cta: false,
+        sql: 'SELECT COUNT(*) from "FCC 2018 Survey"',
+        sql_editor_id: '22',
+        start_time: '1710274202445.992920',
+        status: QueryState.Success,
+        tab_name: 'Untitled Query 2',
+        tmp_table_name: null,
+        tracking_url: null,
+        user: {
+          first_name: 'admin',
+          id: 1,
+          last_name: 'user',
+        },
+      },
+      {
+        changed_on: '2024-03-12T20:01:02.497775',
+        client_id: 'b0ZDzRYzn',
+        database: {
+          database_name: 'examples',
+          id: 1,
+        },
+        end_time: '1710273662496.047852',
+        error_message: null,
+        executed_sql: 'SELECT * from "FCC 2018 Survey"\nLIMIT 1001',
+        id: 693,
+        limit: 1000,
+        limiting_factor: 'DROPDOWN',
+        progress: 100,
+        results_key: null,
+        rows: 443,
+        schema: 'main',
+        select_as_cta: false,
+        sql: 'SELECT * from "FCC 2018 Survey"',
+        sql_editor_id: '22',
+        start_time: '1710273662445.992920',
+        status: QueryState.Success,
+        tab_name: 'Untitled Query 1',
+        tmp_table_name: null,
+        tracking_url: null,
+        user: {
+          first_name: 'admin',
+          id: 1,
+          last_name: 'user',
+        },
+      },
+    ],
+  };
+
+  const editorQueryApiRoute = `glob:*/api/v1/query/?q=*`;
+  fetchMock.get(editorQueryApiRoute, multipleQueriesApiResult);
+  const { container } = render(setup(), { useRedux: true, initialState });
+  
+  await waitFor(() =>
+    expect(fetchMock.calls(editorQueryApiRoute).length).toBe(1),
+  );
+
+  expect(screen.getByTestId('listview-table')).toBeVisible();
+  expect(screen.getByRole('table')).toBeVisible();
+
+  const tableRows = container.querySelectorAll(
+    'table > tbody > tr:not(.ant-table-measure-row)',
+  );
+  expect(tableRows).toHaveLength(2);
+
+  // Check that both queries are present
+  const olderQueryRow = screen.getByText('443');
+  const newerQueryElements = screen.getAllByText('1');
+  expect(olderQueryRow).toBeInTheDocument();
+  expect(newerQueryElements.length).toBeGreaterThan(0);
+
+  // Verify ordering: newer query (1 row) should appear before older query (443 rows)
+  // Find the actual row elements to check their order
+  const firstDataRow = tableRows[0];
+  const secondDataRow = tableRows[1];
+
+  // The newer query should be in the first row (has 1 result row)
+  expect(firstDataRow).toHaveTextContent('1');
+  // The older query should be in the second row (has 443 result rows)
+  expect(secondDataRow).toHaveTextContent('443');
+
+  isFeatureEnabledMock.mockClear();
+});

--- a/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryHistory/index.tsx
@@ -91,7 +91,11 @@ const QueryHistory = ({
             editorId,
           )
             .concat(data.result)
-            .reverse()
+            .sort((a, b) => {
+              const aTime = a.startDttm || 0;
+              const bTime = b.startDttm || 0;
+              return aTime - bTime;
+            })
         : getEditorQueries(queries, editorId),
     [queries, data, editorId],
   );


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Refresh the Query History data immediately after a query finishes running so new entries appear without requiring a page reload.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**Before:** 
After running a query and navigating to the Query History tab, the most recent runs did not appear in the correct order (most recent should be at the top). After refreshing the page (second 22 in video), they were ordered correctly:

https://github.com/user-attachments/assets/88e73df7-ef1d-4b3c-b2b0-7a31786d3674

**After:**
Most recent queries are shown at the top of Query History without the need to refresh the page.

https://github.com/user-attachments/assets/da353ec8-8f91-4ce7-88bd-dce0c55cbd18


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open a new tab in SQL Lab.
2. Run a query.
3. Switch to the Query History tab in SQL Lab (next to Results).
4. Verify that the query history is ordered by the most recent entries (sorted by datetime).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [X] Required feature flags: `ENABLE_TEMPLATE_PROCESSING`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Show newest queries at top of SQL Lab Query History immediately after a run**

### What Changed
- Query History now displays the most recent query runs at the top without requiring a page reload
- Fixed cases where older queries appeared above newer ones so ordering is consistently newest-first
- Added a test that verifies multiple queries are rendered in newest-to-oldest order in the Query History table

### Impact
`✅ Most recent queries show at top immediately`
`✅ Fewer manual page refreshes in SQL Lab`
`✅ More accurate query history ordering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
