### PR TITLE
fix: `is_column_reference` check

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1524,14 +1524,10 @@ class SqlaTable(
         has_timegrain = col.get("columnType") == "BASE_AXIS" and time_grain
         is_dttm = False
         pdf = None
-        is_column_reference = col.get("isColumnReference")
+        is_column_reference = col.get("isColumnReference", False)
 
         # First, check if this is a column reference that exists in metadata
-        col_in_metadata = None
-        if is_column_reference:
-            col_in_metadata = self.get_column(sql_expression)
-
-        if col_in_metadata:
+        if col_in_metadata := self.get_column(sql_expression):
             # Column exists in metadata - use it directly
             sqla_column = col_in_metadata.get_sqla_col(
                 template_processor=template_processor


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes the is_column_reference check in the adhoc column processing logic. The previous implementation had two issues:

1. Unnecessary conditional check: The code checked if `is_column_reference` before calling `self.get_column(sql_expression)`, but looking up a column in metadata is a safe operation that can be performed regardless of the `isColumnReference` flag. If the column exists in metadata, it should be used directly.
2. Missing default value: `col.get("isColumnReference")` returned `None` when the key was missing, which could cause issues in boolean checks downstream in the future.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
