### PR TITLE
docs(badges): Restore project badges on README - and re-implement the Docusaurus ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ under the License.
 [![Latest Release on Github](https://img.shields.io/github/v/release/apache/superset?sort=semver)](https://github.com/apache/superset/releases/latest)
 [![Build Status](https://github.com/apache/superset/actions/workflows/superset-python-unittest.yml/badge.svg)](https://github.com/apache/superset/actions)
 [![PyPI version](https://badge.fury.io/py/apache_superset.svg)](https://badge.fury.io/py/apache_superset)
-[![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache_superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache_superset)
 [![GitHub Stars](https://img.shields.io/github/stars/apache/superset?style=social)](https://github.com/apache/superset/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/apache/superset)](https://github.com/apache/superset/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+# Superset
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/license/apache-2-0)
+[![Latest Release on Github](https://img.shields.io/github/v/release/apache/superset?sort=semver)](https://github.com/apache/superset/releases/latest)
+[![Build Status](https://github.com/apache/superset/actions/workflows/superset-python-unittest.yml/badge.svg)](https://github.com/apache/superset/actions)
+[![PyPI version](https://badge.fury.io/py/apache_superset.svg)](https://badge.fury.io/py/apache_superset)
+[![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
+[![PyPI](https://img.shields.io/pypi/pyversions/apache_superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache_superset)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
+[![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
+
 <picture width="500">
   <source
     width="600"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ under the License.
 [![PyPI version](https://badge.fury.io/py/apache_superset.svg)](https://badge.fury.io/py/apache_superset)
 [![Coverage Status](https://codecov.io/github/apache/superset/coverage.svg?branch=master)](https://codecov.io/github/apache/superset)
 [![PyPI](https://img.shields.io/pypi/pyversions/apache_superset.svg?maxAge=2592000)](https://pypi.python.org/pypi/apache_superset)
+[![GitHub Stars](https://img.shields.io/github/stars/apache/superset?style=social)](https://github.com/apache/superset/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/apache/superset)](https://github.com/apache/superset/graphs/contributors)
+[![Last Commit](https://img.shields.io/github/last-commit/apache/superset)](https://github.com/apache/superset/commits/master)
+[![Open Issues](https://img.shields.io/github/issues/apache/superset)](https://github.com/apache/superset/issues)
+[![Open PRs](https://img.shields.io/github/issues-pr/apache/superset)](https://github.com/apache/superset/pulls)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://bit.ly/join-superset-slack)
 [![Documentation](https://img.shields.io/badge/docs-apache.org-blue.svg)](https://superset.apache.org)
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -23,3 +23,6 @@ docs/.zshrc
 
 # Gets copied from the root of the project at build time (yarn start / yarn build)
 docs/intro.md
+
+# Generated badge images (downloaded at build time by remark-localize-badges plugin)
+static/badges/

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -21,6 +21,7 @@ import type { Config } from '@docusaurus/types';
 import type { Options, ThemeConfig } from '@docusaurus/preset-classic';
 import { themes } from 'prism-react-renderer';
 import remarkImportPartial from 'remark-import-partial';
+import remarkLocalizeBadges from './plugins/remark-localize-badges.mjs';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -44,7 +45,7 @@ if (!versionsConfig.components.disabled) {
       sidebarPath: require.resolve('./sidebarComponents.js'),
       editUrl:
         'https://github.com/apache/superset/edit/master/docs/components',
-      remarkPlugins: [remarkImportPartial],
+      remarkPlugins: [remarkImportPartial, remarkLocalizeBadges],
       docItemComponent: '@theme/DocItem',
       includeCurrentVersion: versionsConfig.components.includeCurrentVersion,
       lastVersion: versionsConfig.components.lastVersion,
@@ -68,7 +69,7 @@ if (!versionsConfig.developer_portal.disabled) {
       sidebarPath: require.resolve('./sidebarTutorials.js'),
       editUrl:
         'https://github.com/apache/superset/edit/master/docs/developer_portal',
-      remarkPlugins: [remarkImportPartial],
+      remarkPlugins: [remarkImportPartial, remarkLocalizeBadges],
       docItemComponent: '@theme/DocItem',
       includeCurrentVersion: versionsConfig.developer_portal.includeCurrentVersion,
       lastVersion: versionsConfig.developer_portal.lastVersion,
@@ -337,6 +338,7 @@ const config: Config = {
             }
             return `https://github.com/apache/superset/edit/master/docs/${versionDocsDirPath}/${docPath}`;
           },
+          remarkPlugins: [remarkImportPartial, remarkLocalizeBadges],
           includeCurrentVersion: versionsConfig.docs.includeCurrentVersion,
           lastVersion: versionsConfig.docs.lastVersion,  // Make 'next' the default
           onlyIncludeVersions: versionsConfig.docs.onlyIncludeVersions,

--- a/docs/package.json
+++ b/docs/package.json
@@ -65,7 +65,8 @@
     "storybook": "^8.6.11",
     "swagger-ui-react": "^5.30.3",
     "tinycolor2": "^1.4.2",
-    "ts-loader": "^9.5.4"
+    "ts-loader": "^9.5.4",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.1",

--- a/docs/plugins/remark-localize-badges.mjs
+++ b/docs/plugins/remark-localize-badges.mjs
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Remark plugin to localize badge images from shields.io and similar services.
+ *
+ * This plugin downloads badge SVGs at build time and serves them locally,
+ * avoiding external dependencies and caching issues with dynamic badges.
+ *
+ * Inspired by Apache Commons' fixshields.py approach.
+ */
+
+import { visit } from 'unist-util-visit';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+// Badge domains to localize (always localize all URLs from these domains)
+const BADGE_DOMAINS = [
+  'img.shields.io',
+  'badge.fury.io',
+  'codecov.io',
+  'badgen.net',
+  'nodei.co',
+];
+
+// Patterns for badge URLs on other domains (e.g., GitHub Actions badges)
+const BADGE_PATH_PATTERNS = [
+  /github\.com\/.*\/actions\/workflows\/.*\/badge\.svg/,
+  /github\.com\/.*\/badge\.svg/,
+];
+
+// Cache for downloaded badges (persists across files in a single build)
+const badgeCache = new Map();
+
+// Track if we've already ensured the badges directory exists
+let badgesDirCreated = false;
+
+/**
+ * Generate a stable filename for a badge URL
+ */
+function getBadgeFilename(url) {
+  const hash = crypto.createHash('md5').update(url).digest('hex').slice(0, 12);
+  // Extract a readable name from the URL
+  const urlPath = new URL(url).pathname;
+  const readablePart = urlPath
+    .replace(/^\//, '')
+    .replace(/[^a-zA-Z0-9-]/g, '_')
+    .slice(0, 40);
+  return `${readablePart}_${hash}.svg`;
+}
+
+/**
+ * Check if a URL is a badge we should localize
+ */
+function isBadgeUrl(url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    // Check if it's from a known badge domain
+    if (BADGE_DOMAINS.some((domain) => parsed.hostname.includes(domain))) {
+      return true;
+    }
+    // Check if it matches a badge path pattern
+    return BADGE_PATH_PATTERNS.some((pattern) => pattern.test(url));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Download a badge and return the local path
+ */
+async function downloadBadge(url, staticDir) {
+  // Check cache first
+  if (badgeCache.has(url)) {
+    return badgeCache.get(url);
+  }
+
+  const badgesDir = path.join(staticDir, 'badges');
+
+  // Ensure badges directory exists
+  if (!badgesDirCreated) {
+    fs.mkdirSync(badgesDir, { recursive: true });
+    badgesDirCreated = true;
+  }
+
+  const filename = getBadgeFilename(url);
+  const localPath = path.join(badgesDir, filename);
+  const webPath = `/badges/${filename}`;
+
+  // Check if already downloaded in a previous build
+  if (fs.existsSync(localPath)) {
+    badgeCache.set(url, webPath);
+    return webPath;
+  }
+
+  console.log(`[remark-localize-badges] Downloading: ${url}`);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        // Some services need a user agent
+        'User-Agent': 'Mozilla/5.0 (compatible; DocusaurusBuild/1.0)',
+        Accept: 'image/svg+xml,image/*,*/*',
+      },
+      // Follow redirects
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    const content = await response.text();
+
+    // Validate it's actually an SVG or image
+    if (
+      !contentType.includes('svg') &&
+      !contentType.includes('image') &&
+      !content.trim().startsWith('<svg') &&
+      !content.trim().startsWith('<?xml')
+    ) {
+      throw new Error(
+        `Invalid content type: ${contentType}. Expected SVG image.`,
+      );
+    }
+
+    // Write the badge to disk
+    fs.writeFileSync(localPath, content, 'utf8');
+    console.log(`[remark-localize-badges] Saved: ${filename}`);
+
+    badgeCache.set(url, webPath);
+    return webPath;
+  } catch (error) {
+    // Fail the build on badge download failure
+    throw new Error(
+      `[remark-localize-badges] Failed to download badge: ${url}\n` +
+        `Error: ${error.message}\n` +
+        `Build cannot continue with broken badges. Please fix the badge URL or remove it.`,
+    );
+  }
+}
+
+/**
+ * The remark plugin factory
+ */
+export default function remarkLocalizeBadges(options = {}) {
+  // __dirname equivalent for ES modules - use import.meta.url
+  const currentDir = path.dirname(new URL(import.meta.url).pathname);
+  const docsRoot = path.resolve(currentDir, '..');
+  const staticDir = options.staticDir || path.join(docsRoot, 'static');
+
+
+  return async function transformer(tree, file) {
+    const promises = [];
+
+    // Find all image nodes
+    visit(tree, 'image', (node) => {
+      if (isBadgeUrl(node.url)) {
+        promises.push(
+          downloadBadge(node.url, staticDir).then((localPath) => {
+            node.url = localPath;
+          }),
+        );
+      }
+    });
+
+    // Also handle HTML img tags in raw HTML or JSX
+    visit(tree, ['html', 'jsx'], (node) => {
+      if (!node.value) return;
+
+      // Find img src attributes pointing to badge URLs
+      const imgRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi;
+      let match;
+
+      while ((match = imgRegex.exec(node.value)) !== null) {
+        const url = match[1];
+        if (isBadgeUrl(url)) {
+          promises.push(
+            downloadBadge(url, staticDir).then((localPath) => {
+              node.value = node.value.replace(url, localPath);
+            }),
+          );
+        }
+      }
+    });
+
+    // Also handle markdown link images: [![alt](img-url)](link-url)
+    visit(tree, 'link', (node) => {
+      if (node.children) {
+        node.children.forEach((child) => {
+          if (child.type === 'image' && isBadgeUrl(child.url)) {
+            promises.push(
+              downloadBadge(child.url, staticDir).then((localPath) => {
+                child.url = localPath;
+              }),
+            );
+          }
+        });
+      }
+    });
+
+    // Wait for all downloads to complete
+    await Promise.all(promises);
+  };
+}

--- a/docs/plugins/remark-localize-badges.mjs
+++ b/docs/plugins/remark-localize-badges.mjs
@@ -169,7 +169,7 @@ export default function remarkLocalizeBadges(options = {}) {
   const staticDir = options.staticDir || path.join(docsRoot, 'static');
 
 
-  return async function transformer(tree, file) {
+  return async function transformer(tree) {
     const promises = [];
 
     // Find all image nodes


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR restores and enhances project badges in the README, while implementing a Docusaurus plugin to localize badges at build time for the documentation site.

**Key Changes:**

1. **Restored badges to README.md** - ASF allows badges on GitHub-hosted README files
2. **Added 5 new community/activity badges:**
   - GitHub Stars (69k+ ⭐)
   - Contributors
   - Last Commit
   - Open Issues
   - Open PRs
3. **Created `remark-localize-badges` Docusaurus plugin** that:
   - Downloads badge SVGs at build time
   - Serves them locally (no external dependencies at runtime)
   - Fails the build if any badge URL is broken (catches issues early)
   - Inspired by [Apache Commons' fixshields.py approach](https://svn.apache.org/repos/asf/commons/cms-site/trunk/fixshields.py)

**Total badges: 12**
| Badge | Type | Links To |
|-------|------|----------|
| License | Static | Apache License |
| Latest Release | Dynamic | GitHub Releases |
| Build Status | Dynamic | GitHub Actions |
| PyPI version | Dynamic | PyPI |
| Python versions | Dynamic | PyPI |
| GitHub Stars | Dynamic | Stargazers |
| Contributors | Dynamic | Contributors graph |
| Last Commit | Dynamic | Commits |
| Open Issues | Dynamic | Issues |
| Open PRs | Dynamic | Pull Requests |
| Slack | Static | Slack invite |
| Documentation | Static | superset.apache.org |

*Note: Removed codecov badge as it was showing 0% (integration not properly configured)*

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** No badges on README
**After:** 12 badges showing project health, activity, and community

### TESTING INSTRUCTIONS

1. View the README.md on GitHub - badges should render
2. Build the docs site locally:
   ```bash
   cd docs
   yarn build
   ```
3. Verify badges are downloaded to `static/badges/` during build
4. Serve the built site and check badges load from local files

### ADDITIONAL INFORMATION

- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Restore project badges in README and serve badge images locally during docs builds

### What Changed
- README now displays a set of project badges (license, release, build status, PyPI version, Python versions, GitHub stars, contributors, last commit, open issues, open PRs, Slack, documentation); codecov badge removed
- Added a Docusaurus remark plugin that downloads badge SVGs at docs build time and replaces remote URLs with local copies so the site serves badges from the docs static files
- The docs build will fail if any badge URL cannot be downloaded, catching broken or unreachable badge links early
- Plugin is enabled across docs, components, and developer portal sections and included in the docs package dependencies

### Impact
`✅ Badges visible on GitHub README`
`✅ Local docs serve badges without runtime external requests`
`✅ Build fails early on broken badge URLs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
