### PR TITLE
fix(dashboard): embedded dashboard box sizing

### DIFF
--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -58,6 +58,7 @@ import {
   focusStyle,
   headerStyles,
   chartHeaderStyles,
+  boxSizing,
 } from '../styles';
 import SyncDashboardState, {
   getDashboardContextLocalStorage,
@@ -250,6 +251,7 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       chartContextMenuStyles(theme),
       focusStyle(theme),
       chartHeaderStyles(theme),
+      boxSizing,
     ],
     [theme],
   );

--- a/superset-frontend/src/dashboard/styles.ts
+++ b/superset-frontend/src/dashboard/styles.ts
@@ -113,3 +113,11 @@ export const focusStyle = (theme: SupersetTheme) => css`
     }
   }
 `;
+
+export const boxSizing = css`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+`;


### PR DESCRIPTION
### SUMMARY
Added correct `box-sizing` for embedded dashboard elements. This fixes overlaps when embedding.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="2592" height="866" alt="Screenshot 2025-12-02 at 10 45 21" src="https://github.com/user-attachments/assets/32449082-09c7-45e7-ad0b-f388a394bd3f" />

After:
<img width="2536" height="744" alt="Screenshot 2025-12-02 at 10 43 57" src="https://github.com/user-attachments/assets/cbaf3ca4-2537-45c1-8644-4f0d469b3771" />

### TESTING INSTRUCTIONS
Embed one of the dashboards in external application.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:  Fixes #36204, Fixes #35900, Fixes #34830
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
