### PR TITLE
fix(charts): Limit retrieval on bigquery queries from Superset

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -73,6 +73,7 @@ export interface ChartDataResponseResult {
   // TODO(hainenber): define proper type for below attributes
   rejected_filters?: any[];
   applied_filters?: any[];
+  warning?: string | null;
 }
 
 export interface TimeseriesChartDataResponseResult

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -34,7 +34,10 @@ import {
   getQuerySettings,
   getChartDataUri,
 } from 'src/explore/exploreUtils';
-import { addDangerToast } from 'src/components/MessageToasts/actions';
+import {
+  addDangerToast,
+  addWarningToast,
+} from 'src/components/MessageToasts/actions';
 import { logEvent } from 'src/logger/actions';
 import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
@@ -473,6 +476,11 @@ export function exploreJSON(
             }),
           ),
         );
+        queriesResponse.forEach(response => {
+          if (response.warning) {
+            dispatch(addWarningToast(response.warning));
+          }
+        });
         return dispatch(chartUpdateSucceeded(queriesResponse, key));
       })
       .catch(response => {

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -21,7 +21,7 @@ import re
 from typing import Any, cast, ClassVar, Sequence, TYPE_CHECKING
 
 import pandas as pd
-from flask import current_app
+from flask import current_app, g
 from flask_babel import gettext as _
 
 from superset.common.chart_data import ChartDataResultFormat
@@ -178,6 +178,11 @@ class QueryContextProcessor:
         )
         cache.df.columns = [unescape_separator(col) for col in cache.df.columns.values]
 
+        warning = None
+        if getattr(g, "bq_memory_limited", False):
+            row_count = getattr(g, "bq_memory_limited_row_count", len(cache.df))
+            warning = f"Results truncated to {row_count:,} rows due to memory constraints."
+
         return {
             "cache_key": cache_key,
             "cached_dttm": cache.cache_dttm,
@@ -197,6 +202,7 @@ class QueryContextProcessor:
             "from_dttm": query_obj.from_dttm,
             "to_dttm": query_obj.to_dttm,
             "label_map": label_map,
+            "warning": warning,
         }
 
     def query_cache_key(self, query_obj: QueryObject, **kwargs: Any) -> str | None:

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -181,8 +181,9 @@ class QueryContextProcessor:
         warning = None
         if getattr(g, "bq_memory_limited", False):
             row_count = getattr(g, "bq_memory_limited_row_count", len(cache.df))
-            warning = f"Results truncated to {row_count:,} rows due to memory constraints."
-
+            chart_id = (self._query_context.form_data or {}).get("slice_id", "")
+            prefix = f"Chart {chart_id}: " if chart_id else ""
+            warning = f"{prefix}Results truncated to {row_count:,} rows due to memory constraints."
         return {
             "cache_key": cache_key,
             "cached_dttm": cache.cache_dttm,

--- a/superset/config.py
+++ b/superset/config.py
@@ -186,7 +186,7 @@ DEFAULT_TIME_FILTER = utils.NO_TIME_RANGE
 # [load balancer / proxy / envoy / kong / ...] timeout settings.
 # You should also make sure to configure your WSGI server
 # (gunicorn, nginx, apache, ...) timeout setting to be <= to this setting
-SUPERSET_WEBSERVER_TIMEOUT = int(timedelta(minutes=1).total_seconds())
+SUPERSET_WEBSERVER_TIMEOUT = int(timedelta(minutes=5).total_seconds())
 
 # this 2 settings are used by dashboard period force refresh feature
 # When user choose auto force refresh frequency
@@ -502,7 +502,9 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # When using a recent version of Druid that supports JOINs turn this on
     "DRUID_JOINS": False,
     "DYNAMIC_PLUGINS": False,
-    "ENABLE_TEMPLATE_PROCESSING": False,
+    "ENABLE_TEMPLATE_PROCESSING": True,
+    # Limits BigQuery fetch to BQ_FETCH_MAX_MB to prevent memory issues
+    "BQ_MEMORY_LIMIT_FETCH": False,
     # Allow for javascript controls components
     # this enables programmers to customize certain charts (like the
     # geospatial ones) by inputting javascript in controls. This exposes
@@ -1245,7 +1247,10 @@ HTTP_HEADERS: dict[str, Any] = {}
 DEFAULT_DB_ID = None
 
 # Timeout duration for SQL Lab synchronous queries
-SQLLAB_TIMEOUT = int(timedelta(seconds=30).total_seconds())
+SQLLAB_TIMEOUT = int(timedelta(minutes=5).total_seconds())
+
+# BigQuery max fetch size in MB (limits memory usage when fetching large results)
+BQ_FETCH_MAX_MB = 200
 
 # Timeout duration for SQL Lab query validation
 SQLLAB_VALIDATION_TIMEOUT = int(timedelta(seconds=10).total_seconds())

--- a/superset/config.py
+++ b/superset/config.py
@@ -186,7 +186,7 @@ DEFAULT_TIME_FILTER = utils.NO_TIME_RANGE
 # [load balancer / proxy / envoy / kong / ...] timeout settings.
 # You should also make sure to configure your WSGI server
 # (gunicorn, nginx, apache, ...) timeout setting to be <= to this setting
-SUPERSET_WEBSERVER_TIMEOUT = int(timedelta(minutes=5).total_seconds())
+SUPERSET_WEBSERVER_TIMEOUT = int(timedelta(minutes=1).total_seconds())
 
 # this 2 settings are used by dashboard period force refresh feature
 # When user choose auto force refresh frequency
@@ -502,7 +502,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # When using a recent version of Druid that supports JOINs turn this on
     "DRUID_JOINS": False,
     "DYNAMIC_PLUGINS": False,
-    "ENABLE_TEMPLATE_PROCESSING": True,
+    "ENABLE_TEMPLATE_PROCESSING": False,
     # Limits BigQuery fetch to BQ_FETCH_MAX_MB to prevent memory issues
     "BQ_MEMORY_LIMIT_FETCH": False,
     # Allow for javascript controls components
@@ -1247,7 +1247,7 @@ HTTP_HEADERS: dict[str, Any] = {}
 DEFAULT_DB_ID = None
 
 # Timeout duration for SQL Lab synchronous queries
-SQLLAB_TIMEOUT = int(timedelta(minutes=5).total_seconds())
+SQLLAB_TIMEOUT = int(timedelta(seconds=30).total_seconds())
 
 # BigQuery max fetch size in MB (limits memory usage when fetching large results)
 BQ_FETCH_MAX_MB = 200

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import re
 import urllib
+import sys
 from datetime import datetime
 from re import Pattern
 from typing import Any, TYPE_CHECKING, TypedDict
@@ -28,6 +29,7 @@ import pandas as pd
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_babel import gettext as __
+from flask import current_app, g
 from marshmallow import fields, Schema
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import column, func, types
@@ -250,13 +252,77 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
 
     @classmethod
     def fetch_data(cls, cursor: Any, limit: int | None = None) -> list[tuple[Any, ...]]:
-        data = super().fetch_data(cursor, limit)
-        # Support type BigQuery Row, introduced here PR #4071
-        # google.cloud.bigquery.table.Row
-        if data and type(data[0]).__name__ == "Row":
-            data = [r.values() for r in data]  # type: ignore
-        return data
+        """
+        Progressive fetch using fetchmany to avoid loading huge results into memory.
+        Fetches first batch to estimate row size, then fetches only what fits in memory limit.
+        Sets flask.g.bq_memory_limited for thread-safe access.
 
+        Enabled via BQ_MEMORY_LIMIT_FETCH feature flag.
+        """
+        from superset import is_feature_enabled
+
+        # If feature flag is off, use default behavior
+        if not is_feature_enabled("BQ_MEMORY_LIMIT_FETCH"):
+            data = super().fetch_data(cursor, limit)
+            if data and type(data[0]).__name__ == "Row":
+                data = [r.values() for r in data]
+            return data
+
+        max_mb = current_app.config.get("BQ_FETCH_MAX_MB", 200) if current_app else 200
+        max_bytes = max_mb * 1024 * 1024
+
+        try:
+            # Fetch first batch to estimate row size
+            initial_batch_size = min(1000, limit) if limit else 1000
+            first_batch = cursor.fetchmany(initial_batch_size)
+
+            if not first_batch:
+                g.bq_memory_limited = False
+                g.bq_memory_limited_row_count = 0
+                return []
+
+            if type(first_batch[0]).__name__ == "Row":
+                first_batch = [r.values() for r in first_batch]
+
+            # Estimate how many rows fit in memory limit
+            first_batch_bytes = sys.getsizeof(str(first_batch))
+            rows_fetched = len(first_batch)
+            avg_bytes_per_row = first_batch_bytes / rows_fetched
+            total_rows_for_target = int(max_bytes / avg_bytes_per_row)
+
+            if limit:
+                total_rows_for_target = min(limit, total_rows_for_target)
+
+            remaining_rows = total_rows_for_target - rows_fetched
+
+            # If first batch is incomplete or we can't fetch more, return what we have
+            if rows_fetched < initial_batch_size or remaining_rows <= 0:
+                memory_limited = remaining_rows <= 0 and rows_fetched == initial_batch_size
+                g.bq_memory_limited = memory_limited
+                g.bq_memory_limited_row_count = len(first_batch)
+                return first_batch
+
+            # Fetch remaining rows
+            second_batch = cursor.fetchmany(remaining_rows) or []
+            if second_batch and type(second_batch[0]).__name__ == "Row":
+                second_batch = [r.values() for r in second_batch]
+
+            data = first_batch + second_batch
+
+            # If we got exactly what we asked for, there might be more (truncated)
+            memory_limited = len(second_batch) == remaining_rows
+            g.bq_memory_limited = memory_limited
+            g.bq_memory_limited_row_count = len(data)
+            return data
+
+        except Exception:
+            # Fallback to parent implementation
+            data = super().fetch_data(cursor, limit)
+            if data and type(data[0]).__name__ == "Row":
+                data = [r.values() for r in data]
+            g.bq_memory_limited = False
+            g.bq_memory_limited_row_count = len(data) if data else 0
+            return data
     @staticmethod
     def _mutate_label(label: str) -> str:
         """


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes: https://github.com/apache/superset/issues/36385

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
<img width="1907" height="1039" alt="image" src="https://github.com/user-attachments/assets/97b78056-7116-4b7c-bfdb-94e2e0a62373" />

after
<img width="1501" height="744" alt="image" src="https://github.com/user-attachments/assets/638f021a-5546-4b61-821e-9a830655c8fd" />
### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
