### PR TITLE
fix: apply `EXCLUDE_USERS_FROM_LISTS` to `/api/v1/security/users/`

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, cast, NamedTuple, Optional, TYPE_CHECKING
 
 from flask import current_app, Flask, g, Request
 from flask_appbuilder import Model
+from flask_appbuilder.models.filters import BaseFilter
 from flask_appbuilder.security.sqla.apis import RoleApi, UserApi
 from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_appbuilder.security.sqla.models import (
@@ -143,11 +144,35 @@ class SupersetRoleApi(RoleApi):
         item.permissions = []
 
 
-class SupersetUserApi(UserApi):
+class ExcludeUsersFilter(BaseFilter):  # pylint: disable=too-few-public-methods
     """
-    Overriding the UserApi to be able to delete users
+    Filter to exclude users from listings based on EXCLUDE_USERS_FROM_LISTS config.
+
+    This filter is designed for use as a base_filter on user listing APIs.
+    It uses the same exclusion logic as BaseFilterRelatedUsers for consistency.
     """
 
+    name = _("username")
+    arg_name = "username"
+
+    def apply(self, query: SqlaQuery, value: Any) -> SqlaQuery:
+        exclude_users = (
+            SupersetSecurityManager.get_exclude_users_from_lists()
+            if current_app.config["EXCLUDE_USERS_FROM_LISTS"] is None
+            else current_app.config["EXCLUDE_USERS_FROM_LISTS"]
+        )
+        if exclude_users:
+            return query.filter(User.username.not_in(exclude_users))
+
+        return query
+
+
+class SupersetUserApi(UserApi):
+    """
+    Overriding the UserApi to be able to delete users and filter excluded users
+    """
+
+    base_filters = [["username", ExcludeUsersFilter, lambda: []]]
     search_columns = [
         "id",
         "roles",

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -157,7 +157,7 @@ class ExcludeUsersFilter(BaseFilter):  # pylint: disable=too-few-public-methods
 
     def apply(self, query: SqlaQuery, value: Any) -> SqlaQuery:
         exclude_users = (
-            SupersetSecurityManager.get_exclude_users_from_lists()
+            current_app.appbuilder.sm.get_exclude_users_from_lists()
             if current_app.config["EXCLUDE_USERS_FROM_LISTS"] is None
             else current_app.config["EXCLUDE_USERS_FROM_LISTS"]
         )

--- a/tests/unit_tests/security/exclude_users_filter_test.py
+++ b/tests/unit_tests/security/exclude_users_filter_test.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.security.sqla.models import User
+from pytest_mock import MockerFixture
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from superset.security.manager import ExcludeUsersFilter, SupersetSecurityManager
+
+
+def test_exclude_users_filter_no_exclusions(mocker: MockerFixture) -> None:
+    """
+    Test ExcludeUsersFilter when no users are configured for exclusion.
+
+    The query should be returned unmodified.
+    """
+    mocker.patch(
+        "superset.security.manager.current_app.config",
+        {"EXCLUDE_USERS_FROM_LISTS": None},
+    )
+    mocker.patch.object(
+        SupersetSecurityManager,
+        "get_exclude_users_from_lists",
+        return_value=[],
+    )
+
+    engine = create_engine("sqlite://")
+    Session = sessionmaker(bind=engine)  # noqa: N806
+    session = Session()
+    query = session.query(User)
+
+    filter_ = ExcludeUsersFilter("username", SQLAInterface(User))
+    filtered_query = filter_.apply(query, None)
+
+    assert filtered_query == query
+
+
+def test_exclude_users_filter_with_config(mocker: MockerFixture) -> None:
+    """
+    Test ExcludeUsersFilter when EXCLUDE_USERS_FROM_LISTS config is set.
+    """
+    mocker.patch(
+        "superset.security.manager.current_app.config",
+        {"EXCLUDE_USERS_FROM_LISTS": ["service_account", "automation_user"]},
+    )
+
+    engine = create_engine("sqlite://")
+    Session = sessionmaker(bind=engine)  # noqa: N806
+    session = Session()
+    query = session.query(User)
+
+    filter_ = ExcludeUsersFilter("username", SQLAInterface(User))
+    filtered_query = filter_.apply(query, None)
+
+    compiled_query = filtered_query.statement.compile(
+        engine,
+        compile_kwargs={"literal_binds": True},
+    )
+    query_str = str(compiled_query)
+
+    assert "ab_user.username NOT IN" in query_str
+    assert "service_account" in query_str
+    assert "automation_user" in query_str
+
+
+def test_exclude_users_filter_with_security_manager(mocker: MockerFixture) -> None:
+    """
+    Test ExcludeUsersFilter when EXCLUDE_USERS_FROM_LISTS is None
+    and security manager provides the exclusion list.
+    """
+    mocker.patch(
+        "superset.security.manager.current_app.config",
+        {"EXCLUDE_USERS_FROM_LISTS": None},
+    )
+    mocker.patch.object(
+        SupersetSecurityManager,
+        "get_exclude_users_from_lists",
+        return_value=["gamma", "guest"],
+    )
+
+    engine = create_engine("sqlite://")
+    Session = sessionmaker(bind=engine)  # noqa: N806
+    session = Session()
+    query = session.query(User)
+
+    filter_ = ExcludeUsersFilter("username", SQLAInterface(User))
+    filtered_query = filter_.apply(query, None)
+
+    compiled_query = filtered_query.statement.compile(
+        engine,
+        compile_kwargs={"literal_binds": True},
+    )
+    query_str = str(compiled_query)
+
+    assert "ab_user.username NOT IN" in query_str
+    assert "gamma" in query_str
+    assert "guest" in query_str
+
+
+def test_exclude_users_filter_config_takes_precedence(mocker: MockerFixture) -> None:
+    """
+    Test that EXCLUDE_USERS_FROM_LISTS config takes precedence over
+    security manager's get_exclude_users_from_lists method.
+    """
+    mocker.patch(
+        "superset.security.manager.current_app.config",
+        {"EXCLUDE_USERS_FROM_LISTS": ["config_user"]},
+    )
+    # This should NOT be called when config is set
+    get_exclude_mock = mocker.patch.object(
+        SupersetSecurityManager,
+        "get_exclude_users_from_lists",
+        return_value=["sm_user"],
+    )
+
+    engine = create_engine("sqlite://")
+    Session = sessionmaker(bind=engine)  # noqa: N806
+    session = Session()
+    query = session.query(User)
+
+    filter_ = ExcludeUsersFilter("username", SQLAInterface(User))
+    filtered_query = filter_.apply(query, None)
+
+    compiled_query = filtered_query.statement.compile(
+        engine,
+        compile_kwargs={"literal_binds": True},
+    )
+    query_str = str(compiled_query)
+
+    # Config user should be excluded
+    assert "config_user" in query_str
+    # SM user should NOT be in the query (config takes precedence)
+    assert "sm_user" not in query_str
+    # get_exclude_users_from_lists should not be called when config is set
+    get_exclude_mock.assert_not_called()


### PR DESCRIPTION
## **User description**
### SUMMARY
The new user listing API (`/api/v1/security/users/`) introduced in #32882 did not respect the `EXCLUDE_USERS_FROM_LISTS` configuration, causing a regression where excluded users appeared in the API response.

This PR adds an `ExcludeUsersFilter` to `SupersetUserApi` that uses the same exclusion logic as `BaseFilterRelatedUsers` for consistency.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - API behavior change

### TESTING INSTRUCTIONS
1. Set `EXCLUDE_USERS_FROM_LISTS = ["admin"]` in your config
2. Call `GET /api/v1/security/users/`
3. Verify that the "admin" user is not included in the response

### ADDITIONAL INFORMATION
- [x] Has associated issue: #32882 (regression from this PR)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Apply EXCLUDE_USERS_FROM_LISTS to the security user listing API so excluded users are omitted

### What Changed
- The user listing endpoint now omits users listed in EXCLUDE_USERS_FROM_LISTS instead of showing them
- When the config is unset, the security manager's exclusion list is used; when the config is set it takes precedence
- Unit tests added to verify no-op when no exclusions, config-driven exclusions, security-manager-driven exclusions, and config precedence

### Impact
`✅ Fewer service/automation accounts visible in user lists`
`✅ Consistent admin user listings across APIs`
`✅ Clearer results when filtering users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
