### PR TITLE
feat(mcp): Caching uses in-memory store by default when no external store is configured

### DIFF
--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -73,18 +73,73 @@ MCP_FACTORY_CONFIG = {
     "config": None,  # No additional config
 }
 
-# MCP Store Configuration - shared infrastructure for all MCP storage needs
-# (caching, auth, events, etc.)
+# =============================================================================
+# MCP Storage and Caching Configuration
+# =============================================================================
+#
+# Overview:
+# ---------
+# MCP caching uses FastMCP's ResponseCachingMiddleware to cache tool responses.
+# By default, caching is DISABLED. When enabled, it can use either:
+#   1. In-memory store (default) - no additional configuration needed
+#   2. Redis store - requires MCP_STORE_CONFIG to be enabled
+#
+# Configuration Flow:
+# -------------------
+# - MCP_CACHE_CONFIG controls whether caching is enabled and its TTL settings
+# - MCP_STORE_CONFIG controls the Redis store (optional)
+#
+# Scenarios:
+# ----------
+# 1. Caching disabled (default):
+#    MCP_CACHE_CONFIG["enabled"] = False
+#    → No caching, MCP_STORE_CONFIG is ignored
+#
+# 2. Caching with in-memory store:
+#    MCP_CACHE_CONFIG["enabled"] = True
+#    MCP_STORE_CONFIG["enabled"] = False (or not configured)
+#    → Caching uses FastMCP's default in-memory store, no Prefix wrapper used
+#
+# 3. Caching with Redis store:
+#    MCP_CACHE_CONFIG["enabled"] = True
+#    MCP_STORE_CONFIG["enabled"] = True
+#    MCP_STORE_CONFIG["CACHE_REDIS_URL"] = "redis://..."
+#    → Caching uses Redis with PrefixKeysWrapper
+#
+# Redis Store Details:
+# --------------------
+# When MCP_STORE_CONFIG is enabled, it creates a RedisStore wrapped with
+# PrefixKeysWrapper (configurable via WRAPPER_TYPE). The wrapper prepends a
+# prefix to all keys, allowing multiple features to share the same Redis
+# instance with isolated key namespaces. The prefix comes from the consumer
+# (e.g., MCP_CACHE_CONFIG["CACHE_KEY_PREFIX"] for caching).
+#
+# Advanced Usage:
+# ---------------
+# The store factory (get_mcp_store) can be used independently for custom
+# purposes like auth token storage or event logging. Import and call:
+#
+#   from superset.mcp_service.storage import get_mcp_store
+#   my_store = get_mcp_store(prefix="my_feature_v1_")
+#
+# Currently, the store is only used by the caching layer when enabled.
+# =============================================================================
+
+# MCP Store Configuration - shared Redis infrastructure for all MCP storage needs
+# (caching, auth, events, etc.). Only used when a consumer explicitly requests it.
 MCP_STORE_CONFIG: Dict[str, Any] = {
-    "enabled": False,  # Disabled by default in OSS
-    "CACHE_REDIS_URL": None,  # Must be configured to enable
+    "enabled": False,  # Disabled by default - caching uses in-memory store
+    "CACHE_REDIS_URL": None,  # Redis URL, e.g., "redis://localhost:6379/0"
+    # Wrapper class that prefixes all keys. Each consumer provides their own prefix.
     "WRAPPER_TYPE": "key_value.aio.wrappers.prefix_keys.PrefixKeysWrapper",
 }
 
-# MCP Response Caching Configuration - feature-specific settings
+# MCP Response Caching Configuration - controls caching behavior and TTLs
+# When enabled without MCP_STORE_CONFIG, uses in-memory store.
+# When enabled with MCP_STORE_CONFIG, uses Redis store.
 MCP_CACHE_CONFIG: Dict[str, Any] = {
-    "enabled": False,  # Disabled by default in OSS
-    "CACHE_KEY_PREFIX": "mcp_cache_v1_",  # Static prefix for OSS
+    "enabled": False,  # Disabled by default
+    "CACHE_KEY_PREFIX": None,  # Only needed when using the store
     "list_tools_ttl": 60 * 5,  # 5 minutes
     "list_resources_ttl": 60 * 5,  # 5 minutes
     "list_prompts_ttl": 60 * 5,  # 5 minutes
@@ -92,7 +147,7 @@ MCP_CACHE_CONFIG: Dict[str, Any] = {
     "get_prompt_ttl": 60 * 60,  # 1 hour
     "call_tool_ttl": 60 * 60,  # 1 hour
     "max_item_size": 1024 * 1024,  # 1MB
-    "excluded_tools": [
+    "excluded_tools": [  # Tools that should never be cached (side effects, dynamic)
         "execute_sql",
         "generate_dashboard",
         "generate_chart",


### PR DESCRIPTION
## **User description**
### SUMMARY
This PR allows us to use in-memory caching which is [the default behavior in fastMCP](https://github.com/jlowin/fastmcp/blob/main/src/fastmcp/server/middleware/caching.py#L164) by removing the hard requirement of having an external Redis store.

Also, added more info in the config section so it's clear how caching and the store work

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Use in-memory cache by default when no external store is configured

### What Changed
- When caching is enabled but no external store is configured, MCP now uses FastMCP's built-in in-memory cache instead of requiring Redis.
- If the optional store config is enabled, caching will use Redis and requires a cache key prefix; if the prefix is missing the code logs a warning and falls back to in-memory caching.
- Configuration documentation updated to show three clear scenarios: caching disabled, caching with in-memory store (default), and caching with Redis store; unit tests updated to cover the new fallback behaviors.

### Impact
`✅ Fewer runtime failures when Redis is not configured`
`✅ Clearer cache configuration for in-memory vs Redis scenarios`
`✅ Consistent caching behavior when external store is optional`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
