### PR TITLE
feat(ci): use TTL labels for showtime cleanup

### DIFF
--- a/.github/workflows/showtime-cleanup.yml
+++ b/.github/workflows/showtime-cleanup.yml
@@ -7,12 +7,6 @@ on:
 
   # Manual trigger for testing
   workflow_dispatch:
-    inputs:
-      max_age_hours:
-        description: 'Maximum age in hours before cleanup'
-        required: false
-        default: '48'
-        type: string
 
 # Common environment variables
 env:
@@ -38,13 +32,5 @@ jobs:
 
       - name: Cleanup expired environments
         run: |
-          MAX_AGE="${{ github.event.inputs.max_age_hours || '48' }}"
-
-          # Validate max_age is numeric
-          if [[ ! "$MAX_AGE" =~ ^[0-9]+$ ]]; then
-            echo "❌ Invalid max_age_hours format: $MAX_AGE (must be numeric)"
-            exit 1
-          fi
-
-          echo "Cleaning up environments older than ${MAX_AGE}h"
-          python -m showtime cleanup --older-than "${MAX_AGE}h"
+          echo "Cleaning up environments respecting TTL labels"
+          python -m showtime cleanup --respect-ttl


### PR DESCRIPTION
## **User description**
### SUMMARY

Switch showtime cleanup from a fixed 48h policy to respecting per-PR TTL labels using `showtime cleanup --respect-ttl`.

This enables contributors to extend their ephemeral environment lifetime by applying labels like:
- **🎪 ⌛ 24h** — 24 hours
- **🎪 ⌛ 48h** — 48 hours (default, auto-created)
- **🎪 ⌛ 72h** — 72 hours
- **🎪 ⌛ 1w** — One week
- **🎪 ⌛ close** — Until PR closes

See: https://github.com/mistercrunch/superset-showtime/pull/1

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - CI workflow change only

### TESTING INSTRUCTIONS

1. Trigger the workflow manually via Actions tab
2. Verify it runs `showtime cleanup --respect-ttl` instead of `--older-than`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Respect per-PR TTL labels when cleaning up showtime environments**

### What Changed
- The scheduled cleanup now uses TTL labels on PRs to decide which ephemeral environments to remove instead of a fixed 48-hour age
- Manual workflow input for a numeric "max_age_hours" and its validation were removed; manual runs now use the same TTL-based behavior
- Cleanup logs now indicate TTL-respecting behavior when the job runs

### Impact
`✅ Longer ephemeral environments when PRs carry longer TTL labels`
`✅ Fewer premature environment deletions for long-running reviews`
`✅ Simpler manual cleanup runs (no numeric age input)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
