### PR TITLE
fix(databricks): handle boolean IN clauses with boolean literals

### DIFF
--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -24,7 +24,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from marshmallow.validate import Range
-from sqlalchemy import text, types
+from sqlalchemy import false, or_, text, types
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
@@ -251,6 +251,51 @@ class DatabricksBaseEngineSpec(BaseEngineSpec):
     @classmethod
     def epoch_to_dttm(cls) -> str:
         return HiveEngineSpec.epoch_to_dttm()
+
+    @classmethod
+    def handle_boolean_in_clause(cls, sqla_col: Any, values: list[Any]) -> Any:
+        """
+        Build an IN-style predicate for a boolean column using boolean literals.
+
+        Databricks requires boolean literals (``TRUE``/``FALSE``) rather than
+        integer literals (``0``/``1``) when comparing against a boolean column,
+        so the IN clause is expanded into OR'd equality checks against real
+        booleans.
+
+        :param sqla_col: SQLAlchemy column element
+        :param values: List of values for the IN clause
+        :return: SQLAlchemy expression, or a constant ``FALSE`` when none of the
+            values map to a boolean
+        """
+        boolean_values: list[bool] = []
+        for val in values:
+            coerced: bool | None
+            if val is None:
+                continue
+            if isinstance(val, bool):
+                coerced = val
+            elif isinstance(val, (int, float)):
+                coerced = bool(val)
+            elif isinstance(val, str):
+                lowered = val.strip().lower()
+                if lowered in ("true", "1"):
+                    coerced = True
+                elif lowered in ("false", "0"):
+                    coerced = False
+                else:
+                    # Unrecognized strings don't map to a boolean, so skip them
+                    coerced = None
+            else:
+                coerced = bool(val)
+            # Deduplicate while preserving order to avoid redundant OR terms
+            if coerced is not None and coerced not in boolean_values:
+                boolean_values.append(coerced)
+
+        if not boolean_values:
+            # Nothing usable (e.g. only None or unrecognized values); match nothing
+            return false()
+
+        return or_(*(sqla_col == val for val in boolean_values))
 
 
 class DatabricksODBCEngineSpec(DatabricksBaseEngineSpec):

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3622,14 +3622,28 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                         raise QueryObjectValidationError(
                             _("Filter value list cannot be empty")
                         )
-                    if len(eq) > len(
-                        eq_without_none := [x for x in eq if x is not None]
-                    ):
+                    # Some engines (e.g. Databricks) require boolean literals
+                    # rather than integers in IN clauses, so they may expose a
+                    # handle_boolean_in_clause hook to build the predicate.
+                    boolean_in_handler = (
+                        getattr(db_engine_spec, "handle_boolean_in_clause", None)
+                        if target_generic_type == utils.GenericDataType.BOOLEAN
+                        else None
+                    )
+                    eq_without_none = [x for x in eq if x is not None]
+                    if len(eq) > len(eq_without_none):
                         is_null_cond = sqla_col.is_(None)
-                        if eq:
-                            cond = or_(is_null_cond, sqla_col.in_(eq_without_none))
+                        if eq_without_none:
+                            in_cond = (
+                                boolean_in_handler(sqla_col, eq_without_none)
+                                if callable(boolean_in_handler)
+                                else sqla_col.in_(eq_without_none)
+                            )
+                            cond = or_(is_null_cond, in_cond)
                         else:
                             cond = is_null_cond
+                    elif callable(boolean_in_handler):
+                        cond = boolean_in_handler(sqla_col, eq)
                     else:
                         cond = sqla_col.in_(eq)
                     if op == utils.FilterOperator.NOT_IN:

--- a/tests/integration_tests/db_engine_specs/databricks_tests.py
+++ b/tests/integration_tests/db_engine_specs/databricks_tests.py
@@ -16,6 +16,8 @@
 # under the License.
 from unittest import mock
 
+from sqlalchemy import Boolean, Column, false, MetaData, Table
+
 from superset.db_engine_specs import get_engine_spec
 from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
 from tests.integration_tests.base_tests import SupersetTestCase
@@ -59,3 +61,56 @@ class TestDatabricksDbEngineSpec(SupersetTestCase):
         extras = DatabricksNativeEngineSpec.get_extra_params(database)
         connect_args = extras["engine_params"]["connect_args"]
         assert connect_args["ssl"] == "1"
+
+    def test_handle_boolean_in_clause(self):
+        """
+        Boolean IN clauses should expand to equality checks against boolean
+        literals (Databricks rejects integer literals like 0/1 here), with
+        coerced values de-duplicated and no usable value yielding a constant
+        FALSE.
+        """
+
+        def compiled(expr):
+            return str(expr.compile(compile_kwargs={"literal_binds": True}))
+
+        metadata = MetaData()
+        test_table = Table(
+            "test_table",
+            metadata,
+            Column("is_test_user", Boolean),
+        )
+        sqla_col = test_table.c.is_test_user
+
+        # A single boolean compares against a literal, not an IN (...) list
+        result = DatabricksNativeEngineSpec.handle_boolean_in_clause(sqla_col, [False])
+        sql = compiled(result).lower()
+        assert "is_test_user = false" in sql
+        assert " in " not in sql
+
+        # Integers coerce to booleans; duplicates collapse to one term each
+        result = DatabricksNativeEngineSpec.handle_boolean_in_clause(
+            sqla_col, [0, 1, 1, False]
+        )
+        sql = compiled(result).lower()
+        assert sql.count("is_test_user") == 2  # only True and False survive
+        assert "true" in sql
+        assert "false" in sql
+
+        # String representations are parsed into booleans
+        result = DatabricksNativeEngineSpec.handle_boolean_in_clause(
+            sqla_col, ["false", "true"]
+        )
+        sql = compiled(result).lower()
+        assert "true" in sql
+        assert "false" in sql
+
+        # Only None / unrecognized values means nothing to match -> FALSE
+        assert str(
+            DatabricksNativeEngineSpec.handle_boolean_in_clause(sqla_col, [None])
+        ) == str(false())
+        assert str(
+            DatabricksNativeEngineSpec.handle_boolean_in_clause(sqla_col, ["maybe"])
+        ) == str(false())
+        assert str(
+            DatabricksNativeEngineSpec.handle_boolean_in_clause(sqla_col, [])
+        ) == str(false())


### PR DESCRIPTION

### SUMMARY
Fix native filter boolean column issue where Databricks queries failed due to type mismatch. The issue was that boolean values in IN clauses were being converted to integers (0/1) instead of boolean literals (True/False), causing Databricks to throw a `DATATYPE_MISMATCH.DATA_DIFF_TYPES` error. 

**Problem:** When creating a native filter with a boolean column, Superset was generating SQL like: WHERE is_test_user IN (0)This caused Databricks to fail with:

This caused Databricks to fail with:
Error: [DATATYPE_MISMATCH.DATA_DIFF_TYPES] Cannot resolve "(is_test_user IN (0))" due to data type mismatch: Input to `in` should all be the same type, but it's ["BOOLEAN", "INT"]. in `helpers.py` to detect boolean columns and use engine-specific handling when available
- Added test to verify boolean IN clause handling

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend SQL generation fix (no UI changes)

### TESTING INSTRUCTIONS
1. Create a native filter on a dashboard with a boolean column from a Databricks dataset
2. Set the filter value to `False` (or `True`)
3. Apply the filter and verify the query executes successfully without type mismatch errors
4. Check the generated SQL - it should use `column = FALSE` (or `column = TRUE`) instead of `column IN (0)`

**Expected Result:**
- Query executes successfully
- No `DATATYPE_MISMATCH` error
- SQL contains boolean literals, not integers

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36765
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No
Solution:
Added handle_boolean_in_clause method to DatabricksBaseEngineSpec that uses OR conditions with equality checks instead of IN clauses
Modified filter handling in helpers.py to detect boolean columns and use engine-specific handling when available
Added test to verify boolean IN clause handling

BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend SQL generation fix (no UI changes)

TESTING INSTRUCTIONS
1. Create a native filter on a dashboard with a boolean column from a Databricks dataset
2. Set the filter value to False (or True)
3. Apply the filter and verify the query executes successfully without type mismatch errors
4. Check the generated SQL - it should use column = FALSE (or column = TRUE) instead of column IN (0)

Expected Result:
1. Query executes successfully
2. No DATATYPE_MISMATCH error
3. SQL contains boolean literals, not integers

ADDITIONAL INFORMATION
[x] Has associated issue: Fixes #36765
[ ] Required feature flags: None
[ ] Changes UI: No
[ ] Includes DB Migration: No
[ ] Introduces new feature or API: No
[ ] Removes existing feature or API: N


___

## **CodeAnt-AI Description**
Fix Databricks boolean IN/NOT IN filters to use boolean literals

### What Changed
- Databricks now evaluates boolean IN/NOT IN filters using boolean literals (True/False) expressed as OR equality checks instead of integer-based IN clauses; mixed input like 0/1/"false"/"true" is normalized to booleans
- The filter builder detects boolean columns and delegates to the engine when available so Databricks-specific handling is applied only for boolean columns
- Empty or all-None boolean value lists produce a consistent always-false condition instead of causing type-mismatch; a unit test verifies these cases

### Impact
`✅ Fewer DATATYPE_MISMATCH errors on Databricks`
`✅ Correct boolean filter results on Databricks`
`✅ Shorter troubleshooting for native boolean filters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
