### PR TITLE
chore(deps-dev): add baseline-browser-mapping

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -212,6 +212,7 @@
         "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-typescript-to-proptypes": "^2.0.0",
+        "baseline-browser-mapping": "^2.9.7",
         "cheerio": "1.1.0",
         "copy-webpack-plugin": "^13.0.1",
         "cross-env": "^10.0.0",
@@ -20519,9 +20520,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
-      "integrity": "sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
+      "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -291,6 +291,7 @@
     "babel-plugin-jsx-remove-data-test-id": "^3.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-typescript-to-proptypes": "^2.0.0",
+    "baseline-browser-mapping": "^2.9.7",
     "cheerio": "1.1.0",
     "copy-webpack-plugin": "^13.0.1",
     "cross-env": "^10.0.0",


### PR DESCRIPTION
## Summary

Add `baseline-browser-mapping` as a dev dependency to resolve peer dependency warnings.

This package is a transitive dependency of `browserslist` (v4.26+), which recently added it to support [Baseline](https://web.dev/baseline/) web platform feature detection. The dependency chain includes:
- `css-minimizer-webpack-plugin` → `cssnano` → `caniuse-api` → `browserslist`
- `@babel/preset-env` → `core-js-compat` → `browserslist`

Adding it explicitly resolves npm peer dependency resolution warnings that were appearing in build logs.

## Test plan

- [x] Package installs successfully
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)