### PR TITLE
fix: Implement SIP-40 error styles for GAQ

### DIFF
--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -20,6 +20,8 @@ import pytest
 from flask_babel import lazy_gettext as _
 
 from superset.commands.chart.exceptions import ChartDataQueryFailedError
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetErrorException, SupersetErrorsException
 
 
 @mock.patch("superset.tasks.async_queries.security_manager")
@@ -53,3 +55,97 @@ def test_load_chart_data_into_cache_with_error(
     mock_async_query_manager.update_job.assert_called_once_with(
         job_metadata, "error", errors=expected_errors
     )
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_with_superset_error_exception(
+    mock_query_context_schema_cls, mock_async_query_manager, mock_security_manager
+):
+    """Test that SupersetErrorException extracts SIP-40 style errors"""
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data = {}
+
+    superset_error = SupersetError(
+        message="Access denied to datasource",
+        error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+        level=ErrorLevel.ERROR,
+        extra={"datasource": "my_table"},
+    )
+    err = SupersetErrorException(superset_error)
+
+    mock_user = mock.MagicMock()
+    mock_query_context_schema = mock.MagicMock()
+
+    mock_security_manager.get_user_by_id.return_value = mock_user
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value = mock_query_context_schema
+
+    mock_query_context_schema.load.side_effect = err
+
+    with pytest.raises(SupersetErrorException):
+        load_chart_data_into_cache(job_metadata, form_data)
+
+    # Verify the full SIP-40 error structure is preserved
+    call_args = mock_async_query_manager.update_job.call_args
+    assert call_args[0] == (job_metadata, "error")
+    errors = call_args[1]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["message"] == "Access denied to datasource"
+    assert errors[0]["error_type"] == SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR
+    assert errors[0]["level"] == ErrorLevel.ERROR
+    assert errors[0]["extra"]["datasource"] == "my_table"
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_with_superset_errors_exception(
+    mock_query_context_schema_cls, mock_async_query_manager, mock_security_manager
+):
+    """Test that SupersetErrorsException extracts multiple SIP-40 style errors"""
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data = {}
+
+    superset_errors = [
+        SupersetError(
+            message="Column not found",
+            error_type=SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR,
+            level=ErrorLevel.ERROR,
+        ),
+        SupersetError(
+            message="Table not found",
+            error_type=SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR,
+            level=ErrorLevel.WARNING,
+        ),
+    ]
+    err = SupersetErrorsException(superset_errors)
+
+    mock_user = mock.MagicMock()
+    mock_query_context_schema = mock.MagicMock()
+
+    mock_security_manager.get_user_by_id.return_value = mock_user
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value = mock_query_context_schema
+
+    mock_query_context_schema.load.side_effect = err
+
+    with pytest.raises(SupersetErrorsException):
+        load_chart_data_into_cache(job_metadata, form_data)
+
+    # Verify all SIP-40 errors are preserved
+    call_args = mock_async_query_manager.update_job.call_args
+    assert call_args[0] == (job_metadata, "error")
+    errors = call_args[1]["errors"]
+    assert len(errors) == 2
+    assert errors[0]["message"] == "Column not found"
+    assert errors[0]["error_type"] == SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR
+    assert errors[0]["level"] == ErrorLevel.ERROR
+    assert errors[1]["message"] == "Table not found"
+    assert errors[1]["error_type"] == SupersetErrorType.TABLE_DOES_NOT_EXIST_ERROR
+    assert errors[1]["level"] == ErrorLevel.WARNING


### PR DESCRIPTION
## **User description**
<!---
fix(async-queries): extract SIP-40 style errors in GAQ tasks
-->

### SUMMARY

This PR implements SIP-40 style error extraction for Global Async Queries (GAQ) in the `load_chart_data_into_cache` task. Previously, all errors were converted to simple strings with only a `message` field, losing rich error information like `error_type`, `level`, and `extra` that is available in `SupersetErrorException` and `SupersetErrorsException`.

The fix follows the existing pattern from `sql_lab.py` to properly extract SIP-40 errors:
- Check if exception is `SupersetErrorException` and extract the `.error` dataclass
- Check if exception is `SupersetErrorsException` and extract the `.errors` list
- Fall back to current string-based handling for other exceptions (backward compatible)
- Convert `SupersetError` dataclasses to dicts using `dataclasses.asdict()` for JSON serialization

This ensures custom error messages with full context are properly propagated to the frontend when using async queries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend change only

### TESTING INSTRUCTIONS

1. Run the unit tests:
   pytest tests/unit_tests/tasks/test_async_queries.py -v
   2. All 3 tests should pass:
   - `test_load_chart_data_into_cache_with_error` - backward compatibility
   - `test_load_chart_data_into_cache_with_superset_error_exception` - SIP-40 single error
   - `test_load_chart_data_into_cache_with_superset_errors_exception` - SIP-40 multiple errors

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Preserve SIP-40 error details for Global Async Query failures

### What Changed
- When an async chart job fails, the task now preserves full SIP-40 error objects (message, error_type, level, extra) and sends them to the async job status instead of collapsing everything to a single message string
- The task still falls back to the original single-message format for non-Superset exceptions
- Added unit tests that verify single and multiple SIP-40 errors are extracted and reported intact to the async job manager

### Impact
`✅ Clearer GAQ error payloads`
`✅ Fewer lost error details for async chart failures`
`✅ More accurate error visibility in async job status`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
