### PR TITLE
fix(pivot-table): rename Subtotal to Aggregate 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -942,7 +942,15 @@ export class TableRenderer extends Component<
               true,
             )}
           >
-            {t('Subtotal')}
+            {allowRenderHtml
+              ? safeHtmlSpan(
+                  t('Aggregate (%(aggregatorName)s)', {
+                    aggregatorName: t(this.props.aggregatorName),
+                  }),
+                )
+              : t('Aggregate (%(aggregatorName)s)', {
+                  aggregatorName: t(this.props.aggregatorName),
+                })}
           </th>,
         );
       }
@@ -1173,7 +1181,15 @@ export class TableRenderer extends Component<
             true,
           )}
         >
-          {t('Subtotal')}
+          {allowRenderHtml
+            ? safeHtmlSpan(
+                t('Aggregate (%(aggregatorName)s)', {
+                  aggregatorName: t(this.props.aggregatorName),
+                }),
+              )
+            : t('Aggregate (%(aggregatorName)s)', {
+                aggregatorName: t(this.props.aggregatorName),
+              })}
         </th>
       ) : null;
 


### PR DESCRIPTION
## **User description**
## **User description**
### SUMMARY

  Update Pivot Table chart to display "Aggregate (Sum)", "Aggregate (Average)", etc. instead of just "Subtotal" for sub-group aggregations.

  This provides consistency with how "Total" labels already display the aggregation function name (e.g., "Total (Sum)").

  **Changes:**
  - `TableRenderers.jsx:493` - Column subtotal label now includes aggregation function
  - `TableRenderers.jsx:708` - Row subtotal label now includes aggregation function

  Both changes follow the existing pattern used for "Total" labels at lines 518-520.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **Before:** Subtotal labels show just "Subtotal"
  **After:** Subtotal labels show "Aggregate (Sum)", "Aggregate (Average)", etc.

  ### TESTING INSTRUCTIONS

  1. Create a Pivot Table chart
  2. Add columns and rows to the configuration
  3. Enable "Show rows subtotal" and "Show columns subtotal"
  4. Verify subtotal labels now display "Aggregate (Sum)" or appropriate aggregation
  5. Change aggregation function and verify label updates accordingly
  6. Compare with "Total" labels - format should be consistent

  ### ADDITIONAL INFORMATION

  - [x] Has associated issue: Fixes #35089
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Show subtotal labels as “Aggregate” with the aggregation name**

### What Changed
- Subtotal labels in pivot table rows and columns now show the active aggregation, such as “Aggregate (Sum)” or “Aggregate (Average)”, instead of just “Subtotal”
- When HTML rendering is allowed, these labels are shown in a safer wrapped format to avoid unsafe display

### Impact
`✅ Clearer pivot table subtotals`
`✅ Consistent row and column labels`
`✅ Safer display when HTML labels are enabled`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
