### PR TITLE
feat(state): remove chart state when navigation away from the dashboard

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -769,6 +769,11 @@ export function restoreChartStates(chartStates) {
   return { type: RESTORE_CHART_STATES, chartStates };
 }
 
+export const CLEAR_ALL_CHART_STATES = 'CLEAR_ALL_CHART_STATES';
+export function clearAllChartStates() {
+  return { type: CLEAR_ALL_CHART_STATES };
+}
+
 // Undo history ---------------------------------------------------------------
 export const SET_MAX_UNDO_HISTORY_EXCEEDED = 'SET_MAX_UNDO_HISTORY_EXCEEDED';
 export function setMaxUndoHistoryExceeded(maxUndoHistoryExceeded = true) {

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -188,6 +188,7 @@ class Dashboard extends PureComponent {
   componentWillUnmount() {
     window.removeEventListener('visibilitychange', this.onVisibilityChange);
     this.props.actions.clearDataMaskState();
+    this.props.actions.clearAllChartStates();
   }
 
   onVisibilityChange() {

--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -46,6 +46,7 @@ describe('Dashboard', () => {
   const mockTriggerQuery = jest.fn();
   const mockLogEvent = jest.fn();
   const mockClearDataMask = jest.fn();
+  const mockClearAllChartStates = jest.fn();
 
   const props = {
     actions: {
@@ -54,6 +55,7 @@ describe('Dashboard', () => {
       triggerQuery: mockTriggerQuery,
       logEvent: mockLogEvent,
       clearDataMaskState: mockClearDataMask,
+      clearAllChartStates: mockClearAllChartStates,
     },
     dashboardState,
     dashboardInfo,

--- a/superset-frontend/src/dashboard/containers/Dashboard.ts
+++ b/superset-frontend/src/dashboard/containers/Dashboard.ts
@@ -23,6 +23,7 @@ import Dashboard from 'src/dashboard/components/Dashboard';
 import {
   addSliceToDashboard,
   removeSliceFromDashboard,
+  clearAllChartStates,
 } from 'src/dashboard/actions/dashboardState';
 import { setDatasources } from 'src/dashboard/actions/datasources';
 
@@ -61,6 +62,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
       {
         setDatasources,
         clearDataMaskState,
+        clearAllChartStates,
         addSliceToDashboard,
         removeSliceFromDashboard,
         triggerQuery,

--- a/superset-frontend/src/dashboard/reducers/dashboardState.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.js
@@ -53,6 +53,7 @@ import {
   UPDATE_CHART_STATE,
   REMOVE_CHART_STATE,
   RESTORE_CHART_STATES,
+  CLEAR_ALL_CHART_STATES,
 } from '../actions/dashboardState';
 import { HYDRATE_DASHBOARD } from '../actions/hydrate';
 
@@ -324,6 +325,12 @@ export default function dashboardStateReducer(state = {}, action) {
       return {
         ...state,
         chartStates: chartStates || {},
+      };
+    },
+    [CLEAR_ALL_CHART_STATES]() {
+      return {
+        ...state,
+        chartStates: {},
       };
     },
   };

--- a/superset-frontend/src/dashboard/reducers/dashboardState.test.js
+++ b/superset-frontend/src/dashboard/reducers/dashboardState.test.js
@@ -29,6 +29,10 @@ import {
   TOGGLE_FAVE_STAR,
   TOGGLE_NATIVE_FILTERS_BAR,
   UNSET_FOCUSED_FILTER_FIELD,
+  UPDATE_CHART_STATE,
+  REMOVE_CHART_STATE,
+  RESTORE_CHART_STATES,
+  CLEAR_ALL_CHART_STATES,
 } from 'src/dashboard/actions/dashboardState';
 
 import dashboardStateReducer from 'src/dashboard/reducers/dashboardState';
@@ -214,5 +218,79 @@ describe('dashboardState reducer', () => {
         { type: TOGGLE_NATIVE_FILTERS_BAR, isOpen: false },
       ),
     ).toEqual({ nativeFiltersBarOpen: false });
+  });
+
+  test('should update chart state', () => {
+    const chartState = { columnState: [], filterModel: {} };
+    const result = dashboardStateReducer(
+      { chartStates: {} },
+      {
+        type: UPDATE_CHART_STATE,
+        chartId: 123,
+        vizType: 'ag-grid-table',
+        chartState,
+        lastModified: 1234567890,
+      },
+    );
+    expect(result.chartStates[123]).toEqual({
+      chartId: 123,
+      vizType: 'ag-grid-table',
+      state: chartState,
+      lastModified: 1234567890,
+    });
+  });
+
+  test('should remove chart state', () => {
+    const initState = {
+      chartStates: {
+        123: { chartId: 123, vizType: 'ag-grid-table', state: {} },
+        456: { chartId: 456, vizType: 'ag-grid-table', state: {} },
+      },
+    };
+    const result = dashboardStateReducer(initState, {
+      type: REMOVE_CHART_STATE,
+      chartId: 123,
+    });
+    expect(result.chartStates[123]).toBeUndefined();
+    expect(result.chartStates[456]).toBeDefined();
+  });
+
+  test('should restore chart states', () => {
+    const chartStates = {
+      123: { chartId: 123, vizType: 'ag-grid-table', state: {} },
+    };
+    const result = dashboardStateReducer(
+      { chartStates: {} },
+      { type: RESTORE_CHART_STATES, chartStates },
+    );
+    expect(result.chartStates).toEqual(chartStates);
+  });
+
+  test('should restore chart states to empty when given null', () => {
+    const initState = {
+      chartStates: {
+        123: { chartId: 123, vizType: 'ag-grid-table', state: {} },
+      },
+    };
+    const result = dashboardStateReducer(initState, {
+      type: RESTORE_CHART_STATES,
+      chartStates: null,
+    });
+    expect(result.chartStates).toEqual({});
+  });
+
+  test('should clear all chart states', () => {
+    const initState = {
+      chartStates: {
+        123: { chartId: 123, vizType: 'ag-grid-table', state: {} },
+        456: { chartId: 456, vizType: 'ag-grid-table', state: {} },
+      },
+      otherState: 'preserved',
+    };
+    const result = dashboardStateReducer(initState, {
+      type: CLEAR_ALL_CHART_STATES,
+    });
+    expect(result.chartStates).toEqual({});
+    expect(result.otherState).toEqual('preserved');
   });
 });


### PR DESCRIPTION
### SUMMARY
The state of the charts should be reverted to default when navigating away from the dashboard.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
