### PR TITLE
fix(tests): resolve flaky "should edit correctly" test in chart list

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/chart_list/list.test.ts
@@ -206,12 +206,20 @@ describe('Charts list', () => {
 
       // edits in list-view
       setGridMode('list');
-      cy.getBySel('edit-alt').eq(1).click();
+      // Wait for list view to fully render after mode change
+      cy.get('.loading').should('not.exist');
+      cy.getBySel('table-row').should('be.visible');
+      // Target the specific row by chart title to avoid flakiness from row ordering
+      cy.getBySel('table-row')
+        .contains('1 - Sample chart | EDITED')
+        .parents('[data-test="table-row"]')
+        .find('[data-test="edit-alt"]')
+        .click();
       cy.getBySel('properties-modal-name-input').clear();
       cy.getBySel('properties-modal-name-input').type('1 - Sample chart');
       cy.get('button:contains("Save")').click();
       cy.wait('@update');
-      cy.getBySel('table-row').eq(1).contains('1 - Sample chart');
+      cy.getBySel('table-row').contains('1 - Sample chart').should('exist');
     });
   });
 });


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes a flaky Cypress test in `cypress/e2e/chart_list/list.test.ts` that was intermittently failing with:

```
CypressError: Timed out retrying after 8050ms: `cy.click()` failed because this element is detached from the DOM.
```

**Root Cause:** After switching from card to list view with `setGridMode('list')`, React re-renders the entire view. The test was immediately trying to click the edit button (`cy.getBySel('edit-alt').eq(1).click()`) before the DOM stabilized, causing the element to be detached between the query and the click.

**Fix:**
1. Add wait for loading indicator to disappear after mode change
2. Add visibility check for table rows before interacting  
3. Scope the edit button selector to a specific table row instead of querying all edit buttons globally, making it more resilient to DOM changes during re-renders

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Test fix only

### TESTING INSTRUCTIONS

1. Run the Cypress test multiple times to verify it's no longer flaky:
   ```bash
   cd superset-frontend/cypress-base
   npm run cypress-run-chrome -- --spec "cypress/e2e/chart_list/list.test.ts"
   ```
2. The "should edit correctly" test should pass consistently

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix flaky "should edit correctly" chart list test by stabilizing DOM interactions

### What Changed
- After switching to list view, the test now waits for the loading indicator to disappear and ensures table rows are visible before continuing
- The edit button is selected within a specific table row instead of querying all edit buttons globally, preventing clicks on elements that get detached during re-renders
- Restores the chart title edit flow in list view with reliable waits around save/update steps

### Impact
`✅ Fewer CI test flakes in chart list suite`
`✅ More reliable end-to-end test runs`
`✅ Shorter CI reruns caused by intermittent DOM-detached click failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
