### PR TITLE
feat(explore): add interactive table query building with SQL visibility

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomHeader.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/components/CustomHeader.tsx
@@ -19,9 +19,16 @@
  * under the License.
  */
 
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
+import { ensureIsArray } from '@superset-ui/core';
+import {
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  GroupOutlined,
+  CalculatorOutlined,
+  EyeInvisibleOutlined,
+} from '@ant-design/icons';
 import { Column } from '@superset-ui/core/components/ThemedAgGridReact';
 import FilterIcon from './Filter';
 import KebabMenu from './KebabMenu';
@@ -113,11 +120,15 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
     onColumnHeaderClicked,
     lastFilteredColumn,
     lastFilteredInputPosition,
+    setControlValue,
+    formData,
   } = context;
   const colId = column?.getColId();
   const colDef = column?.getColDef() as CustomColDef;
   const userColDef = column.getUserProvidedColDef() as UserProvidedColDef;
   const isPercentMetric = colDef?.context?.isPercentMetric;
+  const isMetric = colDef?.context?.isMetric;
+  const isNumeric = colDef?.context?.isNumeric;
 
   const [isFilterVisible, setFilterVisible] = useState(false);
   const [isMenuVisible, setMenuVisible] = useState(false);
@@ -191,12 +202,57 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
     setMenuVisible(!isMenuVisible);
   };
 
+  // Column interaction handlers for Explore
+  const handleGroupBy = useCallback(() => {
+    if (!setControlValue || !formData) return;
+    const currentGroupby = ensureIsArray(formData.groupby);
+    if (!currentGroupby.includes(colId)) {
+      setControlValue('groupby', [...currentGroupby, colId]);
+    }
+    setMenuVisible(false);
+  }, [setControlValue, formData, colId]);
+
+  const handleAddMetric = useCallback(
+    (aggregate: string) => {
+      if (!setControlValue || !formData) return;
+      const currentMetrics = ensureIsArray(formData.metrics);
+      const metricLabel = `${aggregate}(${colId})`;
+      const newMetric = {
+        aggregate,
+        column: { column_name: colId },
+        expressionType: 'SIMPLE',
+        label: metricLabel,
+      };
+      setControlValue('metrics', [...currentMetrics, newMetric]);
+      setMenuVisible(false);
+    },
+    [setControlValue, formData, colId],
+  );
+
+  const handleHideColumn = useCallback(() => {
+    if (!setControlValue || !formData) return;
+    const currentColumnConfig = formData.column_config || {};
+    setControlValue('column_config', {
+      ...currentColumnConfig,
+      [colId]: {
+        ...currentColumnConfig[colId],
+        visible: false,
+      },
+    });
+    setMenuVisible(false);
+  }, [setControlValue, formData, colId]);
+
   const isCurrentColSorted = currentSort?.colId === colId;
   const currentDirection = isCurrentColSorted ? currentSort?.sort : null;
   const shouldShowAsc =
     !isTimeComparison && (!currentDirection || currentDirection === 'desc');
   const shouldShowDesc =
     !isTimeComparison && (!currentDirection || currentDirection === 'asc');
+
+  // Only show column interaction options in Explore context (when setControlValue is available)
+  const showColumnInteractions = !!setControlValue;
+  const canGroupBy = showColumnInteractions && !isMetric && !isPercentMetric;
+  const canAddMetric = showColumnInteractions && !isMetric && !isPercentMetric;
 
   const menuContent = (
     <MenuContainer>
@@ -214,6 +270,73 @@ const CustomHeader: React.FC<CustomHeaderParams> = ({
         <div onClick={clearSort} className="menu-item">
           <span style={{ fontSize: 16 }}>↻</span> {t('Clear Sort')}
         </div>
+      )}
+
+      {/* Column interaction options for Explore */}
+      {canGroupBy && (
+        <>
+          <div className="menu-divider" />
+          <div onClick={handleGroupBy} className="menu-item">
+            <GroupOutlined /> {t('Group by this column')}
+          </div>
+        </>
+      )}
+      {canAddMetric && (
+        <>
+          <div className="menu-item menu-submenu">
+            <CalculatorOutlined /> {t('Add as metric')}
+            <div className="submenu">
+              {isNumeric && (
+                <>
+                  <div
+                    onClick={() => handleAddMetric('SUM')}
+                    className="menu-item"
+                  >
+                    {t('SUM')}
+                  </div>
+                  <div
+                    onClick={() => handleAddMetric('AVG')}
+                    className="menu-item"
+                  >
+                    {t('AVG')}
+                  </div>
+                  <div
+                    onClick={() => handleAddMetric('MIN')}
+                    className="menu-item"
+                  >
+                    {t('MIN')}
+                  </div>
+                  <div
+                    onClick={() => handleAddMetric('MAX')}
+                    className="menu-item"
+                  >
+                    {t('MAX')}
+                  </div>
+                </>
+              )}
+              <div
+                onClick={() => handleAddMetric('COUNT')}
+                className="menu-item"
+              >
+                {t('COUNT')}
+              </div>
+              <div
+                onClick={() => handleAddMetric('COUNT_DISTINCT')}
+                className="menu-item"
+              >
+                {t('COUNT DISTINCT')}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+      {showColumnInteractions && (
+        <>
+          <div className="menu-divider" />
+          <div onClick={handleHideColumn} className="menu-item">
+            <EyeInvisibleOutlined /> {t('Hide column')}
+          </div>
+        </>
       )}
     </MenuContainer>
   );

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -53,7 +53,8 @@ import { SearchOutlined } from '@ant-design/icons';
 import { debounce, isEqual } from 'lodash';
 import Pagination from './components/Pagination';
 import SearchSelectDropdown from './components/SearchSelectDropdown';
-import { SearchOption, SortByItem } from '../types';
+import { SearchOption, SortByItem, TableChartFormData } from '../types';
+import { HandlerFunction } from '@superset-ui/core';
 import getInitialSortState, { shouldSort } from '../utils/getInitialSortState';
 import getInitialFilterModel from '../utils/getInitialFilterModel';
 import reconcileColumnState from '../utils/reconcileColumnState';
@@ -108,6 +109,8 @@ export interface AgGridTableProps {
   metricColumns?: string[];
   gridRef?: RefObject<AgGridReact>;
   chartState?: AgGridChartState;
+  setControlValue?: HandlerFunction;
+  formData?: TableChartFormData;
 }
 
 ModuleRegistry.registerModules([AllCommunityModule, ClientSideRowModelModule]);
@@ -147,6 +150,8 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
     onFilterChanged,
     metricColumns = [],
     chartState,
+    setControlValue,
+    formData,
   }) => {
     const gridRef = useRef<AgGridReact>(null);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -609,6 +614,9 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
             lastFilteredColumn: serverPaginationData?.lastFilteredColumn,
             lastFilteredInputPosition:
               serverPaginationData?.lastFilteredInputPosition,
+            isActiveFilterValue,
+            setControlValue,
+            formData,
           }}
         />
         {serverPagination && (

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -86,6 +86,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     onChartStateChange,
     chartState,
     metricSqlExpressions,
+    setControlValue,
+    formData,
   } = props;
 
   const [searchOptions, setSearchOptions] = useState<SearchOption[]>([]);
@@ -447,6 +449,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         width={width}
         onColumnStateChange={handleColumnStateChange}
         chartState={chartState}
+        setControlValue={setControlValue}
+        formData={formData}
       />
     </StyledChartContainer>
   );

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
@@ -139,6 +139,28 @@ export const MenuContainer = styled.div`
       background-color: ${theme.colorBorderSecondary};
       margin: ${theme.sizeUnit}px 0;
     }
+
+    .menu-submenu {
+      position: relative;
+
+      .submenu {
+        display: none;
+        position: absolute;
+        left: 100%;
+        top: 0;
+        min-width: ${theme.sizeUnit * 35}px;
+        background: var(--ag-menu-background-color, ${theme.colorBgBase});
+        border: var(--ag-menu-border, 1px solid ${theme.colorBorderSecondary});
+        box-shadow: var(--ag-menu-shadow, ${theme.boxShadow});
+        border-radius: ${theme.borderRadius}px;
+        padding: ${theme.sizeUnit}px 0;
+        z-index: 100;
+      }
+
+      &:hover .submenu {
+        display: block;
+      }
+    }
   `}
 `;
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -476,7 +476,7 @@ const transformProps = (
     queriesData = [],
     ownState: serverPaginationData,
     filterState,
-    hooks: { setDataMask = () => {}, onChartStateChange },
+    hooks: { setDataMask = () => {}, onChartStateChange, setControlValue },
     emitCrossFilters,
     theme,
   } = chartProps;
@@ -785,6 +785,7 @@ const transformProps = (
     metricSqlExpressions,
     chartState,
     onChartStateChange,
+    setControlValue,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
@@ -46,6 +46,7 @@ import {
   IHeaderParams,
   CustomCellRendererProps,
 } from '@superset-ui/core/components/ThemedAgGridReact';
+import { HandlerFunction } from '@superset-ui/core';
 
 // Re-export shared types used by internal plugin files that import from './types'
 // Types used locally in this file - re-export from local binding
@@ -131,6 +132,7 @@ export interface AgGridTableChartTransformedProps<
   metricSqlExpressions: Record<string, string>;
   onChartStateChange?: (chartState: JsonObject) => void;
   chartState?: AgGridChartState;
+  setControlValue?: HandlerFunction;
 }
 
 export interface SortState {
@@ -152,6 +154,8 @@ export interface CustomContext {
   onColumnHeaderClicked: (args: { column: SortState }) => void;
   lastFilteredColumn?: string;
   lastFilteredInputPosition?: FilterInputPosition;
+  setControlValue?: HandlerFunction;
+  formData?: TableChartFormData;
 }
 
 export interface CustomHeaderParams extends IHeaderParams {

--- a/superset-frontend/plugins/plugin-chart-table/src/ColumnHeaderContextMenu.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/ColumnHeaderContextMenu.tsx
@@ -18,16 +18,13 @@
  */
 import { useCallback, useMemo } from 'react';
 import { t, ensureIsArray, HandlerFunction } from '@superset-ui/core';
-import { css, useTheme } from '@apache-superset/core/ui';
+import { css } from '@apache-superset/core/ui';
 import { Dropdown, Menu } from '@superset-ui/core/components';
 import { GenericDataType } from '@apache-superset/core/api/core';
 import {
   GroupOutlined,
-  FilterOutlined,
   CalculatorOutlined,
   EyeInvisibleOutlined,
-  SortAscendingOutlined,
-  SortDescendingOutlined,
 } from '@ant-design/icons';
 import { DataColumnMeta, TableChartFormData } from './types';
 
@@ -47,10 +44,7 @@ type MenuAction =
   | 'count_distinct'
   | 'min'
   | 'max'
-  | 'filter'
-  | 'hide'
-  | 'sort_asc'
-  | 'sort_desc';
+  | 'hide';
 
 export default function ColumnHeaderContextMenu({
   column,
@@ -59,8 +53,6 @@ export default function ColumnHeaderContextMenu({
   children,
   disabled = false,
 }: ColumnHeaderContextMenuProps) {
-  const theme = useTheme();
-
   const isNumericColumn =
     column.dataType === GenericDataType.Numeric || column.isNumeric;
   const isMetric = column.isMetric || column.isPercentMetric;
@@ -110,11 +102,6 @@ export default function ColumnHeaderContextMenu({
           setControlValue('metrics', [...currentMetrics, newMetric]);
           break;
         }
-
-        case 'filter':
-          // Open filter modal - for now just add a placeholder filter
-          // This would ideally open a filter UI
-          break;
 
         case 'hide': {
           // Update column_config to hide this column

--- a/superset-frontend/plugins/plugin-chart-table/src/ColumnHeaderContextMenu.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/ColumnHeaderContextMenu.tsx
@@ -1,0 +1,236 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useCallback, useMemo } from 'react';
+import { t, ensureIsArray, HandlerFunction } from '@superset-ui/core';
+import { css, useTheme } from '@apache-superset/core/ui';
+import { Dropdown, Menu } from '@superset-ui/core/components';
+import { GenericDataType } from '@apache-superset/core/api/core';
+import {
+  GroupOutlined,
+  FilterOutlined,
+  CalculatorOutlined,
+  EyeInvisibleOutlined,
+  SortAscendingOutlined,
+  SortDescendingOutlined,
+} from '@ant-design/icons';
+import { DataColumnMeta, TableChartFormData } from './types';
+
+export interface ColumnHeaderContextMenuProps {
+  column: DataColumnMeta;
+  formData?: TableChartFormData;
+  setControlValue?: HandlerFunction;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+type MenuAction =
+  | 'groupby'
+  | 'sum'
+  | 'avg'
+  | 'count'
+  | 'count_distinct'
+  | 'min'
+  | 'max'
+  | 'filter'
+  | 'hide'
+  | 'sort_asc'
+  | 'sort_desc';
+
+export default function ColumnHeaderContextMenu({
+  column,
+  formData,
+  setControlValue,
+  children,
+  disabled = false,
+}: ColumnHeaderContextMenuProps) {
+  const theme = useTheme();
+
+  const isNumericColumn =
+    column.dataType === GenericDataType.Numeric || column.isNumeric;
+  const isMetric = column.isMetric || column.isPercentMetric;
+  const columnName = column.key;
+
+  const handleMenuClick = useCallback(
+    (action: MenuAction) => {
+      if (!setControlValue || !formData) return;
+
+      const currentGroupby = ensureIsArray(formData.groupby);
+      const currentMetrics = ensureIsArray(formData.metrics);
+
+      switch (action) {
+        case 'groupby':
+          // Add column to groupby if not already present
+          if (!currentGroupby.includes(columnName)) {
+            setControlValue('groupby', [...currentGroupby, columnName]);
+          }
+          break;
+
+        case 'sum':
+        case 'avg':
+        case 'count':
+        case 'min':
+        case 'max': {
+          // Create an aggregate metric
+          const aggregate = action.toUpperCase();
+          const metricLabel = `${aggregate}(${columnName})`;
+          const newMetric = {
+            aggregate,
+            column: { column_name: columnName },
+            expressionType: 'SIMPLE',
+            label: metricLabel,
+          };
+          setControlValue('metrics', [...currentMetrics, newMetric]);
+          break;
+        }
+
+        case 'count_distinct': {
+          const metricLabel = `COUNT_DISTINCT(${columnName})`;
+          const newMetric = {
+            aggregate: 'COUNT_DISTINCT',
+            column: { column_name: columnName },
+            expressionType: 'SIMPLE',
+            label: metricLabel,
+          };
+          setControlValue('metrics', [...currentMetrics, newMetric]);
+          break;
+        }
+
+        case 'filter':
+          // Open filter modal - for now just add a placeholder filter
+          // This would ideally open a filter UI
+          break;
+
+        case 'hide': {
+          // Update column_config to hide this column
+          const currentColumnConfig = formData.column_config || {};
+          setControlValue('column_config', {
+            ...currentColumnConfig,
+            [columnName]: {
+              ...currentColumnConfig[columnName],
+              visible: false,
+            },
+          });
+          break;
+        }
+
+        default:
+          break;
+      }
+    },
+    [setControlValue, formData, columnName],
+  );
+
+  const menuItems = useMemo(() => {
+    const items: React.ComponentProps<typeof Menu>['items'] = [];
+
+    // Group By option (only for non-metric columns)
+    if (!isMetric) {
+      items.push({
+        key: 'groupby',
+        icon: <GroupOutlined />,
+        label: t('Group by this column'),
+        onClick: () => handleMenuClick('groupby'),
+      });
+    }
+
+    // Aggregate options (for numeric columns or any column for COUNT)
+    if (!isMetric) {
+      const aggregateItems = [
+        {
+          key: 'count',
+          label: t('COUNT'),
+          onClick: () => handleMenuClick('count'),
+        },
+        {
+          key: 'count_distinct',
+          label: t('COUNT DISTINCT'),
+          onClick: () => handleMenuClick('count_distinct'),
+        },
+      ];
+
+      if (isNumericColumn) {
+        aggregateItems.unshift(
+          {
+            key: 'sum',
+            label: t('SUM'),
+            onClick: () => handleMenuClick('sum'),
+          },
+          {
+            key: 'avg',
+            label: t('AVG'),
+            onClick: () => handleMenuClick('avg'),
+          },
+          {
+            key: 'min',
+            label: t('MIN'),
+            onClick: () => handleMenuClick('min'),
+          },
+          {
+            key: 'max',
+            label: t('MAX'),
+            onClick: () => handleMenuClick('max'),
+          },
+        );
+      }
+
+      items.push({
+        key: 'aggregate',
+        icon: <CalculatorOutlined />,
+        label: t('Add as metric'),
+        children: aggregateItems,
+      });
+    }
+
+    // Divider
+    if (items.length > 0) {
+      items.push({ type: 'divider' });
+    }
+
+    // Hide column
+    items.push({
+      key: 'hide',
+      icon: <EyeInvisibleOutlined />,
+      label: t('Hide column'),
+      onClick: () => handleMenuClick('hide'),
+    });
+
+    return items;
+  }, [isMetric, isNumericColumn, handleMenuClick]);
+
+  // If no setControlValue, just render children without dropdown
+  if (!setControlValue || disabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems }}
+      trigger={['contextMenu']}
+      overlayStyle={{ minWidth: 180 }}
+    >
+      <span
+        css={css`
+          cursor: context-menu;
+        `}
+      >
+        {children}
+      </span>
+    </Dropdown>
+  );
+}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -100,6 +100,7 @@ import { PAGE_SIZE_OPTIONS, SERVER_PAGE_SIZE_OPTIONS } from './consts';
 import { updateTableOwnState } from './DataTable/utils/externalAPIs';
 import getScrollBarSize from './DataTable/utils/getScrollBarSize';
 import DateWithFormatter from './utils/DateWithFormatter';
+import ColumnHeaderContextMenu from './ColumnHeaderContextMenu';
 
 type ValueRange = [number, number];
 
@@ -408,6 +409,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     serverPageLength,
     slice_id,
     columnLabelToNameMap = {},
+    setControlValue,
+    formData,
   } = props;
 
   const comparisonColumns = useMemo(
@@ -1326,16 +1329,22 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                 }}
               />
             ) : null}
-            <div
-              data-column-name={col.id}
-              css={{
-                display: 'inline-flex',
-                alignItems: 'flex-end',
-              }}
+            <ColumnHeaderContextMenu
+              column={column}
+              formData={formData}
+              setControlValue={setControlValue}
             >
-              <span data-column-name={col.id}>{displayLabel}</span>
-              <SortIcon column={col} />
-            </div>
+              <div
+                data-column-name={col.id}
+                css={{
+                  display: 'inline-flex',
+                  alignItems: 'flex-end',
+                }}
+              >
+                <span data-column-name={col.id}>{displayLabel}</span>
+                <SortIcon column={col} />
+              </div>
+            </ColumnHeaderContextMenu>
           </th>
         ),
 
@@ -1396,6 +1405,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       toggleFilter,
       handleContextMenu,
       allowRearrangeColumns,
+      setControlValue,
+      formData,
     ],
   );
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -501,6 +501,7 @@ const transformProps = (
       onAddFilter: onChangeFilter,
       setDataMask = () => {},
       onContextMenu,
+      setControlValue,
     },
     emitCrossFilters,
     theme,
@@ -806,6 +807,8 @@ const transformProps = (
     serverPageLength,
     slice_id,
     columnLabelToNameMap,
+    setControlValue,
+    formData,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -27,6 +27,9 @@ import {
   QueryFormData,
   SetDataMaskHook,
   ContextMenuFilters,
+  CurrencyFormatter,
+  Currency,
+  HandlerFunction,
 } from '@superset-ui/core';
 import type {
   BasicColorFormatterType,
@@ -128,6 +131,14 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   // column names for cross-filtering, so that adhoc columns with custom labels
   // emit the correct column name in cross-filter data masks
   columnLabelToNameMap?: Record<string, string>;
+  // For column header interactions to update explore controls
+  setControlValue?: HandlerFunction;
+  formData?: TableChartFormData;
+}
+
+export enum ColorSchemeEnum {
+  'Green' = 'Green',
+  'Red' = 'Red',
 }
 
 export default {};

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -27,7 +27,7 @@ import {
   setItem,
   LocalStorageKeys,
 } from 'src/utils/localStorageHelpers';
-import { SamplesPane, useResultsPane } from './components';
+import { SamplesPane, QueryPane, useResultsPane } from './components';
 import { DataTablesPaneProps, ResultTypes } from './types';
 
 const StyledDiv = styled.div`
@@ -92,6 +92,7 @@ export const DataTablesPane = ({
   const [isRequest, setIsRequest] = useState<Record<ResultTypes, boolean>>({
     results: false,
     samples: false,
+    query: false,
   });
   const [panelOpen, setPanelOpen] = useState(
     isFeatureEnabled(FeatureFlag.DatapanelClosedByDefault)
@@ -109,6 +110,7 @@ export const DataTablesPane = ({
       setIsRequest({
         results: false,
         samples: false,
+        query: false,
       });
     }
 
@@ -121,6 +123,7 @@ export const DataTablesPane = ({
       setIsRequest({
         results: true,
         samples: false,
+        query: false,
       });
     }
 
@@ -128,6 +131,15 @@ export const DataTablesPane = ({
       setIsRequest({
         results: false,
         samples: true,
+        query: false,
+      });
+    }
+
+    if (panelOpen && activeTabKey === ResultTypes.Query) {
+      setIsRequest({
+        results: false,
+        samples: false,
+        query: true,
       });
     }
   }, [panelOpen, activeTabKey, chartStatus]);
@@ -212,6 +224,19 @@ export const DataTablesPane = ({
             setForceQuery={setForceQuery}
             isVisible={ResultTypes.Samples === activeTabKey}
             canDownload={canDownload}
+          />
+        </StyledDiv>
+      ),
+    },
+    {
+      key: ResultTypes.Query,
+      label: t('Query'),
+      children: (
+        <StyledDiv>
+          <QueryPane
+            queryFormData={queryFormData}
+            isRequest={isRequest.query}
+            isVisible={ResultTypes.Query === activeTabKey}
           />
         </StyledDiv>
       ),

--- a/superset-frontend/src/explore/components/DataTablesPane/components/QueryPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/QueryPane.tsx
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect, useState, useCallback } from 'react';
+import { ensureIsArray, t, getClientErrorObject } from '@superset-ui/core';
+import { css, styled, useTheme } from '@apache-superset/core/ui';
+import {
+  Loading,
+  EmptyState,
+  Icons,
+  Button,
+  Space,
+} from '@superset-ui/core/components';
+import { CopyToClipboard } from 'src/components';
+import { getChartDataRequest } from 'src/components/Chart/chartAction';
+import CodeSyntaxHighlighter, {
+  SupportedLanguage,
+  preloadLanguages,
+} from '@superset-ui/core/components/CodeSyntaxHighlighter';
+import { QueryPaneProps } from '../types';
+
+const QueryPaneContainer = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: ${theme.sizeUnit * 4}px;
+    overflow: auto;
+  `}
+`;
+
+const QueryHeader = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: ${theme.sizeUnit * 3}px;
+    flex-shrink: 0;
+  `}
+`;
+
+const QueryTitle = styled.div`
+  ${({ theme }) => css`
+    font-weight: ${theme.fontWeightBold};
+    color: ${theme.colorTextPrimary};
+  `}
+`;
+
+const QueryContent = styled.div`
+  ${({ theme }) => css`
+    flex: 1;
+    overflow: auto;
+    border: 1px solid ${theme.colorBorderSecondary};
+    border-radius: ${theme.borderRadius}px;
+    background: ${theme.colorBgLayout};
+  `}
+`;
+
+const Error = styled.pre`
+  ${({ theme }) => css`
+    margin-top: ${theme.sizeUnit * 4}px;
+    color: ${theme.colorError};
+  `}
+`;
+
+const StyledSyntaxHighlighter = styled(CodeSyntaxHighlighter)`
+  ${({ theme }) => css`
+    margin: 0 !important;
+    padding: ${theme.sizeUnit * 3}px !important;
+    height: 100%;
+    overflow: auto;
+
+    code {
+      font-size: ${theme.fontSizeSM}px;
+    }
+  `}
+`;
+
+interface QueryResult {
+  query?: string;
+  language: SupportedLanguage;
+  error?: string;
+}
+
+export const QueryPane = ({
+  isRequest,
+  queryFormData,
+  isVisible,
+}: QueryPaneProps) => {
+  const theme = useTheme();
+  const [results, setResults] = useState<QueryResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Preload SQL language for syntax highlighting
+  useEffect(() => {
+    preloadLanguages(['sql']);
+  }, []);
+
+  useEffect(() => {
+    if (isRequest && isVisible && queryFormData) {
+      setIsLoading(true);
+      setError(null);
+
+      getChartDataRequest({
+        formData: queryFormData,
+        resultFormat: 'json',
+        resultType: 'query',
+      })
+        .then(({ json }) => {
+          setResults(ensureIsArray(json.result));
+          setError(null);
+        })
+        .catch(response => {
+          getClientErrorObject(response).then(({ error, message }) => {
+            setError(
+              error ||
+                message ||
+                response.statusText ||
+                t('An error occurred while fetching the query'),
+            );
+          });
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [isRequest, isVisible, JSON.stringify(queryFormData)]);
+
+  const getCurrentQuery = useCallback(() => {
+    if (results.length === 0) return '';
+    return results.map(r => r.query || '').join('\n\n');
+  }, [results]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return (
+      <QueryPaneContainer>
+        <Error>{error}</Error>
+      </QueryPaneContainer>
+    );
+  }
+
+  if (results.length === 0 || !results[0].query) {
+    return (
+      <EmptyState
+        image="document.svg"
+        title={t('No query was generated')}
+        description={t('Run the query to see the generated SQL')}
+      />
+    );
+  }
+
+  return (
+    <QueryPaneContainer>
+      <QueryHeader>
+        <QueryTitle>{t('Generated SQL')}</QueryTitle>
+        <Space size={theme.sizeUnit * 2}>
+          <CopyToClipboard
+            text={getCurrentQuery()}
+            shouldShowText={false}
+            copyNode={
+              <Button
+                buttonStyle="secondary"
+                buttonSize="small"
+                icon={<Icons.CopyOutlined />}
+              >
+                {t('Copy')}
+              </Button>
+            }
+          />
+        </Space>
+      </QueryHeader>
+      <QueryContent>
+        {results.map((result, index) => (
+          <div key={index}>
+            {result.error && <Error>{result.error}</Error>}
+            {result.query && (
+              <StyledSyntaxHighlighter language={result.language || 'sql'}>
+                {result.query}
+              </StyledSyntaxHighlighter>
+            )}
+          </div>
+        ))}
+      </QueryContent>
+    </QueryPaneContainer>
+  );
+};

--- a/superset-frontend/src/explore/components/DataTablesPane/components/index.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/index.ts
@@ -18,5 +18,6 @@
  */
 export { ResultsPaneOnDashboard } from './ResultsPaneOnDashboard';
 export { SamplesPane } from './SamplesPane';
+export { QueryPane } from './QueryPane';
 export { TableControls, TableControlsWrapper } from './DataTableControls';
 export { useResultsPane } from './useResultsPane';

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -23,6 +23,7 @@ import type { ChartStatus, Datasource } from 'src/explore/types';
 export enum ResultTypes {
   Results = 'results',
   Samples = 'samples',
+  Query = 'query',
 }
 
 type SetForceQueryAction = (force: boolean) => void;
@@ -67,6 +68,12 @@ export interface DrillControlsProps {
   onDownloadCSV?: () => void;
   onDownloadXLSX?: () => void;
   onReload?: () => void;
+}
+
+export interface QueryPaneProps {
+  isRequest: boolean;
+  queryFormData: LatestQueryFormData;
+  isVisible: boolean;
 }
 
 export interface TableControlsProps extends DrillControlsProps {


### PR DESCRIPTION
## **User description**
### SUMMARY
This PR introduces interactive table capabilities inspired by a data curation approach, where the table becomes a query-building interface rather than just output.

#### Key Features:

Query Tab in Explore (76c49efb)

Adds a new "Query" tab in the Data panel (alongside Results and Samples)
Displays the generated SQL with syntax highlighting
Auto-updates when form data changes, providing real-time SQL visibility
Column Header Context Menu for Standard Table (a1ea1af1)

Right-click context menu on column headers in the standard Table chart
Options: "Group by this column", "Add as metric" (SUM/AVG/COUNT/etc.), "Hide column"
Uses setControlValue hook to update Explore controls
Column Header Interactions for AG Grid Table (4b2e6d12)

Extends AG Grid's existing kebab menu with the same interactive options
Group by, Add as metric (with submenu for aggregates), Hide column
Only appears in Explore context (when setControlValue is available)
How It Works:

Users can click on column headers to add Group By dimensions or create aggregate metrics
The Query tab shows the SQL updating in real-time as users interact with the table
This creates a bidirectional workflow: see data → click to refine → see SQL change → repeat

#### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Tables are output-only; users must manually configure controls to change the query

After:

Column headers have context menus for quick query modification
New Query tab shows the generated SQL that updates as you interact with the table

#### TESTING INSTRUCTIONS
Navigate to Explore with any dataset
Select either "Table" or "AG Grid Table" visualization
Run a query with some columns
Test Query Tab:
4. Click on the "Query" tab in the data panel (next to Results/Samples)
5. Verify SQL is displayed with syntax highlighting
6. Change a control (e.g., add a metric) and verify SQL updates

Test Column Interactions (Standard Table):
7. Right-click on a dimension column header
8. Click "Group by this column" - verify column is added to Group By control
9. Right-click on a numeric column, hover "Add as metric", select "SUM"
10. Verify a new SUM metric appears in the Metrics control
11. Click "Hide column" and verify the column is hidden

Test Column Interactions (AG Grid Table):
12. Switch to AG Grid Table visualization
13. Click the kebab menu (⋮) on a column header
14. Verify "Group by this column", "Add as metric", and "Hide column" options appear
15. Test each option and verify controls update correctly

#### ADDITIONAL INFORMATION
- [ ]  Has associated issue:
 - [ ]  Required feature flags:
 - [x]  Changes UI
 - [ ]  Includes DB Migration
 - [x]  Introduces new feature or API
 - [ ]  Removes existing feature or API

Technical Notes:

Uses setControlValue from chart hooks to update Explore controls from within chart plugins
Uses getChartDataRequest with resultType: 'query' to fetch generated SQL
Column interactions are only visible in Explore context (not on dashboards)


___

## **CodeAnt-AI Description**
Show generated SQL and enable column-based query edits from table headers

### What Changed
- Adds a new "Query" tab in the data panel that fetches and displays the generated SQL for the current chart, with syntax highlighting and a Copy button; it loads when the panel is open and the query is run.
- Adds context-menu interactions on table and AG Grid column headers that let users directly modify the underlying query: "Group by this column", "Add as metric" (SUM/AVG/MIN/MAX/COUNT/COUNT DISTINCT), and "Hide column". Numeric-only aggregates are shown for numeric columns.
- Column interactions only appear when Explore controls are available and update the chart controls (groupby, metrics, column_config), causing the query to refresh; the metric submenu is shown as a hover submenu.

### Impact
`✅ Real-time SQL visibility for charts`
`✅ Shorter query iteration by clicking table columns to add group-bys or metrics`
`✅ Hide columns from the table without opening the control panel`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
