### PR TITLE
fix(logout):  clicking logout displays an error notification "invalid username or password"

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -378,9 +378,11 @@ test('Logs out and clears local storage item redux', async () => {
     useTheme: true,
   });
 
-  // Set an item in local storage to test if it gets cleared
+  // Set items in local and session storage to test if they get cleared
   localStorage.setItem('redux', JSON.stringify({ test: 'test' }));
+  sessionStorage.setItem('login_attempted', 'true');
   expect(localStorage.getItem('redux')).not.toBeNull();
+  expect(sessionStorage.getItem('login_attempted')).not.toBeNull();
 
   userEvent.hover(await screen.findByText(/Settings/i));
 
@@ -390,8 +392,9 @@ test('Logs out and clears local storage item redux', async () => {
     userEvent.click(logoutButton);
   });
 
-  // Wait for local storage to be cleared
+  // Wait for local and session storage to be cleared
   await waitFor(() => {
     expect(localStorage.getItem('redux')).toBeNull();
+    expect(sessionStorage.getItem('login_attempted')).toBeNull();
   });
 });

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -336,6 +336,7 @@ const RightMenu = ({
 
   const handleLogout = () => {
     localStorage.removeItem('redux');
+    sessionStorage.removeItem('login_attempted');
   };
 
   // Use the theme menu hook

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -336,16 +336,10 @@ const RightMenu = ({
 
   const handleLogout = () => {
     try {
-      if (typeof window !== 'undefined') {
-        if (window.localStorage?.removeItem) {
-          window.localStorage.removeItem('redux');
-        }
-        if (window.sessionStorage?.removeItem) {
-          window.sessionStorage.removeItem('login_attempted');
-        }
-      }
-    } catch {
-      // Swallow storage errors to avoid crashing when storage is unavailable
+      window.localStorage.removeItem('redux');
+      window.sessionStorage.removeItem('login_attempted');
+    } catch (error) {
+      console.warn('Failed to clear storage on logout:', error);
     }
   };
 

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -335,8 +335,18 @@ const RightMenu = ({
   const handleDatabaseAdd = () => setQuery({ databaseAdded: true });
 
   const handleLogout = () => {
-    localStorage.removeItem('redux');
-    sessionStorage.removeItem('login_attempted');
+    try {
+      if (typeof window !== 'undefined') {
+        if (window.localStorage?.removeItem) {
+          window.localStorage.removeItem('redux');
+        }
+        if (window.sessionStorage?.removeItem) {
+          window.sessionStorage.removeItem('login_attempted');
+        }
+      }
+    } catch {
+      // Swallow storage errors to avoid crashing when storage is unavailable
+    }
   };
 
   // Use the theme menu hook


### PR DESCRIPTION
## **User description**
<!---
fix(logout):  clicking logout displays an error notification "invalid username or password"
-->

### SUMMARY
The logout handler in RightMenu.tsx cleared localStorage but not sessionStorage. If login_attempted was still set from a previous failed login, the login page showed the "Invalid username or password" error after logout.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1192" height="856" alt="logout" src="https://github.com/user-attachments/assets/9ff05c97-1dba-423c-90be-dd2150caf5d1" />

AFTER:
<img width="1265" height="1173" alt="Screenshot from 2025-12-10 13-00-13" src="https://github.com/user-attachments/assets/e5e7b667-dd7a-4239-a210-bb228187c316" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #36480
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Clear session login flag on logout to avoid showing a stale login error

### What Changed
- Logout now removes the session login flag so the login page no longer shows a lingering "Invalid username or password" message after logging out
- Tests updated to verify both local storage and session storage login state are cleared when a user logs out

### Impact
`✅ No stale "Invalid username or password" after logout`
`✅ Login page shows correct state immediately after logout`
`✅ Fewer unexpected error notifications during sign-in`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
