### PR TITLE
feat(mcp): return form_data and form_data_key in generate_chart and generate_explore_link responses

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1155,6 +1155,16 @@ class GenerateChartResponse(BaseModel):
         default_factory=dict, description="Related API endpoints for data/updates"
     )
 
+    # Form data for rendering charts in external clients (chatbot rendering)
+    form_data: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Complete form_data configuration for rendering the chart",
+    )
+    form_data_key: str | None = Field(
+        None,
+        description="Cache key for the form_data, used in explore URLs",
+    )
+
     # Performance and accessibility
     performance: PerformanceMetadata | None = Field(
         None, description="Performance metrics"

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -589,3 +589,97 @@ class TestGenerateExploreLink:
                 expected_url = f"http://localhost:9001/explore/?datasource_type=table&datasource_id={dataset_id}"
                 assert result.data["error"] is None
                 assert result.data["url"] == expected_url
+
+    @pytest.mark.asyncio
+    async def test_generate_explore_link_tool_exception_handling(self, mcp_server):
+        """Test that tool-level exceptions are properly handled and return error."""
+        import sys
+
+        # Get the actual module object from sys.modules (not via __init__.py which
+        # returns the function)
+        explore_module = sys.modules[
+            "superset.mcp_service.explore.tool.generate_explore_link"
+        ]
+
+        original_func = explore_module.map_config_to_form_data
+
+        def raise_error(*args, **kwargs):
+            raise ValueError("Invalid config structure")
+
+        explore_module.map_config_to_form_data = raise_error
+        try:
+            config = TableChartConfig(
+                chart_type="table", columns=[ColumnRef(name="test_col")]
+            )
+            request = GenerateExploreLinkRequest(dataset_id="1", config=config)
+
+            async with Client(mcp_server) as client:
+                result = await client.call_tool(
+                    "generate_explore_link", {"request": request.model_dump()}
+                )
+
+                # Should return error response with empty URL
+                assert result.data["url"] == ""
+                assert result.data["form_data"] == {}
+                assert result.data["form_data_key"] is None
+                assert "Invalid config structure" in result.data["error"]
+        finally:
+            # Restore original function
+            explore_module.map_config_to_form_data = original_func
+
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    @patch(
+        "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
+    )
+    @pytest.mark.asyncio
+    async def test_generate_explore_link_returns_form_data_key(
+        self, mock_create_form_data, mock_find_dataset, mcp_server
+    ):
+        """Test that form_data_key is properly extracted from URL."""
+        mock_create_form_data.return_value = "extracted_form_key_xyz"
+        mock_find_dataset.return_value = _mock_dataset(id=1)
+
+        config = TableChartConfig(
+            chart_type="table", columns=[ColumnRef(name="region")]
+        )
+        request = GenerateExploreLinkRequest(dataset_id="1", config=config)
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "generate_explore_link", {"request": request.model_dump()}
+            )
+
+            assert result.data["error"] is None
+            assert result.data["form_data_key"] == "extracted_form_key_xyz"
+            assert "form_data_key=extracted_form_key_xyz" in result.data["url"]
+
+    @patch("superset.daos.dataset.DatasetDAO.find_by_id")
+    @patch(
+        "superset.mcp_service.commands.create_form_data.MCPCreateFormDataCommand.run"
+    )
+    @pytest.mark.asyncio
+    async def test_generate_explore_link_returns_form_data(
+        self, mock_create_form_data, mock_find_dataset, mcp_server
+    ):
+        """Test that form_data dict is returned for external rendering."""
+        mock_create_form_data.return_value = "form_data_test_key"
+        mock_find_dataset.return_value = _mock_dataset(id=1)
+
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="date"),
+            y=[ColumnRef(name="sales", aggregate="SUM")],
+            kind="line",
+        )
+        request = GenerateExploreLinkRequest(dataset_id="1", config=config)
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "generate_explore_link", {"request": request.model_dump()}
+            )
+
+            assert result.data["error"] is None
+            assert "form_data" in result.data
+            assert isinstance(result.data["form_data"], dict)
+            assert result.data["form_data"].get("viz_type") == "echarts_timeseries_line"
+            assert result.data["form_data"].get("x_axis") == "date"


### PR DESCRIPTION
## **User description**
### SUMMARY

The `generate_chart` MCP tool was computing `form_data` but not returning it in the response. This field is required for external clients (e.g., chatbots) to render charts.

**Changes:**
- Add `form_data` and `form_data_key` fields to `GenerateChartResponse` schema
- Generate `form_data_key` for saved charts (previously only generated for preview mode)
- Use `serialize_chart_object` to populate all chart fields properly (fixes many null fields)
- Return `form_data` and `form_data_key` in `generate_explore_link` response

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** `form_data` and `form_data_key` were missing or null in generate_chart response
**After:** Both fields are populated with the chart configuration data
```
 superset-mcp-local-http - generate_explore_link (MCP)(request: {"dataset_id":1,"config":{"chart_type":"xy","x":{"name":"ds"},"y":[{"na
                                                       me":"count","aggregate":"SUM"}],"kind":"bar"}})
  ⎿  {                                                                 
       "url": "http://0.0.0.0:8080/explore/?form_data_key=Ut0pEshubNA",
       "form_data": {
         "viz_type": "echarts_timeseries_bar",
         "x_axis": "ds",
         "metrics": [
           {
             "aggregate": "SUM",
             "column": {
               "column_name": "count"
             },
             "expressionType": "SIMPLE",
             "label": "SUM(count)",
             "optionName": "metric_count",
             "sqlExpression": null,
             "hasCustomLabel": false,
             "datasourceWarning": false
           }
         ]
       },
       "form_data_key": "Ut0pEshubNA",
       "error": null
     }

⏺ superset-mcp-local-http - generate_chart (MCP)(request:
                                                {"dataset_id":1,"config":{"chart_type":"xy","x":{"name":"year"},"y":[{"name":"SP_POP_TOT
                                                L","aggregate":"SUM"}],"kind":"bar"},"save_chart":true,"generate_preview":false})
  ⎿  {                                                                                
       "chart": {
         "id": 131,
         "slice_name": "Bar Chart - year vs SP_POP_TOTL",
         "viz_type": "echarts_timeseries_bar",
         "datasource_name": "main.wb_health_population",
         "datasource_type": "table",
         "url": "http://0.0.0.0:8080/explore/?slice_id=131",
         "description": null,
         "cache_timeout": null,
         "form_data": {
           "viz_type": "echarts_timeseries_bar",
           "x_axis": "year",
           "metrics": [
             {
               "aggregate": "SUM",
               "column": {
                 "column_name": "SP_POP_TOTL"
               },
               "expressionType": "SIMPLE",
               "label": "SUM(SP_POP_TOTL)",
               "optionName": "metric_SP_POP_TOTL",
               "sqlExpression": null,
               "hasCustomLabel": false,
               "datasourceWarning": false
             }
           ],
           "slice_id": 131,
           "datasource": "1__table"
         },
         "query_context": null,
         "changed_by": "Admin I. Strator",
         "changed_by_name": "Admin I. Strator",
         "changed_on": "2025-12-11T13:00:03.362039",
         "changed_on_humanized": "now",
         "created_by": "Admin I. Strator",
         "created_on": "2025-12-11T13:00:03.362037",
         "created_on_humanized": "now",
         "uuid": "73883265-222c-4886-837a-dc1e25488187",
         "tags": [],
         "owners": [
           {
             "id": 1,
             "username": "admin",
             "first_name": "Admin I.",
             "last_name": "Strator",
             "email": "admin@superset.io",
             "active": true
           }
         ]
       },
       "previews": {},
       "capabilities": {
         "supports_interaction": true,
         "supports_real_time": true,
         "supports_drill_down": false,
         "supports_export": true,
         "optimal_formats": [
           "url",
           "interactive",
           "vega_lite",
           "ascii",
           "table"
         ],
         "data_types": [
           "time_series",
           "metric",
           "categorical"
         ]
       },
       "semantics": {
         "primary_insight": "Compares values across categories or time periods",
         "data_story": "This echarts_timeseries_bar chart analyzes year, SP_POP_TOTL",
         "recommended_actions": [
           "Review data patterns and trends",
           "Consider filtering or drilling down for more detail",
           "Export chart for reporting or sharing",
           "Analyze seasonal patterns or cyclical trends"
         ],
         "anomalies": [],
         "statistical_summary": {}
       },
       "explore_url": "http://0.0.0.0:8080/explore/?slice_id=131",
       "embed_code": null,
       "api_endpoints": {
         "data": "http://0.0.0.0:8080/api/v1/chart/131/data/",
         "preview": "http://localhost:5008/screenshot/chart/131.png",
         "export": "http://0.0.0.0:8080/api/v1/chart/131/export/"
       },
       "form_data": {
         "viz_type": "echarts_timeseries_bar",
         "x_axis": "year",
         "metrics": [
           {
             "aggregate": "SUM",
             "column": {
               "column_name": "SP_POP_TOTL"
             },
             "expressionType": "SIMPLE",
             "label": "SUM(SP_POP_TOTL)",
             "optionName": "metric_SP_POP_TOTL",
             "sqlExpression": null,
             "hasCustomLabel": false,
             "datasourceWarning": false
           }
         ]
       },
       "form_data_key": "06RkISdFKvw",
       "performance": {
         "query_duration_ms": 48,
         "estimated_cost": null,
         "cache_status": "miss",
         "optimization_suggestions": []
       },
       "accessibility": {
         "color_blind_safe": true,
         "alt_text": "Chart showing Bar Chart - year vs SP_POP_TOTL",
         "high_contrast_available": false
       },
       "success": true,
       "error": null,
       "warnings": [],
       "schema_version": "2.0",
       "api_version": "v1"
     }

⏺ superset-mcp-local-http - generate_chart (MCP)(request:
                                                {"dataset_id":1,"config":{"chart_type":"xy","x":{"name":"year"},"y":[{"name":"SP_POP_TOT
                                                L","aggregate":"SUM"}],"kind":"line"},"save_chart":false,"generate_preview":false})
  ⎿  {                                                                                 
       "chart": null,
       "previews": {},
       "capabilities": {
         "supports_interaction": true,
         "supports_real_time": true,
         "supports_drill_down": false,
         "supports_export": true,
         "optimal_formats": [
           "url",
           "interactive",
           "vega_lite",
           "ascii",
           "table"
         ],
         "data_types": [
           "time_series",
           "metric",
           "categorical"
         ]
       },
       "semantics": {
         "primary_insight": "Shows trends and changes over time",
         "data_story": "This echarts_timeseries_line chart analyzes year, SP_POP_TOTL",
         "recommended_actions": [
           "Review data patterns and trends",
           "Consider filtering or drilling down for more detail",
           "Export chart for reporting or sharing",
           "Analyze seasonal patterns or cyclical trends"
         ],
         "anomalies": [],
         "statistical_summary": {}
       },
       "explore_url": "http://0.0.0.0:8080/explore/?form_data_key=_qUNX-bP8u0",
       "embed_code": null,
       "api_endpoints": {},
       "form_data": {
         "viz_type": "echarts_timeseries_line",
         "x_axis": "year",
         "metrics": [
           {
             "aggregate": "SUM",
             "column": {
               "column_name": "SP_POP_TOTL"
             },
             "expressionType": "SIMPLE",
             "label": "SUM(SP_POP_TOTL)",
             "optionName": "metric_SP_POP_TOTL",
             "sqlExpression": null,
             "hasCustomLabel": false,
             "datasourceWarning": false
           }
         ]
       },
       "form_data_key": "_qUNX-bP8u0",
       "performance": {
         "query_duration_ms": 40,
         "estimated_cost": null,
         "cache_status": "miss",
         "optimization_suggestions": []
       },
       "accessibility": {
         "color_blind_safe": true,
         "alt_text": "Chart showing Line Chart - year vs SP_POP_TOTL",
         "high_contrast_available": false
       },
       "success": true,
       "error": null,
       "warnings": [],
       "schema_version": "2.0",
       "api_version": "v1"
     }
```
### TESTING INSTRUCTIONS

1. Call the `generate_chart` MCP tool with a valid dataset and chart config
2. Verify the response contains `form_data` with the chart configuration
3. Verify the response contains `form_data_key` with a cache key
4. Verify `chart.form_data` is also populated (previously always null)

  1. generate_explore_link

  Request:
  {"dataset_id": 1, "config": {"chart_type": "xy", "x": {"name": "ds"}, "y": [{"name": "count", "aggregate": "SUM"}], "kind":
  "bar"}}

  Response:
  | Field         | Value                                                  |
  |---------------|--------------------------------------------------------|
  | url           | http://0.0.0.0:8080/explore/?form_data_key=hZ3ldtk4oDw |
  | form_data     | Contains viz_type, x_axis, metrics                     |
  | form_data_key | hZ3ldtk4oDw                                            |
  | error         | null                                                   |

  ---
  2. generate_chart (save_chart=true)

  Request:
  {"dataset_id": 1, "config": {"chart_type": "xy", "x": {"name": "year"}, "y": [{"name": "SP_POP_TOTL", "aggregate": "SUM"}],
  "kind": "bar"}, "save_chart": true, "generate_preview": false}

  Response:
  | Field            | Value                                                                     |
  |------------------|---------------------------------------------------------------------------|
  | chart.id         | 132                                                                       |
  | chart.slice_name | Bar Chart - year vs SP_POP_TOTL                                           |
  | chart.form_data  | Contains full chart config with slice_id and datasource                   |
  | form_data        | Top-level form_data (same as chart.form_data minus slice-specific fields) |
  | form_data_key    | chqWu5a0tAE                                                               |
  | explore_url      | http://0.0.0.0:8080/explore/?slice_id=132                                 |

  ---
  3. generate_chart (save_chart=false - preview mode)

  Request:
  {"dataset_id": 1, "config": {"chart_type": "xy", "x": {"name": "year"}, "y": [{"name": "SP_POP_TOTL", "aggregate": "SUM"}],
  "kind": "line"}, "save_chart": false, "generate_preview": false}

  Response:
  | Field         | Value                                                  |
  |---------------|--------------------------------------------------------|
  | chart         | null (not saved)                                       |
  | form_data     | Contains viz_type, x_axis, metrics                     |
  | form_data_key | Iva8XVmHTB0                                            |
  | explore_url   | http://0.0.0.0:8080/explore/?form_data_key=Iva8XVmHTB0 |


### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Return form_data and form_data_key in generate_chart and generate_explore_link responses

### What Changed
- generate_chart response now includes a complete form_data object and a form_data_key so external clients (for example, chatbots) receive the full chart configuration and its cache key.
- For saved charts, the service now generates and returns a form_data_key (previously only created for preview mode); explore link generation also extracts and returns form_data_key when present.
- Chart metadata returned for saved charts is populated using the serializer so returned chart fields (URL, id, name, viz type, uuid, etc.) are complete instead of containing many nulls.
- When explore link generation fails, responses include an empty form_data and a null form_data_key instead of omitting those fields.

### Impact
`✅ Chatbots and external clients can render charts using returned form_data`
`✅ Explore links now include or expose the form_data cache key for shared/chart URLs`
`✅ Chart responses contain complete, accurate chart metadata`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
