### PR TITLE
fix(deckgl): respect stroked toggle for polygon line width

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
@@ -212,7 +212,7 @@ export const getLayer: GetLayerType<PolygonLayer> = function ({
     getPolygon: getPointsFromPolygon,
     getFillColor: colorScaler,
     getLineColor: sc ? [sc.r, sc.g, sc.b, 255 * sc.a] : undefined,
-    lineWidthMinPixels: fd.stroked ? fd.line_width : 0,
+    getLineWidth: fd.stroked ? fd.line_width : 0,
     extruded: fd.extruded,
     lineWidthUnits: fd.line_width_unit,
     getElevation: (d: JsonObject) => getElevation(d, colorScaler),

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/Polygon.tsx
@@ -212,7 +212,7 @@ export const getLayer: GetLayerType<PolygonLayer> = function ({
     getPolygon: getPointsFromPolygon,
     getFillColor: colorScaler,
     getLineColor: sc ? [sc.r, sc.g, sc.b, 255 * sc.a] : undefined,
-    getLineWidth: fd.line_width,
+    lineWidthMinPixels: fd.stroked ? fd.line_width : 0,
     extruded: fd.extruded,
     lineWidthUnits: fd.line_width_unit,
     getElevation: (d: JsonObject) => getElevation(d, colorScaler),


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### Summary
Fixes an issue in the Deck.gl Polygon chart where `lineWidth` was applied even when the **Stroked** toggle was disabled.

### What changed
- Apply `lineWidth` only when `stroked === true`
- Aligns polygon outline behavior with user expectations and other Deck.gl layers

### Before
- Polygon outlines were rendered even when **Stroked** was disabled
- Changing **Line width** had a visible effect regardless of the toggle state

### Demo
**Before / After:** Line width is now applied only when *Stroked* is enabled.

https://github.com/user-attachments/assets/294ac366-1496-4a96-9bb1-3407d0277f9c  
https://github.com/user-attachments/assets/4ca12fe8-686c-4ec4-b9f0-bab098bed55f

### After
- Polygon outlines are rendered **only** when **Stroked** is enabled
- **Line width** has no effect when **Stroked** is disabled

### Testing
- Verified locally using `docker-compose-non-dev`
- Confirmed UI behavior by toggling **Stroked** and adjusting **Line width**
- `pre-commit` checks passed


___

## **CodeAnt-AI Description**
Respect Stroked toggle when rendering polygon outlines

### What Changed
- Polygon outline width is now applied only when the "Stroked" toggle is enabled
- When "Stroked" is disabled, polygons render with no outline regardless of the Line width setting
- Line width units and other polygon behaviors remain unchanged

### Impact
`✅ Fewer unexpected polygon outlines`
`✅ Clearer stroke control behavior in chart settings`
`✅ Consistent polygon rendering between toggles`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
