### PR TITLE
feat(security): add built-in Public role for anonymous dashboard access

### DIFF
--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -17,192 +17,192 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-|                                                  |Admin|Alpha|Gamma|SQL_LAB|
-|--------------------------------------------------|---|---|---|---|
-| Permission/role description                      |Admins have all possible rights, including granting or revoking rights from other users and altering other people’s slices and dashboards.|Alpha users have access to all data sources, but they cannot grant or revoke access from other users. They are also limited to altering the objects that they own. Alpha users can add and alter data sources.|Gamma users have limited access. They can only consume data coming from data sources they have been given access to through another complementary role. They only have access to view the slices and dashboards made from data sources that they have access to. Currently Gamma users are not able to alter or add data sources. We assume that they are mostly content consumers, though they can create slices and dashboards.|The sql_lab role grants access to SQL Lab. Note that while Admin users have access to all databases by default, both Alpha and Gamma users need to be given access on a per database basis.||
-| can read on SavedQuery                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can write on SavedQuery                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can read on CssTemplate                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on CssTemplate                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on ReportSchedule                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on ReportSchedule                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on Chart                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on Chart                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on Annotation                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on Dataset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on Dataset                             |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on Log                                  |:heavy_check_mark:|O|O|O|
-| can write on Log                                 |:heavy_check_mark:|O|O|O|
-| can read on Dashboard                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on Dashboard                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on Database                             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can write on Database                            |:heavy_check_mark:|O|O|O|
-| can read on Query                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can this form get on ResetPasswordView           |:heavy_check_mark:|O|O|O|
-| can this form post on ResetPasswordView          |:heavy_check_mark:|O|O|O|
-| can this form get on ResetMyPasswordView         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can this form post on ResetMyPasswordView        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can this form get on UserInfoEditView            |:heavy_check_mark:|O|O|O|
-| can this form post on UserInfoEditView           |:heavy_check_mark:|O|O|O|
-| can show on UserDBModelView                      |:heavy_check_mark:|O|O|O|
-| can edit on UserDBModelView                      |:heavy_check_mark:|O|O|O|
-| can delete on UserDBModelView                    |:heavy_check_mark:|O|O|O|
-| can add on UserDBModelView                       |:heavy_check_mark:|O|O|O|
-| can list on UserDBModelView                      |:heavy_check_mark:|O|O|O|
-| can userinfo on UserDBModelView                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| resetmypassword on UserDBModelView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| resetpasswords on UserDBModelView                |:heavy_check_mark:|O|O|O|
-| userinfoedit on UserDBModelView                  |:heavy_check_mark:|O|O|O|
-| can show on RoleModelView                        |:heavy_check_mark:|O|O|O|
-| can edit on RoleModelView                        |:heavy_check_mark:|O|O|O|
-| can delete on RoleModelView                      |:heavy_check_mark:|O|O|O|
-| can add on RoleModelView                         |:heavy_check_mark:|O|O|O|
-| can list on RoleModelView                        |:heavy_check_mark:|O|O|O|
-| copyrole on RoleModelView                        |:heavy_check_mark:|O|O|O|
-| can get on OpenApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on SwaggerView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can get on MenuApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on AsyncEventsRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can invalidate on CacheRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can csv upload on Database                       |:heavy_check_mark:|O|O|O|
-| can excel upload on Database                     |:heavy_check_mark:|O|O|O|
-| can query form data on Api                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can query on Api                                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can time range on Api                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can external metadata on Datasource              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can save on Datasource                           |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can get on Datasource                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can my queries on SqlLab                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can log on Superset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can import dashboards on Superset                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can schemas on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can sqllab history on Superset                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can publish on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can csv on Superset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can slice on Superset                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can sync druid source on Superset                |:heavy_check_mark:|O|O|O|
-| can explore on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can approve on Superset                          |:heavy_check_mark:|O|O|O|
-| can explore json on Superset                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can fetch datasource metadata on Superset        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can csrf token on Superset                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can sqllab on Superset                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can select star on Superset                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can warm up cache on Superset                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can sqllab table viz on Superset                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can available domains on Superset                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can request access on Superset                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can dashboard on Superset                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can post on TableSchemaView                      |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can expanded on TableSchemaView                  |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can delete on TableSchemaView                    |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can get on TabStateView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can post on TabStateView                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can delete query on TabStateView                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can migrate query on TabStateView                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can activate on TabStateView                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can delete on TabStateView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can put on TabStateView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can read on SecurityRestApi                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| menu access on Security                          |:heavy_check_mark:|O|O|O|
-| menu access on List Users                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on List Roles                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Action Log                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Manage                            |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| menu access on Annotation Layers                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on CSS Templates                     |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| menu access on Import Dashboards                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Data                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Databases                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Datasets                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Charts                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Dashboards                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on SQL Lab                           |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| menu access on SQL Editor                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| menu access on Saved Queries                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| menu access on Query Search                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| all datasource access on all_datasource_access   |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| all database access on all_database_access       |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| all query access on all_query_access             |:heavy_check_mark:|O|O|O|
-| can write on DynamicPlugin                       |:heavy_check_mark:|O|O|O|
-| can edit on DynamicPlugin                        |:heavy_check_mark:|O|O|O|
-| can list on DynamicPlugin                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on DynamicPlugin                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can download on DynamicPlugin                    |:heavy_check_mark:|O|O|O|
-| can add on DynamicPlugin                         |:heavy_check_mark:|O|O|O|
-| can delete on DynamicPlugin                      |:heavy_check_mark:|O|O|O|
-| can external metadata by name on Datasource      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can get value on KV                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can store on KV                                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can tagged objects on TagView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can suggestions on TagView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can get on TagView                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can post on TagView                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can delete on TagView                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can edit on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can add on DashboardEmailScheduleView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can delete on DashboardEmailScheduleView         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| muldelete on DashboardEmailScheduleView          |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can edit on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can add on SliceEmailScheduleView                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can delete on SliceEmailScheduleView             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| muldelete on SliceEmailScheduleView              |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can edit on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can add on AlertModelView                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can delete on AlertModelView                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on AlertLogModelView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on AlertLogModelView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can list on AlertObservationModelView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can show on AlertObservationModelView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Row Level Security                |:heavy_check_mark:|O|O|O|
-| menu access on Access requests                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Home                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Plugins                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Dashboard Email Schedules         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Chart Emails                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Alerts                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Alerts & Report                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| menu access on Scan New Datasources              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can share dashboard on Superset                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can share chart on Superset                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can this form get on ColumnarToDatabaseView      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can this form post on ColumnarToDatabaseView     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on Chart                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on DashboardFilterStateRestApi         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on DashboardFilterStateRestApi          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on DashboardPermalinkRestApi           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on DashboardPermalinkRestApi            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can delete embedded on Dashboard                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can set embedded on Dashboard                    |:heavy_check_mark:|O|O|O|
-| can export on Dashboard                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can get embedded on Dashboard                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on Database                           |:heavy_check_mark:|O|O|O|
-| can export on Dataset                            |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can write on ExploreFormDataRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on ExploreFormDataRestApi               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on ExplorePermalinkRestApi             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can import on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can export on SavedQuery                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-| can dashboard permalink on Superset              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can grant guest token on SecurityRestApi         |:heavy_check_mark:|O|O|O|
-| can read on AdvancedDataType                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can read on EmbeddedDashboard                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can duplicate on Dataset                         |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on Explore                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can samples on Datasource                        |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on AvailableDomains                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can get or create dataset on Dataset             |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can get column values on Datasource              |:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can export csv on SQLLab                         |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can get results on SQLLab                        |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can execute sql query on SQLLab                  |:heavy_check_mark:|O|O|:heavy_check_mark:|
-| can recent activity on Log                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+|                                                  |Admin|Alpha|Gamma|Public|SQL_LAB|
+|--------------------------------------------------|---|---|---|---|---|
+| Permission/role description                      |Admins have all possible rights, including granting or revoking rights from other users and altering other people's slices and dashboards.|Alpha users have access to all data sources, but they cannot grant or revoke access from other users. They are also limited to altering the objects that they own. Alpha users can add and alter data sources.|Gamma users have limited access. They can only consume data coming from data sources they have been given access to through another complementary role. They only have access to view the slices and dashboards made from data sources that they have access to. Currently Gamma users are not able to alter or add data sources. We assume that they are mostly content consumers, though they can create slices and dashboards.|Public is the most restrictive built-in role, designed for anonymous/unauthenticated users viewing public dashboards. It provides minimal read-only access for dashboard viewing with interactive filters. Use `PUBLIC_ROLE_LIKE = "Public"` to apply these permissions to anonymous users.|The sql_lab role grants access to SQL Lab. Note that while Admin users have access to all databases by default, both Alpha and Gamma users need to be given access on a per database basis.||
+| can read on SavedQuery                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can write on SavedQuery                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can read on CssTemplate                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can write on CssTemplate                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on ReportSchedule                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can write on ReportSchedule                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on Chart                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can write on Chart                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can write on Annotation                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on Dataset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can write on Dataset                             |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can read on Log                                  |:heavy_check_mark:|O|O|O|O|
+| can write on Log                                 |:heavy_check_mark:|O|O|O|O|
+| can read on Dashboard                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can write on Dashboard                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on Database                             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can write on Database                            |:heavy_check_mark:|O|O|O|O|
+| can read on Query                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can this form get on ResetPasswordView           |:heavy_check_mark:|O|O|O|O|
+| can this form post on ResetPasswordView          |:heavy_check_mark:|O|O|O|O|
+| can this form get on ResetMyPasswordView         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can this form post on ResetMyPasswordView        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can this form get on UserInfoEditView            |:heavy_check_mark:|O|O|O|O|
+| can this form post on UserInfoEditView           |:heavy_check_mark:|O|O|O|O|
+| can show on UserDBModelView                      |:heavy_check_mark:|O|O|O|O|
+| can edit on UserDBModelView                      |:heavy_check_mark:|O|O|O|O|
+| can delete on UserDBModelView                    |:heavy_check_mark:|O|O|O|O|
+| can add on UserDBModelView                       |:heavy_check_mark:|O|O|O|O|
+| can list on UserDBModelView                      |:heavy_check_mark:|O|O|O|O|
+| can userinfo on UserDBModelView                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| resetmypassword on UserDBModelView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| resetpasswords on UserDBModelView                |:heavy_check_mark:|O|O|O|O|
+| userinfoedit on UserDBModelView                  |:heavy_check_mark:|O|O|O|O|
+| can show on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
+| can edit on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
+| can delete on RoleModelView                      |:heavy_check_mark:|O|O|O|O|
+| can add on RoleModelView                         |:heavy_check_mark:|O|O|O|O|
+| can list on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
+| copyrole on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
+| can get on OpenApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can show on SwaggerView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can get on MenuApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can list on AsyncEventsRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can invalidate on CacheRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can csv upload on Database                       |:heavy_check_mark:|O|O|O|O|
+| can excel upload on Database                     |:heavy_check_mark:|O|O|O|O|
+| can query form data on Api                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can query on Api                                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can time range on Api                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can external metadata on Datasource              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can save on Datasource                           |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can get on Datasource                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can my queries on SqlLab                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can log on Superset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can import dashboards on Superset                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can schemas on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can sqllab history on Superset                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can publish on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can csv on Superset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can slice on Superset                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can sync druid source on Superset                |:heavy_check_mark:|O|O|O|O|
+| can explore on Superset                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can approve on Superset                          |:heavy_check_mark:|O|O|O|O|
+| can explore json on Superset                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can fetch datasource metadata on Superset        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can csrf token on Superset                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can sqllab on Superset                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can select star on Superset                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can warm up cache on Superset                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can sqllab table viz on Superset                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can available domains on Superset                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can request access on Superset                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can dashboard on Superset                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can post on TableSchemaView                      |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can expanded on TableSchemaView                  |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can delete on TableSchemaView                    |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can get on TabStateView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can post on TabStateView                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can delete query on TabStateView                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can migrate query on TabStateView                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can activate on TabStateView                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can delete on TabStateView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can put on TabStateView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can read on SecurityRestApi                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| menu access on Security                          |:heavy_check_mark:|O|O|O|O|
+| menu access on List Users                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on List Roles                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Action Log                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Manage                            |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| menu access on Annotation Layers                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on CSS Templates                     |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| menu access on Import Dashboards                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Data                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Databases                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Datasets                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Charts                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Dashboards                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on SQL Lab                           |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| menu access on SQL Editor                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| menu access on Saved Queries                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| menu access on Query Search                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| all datasource access on all_datasource_access   |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| all database access on all_database_access       |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| all query access on all_query_access             |:heavy_check_mark:|O|O|O|O|
+| can write on DynamicPlugin                       |:heavy_check_mark:|O|O|O|O|
+| can edit on DynamicPlugin                        |:heavy_check_mark:|O|O|O|O|
+| can list on DynamicPlugin                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on DynamicPlugin                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can download on DynamicPlugin                    |:heavy_check_mark:|O|O|O|O|
+| can add on DynamicPlugin                         |:heavy_check_mark:|O|O|O|O|
+| can delete on DynamicPlugin                      |:heavy_check_mark:|O|O|O|O|
+| can external metadata by name on Datasource      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can get value on KV                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can store on KV                                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can tagged objects on TagView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can suggestions on TagView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can get on TagView                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can post on TagView                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can delete on TagView                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can edit on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can list on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on DashboardEmailScheduleView           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can add on DashboardEmailScheduleView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can delete on DashboardEmailScheduleView         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| muldelete on DashboardEmailScheduleView          |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can edit on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can list on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on SliceEmailScheduleView               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can add on SliceEmailScheduleView                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can delete on SliceEmailScheduleView             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| muldelete on SliceEmailScheduleView              |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can edit on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can list on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on AlertModelView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can add on AlertModelView                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can delete on AlertModelView                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can list on AlertLogModelView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on AlertLogModelView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can list on AlertObservationModelView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can show on AlertObservationModelView            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Row Level Security                |:heavy_check_mark:|O|O|O|O|
+| menu access on Access requests                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Home                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Plugins                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Dashboard Email Schedules         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Chart Emails                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Alerts                            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Alerts & Report                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| menu access on Scan New Datasources              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can share dashboard on Superset                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can share chart on Superset                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can this form get on ColumnarToDatabaseView      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can this form post on ColumnarToDatabaseView     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can export on Chart                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can write on DashboardFilterStateRestApi         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can read on DashboardFilterStateRestApi          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can write on DashboardPermalinkRestApi           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on DashboardPermalinkRestApi            |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can delete embedded on Dashboard                 |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can set embedded on Dashboard                    |:heavy_check_mark:|O|O|O|O|
+| can export on Dashboard                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can get embedded on Dashboard                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can export on Database                           |:heavy_check_mark:|O|O|O|O|
+| can export on Dataset                            |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can write on ExploreFormDataRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on ExploreFormDataRestApi               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can write on ExplorePermalinkRestApi             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can export on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can import on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can export on SavedQuery                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
+| can dashboard permalink on Superset              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can grant guest token on SecurityRestApi         |:heavy_check_mark:|O|O|O|O|
+| can read on AdvancedDataType                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on EmbeddedDashboard                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can duplicate on Dataset                         |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can read on Explore                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can samples on Datasource                        |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can read on AvailableDomains                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can get or create dataset on Dataset             |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can get column values on Datasource              |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can export csv on SQLLab                         |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can get results on SQLLab                        |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can execute sql query on SQLLab                  |:heavy_check_mark:|O|O|O|:heavy_check_mark:|
+| can recent activity on Log                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|

--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -60,9 +60,9 @@ under the License.
 | can add on RoleModelView                         |:heavy_check_mark:|O|O|O|O|
 | can list on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
 | copyrole on RoleModelView                        |:heavy_check_mark:|O|O|O|O|
-| can get on OpenApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can get on OpenApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can show on SwaggerView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can get on MenuApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can get on MenuApi                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can list on AsyncEventsRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can invalidate on CacheRestApi                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can csv upload on Database                       |:heavy_check_mark:|O|O|O|O|
@@ -104,7 +104,7 @@ under the License.
 | can activate on TabStateView                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
 | can delete on TabStateView                       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
 | can put on TabStateView                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
-| can read on SecurityRestApi                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| can read on SecurityRestApi                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|
 | menu access on Security                          |:heavy_check_mark:|O|O|O|O|
 | menu access on List Users                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | menu access on List Roles                        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
@@ -132,7 +132,7 @@ under the License.
 | can download on DynamicPlugin                    |:heavy_check_mark:|O|O|O|O|
 | can add on DynamicPlugin                         |:heavy_check_mark:|O|O|O|O|
 | can delete on DynamicPlugin                      |:heavy_check_mark:|O|O|O|O|
-| can external metadata by name on Datasource      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can external metadata by name on Datasource      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can get value on KV                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can store on KV                                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can tagged objects on TagView                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|

--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -28,8 +28,9 @@ under the License.
 | can write on ReportSchedule                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can read on Chart                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can write on Chart                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can write on Annotation                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on AnnotationLayerRestApi               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can read on Dataset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can write on Dataset                             |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
 | can read on Log                                  |:heavy_check_mark:|O|O|O|O|
@@ -188,7 +189,7 @@ under the License.
 | can write on ExploreFormDataRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can read on ExploreFormDataRestApi               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can write on ExplorePermalinkRestApi             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
+| can read on ExplorePermalinkRestApi              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can export on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can import on ImportExportRestApi                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can export on SavedQuery                         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|

--- a/RESOURCES/STANDARD_ROLES.md
+++ b/RESOURCES/STANDARD_ROLES.md
@@ -28,9 +28,9 @@ under the License.
 | can write on ReportSchedule                      |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can read on Chart                                |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
 | can write on Chart                               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
-| can write on Annotation                          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
-| can read on AnnotationLayerRestApi               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|
+| can read on Annotation                           |:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|O|
+| can write on Annotation                          |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
+| can read on AnnotationLayerRestApi               |:heavy_check_mark:|:heavy_check_mark:|O|:heavy_check_mark:|O|
 | can read on Dataset                              |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|O|O|
 | can write on Dataset                             |:heavy_check_mark:|:heavy_check_mark:|O|O|O|
 | can read on Log                                  |:heavy_check_mark:|O|O|O|O|

--- a/docs/docs/configuration/networking-settings.mdx
+++ b/docs/docs/configuration/networking-settings.mdx
@@ -51,8 +51,20 @@ Restart Superset for this configuration change to take effect.
 
 #### Making a Dashboard Public
 
-1. Add the `'DASHBOARD_RBAC': True` [Feature Flag](https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md) to `superset_config.py`
-2. Add the `Public` role to your dashboard as described [here](https://superset.apache.org/docs/using-superset/creating-your-first-dashboard/#manage-access-to-dashboards)
+There are two approaches to making dashboards publicly accessible:
+
+**Option 1: Dataset-based access (simpler)**
+1. Set `PUBLIC_ROLE_LIKE = "Public"` in `superset_config.py`
+2. Grant the Public role access to the relevant datasets (Menu → Security → List Roles → Public)
+3. All published dashboards using those datasets become visible to anonymous users
+
+**Option 2: Dashboard-level access (selective control)**
+1. Set `PUBLIC_ROLE_LIKE = "Public"` in `superset_config.py`
+2. Add the `'DASHBOARD_RBAC': True` [Feature Flag](https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md)
+3. Edit each dashboard's properties and add the "Public" role
+4. Only dashboards with the Public role explicitly assigned are visible to anonymous users
+
+See the [Public role documentation](/docs/security/security#public) for more details.
 
 #### Embedding a Public Dashboard
 

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -62,31 +62,46 @@ The Public role explicitly excludes:
 - User profile or admin features
 - Menu access to most Superset features
 
-To enable anonymous access with the built-in Public role, set `PUBLIC_ROLE_LIKE` in your config:
+Anonymous users are automatically assigned the Public role when `AUTH_ROLE_PUBLIC` is configured
+(a Flask-AppBuilder setting). The `PUBLIC_ROLE_LIKE` setting is **optional** and controls what
+permissions are synced to the Public role when you run `superset init`:
 
 ```python
-# Recommended: Use the built-in Public role for minimal, secure public access
+# Optional: Sync sensible default permissions to the Public role
 PUBLIC_ROLE_LIKE = "Public"
 
 # Alternative: Copy permissions from Gamma for broader access
 # PUBLIC_ROLE_LIKE = "Gamma"
 ```
 
+If you prefer to manually configure the Public role's permissions (or use `DASHBOARD_RBAC` to
+grant access at the dashboard level), you do not need to set `PUBLIC_ROLE_LIKE`.
+
 **Important notes:**
 
 - **Data access is still required:** The Public role only grants UI/API permissions. You must
-  also grant access to specific datasets by editing the Public role in the Superset UI
-  (Menu → Security → List Roles → Public) and adding the relevant data sources.
+  also grant access to specific datasets necessary to view a dashboard. As with other roles,
+  this can be done in two ways:
 
-- **Using with DASHBOARD_RBAC:** If you have the `DASHBOARD_RBAC` feature flag enabled,
-  anonymous users will only see dashboards where the "Public" role has been explicitly added
-  as an owner in the dashboard's properties. This provides fine-grained control over which
-  dashboards are publicly visible.
+  - **Without `DASHBOARD_RBAC`:** Dashboards only appear in the list and are accessible if
+    the user has permission to at least one of their datasets. Grant dataset access by editing
+    the Public role in the Superset UI (Menu → Security → List Roles → Public) and adding the
+    relevant data sources. All published dashboards using those datasets become visible.
 
-- **Role synchronization:** The Public role permissions are synchronized on Superset startup
-  when `PUBLIC_ROLE_LIKE = "Public"`. Any manual permission edits to the Public role may be
-  overwritten during upgrades or restarts. To add custom permissions, consider creating a
-  separate role and granting it to users alongside the Public role.
+  - **With `DASHBOARD_RBAC` enabled:** Anonymous users will only see dashboards where the
+    "Public" role has been explicitly added in the dashboard's properties. Dataset permissions
+    are not required—DASHBOARD_RBAC handles the cascading permissions check. This provides
+    fine-grained control over which dashboards are publicly visible.
+
+- **Role synchronization:** Built-in role permissions (Admin, Alpha, Gamma, sql_lab, and Public
+  when `PUBLIC_ROLE_LIKE = "Public"`) are synchronized when you run `superset init`. Any manual
+  permission edits to these roles may be overwritten during upgrades. To customize the Public
+  role permissions, you can either:
+  - Edit the Public role directly and avoid setting `PUBLIC_ROLE_LIKE` (permissions won't be
+    overwritten by `superset init`)
+  - Copy the Public role via "Copy Role" in the Superset web UI, save it under a different name
+    (e.g., "Public_Custom"), customize the permissions, then update **both** configs:
+    `PUBLIC_ROLE_LIKE = "Public_Custom"` and `AUTH_ROLE_PUBLIC = "Public_Custom"`
 
 ### Managing Data Source Access for Gamma Roles
 
@@ -98,6 +113,46 @@ tables in the **Permissions** dropdown. To select the data sources you want to a
 
 You can then confirm with users assigned to the **Gamma** role that they see the
 objects (dashboards and slices) associated with the tables you just extended them.
+
+### Dashboard Access Control
+
+Access to dashboards is managed via owners (users that have edit permissions to the dashboard).
+Non-owner user access can be managed in two ways. Note that dashboards must be published to be
+visible to other users.
+
+#### Dataset-Based Access (Default)
+
+By default, users can view published dashboards if they have access to at least one dataset
+used in that dashboard. Grant dataset access by adding the relevant data source permissions
+to a role (Menu → Security → List Roles).
+
+This is the simplest approach but provides all-or-nothing access based on dataset permissions—
+if a user has access to a dataset, they can see all published dashboards using that dataset.
+
+#### Dashboard-Level Access (DASHBOARD_RBAC)
+
+For fine-grained control over which dashboards specific roles can access, enable the
+`DASHBOARD_RBAC` feature flag:
+
+```python
+FEATURE_FLAGS = {
+    "DASHBOARD_RBAC": True,
+}
+```
+
+With this enabled, you can assign specific roles to each dashboard in its properties. Users
+will only see dashboards where their role is explicitly added.
+
+**Important considerations:**
+- Dashboard access **bypasses** dataset-level checks—granting a role access to a dashboard
+  implicitly grants read access to all charts and datasets in that dashboard
+- Dashboards without any assigned roles fall back to dataset-based access
+- The dashboard must still be published to be visible
+
+This feature is particularly useful for:
+- Making specific dashboards public while keeping others private
+- Granting access to dashboards without exposing the underlying datasets for other uses
+- Creating dashboard-specific access patterns that don't align with dataset ownership
 
 ### SQL Execution Security Considerations
 

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -46,12 +46,34 @@ to all databases by default, both **Alpha** and **Gamma** users need to be given
 
 ### Public
 
-To allow logged-out users to access some Superset features, you can use the `PUBLIC_ROLE_LIKE` config setting and assign it to another role whose permissions you want passed to this role.
+The **Public** role is the most restrictive built-in role, designed specifically for anonymous/unauthenticated
+users who need to view dashboards. It provides minimal read-only access for:
 
-For example, by setting `PUBLIC_ROLE_LIKE = "Gamma"` in your `superset_config.py` file, you grant
-public role the same set of permissions as for the **Gamma** role. This is useful if one
-wants to enable anonymous users to view dashboards. Explicit grant on specific datasets is
-still required, meaning that you need to edit the **Public** role and add the public data sources to the role manually.
+- Viewing dashboards and charts
+- Using interactive dashboard filters
+- Accessing dashboard permalinks
+- Reading embedded dashboards
+
+The Public role explicitly excludes:
+- Any write permissions on dashboards, charts, or datasets
+- SQL Lab access
+- Share functionality
+- User profile or admin features
+- Menu access to most Superset features
+
+To allow logged-out users to access Superset features, use the `PUBLIC_ROLE_LIKE` config setting
+to copy permissions from any built-in role to the actual public/anonymous role:
+
+```python
+# Recommended: Use the new Public role for minimal, secure public access
+PUBLIC_ROLE_LIKE = "Public"
+
+# Alternative: Use Gamma for broader access (includes create/edit permissions)
+# PUBLIC_ROLE_LIKE = "Gamma"
+```
+
+**Important:** Explicit grants on specific datasets are still required. You need to edit the
+public role in the Superset UI and add the public data sources to the role manually.
 
 ### Managing Data Source Access for Gamma Roles
 

--- a/docs/docs/security/security.mdx
+++ b/docs/docs/security/security.mdx
@@ -51,8 +51,9 @@ users who need to view dashboards. It provides minimal read-only access for:
 
 - Viewing dashboards and charts
 - Using interactive dashboard filters
-- Accessing dashboard permalinks
+- Accessing dashboard and chart permalinks
 - Reading embedded dashboards
+- Viewing annotations on charts
 
 The Public role explicitly excludes:
 - Any write permissions on dashboards, charts, or datasets
@@ -61,19 +62,31 @@ The Public role explicitly excludes:
 - User profile or admin features
 - Menu access to most Superset features
 
-To allow logged-out users to access Superset features, use the `PUBLIC_ROLE_LIKE` config setting
-to copy permissions from any built-in role to the actual public/anonymous role:
+To enable anonymous access with the built-in Public role, set `PUBLIC_ROLE_LIKE` in your config:
 
 ```python
-# Recommended: Use the new Public role for minimal, secure public access
+# Recommended: Use the built-in Public role for minimal, secure public access
 PUBLIC_ROLE_LIKE = "Public"
 
-# Alternative: Use Gamma for broader access (includes create/edit permissions)
+# Alternative: Copy permissions from Gamma for broader access
 # PUBLIC_ROLE_LIKE = "Gamma"
 ```
 
-**Important:** Explicit grants on specific datasets are still required. You need to edit the
-public role in the Superset UI and add the public data sources to the role manually.
+**Important notes:**
+
+- **Data access is still required:** The Public role only grants UI/API permissions. You must
+  also grant access to specific datasets by editing the Public role in the Superset UI
+  (Menu → Security → List Roles → Public) and adding the relevant data sources.
+
+- **Using with DASHBOARD_RBAC:** If you have the `DASHBOARD_RBAC` feature flag enabled,
+  anonymous users will only see dashboards where the "Public" role has been explicitly added
+  as an owner in the dashboard's properties. This provides fine-grained control over which
+  dashboards are publicly visible.
+
+- **Role synchronization:** The Public role permissions are synchronized on Superset startup
+  when `PUBLIC_ROLE_LIKE = "Public"`. Any manual permission edits to the Public role may be
+  overwritten during upgrades or restarts. To add custom permissions, consider creating a
+  separate role and granting it to users alongside the Public role.
 
 ### Managing Data Source Access for Gamma Roles
 

--- a/docs/docs/using-superset/creating-your-first-dashboard.mdx
+++ b/docs/docs/using-superset/creating-your-first-dashboard.mdx
@@ -183,14 +183,12 @@ slices and dashboards of your own.
 
 ### Manage access to Dashboards
 
-Access to dashboards is managed via owners (users that have edit permissions to the dashboard).
+Access to dashboards is managed via owners and permissions. Non-owner access can be controlled
+through dataset permissions or dashboard-level roles (using the `DASHBOARD_RBAC` feature flag).
 
-Non-owner users access can be managed in two different ways. The dashboard needs to be published to be visible to other users.
-
-1. Dataset permissions - if you add to the relevant role permissions to datasets it automatically grants implicit access to all dashboards that uses those permitted datasets.
-2. Dashboard roles - if you enable [**DASHBOARD_RBAC** feature flag](/docs/configuration/configuring-superset#feature-flags) then you will be able to manage which roles can access the dashboard
-   - Granting a role access to a dashboard will bypass dataset level checks. Having dashboard access implicitly grants read access to all the featured charts in the dashboard, and thereby also all the associated datasets.
-   - If no roles are specified for a dashboard, regular **Dataset permissions** will apply.
+For detailed information on configuring dashboard access, see the
+[Dashboard Access Control](/docs/security/security#dashboard-access-control) section in the
+Security documentation.
 
 <img src={useBaseUrl("/img/tutorial/tutorial_dashboard_access.png" )} />
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ select = [
 
 ignore = [
     "S101",
+    "PT004",  # Fixtures that don't return values - underscore prefix conflicts with pytest usage
     "PT006",
     "T201",
     "N999",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -264,6 +264,7 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
     }
 
     GAMMA_READ_ONLY_MODEL_VIEWS = {
+        "CssTemplate",
         "Dataset",
         "Datasource",
     } | READ_ONLY_MODEL_VIEWS

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -415,6 +415,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # Datasource metadata for chart rendering
         ("can_get", "Datasource"),
         ("can_external_metadata", "Datasource"),
+        # Annotations on charts
+        ("can_read", "Annotation"),
+        ("can_read", "AnnotationLayerRestApi"),
+        # Chart permalinks (for shared chart links)
+        ("can_read", "ExplorePermalinkRestApi"),
     }
 
     # View menus that Public role should NOT have access to
@@ -1254,10 +1259,12 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         self.set_role("sql_lab", self._is_sql_lab_pvm, pvms)
 
         # Configure public role
-        # If PUBLIC_ROLE_LIKE is not set or is "Public", use the built-in Public role
-        # Otherwise, copy permissions from the specified role (legacy behavior)
+        # If PUBLIC_ROLE_LIKE is "Public", use the built-in Public role with
+        # sensible defaults for anonymous dashboard viewing.
+        # If set to another role name (e.g., "Gamma"), copy permissions from that role.
+        # If not set (None), the Public role remains empty (default/legacy behavior).
         public_role_like = get_conf()["PUBLIC_ROLE_LIKE"]
-        if not public_role_like or public_role_like == "Public":
+        if public_role_like == "Public":
             # Use the built-in Public role with minimal read-only permissions
             self.set_role("Public", self._is_public_pvm, pvms)
         elif public_role_like:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -302,7 +302,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "Annotation",
         "CSS Templates",
         "ColumnarToDatabaseView",
-        "CssTemplate",
         "ExcelToDatabaseView",
         "Import dashboards",
         "ImportExportRestApi",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -415,12 +415,6 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # Datasource metadata for chart rendering
         ("can_get", "Datasource"),
         ("can_external_metadata", "Datasource"),
-        ("can_external_metadata_by_name", "Datasource"),
-        # Security API for CSRF tokens
-        ("can_read", "SecurityRestApi"),
-        # Menu and OpenAPI access
-        ("can_get", "OpenApi"),
-        ("can_get", "MenuApi"),
     }
 
     # View menus that Public role should NOT have access to

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -107,7 +107,7 @@ def sanitize_datasource_data(
 def bootstrap_user_data(user: User, include_perms: bool = False) -> dict[str, Any]:
     if user.is_anonymous:
         payload = {}
-        user.roles = (security_manager.find_role("Public"),)
+        user.roles = (security_manager.get_public_role(),)
     elif security_manager.is_guest_user(user):
         payload = {
             "username": user.username,

--- a/tests/integration_tests/fixtures/__init__.py
+++ b/tests/integration_tests/fixtures/__init__.py
@@ -24,6 +24,7 @@ from .energy_dashboard import (  # noqa: F401
     load_energy_table_with_slice,
 )
 from .public_role import (  # noqa: F401
+    public_role_builtin,
     public_role_like_gamma,
     public_role_like_test_role,
 )

--- a/tests/integration_tests/fixtures/public_role.py
+++ b/tests/integration_tests/fixtures/public_role.py
@@ -21,7 +21,7 @@ from superset.extensions import db, security_manager
 from tests.integration_tests.test_app import app
 
 
-@pytest.fixture
+@pytest.fixture()
 def public_role_like_gamma(app_context: AppContext):
     app.config["PUBLIC_ROLE_LIKE"] = "Gamma"
     security_manager.sync_role_definitions()
@@ -32,12 +32,30 @@ def public_role_like_gamma(app_context: AppContext):
     db.session.commit()
 
 
-@pytest.fixture
+@pytest.fixture()
 def public_role_like_test_role(app_context: AppContext):
     app.config["PUBLIC_ROLE_LIKE"] = "TestRole"
     security_manager.sync_role_definitions()
 
     yield
 
+    security_manager.get_public_role().permissions = []
+    db.session.commit()
+
+
+@pytest.fixture()
+def public_role_builtin(app_context: AppContext):
+    """
+    Fixture that uses the built-in Public role with minimal read-only permissions.
+    This sets PUBLIC_ROLE_LIKE to "Public" to use the new sensible defaults.
+    """
+    original_value = app.config.get("PUBLIC_ROLE_LIKE")
+    app.config["PUBLIC_ROLE_LIKE"] = "Public"
+    security_manager.sync_role_definitions()
+
+    yield
+
+    # Restore original config and clean up
+    app.config["PUBLIC_ROLE_LIKE"] = original_value
     security_manager.get_public_role().permissions = []
     db.session.commit()

--- a/tests/integration_tests/fixtures/public_role.py
+++ b/tests/integration_tests/fixtures/public_role.py
@@ -21,7 +21,7 @@ from superset.extensions import db, security_manager
 from tests.integration_tests.test_app import app
 
 
-@pytest.fixture()
+@pytest.fixture
 def public_role_like_gamma(app_context: AppContext):
     app.config["PUBLIC_ROLE_LIKE"] = "Gamma"
     security_manager.sync_role_definitions()
@@ -32,7 +32,7 @@ def public_role_like_gamma(app_context: AppContext):
     db.session.commit()
 
 
-@pytest.fixture()
+@pytest.fixture
 def public_role_like_test_role(app_context: AppContext):
     app.config["PUBLIC_ROLE_LIKE"] = "TestRole"
     security_manager.sync_role_definitions()
@@ -43,7 +43,7 @@ def public_role_like_test_role(app_context: AppContext):
     db.session.commit()
 
 
-@pytest.fixture()
+@pytest.fixture
 def public_role_builtin(app_context: AppContext):
     """
     Fixture that uses the built-in Public role with minimal read-only permissions.

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1471,6 +1471,8 @@ class TestRolePermission(SupersetTestCase):
 
     def test_public_role_permissions(self):
         """Test that Public role has the expected minimal permissions."""
+        # Ensure Public role is created and populated with permissions
+        security_manager.sync_role_definitions()
         public_perm_set = get_perm_tuples("Public")
 
         # Core dashboard viewing - should be present
@@ -1510,6 +1512,8 @@ class TestRolePermission(SupersetTestCase):
 
     def test_public_role_more_restrictive_than_gamma(self):
         """Test that Public role is more restrictive than Gamma."""
+        # Ensure Public role is created and populated with permissions
+        security_manager.sync_role_definitions()
         public_perm_set = get_perm_tuples("Public")
         gamma_perm_set = get_perm_tuples("Gamma")
 

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1522,9 +1522,9 @@ class TestRolePermission(SupersetTestCase):
 
         # Any permissions Public has that Gamma doesn't should be intentional
         # (there shouldn't be any in the current design)
-        assert (
-            len(public_only) == 0
-        ), f"Public has permissions Gamma doesn't: {public_only}"
+        assert len(public_only) == 0, (
+            f"Public has permissions Gamma doesn't: {public_only}"
+        )
 
         # Public should have significantly fewer permissions than Gamma
         assert len(public_perm_set) < len(gamma_perm_set)

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1520,10 +1520,18 @@ class TestRolePermission(SupersetTestCase):
         # Note: Public has filter state write which Gamma also has
         public_only = public_perm_set - gamma_perm_set
 
-        # Any permissions Public has that Gamma doesn't should be intentional
-        # (there shouldn't be any in the current design)
-        assert len(public_only) == 0, (
-            f"Public has permissions Gamma doesn't: {public_only}"
+        # These permissions are intentionally granted to Public even though
+        # Gamma doesn't have them. Annotation permissions are needed for
+        # charts with annotations to render properly for public users.
+        # Gamma doesn't have these because Annotation is in ALPHA_ONLY_VIEW_MENUS.
+        allowed_public_only_perms = {
+            ("can_read", "Annotation"),
+            ("can_read", "AnnotationLayerRestApi"),
+        }
+
+        unexpected_perms = public_only - allowed_public_only_perms
+        assert len(unexpected_perms) == 0, (
+            f"Public has unexpected permissions Gamma doesn't: {unexpected_perms}"
         )
 
         # Public should have significantly fewer permissions than Gamma

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -52,6 +52,7 @@ from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.constants import GAMMA_USERNAME
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.fixtures.public_role import (
+    public_role_builtin,  # noqa: F401
     public_role_like_gamma,  # noqa: F401
     public_role_like_test_role,  # noqa: F401
 )
@@ -1469,10 +1470,9 @@ class TestRolePermission(SupersetTestCase):
             )
         )
 
+    @pytest.mark.usefixtures("public_role_builtin")
     def test_public_role_permissions(self):
         """Test that Public role has the expected minimal permissions."""
-        # Ensure Public role is created and populated with permissions
-        security_manager.sync_role_definitions()
         public_perm_set = get_perm_tuples("Public")
 
         # Core dashboard viewing - should be present
@@ -1510,10 +1510,9 @@ class TestRolePermission(SupersetTestCase):
         # Should NOT have user management access
         assert ("can_userinfo", "UserDBModelView") not in public_perm_set
 
+    @pytest.mark.usefixtures("public_role_builtin")
     def test_public_role_more_restrictive_than_gamma(self):
         """Test that Public role is more restrictive than Gamma."""
-        # Ensure Public role is created and populated with permissions
-        security_manager.sync_role_definitions()
         public_perm_set = get_perm_tuples("Public")
         gamma_perm_set = get_perm_tuples("Gamma")
 


### PR DESCRIPTION
### SUMMARY

This PR adds a new built-in "Public" role to Superset, designed for anonymous/unauthenticated users who need to view dashboards. The Public role is more restrictive than Gamma and provides sensible defaults for public-facing dashboard deployments.

**Background:** In #36025, it was identified that using `PUBLIC_ROLE_LIKE = "Gamma"` grants excessive permissions including write and delete capabilities that are inappropriate for public access. Rather than documenting a complex set of manual permissions, this PR creates a new built-in role with sensible, secure defaults.

**Key changes:**
- New `PUBLIC_ROLE_PERMISSIONS` set defining minimal dashboard viewing permissions
- New `_is_public_pvm()` method to determine Public role permissions  
- Public role is now created during `sync_role_definitions()` alongside Admin, Alpha, Gamma, and sql_lab
- Users can set `PUBLIC_ROLE_LIKE = "Public"` to use these safe defaults

**The Public role includes:**
- Dashboard and chart viewing (`can_read on Dashboard`, `can_read on Chart`)
- Interactive dashboard filters (`can_read/write on DashboardFilterStateRestApi`)
- Dashboard and chart permalinks (`can_read on DashboardPermalinkRestApi`, `can_read on ExplorePermalinkRestApi`)
- Embedded dashboard support (`can_read on EmbeddedDashboard`)
- Annotations on charts (`can_read on Annotation`, `can_read on AnnotationLayerRestApi`)
- Datasource metadata for chart rendering (`can_get`, `can_external_metadata` on Datasource)
- CSS templates for styling (`can_read on CssTemplate`)
- API access for chart rendering (`can_time_range`, `can_query_form_data`, `can_query` on Api)

**The Public role explicitly excludes:**
- Write permissions on dashboards, charts, datasets
- SQL Lab access
- Share functionality  
- User profile/admin features
- Menu access to most features
- Any `all_datasource_access` or `all_database_access` permissions

**Important notes:**
- The built-in Public role only activates when `PUBLIC_ROLE_LIKE = "Public"` is explicitly set. If unset (`None`), the Public role remains empty, preserving existing/legacy behavior.
- When using with `DASHBOARD_RBAC` feature flag enabled, anonymous users only see dashboards where the "Public" role has been explicitly added as an owner.
- The Public role permissions sync on Superset startup. Manual permission edits may be overwritten during upgrades/restarts.
- Data access must still be granted separately by adding datasets to the Public role.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - This is a backend role/permission change.

### TESTING INSTRUCTIONS

1. Run `superset init` to sync role definitions
2. Verify the new "Public" role exists in Security > List Roles
3. Check the Public role has the expected minimal permissions (see list above)
4. Test setting `PUBLIC_ROLE_LIKE = "Public"` in config and verify anonymous users can view dashboards but cannot:
   - Edit dashboards or charts
   - Access SQL Lab
   - Share content
   - Access admin menus

### ADDITIONAL INFORMATION

- [x] Has associated issue: #36025
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)