### PR TITLE
feat(mcp): add datasource field to generate_explore_link form_data

### DIFF
--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -95,7 +95,9 @@ async def generate_explore_link(
         form_data = map_config_to_form_data(request.config)
 
         # Add datasource to form_data for consistency with generate_chart
-        form_data["datasource"] = f"{request.dataset_id}__table"
+        # Only set if not already present to avoid overwriting
+        if "datasource" not in form_data:
+            form_data["datasource"] = f"{request.dataset_id}__table"
 
         await ctx.debug(
             "Form data generated with keys: %s, has_viz_type=%s, has_datasource=%s"

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -94,6 +94,9 @@ async def generate_explore_link(
         # Map config to form_data using shared utilities
         form_data = map_config_to_form_data(request.config)
 
+        # Add datasource to form_data for consistency with generate_chart
+        form_data["datasource"] = f"{request.dataset_id}__table"
+
         await ctx.debug(
             "Form data generated with keys: %s, has_viz_type=%s, has_datasource=%s"
             % (

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -683,3 +683,5 @@ class TestGenerateExploreLink:
             assert isinstance(result.data["form_data"], dict)
             assert result.data["form_data"].get("viz_type") == "echarts_timeseries_line"
             assert result.data["form_data"].get("x_axis") == "date"
+            # Verify datasource field format: "{dataset_id}__table"
+            assert result.data["form_data"].get("datasource") == "1__table"


### PR DESCRIPTION
## **User description**
## SUMMARY

Add the `datasource` field to the `form_data` returned by `generate_explore_link` for consistency with `generate_chart`.

This field (e.g., `"1__table"`) is needed by external clients (chatbots, etc.) to properly render charts using the form_data.

### Changes
- Add `datasource` field to `generate_explore_link` response's `form_data`
- Format: `"{dataset_id}__table"` (e.g., `"1__table"`)

### BEFORE/AFTER

**Before:**
```json
{
  "form_data": {
    "viz_type": "echarts_timeseries_bar",
    "x_axis": "ds",
    "metrics": [...]
  }
}
```

**After:**
```json
{
  "form_data": {
    "viz_type": "echarts_timeseries_bar",
    "x_axis": "ds",
    "metrics": [...],
    "datasource": "1__table"
  }
}
```

### TESTING INSTRUCTIONS

1. Call `generate_explore_link` MCP tool with a valid dataset and chart config
2. Verify the response `form_data` contains a `datasource` field with format `"{dataset_id}__table"`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Add datasource to explore-link form_data to enable external chart rendering**

### What Changed
- The explore-link response now includes a "datasource" field in its form_data, formatted as "{dataset_id}__table" (for example, "1__table")
- External clients (chatbots, embedders, or visualization tools) can consume the returned form_data directly to render charts without requiring an additional dataset lookup
- The form_data returned by generate_explore_link now matches the structure produced by generate_chart

### Impact
`✅ External clients can render charts from explore links`
`✅ Consistent form_data between explore link and chart generation`
`✅ Fewer chart rendering failures for integrations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
