### PR TITLE
fix(tests): resolve flakey selectOption helper race condition

### DIFF
--- a/superset-frontend/spec/helpers/testing-library.tsx
+++ b/superset-frontend/spec/helpers/testing-library.tsx
@@ -135,7 +135,8 @@ export { customRender as render };
 export { default as userEvent } from '@testing-library/user-event';
 
 export async function selectOption(option: string, selectName?: string) {
-  const select = screen.getByRole(
+  // Use findByRole (async) to wait for element to be ready, preventing race conditions on slow CI
+  const select = await screen.findByRole(
     'combobox',
     selectName ? { name: selectName } : {},
   );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes flakey test "changes currency symbol from USD to GBP" in `DatasourceEditorCurrency.test.tsx` by using async `findByRole` instead of sync `getByRole` in the shared `selectOption` helper.

### Root Cause
The `selectOption()` helper used synchronous `getByRole` which could fail on slower CI runners where the combobox element wasn't fully ready. This caused race conditions leading to 30-second test timeouts.

### Fix
Changed `screen.getByRole` → `await screen.findByRole` which waits up to 1000ms for the element to appear, following React Testing Library best practices.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
All tests using `selectOption` were verified passing:
  - `DatasourceEditorCurrency.test.tsx` (3 tests)
  - `RowLevelSecurityModal.test.tsx` (6 tests)
  - `AdhocMetricEditPopover.test.tsx`
  - `MetricsControl.test.jsx`
  - `AdhocFilterEditPopoverSqlTabContent.test.tsx`
  - `ScopingModal.test.tsx`

  ```bash
  npm run test -- DatasourceEditorCurrency.test.tsx
  ```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
