### PR TITLE
fix(dashboards): Use same decorators as FAB

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -260,6 +260,7 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @expose("/", methods=("GET",))
     @protect()
     @safe
+    @permission_name("get")
     @merge_response_func(
         BaseSupersetModelRestApi.merge_order_columns, API_ORDER_COLUMNS_RIS_KEY
     )

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -24,7 +24,14 @@ from zipfile import is_zipfile, ZipFile
 
 from flask import current_app, g, redirect, request, Response, send_file, url_for
 from flask_appbuilder import permission_name
-from flask_appbuilder.api import expose, protect, rison, safe
+from flask_appbuilder.api import expose, merge_response_func, protect, rison, safe
+from flask_appbuilder.const import (
+    API_DESCRIPTION_COLUMNS_RIS_KEY,
+    API_LABEL_COLUMNS_RIS_KEY,
+    API_LIST_COLUMNS_RIS_KEY,
+    API_LIST_TITLE_RIS_KEY,
+    API_ORDER_COLUMNS_RIS_KEY,
+)
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext, ngettext
 from marshmallow import ValidationError
@@ -253,6 +260,22 @@ class DashboardRestApi(CustomTagsOptimizationMixin, BaseSupersetModelRestApi):
     @expose("/", methods=("GET",))
     @protect()
     @safe
+    @merge_response_func(
+        BaseSupersetModelRestApi.merge_order_columns, API_ORDER_COLUMNS_RIS_KEY
+    )
+    @merge_response_func(
+        BaseSupersetModelRestApi.merge_list_label_columns, API_LABEL_COLUMNS_RIS_KEY
+    )
+    @merge_response_func(
+        BaseSupersetModelRestApi.merge_description_columns,
+        API_DESCRIPTION_COLUMNS_RIS_KEY,
+    )
+    @merge_response_func(
+        BaseSupersetModelRestApi.merge_list_columns, API_LIST_COLUMNS_RIS_KEY
+    )
+    @merge_response_func(
+        BaseSupersetModelRestApi.merge_list_title, API_LIST_TITLE_RIS_KEY
+    )
     @event_logger.log_this_with_context(
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.get_list",
         log_to_statsd=False,


### PR DESCRIPTION
## **User description**
### SUMMARY
After https://github.com/apache/superset/pull/36246 the dashboard API was not setting the session cookie because we override the API but didn't include all the decorators from FAB. By including these, we can see the API sets the cookie correctly

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before
<img width="1380" height="60" alt="before" src="https://github.com/user-attachments/assets/c2e83933-7089-4003-bbde-72ee420d2d71" />

After
<img width="1448" height="128" alt="after" src="https://github.com/user-attachments/assets/1e177da4-7fba-4dae-927d-690d45c5ef00" />


### TESTING INSTRUCTIONS
Load the dashboard list page and make sure you see the cookie being set

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Dashboard list API sets session cookie and supports merged response options

### What Changed
- Visiting the dashboard list page/API now sets the session cookie so browser requests remain authenticated.
- Dashboard list responses now honor request options to merge visible columns, label columns, description columns, ordering, and the list title — matching other list endpoints.
- Dashboard list behavior and response formatting are now consistent with other FAB-backed list APIs.

### Impact
`✅ Session cookie set for dashboard list`
`✅ Dashboard list returns requested columns/labels/descriptions/order/title`
`✅ Consistent list responses with other APIs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
