### PR TITLE
fix: fix error with dashboard filters when global async queries is enabled and user navigates quickly

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -477,10 +477,9 @@ export function exploreJSON(
       })
       .catch(response => {
         // Ignore abort errors - they're expected when filters change quickly
-        if (
-          response?.name === 'AbortError' ||
-          response?.message === 'Request aborted'
-        ) {
+        const isAbort =
+          response?.name === 'AbortError' || response?.statusText === 'abort';
+        if (isAbort) {
           // Abort is expected: filters changed, chart unmounted, etc.
           return dispatch(chartUpdateStopped(key));
         }

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -357,6 +357,28 @@ describe('chart actions', () => {
       });
     });
 
+    test('should dispatch CHART_UPDATE_STOPPED action upon abort', () => {
+      fetchMock.post(
+        MOCK_URL,
+        { throws: { name: 'AbortError' } },
+        { overwriteRoutes: true },
+      );
+
+      const timeoutInSec = 100;
+      const actionThunk = actions.postChartFormData({}, false, timeoutInSec);
+
+      return actionThunk(dispatch, mockGetState).then(() => {
+        const types = dispatch.args
+          .map(call => call[0] && call[0].type)
+          .filter(Boolean);
+
+        expect(types).toContain(actions.CHART_UPDATE_STOPPED);
+        expect(types).not.toContain(actions.CHART_UPDATE_FAILED);
+
+        setupDefaultFetchMock();
+      });
+    });
+
     test('should handle the bigint without regression', async () => {
       getExploreUrlStub.restore();
       const mockBigIntUrl = '/mock/chart/data/bigint';


### PR DESCRIPTION
## **User description**
<!---
fix: fix error with dashboard filters when global async queries is enabled and user navigates quickly
-->

### SUMMARY
Related to [Pr](https://github.com/apache/superset/pull/35998). Prevents aborted chart requests from surfacing as hard errors in the UI.
Treats AbortError / "Request aborted" responses as expected behavior (e.g. when filters change quickly or charts unmount) and dispatches chartUpdateStopped(key) instead of chartUpdateFailed.
Keeps real failures unchanged: for non-abort errors, especially when GlobalAsyncQueries is enabled, the raw error still flows through chartUpdateFailed, preserving existing error handling.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:

https://github.com/user-attachments/assets/c489e3af-0d2f-44b1-8c20-dac414d86f1c

AFTER:

https://github.com/user-attachments/assets/8c4e1fc9-23e3-42ed-ab54-23449b8cebce

### TESTING INSTRUCTIONS
Make sure global async queries is enabled first:
On a dashboard, add cross filters
Quickly change them to other filters
OR
On a dashboard, apply filters, then quickly use the browser forward button then back
Currently:
Signal aborted error does not appear. User does not  see an error and the dashboards with filters should load properly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Ignore aborted chart requests so quick filter changes don't surface as hard errors

### What Changed
- Aborted chart requests (e.g., from quickly changing filters or unmounting charts) no longer surface as errors; the UI treats them as stopped updates instead of failures
- When global async queries is enabled, real server/client errors continue to surface as failures exactly as before
- Non-abort errors are still logged and reported so actual failures remain visible to users

### Impact
`✅ Fewer spurious dashboard error messages when changing filters quickly`
`✅ Less confusing behavior when navigating away or unmounting charts rapidly`
`✅ Real chart failures still reported and logged`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
