### PR TITLE
fix: prevent alpha role users to delete and edit non owning Dashboards

### DIFF
--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -213,6 +213,7 @@ function DashboardList(props: DashboardListProps) {
     addSuccessToast(t('Dashboard imported'));
   };
 
+
   // TODO: Fix usage of localStorage keying on the user id
   const userKey = dangerouslyGetItemDoNotUse(user?.userId?.toString(), null);
 
@@ -221,13 +222,10 @@ function DashboardList(props: DashboardListProps) {
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
 
-  const canEditDashboard = (dashboard: Dashboard) => {
-    return canEdit && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
-  };
+  const canEditDashboard = (dashboard: Dashboard) => canEdit && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
+  ;
 
-  const canDeleteDashboard = (dashboard: Dashboard) => {
-    return canDelete && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
-  };
+  const canDeleteDashboard = (dashboard: Dashboard) =>  canDelete && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -148,6 +148,7 @@ function DashboardList(props: DashboardListProps) {
     state => state.user,
   );
   const canReadTag = findPermission('can_read', 'Tag', roles);
+  const isAdmin = !!roles?.Admin;
 
   const {
     state: {
@@ -219,6 +220,14 @@ function DashboardList(props: DashboardListProps) {
   const canEdit = hasPerm('can_write');
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
+
+  const canEditDashboard = (dashboard: Dashboard) => {
+    return canEdit && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
+  };
+
+  const canDeleteDashboard = (dashboard: Dashboard) => {
+    return canDelete && (isAdmin || dashboard.owners.some((owner: Owner) => owner.id === user.userId));
+  };
 
   const initialSort = [{ id: 'changed_on_delta_humanized', desc: true }];
 
@@ -433,7 +442,7 @@ function DashboardList(props: DashboardListProps) {
 
           return (
             <Actions className="actions">
-              {canDelete && (
+              {canDeleteDashboard(original) && (
                 <ConfirmStatusChange
                   title={t('Please confirm')}
                   description={
@@ -481,7 +490,7 @@ function DashboardList(props: DashboardListProps) {
                   </span>
                 </Tooltip>
               )}
-              {canEdit && (
+              {canEditDashboard(original) && (
                 <Tooltip
                   id="edit-action-tooltip"
                   title={t('Edit')}
@@ -518,6 +527,7 @@ function DashboardList(props: DashboardListProps) {
       canExport,
       saveFavoriteStatus,
       favoriteStatus,
+      isAdmin,
       refreshData,
       addSuccessToast,
       addDangerToast,


### PR DESCRIPTION
### SUMMARY
Users with the `alpha` role in Superset can interact with the options `edit` and `delete` for dashboards they do not own through the dashboard list, although the action gets blocked later, users shouldn't be able to interact with these buttons. 

With this Pull Request, `edit` and `delete` options will now be unavailable for dashboards where the user is not the owner.



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
**BEFORE**:

https://github.com/user-attachments/assets/36e5da92-f539-4719-b9a9-956fb821dd94




**AFTER**: 

https://github.com/user-attachments/assets/219c1df4-d328-410a-916a-4be923c31e50



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Try deleting or editing a non owning dashboard with a Alpha role user
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

@michael-s-molina 
