### PR TITLE
fix(tests): resolve flaky ExploreChartHeader export menu tests

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -437,7 +437,7 @@ describe('Additional actions tests', () => {
 
     userEvent.click(screen.getByLabelText('Menu actions trigger'));
 
-    userEvent.hover(screen.getByText('Data Export Options'));
+    userEvent.hover(await screen.findByText('Data Export Options'));
     userEvent.hover(await screen.findByText('Export All Data'));
 
     expect(await screen.findByText('Export to .CSV')).toBeInTheDocument();
@@ -461,7 +461,7 @@ describe('Additional actions tests', () => {
     render(<ExploreHeader {...props} />, { useRedux: true });
 
     userEvent.click(screen.getByLabelText('Menu actions trigger'));
-    userEvent.hover(screen.getByText('Data Export Options'));
+    userEvent.hover(await screen.findByText('Data Export Options'));
 
     // Now the submenu should exist
     userEvent.hover(await screen.findByText('Export Current View'));
@@ -575,19 +575,12 @@ describe('Additional actions tests', () => {
 
     test('Should call downloadAsImage when click on "Export screenshot (jpeg)"', async () => {
       const props = createProps();
-      const spy = jest.spyOn(downloadAsImage, 'default');
       render(<ExploreHeader {...props} />, {
         useRedux: true,
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByLabelText('Menu actions trigger'),
-        ).toBeInTheDocument();
-      });
-
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
 
       const downloadAsImageElement = await screen.findByText(
@@ -596,7 +589,7 @@ describe('Additional actions tests', () => {
       userEvent.click(downloadAsImageElement);
 
       await waitFor(() => {
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spyDownloadAsImage.callCount).toBe(1);
       });
     });
 
@@ -606,7 +599,7 @@ describe('Additional actions tests', () => {
         useRedux: true,
       });
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportCSVElement = await screen.findByText('Export to .CSV');
       userEvent.click(exportCSVElement);
@@ -622,7 +615,7 @@ describe('Additional actions tests', () => {
       });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportCSVElement = await screen.findByText('Export to .CSV');
       userEvent.click(exportCSVElement);
@@ -636,7 +629,7 @@ describe('Additional actions tests', () => {
         useRedux: true,
       });
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportJsonElement = await screen.findByText('Export to .JSON');
       userEvent.click(exportJsonElement);
@@ -652,7 +645,7 @@ describe('Additional actions tests', () => {
       });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportJsonElement = await screen.findByText('Export to .JSON');
       userEvent.click(exportJsonElement);
@@ -667,7 +660,7 @@ describe('Additional actions tests', () => {
       });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportCSVElement = await screen.findByText(
         'Export to pivoted .CSV',
@@ -685,7 +678,7 @@ describe('Additional actions tests', () => {
       });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportCSVElement = await screen.findByText(
         'Export to pivoted .CSV',
@@ -700,7 +693,7 @@ describe('Additional actions tests', () => {
         useRedux: true,
       });
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportExcelElement = await screen.findByText('Export to Excel');
       userEvent.click(exportExcelElement);
@@ -715,7 +708,7 @@ describe('Additional actions tests', () => {
         useRedux: true,
       });
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export All Data'));
       const exportExcelElement = await screen.findByText('Export to Excel');
       userEvent.click(exportExcelElement);
@@ -788,7 +781,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       // clear previous calls on the sinon spy you created in beforeEach
@@ -828,7 +821,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       spyExportChart.resetHistory();
@@ -858,7 +851,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       spyExportChart.resetHistory();
@@ -880,7 +873,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       spyExportChart.resetHistory();
@@ -911,7 +904,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(await screen.findByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       spyExportChart.resetHistory();
@@ -931,7 +924,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(await screen.findByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       spyExportChart.resetHistory();
@@ -963,7 +956,7 @@ describe('Additional actions tests', () => {
       render(<ExploreHeader {...props} />, { useRedux: true });
 
       userEvent.click(screen.getByLabelText('Menu actions trigger'));
-      userEvent.hover(screen.getByText('Data Export Options'));
+      userEvent.hover(await screen.findByText('Data Export Options'));
       userEvent.hover(await screen.findByText('Export Current View'));
 
       // server path expected → use the sinon spy and inspect call args


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes flaky tests in `ExploreChartHeader.test.tsx` that were intermittently failing with:

```
Unable to find an element with the text: Export All Data
```

**Root Cause:** After hovering on the menu trigger, the tests immediately tried to hover on nested submenu items ("Data Export Options" → "Export All Data") without waiting for them to render. The `screen.getByText('Data Export Options')` call was synchronous while the submenu rendering was asynchronous.

**Fix:**
1. Replace all synchronous `screen.getByText('Data Export Options')` with async `await screen.findByText('Data Export Options')` in hover operations
2. Remove duplicate jest spy in "Export screenshot (jpeg)" test that conflicted with the sinon spy from beforeEach

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Test fix only

### TESTING INSTRUCTIONS

Run the ExploreChartHeader tests multiple times to verify stability:
```bash
cd superset-frontend
npm run test -- --testPathPatterns="ExploreChartHeader.test.tsx" --no-coverage
```

All 34 tests should pass consistently.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stabilize ExploreChartHeader export menu tests by awaiting submenu rendering

### What Changed
- All hover steps that targeted the "Data Export Options" submenu now wait for that submenu to render before continuing, preventing race conditions that caused missing "Export All Data" items
- Removed a duplicate jest spy in the "Export screenshot (jpeg)" test and consolidated assertions to use the existing sinon spies, preventing spy conflicts and incorrect call counts
- Adjusted several tests to use asynchronous element lookups so export menu interactions (CSV/JSON/Excel/screenshot and current-view exports) consistently find and click submenu items

### Impact
`✅ Fewer flaky tests`
`✅ More consistent test runs for ExploreChartHeader`
`✅ Reduced intermittent CI failures` 
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
