### PR TITLE
fix(export): URL prefix handling for subdirectory deployments

### DIFF
--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -743,7 +743,7 @@ describe('ResultSet', () => {
       expectedUrl: '/my-app/superset/api/v1/sqllab/export_streaming/',
     },
   ])(
-    'streaming export URL should be correctly prefixed: $name',
+    'streaming export URL respects app root configuration: $name',
     async ({ appRoot, expectedUrl }) => {
       // This test validates that streaming export startExport receives the correct URL
       // based on the applicationRoot configuration.

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -47,6 +47,19 @@ jest.mock('src/components/ErrorMessage', () => ({
   ErrorMessageWithStackTrace: () => <div data-test="error-message">Error</div>,
 }));
 
+// Mock useStreamingExport to capture startExport calls
+const mockStartExport = jest.fn();
+const mockResetExport = jest.fn();
+const mockCancelExport = jest.fn();
+jest.mock('src/components/StreamingExportModal/useStreamingExport', () => ({
+  useStreamingExport: () => ({
+    startExport: mockStartExport,
+    resetExport: mockResetExport,
+    cancelExport: mockCancelExport,
+    progress: { status: 'streaming', rowsProcessed: 0 },
+  }),
+}));
+
 jest.mock(
   'react-virtualized-auto-sizer',
   () =>
@@ -160,6 +173,7 @@ describe('ResultSet', () => {
 
   beforeEach(() => {
     applicationRootMock.mockReturnValue('');
+    mockStartExport.mockClear();
   });
 
   // Add cleanup after each test
@@ -657,4 +671,132 @@ describe('ResultSet', () => {
     const resultsCalls = fetchMock.calls('glob:*/api/v1/sqllab/results/*');
     expect(resultsCalls).toHaveLength(1);
   });
+
+  test('should use non-streaming export (href) when rows below threshold', async () => {
+    // This test validates that when rows < CSV_STREAMING_ROW_THRESHOLD,
+    // the component uses the direct download href instead of streaming export.
+    const appRoot = '/superset';
+    applicationRootMock.mockReturnValue(appRoot);
+
+    // Create a query with rows BELOW the threshold
+    const smallQuery = {
+      ...queries[0],
+      rows: 500, // Below the 1000 threshold
+      limitingFactor: 'NOT_LIMITED',
+    };
+
+    const { getByTestId } = setup(
+      mockedProps,
+      mockStore({
+        ...initialState,
+        user: {
+          ...user,
+          roles: {
+            sql_lab: [['can_export_csv', 'SQLLab']],
+          },
+        },
+        sqlLab: {
+          ...initialState.sqlLab,
+          queries: {
+            [smallQuery.id]: smallQuery,
+          },
+        },
+        common: {
+          conf: {
+            CSV_STREAMING_ROW_THRESHOLD: 1000,
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('export-csv-button')).toBeInTheDocument();
+    });
+
+    const exportButton = getByTestId('export-csv-button');
+
+    // Non-streaming export should have href attribute with prefixed URL
+    expect(exportButton).toHaveAttribute(
+      'href',
+      expect.stringMatching(new RegExp(`^${appRoot}/api/v1/sqllab/export/`)),
+    );
+
+    // Click should NOT trigger startExport for non-streaming
+    fireEvent.click(exportButton);
+    expect(mockStartExport).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    {
+      name: 'no prefix (default deployment)',
+      appRoot: '',
+      expectedUrl: '/api/v1/sqllab/export_streaming/',
+    },
+    {
+      name: 'with subdirectory prefix',
+      appRoot: '/superset',
+      expectedUrl: '/superset/api/v1/sqllab/export_streaming/',
+    },
+    {
+      name: 'with nested subdirectory prefix',
+      appRoot: '/my-app/superset',
+      expectedUrl: '/my-app/superset/api/v1/sqllab/export_streaming/',
+    },
+  ])(
+    'streaming export URL should be correctly prefixed: $name',
+    async ({ appRoot, expectedUrl }) => {
+      // This test validates that streaming export startExport receives the correct URL
+      // based on the applicationRoot configuration.
+      // Without the fix, all cases will receive '/api/v1/sqllab/export_streaming/' without prefix.
+      applicationRootMock.mockReturnValue(appRoot);
+
+      // Create a query with enough rows to trigger streaming export (>= threshold)
+      const largeQuery = {
+        ...queries[0],
+        rows: 5000, // Above the default 1000 threshold
+        limitingFactor: 'NOT_LIMITED',
+      };
+
+      const { getByTestId } = setup(
+        mockedProps,
+        mockStore({
+          ...initialState,
+          user: {
+            ...user,
+            roles: {
+              sql_lab: [['can_export_csv', 'SQLLab']],
+            },
+          },
+          sqlLab: {
+            ...initialState.sqlLab,
+            queries: {
+              [largeQuery.id]: largeQuery,
+            },
+          },
+          common: {
+            conf: {
+              CSV_STREAMING_ROW_THRESHOLD: 1000,
+            },
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('export-csv-button')).toBeInTheDocument();
+      });
+
+      const exportButton = getByTestId('export-csv-button');
+      fireEvent.click(exportButton);
+
+      // Verify startExport was called exactly once
+      expect(mockStartExport).toHaveBeenCalledTimes(1);
+
+      // The URL should match the expected prefixed URL
+      expect(mockStartExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expectedUrl,
+        }),
+      );
+    },
+  );
 });

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -747,7 +747,6 @@ describe('ResultSet', () => {
     async ({ appRoot, expectedUrl }) => {
       // This test validates that streaming export startExport receives the correct URL
       // based on the applicationRoot configuration.
-      // Without the fix, all cases will receive '/api/v1/sqllab/export_streaming/' without prefix.
       applicationRootMock.mockReturnValue(appRoot);
 
       // Create a query with enough rows to trigger streaming export (>= threshold)

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -420,7 +420,7 @@ const ResultSet = ({
                     setShowStreamingModal(true);
 
                     startExport({
-                      url: '/api/v1/sqllab/export_streaming/',
+                      url: makeUrl('/api/v1/sqllab/export_streaming/'),
                       payload: { client_id: query.id },
                       exportType: 'csv',
                       expectedRows: rows,

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -321,7 +321,7 @@ test('URL prefix guard leaves URL unchanged when no app root is configured', asy
   );
 });
 
-test('URL prefix guard leaves relative URL without leading slash unchanged', async () => {
+test('URL prefix guard normalizes relative URL without leading slash and applies prefix', async () => {
   const appRoot = '/superset';
   applicationRoot.mockReturnValue(appRoot);
   makeUrl.mockImplementation((path: string) => `${appRoot}${path}`);
@@ -343,8 +343,9 @@ test('URL prefix guard leaves relative URL without leading slash unchanged', asy
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  // Should add leading slash and apply prefix
   expect(mockFetch).toHaveBeenCalledWith(
-    'api/v1/sqllab/export_streaming/',
+    '/superset/api/v1/sqllab/export_streaming/',
     expect.any(Object),
   );
 });

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -350,6 +350,34 @@ test('URL prefix guard normalizes relative URL without leading slash and applies
   );
 });
 
+test('URL prefix guard normalizes non-slash URL to leading slash when no app root configured', async () => {
+  applicationRoot.mockReturnValue('');
+  makeUrl.mockImplementation((path: string) => path);
+
+  const mockFetch = createPrefixTestMockFetch();
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: 'api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Should normalize to leading slash even without app root
+  expect(mockFetch).toHaveBeenCalledWith(
+    '/api/v1/sqllab/export_streaming/',
+    expect.any(Object),
+  );
+});
+
 test('URL prefix guard leaves absolute URLs (https) unchanged', async () => {
   const appRoot = '/superset';
   applicationRoot.mockReturnValue(appRoot);

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.test.ts
@@ -16,10 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { TextEncoder, TextDecoder } from 'util';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import { useStreamingExport } from './useStreamingExport';
 import { ExportStatus } from './StreamingExportModal';
+
+// Polyfill TextEncoder/TextDecoder for Jest environment
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder as typeof global.TextDecoder;
 
 // Mock SupersetClient
 jest.mock('@superset-ui/core', () => ({
@@ -427,4 +432,567 @@ test('URL prefix guard correctly handles sibling paths (prefixes /app2 when appR
     '/app/app2/api/v1/export/',
     expect.any(Object),
   );
+});
+
+// Streaming export behavior tests
+
+test('sets ERROR status and calls onError when stream contains __STREAM_ERROR__ marker', async () => {
+  const errorMessage = 'Database connection failed';
+  const errorChunk = new TextEncoder().encode(
+    `__STREAM_ERROR__:${errorMessage}`,
+  );
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="export.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: errorChunk });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const onError = jest.fn();
+  const { result } = renderHook(() => useStreamingExport({ onError }));
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.ERROR);
+  });
+
+  expect(result.current.progress.error).toBe(errorMessage);
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(onError).toHaveBeenCalledWith(errorMessage);
+});
+
+test('completes CSV export successfully with correct status and downloadUrl', async () => {
+  applicationRoot.mockReturnValue('');
+  const csvData = new TextEncoder().encode('id,name\n1,Alice\n2,Bob\n');
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="results.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const onComplete = jest.fn();
+  const { result } = renderHook(() => useStreamingExport({ onComplete }));
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(result.current.progress.downloadUrl).toBe('blob:mock-url');
+  expect(result.current.progress.filename).toBe('results.csv');
+  expect(onComplete).toHaveBeenCalledTimes(1);
+  expect(onComplete).toHaveBeenCalledWith('blob:mock-url', 'results.csv');
+});
+
+test('completes XLSX export successfully with correct filename', async () => {
+  applicationRoot.mockReturnValue('');
+  const xlsxData = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // XLSX magic bytes
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="report.xlsx"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: xlsxData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const onComplete = jest.fn();
+  const { result } = renderHook(() => useStreamingExport({ onComplete }));
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/chart/data',
+      payload: { datasource: '1__table', viz_type: 'table' },
+      exportType: 'xlsx',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(result.current.progress.filename).toBe('report.xlsx');
+  expect(onComplete).toHaveBeenCalledWith('blob:mock-url', 'report.xlsx');
+});
+
+test('sets ERROR status when response is not ok (4xx/5xx)', async () => {
+  applicationRoot.mockReturnValue('');
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    statusText: 'Internal Server Error',
+    headers: new Headers({}),
+  });
+  global.fetch = mockFetch;
+
+  const onError = jest.fn();
+  const { result } = renderHook(() => useStreamingExport({ onError }));
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.ERROR);
+  });
+
+  expect(result.current.progress.error).toBe(
+    'Export failed: 500 Internal Server Error',
+  );
+  expect(onError).toHaveBeenCalledWith(
+    'Export failed: 500 Internal Server Error',
+  );
+});
+
+test('sets ERROR status when response body is missing', async () => {
+  applicationRoot.mockReturnValue('');
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({}),
+    body: null,
+  });
+  global.fetch = mockFetch;
+
+  const onError = jest.fn();
+  const { result } = renderHook(() => useStreamingExport({ onError }));
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.ERROR);
+  });
+
+  expect(result.current.progress.error).toBe(
+    'Response body is not available for streaming',
+  );
+  expect(onError).toHaveBeenCalledWith(
+    'Response body is not available for streaming',
+  );
+});
+
+test('cancelExport sets CANCELLED status and aborts the request', async () => {
+  applicationRoot.mockReturnValue('');
+  let abortSignal: AbortSignal | undefined;
+
+  // Create a reader that will hang until aborted
+  const mockFetch = jest.fn().mockImplementation((_url, options) => {
+    abortSignal = options?.signal;
+    return Promise.resolve({
+      ok: true,
+      headers: new Headers({
+        'Content-Disposition': 'attachment; filename="export.csv"',
+      }),
+      body: {
+        getReader: () => ({
+          read: jest.fn().mockImplementation(
+            () =>
+              new Promise((resolve, reject) => {
+                // Simulate slow stream that can be aborted
+                const timeout = setTimeout(() => {
+                  resolve({
+                    done: false,
+                    value: new TextEncoder().encode('data'),
+                  });
+                }, 10000);
+                abortSignal?.addEventListener('abort', () => {
+                  clearTimeout(timeout);
+                  reject(new Error('Export cancelled by user'));
+                });
+              }),
+          ),
+        }),
+      },
+    });
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  // Wait for fetch to be called
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Cancel the export
+  act(() => {
+    result.current.cancelExport();
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.CANCELLED);
+  });
+});
+
+test('parses filename from Content-Disposition header with quotes', async () => {
+  applicationRoot.mockReturnValue('');
+  const csvData = new TextEncoder().encode('data\n');
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="my export file.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(result.current.progress.filename).toBe('my export file.csv');
+});
+
+test('uses default filename when Content-Disposition header is missing', async () => {
+  applicationRoot.mockReturnValue('');
+  const csvData = new TextEncoder().encode('data\n');
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({}),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  expect(result.current.progress.filename).toBe('export.csv');
+});
+
+test('updates progress with rowsProcessed and totalSize during streaming', async () => {
+  applicationRoot.mockReturnValue('');
+  const chunk1 = new TextEncoder().encode('id,name\n1,Alice\n');
+  const chunk2 = new TextEncoder().encode('2,Bob\n3,Charlie\n');
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="export.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: chunk1 });
+          }
+          if (readCount === 2) {
+            return Promise.resolve({ done: false, value: chunk2 });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+      expectedRows: 100,
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  // Verify final progress reflects data received
+  expect(result.current.progress.totalSize).toBe(chunk1.length + chunk2.length);
+  // 4 newlines total (2 in chunk1, 2 in chunk2)
+  expect(result.current.progress.rowsProcessed).toBe(4);
+});
+
+test('prevents double startExport calls while export is in progress', async () => {
+  applicationRoot.mockReturnValue('');
+
+  // Create a slow reader that takes time to complete
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="export.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(
+          () =>
+            new Promise(resolve => {
+              readCount += 1;
+              if (readCount === 1) {
+                // Delay first chunk to simulate in-progress export
+                setTimeout(() => {
+                  resolve({
+                    done: false,
+                    value: new TextEncoder().encode('data\n'),
+                  });
+                }, 50);
+              } else {
+                resolve({ done: true, value: undefined });
+              }
+            }),
+        ),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  // Start first export
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/first/',
+      payload: { client_id: 'first' },
+      exportType: 'csv',
+    });
+  });
+
+  // Immediately try to start second export
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/second/',
+      payload: { client_id: 'second' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  // Only one fetch call should have been made (first export)
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch).toHaveBeenCalledWith('/api/v1/first/', expect.any(Object));
+});
+
+test('retryExport does nothing when no prior export exists', async () => {
+  applicationRoot.mockReturnValue('');
+  const mockFetch = jest.fn();
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  // Call retry without ever calling startExport
+  act(() => {
+    result.current.retryExport();
+  });
+
+  // Give it time to potentially make a call
+  await new Promise(resolve => {
+    setTimeout(resolve, 50);
+  });
+
+  // No fetch should have been made
+  expect(mockFetch).not.toHaveBeenCalled();
+});
+
+test('state resets correctly after successful export and resetExport call', async () => {
+  applicationRoot.mockReturnValue('');
+  const csvData = new TextEncoder().encode('data\n');
+
+  let readCount = 0;
+  const mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({
+      'Content-Disposition': 'attachment; filename="export.csv"',
+    }),
+    body: {
+      getReader: () => ({
+        read: jest.fn().mockImplementation(() => {
+          readCount += 1;
+          if (readCount === 1) {
+            return Promise.resolve({ done: false, value: csvData });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        }),
+      }),
+    },
+  });
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.COMPLETED);
+  });
+
+  // Verify completed state
+  expect(result.current.progress.downloadUrl).toBe('blob:mock-url');
+
+  // Reset the export
+  act(() => {
+    result.current.resetExport();
+  });
+
+  // Verify state is reset
+  expect(result.current.progress.status).toBe(ExportStatus.STREAMING);
+  expect(result.current.progress.rowsProcessed).toBe(0);
+  expect(result.current.progress.totalSize).toBe(0);
+  expect(result.current.progress.downloadUrl).toBeUndefined();
+  expect(result.current.progress.error).toBeUndefined();
+  expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+});
+
+test('state resets correctly after failed export and resetExport call', async () => {
+  applicationRoot.mockReturnValue('');
+  const mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));
+  global.fetch = mockFetch;
+
+  const { result } = renderHook(() => useStreamingExport());
+
+  act(() => {
+    result.current.startExport({
+      url: '/api/v1/sqllab/export_streaming/',
+      payload: { client_id: 'test-id' },
+      exportType: 'csv',
+    });
+  });
+
+  await waitFor(() => {
+    expect(result.current.progress.status).toBe(ExportStatus.ERROR);
+  });
+
+  // Verify error state
+  expect(result.current.progress.error).toBe('Network error');
+
+  // Reset the export
+  act(() => {
+    result.current.resetExport();
+  });
+
+  // Verify state is reset
+  expect(result.current.progress.status).toBe(ExportStatus.STREAMING);
+  expect(result.current.progress.error).toBeUndefined();
+  expect(result.current.progress.rowsProcessed).toBe(0);
 });

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -32,6 +32,16 @@ interface StreamingExportPayload {
 }
 
 interface StreamingExportParams {
+  /**
+   * The API endpoint URL for the export request.
+   *
+   * URLs should be prefixed with the application root at the call site using
+   * `makeUrl()` from 'src/utils/pathUtils'. This ensures proper handling for
+   * subdirectory deployments (e.g., /superset/api/v1/...).
+   *
+   * A defensive guard (`ensureUrlPrefix`) will apply the prefix if missing,
+   * but callers should not rely on this fallback behavior.
+   */
   url: string;
   payload: StreamingExportPayload;
   filename?: string;

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -62,7 +62,13 @@ const ensureUrlPrefix = (url: string): string => {
   }
   // If URL already has the app root prefix, return as-is
   // Use strict check to avoid false positives with sibling paths (e.g., /app2 when appRoot is /app)
-  if (url === appRoot || url.startsWith(`${appRoot}/`)) {
+  // Also handle query strings and hashes (e.g., /superset?foo=1 or /superset#hash)
+  if (
+    url === appRoot ||
+    url.startsWith(`${appRoot}/`) ||
+    url.startsWith(`${appRoot}?`) ||
+    url.startsWith(`${appRoot}#`)
+  ) {
     return url;
   }
   // Apply prefix via makeUrl

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -62,9 +62,14 @@ const ensureUrlPrefix = (url: string): string => {
   if (url.startsWith('//')) {
     return url;
   }
-  // Only process relative URLs (starting with /)
-  if (!url.startsWith('/')) {
+  // Absolute URLs (http:// or https://) should pass through unchanged
+  if (url.match(/^https?:\/\//)) {
     return url;
+  }
+  // Relative URLs without leading slash (e.g., "api/v1/...") need normalization
+  // Add leading slash and apply prefix
+  if (!url.startsWith('/')) {
+    return makeUrl(`/${url}`);
   }
   // If no app root configured, return as-is
   if (!appRoot) {
@@ -109,7 +114,7 @@ const createFetchRequest = async (
     formParams.filename = filename;
   }
 
-  if (expectedRows) {
+  if (expectedRows !== undefined) {
     formParams.expected_rows = expectedRows.toString();
   }
 

--- a/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
+++ b/superset-frontend/src/components/StreamingExportModal/useStreamingExport.ts
@@ -48,6 +48,10 @@ const NEWLINE_BYTE = 10; // '\n' character code
  */
 const ensureUrlPrefix = (url: string): string => {
   const appRoot = applicationRoot();
+  // Protocol-relative URLs (//example.com/...) should pass through unchanged
+  if (url.startsWith('//')) {
+    return url;
+  }
   // Only process relative URLs (starting with /)
   if (!url.startsWith('/')) {
     return url;
@@ -57,7 +61,8 @@ const ensureUrlPrefix = (url: string): string => {
     return url;
   }
   // If URL already has the app root prefix, return as-is
-  if (url.startsWith(appRoot)) {
+  // Use strict check to avoid false positives with sibling paths (e.g., /app2 when appRoot is /app)
+  if (url === appRoot || url.startsWith(`${appRoot}/`)) {
     return url;
   }
   // Apply prefix via makeUrl

--- a/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
+++ b/superset-frontend/src/explore/exploreUtils/exportChart.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { exportChart } from '.';
+
+// Mock pathUtils to control app root prefix
+jest.mock('src/utils/pathUtils', () => ({
+  ensureAppRoot: jest.fn((path: string) => path),
+}));
+
+// Mock SupersetClient
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  SupersetClient: {
+    postForm: jest.fn(),
+    get: jest.fn().mockResolvedValue({ json: {} }),
+    post: jest.fn().mockResolvedValue({ json: {} }),
+  },
+  getChartBuildQueryRegistry: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(() => () => ({})),
+  }),
+  getChartMetadataRegistry: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue({ parseMethod: 'json' }),
+  }),
+}));
+
+const { ensureAppRoot } = jest.requireMock('src/utils/pathUtils');
+
+
+describe('exportChart URL prefix for streaming export', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no prefix
+    ensureAppRoot.mockImplementation((path: string) => path);
+  });
+
+  // Minimal formData that won't trigger legacy API (useLegacyApi = false)
+  const baseFormData = {
+    datasource: '1__table',
+    viz_type: 'table',
+  };
+
+  describe('v1 API endpoint', () => {
+    test('passes prefixed URL to onStartStreamingExport when app root is configured', async () => {
+      const appRoot = '/superset';
+      ensureAppRoot.mockImplementation((path: string) => `${appRoot}${path}`);
+
+      const onStartStreamingExport = jest.fn();
+
+      await exportChart({
+        formData: baseFormData,
+        resultFormat: 'csv',
+        onStartStreamingExport: onStartStreamingExport as unknown as null,
+      });
+
+      expect(onStartStreamingExport).toHaveBeenCalledTimes(1);
+      const callArgs = onStartStreamingExport.mock.calls[0][0];
+      expect(callArgs.url).toBe('/superset/api/v1/chart/data');
+      expect(callArgs.exportType).toBe('csv');
+    });
+
+    test('passes unprefixed URL when no app root is configured', async () => {
+      ensureAppRoot.mockImplementation((path: string) => path);
+
+      const onStartStreamingExport = jest.fn();
+
+      await exportChart({
+        formData: baseFormData,
+        resultFormat: 'csv',
+        onStartStreamingExport: onStartStreamingExport as unknown as null,
+      });
+
+      expect(onStartStreamingExport).toHaveBeenCalledTimes(1);
+      const callArgs = onStartStreamingExport.mock.calls[0][0];
+      expect(callArgs.url).toBe('/api/v1/chart/data');
+    });
+
+    test('passes nested prefix for deeply nested deployments', async () => {
+      const appRoot = '/my-company/analytics/superset';
+      ensureAppRoot.mockImplementation((path: string) => `${appRoot}${path}`);
+
+      const onStartStreamingExport = jest.fn();
+
+      await exportChart({
+        formData: baseFormData,
+        resultFormat: 'xlsx',
+        onStartStreamingExport: onStartStreamingExport as unknown as null,
+      });
+
+      expect(onStartStreamingExport).toHaveBeenCalledTimes(1);
+      const callArgs = onStartStreamingExport.mock.calls[0][0];
+      expect(callArgs.url).toBe(
+        '/my-company/analytics/superset/api/v1/chart/data',
+      );
+      expect(callArgs.exportType).toBe('xlsx');
+    });
+  });
+
+  describe('exportType passthrough', () => {
+    test('passes csv exportType for CSV exports', async () => {
+      const onStartStreamingExport = jest.fn();
+
+      await exportChart({
+        formData: baseFormData,
+        resultFormat: 'csv',
+        onStartStreamingExport: onStartStreamingExport as unknown as null,
+      });
+
+      expect(onStartStreamingExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exportType: 'csv',
+        }),
+      );
+    });
+
+    test('passes xlsx exportType for Excel exports', async () => {
+      const onStartStreamingExport = jest.fn();
+
+      await exportChart({
+        formData: baseFormData,
+        resultFormat: 'xlsx',
+        onStartStreamingExport: onStartStreamingExport as unknown as null,
+      });
+
+      expect(onStartStreamingExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exportType: 'xlsx',
+        }),
+      );
+    });
+  });
+});

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -33,7 +33,7 @@ jest.mock('@superset-ui/core', () => ({
 
 jest.mock('content-disposition');
 
-// Mock pathUtils for double-prefix prevention tests
+// Default no-op mock for pathUtils; specific tests customize ensureAppRoot to simulate app root prefixing
 jest.mock('./pathUtils', () => ({
   ensureAppRoot: jest.fn((path: string) => path),
 }));

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -396,3 +396,42 @@ test('handles export with empty IDs array', async () => {
     }),
   );
 });
+
+// Test to prevent double-prefix bug: SupersetClient.getUrl() already adds
+// the appRoot prefix, so handleResourceExport should NOT pre-apply it.
+// If we use ensureAppRoot() in export.ts, SupersetClient.getUrl() adds the
+// prefix again, resulting in double-prefixed URLs like /app/app/api/v1/...
+describe('double-prefix prevention', () => {
+  // Import the mocked ensureAppRoot to control its behavior per test
+  const { ensureAppRoot } = jest.requireMock('./pathUtils');
+
+  const prefixTestCases = [
+    { name: 'subdirectory prefix', appRoot: '/superset', resource: 'dashboard', ids: [1] },
+    { name: 'nested prefix', appRoot: '/my-app/superset', resource: 'dataset', ids: [1, 2] },
+  ];
+
+  test.each(prefixTestCases)(
+    'endpoint should not include app prefix: $name',
+    async ({ appRoot, resource, ids }) => {
+      // Simulate real ensureAppRoot behavior: prepend the appRoot
+      (ensureAppRoot as jest.Mock).mockImplementation(
+        (path: string) => `${appRoot}${path}`,
+      );
+
+      const doneMock = jest.fn();
+      await handleResourceExport(resource, ids, doneMock);
+
+      // The endpoint passed to SupersetClient.get should NOT have the appRoot prefix
+      // because SupersetClient.getUrl() adds it when building the full URL.
+      const expectedEndpoint = `/api/v1/${resource}/export/?q=!(${ids.join(',')})`;
+
+      // Explicitly verify no prefix in endpoint - this will fail if ensureAppRoot is used
+      const callArgs = (SupersetClient.get as jest.Mock).mock.calls.slice(-1)[0][0];
+      expect(callArgs.endpoint).not.toContain(appRoot);
+      expect(callArgs.endpoint).toBe(expectedEndpoint);
+
+      // Reset mock for next test
+      (ensureAppRoot as jest.Mock).mockImplementation((path: string) => path);
+    },
+  );
+});

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -403,6 +403,7 @@ describe('double-prefix prevention', () => {
 
   const prefixTestCases = [
     { name: 'subdirectory prefix', appRoot: '/superset', resource: 'dashboard', ids: [1] },
+    { name: 'subdirectory prefix (dataset)', appRoot: '/superset', resource: 'dataset', ids: [1] },
     { name: 'nested prefix', appRoot: '/my-app/superset', resource: 'dataset', ids: [1, 2] },
   ];
 

--- a/superset-frontend/src/utils/export.test.ts
+++ b/superset-frontend/src/utils/export.test.ts
@@ -33,10 +33,6 @@ jest.mock('@superset-ui/core', () => ({
 
 jest.mock('content-disposition');
 
-jest.mock('./pathUtils', () => ({
-  ensureAppRoot: jest.fn((path: string) => path),
-}));
-
 let mockBlob: Blob;
 let mockResponse: Response;
 let createElementSpy: jest.SpyInstance;

--- a/superset-frontend/src/utils/export.ts
+++ b/superset-frontend/src/utils/export.ts
@@ -19,7 +19,6 @@
 import { SupersetClient, logging } from '@superset-ui/core';
 import rison from 'rison';
 import contentDisposition from 'content-disposition';
-import { ensureAppRoot } from './pathUtils';
 
 // Maximum blob size for in-memory downloads (100MB)
 const MAX_BLOB_SIZE = 100 * 1024 * 1024;
@@ -49,9 +48,7 @@ export default async function handleResourceExport(
   ids: number[],
   done: () => void,
 ): Promise<void> {
-  const endpoint = ensureAppRoot(
-    `/api/v1/${resource}/export/?q=${rison.encode(ids)}`,
-  );
+  const endpoint = `/api/v1/${resource}/export/?q=${rison.encode(ids)}`;
 
   try {
     // Use fetch with blob response instead of iframe to avoid CSP frame-src violations


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes streaming exports failing with 404 errors when Superset is deployed under a subdirectory (e.g., `/superset/`, `/my-company/analytics/superset/`).

**Root Cause:** 
The streaming export functionality uses native `fetch()` which bypasses SupersetClient`'s URL prefixing. When Superset runs at a subdirectory, hardcoded URLs like `/api/v1/sqllab/export_streaming/` don't include the application root prefix.

**Changes:**
1. **SQL Lab streaming export** - Apply `makeUrl()` to prefix the export URL
2. **Resource export (Dashboard/Chart/Dataset)** - Remove redundant `ensureAppRoot()` that caused double-prefixing when combined with `SupersetClient.get()`
3. **URL prefix guard** - Add `ensureUrlPrefix()` in `useStreamingExport` as a defensive guard to catch any forgotten prefixes

**Test Coverage:** 86 tests covering URL prefix scenarios, streaming behavior, error handling, and edge cases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
   1. Configure Superset with `APPLICATION_ROOT=/superset` (or any subdirectory)
   2. Navigate to SQL Lab and run a query
   3. Click "Download to CSV" (streaming export)
   4. Verify the export completes successfully (previously would 404)
   5. Navigate to Dashboard/Chart/Dataset list
   6. Select items and click Export
   7. Verify export works (previously would fail with double-prefixed URLs)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #35883
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix export URLs so exports work when Superset runs under a subdirectory

### What Changed
- Streaming CSV/XLSX exports now include the application root prefix when needed so downloads no longer 404 for subdirectory deployments.
- Resource exports (dashboard/chart/dataset) stop sending double-prefixed endpoints to the client URL builder, preventing broken export requests.
- Small (non-streaming) CSV downloads use a prefixed direct download link and do not trigger streaming logic.
- Retry and error paths for streaming exports preserve the exact URL used originally and report errors to the UI via onError.
- Comprehensive tests added to cover prefixed and unprefixed deployments, retry behavior, error handling, and various streaming scenarios.

### Impact
`✅ Successful CSV/XLSX downloads on subdirectory deployments`
`✅ No double-prefixed export URLs (prevents broken export requests)`
`✅ Clearer streaming export errors and reliable retries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
