### PR TITLE
fix(dashboard): prevent table chart infinite reload loop

### DIFF
--- a/superset-frontend/src/dashboard/components/Dashboard.test.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.test.jsx
@@ -332,4 +332,73 @@ describe('Dashboard', () => {
       expect(mockTriggerQuery).not.toHaveBeenCalled();
     });
   });
+
+  test('should NOT call refresh when ownDataCharts content is unchanged', () => {
+    // When only clientView changes, getRelevantDataMask strips it,
+    // so Dashboard receives identical ownDataCharts and should not refresh
+    const initialOwnDataCharts = {
+      1: { pageSize: 10, currentPage: 0 },
+    };
+
+    const { rerender } = renderDashboard({
+      ownDataCharts: initialOwnDataCharts,
+      dashboardState: {
+        ...dashboardState,
+        editMode: false,
+      },
+    });
+
+    // Rerender with same ownDataCharts (simulates clientView-only change after stripping)
+    rerender(
+      <PluginContext.Provider value={{ loading: false }}>
+        <Dashboard
+          {...props}
+          ownDataCharts={initialOwnDataCharts}
+          dashboardState={{
+            ...dashboardState,
+            editMode: false,
+          }}
+        >
+          <ChildrenComponent />
+        </Dashboard>
+      </PluginContext.Provider>,
+    );
+
+    expect(mockTriggerQuery).not.toHaveBeenCalled();
+  });
+
+  test('should call refresh when ownDataCharts pageSize changes', () => {
+    const initialOwnDataCharts = {
+      1: { pageSize: 10, currentPage: 0 },
+    };
+
+    const { rerender } = renderDashboard({
+      ownDataCharts: initialOwnDataCharts,
+      dashboardState: {
+        ...dashboardState,
+        editMode: false,
+      },
+    });
+
+    const updatedOwnDataCharts = {
+      1: { pageSize: 20, currentPage: 0 },
+    };
+
+    rerender(
+      <PluginContext.Provider value={{ loading: false }}>
+        <Dashboard
+          {...props}
+          ownDataCharts={updatedOwnDataCharts}
+          dashboardState={{
+            ...dashboardState,
+            editMode: false,
+          }}
+        >
+          <ChildrenComponent />
+        </Dashboard>
+      </PluginContext.Provider>,
+    );
+
+    expect(mockTriggerQuery).toHaveBeenCalledWith(true, '1');
+  });
 });

--- a/superset-frontend/src/dashboard/util/activeAllDashboardFilters.test.ts
+++ b/superset-frontend/src/dashboard/util/activeAllDashboardFilters.test.ts
@@ -165,3 +165,153 @@ test('should preserve the structure of the property value', () => {
     },
   });
 });
+
+test('should strip clientView from ownState to prevent infinite reload loops', () => {
+  // TableChart writes clientView to ownState on every filtered-row change
+  // If clientView is not stripped, Dashboard treats it as a chart-state change
+  // and re-triggers queries, causing an infinite reload loop
+  const mockDataMaskWithClientView: DataMaskStateWithId = {
+    chart1: {
+      id: 'chart1',
+      ownState: {
+        pageSize: 10,
+        currentPage: 0,
+        // clientView is added by TableChart for export functionality
+        // but should NOT trigger chart re-queries
+        clientView: {
+          rows: [{ id: 1, name: 'Test' }],
+          columns: [{ key: 'id' }, { key: 'name' }],
+          count: 1,
+        },
+      },
+    },
+    chart2: {
+      id: 'chart2',
+      ownState: {
+        sortBy: [{ id: 'col1', desc: true }],
+        clientView: {
+          rows: [{ id: 2, name: 'Test2' }],
+          columns: [{ key: 'id' }, { key: 'name' }],
+          count: 1,
+        },
+      },
+    },
+  };
+
+  const result = getRelevantDataMask(mockDataMaskWithClientView, 'ownState');
+
+  // clientView should be stripped from ownState
+  // Only pageSize, currentPage, sortBy etc should remain
+  expect(result).toEqual({
+    chart1: {
+      pageSize: 10,
+      currentPage: 0,
+    },
+    chart2: {
+      sortBy: [{ id: 'col1', desc: true }],
+    },
+  });
+});
+
+test('should return equal results when only clientView changes', () => {
+  // When TableChart updates clientView (on every filtered-row change),
+  // the selector output should remain equal, so Dashboard.jsx's
+  // areObjectsEqual comparison returns true and doesn't trigger re-queries
+
+  const dataMaskBefore: DataMaskStateWithId = {
+    chart1: {
+      id: 'chart1',
+      ownState: {
+        pageSize: 10,
+        currentPage: 0,
+        clientView: {
+          rows: [{ id: 1, name: 'Original' }],
+          count: 1,
+        },
+      },
+    },
+  };
+
+  const dataMaskAfter: DataMaskStateWithId = {
+    chart1: {
+      id: 'chart1',
+      ownState: {
+        pageSize: 10,
+        currentPage: 0,
+        // clientView changed (simulating TableChart updating filtered rows)
+        clientView: {
+          rows: [
+            { id: 1, name: 'Updated' },
+            { id: 2, name: 'New Row' },
+          ],
+          count: 2,
+        },
+      },
+    },
+  };
+
+  const resultBefore = getRelevantDataMask(dataMaskBefore, 'ownState');
+  const resultAfter = getRelevantDataMask(dataMaskAfter, 'ownState');
+
+  // Both results should be equal since clientView is stripped
+  // This is what prevents the infinite reload loop in Dashboard
+  expect(resultBefore).toEqual(resultAfter);
+  expect(resultBefore).toEqual({
+    chart1: { pageSize: 10, currentPage: 0 },
+  });
+});
+
+test('should return extraFormData unchanged (clientView stripping only applies to ownState)', () => {
+  // Verify extraFormData is passed through without modification
+  const mockDataMask: DataMaskStateWithId = {
+    filter1: {
+      id: 'filter1',
+      extraFormData: {
+        filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
+        granularity_sqla: 'ds',
+      },
+    },
+    filter2: {
+      id: 'filter2',
+      extraFormData: {
+        time_range: 'Last 7 days',
+      },
+    },
+  };
+
+  const result = getRelevantDataMask(mockDataMask, 'extraFormData');
+
+  // extraFormData should be returned unchanged
+  expect(result).toEqual({
+    filter1: {
+      filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
+      granularity_sqla: 'ds',
+    },
+    filter2: {
+      time_range: 'Last 7 days',
+    },
+  });
+});
+
+test('should return filterState unchanged (clientView stripping only applies to ownState)', () => {
+  // Verify filterState is passed through without modification
+  const mockDataMask: DataMaskStateWithId = {
+    filter1: {
+      id: 'filter1',
+      filterState: {
+        value: ['A', 'B'],
+        label: 'Categories A and B',
+      },
+    },
+  };
+
+  const result = getRelevantDataMask(mockDataMask, 'filterState');
+
+  // filterState should be returned unchanged
+  expect(result).toEqual({
+    filter1: {
+      value: ['A', 'B'],
+      label: 'Categories A and B',
+    },
+  });
+});


### PR DESCRIPTION
### SUMMARY
Fixes an infinite reload loop in Dashboard context where table charts would continuously re-query, causing hundreds/thousands of API calls per user.

**Root Cause:** The recent "Export table data with Search box" feature (PR #36281) added clientView to ownState on every filtered-row change. In Dashboard context, getRelevantDataMask passed this through unchanged, causing Dashboard.jsx to see continuous state changes and trigger re-queries in an infinite loop.

**Fix:** Strip clientView from ownState in getRelevantDataMask (the selector that extracts chart state for Dashboard). This matches the existing pattern in ExploreViewContainer which already strips clientView before comparing state changes.

```
  // Before: passed ownState through unchanged
  .map(item => [item.id, item[prop]])

  // After: strips clientView when prop is 'ownState'
  .map(item => [
    item.id,
    prop === 'ownState' ? omit(item[prop], ['clientView']) : item[prop],
  ])
```

**Why this location:** clientView is explicitly for export functionality, not for triggering re-queries. Stripping at the selector level ensures Dashboard never sees these changes as state updates.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open a dashboard containing a table chart with server-side pagination disabled
2. Apply a filter or interact with the table search box
3. Open browser DevTools → Network tab
4. Verify there are NO repeated /api/v1/chart/data calls
5. Verify the "Export" functionality still works correctly (exports filtered data)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: Fixes #36595
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
