### PR TITLE
fix(SaveModal): reset chart state when saving and going to a dashboard

### DIFF
--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -413,11 +413,12 @@ test('dispatches removeChartState when saving and going to dashboard', async () 
   // Verify removeChartState was called with the correct chart ID
   expect(removeChartStateSpy).toHaveBeenCalledWith(chartId);
   
-  // Verify the action was dispatched
+  // Verify the action was dispatched (check the action object directly)
   expect(mockDispatch).toHaveBeenCalled();
-  expect(mockDispatch).toHaveBeenCalledWith(
-    dashboardStateActions.removeChartState(chartId)
-  );
+  expect(mockDispatch).toHaveBeenCalledWith({
+    type: 'REMOVE_CHART_STATE',
+    chartId,
+  });
 
   // Verify navigation happened
   expect(mockHistory.push).toHaveBeenCalled();

--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -30,6 +30,7 @@ import fetchMock from 'fetch-mock';
 
 import * as saveModalActions from 'src/explore/actions/saveModalActions';
 import SaveModal, { PureSaveModal } from 'src/explore/components/SaveModal';
+import * as dashboardStateActions from 'src/dashboard/actions/dashboardState';
 
 jest.mock('@superset-ui/core/components/Select', () => ({
   ...jest.requireActual('@superset-ui/core/components/Select/AsyncSelect'),
@@ -344,4 +345,83 @@ test('removes form_data_key from URL parameters after save', () => {
   expect(result.get('other_param')).toEqual('value');
   expect(result.get('slice_id')).toEqual('1');
   expect(result.get('save_action')).toEqual('overwrite');
+});
+
+test('dispatches removeChartState when saving and going to dashboard', async () => {
+  // Spy on the removeChartState action creator
+  const removeChartStateSpy = jest.spyOn(dashboardStateActions, 'removeChartState');
+  
+  // Mock the dashboard API response
+  const dashboardId = 123;
+  const dashboardUrl = '/superset/dashboard/test-dashboard/';
+  fetchMock.get(
+    `glob:*/api/v1/dashboard/${dashboardId}*`,
+    {
+      result: { 
+        id: dashboardId, 
+        dashboard_title: 'Test Dashboard',
+        url: dashboardUrl 
+      },
+    },
+    { overwriteRoutes: true }
+  );
+
+  const mockDispatch = jest.fn();
+  const mockHistory = {
+    push: jest.fn(),
+    replace: jest.fn(),
+  };
+  const chartId = 42;
+  const mockUpdateSlice = jest.fn(() => Promise.resolve({ id: chartId }));
+  const mockSetFormData = jest.fn();
+  
+  const myProps = {
+    ...defaultProps,
+    slice: { slice_id: 1, slice_name: 'title', owners: [1] },
+    actions: {
+      setFormData: mockSetFormData,
+      updateSlice: mockUpdateSlice,
+      getSliceDashboards: jest.fn(() => Promise.resolve([])),
+      saveSliceFailed: jest.fn(),
+    },
+    user: { userId: 1 },
+    history: mockHistory,
+    dispatch: mockDispatch,
+  };
+
+  const saveModal = new PureSaveModal(myProps);
+  saveModal.state = {
+    action: 'overwrite',
+    newSliceName: 'test chart',
+    datasetName: 'test dataset',
+    dashboard: { label: 'Test Dashboard', value: dashboardId },
+    saveStatus: null,
+  };
+
+  // Mock onHide to prevent errors
+  saveModal.onHide = jest.fn();
+
+  // Trigger save and go to dashboard (gotodash = true)
+  await saveModal.saveOrOverwrite(true);
+
+  // Wait for async operations
+  await waitFor(() => {
+    expect(mockUpdateSlice).toHaveBeenCalled();
+    expect(mockSetFormData).toHaveBeenCalled();
+  });
+
+  // Verify removeChartState was called with the correct chart ID
+  expect(removeChartStateSpy).toHaveBeenCalledWith(chartId);
+  
+  // Verify the action was dispatched
+  expect(mockDispatch).toHaveBeenCalled();
+  expect(mockDispatch).toHaveBeenCalledWith(
+    dashboardStateActions.removeChartState(chartId)
+  );
+
+  // Verify navigation happened
+  expect(mockHistory.push).toHaveBeenCalled();
+  
+  // Clean up
+  removeChartStateSpy.mockRestore();
 });

--- a/superset-frontend/src/explore/components/SaveModal.test.jsx
+++ b/superset-frontend/src/explore/components/SaveModal.test.jsx
@@ -349,21 +349,24 @@ test('removes form_data_key from URL parameters after save', () => {
 
 test('dispatches removeChartState when saving and going to dashboard', async () => {
   // Spy on the removeChartState action creator
-  const removeChartStateSpy = jest.spyOn(dashboardStateActions, 'removeChartState');
-  
+  const removeChartStateSpy = jest.spyOn(
+    dashboardStateActions,
+    'removeChartState',
+  );
+
   // Mock the dashboard API response
   const dashboardId = 123;
   const dashboardUrl = '/superset/dashboard/test-dashboard/';
   fetchMock.get(
     `glob:*/api/v1/dashboard/${dashboardId}*`,
     {
-      result: { 
-        id: dashboardId, 
+      result: {
+        id: dashboardId,
         dashboard_title: 'Test Dashboard',
-        url: dashboardUrl 
+        url: dashboardUrl,
       },
     },
-    { overwriteRoutes: true }
+    { overwriteRoutes: true },
   );
 
   const mockDispatch = jest.fn();
@@ -374,7 +377,7 @@ test('dispatches removeChartState when saving and going to dashboard', async () 
   const chartId = 42;
   const mockUpdateSlice = jest.fn(() => Promise.resolve({ id: chartId }));
   const mockSetFormData = jest.fn();
-  
+
   const myProps = {
     ...defaultProps,
     slice: { slice_id: 1, slice_name: 'title', owners: [1] },
@@ -412,7 +415,7 @@ test('dispatches removeChartState when saving and going to dashboard', async () 
 
   // Verify removeChartState was called with the correct chart ID
   expect(removeChartStateSpy).toHaveBeenCalledWith(chartId);
-  
+
   // Verify the action was dispatched (check the action object directly)
   expect(mockDispatch).toHaveBeenCalled();
   expect(mockDispatch).toHaveBeenCalledWith({
@@ -422,7 +425,7 @@ test('dispatches removeChartState when saving and going to dashboard', async () 
 
   // Verify navigation happened
   expect(mockHistory.push).toHaveBeenCalled();
-  
+
   // Clean up
   removeChartStateSpy.mockRestore();
 });

--- a/superset-frontend/src/explore/components/SaveModal.tsx
+++ b/superset-frontend/src/explore/components/SaveModal.tsx
@@ -46,6 +46,7 @@ import { canUserEditDashboard } from 'src/dashboard/util/permissionUtils';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { SaveActionType } from 'src/explore/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { removeChartState } from 'src/dashboard/actions/dashboardState';
 import { Dashboard } from 'src/types/Dashboard';
 
 // Session storage key for recent dashboard
@@ -276,6 +277,7 @@ class SaveModal extends Component<SaveModalProps, SaveModalState> {
 
       // Go to new dashboard url
       if (gotodash && dashboard) {
+        this.props.dispatch(removeChartState(value.id));
         this.props.history.push(dashboard.url);
         return;
       }


### PR DESCRIPTION
### SUMMARY
When saving a chart from the explore view and choosing "Save & go to dashboard", the chart's state from the explore view was persisting in Redux store and affecting the dashboard's chart rendering. This fix ensures that the chart state is properly cleaned up before navigating to the dashboard.

The issue occurs because the explore view's chart state remains in Redux when navigating directly to a dashboard. By dispatching `removeChartState` before navigation, we ensure a clean state transition.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a state management fix that prevents incorrect chart rendering

### TESTING INSTRUCTIONS
1. Go to explore view and create/edit a chart
2. Click "Save" 
3. Select a dashboard from the dropdown
4. Click "Save & go to dashboard"
5. Verify that the chart renders correctly in the dashboard without any state issues from the explore view

**Unit Test:**
A new unit test has been added to verify that `removeChartState` is dispatched when saving and navigating to a dashboard. Run:
```bash
npm run test -- src/explore/components/SaveModal.test.jsx -t "dispatches removeChartState"
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI (prevents chart rendering issues)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Prevent saved chart settings in Explore from leaking into the dashboard view

### What Changed
- When using “Save & go to dashboard” from Explore, the temporary chart state from Explore is cleared before opening the dashboard so the chart renders with the dashboard’s own settings
- Added an automated test to ensure the chart state is cleared and navigation to the dashboard still works as expected

### Impact
 `✅ Correct chart rendering after Save & go to dashboard`
 `✅ Fewer stale explore settings appearing on dashboards`
 `✅ More reliable dashboard view after saving charts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
