### PR TITLE
chore(deps): Remove unused direct dependency geostyler-qgis-parser

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -77,7 +77,6 @@
         "geostyler": "^14.1.3",
         "geostyler-data": "^1.1.0",
         "geostyler-openlayers-parser": "^4.3.0",
-        "geostyler-qgis-parser": "2.0.1",
         "geostyler-style": "7.5.0",
         "geostyler-wfs-parser": "^2.0.3",
         "googleapis": "^154.1.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -156,7 +156,6 @@
     "geostyler": "^14.1.3",
     "geostyler-data": "^1.1.0",
     "geostyler-openlayers-parser": "^4.3.0",
-    "geostyler-qgis-parser": "2.0.1",
     "geostyler-style": "7.5.0",
     "geostyler-wfs-parser": "^2.0.3",
     "googleapis": "^154.1.0",


### PR DESCRIPTION
## **User description**
## Summary
This PR removes `geostyler-qgis-parser` from direct dependencies as it's never used directly in the codebase and is already included as a transitive dependency through `geostyler`.

## Analysis
After investigating the codebase:
- **No direct imports**: Zero imports of `geostyler-qgis-parser` found anywhere in the codebase
- **Already a sub-dependency**: The `geostyler` package (^14.1.3) already includes `geostyler-qgis-parser` (^2.0.0) as a dependency
- **Redundant specification**: Having it as both a direct and transitive dependency is unnecessary

## Changes
- Removed `geostyler-qgis-parser` (2.0.1) from package.json direct dependencies
- Updated package-lock.json accordingly
- The package remains available through `geostyler`'s dependencies

## Testing
- Run `npm install` to verify dependencies resolve correctly
- Verify map/geostyler functionality still works (the package is still available as a transitive dependency)
- No functionality changes expected as the package was never directly imported

## Benefits
- Cleaner dependency tree
- Reduces maintenance burden (one less direct dependency to track)
- Lets npm/yarn handle version resolution through the parent package
- Follows best practices of not declaring unused direct dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
**Remove unused direct dependency geostyler-qgis-parser**

### What Changed
- Removed geostyler-qgis-parser from package.json and package-lock.json so it is no longer a direct dependency
- The parser remains available transitively via the geostyler package, so map/geostyler features are unchanged
- Updated lockfile to reflect the dependency removal; installs should resolve the same runtime packages

### Impact
`✅ Fewer direct dependencies`
`✅ Cleaner package.json and lockfile`
`✅ Unchanged map and geostyler behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
