### PR TITLE
fix(dashboard): prevent label overlap in non-English locales

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/index.tsx
@@ -95,10 +95,13 @@ const TitleLink = styled.span`
 const TitleRight = styled.span`
   ${({ theme }) => css`
     position: absolute;
-    right: -1px;
     font-weight: 400;
     bottom: ${theme.sizeUnit * 3}px;
     right: ${theme.sizeUnit * 2}px;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   `}
 `;
 const CoverFooter = styled.div`
@@ -244,7 +247,11 @@ function ListViewCard({
                     {title}
                   </TitleLink>
                 </Tooltip>
-                {titleRight && <TitleRight>{titleRight}</TitleRight>}
+                {titleRight && (
+                  <Tooltip title={titleRight}>
+                    <TitleRight>{titleRight}</TitleRight>
+                  </Tooltip>
+                )}
                 <div className="card-actions" data-test="card-actions">
                   {actions}
                 </div>


### PR DESCRIPTION
## **User description**
### SUMMARY

  This PR fixes the layout issue where "Published"/"Draft" labels overlap with the "Modified X ago" timestamp on dashboard cards when using non-English languages with longer translations (e.g., German "Veröffentlicht", Russian "Опубликовано").

  **Root Cause**: The `TitleRight` styled component used absolute positioning without width constraints, allowing longer translated labels to extend beyond their allocated space and overlap with adjacent text.

  **Changes**:
  - Added `max-width: 120px` to constrain label width
  - Added `overflow: hidden` and `text-overflow: ellipsis` for graceful truncation
  - Added `white-space: nowrap` to prevent text wrapping
  - Wrapped label with `Tooltip` component so truncated text can be read on hover
  - Removed duplicate `right: -1px` CSS property (minor cleanup)

  ### TESTING INSTRUCTIONS

  1. Start Superset locally
  2. Navigate to the Welcome page (dashboard list view)
  3. Verify English "Published"/"Draft" labels display correctly (no regression)
  4. Change browser language to German (`de`) or another language with longer translations:
     - Chrome: Settings → Languages → Add German → Move to top → Reload
     - Or use DevTools: Network conditions → Override language
  5. Refresh and verify:
     - Labels no longer overlap with "Modified X ago" text
     - Long labels truncate with ellipsis ("...")
     - Hovering over truncated labels shows full text in tooltip
  6. Test with multiple languages: Spanish (`es`), Russian (`ru`), French (`fr`)

  ### ADDITIONAL INFORMATION

  - [x] Has associated issue: Fixes #36357
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Prevent translated dashboard labels from overlapping nearby card text

### What Changed
- Long status labels on dashboard cards now stay within their space instead of overlapping the “Modified X ago” text
- Truncated labels now show the full text on hover
- The main title already kept its hover text, so both the title and right-side label are now readable when shortened

### Impact
`✅ Fewer dashboard label overlaps`
`✅ Clearer card timestamps in non-English languages`
`✅ Readable truncated labels on hover`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
