### PR TITLE
feat(dashboard): add password change functionality in user management

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -59,7 +59,7 @@ module.exports = {
   ],
   coverageReporters: ['lcov', 'json-summary', 'html', 'text'],
   transformIgnorePatterns: [
-    'node_modules/(?!d3-(array|interpolate|color|time|scale|time-format)|internmap|@mapbox/tiny-sdf|remark-gfm|(?!@ngrx|(?!deck.gl)|d3-scale)|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|@rjsf/*.|sinon|echarts|zrender|fetch-mock|pretty-ms|parse-ms|ol|@babel/runtime|@emotion|cheerio|cheerio/lib|parse5|dom-serializer|entities|htmlparser2|rehype-sanitize|hast-util-sanitize|unified|unist-.*|hast-.*|rehype-.*|remark-.*|mdast-.*|micromark-.*|parse-entities|property-information|space-separated-tokens|comma-separated-tokens|bail|devlop|zwitch|longest-streak|geostyler|geostyler-.*|react-error-boundary|react-json-tree|react-base16-styling|lodash-es)',
+    'node_modules/(?!d3-(array|interpolate|color|time|scale|time-format|format)|internmap|@mapbox/tiny-sdf|remark-gfm|(?!@ngrx|(?!deck.gl)|d3-scale)|markdown-table|micromark-*.|decode-named-character-reference|character-entities|mdast-util-*.|unist-util-*.|ccount|escape-string-regexp|nanoid|@rjsf/*.|sinon|echarts|zrender|fetch-mock|pretty-ms|parse-ms|ol|@babel/runtime|@emotion|cheerio|cheerio/lib|parse5|dom-serializer|entities|htmlparser2|rehype-sanitize|hast-util-sanitize|unified|unist-.*|hast-.*|rehype-.*|remark-.*|mdast-.*|micromark-.*|parse-entities|property-information|space-separated-tokens|comma-separated-tokens|bail|devlop|zwitch|longest-streak|geostyler|geostyler-.*|react-error-boundary|react-json-tree|react-base16-styling|lodash-es)',
   ],
   preset: 'ts-jest',
   transform: {

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -193,6 +193,7 @@ export enum FilterPlugins {
 export enum Actions {
   CREATE = 'create',
   UPDATE = 'update',
+  PASSWORD_CHANGE = 'password_change',
 }
 
 /**

--- a/superset-frontend/src/features/users/UserListModal.test.tsx
+++ b/superset-frontend/src/features/users/UserListModal.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import { UserListPasswordChangeModal } from './UserListModal';
+import { updateUser } from './utils';
+
+const mockToasts = {
+  addDangerToast: jest.fn(),
+  addSuccessToast: jest.fn(),
+};
+
+jest.mock('./utils');
+const mockUpdateUser = jest.mocked(updateUser);
+
+jest.mock('src/components/MessageToasts/withToasts', () => ({
+  __esModule: true,
+  default: (Component: React.ComponentType) => Component,
+  useToasts: () => mockToasts,
+}));
+
+const mockUser = {
+  id: 1,
+  first_name: 'John',
+  last_name: 'Doe',
+  username: 'johndoe',
+  email: 'john@example.com',
+  active: true,
+  changed_by: null,
+  changed_on: '2024-01-01',
+  created_by: null,
+  created_on: '2024-01-01',
+  fail_login_count: 0,
+  last_login: '2024-01-01',
+  login_count: 10,
+  roles: [{ id: 1, name: 'Admin' }],
+  groups: [{ id: 1, name: 'Group A' }],
+};
+
+const mockRoles = [
+  { id: 1, name: 'Admin' },
+  { id: 2, name: 'Alpha' },
+];
+
+const mockGroups = [
+  { id: 1, name: 'Group A' },
+  { id: 2, name: 'Group B' },
+];
+
+const defaultProps = {
+  show: true,
+  onHide: jest.fn(),
+  onSave: jest.fn(),
+  roles: mockRoles,
+  groups: mockGroups,
+  user: mockUser,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders password change modal with correct title', () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+  expect(screen.getAllByText('Change password')[0]).toBeInTheDocument();
+});
+
+test('renders only password fields in password change mode', () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  // Password fields should be visible
+  expect(screen.getByText('Password')).toBeInTheDocument();
+  expect(screen.getByText('Confirm Password')).toBeInTheDocument();
+
+  // Profile fields should NOT be visible
+  expect(screen.queryByText('First name')).not.toBeInTheDocument();
+  expect(screen.queryByText('Last name')).not.toBeInTheDocument();
+  expect(screen.queryByText('Username')).not.toBeInTheDocument();
+  expect(screen.queryByText('Email')).not.toBeInTheDocument();
+
+  // Association fields should NOT be visible
+  expect(screen.queryByText('Roles')).not.toBeInTheDocument();
+  expect(screen.queryByText('Groups')).not.toBeInTheDocument();
+});
+
+test('disables save button when password fields are empty', () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+  expect(screen.getByTestId('form-modal-save-button')).toBeDisabled();
+});
+
+test('shows validation error when passwords do not match', async () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'differentPassword' },
+  });
+  fireEvent.blur(confirmPasswordInput);
+
+  await waitFor(() => {
+    expect(screen.getByText('Passwords do not match!')).toBeInTheDocument();
+  });
+});
+
+test('enables save button when passwords match', async () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'newPassword123' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
+  });
+});
+
+test('calls updateUser with only password when form is submitted', async () => {
+  mockUpdateUser.mockResolvedValueOnce(undefined);
+
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'newPassword123' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
+  });
+
+  fireEvent.click(screen.getByTestId('form-modal-save-button'));
+
+  await waitFor(() => {
+    expect(mockUpdateUser).toHaveBeenCalledWith(mockUser.id, {
+      password: 'newPassword123',
+    });
+  });
+});
+
+test('shows success toast on successful password change', async () => {
+  mockUpdateUser.mockResolvedValueOnce(undefined);
+
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'newPassword123' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
+  });
+
+  fireEvent.click(screen.getByTestId('form-modal-save-button'));
+
+  await waitFor(() => {
+    expect(mockToasts.addSuccessToast).toHaveBeenCalledWith(
+      'The user password has been changed successfully.',
+    );
+  });
+});
+
+test('shows error toast on failed password change', async () => {
+  mockUpdateUser.mockRejectedValueOnce(new Error('Update failed'));
+
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'newPassword123' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
+  });
+
+  fireEvent.click(screen.getByTestId('form-modal-save-button'));
+
+  await waitFor(() => {
+    expect(mockToasts.addDangerToast).toHaveBeenCalledWith(
+      'There was an error changing the user password. Please, try again.',
+    );
+  });
+});
+
+test('calls onHide when cancel button is clicked', () => {
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+  fireEvent.click(screen.getByTestId('modal-cancel-button'));
+  expect(defaultProps.onHide).toHaveBeenCalled();
+});
+
+test('calls onSave after successful password change', async () => {
+  mockUpdateUser.mockResolvedValueOnce(undefined);
+
+  render(<UserListPasswordChangeModal {...defaultProps} />);
+
+  const passwordInputs = screen.getAllByPlaceholderText(/password/i);
+  const passwordInput = passwordInputs[0];
+  const confirmPasswordInput = passwordInputs[1];
+
+  fireEvent.change(passwordInput, { target: { value: 'newPassword123' } });
+  fireEvent.change(confirmPasswordInput, {
+    target: { value: 'newPassword123' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('form-modal-save-button')).toBeEnabled();
+  });
+
+  fireEvent.click(screen.getByTestId('form-modal-save-button'));
+
+  await waitFor(() => {
+    expect(defaultProps.onSave).toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -165,10 +165,7 @@ function UserListModal({
       onHide={onHide}
       name={modalName}
       title={
-        <ModalTitleWithIcon
-          isEditMode={modalIsEditLike}
-          title={modalTitle}
-        />
+        <ModalTitleWithIcon isEditMode={modalIsEditLike} title={modalTitle} />
       }
       onSave={onSave}
       formSubmitHandler={handleFormSubmit}
@@ -182,7 +179,9 @@ function UserListModal({
               <FormItem
                 name="first_name"
                 label={t('First name')}
-                rules={[{ required: true, message: t('First name is required') }]}
+                rules={[
+                  { required: true, message: t('First name is required') },
+                ]}
               >
                 <Input
                   name="first_name"
@@ -192,7 +191,9 @@ function UserListModal({
               <FormItem
                 name="last_name"
                 label={t('Last name')}
-                rules={[{ required: true, message: t('Last name is required') }]}
+                rules={[
+                  { required: true, message: t('Last name is required') },
+                ]}
               >
                 <Input
                   name="last_name"
@@ -231,10 +232,7 @@ function UserListModal({
                   },
                 ]}
               >
-                <Input
-                  name="email"
-                  placeholder={t("Enter the user's email")}
-                />
+                <Input name="email" placeholder={t("Enter the user's email")} />
               </FormItem>
             </>
           )}

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -63,7 +63,7 @@ function UserListModal({
   const showPasswordFields = !isEditMode || isPasswordChange;
 
   const sanitizeValues = (formValues: FormValues) => {
-    const { confirmPassword, ...rest } = formValues;
+    const { confirmPassword: _confirmPassword, ...rest } = formValues;
     return rest;
   };
 

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -332,12 +332,12 @@ export const UserListAddModal = (
 
 export const UserListEditModal = (
   props: Omit<UserModalProps, 'isEditMode'> & { user: UserObject },
-) => <UserListModal {...props} isEditMode={true} isPasswordChange={false} />;
+) => <UserListModal {...props} isEditMode isPasswordChange={false} />;
 
 export const UserListPasswordChangeModal = (
   props: Omit<UserModalProps, 'isEditMode' | 'isPasswordChange'> & {
     user: UserObject;
   },
-) => <UserListModal {...props} isEditMode={false} isPasswordChange={true} />;
+) => <UserListModal {...props} isEditMode={false} isPasswordChange />;
 
 export default UserListModal;

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -35,6 +35,7 @@ import { createUser, updateUser, atLeastOneRoleOrGroup } from './utils';
 export interface UserModalProps extends BaseUserListModalProps {
   roles: Role[];
   isEditMode?: boolean;
+  isPasswordChange?: boolean;
   user?: UserObject;
   groups: Group[];
 }
@@ -45,19 +46,42 @@ function UserListModal({
   onSave,
   roles,
   isEditMode = false,
+  isPasswordChange = false,
   user,
   groups,
 }: UserModalProps) {
   const { addDangerToast, addSuccessToast } = useToasts();
+  const modalTitle = isPasswordChange
+    ? t('Change password')
+    : isEditMode
+      ? t('Edit User')
+      : t('Add User');
+  const modalName = modalTitle;
+  const modalIsEditLike = isEditMode || isPasswordChange;
+  const showProfileFields = !isPasswordChange;
+  const showAssociationFields = !isPasswordChange;
+  const showPasswordFields = !isEditMode || isPasswordChange;
+
+  const sanitizeValues = (formValues: FormValues) => {
+    const { confirmPassword, ...rest } = formValues;
+    return rest;
+  };
+
   const handleFormSubmit = async (values: FormValues) => {
     const handleError = async (
       err: any,
-      action: Actions.CREATE | Actions.UPDATE,
+      action: Actions.CREATE | Actions.UPDATE | Actions.PASSWORD_CHANGE,
     ) => {
       let errorMessage =
         action === Actions.CREATE
           ? t('There was an error creating the user. Please, try again.')
-          : t('There was an error updating the user. Please, try again.');
+          : action === Actions.UPDATE
+            ? t('There was an error updating the user. Please, try again.')
+            : action === Actions.PASSWORD_CHANGE
+              ? t(
+                  'There was an error changing the user password. Please, try again.',
+                )
+              : t('An unexpected error occurred. Please, try again.');
 
       if (err.status === 422) {
         const errorData = await err.json();
@@ -80,36 +104,54 @@ function UserListModal({
       throw err;
     };
 
+    const sanitizedValues = sanitizeValues(values);
+
     if (isEditMode) {
       if (!user) {
         throw new Error('User is required in edit mode');
       }
       try {
-        await updateUser(user.id, values);
+        await updateUser(user.id, sanitizedValues);
         addSuccessToast(t('The user has been updated successfully.'));
       } catch (err) {
         await handleError(err, Actions.UPDATE);
       }
+    } else if (isPasswordChange) {
+      if (!user) {
+        throw new Error('User is required in password change mode');
+      }
+      try {
+        const password = sanitizedValues.password as string | undefined;
+        if (!password) {
+          throw new Error('Password is required');
+        }
+        await updateUser(user.id, { password });
+        addSuccessToast(t('The user password has been changed successfully.'));
+      } catch (err) {
+        await handleError(err, Actions.PASSWORD_CHANGE);
+      }
     } else {
       try {
-        await createUser(values);
-        addSuccessToast(t('The group has been created successfully.'));
+        await createUser(sanitizedValues);
+        addSuccessToast(t('The user has been created successfully.'));
       } catch (err) {
         await handleError(err, Actions.CREATE);
       }
     }
   };
 
-  const requiredFields = isEditMode
-    ? ['first_name', 'last_name', 'username', 'email']
-    : [
-        'first_name',
-        'last_name',
-        'username',
-        'email',
-        'password',
-        'confirmPassword',
-      ];
+  const requiredFields = isPasswordChange
+    ? ['password', 'confirmPassword']
+    : isEditMode
+      ? ['first_name', 'last_name', 'username', 'email']
+      : [
+          'first_name',
+          'last_name',
+          'username',
+          'email',
+          'password',
+          'confirmPassword',
+        ];
 
   const initialValues = {
     ...user,
@@ -121,11 +163,11 @@ function UserListModal({
     <FormModal
       show={show}
       onHide={onHide}
-      name={isEditMode ? 'Edit User' : 'Add User'}
+      name={modalName}
       title={
         <ModalTitleWithIcon
-          isEditMode={isEditMode}
-          title={isEditMode ? t('Edit User') : t('Add User')}
+          isEditMode={modalIsEditLike}
+          title={modalTitle}
         />
       }
       onSave={onSave}
@@ -135,99 +177,110 @@ function UserListModal({
     >
       {(form: FormInstance) => (
         <>
-          <FormItem
-            name="first_name"
-            label={t('First name')}
-            rules={[{ required: true, message: t('First name is required') }]}
-          >
-            <Input
-              name="first_name"
-              placeholder={t("Enter the user's first name")}
-            />
-          </FormItem>
-          <FormItem
-            name="last_name"
-            label={t('Last name')}
-            rules={[{ required: true, message: t('Last name is required') }]}
-          >
-            <Input
-              name="last_name"
-              placeholder={t("Enter the user's last name")}
-            />
-          </FormItem>
-          <FormItem
-            name="username"
-            label={t('Username')}
-            rules={[{ required: true, message: t('Username is required') }]}
-          >
-            <Input
-              name="username"
-              placeholder={t("Enter the user's username")}
-            />
-          </FormItem>
-          <FormItem
-            name="active"
-            label={t('Is active?')}
-            valuePropName="checked"
-          >
-            <Checkbox
-              onChange={checked => {
-                form.setFieldsValue({ isActive: checked });
-              }}
-            />
-          </FormItem>
-          <FormItem
-            name="email"
-            label={t('Email')}
-            rules={[
-              { required: true, message: t('Email is required') },
-              {
-                type: 'email',
-                message: t('Please enter a valid email address'),
-              },
-            ]}
-          >
-            <Input name="email" placeholder={t("Enter the user's email")} />
-          </FormItem>
-          <FormItem
-            name="roles"
-            label={t('Roles')}
-            dependencies={['groups']}
-            rules={[atLeastOneRoleOrGroup('groups')]}
-          >
-            <Select
-              name="roles"
-              mode="multiple"
-              placeholder={t('Select roles')}
-              options={roles.map(role => ({
-                value: role.id,
-                label: role.name,
-              }))}
-              getPopupContainer={trigger =>
-                trigger.closest('.ant-modal-content')
-              }
-            />
-          </FormItem>
-          <FormItem
-            name="groups"
-            label={t('Groups')}
-            dependencies={['roles']}
-            rules={[atLeastOneRoleOrGroup('roles')]}
-          >
-            <Select
-              name="groups"
-              mode="multiple"
-              placeholder={t('Select groups')}
-              options={groups.map(group => ({
-                value: group.id,
-                label: group.name,
-              }))}
-              getPopupContainer={trigger =>
-                trigger.closest('.ant-modal-content')
-              }
-            />
-          </FormItem>
-          {!isEditMode && (
+          {showProfileFields && (
+            <>
+              <FormItem
+                name="first_name"
+                label={t('First name')}
+                rules={[{ required: true, message: t('First name is required') }]}
+              >
+                <Input
+                  name="first_name"
+                  placeholder={t("Enter the user's first name")}
+                />
+              </FormItem>
+              <FormItem
+                name="last_name"
+                label={t('Last name')}
+                rules={[{ required: true, message: t('Last name is required') }]}
+              >
+                <Input
+                  name="last_name"
+                  placeholder={t("Enter the user's last name")}
+                />
+              </FormItem>
+              <FormItem
+                name="username"
+                label={t('Username')}
+                rules={[{ required: true, message: t('Username is required') }]}
+              >
+                <Input
+                  name="username"
+                  placeholder={t("Enter the user's username")}
+                />
+              </FormItem>
+              <FormItem
+                name="active"
+                label={t('Is active?')}
+                valuePropName="checked"
+              >
+                <Checkbox
+                  onChange={checked => {
+                    form.setFieldsValue({ isActive: checked });
+                  }}
+                />
+              </FormItem>
+              <FormItem
+                name="email"
+                label={t('Email')}
+                rules={[
+                  { required: true, message: t('Email is required') },
+                  {
+                    type: 'email',
+                    message: t('Please enter a valid email address'),
+                  },
+                ]}
+              >
+                <Input
+                  name="email"
+                  placeholder={t("Enter the user's email")}
+                />
+              </FormItem>
+            </>
+          )}
+          {showAssociationFields && (
+            <>
+              <FormItem
+                name="roles"
+                label={t('Roles')}
+                dependencies={['groups']}
+                rules={[atLeastOneRoleOrGroup('groups')]}
+              >
+                <Select
+                  name="roles"
+                  mode="multiple"
+                  placeholder={t('Select roles')}
+                  options={roles.map(role => ({
+                    value: role.id,
+                    label: role.name,
+                  }))}
+                  getPopupContainer={trigger =>
+                    trigger.closest('.ant-modal-content')
+                  }
+                />
+              </FormItem>
+              <FormItem
+                name="groups"
+                label={t('Groups')}
+                dependencies={['roles']}
+                rules={[atLeastOneRoleOrGroup('roles')]}
+              >
+                <Select
+                  name="groups"
+                  mode="multiple"
+                  placeholder={t('Select groups')}
+                  options={groups.map(group => ({
+                    value: group.id,
+                    label: group.name,
+                  }))}
+                  getPopupContainer={trigger =>
+                    trigger.closest('.ant-modal-content')
+                  }
+                />
+              </FormItem>
+            </>
+          )}
+          {showPasswordFields && (
             <>
               <FormItem
                 name="password"
@@ -236,7 +289,7 @@ function UserListModal({
               >
                 <Input.Password
                   name="password"
-                  placeholder="Enter the user's password"
+                  placeholder={t("Enter the user's password")}
                 />
               </FormItem>
               <FormItem
@@ -275,10 +328,16 @@ function UserListModal({
 
 export const UserListAddModal = (
   props: Omit<UserModalProps, 'isEditMode' | 'initialValues'>,
-) => <UserListModal {...props} isEditMode={false} />;
+) => <UserListModal {...props} isEditMode={false} isPasswordChange={false} />;
 
 export const UserListEditModal = (
   props: Omit<UserModalProps, 'isEditMode'> & { user: UserObject },
-) => <UserListModal {...props} isEditMode />;
+) => <UserListModal {...props} isEditMode={true} isPasswordChange={false} />;
+
+export const UserListPasswordChangeModal = (
+  props: Omit<UserModalProps, 'isEditMode' | 'isPasswordChange'> & {
+    user: UserObject;
+  },
+) => <UserListModal {...props} isEditMode={false} isPasswordChange={true} />;
 
 export default UserListModal;

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -157,7 +157,7 @@ function UsersList({ user }: UsersListProps) {
       refreshData();
       setUserCurrentlyDeleting(null);
       addSuccessToast(t('Deleted user: %s', username));
-    } catch (error) {
+    } catch {
       addDangerToast(t('There was an issue deleting %s', username));
     }
   };
@@ -171,7 +171,7 @@ function UsersList({ user }: UsersListProps) {
           .then(() => {
             deletedUserNames.push(user.username);
           })
-          .catch(err => {
+          .catch(_err => {
             addDangerToast(t('Error deleting %s', user.username));
           }),
       ),

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -342,7 +342,7 @@ function UsersList({ user }: UsersListProps) {
           const handlePasswordChange = () => {
             setCurrentUser(original);
             openModal(ModalType.PASSWORD_CHANGE);
-          }
+          };
           const actions = isAdmin
             ? [
                 {
@@ -365,7 +365,7 @@ function UsersList({ user }: UsersListProps) {
                   placement: 'bottom',
                   icon: 'KeyOutlined',
                   onClick: handlePasswordChange,
-                }
+                },
               ]
             : [];
 
@@ -592,7 +592,6 @@ function UsersList({ user }: UsersListProps) {
           groups={groups}
         />
       )}
-
 
       <ConfirmStatusChange
         title={t('Please confirm')}

--- a/superset-frontend/src/pages/UsersList/index.tsx
+++ b/superset-frontend/src/pages/UsersList/index.tsx
@@ -38,6 +38,7 @@ import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import {
   UserListAddModal,
   UserListEditModal,
+  UserListPasswordChangeModal,
 } from 'src/features/users/UserListModal';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
 import { deleteUser } from 'src/features/users/utils';
@@ -49,6 +50,7 @@ const PAGE_SIZE = 25;
 enum ModalType {
   ADD = 'add',
   EDIT = 'edit',
+  PASSWORD_CHANGE = 'password_change',
 }
 
 const isActiveOptions = [
@@ -82,6 +84,7 @@ function UsersList({ user }: UsersListProps) {
   const [modalState, setModalState] = useState({
     edit: false,
     add: false,
+    password_change: false,
   });
   const openModal = (type: ModalType) =>
     setModalState(prev => ({ ...prev, [type]: true }));
@@ -336,6 +339,10 @@ function UsersList({ user }: UsersListProps) {
             openModal(ModalType.EDIT);
           };
           const handleDelete = () => setUserCurrentlyDeleting(original);
+          const handlePasswordChange = () => {
+            setCurrentUser(original);
+            openModal(ModalType.PASSWORD_CHANGE);
+          }
           const actions = isAdmin
             ? [
                 {
@@ -352,6 +359,13 @@ function UsersList({ user }: UsersListProps) {
                   icon: 'DeleteOutlined',
                   onClick: handleDelete,
                 },
+                {
+                  label: 'user-list-password-action',
+                  tooltip: t('Change password'),
+                  placement: 'bottom',
+                  icon: 'KeyOutlined',
+                  onClick: handlePasswordChange,
+                }
               ]
             : [];
 
@@ -564,6 +578,22 @@ function UsersList({ user }: UsersListProps) {
           title={t('Delete User?')}
         />
       )}
+
+      {modalState.password_change && currentUser && (
+        <UserListPasswordChangeModal
+          user={currentUser}
+          show={modalState.password_change}
+          onHide={() => closeModal(ModalType.PASSWORD_CHANGE)}
+          onSave={() => {
+            refreshData();
+            closeModal(ModalType.PASSWORD_CHANGE);
+          }}
+          roles={roles}
+          groups={groups}
+        />
+      )}
+
+
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t('Are you sure you want to delete the selected users?')}


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A password change modal has been added to the user management UI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE:
<img width="505" height="296" alt="image" src="https://github.com/user-attachments/assets/3e195ca5-ebae-4ef6-b88a-0622d344d290" />
AFTER:
<img width="482" height="347" alt="image" src="https://github.com/user-attachments/assets/94b1d31c-30b8-4755-9eef-f532eba78912" />
<img width="608" height="336" alt="image" src="https://github.com/user-attachments/assets/25ecc0f7-0a5e-4e42-a1e2-3e298e10b0ef" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Go to the user management UI and press the password change (key) button.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #36223
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Add "Change password" action and modal to user management

### What Changed
- A "Change password" button (Key icon) is now available in each user's Actions menu for admins.
- Clicking it opens a modal that only requires a new password and confirmation; submitting updates that user's password and refreshes the user list.
- Success and error messages are shown specifically for password-change outcomes; other user add/edit flows keep existing behavior.

### Impact
`✅ Shorter admin password updates`
`✅ Clearer password change errors`
`✅ Fewer support password reset requests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
