### PR TITLE
feat: add timeseries range selection 

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -241,11 +241,12 @@ export default function EchartsTimeseries({
       const area = brushAreas[0];
       const coordRange = area.coordRange;
 
-      if (!coordRange || !coordRange[0] || coordRange[0].length < 2) {
+      // For lineX brush, coordRange is [xMin, xMax] (flat array)
+      if (!coordRange || coordRange.length < 2) {
         return;
       }
 
-      const [startValue, endValue] = coordRange[0].map(Number);
+      const [startValue, endValue] = coordRange.map(Number);
 
       // Convert timestamps to ISO date strings for time_range format
       const startDate = new Date(startValue).toISOString().slice(0, 19);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -95,6 +95,39 @@ export default function EchartsTimeseries({
     };
   }, [formData.showExtraControls]);
 
+  // Activate brush mode for time-axis charts
+  useEffect(() => {
+    if (xAxis.type !== AxisType.Time) {
+      return;
+    }
+
+    // Skip on touch devices to avoid interfering with scrolling
+    if (
+      typeof window !== 'undefined' &&
+      ('ontouchstart' in window ||
+        (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0))
+    ) {
+      return;
+    }
+
+    // Small delay to ensure chart is fully rendered
+    const timer = setTimeout(() => {
+      const echartInstance = echartRef.current?.getEchartInstance();
+      if (echartInstance) {
+        echartInstance.dispatchAction({
+          type: 'takeGlobalCursor',
+          key: 'brush',
+          brushOption: {
+            brushType: 'rect',
+            brushMode: 'single',
+          },
+        });
+      }
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [xAxis.type]);
+
   const hasDimensions = ensureIsArray(groupby).length > 0;
 
   const getModelInfo = (target: ViewRootGroup, globalModel: GlobalModel) => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -199,7 +199,14 @@ export default function EchartsTimeseries({
 
   const handleBrushEnd = useCallback(
     (params: any) => {
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] handleBrushEnd called', params);
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] xAxis:', xAxis);
+
       if (xAxis.type !== AxisType.Time) {
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] Skipping: not time axis');
         return;
       }
 
@@ -209,14 +216,20 @@ export default function EchartsTimeseries({
         ('ontouchstart' in window ||
           (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0));
       if (isTouchDevice) {
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] Skipping: touch device');
         return;
       }
 
       // Get the brush areas from the event
       // brushEnd event has areas directly in params.areas
       const brushAreas = params.areas || [];
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] brushAreas:', brushAreas);
 
       if (brushAreas.length === 0) {
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] No areas, resetting filter');
         // Brush was cleared, reset the filter
         // Defer to let brush event complete before re-render
         setTimeout(() => {
@@ -235,16 +248,26 @@ export default function EchartsTimeseries({
       // coordRange contains the data values of the brush selection
       // For rect brush, coordRange is [[minX, maxX], [minY, maxY]]
       const coordRange = area.coordRange;
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] coordRange:', coordRange);
+
       if (!coordRange || !coordRange[0] || coordRange[0].length < 2) {
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] Invalid coordRange');
         return;
       }
 
       const [startValue, endValue] = coordRange[0].map(Number);
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] startValue:', startValue, 'endValue:', endValue);
 
       const col =
         xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
       const startFormatted = xValueFormatter(startValue);
       const endFormatted = xValueFormatter(endValue);
+
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] Setting filter - col:', col, 'range:', startFormatted, '-', endFormatted);
 
       // Defer to let brush event complete before triggering re-render
       setTimeout(() => {
@@ -261,6 +284,8 @@ export default function EchartsTimeseries({
             label: `${startFormatted} - ${endFormatted}`,
           },
         });
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] setDataMask called');
       }, 0);
     },
     [formData, setDataMask, xAxis, xValueFormatter],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -205,6 +205,14 @@ export default function EchartsTimeseries({
       console.log('[BRUSH DEBUG] handleBrushEnd called', params);
       // eslint-disable-next-line no-console
       console.log('[BRUSH DEBUG] xAxis:', xAxis);
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] emitCrossFilters:', emitCrossFilters);
+
+      if (!emitCrossFilters) {
+        // eslint-disable-next-line no-console
+        console.log('[BRUSH DEBUG] Skipping: cross-filters not enabled');
+        return;
+      }
 
       if (xAxis.type !== AxisType.Time) {
         // eslint-disable-next-line no-console
@@ -303,7 +311,7 @@ export default function EchartsTimeseries({
         console.log('[BRUSH DEBUG] setDataMask called');
       }, 0);
     },
-    [formData, setDataMask, xAxis, xValueFormatter],
+    [emitCrossFilters, formData, setDataMask, xAxis, xValueFormatter],
   );
 
   const eventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -201,7 +201,7 @@ export default function EchartsTimeseries({
         return;
       }
 
-      const [startValue, endValue] = coordRange[0];
+      const [startValue, endValue] = coordRange[0].map(Number);
 
       const col =
         xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -197,7 +197,7 @@ export default function EchartsTimeseries({
     [emitCrossFilters, setDataMask, getCrossFilterDataMask],
   );
 
-  const handleBrushSelected = useCallback(
+  const handleBrushEnd = useCallback(
     (params: any) => {
       if (xAxis.type !== AxisType.Time) {
         return;
@@ -215,6 +215,22 @@ export default function EchartsTimeseries({
       // Get the brush areas from the event
       // brushEnd event has areas directly in params.areas
       const brushAreas = params.areas || [];
+
+      // Re-activate brush mode for the next selection
+      const echartInstance = echartRef.current?.getEchartInstance();
+      if (echartInstance) {
+        setTimeout(() => {
+          echartInstance.dispatchAction({
+            type: 'takeGlobalCursor',
+            key: 'brush',
+            brushOption: {
+              brushType: 'rect',
+              brushMode: 'single',
+            },
+          });
+        }, 0);
+      }
+
       if (brushAreas.length === 0) {
         // Brush was cleared, reset the filter
         setDataMask({
@@ -356,7 +372,7 @@ export default function EchartsTimeseries({
         });
       }
     },
-    brushEnd: handleBrushSelected,
+    brushEnd: handleBrushEnd,
   };
 
   const zrEventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -97,13 +97,8 @@ export default function EchartsTimeseries({
     };
   }, [formData.showExtraControls]);
 
-  // Activate brush mode for time-axis charts when cross-filters are enabled
+  // Activate brush mode for time-axis charts
   useEffect(() => {
-    // Only enable brush when cross-filters are enabled (on dashboards)
-    if (!emitCrossFilters) {
-      return;
-    }
-
     if (xAxis.type !== AxisType.Time) {
       return;
     }
@@ -133,7 +128,7 @@ export default function EchartsTimeseries({
     }, 100);
 
     return () => clearTimeout(timer);
-  }, [emitCrossFilters, xAxis.type]);
+  }, [xAxis.type]);
 
   const hasDimensions = ensureIsArray(groupby).length > 0;
 
@@ -206,10 +201,6 @@ export default function EchartsTimeseries({
 
   const handleBrushEnd = useCallback(
     (params: any) => {
-      if (!emitCrossFilters) {
-        return;
-      }
-
       if (xAxis.type !== AxisType.Time) {
         return;
       }
@@ -279,7 +270,7 @@ export default function EchartsTimeseries({
         });
       }, 0);
     },
-    [emitCrossFilters, formData, setDataMask, xAxis, xValueFormatter],
+    [formData, setDataMask, xAxis, xValueFormatter],
   );
 
   const eventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -58,7 +58,6 @@ export default function EchartsTimeseries({
   emitCrossFilters,
   coltypeMapping,
   onLegendScroll,
-  isHorizontal,
 }: TimeseriesChartTransformedProps) {
   const { stack } = formData;
   const echartRef = useRef<EchartsHandler | null>(null);
@@ -173,7 +172,9 @@ export default function EchartsTimeseries({
 
       // Skip on touch devices to avoid interfering with scrolling
       const isTouchDevice =
-        'ontouchstart' in window || navigator.maxTouchPoints > 0;
+        typeof window !== 'undefined' &&
+        ('ontouchstart' in window ||
+          (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0));
       if (isTouchDevice) {
         return;
       }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -213,7 +213,8 @@ export default function EchartsTimeseries({
       }
 
       // Get the brush areas from the event
-      const brushAreas = params.batch?.[0]?.areas || [];
+      // brushEnd event has areas directly in params.areas
+      const brushAreas = params.areas || [];
       if (brushAreas.length === 0) {
         // Brush was cleared, reset the filter
         setDataMask({
@@ -355,7 +356,7 @@ export default function EchartsTimeseries({
         });
       }
     },
-    brushSelected: handleBrushSelected,
+    brushEnd: handleBrushSelected,
   };
 
   const zrEventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -216,30 +216,18 @@ export default function EchartsTimeseries({
       // brushEnd event has areas directly in params.areas
       const brushAreas = params.areas || [];
 
-      // Re-activate brush mode for the next selection
-      const echartInstance = echartRef.current?.getEchartInstance();
-      if (echartInstance) {
+      if (brushAreas.length === 0) {
+        // Brush was cleared, reset the filter
+        // Defer to let brush event complete before re-render
         setTimeout(() => {
-          echartInstance.dispatchAction({
-            type: 'takeGlobalCursor',
-            key: 'brush',
-            brushOption: {
-              brushType: 'rect',
-              brushMode: 'single',
+          setDataMask({
+            extraFormData: {},
+            filterState: {
+              value: null,
+              selectedValues: null,
             },
           });
         }, 0);
-      }
-
-      if (brushAreas.length === 0) {
-        // Brush was cleared, reset the filter
-        setDataMask({
-          extraFormData: {},
-          filterState: {
-            value: null,
-            selectedValues: null,
-          },
-        });
         return;
       }
 
@@ -258,19 +246,22 @@ export default function EchartsTimeseries({
       const startFormatted = xValueFormatter(startValue);
       const endFormatted = xValueFormatter(endValue);
 
-      setDataMask({
-        extraFormData: {
-          filters: [
-            { col, op: '>=', val: startValue },
-            { col, op: '<=', val: endValue },
-          ],
-        },
-        filterState: {
-          value: [startValue, endValue],
-          selectedValues: [startValue, endValue],
-          label: `${startFormatted} - ${endFormatted}`,
-        },
-      });
+      // Defer to let brush event complete before triggering re-render
+      setTimeout(() => {
+        setDataMask({
+          extraFormData: {
+            filters: [
+              { col, op: '>=', val: startValue },
+              { col, op: '<=', val: endValue },
+            ],
+          },
+          filterState: {
+            value: [startValue, endValue],
+            selectedValues: [startValue, endValue],
+            label: `${startFormatted} - ${endFormatted}`,
+          },
+        });
+      }, 0);
     },
     [formData, setDataMask, xAxis, xValueFormatter],
   );

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -241,12 +241,30 @@ export default function EchartsTimeseries({
       const area = brushAreas[0];
       const coordRange = area.coordRange;
 
+      // Debug: log the brush area structure
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] area:', JSON.stringify(area));
+
       // For lineX brush, coordRange is [xMin, xMax] (flat array)
       if (!coordRange || coordRange.length < 2) {
         return;
       }
 
       const [startValue, endValue] = coordRange.map(Number);
+
+      // Debug: log the extracted values
+      // eslint-disable-next-line no-console
+      console.log('[BRUSH DEBUG] startValue:', startValue, 'endValue:', endValue);
+
+      // Validate that we have valid timestamps
+      if (
+        !Number.isFinite(startValue) ||
+        !Number.isFinite(endValue) ||
+        startValue <= 0 ||
+        endValue <= 0
+      ) {
+        return;
+      }
 
       // Convert timestamps to ISO date strings for time_range format
       const startDate = new Date(startValue).toISOString().slice(0, 19);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -166,7 +166,7 @@ export default function EchartsTimeseries({
 
   const handleBrushSelected = useCallback(
     (params: any) => {
-      if (xAxis.type !== AxisType.time) {
+      if (xAxis.type !== AxisType.Time) {
         return;
       }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -77,6 +77,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   truncateYAxis: false,
   yAxisBounds: [null, null],
   zoomable: false,
+  timeRangeSelection: false,
   richTooltip: true,
   xAxisForceCategorical: false,
   xAxisLabelRotation: defaultXAxis.xAxisLabelRotation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -749,7 +749,7 @@ export default function transformProps(
       xAxisType === AxisType.Time
         ? {
             toolbox: [],
-            brushType: 'rect',
+            brushType: 'lineX',
             xAxisIndex: 0,
             throttleType: 'debounce',
             throttleDelay: 300,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -745,6 +745,21 @@ export default function transformProps(
           },
         ]
       : [],
+    brush:
+      xAxisType === AxisType.time
+        ? {
+            toolbox: [],
+            brushType: 'rect',
+            xAxisIndex: 0,
+            throttleType: 'debounce',
+            throttleDelay: 300,
+            brushStyle: {
+              borderWidth: 1,
+              color: 'rgba(120, 140, 180, 0.3)',
+              borderColor: 'rgba(120, 140, 180, 0.8)',
+            },
+          }
+        : undefined,
   };
 
   const onFocusedSeries = (seriesName: string | null) => {
@@ -773,5 +788,6 @@ export default function transformProps(
     refs,
     coltypeMapping: dataTypes,
     onLegendScroll,
+    isHorizontal,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -746,7 +746,7 @@ export default function transformProps(
         ]
       : [],
     brush:
-      xAxisType === AxisType.time
+      xAxisType === AxisType.Time
         ? {
             toolbox: [],
             brushType: 'rect',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -116,4 +116,5 @@ export type TimeseriesChartTransformedProps =
         type: AxisType;
       };
       onFocusedSeries: (series: string | null) => void;
+      isHorizontal?: boolean;
     };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -62,6 +62,7 @@ import {
   AriaComponent,
   MarkAreaComponent,
   MarkLineComponent,
+  BrushComponent,
 } from 'echarts/components';
 import { LabelLayout } from 'echarts/features';
 import { EchartsHandler, EchartsProps, EchartsStylesProps } from '../types';
@@ -99,6 +100,7 @@ use([
   TreeChart,
   TreemapChart,
   AriaComponent,
+  BrushComponent,
   DataZoomComponent,
   GraphicComponent,
   GridComponent,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -250,18 +250,14 @@ describe('EchartsTimeseries handleBrushEnd', () => {
 
     it('should not process when coordRange[0] is empty', () => {
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: [[]],
-              },
-            ],
+            coordRange: [[]],
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,
@@ -277,21 +273,17 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const endTime = 1609545600000;
 
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: [
-                  [startTime, endTime],
-                  [0, 100],
-                ],
-              },
+            coordRange: [
+              [startTime, endTime],
+              [0, 100],
             ],
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,
@@ -312,21 +304,17 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const customFormatter = (val: number) => `Formatted: ${val}`;
 
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: [
-                  [startTime, endTime],
-                  [0, 100],
-                ],
-              },
+            coordRange: [
+              [startTime, endTime],
+              [0, 100],
             ],
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -45,14 +45,9 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       formData: Partial<EchartsTimeseriesFormData>,
       setDataMask: jest.Mock,
       xValueFormatter: (val: number) => string,
-      options: { isTouchDevice?: boolean; emitCrossFilters?: boolean } = {},
+      options: { isTouchDevice?: boolean } = {},
     ) => {
-      const { isTouchDevice = false, emitCrossFilters = true } = options;
-
-      // Only emit cross-filters when enabled (on dashboards)
-      if (!emitCrossFilters) {
-        return;
-      }
+      const { isTouchDevice = false } = options;
 
       // Only handle brush events for time axis charts
       if (xAxis.type !== AxisType.Time) {
@@ -106,23 +101,6 @@ describe('EchartsTimeseries handleBrushEnd', () => {
         },
       });
     };
-
-    it('should not process brush events when emitCrossFilters is false', () => {
-      const params = {
-        areas: [{ coordRange: [[1000, 2000], [0, 100]] }],
-      };
-
-      handleBrushEnd(
-        params,
-        baseXAxis,
-        baseFormData,
-        mockSetDataMask,
-        mockXValueFormatter,
-        { emitCrossFilters: false },
-      );
-
-      expect(mockSetDataMask).not.toHaveBeenCalled();
-    });
 
     it('should not process brush events when x-axis type is not time', () => {
       const params = {
@@ -350,45 +328,6 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       expect(call.filterState.label).toBe(
         `Formatted: ${startTime} - Formatted: ${endTime}`,
       );
-    });
-
-    it('should process brush events when emitCrossFilters is true (dashboard context)', () => {
-      const startTime = 1609459200000;
-      const endTime = 1609545600000;
-
-      const params = {
-        areas: [
-          {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
-          },
-        ],
-      };
-
-      handleBrushEnd(
-        params,
-        baseXAxis,
-        baseFormData,
-        mockSetDataMask,
-        mockXValueFormatter,
-        { emitCrossFilters: true },
-      );
-
-      expect(mockSetDataMask).toHaveBeenCalledWith({
-        extraFormData: {
-          filters: [
-            { col: 'ds', op: '>=', val: startTime },
-            { col: 'ds', op: '<=', val: endTime },
-          ],
-        },
-        filterState: {
-          value: [startTime, endTime],
-          selectedValues: [startTime, endTime],
-          label: expect.stringContaining(' - '),
-        },
-      });
     });
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -17,7 +17,8 @@
  * under the License.
  */
 import { render, waitFor } from '@testing-library/react';
-import { ThemeProvider, supersetTheme, AxisType } from '@superset-ui/core';
+import { ThemeProvider, supersetTheme } from '@apache-superset/core/ui';
+import { AxisType } from '@superset-ui/core';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import EchartsTimeseries from '../../src/Timeseries/EchartsTimeseries';
@@ -156,7 +157,7 @@ test('brush selection in Explore view calls setControlValue with time_range', as
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={baseXAxis}
       refs={refs}
       emitCrossFilters={false}
@@ -234,7 +235,7 @@ test('brush selection on dashboard calls setDataMask with cross-filter', async (
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={baseXAxis}
       refs={refs}
       emitCrossFilters={true}
@@ -328,7 +329,7 @@ test('brush selection does nothing for non-time axis', async () => {
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => String(val)}
+      xValueFormatter={((val: number) => String(val)) as any}
       xAxis={categoryXAxis}
       refs={refs}
       emitCrossFilters={true}
@@ -393,7 +394,7 @@ test('clearing brush on dashboard resets filter', async () => {
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={baseXAxis}
       refs={refs}
       emitCrossFilters={true}
@@ -472,7 +473,7 @@ test('brush selection uses custom column name when xAxis.label is not DTTM_ALIAS
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={customXAxis}
       refs={refs}
       emitCrossFilters={true}
@@ -550,7 +551,7 @@ test('brush selection with invalid coordRange does not trigger filter', async ()
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={baseXAxis}
       refs={refs}
       emitCrossFilters={true}
@@ -623,7 +624,7 @@ test('brush selection formats time range correctly for different timestamps', as
       onContextMenu={jest.fn()}
       onLegendStateChanged={jest.fn()}
       onFocusedSeries={jest.fn()}
-      xValueFormatter={(val: number) => new Date(val).toISOString()}
+      xValueFormatter={((val: number) => new Date(val).toISOString()) as any}
       xAxis={baseXAxis}
       refs={refs}
       emitCrossFilters={false}

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -106,7 +106,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
       handleBrushSelected(
         params,
-        { label: 'category', type: AxisType.category },
+        { label: 'category', type: AxisType.Category },
         baseFormData,
         mockSetDataMask,
         mockXValueFormatter,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -88,11 +88,12 @@ describe('EchartsTimeseries handleBrushEnd', () => {
 
       const area = brushAreas[0];
       const coordRange = area.coordRange;
-      if (!coordRange || !coordRange[0] || coordRange[0].length < 2) {
+      // For lineX brush, coordRange is [xMin, xMax] (flat array)
+      if (!coordRange || coordRange.length < 2) {
         return;
       }
 
-      const [startValue, endValue] = coordRange[0].map(Number);
+      const [startValue, endValue] = coordRange.map(Number);
 
       // Convert timestamps to ISO date strings for time_range format
       const startDate = new Date(startValue).toISOString().slice(0, 19);
@@ -144,8 +145,9 @@ describe('EchartsTimeseries handleBrushEnd', () => {
     });
 
     it('should not process brush events on touch devices', () => {
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
-        areas: [{ coordRange: [[1000, 2000], [0, 100]] }],
+        areas: [{ coordRange: [1000, 2000] }],
       };
 
       handleBrushEnd(
@@ -187,13 +189,11 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const startTime = 1609459200000; // 2021-01-01T00:00:00.000Z
       const endTime = 1609545600000; // 2021-01-02T00:00:00.000Z
 
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
+            coordRange: [startTime, endTime],
           },
         ],
       };
@@ -218,13 +218,11 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const startTime = 1609459200000; // 2021-01-01
       const endTime = 1609545600000; // 2021-01-02
 
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
+            coordRange: [startTime, endTime],
           },
         ],
       };
@@ -257,13 +255,11 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const startTime = 1609459200000;
       const endTime = 1609545600000;
 
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
+            coordRange: [startTime, endTime],
           },
         ],
       };
@@ -309,11 +305,12 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       expect(mockSetDataMask).not.toHaveBeenCalled();
     });
 
-    it('should not process when coordRange[0] is empty', () => {
+    it('should not process when coordRange has less than 2 values', () => {
+      // For lineX brush, coordRange should be [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [[]],
+            coordRange: [123],
           },
         ],
       };
@@ -333,13 +330,11 @@ describe('EchartsTimeseries handleBrushEnd', () => {
       const startTime = 1609459200000;
       const endTime = 1609545600000;
 
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
+            coordRange: [startTime, endTime],
           },
         ],
       };
@@ -365,13 +360,11 @@ describe('EchartsTimeseries handleBrushEnd', () => {
 
       const customFormatter = (val: number) => `Formatted: ${val}`;
 
+      // For lineX brush, coordRange is a flat array [xMin, xMax]
       const params = {
         areas: [
           {
-            coordRange: [
-              [startTime, endTime],
-              [0, 100],
-            ],
+            coordRange: [startTime, endTime],
           },
         ],
       };

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -29,7 +29,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
   const baseXAxis = {
     label: '__timestamp',
-    type: AxisType.time,
+    type: AxisType.Time,
   };
 
   beforeEach(() => {
@@ -48,7 +48,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       isTouchDevice = false,
     ) => {
       // Only handle brush events for time axis charts
-      if (xAxis.type !== AxisType.time) {
+      if (xAxis.type !== AxisType.Time) {
         return;
       }
 
@@ -217,7 +217,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
       handleBrushSelected(
         params,
-        { label: 'custom_time_column', type: AxisType.time },
+        { label: 'custom_time_column', type: AxisType.Time },
         baseFormData,
         mockSetDataMask,
         mockXValueFormatter,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -19,7 +19,7 @@
 import { AxisType, DTTM_ALIAS } from '@superset-ui/core';
 import { EchartsTimeseriesFormData } from '../../src/Timeseries/types';
 
-describe('EchartsTimeseries handleBrushSelected', () => {
+describe('EchartsTimeseries handleBrushEnd', () => {
   const mockSetDataMask = jest.fn();
   const mockXValueFormatter = jest.fn((val: number) => new Date(val).toISOString());
 
@@ -37,9 +37,9 @@ describe('EchartsTimeseries handleBrushSelected', () => {
     mockXValueFormatter.mockClear();
   });
 
-  describe('handleBrushSelected logic', () => {
+  describe('handleBrushEnd logic', () => {
     // Simulating the handler logic since we can't easily test React hooks directly
-    const handleBrushSelected = (
+    const handleBrushEnd = (
       params: any,
       xAxis: { label: string; type: AxisType },
       formData: Partial<EchartsTimeseriesFormData>,
@@ -58,7 +58,8 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       }
 
       // Get the brush areas from the event
-      const brushAreas = params.batch?.[0]?.areas || [];
+      // brushEnd event has areas directly in params.areas
+      const brushAreas = params.areas || [];
       if (brushAreas.length === 0) {
         // Brush was cleared, reset the filter
         setDataMask({
@@ -77,7 +78,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
         return;
       }
 
-      const [startValue, endValue] = coordRange[0];
+      const [startValue, endValue] = coordRange[0].map(Number);
 
       const col =
         xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
@@ -101,10 +102,10 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
     it('should not process brush events when x-axis type is not time', () => {
       const params = {
-        batch: [{ areas: [{ coordRange: [[1000, 2000], [0, 100]] }] }],
+        areas: [{ coordRange: [[1000, 2000], [0, 100]] }],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         { label: 'category', type: AxisType.Category },
         baseFormData,
@@ -117,10 +118,10 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
     it('should not process brush events on touch devices', () => {
       const params = {
-        batch: [{ areas: [{ coordRange: [[1000, 2000], [0, 100]] }] }],
+        areas: [{ coordRange: [[1000, 2000], [0, 100]] }],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,
@@ -134,10 +135,10 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
     it('should reset filter when brush is cleared (no areas)', () => {
       const params = {
-        batch: [{ areas: [] }],
+        areas: [],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,
@@ -159,21 +160,17 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       const endTime = 1609545600000; // 2021-01-02
 
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: [
-                  [startTime, endTime],
-                  [0, 100],
-                ],
-              },
+            coordRange: [
+              [startTime, endTime],
+              [0, 100],
             ],
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,
@@ -201,21 +198,17 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       const endTime = 1609545600000;
 
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: [
-                  [startTime, endTime],
-                  [0, 100],
-                ],
-              },
+            coordRange: [
+              [startTime, endTime],
+              [0, 100],
             ],
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         { label: 'custom_time_column', type: AxisType.Time },
         baseFormData,
@@ -237,18 +230,14 @@ describe('EchartsTimeseries handleBrushSelected', () => {
 
     it('should not process when coordRange is invalid', () => {
       const params = {
-        batch: [
+        areas: [
           {
-            areas: [
-              {
-                coordRange: null,
-              },
-            ],
+            coordRange: null,
           },
         ],
       };
 
-      handleBrushSelected(
+      handleBrushEnd(
         params,
         baseXAxis,
         baseFormData,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { AxisType } from '@superset-ui/core';
+import { EchartsTimeseriesFormData } from '../../src/Timeseries/types';
+
+describe('EchartsTimeseries handleBrushSelected', () => {
+  const mockSetDataMask = jest.fn();
+  const mockXValueFormatter = jest.fn((val: number) => new Date(val).toISOString());
+
+  const baseFormData: Partial<EchartsTimeseriesFormData> = {
+    granularitySqla: 'ds',
+  };
+
+  const baseXAxis = {
+    label: '__timestamp',
+    type: AxisType.time,
+  };
+
+  beforeEach(() => {
+    mockSetDataMask.mockClear();
+    mockXValueFormatter.mockClear();
+  });
+
+  describe('handleBrushSelected logic', () => {
+    // Simulating the handler logic since we can't easily test React hooks directly
+    const handleBrushSelected = (
+      params: any,
+      xAxis: { label: string; type: AxisType },
+      formData: Partial<EchartsTimeseriesFormData>,
+      setDataMask: jest.Mock,
+      xValueFormatter: (val: number) => string,
+      isTouchDevice = false,
+    ) => {
+      // Only handle brush events for time axis charts
+      if (xAxis.type !== AxisType.time) {
+        return;
+      }
+
+      // Disable brush selection on touch devices
+      if (isTouchDevice) {
+        return;
+      }
+
+      // Get the brush areas from the event
+      const brushAreas = params.batch?.[0]?.areas || [];
+      if (brushAreas.length === 0) {
+        // Brush was cleared, reset the filter
+        setDataMask({
+          extraFormData: {},
+          filterState: {
+            value: null,
+            selectedValues: null,
+          },
+        });
+        return;
+      }
+
+      const area = brushAreas[0];
+      const coordRange = area.coordRange;
+      if (!coordRange || !coordRange[0] || coordRange[0].length < 2) {
+        return;
+      }
+
+      const [startValue, endValue] = coordRange[0];
+
+      const col =
+        xAxis.label === '__timestamp' ? formData.granularitySqla : xAxis.label;
+      const startFormatted = xValueFormatter(startValue);
+      const endFormatted = xValueFormatter(endValue);
+
+      setDataMask({
+        extraFormData: {
+          filters: [
+            { col, op: '>=', val: startValue },
+            { col, op: '<=', val: endValue },
+          ],
+        },
+        filterState: {
+          value: [startValue, endValue],
+          selectedValues: [startValue, endValue],
+          label: `${startFormatted} - ${endFormatted}`,
+        },
+      });
+    };
+
+    it('should not process brush events when x-axis type is not time', () => {
+      const params = {
+        batch: [{ areas: [{ coordRange: [[1000, 2000], [0, 100]] }] }],
+      };
+
+      handleBrushSelected(
+        params,
+        { label: 'category', type: AxisType.category },
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+    });
+
+    it('should not process brush events on touch devices', () => {
+      const params = {
+        batch: [{ areas: [{ coordRange: [[1000, 2000], [0, 100]] }] }],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+        true, // isTouchDevice
+      );
+
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+    });
+
+    it('should reset filter when brush is cleared (no areas)', () => {
+      const params = {
+        batch: [{ areas: [] }],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).toHaveBeenCalledWith({
+        extraFormData: {},
+        filterState: {
+          value: null,
+          selectedValues: null,
+        },
+      });
+    });
+
+    it('should create time range filter when brush selection is made', () => {
+      const startTime = 1609459200000; // 2021-01-01
+      const endTime = 1609545600000; // 2021-01-02
+
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: [
+                  [startTime, endTime],
+                  [0, 100],
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).toHaveBeenCalledWith({
+        extraFormData: {
+          filters: [
+            { col: 'ds', op: '>=', val: startTime },
+            { col: 'ds', op: '<=', val: endTime },
+          ],
+        },
+        filterState: {
+          value: [startTime, endTime],
+          selectedValues: [startTime, endTime],
+          label: expect.stringContaining(' - '),
+        },
+      });
+    });
+
+    it('should use xAxis.label as column when not __timestamp', () => {
+      const startTime = 1609459200000;
+      const endTime = 1609545600000;
+
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: [
+                  [startTime, endTime],
+                  [0, 100],
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        { label: 'custom_time_column', type: AxisType.time },
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraFormData: {
+            filters: [
+              { col: 'custom_time_column', op: '>=', val: startTime },
+              { col: 'custom_time_column', op: '<=', val: endTime },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('should not process when coordRange is invalid', () => {
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: null,
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+    });
+
+    it('should not process when coordRange[0] is empty', () => {
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: [[]],
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      expect(mockSetDataMask).not.toHaveBeenCalled();
+    });
+
+    it('should use range operators (>= and <=) for time filter', () => {
+      const startTime = 1609459200000;
+      const endTime = 1609545600000;
+
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: [
+                  [startTime, endTime],
+                  [0, 100],
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        mockXValueFormatter,
+      );
+
+      const call = mockSetDataMask.mock.calls[0][0];
+      expect(call.extraFormData.filters).toHaveLength(2);
+      expect(call.extraFormData.filters[0].op).toBe('>=');
+      expect(call.extraFormData.filters[1].op).toBe('<=');
+    });
+
+    it('should format the label using xValueFormatter', () => {
+      const startTime = 1609459200000;
+      const endTime = 1609545600000;
+
+      const customFormatter = (val: number) => `Formatted: ${val}`;
+
+      const params = {
+        batch: [
+          {
+            areas: [
+              {
+                coordRange: [
+                  [startTime, endTime],
+                  [0, 100],
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      handleBrushSelected(
+        params,
+        baseXAxis,
+        baseFormData,
+        mockSetDataMask,
+        customFormatter,
+      );
+
+      const call = mockSetDataMask.mock.calls[0][0];
+      expect(call.filterState.label).toBe(
+        `Formatted: ${startTime} - Formatted: ${endTime}`,
+      );
+    });
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { AxisType } from '@superset-ui/core';
+import { AxisType, DTTM_ALIAS } from '@superset-ui/core';
 import { EchartsTimeseriesFormData } from '../../src/Timeseries/types';
 
 describe('EchartsTimeseries handleBrushSelected', () => {
@@ -28,7 +28,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
   };
 
   const baseXAxis = {
-    label: '__timestamp',
+    label: DTTM_ALIAS,
     type: AxisType.Time,
   };
 
@@ -80,7 +80,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       const [startValue, endValue] = coordRange[0];
 
       const col =
-        xAxis.label === '__timestamp' ? formData.granularitySqla : xAxis.label;
+        xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
       const startFormatted = xValueFormatter(startValue);
       const endFormatted = xValueFormatter(endValue);
 
@@ -196,7 +196,7 @@ describe('EchartsTimeseries handleBrushSelected', () => {
       });
     });
 
-    it('should use xAxis.label as column when not __timestamp', () => {
+    it('should use xAxis.label as column when not DTTM_ALIAS', () => {
       const startTime = 1609459200000;
       const endTime = 1609545600000;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -20,6 +20,7 @@ import {
   AnnotationSourceType,
   AnnotationStyle,
   AnnotationType,
+  AxisType,
   ChartProps,
   EventAnnotationLayer,
   FormulaAnnotationLayer,
@@ -721,5 +722,133 @@ describe('legend sorting', () => {
       'Milton',
       'Boston',
     ]);
+  });
+});
+
+describe('EchartsTimeseries brush configuration for time range selection', () => {
+  const brushFormData: SqlaFormData = {
+    colorScheme: 'bnbColors',
+    datasource: '3__table',
+    granularity_sqla: 'ds',
+    metric: 'sum__num',
+    groupby: ['foo', 'bar'],
+    viz_type: 'echarts_timeseries_line',
+  };
+
+  const queriesDataWithTimeAxis = [
+    {
+      data: [
+        { 'San Francisco': 1, 'New York': 2, __timestamp: 599616000000 },
+        { 'San Francisco': 3, 'New York': 4, __timestamp: 599916000000 },
+      ],
+    },
+  ];
+
+  const brushChartPropsConfig = {
+    formData: brushFormData,
+    width: 800,
+    height: 600,
+    queriesData: queriesDataWithTimeAxis,
+    theme: supersetTheme,
+  };
+
+  it('should enable brush configuration when x-axis type is time', () => {
+    const chartProps = new ChartProps(brushChartPropsConfig);
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.brush).toBeDefined();
+    expect(transformedProps.echartOptions.brush).toEqual(
+      expect.objectContaining({
+        brushType: 'rect',
+        xAxisIndex: 0,
+        toolbox: [],
+        throttleType: 'debounce',
+        throttleDelay: 300,
+      }),
+    );
+  });
+
+  it('should have correct brush style', () => {
+    const chartProps = new ChartProps(brushChartPropsConfig);
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.brush).toEqual(
+      expect.objectContaining({
+        brushStyle: expect.objectContaining({
+          borderWidth: 1,
+          color: 'rgba(120, 140, 180, 0.3)',
+          borderColor: 'rgba(120, 140, 180, 0.8)',
+        }),
+      }),
+    );
+  });
+
+  it('should return xAxis type as time for time-based data', () => {
+    const chartProps = new ChartProps(brushChartPropsConfig);
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.xAxis.type).toBe(AxisType.time);
+  });
+
+  it('should not enable brush configuration when x-axis type is category', () => {
+    const categoryFormData = {
+      ...brushFormData,
+      x_axis: 'category_column',
+    };
+    const queriesDataWithCategoryAxis = [
+      {
+        data: [
+          { 'San Francisco': 1, 'New York': 2, category_column: 'A' },
+          { 'San Francisco': 3, 'New York': 4, category_column: 'B' },
+        ],
+        colnames: ['category_column', 'San Francisco', 'New York'],
+        coltypes: [1, 0, 0], // 1 = string/category, 0 = number
+      },
+    ];
+
+    const chartProps = new ChartProps({
+      ...brushChartPropsConfig,
+      formData: categoryFormData,
+      queriesData: queriesDataWithCategoryAxis,
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.echartOptions.brush).toBeUndefined();
+  });
+
+  it('should include isHorizontal in transformed props', () => {
+    const chartProps = new ChartProps(brushChartPropsConfig);
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.isHorizontal).toBe(false);
+  });
+
+  it('should set isHorizontal to true for horizontal orientation', () => {
+    const horizontalFormData = {
+      ...brushFormData,
+      orientation: 'horizontal',
+    };
+
+    const chartProps = new ChartProps({
+      ...brushChartPropsConfig,
+      formData: horizontalFormData,
+    });
+
+    const transformedProps = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+
+    expect(transformedProps.isHorizontal).toBe(true);
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -819,7 +819,7 @@ describe('EchartsTimeseries brush configuration for time range selection', () =>
     });
 
     const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
+      chartProps as unknown as EchartsTimeseriesChartProps,
     );
 
     expect(transformedProps.echartOptions.brush).toBeUndefined();

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -741,6 +741,8 @@ describe('EchartsTimeseries brush configuration for time range selection', () =>
         { 'San Francisco': 1, 'New York': 2, __timestamp: 599616000000 },
         { 'San Francisco': 3, 'New York': 4, __timestamp: 599916000000 },
       ],
+      colnames: ['__timestamp', 'San Francisco', 'New York'],
+      coltypes: [2, 0, 0], // 2 = Temporal, 0 = Numeric
     },
   ];
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -793,7 +793,7 @@ describe('EchartsTimeseries brush configuration for time range selection', () =>
       chartProps as EchartsTimeseriesChartProps,
     );
 
-    expect(transformedProps.xAxis.type).toBe(AxisType.time);
+    expect(transformedProps.xAxis.type).toBe(AxisType.Time);
   });
 
   it('should not enable brush configuration when x-axis type is category', () => {


### PR DESCRIPTION
### SUMMARY
This PR adds a click-and-drag time range selection feature to all timeseries chart types (Line, Area, Bar, Scatter, SmoothLine, Step). Users can draw a rectangle on the chart to select a time range, which automatically applies as a cross-filter.

#### Key features:
Automatic enablement: The brush selection is automatically enabled for charts with a time-based x-axis. No configuration required.
Rectangle selection: Users draw a rectangle to select a time range (vertical extent is ignored for filtering but provides visual flexibility).
Cross-filter integration: Selected time range creates a cross-filter with >= and <= operators, affecting other charts on the dashboard.
Touch device handling: Disabled on touch devices to avoid interfering with scrolling gestures.
Visual feedback: Selection area has a semi-transparent blue overlay with a subtle border.

#### Technical implementation:
Uses ECharts' brush component with brushType: 'rect'
Brush configuration is conditionally added when xAxisType === AxisType.time
brushSelected event handler extracts time range from coordRange and calls setDataMask
Filter label displays formatted time range (e.g., "Jan 1, 2024 - Mar 15, 2024")
BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Users had no way to directly select a time range on timeseries charts.

After: Users can click and drag to draw a rectangle, creating a time range cross-filter.

### TESTING INSTRUCTIONS
Create a dashboard with a timeseries chart (Line, Area, Bar, etc.) using a time-based x-axis
Add another chart to the dashboard that shares the same time column
Click and drag on the timeseries chart to draw a rectangle selection
Verify:
A blue selection rectangle appears while dragging
After releasing, a cross-filter badge appears on the chart
Other charts on the dashboard are filtered to the selected time range
The filter label shows the formatted time range
Click elsewhere on the chart to clear the selection
Test on a mobile device or emulator to verify the feature is disabled (no brush on touch)
Test with a category x-axis to verify brush is not enabled (only for time axis)

### ADDITIONAL INFORMATION

- [ ]  Has associated issue:
 - [ ]  Required feature flags:
 - [x]  Changes UI
 - [ ]  Includes DB Migration
 - [x]  Introduces new feature or API
 - [ ]  Removes existing feature or API
