### PR TITLE
fix(echarts): pass vizType to enable theme overrides in all chart types

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -379,6 +379,7 @@ function BigNumberVis({
           height={maxHeight}
           echartOptions={echartOptions}
           eventHandlers={eventHandlers}
+          vizType={formData?.vizType}
         />
       )
     );

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/EchartsBoxPlot.tsx
@@ -21,7 +21,8 @@ import { allEventHandlers } from '../utils/eventHandlers';
 import { BoxPlotChartTransformedProps } from './types';
 
 export default function EchartsBoxPlot(props: BoxPlotChartTransformedProps) {
-  const { height, width, echartOptions, selectedValues, refs } = props;
+  const { height, width, echartOptions, selectedValues, refs, formData } =
+    props;
 
   const eventHandlers = allEventHandlers(props);
 
@@ -33,6 +34,7 @@ export default function EchartsBoxPlot(props: BoxPlotChartTransformedProps) {
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
       selectedValues={selectedValues}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/EchartsGantt.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/EchartsGantt.tsx
@@ -83,6 +83,7 @@ export default function EchartsGantt(props: EchartsGanttChartTransformedProps) {
         echartOptions={echartOptions}
         selectedValues={selectedValues}
         eventHandlers={eventHandlers}
+        vizType={formData.vizType}
       />
     </>
   );

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Graph/EchartsGraph.tsx
@@ -175,6 +175,7 @@ export default function EchartsGraph({
       width={width}
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/Heatmap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Heatmap/Heatmap.tsx
@@ -20,13 +20,14 @@ import { HeatmapTransformedProps } from './types';
 import Echart from '../components/Echart';
 
 export default function Heatmap(props: HeatmapTransformedProps) {
-  const { height, width, echartOptions, refs } = props;
+  const { height, width, echartOptions, refs, formData } = props;
   return (
     <Echart
       refs={refs}
       height={height}
       width={width}
       echartOptions={echartOptions}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/Histogram.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/Histogram.tsx
@@ -28,6 +28,7 @@ export default function Histogram(props: HistogramTransformedProps) {
     onFocusedSeries,
     onLegendStateChanged,
     refs,
+    formData,
   } = props;
 
   const eventHandlers: EventHandlers = {
@@ -55,6 +56,7 @@ export default function Histogram(props: HistogramTransformedProps) {
       width={width}
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/EchartsMixedTimeseries.tsx
@@ -215,6 +215,7 @@ export default function EchartsMixedTimeseries({
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
       selectedValues={selectedValues}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/Sankey.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sankey/Sankey.tsx
@@ -20,7 +20,7 @@ import { SankeyTransformedProps } from './types';
 import Echart from '../components/Echart';
 
 export default function Sankey(props: SankeyTransformedProps) {
-  const { height, width, echartOptions, refs } = props;
+  const { height, width, echartOptions, refs, formData } = props;
 
   return (
     <Echart
@@ -28,6 +28,7 @@ export default function Sankey(props: SankeyTransformedProps) {
       height={height}
       width={width}
       echartOptions={echartOptions}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/EchartsSunburst.tsx
@@ -160,6 +160,7 @@ export default function EchartsSunburst(props: SunburstTransformedProps) {
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
       selectedValues={selectedValues}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Tree/EchartsTree.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Tree/EchartsTree.tsx
@@ -16,21 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { EchartsProps } from '../types';
+import { TreeTransformedProps } from './types';
 import Echart from '../components/Echart';
 
-export default function EchartsGraph({
+export default function EchartsTree({
   echartOptions,
   height,
   refs,
   width,
-}: EchartsProps) {
+  formData,
+}: TreeTransformedProps) {
   return (
     <Echart
       refs={refs}
       height={height}
       width={width}
       echartOptions={echartOptions}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/EchartsTreemap.tsx
@@ -163,6 +163,7 @@ export default function EchartsTreemap({
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
       selectedValues={selectedValues}
+      vizType={formData.vizType}
     />
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/EchartsWaterfall.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Waterfall/EchartsWaterfall.tsx
@@ -23,7 +23,8 @@ import { EventHandlers } from '../types';
 export default function EchartsWaterfall(
   props: WaterfallChartTransformedProps,
 ) {
-  const { height, width, echartOptions, refs, onLegendStateChanged } = props;
+  const { height, width, echartOptions, refs, onLegendStateChanged, formData } =
+    props;
 
   const eventHandlers: EventHandlers = {
     legendselectchanged: payload => {
@@ -44,6 +45,7 @@ export default function EchartsWaterfall(
       width={width}
       echartOptions={echartOptions}
       eventHandlers={eventHandlers}
+      vizType={formData.vizType}
     />
   );
 }


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a theming issue where several ECharts visualization types were not receiving viz-specific theme overrides. The root cause was that these components were not passing the `vizType` property to the underlying `Echart` component.

**Changes:**
Updated 12 chart components to pass `vizType` prop to the `Echart` component:
- BigNumber (when trendline is shown)
- BoxPlot
- Gantt
- Graph
- Heatmap
- Histogram
- MixedTimeseries
- Sankey
- Sunburst
- Tree
- Treemap
- Waterfall

This ensures that chart-specific theme customizations (fonts, colors, etc.) are properly applied to these visualization types.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Add a theme override with chart-specific ECharts options:
```json  
{
  "token": {
    "echartsOptionsOverridesByChartType": {
      "box_plot": {
        "backgroundColor": "#ffeeff"
      }
    }
  }
}
```
2. Create a Box Plot chart in a dashboard
3. Verify that the chart now uses the custom background color
4. Repeat for other affected chart types (Gantt, Heatmap, Histogram, Treemap, etc.)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Ensure all ECharts charts honor chart-specific theme overrides

### What Changed
- All affected ECharts-based charts (Big Number with trendline, Box Plot, Gantt, Graph, Heatmap, Histogram, Mixed Timeseries, Sankey, Sunburst, Tree, Treemap, Waterfall) now correctly receive their chart type so theme overrides can apply
- Chart-specific theme settings (such as colors, fonts, and backgrounds) now render consistently for these visualizations wherever they are used

### Impact
`✅ Consistent theming across ECharts visualizations`
`✅ Custom chart themes apply reliably to all chart types`
`✅ Clearer visual distinctions between different chart types`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
