### PR TITLE
feat(SIP-192): Labeled Version History + Restore

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -37,6 +37,7 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import { ErrorMessageWithStackTrace } from 'src/components';
 import type { DatasetObject } from 'src/features/datasets/types';
 import type { DatasourceModalProps } from '../types';
+import { VersionHistoryModal } from 'src/components/VersionControl';
 
 const DatasourceEditor = AsyncEsmComponent(
   () => import('../components/DatasourceEditor'),
@@ -104,6 +105,7 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
   const [errors, setErrors] = useState<any[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [modal, contextHolder] = Modal.useModal();
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const buildPayload = (datasource: Record<string, any>) => {
@@ -333,6 +335,14 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       footer={
         <>
           <Button
+            data-test="datasource-modal-version-history"
+            buttonSize="small"
+            buttonStyle="secondary"
+            onClick={() => setShowVersionHistory(true)}
+          >
+            {t('Version History')}
+          </Button>
+          <Button
             data-test="datasource-modal-cancel"
             buttonSize="small"
             buttonStyle="secondary"
@@ -383,6 +393,15 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
       >
         {getSaveDialog()}
       </Modal>
+      {currentDatasource.id && currentDatasource.table_name && (
+        <VersionHistoryModal
+          visible={showVersionHistory}
+          assetType="dataset"
+          assetId={currentDatasource.id}
+          assetName={currentDatasource.table_name}
+          onCancel={() => setShowVersionHistory(false)}
+        />
+      )}
     </StyledDatasourceModal>
   );
 };

--- a/superset-frontend/src/components/Modal/StandardModal.tsx
+++ b/superset-frontend/src/components/Modal/StandardModal.tsx
@@ -18,7 +18,7 @@
  */
 import { ReactNode } from 'react';
 import { t } from '@superset-ui/core';
-import { styled, css } from '@apache-superset/core/ui';
+import { styled } from '@apache-superset/core/ui';
 import { Modal, Loading, Flex, Button, Tooltip } from '@superset-ui/core/components';
 import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
 

--- a/superset-frontend/src/components/Modal/StandardModal.tsx
+++ b/superset-frontend/src/components/Modal/StandardModal.tsx
@@ -18,8 +18,8 @@
  */
 import { ReactNode } from 'react';
 import { t } from '@superset-ui/core';
-import { styled } from '@apache-superset/core/ui';
-import { Modal, Loading, Flex } from '@superset-ui/core/components';
+import { styled, css } from '@apache-superset/core/ui';
+import { Modal, Loading, Flex, Button, Tooltip } from '@superset-ui/core/components';
 import { ModalTitleWithIcon } from 'src/components/ModalTitleWithIcon';
 
 interface StandardModalProps {
@@ -41,6 +41,8 @@ interface StandardModalProps {
   maskClosable?: boolean;
   wrapProps?: object;
   contentLoading?: boolean;
+  /** Extra content to render in the footer before the cancel button */
+  extraFooter?: ReactNode;
 }
 
 // Standard modal widths
@@ -116,12 +118,42 @@ export function StandardModal({
   maskClosable = false,
   wrapProps,
   contentLoading = false,
+  extraFooter,
 }: StandardModalProps) {
   const primaryButtonName = saveText || (isEditMode ? t('Save') : t('Add'));
+  const isDisabled = saveDisabled || saveLoading || contentLoading;
+
+  const customFooter = extraFooter ? (
+    <>
+      {extraFooter}
+      <Button
+        key="back"
+        cta
+        data-test="modal-cancel-button"
+        buttonStyle="secondary"
+        onClick={onHide}
+      >
+        {cancelText || t('Cancel')}
+      </Button>
+      <Tooltip title={errorTooltip}>
+        <Button
+          key="submit"
+          buttonStyle="primary"
+          disabled={isDisabled}
+          loading={saveLoading}
+          onClick={onSave}
+          cta
+          data-test="modal-confirm-button"
+        >
+          {primaryButtonName}
+        </Button>
+      </Tooltip>
+    </>
+  ) : undefined;
 
   return (
     <StyledModal
-      disablePrimaryButton={saveDisabled || saveLoading || contentLoading}
+      disablePrimaryButton={isDisabled}
       primaryButtonLoading={saveLoading}
       primaryTooltipMessage={errorTooltip}
       onHandledPrimaryAction={onSave}
@@ -130,6 +162,7 @@ export function StandardModal({
       show={show}
       width={`${width}px`}
       wrapProps={wrapProps}
+      footer={customFooter}
       title={
         icon ? (
           <ModalTitleWithIcon

--- a/superset-frontend/src/components/VersionControl/VersionHistoryModal.test.tsx
+++ b/superset-frontend/src/components/VersionControl/VersionHistoryModal.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, waitFor, userEvent } from 'spec/helpers/testing-library';
+import fetchMock from 'fetch-mock';
+import { VersionHistoryModal } from './VersionHistoryModal';
+
+const defaultProps = {
+  visible: true,
+  assetType: 'dashboard' as const,
+  assetId: 1,
+  assetName: 'Test Dashboard',
+  onCancel: jest.fn(),
+};
+
+const mockVersions = {
+  result: {
+    count: 2,
+    versions: [
+      {
+        version_number: 2,
+        description: 'Added new chart',
+        created_by: 'admin',
+        created_on: '2024-01-02T12:00:00Z',
+        commit_sha: '',
+      },
+      {
+        version_number: 1,
+        description: 'Initial version',
+        created_by: 'admin',
+        created_on: '2024-01-01T12:00:00Z',
+        commit_sha: '',
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock.reset();
+});
+
+afterEach(() => {
+  fetchMock.restore();
+});
+
+test('renders modal with title', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  expect(
+    screen.getByText('Version History - Test Dashboard'),
+  ).toBeInTheDocument();
+});
+
+test('loads and displays versions', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+  });
+
+  expect(screen.getByText('Added new chart')).toBeInTheDocument();
+  expect(screen.getByText('Version 1')).toBeInTheDocument();
+  expect(screen.getByText('Initial version')).toBeInTheDocument();
+});
+
+test('displays empty state when no versions exist', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', {
+    result: { count: 0, versions: [] },
+  });
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(/No versions yet/),
+    ).toBeInTheDocument();
+  });
+});
+
+test('calls onCancel when close button is clicked', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+  const onCancel = jest.fn();
+
+  render(<VersionHistoryModal {...defaultProps} onCancel={onCancel} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+  });
+
+  // Get all Close buttons and click the one in the footer (last one)
+  const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+  await userEvent.click(closeButtons[closeButtons.length - 1]);
+  expect(onCancel).toHaveBeenCalledTimes(1);
+});
+
+test('shows save version modal when save button is clicked', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+  });
+
+  await userEvent.click(screen.getByRole('button', { name: 'Save Version' }));
+
+  expect(screen.getByText('Save Version')).toBeInTheDocument();
+  expect(screen.getByText(/Save a version of/)).toBeInTheDocument();
+});
+
+test('does not render when visible is false', () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+
+  render(<VersionHistoryModal {...defaultProps} visible={false} />);
+
+  expect(
+    screen.queryByText('Version History - Test Dashboard'),
+  ).not.toBeInTheDocument();
+});
+
+test('shows restore button when a version is selected', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', mockVersions);
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Version 2')).toBeInTheDocument();
+  });
+
+  // Initially no restore button
+  expect(
+    screen.queryByRole('button', { name: 'Restore version' }),
+  ).not.toBeInTheDocument();
+
+  // Click on a version to select it
+  await userEvent.click(screen.getByText('Version 1'));
+
+  // Restore button should appear
+  expect(
+    screen.getByRole('button', { name: 'Restore version' }),
+  ).toBeInTheDocument();
+});
+
+test('displays error when API call fails', async () => {
+  fetchMock.get('glob:*/api/v1/version/dashboard/1/list', {
+    status: 500,
+    body: { message: 'Server error' },
+  });
+
+  render(<VersionHistoryModal {...defaultProps} />);
+
+  await waitFor(() => {
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/components/VersionControl/VersionHistoryModal.tsx
+++ b/superset-frontend/src/components/VersionControl/VersionHistoryModal.tsx
@@ -1,0 +1,231 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState, useEffect } from 'react';
+import { t, SupersetClient } from '@superset-ui/core';
+import { styled, Alert } from '@apache-superset/core/ui';
+import { Modal, Input, Button, Loading } from '@superset-ui/core/components';
+
+const VersionCard = styled.div<{ selected?: boolean }>`
+  ${({ theme, selected }) => `
+    border: 1px solid ${theme.colorBorder};
+    padding: ${theme.paddingSM}px;
+    margin-bottom: ${theme.marginXS}px;
+    cursor: pointer;
+    border-radius: ${theme.borderRadius}px;
+    background: ${selected ? theme.colorPrimaryBg : theme.colorBgContainer};
+
+    &:hover {
+      border-color: ${theme.colorPrimary};
+    }
+  `}
+`;
+
+interface Version {
+  version_number: number;
+  description: string;
+  created_by: string;
+  created_on: string;
+  commit_sha?: string;
+}
+
+interface Props {
+  visible: boolean;
+  assetType: 'chart' | 'dashboard' | 'dataset';
+  assetId: number;
+  assetName: string;
+  onCancel: () => void;
+}
+
+export const VersionHistoryModal: React.FC<Props> = ({
+  visible,
+  assetType,
+  assetId,
+  assetName,
+  onCancel,
+}) => {
+  const [versions, setVersions] = useState<Version[]>([]);
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      loadVersions();
+    }
+  }, [visible]);
+
+  const loadVersions = async () => {
+    setLoading(true);
+    try {
+      const response = await SupersetClient.get({
+        endpoint: `/api/v1/version/${assetType}/${assetId}/list`,
+      });
+      setVersions(response.json.result.versions);
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to load versions';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!description.trim()) {
+      setError('Please enter a description');
+      return;
+    }
+    setLoading(true);
+    try {
+      await SupersetClient.post({
+        endpoint: `/api/v1/version/${assetType}/${assetId}/save`,
+        jsonPayload: { description },
+      });
+      setSuccess('Version saved successfully');
+      setDescription('');
+      setShowSaveModal(false);
+      loadVersions();
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to save version';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!selectedVersion) return;
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Restore to Version ${selectedVersion}?`)) return;
+
+    setLoading(true);
+    try {
+      await SupersetClient.post({
+        endpoint: `/api/v1/version/${assetType}/${assetId}/restore`,
+        jsonPayload: { version_number: selectedVersion },
+      });
+      setSuccess('Version restored - reloading...');
+      setTimeout(() => window.location.reload(), 1500);
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to restore version';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (dateStr: string) => new Date(dateStr).toLocaleString();
+
+  if (showSaveModal) {
+    return (
+      <Modal
+        title={t('Save Version')}
+        show
+        onHide={() => setShowSaveModal(false)}
+        onHandledPrimaryAction={handleSave}
+        primaryButtonName={t('Save')}
+        primaryButtonLoading={loading}
+        width="600px"
+      >
+        <p>Save a version of &quot;{assetName}&quot;</p>
+        <Input.TextArea
+          placeholder="Describe what changed..."
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          rows={3}
+          maxLength={500}
+          showCount
+        />
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal
+      title={`Version History - ${assetName}`}
+      show={visible}
+      onHide={onCancel}
+      width="700px"
+      footer={
+        <>
+          <Button
+            htmlType="button"
+            buttonSize="small"
+            onClick={() => setShowSaveModal(true)}
+            cta
+          >
+            {t('Save Version')}
+          </Button>
+          {selectedVersion && (
+            <Button
+              htmlType="button"
+              buttonSize="small"
+              buttonStyle="primary"
+              onClick={handleRestore}
+              cta
+            >
+              {t('Restore version')}
+            </Button>
+          )}
+          <Button htmlType="button" buttonSize="small" onClick={onCancel} cta>
+            {t('Close')}
+          </Button>
+        </>
+      }
+    >
+      {error && <Alert type="error" message={error} closable />}
+      {success && <Alert type="success" message={success} closable />}
+
+      {loading && <Loading />}
+
+      {!loading && versions.length === 0 && (
+        <div style={{ textAlign: 'center', padding: 40, color: '#999' }}>
+          No versions yet. Click &quot;Save Version&quot; to create one.
+        </div>
+      )}
+
+      {!loading &&
+        versions.map(v => (
+          <VersionCard
+            key={v.version_number}
+            selected={selectedVersion === v.version_number}
+            onClick={() => setSelectedVersion(v.version_number)}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <strong>Version {v.version_number}</strong>
+              <span style={{ fontSize: 12, color: '#666' }}>
+                {formatDate(v.created_on)}
+              </span>
+            </div>
+            <div style={{ margin: '8px 0' }}>{v.description}</div>
+            <div style={{ fontSize: 12, color: '#999' }}>
+              By {v.created_by}
+              {v.commit_sha && ` • ${v.commit_sha.substring(0, 7)}`}
+            </div>
+          </VersionCard>
+        ))}
+    </Modal>
+  );
+};

--- a/superset-frontend/src/components/VersionControl/index.ts
+++ b/superset-frontend/src/components/VersionControl/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { VersionHistoryModal } from './VersionHistoryModal';

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -24,6 +24,7 @@ import {
   Collapse,
   CollapseLabelInModal,
   JsonEditor,
+  Button,
 } from '@superset-ui/core/components';
 import { useJsonValidation } from '@superset-ui/core/components/AsyncAceEditor';
 import { type TagType } from 'src/components';
@@ -60,6 +61,7 @@ import {
   CertificationSection,
   AdvancedSection,
 } from './sections';
+import { VersionHistoryModal } from 'src/components/VersionControl';
 
 type PropertiesModalProps = {
   dashboardId: number;
@@ -136,6 +138,7 @@ const PropertiesModal = ({
   >([]);
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const originalDashboardMetadata = useRef<Record<string, any>>({});
+  const [showVersionHistory, setShowVersionHistory] = useState(false);
 
   const handleErrorResponse = async (response: Response) => {
     const { error, statusText, message } = await getClientErrorObject(response);
@@ -632,6 +635,17 @@ const PropertiesModal = ({
       }
       saveText={saveLabel}
       wrapProps={{ 'data-test': 'properties-edit-modal' }}
+      extraFooter={
+        <Button
+          htmlType="button"
+          buttonSize="small"
+          onClick={() => setShowVersionHistory(true)}
+          data-test="properties-modal-version-history-button"
+          cta
+        >
+          {t('Version History')}
+        </Button>
+      }
     >
       <Form
         form={form}
@@ -771,6 +785,15 @@ const PropertiesModal = ({
           ]}
         />
       </Form>
+      {dashboardId && dashboardInfo?.title && (
+        <VersionHistoryModal
+          visible={showVersionHistory}
+          assetType="dashboard"
+          assetId={dashboardId}
+          assetName={dashboardInfo.title}
+          onCancel={() => setShowVersionHistory(false)}
+        />
+      )}
     </StandardModal>
   );
 };

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -23,6 +23,7 @@ import {
   AsyncSelect,
   Collapse,
   CollapseLabelInModal,
+  Button,
   type SelectValue,
 } from '@superset-ui/core/components';
 import rison from 'rison';
@@ -44,6 +45,7 @@ import {
   ModalFormField,
   useModalValidation,
 } from 'src/components/Modal';
+import { VersionHistoryModal } from 'src/components/VersionControl';
 
 export type PropertiesModalProps = {
   slice: Slice;
@@ -81,6 +83,7 @@ function PropertiesModal({
     null,
   );
   const [tags, setTags] = useState<TagType[]>([]);
+  const [showVersionHistory, setShowVersionHistory] = useState(false);
 
   // Validation setup
   const modalSections = useMemo(
@@ -305,6 +308,17 @@ function PropertiesModal({
           : errorTooltip
       }
       wrapProps={{ 'data-test': 'properties-edit-modal' }}
+      extraFooter={
+        <Button
+          htmlType="button"
+          buttonSize="small"
+          onClick={() => setShowVersionHistory(true)}
+          data-test="properties-modal-version-history-button"
+          cta
+        >
+          {t('Version History')}
+        </Button>
+      }
     >
       <Collapse
         expandIconPosition="end"
@@ -477,6 +491,15 @@ function PropertiesModal({
           },
         ]}
       />
+      {slice.slice_id && slice.slice_name && (
+        <VersionHistoryModal
+          visible={showVersionHistory}
+          assetType="chart"
+          assetId={slice.slice_id}
+          assetName={slice.slice_name}
+          onCancel={() => setShowVersionHistory(false)}
+        />
+      )}
     </StandardModal>
   );
 }

--- a/superset/config.py
+++ b/superset/config.py
@@ -797,6 +797,11 @@ THEME_DARK: Optional[Theme] = {
 # Enable UI-based theme administration for admins
 ENABLE_UI_THEME_ADMINISTRATION = True  # Allows admins to set system themes via UI
 
+# Enable version history for charts, dashboards, and datasets
+VERSION_CONTROL_ENABLED = True
+# Maximum number of versions to retain per asset (older versions are deleted)
+VERSION_RETENTION_LIMIT = 10
+
 # Custom font configuration
 # Load external fonts at runtime without rebuilding the application
 # Example:

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -223,6 +223,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         from superset.views.user_registrations import UserRegistrationsView
         from superset.views.users.api import CurrentUserRestApi, UserRestApi
         from superset.views.users_list import UsersListView
+        from superset.version_control.api import VersionControlRestApi
 
         set_app_error_handlers(self.superset_app)
         self.register_request_handlers()
@@ -269,6 +270,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         appbuilder.add_api(SqlLabRestApi)
         appbuilder.add_api(SqlLabPermalinkRestApi)
         appbuilder.add_api(LogRestApi)
+        appbuilder.add_api(VersionControlRestApi)
 
         if feature_flag_manager.is_feature_enabled("ENABLE_EXTENSIONS"):
             from superset.extensions.api import ExtensionsRestApi

--- a/superset/migrations/versions/2025-12-03_12-00_1adc0d8eb420_add_version_history_table.py
+++ b/superset/migrations/versions/2025-12-03_12-00_1adc0d8eb420_add_version_history_table.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_version_history_table
+
+Revision ID: 1adc0d8eb420
+Revises: a9c01ec10479
+Create Date: 2025-12-03 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "1adc0d8eb420"
+down_revision = "a9c01ec10479"
+
+
+def upgrade():
+    # Create version_history table
+    op.create_table(
+        "version_history",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "asset_type",
+            sa.Enum("CHART", "DASHBOARD", "DATASET", name="assettype"),
+            nullable=False,
+        ),
+        sa.Column(
+            "asset_id",
+            sa.Integer(),
+            nullable=False,
+        ),
+        sa.Column(
+            "version_number",
+            sa.Integer(),
+            nullable=False,
+        ),
+        sa.Column(
+            "version_data",
+            sa.Text().with_variant(mysql.MEDIUMTEXT(), "mysql"),
+            nullable=False,
+        ),
+        sa.Column(
+            "description",
+            sa.Text(),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_on",
+            sa.DateTime(),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_by_fk",
+            sa.Integer(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_fk"],
+            ["ab_user.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "asset_type",
+            "asset_id",
+            "version_number",
+            name="uq_version_history_asset_version",
+        ),
+    )
+
+    # Create indexes for better query performance
+    op.create_index(
+        "idx_version_history_asset",
+        "version_history",
+        ["asset_type", "asset_id"],
+        unique=False,
+    )
+
+    op.create_index(
+        "idx_version_history_created_on",
+        "version_history",
+        ["created_on"],
+        unique=False,
+    )
+
+
+def downgrade():
+    # Drop indexes
+    op.drop_index("idx_version_history_created_on", table_name="version_history")
+    op.drop_index("idx_version_history_asset", table_name="version_history")
+
+    # Drop table
+    op.drop_table("version_history")

--- a/superset/models/version_history.py
+++ b/superset/models/version_history.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Version History Models
+
+This module contains database models for storing version history of charts,
+dashboards, and datasets.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timezone
+
+from flask_appbuilder import Model
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from superset import security_manager
+from superset.utils import core as utils
+
+
+class AssetType(str, enum.Enum):
+    """Enum for asset types that can have version history"""
+
+    CHART = "chart"
+    DASHBOARD = "dashboard"
+    DATASET = "dataset"
+
+
+class VersionHistory(Model):
+    """
+    Model for storing version history of charts, dashboards, and datasets.
+
+    Each row represents a single version of an asset. The version data is stored
+    as a JSON blob containing the complete YAML export of the asset at that point
+    in time.
+    """
+
+    __tablename__ = "version_history"
+    __table_args__ = (
+        UniqueConstraint(
+            "asset_type",
+            "asset_id",
+            "version_number",
+            name="uq_version_history_asset_version",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    # Asset identification
+    asset_type = Column(
+        Enum(AssetType),
+        nullable=False,
+        comment="Type of asset: chart, dashboard, or dataset",
+    )
+    asset_id = Column(
+        Integer,
+        nullable=False,
+        comment="ID of the asset (slice_id, dashboard_id, or dataset_id)",
+    )
+
+    # Version information
+    version_number = Column(
+        Integer, nullable=False, comment="Sequential version number starting from 1"
+    )
+
+    # Version data - stored as JSON containing the YAML export
+    version_data = Column(
+        utils.MediumText(),
+        nullable=False,
+        comment="JSON blob containing the complete YAML export of the asset",
+    )
+
+    # Metadata
+    description = Column(
+        Text,
+        nullable=True,
+        comment="User-provided description of changes in this version",
+    )
+
+    # Audit fields
+    created_on = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        comment="Timestamp when this version was created",
+    )
+    created_by_fk = Column(
+        Integer,
+        ForeignKey("ab_user.id"),
+        nullable=False,
+        comment="User who created this version",
+    )
+
+    # Relationships
+    created_by = relationship(security_manager.user_model, foreign_keys=[created_by_fk])
+
+    def __repr__(self) -> str:
+        return (
+            f"<VersionHistory("
+            f"asset_type={self.asset_type.value}, "
+            f"asset_id={self.asset_id}, "
+            f"version={self.version_number}"
+            f")>"
+        )
+
+    @property
+    def created_by_name(self) -> str:
+        """Get the username of the creator"""
+        if self.created_by:
+            return self.created_by.username or ""
+        return ""

--- a/superset/version_control/__init__.py
+++ b/superset/version_control/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/superset/version_control/api.py
+++ b/superset/version_control/api.py
@@ -274,7 +274,50 @@ class VersionControlRestApi(BaseSupersetApi):
     @protect()
     @safe
     def save_version(self, asset_type: str, asset_id: int) -> Response:
-        """Save a new version to the database"""
+        """Save a new version to the database.
+        ---
+        post:
+          summary: Save a new version of an asset
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: asset_type
+            description: Type of asset (chart, dashboard, dataset)
+          - in: path
+            schema:
+              type: integer
+            name: asset_id
+            description: The asset id
+          requestBody:
+            description: Version description
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+          responses:
+            200:
+              description: Version saved successfully
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
         cfg = self.cfg
         if not cfg["enabled"]:
             return self.response_400(message="Version control not configured")
@@ -358,7 +401,43 @@ class VersionControlRestApi(BaseSupersetApi):
     @protect()
     @safe
     def list_versions(self, asset_type: str, asset_id: int) -> Response:
-        """List all versions from the database"""
+        """List all versions from the database.
+        ---
+        get:
+          summary: List all versions of an asset
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: asset_type
+            description: Type of asset (chart, dashboard, dataset)
+          - in: path
+            schema:
+              type: integer
+            name: asset_id
+            description: The asset id
+          responses:
+            200:
+              description: List of versions
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+                        properties:
+                          count:
+                            type: integer
+                          versions:
+                            type: array
+                            items:
+                              type: object
+            401:
+              $ref: '#/components/responses/401'
+            500:
+              $ref: '#/components/responses/500'
+        """
         try:
             if not self.cfg["enabled"]:
                 return self.response(200, result={"count": 0, "versions": []})
@@ -395,7 +474,50 @@ class VersionControlRestApi(BaseSupersetApi):
     @protect()
     @safe
     def restore_version(self, asset_type: str, asset_id: int) -> Response:
-        """Restore a previous version from the database"""
+        """Restore a previous version from the database.
+        ---
+        post:
+          summary: Restore a previous version of an asset
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: asset_type
+            description: Type of asset (chart, dashboard, dataset)
+          - in: path
+            schema:
+              type: integer
+            name: asset_id
+            description: The asset id
+          requestBody:
+            description: Version to restore
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    version_number:
+                      type: integer
+          responses:
+            200:
+              description: Version restored successfully
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
         if not self.cfg["enabled"]:
             return self.response_400(message="Version control not enabled")
 

--- a/superset/version_control/api.py
+++ b/superset/version_control/api.py
@@ -1,0 +1,439 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import yaml
+from flask import g, request, Response, current_app as app
+from flask_appbuilder.api import expose, protect, safe
+from sqlalchemy import and_, desc
+
+from superset import db
+from superset.commands.chart.export import ExportChartsCommand
+from superset.commands.chart.importers.v1.utils import import_chart
+from superset.commands.dashboard.export import ExportDashboardsCommand
+from superset.commands.dashboard.importers.v1.utils import import_dashboard
+from superset.commands.dataset.export import ExportDatasetsCommand
+from superset.commands.dataset.importers.v1.utils import import_dataset
+from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
+from superset.daos.chart import ChartDAO
+from superset.daos.dashboard import DashboardDAO
+from superset.daos.dataset import DatasetDAO
+from superset.models.dashboard import dashboard_slices
+from superset.models.slice import Slice
+from superset.models.version_history import AssetType, VersionHistory
+from superset.views.base_api import BaseSupersetApi
+
+logger = logging.getLogger(__name__)
+
+
+class VersionControlRestApi(BaseSupersetApi):
+    """Version control API that stores versions in the database"""
+
+    resource_name = "version"
+    allow_browser_login = True
+    openapi_spec_tag = "Version Control"
+    class_permission_name = "Version"
+    method_permission_name = MODEL_API_RW_METHOD_PERMISSION_MAP | {
+        "save_version": "write",
+        "list_versions": "read",
+        "restore_version": "write",
+    }
+
+    # Asset type mappings
+    DAO_MAP: dict[str, type[ChartDAO] | type[DashboardDAO] | type[DatasetDAO]] = {
+        "chart": ChartDAO,
+        "dashboard": DashboardDAO,
+        "dataset": DatasetDAO,
+    }
+    EXPORT_MAP: dict[str, type] = {
+        "chart": ExportChartsCommand,
+        "dashboard": ExportDashboardsCommand,
+        "dataset": ExportDatasetsCommand,
+    }
+    NAME_ATTR: dict[str, str] = {
+        "chart": "slice_name",
+        "dashboard": "dashboard_title",
+        "dataset": "table_name",
+    }
+    ASSET_TYPE_ENUM: dict[str, AssetType] = {
+        "chart": AssetType.CHART,
+        "dashboard": AssetType.DASHBOARD,
+        "dataset": AssetType.DATASET,
+    }
+
+    @property
+    def cfg(self) -> dict[str, Any]:
+        """Get version control configuration"""
+        c = app.config
+        return {
+            "enabled": c.get("VERSION_CONTROL_ENABLED", False),
+            "retention": c.get("VERSION_RETENTION_LIMIT", 10),
+        }
+
+    def _export_asset(self, asset_type: str, asset_id: int) -> dict[str, Any]:
+        """Export asset to YAML bundle"""
+        configs: dict[str, Any] = {}
+        for fname, content_fn in self.EXPORT_MAP[asset_type]([asset_id]).run():
+            configs[fname] = content_fn()
+        return configs
+
+    def _import_asset(
+        self, asset_type: str, asset_id: int, yaml_bundle: dict[str, Any]
+    ) -> None:
+        """Import asset from YAML bundle, preserving roles, owners, and dependencies"""
+        # Get current asset to preserve roles/owners and references
+        current_asset = self.DAO_MAP[asset_type].find_by_id(asset_id)
+        current_roles = list(getattr(current_asset, "roles", []))
+        current_owners = list(getattr(current_asset, "owners", []))
+
+        logger.info(
+            "Preserving %d owners and %d roles for %s %d",
+            len(current_owners),
+            len(current_roles),
+            asset_type,
+            asset_id,
+        )
+
+        # Parse the YAML bundle
+        configs: dict[str, Any] = {}
+        for fname, content in yaml_bundle.items():
+            parsed = yaml.safe_load(content) if isinstance(content, str) else content
+            configs[fname] = parsed
+
+        # Import only the main asset, preserving current dataset/database/chart references
+        for fname, config in configs.items():
+            if fname.startswith(f"{asset_type}s/"):
+                # Remove roles and owners from config
+                if isinstance(config, list):
+                    config = config[0] if config else {}
+
+                # Strip out all permission-related fields
+                config.pop("roles", None)
+                config.pop("owners", None)
+                config.pop("owner", None)
+                config.pop("role", None)
+
+                # Log what fields we're importing
+                logger.info(
+                    "Importing %s with fields: %s", asset_type, list(config.keys())
+                )
+                if asset_type == "dashboard":
+                    logger.info(
+                        "Dashboard title in config: %s",
+                        config.get("dashboard_title", "NOT FOUND"),
+                    )
+
+                # For charts, ensure we keep the current dataset reference
+                if asset_type == "chart" and hasattr(current_asset, "datasource_id"):
+                    config["datasource_id"] = current_asset.datasource_id
+                    config["datasource_type"] = current_asset.datasource_type
+                    config["datasource_name"] = getattr(
+                        current_asset.datasource, "table_name", ""
+                    )
+
+                # For datasets, preserve the current database reference
+                elif asset_type == "dataset" and hasattr(current_asset, "database_id"):
+                    config["database_id"] = current_asset.database_id
+
+                # For dashboards, look up chart IDs by UUID from the database
+                # and rebuild dashboard_slices
+                elif asset_type == "dashboard":
+                    chart_ids_to_add: list[int] = []
+                    if "position" in config:
+                        for key, child in config["position"].items():
+                            if (
+                                isinstance(child, dict)
+                                and child.get("type") == "CHART"
+                                and "uuid" in child.get("meta", {})
+                            ):
+                                chart_uuid = child["meta"]["uuid"]
+
+                                # Look up chart by UUID in database
+                                chart = (
+                                    db.session.query(Slice)
+                                    .filter_by(uuid=chart_uuid)
+                                    .first()
+                                )
+                                if chart:
+                                    # Chart exists, use its current ID and remove UUID
+                                    child["meta"]["chartId"] = chart.id
+                                    child["meta"].pop("uuid", None)
+                                    chart_ids_to_add.append(chart.id)
+                                else:
+                                    # Chart truly doesn't exist
+                                    logger.warning(
+                                        "Chart with UUID %s not found, "
+                                        "will skip this chart",
+                                        chart_uuid,
+                                    )
+
+                # Call the appropriate import function directly
+                if asset_type == "chart":
+                    import_chart(config, overwrite=True, ignore_permissions=True)
+                elif asset_type == "dashboard":
+                    logger.info(
+                        "Calling import_dashboard with dashboard_title: %s",
+                        config.get("dashboard_title", "MISSING"),
+                    )
+                    dashboard = import_dashboard(
+                        config, overwrite=True, ignore_permissions=True
+                    )
+                    logger.info(
+                        "After import_dashboard, dashboard.dashboard_title: %s",
+                        dashboard.dashboard_title,
+                    )
+
+                    # Rebuild the dashboard_slices relationship to match
+                    # the restored version
+                    existing_relationships = db.session.execute(
+                        db.select(
+                            dashboard_slices.c.dashboard_id, dashboard_slices.c.slice_id
+                        ).where(dashboard_slices.c.dashboard_id == dashboard.id)
+                    ).fetchall()
+                    existing_chart_ids = {
+                        chart_id for _, chart_id in existing_relationships
+                    }
+
+                    # Convert chart_ids_to_add to a set for easier comparison
+                    chart_ids_set = set(chart_ids_to_add)
+
+                    # Add missing chart relationships
+                    new_relationships = [
+                        {"dashboard_id": dashboard.id, "slice_id": chart_id}
+                        for chart_id in chart_ids_to_add
+                        if chart_id not in existing_chart_ids
+                    ]
+                    if new_relationships:
+                        db.session.execute(
+                            dashboard_slices.insert(), new_relationships
+                        )
+
+                    # Remove chart relationships that shouldn't be there anymore
+                    charts_to_remove = existing_chart_ids - chart_ids_set
+                    if charts_to_remove:
+                        db.session.execute(
+                            dashboard_slices.delete().where(
+                                and_(
+                                    dashboard_slices.c.dashboard_id == dashboard.id,
+                                    dashboard_slices.c.slice_id.in_(charts_to_remove),
+                                )
+                            )
+                        )
+
+                elif asset_type == "dataset":
+                    import_dataset(config, overwrite=True, ignore_permissions=True)
+
+        # Commit the import changes first before restoring roles/owners
+        db.session.commit()
+
+        # Restore original roles and owners after import
+        # Refresh the asset from DB to get the updated state
+        db.session.expire_all()
+        restored_asset = self.DAO_MAP[asset_type].find_by_id(asset_id)
+
+        logger.info(
+            "After import, asset has %d owners and %d roles",
+            len(getattr(restored_asset, "owners", [])),
+            len(getattr(restored_asset, "roles", [])),
+        )
+
+        # Explicitly set roles and owners back to original values
+        restored_asset.roles = current_roles
+        restored_asset.owners = current_owners
+
+        logger.info(
+            "Restored to %d owners and %d roles",
+            len(current_owners),
+            len(current_roles),
+        )
+
+        # Commit the role/owner restoration
+        db.session.commit()
+
+    @expose("/<asset_type>/<int:asset_id>/save", methods=["POST"])
+    @protect()
+    @safe
+    def save_version(self, asset_type: str, asset_id: int) -> Response:
+        """Save a new version to the database"""
+        cfg = self.cfg
+        if not cfg["enabled"]:
+            return self.response_400(message="Version control not configured")
+
+        description = (request.json or {}).get("description", "").strip()
+        if not description:
+            return self.response_400(message="Description required")
+
+        asset = self.DAO_MAP[asset_type].find_by_id(asset_id)
+        if not asset:
+            return self.response_404()
+
+        try:
+            # Export asset
+            yaml_bundle = self._export_asset(asset_type, asset_id)
+
+            # Get next version number
+            last_version = (
+                db.session.query(VersionHistory)
+                .filter(
+                    VersionHistory.asset_type == self.ASSET_TYPE_ENUM[asset_type],
+                    VersionHistory.asset_id == asset_id,
+                )
+                .order_by(desc(VersionHistory.version_number))
+                .first()
+            )
+            version_num = (last_version.version_number + 1) if last_version else 1
+
+            # Get current user
+            username = g.user.username if hasattr(g, "user") and g.user else "Unknown"
+            user_id = g.user.id if hasattr(g, "user") and g.user else None
+
+            if not user_id:
+                return self.response_400(message="User not authenticated")
+
+            # Create version record
+            version_record = VersionHistory(
+                asset_type=self.ASSET_TYPE_ENUM[asset_type],
+                asset_id=asset_id,
+                version_number=version_num,
+                version_data=json.dumps(yaml_bundle),
+                description=description,
+                created_on=datetime.now(timezone.utc),
+                created_by_fk=user_id,
+            )
+            db.session.add(version_record)
+            db.session.commit()
+
+            # Cleanup old versions based on retention policy
+            all_versions = (
+                db.session.query(VersionHistory)
+                .filter(
+                    VersionHistory.asset_type == self.ASSET_TYPE_ENUM[asset_type],
+                    VersionHistory.asset_id == asset_id,
+                )
+                .order_by(desc(VersionHistory.version_number))
+                .all()
+            )
+
+            if len(all_versions) > cfg["retention"]:
+                versions_to_delete = all_versions[cfg["retention"] :]
+                for old_version in versions_to_delete:
+                    db.session.delete(old_version)
+                db.session.commit()
+
+            return self.response(
+                200,
+                result={
+                    "version_number": version_num,
+                    "description": description,
+                    "created_by": username,
+                    "created_on": version_record.created_on.isoformat(),
+                },
+            )
+        except Exception as e:
+            db.session.rollback()
+            logger.exception("Error saving version")
+            return self.response_500(message=str(e))
+
+    @expose("/<asset_type>/<int:asset_id>/list", methods=["GET"])
+    @protect()
+    @safe
+    def list_versions(self, asset_type: str, asset_id: int) -> Response:
+        """List all versions from the database"""
+        try:
+            if not self.cfg["enabled"]:
+                return self.response(200, result={"count": 0, "versions": []})
+
+            versions = (
+                db.session.query(VersionHistory)
+                .filter(
+                    VersionHistory.asset_type == self.ASSET_TYPE_ENUM[asset_type],
+                    VersionHistory.asset_id == asset_id,
+                )
+                .order_by(desc(VersionHistory.version_number))
+                .all()
+            )
+
+            version_list = [
+                {
+                    "version_number": v.version_number,
+                    "description": v.description or "",
+                    "created_by": v.created_by_name,
+                    "created_on": v.created_on.isoformat() if v.created_on else "",
+                    "commit_sha": "",
+                }
+                for v in versions
+            ]
+
+            return self.response(
+                200, result={"count": len(version_list), "versions": version_list}
+            )
+        except Exception as e:
+            logger.exception("Error listing versions")
+            return self.response_500(message=str(e))
+
+    @expose("/<asset_type>/<int:asset_id>/restore", methods=["POST"])
+    @protect()
+    @safe
+    def restore_version(self, asset_type: str, asset_id: int) -> Response:
+        """Restore a previous version from the database"""
+        if not self.cfg["enabled"]:
+            return self.response_400(message="Version control not enabled")
+
+        version_num = (request.json or {}).get("version_number")
+        if not version_num:
+            return self.response_400(message="version_number required")
+
+        try:
+            # Load version record
+            version_record = (
+                db.session.query(VersionHistory)
+                .filter(
+                    VersionHistory.asset_type == self.ASSET_TYPE_ENUM[asset_type],
+                    VersionHistory.asset_id == asset_id,
+                    VersionHistory.version_number == version_num,
+                )
+                .first()
+            )
+
+            if not version_record:
+                return self.response_404(message=f"Version {version_num} not found")
+
+            # Parse version data
+            yaml_bundle = json.loads(version_record.version_data)
+
+            # Import the asset
+            self._import_asset(asset_type, asset_id, yaml_bundle)
+
+            return self.response(
+                200,
+                result={
+                    "asset_type": asset_type,
+                    "asset_id": asset_id,
+                    "version_number": version_num,
+                    "success": True,
+                },
+            )
+        except Exception as e:
+            db.session.rollback()
+            logger.exception("Error restoring version")
+            return self.response_500(message=str(e))

--- a/tests/unit_tests/version_control/__init__.py
+++ b/tests/unit_tests/version_control/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/version_control/api_test.py
+++ b/tests/unit_tests/version_control/api_test.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any
+
+from sqlalchemy.orm.session import Session
+
+from superset import db
+
+
+def test_list_versions_empty(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test listing versions when no versions exist.
+    """
+    from superset.models.version_history import VersionHistory
+
+    VersionHistory.metadata.create_all(db.session.get_bind())
+
+    response = client.get("/api/v1/version/dashboard/999/list")
+    assert response.status_code == 200
+    result = response.json.get("result", {})
+    assert result.get("count") == 0 or result.get("versions") == []
+
+
+def test_list_versions_invalid_asset_type(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test listing versions with invalid asset type returns error.
+    """
+    from superset.models.version_history import VersionHistory
+
+    VersionHistory.metadata.create_all(db.session.get_bind())
+
+    response = client.get("/api/v1/version/invalid_type/1/list")
+    assert response.status_code in (400, 500)
+
+
+def test_save_version_missing_description(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test saving a version without description returns error.
+    """
+    from superset.models.version_history import VersionHistory
+
+    VersionHistory.metadata.create_all(db.session.get_bind())
+
+    response = client.post(
+        "/api/v1/version/dashboard/1/save",
+        json={},
+    )
+    assert response.status_code == 400
+
+
+def test_restore_version_missing_version_number(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test restoring a version without version_number returns error.
+    """
+    from superset.models.version_history import VersionHistory
+
+    VersionHistory.metadata.create_all(db.session.get_bind())
+
+    response = client.post(
+        "/api/v1/version/dashboard/1/restore",
+        json={},
+    )
+    assert response.status_code == 400

--- a/tests/unit_tests/version_control/models_test.py
+++ b/tests/unit_tests/version_control/models_test.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm.session import Session
+
+from superset import db
+
+
+@pytest.fixture
+def session_with_data(session: Session) -> Iterator[Session]:
+    from superset.models.version_history import AssetType, VersionHistory
+
+    engine = session.get_bind()
+    VersionHistory.metadata.create_all(engine)
+
+    version = VersionHistory(
+        asset_type=AssetType.DASHBOARD,
+        asset_id=1,
+        version_number=1,
+        version_data='{"test": "data"}',
+        description="Test version",
+        created_on=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        created_by_fk=1,
+    )
+
+    session.add(version)
+    session.flush()
+    yield session
+    session.rollback()
+
+
+def test_version_history_query(session_with_data: Session) -> None:
+    from superset.models.version_history import AssetType, VersionHistory
+
+    result = (
+        db.session.query(VersionHistory)
+        .filter(
+            VersionHistory.asset_type == AssetType.DASHBOARD,
+            VersionHistory.asset_id == 1,
+        )
+        .first()
+    )
+
+    assert result
+    assert result.version_number == 1
+    assert result.description == "Test version"
+
+
+def test_version_history_query_not_found(session_with_data: Session) -> None:
+    from superset.models.version_history import AssetType, VersionHistory
+
+    result = (
+        db.session.query(VersionHistory)
+        .filter(
+            VersionHistory.asset_type == AssetType.CHART,
+            VersionHistory.asset_id == 999,
+        )
+        .first()
+    )
+
+    assert result is None
+
+
+def test_version_history_repr(session_with_data: Session) -> None:
+    from superset.models.version_history import AssetType, VersionHistory
+
+    result = (
+        db.session.query(VersionHistory)
+        .filter(
+            VersionHistory.asset_type == AssetType.DASHBOARD,
+            VersionHistory.asset_id == 1,
+        )
+        .first()
+    )
+
+    assert result
+    repr_str = repr(result)
+    assert "asset_type=dashboard" in repr_str
+    assert "asset_id=1" in repr_str
+    assert "version=1" in repr_str


### PR DESCRIPTION

### SUMMARY
This commit implements the version changes proposed in GitHub issue https://github.com/apache/superset/issues/36145 (SIP-192) to create a way to save a dashboard/chart/dataset state.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
I have a few recordings in the comment sections of the SIP going over how it works.

### TESTING INSTRUCTIONS
1. Save the state of the asset (i'm just going to call them dashboards for now)
<img width="449" height="544" alt="image" src="https://github.com/user-attachments/assets/bec27763-46e1-45f2-b767-41f75cd99d33" />
2. Make changes to the dashboard, add charts, remove charts, change the title
3. Restore the dashboard
4. Check to see if it's actually reverted.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/36145
- [ ] Required feature flags:
VERSION_CONTROL_ENABLED = True
VERSION_RETENTION_LIMIT = 10
- [x] Changes UI: Properties modal has a new button and modal with the version history info
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
