### PR TITLE
Add relative day formatters for time-series X-axis

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -19,6 +19,7 @@
 import {
   t,
   SMART_DATE_ID,
+  RELATIVE_DAY_ID,
   NumberFormats,
   getNumberFormatter,
 } from '@superset-ui/core';
@@ -76,6 +77,7 @@ export const D3_TIME_FORMAT_DOCS = t(
 
 export const D3_TIME_FORMAT_OPTIONS: [string, string][] = [
   [SMART_DATE_ID, t('Adaptive formatting')],
+  [RELATIVE_DAY_ID, t('Relative Day (Day 1: 12:00am)')],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%d.%m.%Y', '%d.%m.%Y | 14.01.2019'],

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/D3Formatting.ts
@@ -20,6 +20,7 @@ import {
   t,
   SMART_DATE_ID,
   RELATIVE_DAY_ID,
+  RELATIVE_DAY_NO_TIME_ID,
   NumberFormats,
   getNumberFormatter,
 } from '@superset-ui/core';
@@ -78,6 +79,7 @@ export const D3_TIME_FORMAT_DOCS = t(
 export const D3_TIME_FORMAT_OPTIONS: [string, string][] = [
   [SMART_DATE_ID, t('Adaptive formatting')],
   [RELATIVE_DAY_ID, t('Relative Day (Day 1: 12:00am)')],
+  [RELATIVE_DAY_NO_TIME_ID, t('Relative Day (Day 1)')],
   ['%d/%m/%Y', '%d/%m/%Y | 14/01/2019'],
   ['%m/%d/%Y', '%m/%d/%Y | 01/14/2019'],
   ['%d.%m.%Y', '%d.%m.%Y | 14.01.2019'],

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatter.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import TimeFormatter from '../TimeFormatter';
+
+export const RELATIVE_DAY_ID = 'relative_day';
+
+// Reference date: January 1, 2000 00:00:00 UTC = Day 1
+const DAY_ONE_DATE = Date.UTC(2000, 0, 1, 0, 0, 0, 0);
+const MS_PER_DAY = 86400000;
+
+export function createRelativeDayFormatter() {
+  return new TimeFormatter({
+    id: RELATIVE_DAY_ID,
+    label: 'Relative Day',
+    description: 'Formats dates as relative days from Day 1 (01/01/2000) with time',
+    formatFunc: (date: Date) => {
+      const ms = date.getTime();
+
+      // Calculate day difference from Day 1 (01/01/2000)
+      // Day 1 = 01/01/2000, Day 2 = 02/01/2000, Day -1 = 31/12/1999
+      // There is no Day 0
+      const msDiff = ms - DAY_ONE_DATE;
+      const daysDiff = Math.floor(msDiff / MS_PER_DAY);
+      // Adjust for no Day 0: if >= 0, add 1; if < 0, keep as is
+      const relativeDay = daysDiff >= 0 ? daysDiff + 1 : daysDiff;
+
+      // Format time as "h:mm am/pm"
+      const hours = date.getUTCHours();
+      const minutes = date.getUTCMinutes();
+      const ampm = hours >= 12 ? 'pm' : 'am';
+      const displayHours = hours % 12 || 12; // Convert 0 to 12
+      const displayMinutes = minutes.toString().padStart(2, '0');
+
+      return `Day ${relativeDay}: ${displayHours}:${displayMinutes}${ampm}`;
+    },
+    useLocalTime: false,
+  });
+}

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatter.ts
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import TimeFormatter from '../TimeFormatter';
 
 export const RELATIVE_DAY_ID = 'relative_day';

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatterNoTime.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatterNoTime.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import TimeFormatter from '../TimeFormatter';
+
+export const RELATIVE_DAY_NO_TIME_ID = 'relative_day_no_time';
+
+// Reference date: January 1, 2000 00:00:00 UTC = Day 1
+const DAY_ONE_DATE = Date.UTC(2000, 0, 1, 0, 0, 0, 0);
+const MS_PER_DAY = 86400000;
+
+export function createRelativeDayFormatterNoTime() {
+  return new TimeFormatter({
+    id: RELATIVE_DAY_NO_TIME_ID,
+    label: 'Relative Day (No Time)',
+    description: 'Formats dates as relative days from Day 1 (01/01/2000) without time',
+    formatFunc: (date: Date) => {
+      const ms = date.getTime();
+
+      // Calculate day difference from Day 1 (01/01/2000)
+      // Day 1 = 01/01/2000, Day 2 = 02/01/2000, Day -1 = 31/12/1999
+      // There is no Day 0
+      const msDiff = ms - DAY_ONE_DATE;
+      const daysDiff = Math.floor(msDiff / MS_PER_DAY);
+      // Adjust for no Day 0: if >= 0, add 1; if < 0, keep as is
+      const relativeDay = daysDiff >= 0 ? daysDiff + 1 : daysDiff;
+
+      return `Day ${relativeDay}`;
+    },
+    useLocalTime: false,
+  });
+}

--- a/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatterNoTime.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/formatters/relativeDayFormatterNoTime.ts
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import TimeFormatter from '../TimeFormatter';
 
 export const RELATIVE_DAY_NO_TIME_ID = 'relative_day_no_time';

--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -49,6 +49,10 @@ export {
   RELATIVE_DAY_ID,
   createRelativeDayFormatter,
 } from './formatters/relativeDayFormatter';
+export {
+  RELATIVE_DAY_NO_TIME_ID,
+  createRelativeDayFormatterNoTime,
+} from './formatters/relativeDayFormatterNoTime';
 export { default as finestTemporalGrainFormatter } from './formatters/finestTemporalGrain';
 
 export { default as normalizeTimestamp } from './utils/normalizeTimestamp';

--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -45,6 +45,10 @@ export {
   SMART_DATE_VERBOSE_ID,
   createSmartDateVerboseFormatter,
 } from './formatters/smartDateVerbose';
+export {
+  RELATIVE_DAY_ID,
+  createRelativeDayFormatter,
+} from './formatters/relativeDayFormatter';
 export { default as finestTemporalGrainFormatter } from './formatters/finestTemporalGrain';
 
 export { default as normalizeTimestamp } from './utils/normalizeTimestamp';

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatter.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createRelativeDayFormatter } from '@superset-ui/core';
+
+test('createRelativeDayFormatter returns a formatter', () => {
+  const formatter = createRelativeDayFormatter();
+  expect(formatter).toBeDefined();
+  expect(typeof formatter.format).toBe('function');
+});
+
+test('formats Day 1 correctly (01/01/2000 00:00 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 1: 12:00am');
+});
+
+test('formats Day 4 with time correctly (04/01/2000 18:30 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(2000, 0, 4, 18, 30, 0, 0));
+  expect(formatter(date)).toBe('Day 4: 6:30pm');
+});
+
+test('formats Day -1 correctly (31/12/1999 11:15 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(1999, 11, 31, 11, 15, 0, 0));
+  expect(formatter(date)).toBe('Day -1: 11:15am');
+});
+
+test('formats Day -4 correctly (28/12/1999 11:15 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(1999, 11, 28, 11, 15, 0, 0));
+  expect(formatter(date)).toBe('Day -4: 11:15am');
+});
+
+test('formats Day 2 with midnight correctly (02/01/2000 00:00 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(2000, 0, 2, 0, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 2: 12:00am');
+});
+
+test('formats Day 1 with noon correctly (01/01/2000 12:00 UTC)', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(2000, 0, 1, 12, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 1: 12:00pm');
+});
+
+test('formats minutes with leading zeros correctly', () => {
+  const formatter = createRelativeDayFormatter();
+  const date = new Date(Date.UTC(2000, 0, 1, 14, 5, 0, 0));
+  expect(formatter(date)).toBe('Day 1: 2:05pm');
+});
+
+test('handles timestamp numbers as input', () => {
+  const formatter = createRelativeDayFormatter();
+  const timestamp = Date.UTC(2000, 0, 4, 18, 30, 0, 0);
+  expect(formatter(timestamp)).toBe('Day 4: 6:30pm');
+});

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatter.test.ts
@@ -1,22 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import { createRelativeDayFormatter } from '@superset-ui/core';
 
 test('createRelativeDayFormatter returns a formatter', () => {

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatterNoTime.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatterNoTime.test.ts
@@ -1,22 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import { createRelativeDayFormatterNoTime } from '@superset-ui/core';
 
 test('createRelativeDayFormatterNoTime returns a formatter', () => {

--- a/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatterNoTime.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/formatters/relativeDayFormatterNoTime.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createRelativeDayFormatterNoTime } from '@superset-ui/core';
+
+test('createRelativeDayFormatterNoTime returns a formatter', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  expect(formatter).toBeDefined();
+  expect(typeof formatter.format).toBe('function');
+});
+
+test('formats Day 1 correctly (01/01/2000 00:00 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 1');
+});
+
+test('formats Day 4 without time (04/01/2000 18:30 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(2000, 0, 4, 18, 30, 0, 0));
+  expect(formatter(date)).toBe('Day 4');
+});
+
+test('formats Day -1 correctly (31/12/1999 11:15 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(1999, 11, 31, 11, 15, 0, 0));
+  expect(formatter(date)).toBe('Day -1');
+});
+
+test('formats Day -4 correctly (28/12/1999 11:15 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(1999, 11, 28, 11, 15, 0, 0));
+  expect(formatter(date)).toBe('Day -4');
+});
+
+test('formats Day 2 without time (02/01/2000 00:00 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(2000, 0, 2, 0, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 2');
+});
+
+test('ignores time component (01/01/2000 12:00 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(2000, 0, 1, 12, 0, 0, 0));
+  expect(formatter(date)).toBe('Day 1');
+});
+
+test('ignores time component (01/01/2000 14:05 UTC)', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const date = new Date(Date.UTC(2000, 0, 1, 14, 5, 0, 0));
+  expect(formatter(date)).toBe('Day 1');
+});
+
+test('handles timestamp numbers as input', () => {
+  const formatter = createRelativeDayFormatterNoTime();
+  const timestamp = Date.UTC(2000, 0, 4, 18, 30, 0, 0);
+  expect(formatter(timestamp)).toBe('Day 4');
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -26,6 +26,7 @@ import {
   NumberFormats,
   QueryFormMetric,
   RELATIVE_DAY_ID,
+  RELATIVE_DAY_NO_TIME_ID,
   SMART_DATE_DETAILED_ID,
   SMART_DATE_ID,
   SMART_DATE_VERBOSE_ID,
@@ -95,6 +96,9 @@ export function getXAxisFormatter(
   }
   if (format === RELATIVE_DAY_ID) {
     return getTimeFormatter(RELATIVE_DAY_ID);
+  }
+  if (format === RELATIVE_DAY_NO_TIME_ID) {
+    return getTimeFormatter(RELATIVE_DAY_NO_TIME_ID);
   }
   if (format) {
     return getTimeFormatter(format);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/formatters.ts
@@ -25,6 +25,7 @@ import {
   isSavedMetric,
   NumberFormats,
   QueryFormMetric,
+  RELATIVE_DAY_ID,
   SMART_DATE_DETAILED_ID,
   SMART_DATE_ID,
   SMART_DATE_VERBOSE_ID,
@@ -91,6 +92,9 @@ export function getXAxisFormatter(
 ): TimeFormatter | StringConstructor | undefined {
   if (format === SMART_DATE_ID || !format) {
     return undefined;
+  }
+  if (format === RELATIVE_DAY_ID) {
+    return getTimeFormatter(RELATIVE_DAY_ID);
   }
   if (format) {
     return getTimeFormatter(format);

--- a/superset-frontend/src/setup/setupFormatters.ts
+++ b/superset-frontend/src/setup/setupFormatters.ts
@@ -28,6 +28,8 @@ import {
   createSmartDateFormatter,
   createSmartDateVerboseFormatter,
   createSmartDateDetailedFormatter,
+  RELATIVE_DAY_ID,
+  createRelativeDayFormatter,
   createMemoryFormatter,
 } from '@superset-ui/core';
 import { FormatLocaleDefinition } from 'd3-format';
@@ -109,5 +111,6 @@ export default function setupFormatters(
       SMART_DATE_DETAILED_ID,
       createSmartDateDetailedFormatter(timeFormatterRegistry.d3Format),
     )
+    .registerValue(RELATIVE_DAY_ID, createRelativeDayFormatter())
     .setDefaultKey(SMART_DATE_ID);
 }

--- a/superset-frontend/src/setup/setupFormatters.ts
+++ b/superset-frontend/src/setup/setupFormatters.ts
@@ -30,6 +30,8 @@ import {
   createSmartDateDetailedFormatter,
   RELATIVE_DAY_ID,
   createRelativeDayFormatter,
+  RELATIVE_DAY_NO_TIME_ID,
+  createRelativeDayFormatterNoTime,
   createMemoryFormatter,
 } from '@superset-ui/core';
 import { FormatLocaleDefinition } from 'd3-format';
@@ -112,5 +114,9 @@ export default function setupFormatters(
       createSmartDateDetailedFormatter(timeFormatterRegistry.d3Format),
     )
     .registerValue(RELATIVE_DAY_ID, createRelativeDayFormatter())
+    .registerValue(
+      RELATIVE_DAY_NO_TIME_ID,
+      createRelativeDayFormatterNoTime(),
+    )
     .setDefaultKey(SMART_DATE_ID);
 }


### PR DESCRIPTION
## **User description**
SUMMARY

This PR adds two new time formatters for time-series charts that display dates as relative days from a reference point (Day 1 = 01/01/2000), enabling use cases where data is normalized to a common timeline but needs to display relative day labels instead of actual timestamps. Problem: Users working with normalized time-series data (e.g., clinical trials, A/B tests, cohort studies) often need to:

- Keep datetime columns for proper time-based chart features (zooming, panning, time-grain aggregation)
- Display X-axis labels as relative days ("Day 1", "Day -1", "Day 14") instead of raw timestamps
- This was not possible with existing formatters, requiring users to choose between proper datetime functionality OR readable relative labels

Solution: Added two new time formatters:

1. Relative Day (Day 1: 12:00am) - Shows both day and time (e.g., "Day 4: 6:30pm")
2. Relative Day (Day 1) - Shows only the day (e.g., "Day 4")

Both formatters:
- Use 01/01/2000 00:00 UTC as the reference date (Day 1)
- Skip Day 0 (go from Day -1 to Day 1)
- Support negative days for dates before the reference
- Work with any datetime/timestamp column that has been normalized to this reference

Implementation:
- Created new TimeFormatter implementations in @superset-ui/core/time-format
- Registered formatters in the global formatter registry
- Added to time format dropdown in chart controls
- Wired into ECharts X-axis rendering logic

BEFORE:
- X-axis shows raw timestamps: "2000-01-01", "2000-01-04", "1999-12-31"
- Users must choose between datetime features OR readable labels

AFTER:
- X-axis shows relative days: "Day 1", "Day 4", "Day -1"
- Users get both datetime functionality AND readable relative labels
- Available in the "Time format" dropdown under chart customization

Run tests:
```
cd superset-frontend
npm run test -- relativeDayFormatter
```


___

## **CodeAnt-AI Description**
Add "Relative Day" X-axis formatters to show normalized-day labels for time-series charts

### What Changed
- Two new time format options are available in the Time format dropdown: "Relative Day (Day 1: 12:00am)" and "Relative Day (Day 1)"
- Charts can display X-axis labels as "Day N" (or "Day N: h:mmam/pm") using a Day 1 reference of 01/01/2000 00:00 UTC; negative days are supported and Day 0 is skipped
- These formatters work with real datetime/timestamp columns so chart interactions (zoom, pan, time-grain) remain functional while showing relative-day labels
- Unit tests added to verify formatting for various days, times, negative days, midnight/noon, and numeric timestamps

### Impact
`✅ Can label time-series X-axis with relative day numbers`
`✅ Preserve datetime interactions while showing relative labels`
`✅ Clearer timeline labels for normalized datasets (clinical trials, cohorts, experiments)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
