### PR TITLE
feat(docs): enhance Matomo analytics tracking

### DIFF
--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -128,9 +128,8 @@ export default function Root({ children }) {
                     debounceTimer = setTimeout(() => {
                       const query = e.target.value.trim();
                       if (query.length >= 3) {
-                        // Get result count if available
                         const results = document.querySelectorAll('.DocSearch-Hit');
-                        trackSiteSearch(query, 'Documentation', results.length || false);
+                        trackSiteSearch(query, 'Documentation', results.length);
                       }
                     }, 1000); // Debounce to avoid tracking every keystroke
                   });

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -30,13 +30,6 @@ const DOWNLOAD_EXTENSIONS = [
 // Scroll depth milestones to track
 const SCROLL_MILESTONES = [25, 50, 75, 100];
 
-// Custom dimension IDs (configure these in Matomo admin)
-// Using visit-scoped dimensions for user preferences
-const CUSTOM_DIMENSIONS = {
-  DOCS_VERSION: 1,
-  COLOR_MODE: 2,
-};
-
 export default function Root({ children }) {
   const { siteConfig } = useDocusaurusContext();
   const { customFields } = siteConfig;
@@ -81,13 +74,6 @@ export default function Root({ children }) {
         window._paq.push(['trackSiteSearch', keyword, category, resultsCount]);
       };
 
-      // Helper to set custom dimensions
-      const setCustomDimension = (dimensionId, value) => {
-        if (devMode) {
-          console.log('Matomo setCustomDimension:', { dimensionId, value });
-        }
-        window._paq.push(['setCustomDimension', dimensionId, value]);
-      };
 
       // Track external link clicks using domain as category (vendor-agnostic)
       const handleLinkClick = (event) => {
@@ -203,18 +189,18 @@ export default function Root({ children }) {
         }
       };
 
-      // Track color mode preference
+      // Track color mode preference (as event, no admin config needed)
       const trackColorMode = () => {
         const colorMode = document.documentElement.getAttribute('data-theme') ||
                          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-        setCustomDimension(CUSTOM_DIMENSIONS.COLOR_MODE, colorMode);
+        trackEvent('User Preference', 'Color Mode', colorMode);
       };
 
-      // Track docs version from URL or version selector
+      // Track docs version from URL (as event, no admin config needed)
       const trackDocsVersion = () => {
         const pathMatch = window.location.pathname.match(/\/docs\/([\d.]+)\//);
         const version = pathMatch ? pathMatch[1] : 'latest';
-        setCustomDimension(CUSTOM_DIMENSIONS.DOCS_VERSION, version);
+        trackEvent('User Preference', 'Docs Version', version);
       };
 
       // Handle route changes for SPA
@@ -297,7 +283,6 @@ export default function Root({ children }) {
       const colorModeObserver = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
           if (mutation.attributeName === 'data-theme') {
-            trackColorMode();
             trackEvent('User Preference', 'Color Mode Change',
               document.documentElement.getAttribute('data-theme'));
           }

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -46,7 +46,7 @@ export default function Root({ children }) {
     const { matomoUrl, matomoSiteId } = customFields;
 
     if (typeof window !== 'undefined') {
-      const devMode = window.location.hostname === 'localhost';
+      const devMode = ['localhost', '127.0.0.1', '::1', '0.0.0.0'].includes(window.location.hostname);
 
       // Initialize the _paq array
       window._paq = window._paq || [];

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -27,16 +27,6 @@ const DOWNLOAD_EXTENSIONS = [
   'csv', 'json', 'yaml', 'yml',
 ];
 
-// External domains to categorize for better analytics
-const EXTERNAL_LINK_CATEGORIES = {
-  'github.com': 'GitHub',
-  'slack.com': 'Slack',
-  'bit.ly': 'Slack', // Slack invite link
-  'stackoverflow.com': 'Stack Overflow',
-  'lists.apache.org': 'Mailing List',
-  'preset.io': 'Preset',
-  'kapa.ai': 'Kapa AI',
-};
 
 export default function Root({ children }) {
   const { siteConfig } = useDocusaurusContext();
@@ -82,7 +72,7 @@ export default function Root({ children }) {
         window._paq.push(['trackSiteSearch', keyword, category, resultsCount]);
       };
 
-      // Track external link clicks with categorization
+      // Track external link clicks using domain as category (vendor-agnostic)
       const handleLinkClick = (event) => {
         const link = event.target.closest('a');
         if (!link) return;
@@ -96,16 +86,8 @@ export default function Root({ children }) {
           // Skip internal links
           if (url.hostname === window.location.hostname) return;
 
-          // Determine category based on domain
-          let category = 'External Link';
-          for (const [domain, cat] of Object.entries(EXTERNAL_LINK_CATEGORIES)) {
-            if (url.hostname.includes(domain)) {
-              category = cat;
-              break;
-            }
-          }
-
-          trackEvent('Outbound Link', category, href);
+          // Use hostname as category for vendor-agnostic tracking
+          trackEvent('Outbound Link', url.hostname, href);
         } catch {
           // Invalid URL, skip tracking
         }

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -19,6 +19,25 @@
 import { useEffect } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
+// File extensions to track as downloads
+const DOWNLOAD_EXTENSIONS = [
+  'pdf', 'zip', 'tar', 'gz', 'tgz', 'bz2',
+  'exe', 'dmg', 'pkg', 'deb', 'rpm',
+  'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+  'csv', 'json', 'yaml', 'yml',
+];
+
+// External domains to categorize for better analytics
+const EXTERNAL_LINK_CATEGORIES = {
+  'github.com': 'GitHub',
+  'slack.com': 'Slack',
+  'bit.ly': 'Slack', // Slack invite link
+  'stackoverflow.com': 'Stack Overflow',
+  'lists.apache.org': 'Mailing List',
+  'preset.io': 'Preset',
+  'kapa.ai': 'Kapa AI',
+};
+
 export default function Root({ children }) {
   const { siteConfig } = useDocusaurusContext();
   const { customFields } = siteConfig;
@@ -27,10 +46,9 @@ export default function Root({ children }) {
     const { matomoUrl, matomoSiteId } = customFields;
 
     if (typeof window !== 'undefined') {
-      // Making testing easier, logging debug junk if we're in development
-      const devMode = window.location.hostname === 'localhost' ? true : false;
+      const devMode = window.location.hostname === 'localhost';
 
-      // Initialize the _paq array first
+      // Initialize the _paq array
       window._paq = window._paq || [];
 
       // Configure the tracker before loading matomo.js
@@ -39,7 +57,8 @@ export default function Root({ children }) {
       window._paq.push(['setTrackerUrl', `${matomoUrl}/matomo.php`]);
       window._paq.push(['setSiteId', matomoSiteId]);
 
-      // Initial page view is handled by handleRouteChange
+      // Track downloads with custom extensions
+      window._paq.push(['setDownloadExtensions', DOWNLOAD_EXTENSIONS.join('|')]);
 
       // Now load the matomo.js script
       const script = document.createElement('script');
@@ -47,19 +66,112 @@ export default function Root({ children }) {
       script.src = `${matomoUrl}/matomo.js`;
       document.head.appendChild(script);
 
+      // Helper to track events
+      const trackEvent = (category, action, name, value) => {
+        if (devMode) {
+          console.log('Matomo trackEvent:', { category, action, name, value });
+        }
+        window._paq.push(['trackEvent', category, action, name, value]);
+      };
+
+      // Helper to track site search
+      const trackSiteSearch = (keyword, category, resultsCount) => {
+        if (devMode) {
+          console.log('Matomo trackSiteSearch:', { keyword, category, resultsCount });
+        }
+        window._paq.push(['trackSiteSearch', keyword, category, resultsCount]);
+      };
+
+      // Track external link clicks with categorization
+      const handleLinkClick = (event) => {
+        const link = event.target.closest('a');
+        if (!link) return;
+
+        const href = link.getAttribute('href');
+        if (!href) return;
+
+        try {
+          const url = new URL(href, window.location.origin);
+
+          // Skip internal links
+          if (url.hostname === window.location.hostname) return;
+
+          // Determine category based on domain
+          let category = 'External Link';
+          for (const [domain, cat] of Object.entries(EXTERNAL_LINK_CATEGORIES)) {
+            if (url.hostname.includes(domain)) {
+              category = cat;
+              break;
+            }
+          }
+
+          trackEvent('Outbound Link', category, href);
+        } catch {
+          // Invalid URL, skip tracking
+        }
+      };
+
+      // Track Algolia search queries
+      const setupAlgoliaTracking = () => {
+        // Watch for Algolia search modal
+        const observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            mutation.addedNodes.forEach((node) => {
+              if (node.nodeType === Node.ELEMENT_NODE) {
+                // Check for Algolia search input
+                const searchInput = node.querySelector?.('.DocSearch-Input') ||
+                                   (node.classList?.contains('DocSearch-Input') ? node : null);
+                if (searchInput) {
+                  let debounceTimer;
+                  searchInput.addEventListener('input', (e) => {
+                    clearTimeout(debounceTimer);
+                    debounceTimer = setTimeout(() => {
+                      const query = e.target.value.trim();
+                      if (query.length >= 3) {
+                        // Get result count if available
+                        const results = document.querySelectorAll('.DocSearch-Hit');
+                        trackSiteSearch(query, 'Documentation', results.length || false);
+                      }
+                    }, 1000); // Debounce to avoid tracking every keystroke
+                  });
+                }
+              }
+            });
+          });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+        return observer;
+      };
+
+      // Track video plays
+      const handleVideoPlay = (event) => {
+        if (event.target.tagName === 'VIDEO') {
+          const videoSrc = event.target.currentSrc || event.target.src || 'unknown';
+          trackEvent('Video', 'Play', videoSrc);
+        }
+      };
+
+      // Track CTA button clicks
+      const handleCTAClick = (event) => {
+        const button = event.target.closest('.get-started-button, .default-button-theme');
+        if (button) {
+          const buttonText = button.textContent?.trim() || 'Unknown';
+          const href = button.getAttribute('href') || '';
+          trackEvent('CTA', 'Click', `${buttonText} - ${href}`);
+        }
+      };
+
       // Handle route changes for SPA
       const handleRouteChange = () => {
         if (devMode) {
           console.log('Route changed to:', window.location.pathname);
         }
 
-        // Short timeout to ensure the page has fully rendered
         setTimeout(() => {
-          // Get the current page title from the document
           const currentTitle = document.title;
           const currentPath = window.location.pathname;
 
-          // For testing: impersonate real domain - ONLY FOR DEVELOPMENT
           if (devMode) {
             console.log('Tracking page view:', currentPath, currentTitle);
             window._paq.push(['setDomains', ['superset.apache.org']]);
@@ -74,10 +186,10 @@ export default function Root({ children }) {
           window._paq.push(['setReferrerUrl', window.location.href]);
           window._paq.push(['setDocumentTitle', currentTitle]);
           window._paq.push(['trackPageView']);
-        }, 100); // Increased delay to ensure page has fully rendered
+        }, 100);
       };
 
-      // Try all possible Docusaurus events - they've changed between versions
+      // Set up Docusaurus route listeners
       const possibleEvents = [
         'docusaurus.routeDidUpdate',
         'docusaurusRouteDidUpdate',
@@ -85,8 +197,9 @@ export default function Root({ children }) {
       ];
 
       if (devMode) {
-        console.log('Setting up Docusaurus route listeners');
+        console.log('Setting up Matomo tracking with enhanced features');
       }
+
       possibleEvents.forEach(eventName => {
         document.addEventListener(eventName, () => {
           if (devMode) {
@@ -96,10 +209,7 @@ export default function Root({ children }) {
         });
       });
 
-      // Also set up manual history tracking as fallback
-      if (devMode) {
-        console.log('Setting up manual history tracking as fallback');
-      }
+      // Manual history tracking as fallback
       const originalPushState = window.history.pushState;
       window.history.pushState = function () {
         originalPushState.apply(this, arguments);
@@ -108,11 +218,19 @@ export default function Root({ children }) {
 
       window.addEventListener('popstate', handleRouteChange);
 
+      // Set up event listeners
+      document.addEventListener('click', handleLinkClick);
+      document.addEventListener('click', handleCTAClick);
+      document.addEventListener('play', handleVideoPlay, true);
+
+      // Set up Algolia tracking
+      const algoliaObserver = setupAlgoliaTracking();
+
       // Initial page tracking
       handleRouteChange();
 
+      // Cleanup
       return () => {
-        // Cleanup listeners
         possibleEvents.forEach(eventName => {
           document.removeEventListener(eventName, handleRouteChange);
         });
@@ -120,6 +238,14 @@ export default function Root({ children }) {
         if (originalPushState) {
           window.history.pushState = originalPushState;
           window.removeEventListener('popstate', handleRouteChange);
+        }
+
+        document.removeEventListener('click', handleLinkClick);
+        document.removeEventListener('click', handleCTAClick);
+        document.removeEventListener('play', handleVideoPlay, true);
+
+        if (algoliaObserver) {
+          algoliaObserver.disconnect();
         }
       };
     }

--- a/docs/src/theme/Root.js
+++ b/docs/src/theme/Root.js
@@ -199,13 +199,16 @@ export default function Root({ children }) {
         console.log('Setting up Matomo tracking with enhanced features');
       }
 
-      possibleEvents.forEach(eventName => {
-        document.addEventListener(eventName, () => {
+      // Store handler references for proper cleanup
+      const routeHandlers = possibleEvents.map(eventName => {
+        const handler = () => {
           if (devMode) {
             console.log(`Docusaurus route update detected via ${eventName}`);
           }
           handleRouteChange();
-        });
+        };
+        document.addEventListener(eventName, handler);
+        return { eventName, handler };
       });
 
       // Manual history tracking as fallback
@@ -230,8 +233,8 @@ export default function Root({ children }) {
 
       // Cleanup
       return () => {
-        possibleEvents.forEach(eventName => {
-          document.removeEventListener(eventName, handleRouteChange);
+        routeHandlers.forEach(({ eventName, handler }) => {
+          document.removeEventListener(eventName, handler);
         });
 
         if (originalPushState) {


### PR DESCRIPTION
## Summary

Comprehensive enhancement of Matomo analytics on the Superset docs site to capture richer user behavior data. This addresses the observation that our stats are lower than other ASF projects.

### New Tracking Features

| Feature | What it tracks | Why it matters |
|---------|---------------|----------------|
| **Site search** | Algolia queries + result counts | See what users search for (and don't find) |
| **Scroll depth** | 25%, 50%, 75%, 100% milestones | Identify pages that lose readers |
| **404 errors** | Not-found page visits | Find broken links and missing content |
| **Code copying** | Copy events on code blocks | See which snippets are most useful |
| **External links** | Clicks by domain (vendor-agnostic) | Understand which resources users want |
| **Downloads** | PDF, ZIP, office docs, data files | Track file download engagement |
| **Video plays** | Homepage video engagement | Measure video effectiveness |
| **CTA clicks** | "Get Started" button clicks | Track conversion funnel |
| **Docs version** | Which version users are reading | Segment by version popularity |
| **Color mode** | Dark/light mode preference + changes | Understand user preferences |

### Implementation Details

- **Zero admin config**: All tracking uses events, no custom dimensions needed
- **Vendor-agnostic**: External links tracked by hostname, not hardcoded categories (ASF neutral)
- **Privacy-conscious**: No PII collected, just behavioral events
- **Performance**: Scroll tracking uses passive listeners, copy tracking is lightweight
- **Proper cleanup**: All event listeners properly removed on unmount

## Test plan

- [ ] Run docs site locally (`yarn start`) and open browser console
- [ ] Verify page views logged on navigation
- [ ] Test scroll tracking shows 25/50/75/100% events
- [ ] Test Algolia search triggers `trackSiteSearch`
- [ ] Test clicking external links triggers categorized events
- [ ] Test copying code triggers `Code > Copy` event
- [ ] Visit a non-existent URL and verify 404 tracking
- [ ] Toggle dark/light mode and verify `Color Mode Change` event
- [ ] Check no errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)