### PR TITLE
fix(sqlglot): use Athena dialect for awsathena parsing

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 SQLGLOT_DIALECTS = {
     "base": Dialects.DIALECT,
     "ascend": Dialects.HIVE,
-    "awsathena": Dialects.PRESTO,
+    "awsathena": Dialects.ATHENA,
     "bigquery": Dialects.BIGQUERY,
     "clickhouse": Dialects.CLICKHOUSE,
     "clickhousedb": Dialects.CLICKHOUSE,

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2891,6 +2891,20 @@ def test_singlestore_engine_mapping():
     assert "COUNT(*)" in formatted
 
 
+def test_awsathena_engine_mapping():
+    """
+    Test the `awsathena` dialect is properly mapped to ATHENA instead of PRESTO.
+    """
+    sql = (
+        "USING EXTERNAL FUNCTION my_func(x INT) RETURNS INT LAMBDA 'lambda_name' "
+        "SELECT my_func(id) FROM my_table"
+    )
+    statement = SQLStatement(sql, engine="awsathena")
+
+    # Should parse without errors using Athena dialect
+    statement.format()
+
+
 def test_remove_quotes() -> None:
     """
     Test the `remove_quotes` helper function.


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR updates the SQLGlot dialect mapping for AWS Athena from `PRESTO` to `ATHENA`.  
Athena-specific SQL syntax (e.g., `USING EXTERNAL FUNCTION`) now parses correctly in Superset, preventing “Unable to parse SQL” errors for queries that are valid in Athena but not in Presto.


### Related Issue
Fixes #36717

### Changes
- Updated SQLGlot dialect mapping for `awsathena` in `superset/sql/parse.py`
- Added unit tests in `tests/unit_tests/sql/parse_tests.py` covering Athena-specific SQL parsing
- Verified parsing does not fail for `USING EXTERNAL FUNCTION` constructs
- Tested with local Superset Athena database connection

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. **Unit tests**

   ```bash
   pytest tests/unit_tests/sql/parse_tests.py

2. **Local Superset setup with Athena**
- Configure Athena database connection locally in Superset.
- Execute a query using USING EXTERNAL FUNCTION, e.g.:

   ```bash
   USING EXTERNAL FUNCTION decrypt(data varbinary) RETURNS VARCHAR LAMBDA 'arn:aws:lambda:ap-south-1:123456789111:function:lambda-test' SELECT 1

- Verify parsing succeeds and no Superset errors occur.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: #36717
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
**Use Athena dialect for awsathena so Athena-specific SQL parses correctly**

### What Changed
- Switched the SQL parser mapping for engine "awsathena" from Presto to Athena so Athena-only syntax parses correctly
- Added a unit test that verifies queries using "USING EXTERNAL FUNCTION" parse and format without errors

### Impact
`✅ Fewer Athena parse failures for valid queries`
`✅ Clearer parsing for queries using Athena-specific syntax`
`✅ Prevents "Unable to parse SQL" errors for awsathena connections`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
