### PR TITLE
fix(TableCollection): only apply highlight class when defined

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -248,7 +248,7 @@ test('should not apply highlight class when highlightRowId is undefined', () => 
   };
 
   const { container } = render(<TableCollection {...propsWithoutHighlight} />);
-  
+
   // Check that no rows have the highlight class
   const highlightedRows = container.querySelectorAll('.table-row-highlighted');
   expect(highlightedRows).toHaveLength(0);
@@ -261,7 +261,7 @@ test('should not apply highlight class when highlightRowId is null', () => {
   };
 
   const { container } = render(<TableCollection {...propsWithNullHighlight} />);
-  
+
   // Check that no rows have the highlight class
   const highlightedRows = container.querySelectorAll('.table-row-highlighted');
   expect(highlightedRows).toHaveLength(0);
@@ -291,7 +291,9 @@ test('should apply highlight class only to matching row when highlightRowId is p
   ];
 
   // Create new table hook with data that has ids
-  const { result } = renderHook(() => useTable({ columns: tableHook.columns, data: dataWithIds }));
+  const { result } = renderHook(() =>
+    useTable({ columns: tableHook.columns, data: dataWithIds }),
+  );
   const newTableHook = result.current;
 
   const propsWithHighlight = {
@@ -302,7 +304,7 @@ test('should apply highlight class only to matching row when highlightRowId is p
   };
 
   const { container } = render(<TableCollection {...propsWithHighlight} />);
-  
+
   // Check that only one row has the highlight class
   const highlightedRows = container.querySelectorAll('.table-row-highlighted');
   expect(highlightedRows).toHaveLength(1);
@@ -316,7 +318,7 @@ test('should not apply highlight when records have no id field and highlightRowI
   };
 
   const { container } = render(<TableCollection {...propsWithNoIds} />);
-  
+
   // Check that no rows have the highlight class (was the bug: all rows were highlighted)
   const highlightedRows = container.querySelectorAll('.table-row-highlighted');
   expect(highlightedRows).toHaveLength(0);

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -240,3 +240,84 @@ test('should call setSortBy when clicking sortable column header', () => {
     },
   ]);
 });
+
+test('should not apply highlight class when highlightRowId is undefined', () => {
+  const propsWithoutHighlight = {
+    ...defaultProps,
+    highlightRowId: undefined,
+  };
+
+  const { container } = render(<TableCollection {...propsWithoutHighlight} />);
+  
+  // Check that no rows have the highlight class
+  const highlightedRows = container.querySelectorAll('.table-row-highlighted');
+  expect(highlightedRows).toHaveLength(0);
+});
+
+test('should not apply highlight class when highlightRowId is null', () => {
+  const propsWithNullHighlight = {
+    ...defaultProps,
+    highlightRowId: null,
+  };
+
+  const { container } = render(<TableCollection {...propsWithNullHighlight} />);
+  
+  // Check that no rows have the highlight class
+  const highlightedRows = container.querySelectorAll('.table-row-highlighted');
+  expect(highlightedRows).toHaveLength(0);
+});
+
+test('should apply highlight class only to matching row when highlightRowId is provided', () => {
+  // Create data where the first row has id: 1 to match highlightRowId: 1
+  const dataWithIds = [
+    {
+      col1: 'Line 01 - Col 01',
+      col2: 'Line 01 - Col 02',
+      id: 1, // This should be highlighted
+      parent: { child: 'Nested Value 1' },
+    },
+    {
+      col1: 'Line 02 - Col 01',
+      col2: 'Line 02 - Col 02',
+      id: 2,
+      parent: { child: 'Nested Value 2' },
+    },
+    {
+      col1: 'Line 03 - Col 01',
+      col2: 'Line 03 - Col 02',
+      id: 3,
+      parent: { child: 'Nested Value 3' },
+    },
+  ];
+
+  // Create new table hook with data that has ids
+  const { result } = renderHook(() => useTable({ columns: tableHook.columns, data: dataWithIds }));
+  const newTableHook = result.current;
+
+  const propsWithHighlight = {
+    ...defaultProps,
+    highlightRowId: 1,
+    rows: newTableHook.rows,
+    prepareRow: newTableHook.prepareRow,
+  };
+
+  const { container } = render(<TableCollection {...propsWithHighlight} />);
+  
+  // Check that only one row has the highlight class
+  const highlightedRows = container.querySelectorAll('.table-row-highlighted');
+  expect(highlightedRows).toHaveLength(1);
+});
+
+test('should not apply highlight when records have no id field and highlightRowId is undefined', () => {
+  // This is the key test for the bug fix - use original data without id field
+  const propsWithNoIds = {
+    ...defaultProps,
+    highlightRowId: undefined,
+  };
+
+  const { container } = render(<TableCollection {...propsWithNoIds} />);
+  
+  // Check that no rows have the highlight class (was the bug: all rows were highlighted)
+  const highlightedRows = container.querySelectorAll('.table-row-highlighted');
+  expect(highlightedRows).toHaveLength(0);
+});

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -280,7 +280,9 @@ function TableCollection<T extends object>({
 
   const getRowClassName = useCallback(
     (record: Record<string, unknown>) =>
-      record?.id === highlightRowId ? 'table-row-highlighted' : '',
+      highlightRowId !== undefined && record?.id === highlightRowId
+        ? 'table-row-highlighted'
+        : '',
     [highlightRowId],
   );
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  Fix an issue where the TableCollection component incorrectly applies the highlight CSS class to all rows when `highlightRowId` is undefined. The component was checking `record?.id ===
  highlightRowId` which evaluates to true when both values are undefined, causing all rows without an id field to be highlighted.

  The fix adds an explicit check to ensure `highlightRowId` is defined before applying the highlight class, preventing unintended highlighting of all rows when no row should be
  highlighted.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
<img width="1688" height="1154" alt="image" src="https://github.com/user-attachments/assets/114dfb7f-d90c-49a7-9d6d-ac58fe8f814a" />

After:
<img width="1688" height="1154" alt="image" src="https://github.com/user-attachments/assets/debb9261-2148-46c3-9ab3-91917c872d1e" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run the new unit tests: `npm run test -- TableCollection.test.tsx`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
