### PR TITLE
fix: store form_data as dict during viz type migration

### DIFF
--- a/superset/commands/chart/importers/v1/utils.py
+++ b/superset/commands/chart/importers/v1/utils.py
@@ -123,7 +123,7 @@ def migrate_chart(config: dict[str, Any]) -> dict[str, Any]:
     except (json.JSONDecodeError, TypeError):
         query_context = {}
     if "form_data" in query_context:
-        query_context["form_data"] = output["params"]
+        query_context["form_data"] = params
         output["query_context"] = json.dumps(query_context)
 
     return output

--- a/superset/migrations/versions/2025-12-16_12-00_f5b5f88d8526_fix_form_data_string_in_query_context.py
+++ b/superset/migrations/versions/2025-12-16_12-00_f5b5f88d8526_fix_form_data_string_in_query_context.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""fix_form_data_string_in_query_context
+
+Revision ID: f5b5f88d8526
+Revises: a9c01ec10479
+Create Date: 2025-12-16 12:00:00.000000
+
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+
+from superset import db
+from superset.migrations.shared.utils import paginated_update
+from superset.utils import json
+
+# revision identifiers, used by Alembic.
+revision = "f5b5f88d8526"
+down_revision = "a9c01ec10479"
+
+Base = declarative_base()
+logger = logging.getLogger(__name__)
+
+# Viz types that have migrations that were going through the bug
+MIGRATED_VIZ_TYPES = [
+    "treemap_v2",
+    "pivot_table_v2",
+    "mixed_timeseries",
+    "sunburst_v2",
+    "echarts_timeseries_line",
+    "echarts_timeseries_smooth",
+    "echarts_timeseries_step",
+    "echarts_area",
+    "echarts_timeseries_bar",
+    "bubble_v2",
+    "heatmap_v2",
+    "histogram_v2",
+    "sankey_v2",
+]
+
+
+class Slice(Base):
+    __tablename__ = "slices"
+
+    id = Column(Integer, primary_key=True)
+    viz_type = Column(String(250))
+    query_context = Column(Text)
+
+
+def upgrade():
+    """
+    Fix charts where form_data in query_context was stored as a JSON string
+    instead of a dict during chart import migration.
+    """
+    bind = op.get_bind()
+    session = db.Session(bind=bind)
+
+    for slc in paginated_update(
+        session.query(Slice).filter(
+            Slice.viz_type.in_(MIGRATED_VIZ_TYPES),
+            Slice.query_context.isnot(None),
+        )
+    ):
+        try:
+            query_context = json.loads(slc.query_context)
+            form_data = query_context.get("form_data")
+
+            # Check if form_data is a non-empty string (the bug)
+            if form_data and isinstance(form_data, str):
+                try:
+                    query_context["form_data"] = json.loads(form_data)
+                    slc.query_context = json.dumps(query_context, sort_keys=True)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Could not parse form_data for slice %s, skipping", slc.id
+                    )
+        except json.JSONDecodeError:
+            logger.warning(
+                "Could not parse query_context for slice %s, skipping", slc.id
+            )
+        except Exception:  # noqa: S110
+            logger.warning("Could not update form_data for slice %s, skipping", slc.id)
+
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    # This migration fixes data corruption, downgrade is not meaningful
+    pass

--- a/tests/unit_tests/charts/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/utils_test.py
@@ -171,3 +171,44 @@ def test_migrate_pivot_table() -> None:
         "version": "1.0.0",
         "dataset_uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
     }
+
+
+def test_migrate_chart_query_context_form_data_is_dict() -> None:
+    """
+    Test that form_data in query_context remains a dict after migration.
+    """
+    chart_config = {
+        "slice_name": "Pivot Table with Query Context",
+        "description": None,
+        "certified_by": None,
+        "certification_details": None,
+        "viz_type": "pivot_table",
+        "params": json.dumps(
+            {
+                "columns": ["state"],
+                "groupby": ["name"],
+                "metrics": ["count"],
+                "viz_type": "pivot_table",
+            }
+        ),
+        "query_context": json.dumps(
+            {
+                "form_data": {
+                    "slice_id": 123,
+                    "viz_type": "pivot_table",
+                    "columns": ["state"],
+                },
+                "queries": [{"columns": ["state"]}],
+            }
+        ),
+        "cache_timeout": None,
+        "uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
+        "version": "1.0.0",
+        "dataset_uuid": "ffd15af2-2188-425c-b6b4-df28aac45872",
+    }
+
+    new_config = migrate_chart(chart_config)
+    query_context = json.loads(new_config["query_context"])
+
+    assert query_context["form_data"]["viz_type"] == "pivot_table_v2"
+    assert isinstance(query_context["form_data"], dict)


### PR DESCRIPTION
## **User description**
### SUMMARY
This is a follow up to https://github.com/apache/superset/pull/24703. During the viz type migration, we were storing the `form_data` as a string, which would then cause issues when loading a dashboard.

This PR fixes the issue for new viz type migrations, and also has a DB migration for existing charts in this state.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before**

https://github.com/user-attachments/assets/d11ef404-096e-46c3-84da-22a2f40302dc

**After

https://github.com/user-attachments/assets/c6cd0ae0-d185-476b-b6ff-4ddaafce85dc

### TESTING INSTRUCTIONS
Unit test added. For manual testing:
1. Create a legacy chart.
2. Add it to a dashboard.
3. Export the chart.
4. Import it.
5. Access the dashboard, and confirm you don't get any errors.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**fix: store form_data as dict during viz type migration**

### What Changed
- When migrating chart definitions, the query_context's form_data is now stored as a JSON object (dict) instead of a JSON-encoded string, preventing type mismatches when dashboards load.
- A database migration scans charts of several migrated viz types and converts any query_context.form_data that was saved as a string back into a JSON object so existing dashboards no longer error.
- Added a unit test that verifies query_context.form_data stays a dict and the migrated viz_type is applied.

### Impact
`✅ Fewer dashboard load errors after importing legacy charts`
`✅ Fixed corrupted imported charts for affected visualization types`
`✅ Consistent query_context.form_data type across migrations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
