### PR TITLE
fix(webpack): include devserverHost in allowedHosts for Docker environments

### DIFF
--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -632,7 +632,16 @@ if (isDevMode) {
     hot: true,
     host: devserverHost,
     port: devserverPort,
-    allowedHosts: ['localhost', '.localhost', '127.0.0.1', '::1', '.local'],
+    allowedHosts: [
+      ...new Set([
+        devserverHost,
+        'localhost',
+        '.localhost',
+        '127.0.0.1',
+        '::1',
+        '.local',
+      ]),
+    ],
     proxy: [() => proxyConfig],
     client: {
       overlay: {


### PR DESCRIPTION
## **User description**
### SUMMARY

When running webpack-dev-server with `WEBPACK_DEVSERVER_HOST=0.0.0.0` in Docker environments, external IP access was blocked because `allowedHosts` was hardcoded to only allow localhost variants.

This adds `devserverHost` to the `allowedHosts` array so that accessing the dev server via external IPs works when explicitly configured to bind to all interfaces. The `Set` ensures deduplication if `devserverHost` happens to match an existing entry.

**Before:** Setting `WEBPACK_DEVSERVER_HOST=0.0.0.0` binds the server to all interfaces, but requests from external IPs are rejected due to Host header validation.

**After:** The configured `devserverHost` is automatically included in `allowedHosts`, allowing access from the bound interface.

### TESTING INSTRUCTIONS

1. Start the dev environment with external binding:
   ```bash
   WEBPACK_DEVSERVER_HOST=0.0.0.0 NODE_PORT=9001 docker compose -f docker-compose-light.yml up -d
   ```
2. Access from an external IP (e.g., `http://<your-machine-ip>:9001/`)
3. Verify the page loads instead of being blocked

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Include configured dev server host in allowedHosts to permit external access**

### What Changed
- The dev server now adds the configured host (e.g., WEBPACK_DEVSERVER_HOST) to its allowed hosts, so requests using that host header are accepted.
- Duplicate host entries are deduplicated so adding the configured host won't create repeated entries.

### Impact
`✅ Access dev server from external IPs in Docker`
`✅ Fewer blocked requests to the dev server`
`✅ Easier local Docker development with custom dev server binding`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
