### PR TITLE
fix(mcp): Use config-based URL for MCP service instead of request auto-detection

### DIFF
--- a/superset/mcp_service/utils/url_utils.py
+++ b/superset/mcp_service/utils/url_utils.py
@@ -46,33 +46,14 @@ def get_superset_base_url() -> str:
     Returns:
         Base URL for Superset web server (e.g., "http://localhost:9001")
     """
-    # Default fallback to localhost:9001
     default_url = "http://localhost:9001"
 
     try:
-        # Try to get from configuration
         config = current_app.config
-
-        # Check for SUPERSET_WEBSERVER_ADDRESS first
-        webserver_address = config.get("SUPERSET_WEBSERVER_ADDRESS")
-        if webserver_address:
-            return webserver_address
-
-        # Fallback to other potential config keys
-        public_role_like_gamma = config.get("PUBLIC_ROLE_LIKE_GAMMA", False)
-        if public_role_like_gamma:
-            # If public access is enabled, might be on a different host
-            webserver_protocol = config.get("ENABLE_PROXY_FIX", False)
-            protocol = "https" if webserver_protocol else "http"
-            host = config.get("WEBSERVER_HOST", "localhost")
-            port = config.get("WEBSERVER_PORT", 9001)
-            return f"{protocol}://{host}:{port}"
-
+        if user_friendly_url := config["WEBDRIVER_BASEURL_USER_FRIENDLY"]:
+            return user_friendly_url.rstrip("/")
         return default_url
-
     except Exception:
-        # If we can't access Flask config (e.g., outside app context),
-        # return default
         return default_url
 
 

--- a/superset/mcp_service/utils/url_utils.py
+++ b/superset/mcp_service/utils/url_utils.py
@@ -79,11 +79,14 @@ def get_mcp_service_url() -> str:
             return mcp_service_url
 
         # In production, MCP service is accessed via main URL with /mcp prefix
-        # SUPERSET_WEBSERVER_ADDRESS is dynamically set per workspace
-        webserver_address = config.get("SUPERSET_WEBSERVER_ADDRESS")
-        if webserver_address and webserver_address != "http://localhost:9001":
-            # Production/staging - use main URL with /mcp prefix
-            return f"{webserver_address}/mcp"
+        # WEBDRIVER_BASEURL_USER_FRIENDLY is the user-facing URL for the instance
+        user_friendly_url = config.get("WEBDRIVER_BASEURL_USER_FRIENDLY")
+        if user_friendly_url:
+            # Remove trailing slash if present and add /mcp prefix
+            base_url = user_friendly_url.rstrip("/")
+            # Skip localhost URLs (development)
+            if "localhost" not in base_url:
+                return f"{base_url}/mcp"
 
     except Exception as e:
         import logging

--- a/superset/mcp_service/utils/url_utils.py
+++ b/superset/mcp_service/utils/url_utils.py
@@ -19,12 +19,15 @@
 URL utilities for MCP service
 """
 
+import logging
 from urllib.parse import urlparse
 
 from flask import current_app
 
+logger = logging.getLogger(__name__)
+
 # Hostnames that indicate a development/local environment
-LOCAL_HOSTNAMES = {"localhost", "127.0.0.1", "0.0.0.0"}
+LOCAL_HOSTNAMES = {"localhost", "127.0.0.1", "0.0.0.0"}  # noqa: S104
 
 
 def _is_local_url(url: str) -> bool:
@@ -77,8 +80,8 @@ def get_mcp_service_url() -> str:
     """
     Get the MCP service base URL where screenshot endpoints are served.
 
-    In production (multi-tenant), the MCP service is accessed via the main
-    Superset URL with /mcp prefix (routed by api-gateway). In development,
+    In production, the MCP service is typically accessed via the main
+    Superset URL with /mcp prefix. In development,
     it's accessed directly on port 5008.
 
     Returns:
@@ -94,16 +97,14 @@ def get_mcp_service_url() -> str:
 
         # In production, MCP service is accessed via main URL with /mcp prefix
         # WEBDRIVER_BASEURL_USER_FRIENDLY is the user-facing URL for the instance
-        user_friendly_url = config["WEBDRIVER_BASEURL_USER_FRIENDLY"]
-        if user_friendly_url and not _is_local_url(user_friendly_url):
-            # Production/staging - use main URL with /mcp prefix
+        if (
+            user_friendly_url := config["WEBDRIVER_BASEURL_USER_FRIENDLY"]
+        ) and not _is_local_url(user_friendly_url):
             base_url = user_friendly_url.rstrip("/")
             return f"{base_url}/mcp"
 
     except Exception as e:
-        import logging
-
-        logging.getLogger(__name__).debug("Config access failed: %s", e)
+        logger.debug("Config access failed: %s", e)
 
     # Development fallback - direct access to MCP service on port 5008
     return "http://localhost:5008"

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -56,6 +56,17 @@ def mock_auth():
         yield mock_get_user
 
 
+@pytest.fixture(autouse=True)
+def mock_webdriver_baseurl(app_context):
+    """Mock WEBDRIVER_BASEURL_USER_FRIENDLY for consistent test URLs."""
+    from flask import current_app
+
+    original_value = current_app.config.get("WEBDRIVER_BASEURL_USER_FRIENDLY")
+    current_app.config["WEBDRIVER_BASEURL_USER_FRIENDLY"] = "http://localhost:9001/"
+    yield
+    current_app.config["WEBDRIVER_BASEURL_USER_FRIENDLY"] = original_value
+
+
 def _mock_dataset(id: int = 1) -> Mock:
     """Create a mock dataset object."""
     dataset = Mock()


### PR DESCRIPTION
### SUMMARY
In production (Kubernetes), the MCP service receives requests via internal networking, causing `request.host` to return internal k8s service URLs like `ws--xxx--main-superset-mcp.ws--xxx--main.svc.cluster.local:5008` which are not accessible externally.

This fix replaces `request.host` auto-detection with config-based URL resolution using `WEBDRIVER_BASEURL_USER_FRIENDLY`, which is the standard config for user-facing URLs in Superset.

**Changes:**
- Use `WEBDRIVER_BASEURL_USER_FRIENDLY` config for determining the Superset base URL
- Add `/mcp` suffix for MCP service URL in production environments
- Skip local URLs (localhost, 127.0.0.1, 0.0.0.0) and fall back to direct port access for development
- `MCP_SERVICE_URL` config still available as explicit override

**Order of precedence for MCP service URL:**
1. `MCP_SERVICE_URL` config (explicit override)
2. `WEBDRIVER_BASEURL_USER_FRIENDLY` + `/mcp` suffix (production)
3. `localhost:5008` fallback (development)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend change only

### TESTING INSTRUCTIONS
1. In development: MCP service should use `localhost:5008` by default
2. With `WEBDRIVER_BASEURL_USER_FRIENDLY` set to a non-localhost URL: MCP service URLs should use that address with `/mcp` suffix
3. With explicit `MCP_SERVICE_URL` config: Should use that value directly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API