### PR TITLE
refactor(mcp): use dynamic APP_NAME instead of hardcoded Superset branding

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """
-FastMCP app factory and initialization for Superset MCP service.
+FastMCP app factory and initialization for the MCP service.
 This file provides a configurable factory function to create FastMCP instances
 following the Flask application factory pattern. All tool modules should import
 mcp from here and use @mcp.tool decorators.
@@ -81,11 +81,11 @@ System Information:
 - health_check: Simple health check tool (takes NO parameters, call without arguments)
 
 Available Resources:
-- superset://instance/metadata: Access instance configuration and metadata
-- superset://chart/templates: Access chart configuration templates
+- instance/metadata: Access instance configuration and metadata
+- chart/templates: Access chart configuration templates
 
 Available Prompts:
-- superset_quickstart: Interactive guide for getting started with the MCP service
+- quickstart: Interactive guide for getting started with the MCP service
 - create_chart_guided: Step-by-step chart creation wizard
 
 Common Chart Types (viz_type) and Behaviors:
@@ -130,7 +130,7 @@ General usage tips:
 - Chart previews are served as PNG images via custom screenshot endpoints
 
 If you are unsure which tool to use, start with get_instance_info
-or use the superset_quickstart prompt for an interactive guide.
+or use the quickstart prompt for an interactive guide.
 """
 
 
@@ -197,7 +197,7 @@ def _log_instance_creation(
 
 
 def create_mcp_app(
-    name: str = "Superset MCP Server",
+    name: str | None = None,
     instructions: str | None = None,
     branding: str | None = None,
     auth: Any | None = None,
@@ -230,6 +230,10 @@ def create_mcp_app(
     Returns:
         Configured FastMCP instance
     """
+    # Default name if not provided
+    if name is None:
+        name = "MCP Server"
+
     # Use default instructions if none provided
     if instructions is None:
         # If branding is provided, use it to generate instructions

--- a/superset/mcp_service/chart/resources/chart_configs.py
+++ b/superset/mcp_service/chart/resources/chart_configs.py
@@ -27,7 +27,7 @@ from superset.mcp_service.auth import mcp_auth_hook
 logger = logging.getLogger(__name__)
 
 
-@mcp.resource("superset://chart/configs")
+@mcp.resource("chart://configs")
 @mcp_auth_hook
 def get_chart_configs_resource() -> str:
     """

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Default MCP service configuration for Apache Superset"""
+"""Default MCP service configuration"""
 
 import logging
 import secrets
@@ -143,7 +143,7 @@ def default_user_resolver(app: Any, access_token: Any) -> Optional[str]:
 
 
 def generate_secret_key() -> str:
-    """Generate a secure random secret key for Superset"""
+    """Generate a secure random secret key."""
     return secrets.token_urlsafe(42)
 
 

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -89,8 +89,8 @@ def _sanitize_error_for_logging(error: Exception) -> str:
 
 class LoggingMiddleware(Middleware):
     """
-    Middleware that logs every MCP message (request and response) using Superset's
-    event logger. This matches the core Superset audit log system (Action Log UI,
+    Middleware that logs every MCP message (request and response) using the
+    event logger. This matches the core audit log system (Action Log UI,
     logs table, custom loggers). Also attempts to log dashboard_id, chart_id
     (slice_id), and dataset_id if present in tool params.
     """

--- a/superset/mcp_service/simple_proxy.py
+++ b/superset/mcp_service/simple_proxy.py
@@ -57,9 +57,7 @@ def main() -> None:
         logger.info("Starting MCP proxy server...")
 
         # Create a proxy to the remote FastMCP server
-        proxy = FastMCP.as_proxy(
-            "http://localhost:5008/mcp/", name="Superset MCP Proxy"
-        )
+        proxy = FastMCP.as_proxy("http://localhost:5008/mcp/", name="MCP Proxy")
 
         logger.info("Proxy created successfully, starting...")
 

--- a/superset/mcp_service/system/prompts/quickstart.py
+++ b/superset/mcp_service/system/prompts/quickstart.py
@@ -16,22 +16,32 @@
 # under the License.
 
 """
-System prompts for general Superset guidance
+System prompts for general guidance
 """
 
 import logging
 
+from flask import current_app
 from superset_core.mcp import prompt
 
 logger = logging.getLogger(__name__)
 
 
-@prompt("superset_quickstart")
-async def superset_quickstart_prompt(
+def _get_app_name() -> str:
+    """Get the application name from Flask config."""
+    try:
+        return current_app.config.get("APP_NAME", "Superset")
+    except RuntimeError:
+        # Outside of Flask application context
+        return "Superset"
+
+
+@prompt("quickstart")
+async def quickstart_prompt(
     user_type: str = "analyst", focus_area: str = "general"
 ) -> str:
     """
-    Guide new users through their first Superset experience.
+    Guide new users through their first experience with the platform.
 
     This prompt helps users:
     1. Understand what data is available
@@ -66,27 +76,28 @@ async def superset_quickstart_prompt(
 
     intro = intro_messages.get(user_type, intro_messages["analyst"])
     focus = focus_examples.get(focus_area, focus_examples["general"])
+    app_name = _get_app_name()
 
-    return f"""Welcome to Apache Superset! I'll guide you through creating your first
+    return f"""Welcome to {app_name}! I'll guide you through creating your first
     dashboard.
 
 {intro} {focus}
 
 I'll help you through these steps:
-1. 📊 **Explore Available Data** - See what datasets you can work with
-2. 🔍 **Understand Your Data** - Examine columns, metrics, and sample data
-3. 📈 **Create Visualizations** - Build charts that tell a story
-4. 🎯 **Design a Dashboard** - Combine charts into an interactive dashboard
-5. 🚀 **Learn Advanced Features** - Discover filters, SQL Lab, and more
+1. **Explore Available Data** - See what datasets you can work with
+2. **Understand Your Data** - Examine columns, metrics, and sample data
+3. **Create Visualizations** - Build charts that tell a story
+4. **Design a Dashboard** - Combine charts into an interactive dashboard
+5. **Learn Advanced Features** - Discover filters, SQL Lab, and more
 
 To get started, I'll use these tools:
-- `get_instance_info` - Overview of your Superset instance
+- `get_instance_info` - Overview of your {app_name} instance
 - `list_datasets` - Find available datasets
 - `get_dataset_info` - Explore dataset details
 - `generate_chart` - Create visualizations
 - `generate_dashboard` - Build your dashboard
 
-Let me begin by checking what's available in your Superset instance. I'll first get
+Let me begin by checking what's available in your {app_name} instance. I'll first get
 an overview, then show you the datasets filtered by your interest in {focus_area}.
 
 Would you like me to start by showing you what data you can work with?"""

--- a/superset/mcp_service/system/resources/instance_metadata.py
+++ b/superset/mcp_service/system/resources/instance_metadata.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """
-System resources for providing Superset configuration and stats
+System resources for providing instance configuration and stats
 """
 
 import logging
@@ -27,11 +27,11 @@ from superset.mcp_service.auth import mcp_auth_hook
 logger = logging.getLogger(__name__)
 
 
-@mcp.resource("superset://instance/metadata")
+@mcp.resource("instance://metadata")
 @mcp_auth_hook
 def get_instance_metadata_resource() -> str:
     """
-    Provide comprehensive metadata about the Superset instance.
+    Provide comprehensive metadata about the instance.
 
     This resource gives LLMs context about:
     - Available datasets and their popularity

--- a/superset/mcp_service/system/tool/get_instance_info.py
+++ b/superset/mcp_service/system/tool/get_instance_info.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """
-Get Superset instance high-level information FastMCP tool using configurable
+Get instance high-level information FastMCP tool using configurable
 InstanceInfoCore for flexible, extensible metrics calculation.
 """
 
@@ -74,7 +74,7 @@ _instance_info_core = InstanceInfoCore(
 def get_instance_info(
     request: GetSupersetInstanceInfoRequest, ctx: Context
 ) -> InstanceInfo:
-    """Get Superset instance statistics.
+    """Get instance statistics.
 
     Returns counts, activity metrics, and database types.
     """

--- a/superset/mcp_service/system/tool/health_check.py
+++ b/superset/mcp_service/system/tool/health_check.py
@@ -48,8 +48,8 @@ async def health_check(ctx: Context) -> HealthCheckResponse:
         HealthCheckResponse: Health status and system information including:
             - status: "healthy" or "error"
             - timestamp: ISO format timestamp
-            - service: Service name from APP_NAME config (e.g., "Superset MCP Service")
-            - version: Superset version string
+            - service: Service name from APP_NAME config (e.g., "{APP_NAME} MCP Service")
+            - version: Application version string
             - python_version: Python version
             - platform: Operating system platform
 

--- a/superset/mcp_service/system/tool/health_check.py
+++ b/superset/mcp_service/system/tool/health_check.py
@@ -48,7 +48,7 @@ async def health_check(ctx: Context) -> HealthCheckResponse:
         HealthCheckResponse: Health status and system information including:
             - status: "healthy" or "error"
             - timestamp: ISO format timestamp
-            - service: Service name from APP_NAME config (e.g., "{APP_NAME} MCP Service")
+            - service: Service name derived from APP_NAME config
             - version: Application version string
             - python_version: Python version
             - platform: Operating system platform


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR updates the MCP service to use the dynamic `APP_NAME` configuration instead of hardcoded "Superset" and "Apache Superset" references in documentation, instructions, and prompts exposed to LLMs.

**Problem:** The MCP service had hardcoded "Superset" branding throughout its LLM-facing documentation, tool docstrings, and prompts. This prevented downstream projects from customizing the branding shown to LLMs and users when they configure a different `APP_NAME`.

**Solution:** Replace hardcoded branding with dynamic values derived from the Flask `APP_NAME` config:

- **`app.py`**: Updated default instructions to use generic resource URIs (`instance/metadata` instead of `superset://instance/metadata`) and renamed prompt reference from `superset_quickstart` to `quickstart`
- **`quickstart.py`**: Added `_get_app_name()` helper and updated prompt to dynamically include the app name in welcome message and tool descriptions. Renamed prompt from `superset_quickstart` to `quickstart`
- **`instance_metadata.py`**: Changed resource URI from `superset://instance/metadata` to `instance://metadata` and updated docstring
- **`chart_configs.py`**: Changed resource URI from `superset://chart/configs` to `chart://configs`
- **`get_instance_info.py`**: Removed "Superset" from module and tool docstrings
- **`health_check.py`**: Updated docstring to show dynamic `{APP_NAME}` example instead of hardcoded "Superset"
- **`simple_proxy.py`**: Changed proxy name from "Superset MCP Proxy" to "MCP Proxy"
- **`mcp_config.py`**: Removed "Apache Superset" from module docstring
- **`middleware.py`**: Removed "Superset's" reference from logging middleware docstring

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a backend refactoring change affecting documentation/instructions

### TESTING INSTRUCTIONS
1. Start the MCP service and verify the instructions returned use the configured `APP_NAME`
2. Verify the quickstart prompt dynamically includes the app name
3. Verify health check response includes the configured app name in the service field
4. Check that resource URIs work with the new naming scheme

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Enable dynamic app branding and generic MCP resource URLs

### What Changed
- Quickstart onboarding prompt now uses the configured application name in its welcome text and tool descriptions, and is exposed under the generic `quickstart` name instead of `superset_quickstart`
- MCP resources for instance metadata and chart configurations no longer use the `superset://` scheme and are now available under generic `instance://metadata` and `chart://configs` URLs, so clients should update any hardcoded references
- Default MCP server name and health check output no longer hardcode "Superset", allowing the service name and version to reflect the host application configuration
- Tool and logging descriptions shown to LLMs use product-agnostic wording so downstream applications can present their own branding

### Impact
 `✅ Custom app branding in MCP quickstart and docs`
 `✅ Easier reuse of MCP service in white-label deployments`
 `✅ Clearer, product-agnostic MCP resource URLs for client tools`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
