### PR TITLE
fix: UI cut off

### DIFF
--- a/superset-frontend/src/explore/components/ControlHeader.tsx
+++ b/superset-frontend/src/explore/components/ControlHeader.tsx
@@ -42,9 +42,15 @@ export type ControlHeaderProps = {
 const iconStyles = css`
   &.anticon {
     font-size: unset;
+    overflow: visible;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 1;
+    padding-bottom: 0.1em;
     .anticon {
       line-height: unset;
       vertical-align: unset;
+      overflow: visible;
     }
   }
 `;
@@ -121,6 +127,8 @@ const ControlHeader: FC<ControlHeaderProps> = ({
             margin-bottom: ${theme.sizeUnit * 0.5}px;
             position: relative;
             font-size: ${theme.fontSizeSM}px;
+            overflow: visible;
+            padding-bottom: 0.1em;
           `}
           htmlFor={name}
         >

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -138,6 +138,10 @@ const ExplorePanelContainer = styled.div`
       justify-content: space-between;
       .horizontal-text {
         font-size: ${theme.fontSize}px;
+        line-height: 1.5;
+        display: inline-block;
+        height: auto;
+        overflow: visible;
       }
     }
     .no-show {

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTile.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTile.tsx
@@ -137,7 +137,7 @@ export const VizTile = ({
             font-size: ${theme.fontSizeSM}px;
             min-width: 0;
             padding-right: ${theme.sizeUnit}px;
-            line-height: 1;
+            line-height: 1.5;
           `}
           ref={chartNameRef}
         >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Addressed some styling issues in Explore where some parts were clipped off. Updated line-height from 1/1em to 1.5 for text elements to allow descenders. Added overflow: visible and `height: auto` to prevent container clipping. Added `padding-bottom` and `vertical-align `adjustments for Firefox compatibility.

### BEFORE
<img width="1100" height="973" alt="518656450-1bb59a88-84b9-4eb1-a22f-27b7f3b77412" src="https://github.com/user-attachments/assets/d6afa75f-a4be-4099-bd3e-069b7242d5f3" />

### AFTER
<img width="1219" height="1136" alt="518656589-b08a9bde-7d78-4279-b724-c0691f16b4d3" src="https://github.com/user-attachments/assets/3aad3423-0e30-4847-9b8f-bdd42847831a" />


### TESTING INSTRUCTIONS
Browse the UI to ensure no visual elements are cut off

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
