### PR TITLE
feat: use default catalog/schema on DB selector

### DIFF
--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.test.ts
@@ -73,11 +73,14 @@ beforeEach(() => {
           dbId: expectDbId,
           forceRefresh: false,
         },
-        fakeSchemaApiResult.map(value => ({
-          value,
-          label: value,
-          title: value,
-        })),
+        {
+          schemas: fakeSchemaApiResult.map(value => ({
+            value,
+            label: value,
+            title: value,
+          })),
+          defaultSchema: null,
+        },
       ),
     );
     store.dispatch(
@@ -307,11 +310,14 @@ test('returns long keywords with docText', async () => {
           dbId: expectLongKeywordDbId,
           forceRefresh: false,
         },
-        ['short', longKeyword].map(value => ({
-          value,
-          label: value,
-          title: value,
-        })),
+        {
+          schemas: ['short', longKeyword].map(value => ({
+            value,
+            label: value,
+            title: value,
+          })),
+          defaultSchema: null,
+        },
       ),
     );
   });

--- a/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
+++ b/superset-frontend/src/SqlLab/components/AceEditorWrapper/useKeywords.ts
@@ -78,7 +78,7 @@ export function useKeywords(
   // skipFetch is used to prevent re-evaluating memoized keywords
   // due to updated api results by skip flag
   const skipFetch = hasFetchedKeywords && skip;
-  const { currentData: schemaOptions } = useSchemasQueryState(
+  const { currentData: schemaData } = useSchemasQueryState(
     {
       dbId,
       catalog: catalog || undefined,
@@ -86,6 +86,7 @@ export function useKeywords(
     },
     { skip: skipFetch || !dbId },
   );
+  const schemaOptions = schemaData?.schemas;
   const { currentData: tableData } = useTablesQueryState(
     {
       dbId,

--- a/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/DatabaseSelector.test.tsx
@@ -371,10 +371,11 @@ test('Sends the correct schema when changing the schema', async () => {
   });
   await waitFor(() => expect(fetchMock.calls(databaseApiRoute).length).toBe(1));
   rerender(<DatabaseSelector {...props} />);
-  expect(props.onSchemaChange).toHaveBeenCalledTimes(0);
-  const select = screen.getByRole('combobox', {
+  // Wait for schema data to load
+  const select = await screen.findByRole('combobox', {
     name: 'Select schema or type to search schemas: public',
   });
+  expect(props.onSchemaChange).toHaveBeenCalledTimes(0);
   expect(select).toBeInTheDocument();
   await userEvent.click(select);
   const schemaOption = await screen.findByText('information_schema');

--- a/superset-frontend/src/components/DatabaseSelector/index.tsx
+++ b/superset-frontend/src/components/DatabaseSelector/index.tsx
@@ -341,8 +341,8 @@ export function DatabaseSelector({
       // Only clear catalog if it's not already null
       if (currentCatalog !== null) {
         setCurrentCatalog(null);
-        if (onCatalogChange && catalogRef.current !== null) {
-          onCatalogChange(null);
+        if (onCatalogChange && catalogRef.current != null) {
+          onCatalogChange(undefined);
         }
       }
     } else if (catalogData && catalogData.length === 1) {

--- a/superset-frontend/src/hooks/apiResources/catalogs.ts
+++ b/superset-frontend/src/hooks/apiResources/catalogs.ts
@@ -30,7 +30,11 @@ export type CatalogOption = {
 export type FetchCatalogsQueryParams = {
   dbId?: string | number;
   forceRefresh: boolean;
-  onSuccess?: (data: CatalogOption[], isRefetched: boolean) => void;
+  onSuccess?: (
+    data: CatalogOption[],
+    isRefetched: boolean,
+    defaultCatalog: string | null,
+  ) => void;
   onError?: (error: ClientErrorObject) => void;
 };
 
@@ -97,7 +101,11 @@ export function useCatalogs(options: Params) {
       if (dbId && (!result.currentData || forceRefresh)) {
         trigger({ dbId, forceRefresh }).then(({ isSuccess, isError, data }) => {
           if (isSuccess) {
-            onSuccess?.(data?.catalogs || EMPTY_CATALOGS, forceRefresh);
+            onSuccess?.(
+              data?.catalogs || EMPTY_CATALOGS,
+              forceRefresh,
+              data?.defaultCatalog ?? null,
+            );
           }
           if (isError) {
             onError?.(result.error as ClientErrorObject);

--- a/superset-frontend/src/hooks/apiResources/schemas.ts
+++ b/superset-frontend/src/hooks/apiResources/schemas.ts
@@ -31,7 +31,11 @@ export type FetchSchemasQueryParams = {
   dbId?: string | number;
   catalog?: string;
   forceRefresh: boolean;
-  onSuccess?: (data: SchemaOption[], isRefetched: boolean) => void;
+  onSuccess?: (
+    data: SchemaOption[],
+    isRefetched: boolean,
+    defaultSchema: string | null,
+  ) => void;
   onError?: (error: ClientErrorObject) => void;
 };
 
@@ -106,7 +110,11 @@ export function useSchemas(options: Params) {
         trigger({ dbId, catalog, forceRefresh }).then(
           ({ isSuccess, isError, data }) => {
             if (isSuccess) {
-              onSuccess?.(data?.schemas || EMPTY_SCHEMAS, forceRefresh);
+              onSuccess?.(
+                data?.schemas || EMPTY_SCHEMAS,
+                forceRefresh,
+                data?.defaultSchema ?? null,
+              );
             }
             if (isError) {
               onError?.(result.error as ClientErrorObject);

--- a/superset-frontend/src/hooks/apiResources/tables.ts
+++ b/superset-frontend/src/hooks/apiResources/tables.ts
@@ -167,7 +167,7 @@ export const {
 export function useTables(options: Params) {
   const { dbId, catalog, schema, onSuccess, onError } = options || {};
   const isMountedRef = useRef(false);
-  const { currentData: schemaOptions, isFetching } = useSchemas({
+  const { data: schemaOptions, isFetching } = useSchemas({
     dbId,
     catalog: catalog || undefined,
   });

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -742,11 +742,21 @@ class SchemasResponseSchema(Schema):
     result = fields.List(
         fields.String(metadata={"description": "A database schema name"})
     )
+    default = fields.String(
+        allow_none=True,
+        load_default=None,
+        metadata={"description": "The default schema for this database/catalog"},
+    )
 
 
 class CatalogsResponseSchema(Schema):
     result = fields.List(
         fields.String(metadata={"description": "A database catalog name"})
+    )
+    default = fields.String(
+        allow_none=True,
+        load_default=None,
+        metadata={"description": "The default catalog for this database"},
     )
 
 

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -225,96 +225,93 @@ def test_database_connection(
     mocker.patch("superset.utils.log.DBEventLogger.log")
 
     response = client.get("/api/v1/database/1/connection")
-    assert (
-        response.json
-        == {
+    assert response.json == {
+        "id": 1,
+        "result": {
+            "allow_ctas": False,
+            "allow_cvas": False,
+            "allow_dml": False,
+            "allow_file_upload": False,
+            "allow_run_async": False,
+            "backend": "gsheets",
+            "cache_timeout": None,
+            "configuration_method": "sqlalchemy_form",
+            "database_name": "my_database",
+            "driver": "gsheets",
+            "engine_information": {
+                "disable_ssh_tunneling": True,
+                "supports_dynamic_catalog": False,
+                "supports_file_upload": True,
+                "supports_oauth2": True,
+            },
+            "expose_in_sqllab": True,
+            "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',  # noqa: E501
+            "force_ctas_schema": None,
             "id": 1,
-            "result": {
-                "allow_ctas": False,
-                "allow_cvas": False,
-                "allow_dml": False,
-                "allow_file_upload": False,
-                "allow_run_async": False,
-                "backend": "gsheets",
-                "cache_timeout": None,
-                "configuration_method": "sqlalchemy_form",
-                "database_name": "my_database",
-                "driver": "gsheets",
-                "engine_information": {
-                    "disable_ssh_tunneling": True,
-                    "supports_dynamic_catalog": False,
-                    "supports_file_upload": True,
-                    "supports_oauth2": True,
-                },
-                "expose_in_sqllab": True,
-                "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',  # noqa: E501
-                "force_ctas_schema": None,
-                "id": 1,
-                "impersonate_user": False,
-                "is_managed_externally": False,
-                "masked_encrypted_extra": json.dumps(
-                    {
-                        "service_account_info": {
-                            "type": "service_account",
-                            "project_id": "black-sanctum-314419",
-                            "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",  # noqa: E501
-                            "private_key": "XXXXXXXXXX",
-                            "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
-                            "client_id": "114567578578109757129",
-                            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                            "token_uri": "https://oauth2.googleapis.com/token",
-                            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-                            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
-                        }
-                    }
-                ),
-                "parameters": {
+            "impersonate_user": False,
+            "is_managed_externally": False,
+            "masked_encrypted_extra": json.dumps(
+                {
                     "service_account_info": {
-                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "type": "service_account",
+                        "project_id": "black-sanctum-314419",
+                        "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",  # noqa: E501
+                        "private_key": "XXXXXXXXXX",
                         "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
                         "client_id": "114567578578109757129",
-                        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
-                        "private_key": "XXXXXXXXXX",
-                        "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
-                        "project_id": "black-sanctum-314419",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                         "token_uri": "https://oauth2.googleapis.com/token",
-                        "type": "service_account",
+                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
                     }
-                },
-                "parameters_schema": {
-                    "properties": {
-                        "catalog": {"type": "object"},
-                        "oauth2_client_info": {
-                            "default": {
-                                "authorization_request_uri": "https://accounts.google.com/o/oauth2/v2/auth",
-                                "scope": (
-                                    "https://www.googleapis.com/auth/drive.readonly "
-                                    "https://www.googleapis.com/auth/spreadsheets "
-                                    "https://spreadsheets.google.com/feeds"
-                                ),
-                                "token_request_uri": "https://oauth2.googleapis.com/token",
-                            },
-                            "description": "OAuth2 client information",
-                            "nullable": True,
-                            "type": "string",
-                            "x-encrypted-extra": True,
-                        },
-                        "service_account_info": {
-                            "description": "Contents of GSheets JSON credentials.",
-                            "type": "string",
-                            "x-encrypted-extra": True,
-                        },
-                    },
-                    "type": "object",
-                },
-                "server_cert": None,
-                "sqlalchemy_uri": "gsheets://",
-                "ssh_tunnel": None,
-                "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
+                }
+            ),
+            "parameters": {
+                "service_account_info": {
+                    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
+                    "client_id": "114567578578109757129",
+                    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                    "private_key": "XXXXXXXXXX",
+                    "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
+                    "project_id": "black-sanctum-314419",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "type": "service_account",
+                }
             },
-        }
-    )
+            "parameters_schema": {
+                "properties": {
+                    "catalog": {"type": "object"},
+                    "oauth2_client_info": {
+                        "default": {
+                            "authorization_request_uri": "https://accounts.google.com/o/oauth2/v2/auth",
+                            "scope": (
+                                "https://www.googleapis.com/auth/drive.readonly "
+                                "https://www.googleapis.com/auth/spreadsheets "
+                                "https://spreadsheets.google.com/feeds"
+                            ),
+                            "token_request_uri": "https://oauth2.googleapis.com/token",
+                        },
+                        "description": "OAuth2 client information",
+                        "nullable": True,
+                        "type": "string",
+                        "x-encrypted-extra": True,
+                    },
+                    "service_account_info": {
+                        "description": "Contents of GSheets JSON credentials.",
+                        "type": "string",
+                        "x-encrypted-extra": True,
+                    },
+                },
+                "type": "object",
+            },
+            "server_cert": None,
+            "sqlalchemy_uri": "gsheets://",
+            "ssh_tunnel": None,
+            "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
+        },
+    }
 
     response = client.get("/api/v1/database/1")
     assert response.json == {

--- a/tests/unit_tests/databases/api_test.py
+++ b/tests/unit_tests/databases/api_test.py
@@ -225,93 +225,96 @@ def test_database_connection(
     mocker.patch("superset.utils.log.DBEventLogger.log")
 
     response = client.get("/api/v1/database/1/connection")
-    assert response.json == {
-        "id": 1,
-        "result": {
-            "allow_ctas": False,
-            "allow_cvas": False,
-            "allow_dml": False,
-            "allow_file_upload": False,
-            "allow_run_async": False,
-            "backend": "gsheets",
-            "cache_timeout": None,
-            "configuration_method": "sqlalchemy_form",
-            "database_name": "my_database",
-            "driver": "gsheets",
-            "engine_information": {
-                "disable_ssh_tunneling": True,
-                "supports_dynamic_catalog": False,
-                "supports_file_upload": True,
-                "supports_oauth2": True,
-            },
-            "expose_in_sqllab": True,
-            "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',  # noqa: E501
-            "force_ctas_schema": None,
+    assert (
+        response.json
+        == {
             "id": 1,
-            "impersonate_user": False,
-            "is_managed_externally": False,
-            "masked_encrypted_extra": json.dumps(
-                {
+            "result": {
+                "allow_ctas": False,
+                "allow_cvas": False,
+                "allow_dml": False,
+                "allow_file_upload": False,
+                "allow_run_async": False,
+                "backend": "gsheets",
+                "cache_timeout": None,
+                "configuration_method": "sqlalchemy_form",
+                "database_name": "my_database",
+                "driver": "gsheets",
+                "engine_information": {
+                    "disable_ssh_tunneling": True,
+                    "supports_dynamic_catalog": False,
+                    "supports_file_upload": True,
+                    "supports_oauth2": True,
+                },
+                "expose_in_sqllab": True,
+                "extra": '{\n    "metadata_params": {},\n    "engine_params": {},\n    "metadata_cache_timeout": {},\n    "schemas_allowed_for_file_upload": []\n}\n',  # noqa: E501
+                "force_ctas_schema": None,
+                "id": 1,
+                "impersonate_user": False,
+                "is_managed_externally": False,
+                "masked_encrypted_extra": json.dumps(
+                    {
+                        "service_account_info": {
+                            "type": "service_account",
+                            "project_id": "black-sanctum-314419",
+                            "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",  # noqa: E501
+                            "private_key": "XXXXXXXXXX",
+                            "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
+                            "client_id": "114567578578109757129",
+                            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                            "token_uri": "https://oauth2.googleapis.com/token",
+                            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                        }
+                    }
+                ),
+                "parameters": {
                     "service_account_info": {
-                        "type": "service_account",
-                        "project_id": "black-sanctum-314419",
-                        "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
-                        "private_key": "XXXXXXXXXX",
+                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                         "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
                         "client_id": "114567578578109757129",
-                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                        "token_uri": "https://oauth2.googleapis.com/token",
-                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
                         "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
+                        "private_key": "XXXXXXXXXX",
+                        "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
+                        "project_id": "black-sanctum-314419",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                        "type": "service_account",
                     }
-                }
-            ),
-            "parameters": {
-                "service_account_info": {
-                    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                    "client_email": "google-spreadsheets-demo-servi@black-sanctum-314419.iam.gserviceaccount.com",  # noqa: E501
-                    "client_id": "114567578578109757129",
-                    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/google-spreadsheets-demo-servi%40black-sanctum-314419.iam.gserviceaccount.com",
-                    "private_key": "XXXXXXXXXX",
-                    "private_key_id": "259b0d419a8f840056158763ff54d8b08f7b8173",
-                    "project_id": "black-sanctum-314419",
-                    "token_uri": "https://oauth2.googleapis.com/token",
-                    "type": "service_account",
-                }
-            },
-            "parameters_schema": {
-                "properties": {
-                    "catalog": {"type": "object"},
-                    "oauth2_client_info": {
-                        "default": {
-                            "authorization_request_uri": "https://accounts.google.com/o/oauth2/v2/auth",
-                            "scope": (
-                                "https://www.googleapis.com/auth/drive.readonly "
-                                "https://www.googleapis.com/auth/spreadsheets "
-                                "https://spreadsheets.google.com/feeds"
-                            ),
-                            "token_request_uri": "https://oauth2.googleapis.com/token",
-                        },
-                        "description": "OAuth2 client information",
-                        "nullable": True,
-                        "type": "string",
-                        "x-encrypted-extra": True,
-                    },
-                    "service_account_info": {
-                        "description": "Contents of GSheets JSON credentials.",
-                        "type": "string",
-                        "x-encrypted-extra": True,
-                    },
                 },
-                "type": "object",
+                "parameters_schema": {
+                    "properties": {
+                        "catalog": {"type": "object"},
+                        "oauth2_client_info": {
+                            "default": {
+                                "authorization_request_uri": "https://accounts.google.com/o/oauth2/v2/auth",
+                                "scope": (
+                                    "https://www.googleapis.com/auth/drive.readonly "
+                                    "https://www.googleapis.com/auth/spreadsheets "
+                                    "https://spreadsheets.google.com/feeds"
+                                ),
+                                "token_request_uri": "https://oauth2.googleapis.com/token",
+                            },
+                            "description": "OAuth2 client information",
+                            "nullable": True,
+                            "type": "string",
+                            "x-encrypted-extra": True,
+                        },
+                        "service_account_info": {
+                            "description": "Contents of GSheets JSON credentials.",
+                            "type": "string",
+                            "x-encrypted-extra": True,
+                        },
+                    },
+                    "type": "object",
+                },
+                "server_cert": None,
+                "sqlalchemy_uri": "gsheets://",
+                "ssh_tunnel": None,
+                "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
             },
-            "server_cert": None,
-            "sqlalchemy_uri": "gsheets://",
-            "ssh_tunnel": None,
-            "uuid": "02feae18-2dd6-4bb4-a9c0-49e9d4f29d58",
-        },
-    }
+        }
+    )
 
     response = client.get("/api/v1/database/1")
     assert response.json == {
@@ -2104,6 +2107,7 @@ def test_catalogs(
     """
     database = mocker.MagicMock()
     database.get_all_catalog_names.return_value = {"db1", "db2"}
+    database.get_default_catalog.return_value = "db2"
     DatabaseDAO = mocker.patch("superset.databases.api.DatabaseDAO")  # noqa: N806
     DatabaseDAO.find_by_id.return_value = database
 
@@ -2115,7 +2119,7 @@ def test_catalogs(
 
     response = client.get("/api/v1/database/1/catalogs/")
     assert response.status_code == 200
-    assert response.json == {"result": ["db2"]}
+    assert response.json == {"result": ["db2"], "default": "db2"}
     database.get_all_catalog_names.assert_called_with(
         cache=database.catalog_cache_enabled,
         cache_timeout=database.catalog_cache_timeout,
@@ -2187,6 +2191,7 @@ def test_schemas(
 
     database = mocker.MagicMock()
     database.get_all_schema_names.return_value = {"schema1", "schema2"}
+    database.get_default_schema.return_value = "schema2"
     datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
     datamodel.get.return_value = database
 
@@ -2198,7 +2203,7 @@ def test_schemas(
 
     response = client.get("/api/v1/database/1/schemas/")
     assert response.status_code == 200
-    assert response.json == {"result": ["schema2"]}
+    assert response.json == {"result": ["schema2"], "default": "schema2"}
     database.get_all_schema_names.assert_called_with(
         catalog=None,
         cache=database.schema_cache_enabled,
@@ -2274,3 +2279,184 @@ def test_schemas_with_oauth2(
             }
         ]
     }
+
+
+def test_catalogs_default_not_accessible(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that `default` is null when the default catalog is not accessible to the user.
+    """
+    database = mocker.MagicMock()
+    database.get_all_catalog_names.return_value = {"db1", "db2"}
+    database.get_default_catalog.return_value = "db1"  # default is db1
+    DatabaseDAO = mocker.patch("superset.databases.api.DatabaseDAO")  # noqa: N806
+    DatabaseDAO.find_by_id.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    # User only has access to db2, not the default db1
+    security_manager.get_catalogs_accessible_by_user.return_value = {"db2"}
+
+    response = client.get("/api/v1/database/1/catalogs/")
+    assert response.status_code == 200
+    assert response.json == {"result": ["db2"], "default": None}
+
+
+def test_catalogs_default_retrieval_fails(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that the endpoint still works when get_default_catalog fails.
+    """
+    database = mocker.MagicMock()
+    database.get_all_catalog_names.return_value = {"db1", "db2"}
+    database.get_default_catalog.side_effect = Exception("Connection failed")
+    DatabaseDAO = mocker.patch("superset.databases.api.DatabaseDAO")  # noqa: N806
+    DatabaseDAO.find_by_id.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_catalogs_accessible_by_user.return_value = {"db1", "db2"}
+
+    response = client.get("/api/v1/database/1/catalogs/")
+    assert response.status_code == 200
+    # Result should still be returned, default is null due to error
+    assert set(response.json["result"]) == {"db1", "db2"}
+    assert response.json["default"] is None
+
+
+def test_schemas_default_not_accessible(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that `default` is null when the default schema is not accessible to the user.
+    """
+    from superset.databases.api import DatabaseRestApi
+
+    database = mocker.MagicMock()
+    database.get_all_schema_names.return_value = {"public", "private"}
+    database.get_default_schema.return_value = "public"  # default is public
+    datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
+    datamodel.get.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    # User only has access to private, not the default public
+    security_manager.get_schemas_accessible_by_user.return_value = {"private"}
+
+    response = client.get("/api/v1/database/1/schemas/")
+    assert response.status_code == 200
+    assert response.json == {"result": ["private"], "default": None}
+
+
+def test_schemas_default_retrieval_fails(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that the endpoint still works when get_default_schema fails.
+    """
+    from superset.databases.api import DatabaseRestApi
+
+    database = mocker.MagicMock()
+    database.get_all_schema_names.return_value = {"public", "private"}
+    database.get_default_schema.side_effect = Exception("Connection failed")
+    datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
+    datamodel.get.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_schemas_accessible_by_user.return_value = {"public", "private"}
+
+    response = client.get("/api/v1/database/1/schemas/")
+    assert response.status_code == 200
+    # Result should still be returned, default is null due to error
+    assert set(response.json["result"]) == {"public", "private"}
+    assert response.json["default"] is None
+
+
+def test_schemas_default_with_upload_allowed(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that default schema is returned correctly with upload_allowed filter.
+    """
+    from superset.databases.api import DatabaseRestApi
+
+    database = mocker.MagicMock()
+    database.get_all_schema_names.return_value = {"public", "uploads", "private"}
+    database.get_default_schema.return_value = "public"
+    database.allow_file_upload = True
+    database.get_schema_access_for_file_upload.return_value = ["uploads", "public"]
+    datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
+    datamodel.get.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_schemas_accessible_by_user.return_value = {
+        "public",
+        "uploads",
+        "private",
+    }
+
+    response = client.get("/api/v1/database/1/schemas/?q=(upload_allowed:!t)")
+    assert response.status_code == 200
+    # Only upload-allowed schemas should be returned
+    assert set(response.json["result"]) == {"public", "uploads"}
+    # Default should be public since it's in the allowed list
+    assert response.json["default"] == "public"
+
+
+def test_schemas_default_not_in_upload_allowed(
+    mocker: MockerFixture,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Test that default schema is null when not in upload_allowed schemas.
+    """
+    from superset.databases.api import DatabaseRestApi
+
+    database = mocker.MagicMock()
+    database.get_all_schema_names.return_value = {"public", "uploads", "private"}
+    database.get_default_schema.return_value = "private"  # default not in allowed list
+    database.allow_file_upload = True
+    database.get_schema_access_for_file_upload.return_value = ["uploads", "public"]
+    datamodel = mocker.patch.object(DatabaseRestApi, "datamodel")
+    datamodel.get.return_value = database
+
+    security_manager = mocker.patch(
+        "superset.databases.api.security_manager",
+        new=mocker.MagicMock(),
+    )
+    security_manager.get_schemas_accessible_by_user.return_value = {
+        "public",
+        "uploads",
+        "private",
+    }
+
+    response = client.get("/api/v1/database/1/schemas/?q=(upload_allowed:!t)")
+    assert response.status_code == 200
+    assert set(response.json["result"]) == {"public", "uploads"}
+    # Default should be null since "private" is not in allowed list
+    assert response.json["default"] is None


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

(Cleaner implementation of https://github.com/apache/superset/pull/35004.)

This PR adds automatic selection of default catalog and schema in the `DatabaseSelector` component, improving UX by pre-populating sensible defaults when users select a database.

#### Changes

Backend:
- Added default field to `/api/v1/database/{id}/catalogs/` and `/api/v1/database/{id}/schemas/` API responses
- The default is retrieved from the database engine spec and only returned if the user has access to it
- Graceful fallback to `null` if retrieving the default fails

Frontend:
- Updated `useCatalogs` and `useSchemas` hooks to extract and expose `defaultCatalog`/`defaultSchema`
- Updated `DatabaseSelector` to auto-select defaults on first load when no selection exists
- User selections are preserved - defaults don't override explicit user choices
- When switching databases, defaults are re-applied for the new database

#### Behavior

- Single catalog/schema: auto-selected (existing behavior)
- Multiple catalogs/schemas with default: default is auto-selected on first load
- User clears selection: default is NOT re-applied (respects user intent)
- Switching databases: resets and applies new defaults

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Backend unit tests for default field in API responses
- Frontend hook tests for defaultCatalog/defaultSchema extraction
- Component tests for auto-selection behavior
- Manual testing: SQL Lab database switching with various database types

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Auto-select default catalog and schema and expose defaults in APIs and hooks

### What Changed
- Database API endpoints for catalogs and schemas now include a "default" value when a default catalog/schema is available and accessible; if it cannot be determined or is not accessible, the API returns null for default.
- Frontend data hooks return the default catalog/schema alongside options so callers can read the API-provided default.
- The database selector UI auto-applies the default catalog or schema on first load when no choice exists, preserves explicit user selections, and re-applies new defaults when switching databases or catalogs.
- Behavior when upload_allowed is used: response and default respect the upload-allowed filter (default cleared if not allowed).
- Tests updated to cover default propagation, error handling when default retrieval fails, and access control scenarios.

### Impact
`✅ Shorter database/schema selection`
`✅ Fewer manual schema/catalog changes when defaults exist`
`✅ Clearer default values in catalog/schema APIs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
