### PR TITLE
fix(database): handle undefined schema during CSV upload

### DIFF
--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -37,7 +37,7 @@ from superset.daos.database import DatabaseDAO
 from superset.models.core import Database
 from superset.sql.parse import Table
 from superset.utils.backports import StrEnum
-from superset.utils.core import get_user
+from superset.utils.core import get_user, parse_js_uri_path_item
 from superset.utils.decorators import on_error, transaction
 from superset.views.database.validators import schema_allows_file_upload
 
@@ -155,16 +155,17 @@ class UploadCommand(BaseCommand):
 
     @transaction(on_error=partial(on_error, reraise=DatabaseUploadSaveMetadataFailed))
     def run(self) -> None:
+        self._schema = parse_js_uri_path_item(
+            self._schema,
+            eval_undefined=True,
+        )
+        if self._schema is None:
+            logger.warning(
+                "File upload: schema was empty or undefined, using database default"
+            )
         self.validate()
         if not self._model:
             return
-
-        # Treat empty or frontend-sent "undefined" schema as no schema
-        if not self._schema or self._schema == "undefined":
-            logger.warning(
-                "CSV UPLOAD: schema was empty or undefined, using database default"
-            )
-            self._schema = None
 
         self._table_name, self._schema = (
             self._model.db_engine_spec.normalize_table_name_for_upload(

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -159,6 +159,13 @@ class UploadCommand(BaseCommand):
         if not self._model:
             return
 
+        # Treat empty or frontend-sent "undefined" schema as no schema
+        if not self._schema or self._schema == "undefined":
+            logger.warning(
+                "CSV UPLOAD: schema was empty or undefined, using database default"
+            )
+            self._schema = None
+
         self._table_name, self._schema = (
             self._model.db_engine_spec.normalize_table_name_for_upload(
                 self._table_name, self._schema

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -239,26 +239,18 @@ def test_csv_upload_schema_not_allowed():
             CSVReader({}),
         ).run()
 
-@pytest.mark.parametrize(
-    "schema",
-    ["", "undefined"],
-)
+@pytest.mark.parametrize("schema", ["", "undefined"])
 def test_upload_with_empty_or_undefined_schema(
-    app_context,
-    db,
+    setup_csv_upload_with_context,
     schema,
 ):
-    from superset.commands.database.uploaders.csv import CsvUploadCommand
+    upload_db_id, table_name, csv_file, reader = setup_csv_upload_with_context
 
-    payload = {
-        "database_id": db.id,
-        "table_name": "test_upload_schema_default",
-        "schema": schema,
-        "delimiter": ",",
-        "file": "a,b\n1,2\n",
-    }
+    UploadCommand(
+        upload_db_id,
+        table_name,
+        csv_file,
+        schema,
+        reader,
+    ).run()
 
-    command = CsvUploadCommand(payload)
-    result = command.run()
-
-    assert result is not None

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -238,3 +238,27 @@ def test_csv_upload_schema_not_allowed():
             "public",
             CSVReader({}),
         ).run()
+
+@pytest.mark.parametrize(
+    "schema",
+    ["", "undefined"],
+)
+def test_upload_with_empty_or_undefined_schema(
+    app_context,
+    db,
+    schema,
+):
+    from superset.commands.database.uploaders.csv import CsvUploadCommand
+
+    payload = {
+        "database_id": db.id,
+        "table_name": "test_upload_schema_default",
+        "schema": schema,
+        "delimiter": ",",
+        "file": "a,b\n1,2\n",
+    }
+
+    command = CsvUploadCommand(payload)
+    result = command.run()
+
+    assert result is not None

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -241,16 +241,23 @@ def test_csv_upload_schema_not_allowed():
 
 
 @pytest.mark.parametrize("schema", ["", "undefined"])
-def test_upload_with_empty_or_undefined_schema(
-    setup_csv_upload_with_context,
-    schema,
-):
-    upload_db_id, table_name, csv_file, reader = setup_csv_upload_with_context()
+@pytest.mark.usefixtures("setup_csv_upload_with_context")
+def test_upload_with_empty_or_undefined_schema(schema):
+    admin_user = security_manager.find_user(username="admin")
+    upload_database = get_upload_db()
 
-    UploadCommand(
-        upload_db_id,
-        table_name,
-        csv_file,
-        schema,
-        reader,
-    ).run()
+    with override_user(admin_user):
+        UploadCommand(
+            upload_database.id,
+            CSV_UPLOAD_TABLE,
+            create_csv_file(CSV_FILE_1),
+            schema,
+            CSVReader({}),
+        ).run()
+
+    dataset = (
+        db.session.query(SqlaTable)
+        .filter_by(database_id=upload_database.id, table_name=CSV_UPLOAD_TABLE)
+        .one_or_none()
+    )
+    assert dataset is not None

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -239,12 +239,13 @@ def test_csv_upload_schema_not_allowed():
             CSVReader({}),
         ).run()
 
+
 @pytest.mark.parametrize("schema", ["", "undefined"])
 def test_upload_with_empty_or_undefined_schema(
     setup_csv_upload_with_context,
     schema,
 ):
-    upload_db_id, table_name, csv_file, reader = setup_csv_upload_with_context
+    upload_db_id, table_name, csv_file, reader = setup_csv_upload_with_context()
 
     UploadCommand(
         upload_db_id,
@@ -253,4 +254,3 @@ def test_upload_with_empty_or_undefined_schema(
         schema,
         reader,
     ).run()
-


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### Summary
Fixes #36305 

### What changed
- Treat empty or "undefined" schema as no schema
- Let the database apply its default schema instead
- Prevents InvalidSchemaName errors during CSV upload

###Demo

#Before:
<img width="1590" height="844" alt="image" src="https://github.com/user-attachments/assets/4069baa1-83ac-47cb-8e55-1c904e156391" />

#After:

https://github.com/user-attachments/assets/f5519586-f227-4d12-9e56-661c24a79667


### Reproduction
1. Upload CSV
2. Leave schema empty
3. Upload previously failed, now succeeds


___

## **CodeAnt-AI Description**
Handle empty or "undefined" schema values during CSV upload so database defaults are used

### What Changed
- If the uploaded CSV specifies an empty string or the literal "undefined" for schema, the uploader now treats that as no schema and lets the database apply its default
- A warning is logged when this fallback occurs to aid debugging
- Prevents failures during CSV upload caused by invalid or frontend-sent "undefined" schema values

### Impact
`✅ Fewer CSV upload failures when schema is blank`
`✅ Successful uploads when frontend sends "undefined" for schema`
`✅ Clearer logs for schema-related upload fallbacks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
