### PR TITLE
fix: Stale editor content in @apache-superset/core

### DIFF
--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -60,8 +60,14 @@ const activeEditorId = () => {
 };
 
 const findQueryEditor = (editorId: string) => {
-  const { queryEditors } = getSqlLabState();
-  return queryEditors.find(editor => editor.id === editorId);
+  const { queryEditors, unsavedQueryEditor } = getSqlLabState();
+  const editor = queryEditors.find(qe => qe.id === editorId);
+  if (!editor) return undefined;
+  // Merge unsaved changes
+  if (unsavedQueryEditor?.id === editorId) {
+    return { ...editor, ...unsavedQueryEditor };
+  }
+  return editor;
 };
 
 const createTab = (


### PR DESCRIPTION
## **User description**
### SUMMARY
Fix a bug in `@apache-superset/core` where the returned editor content was stale given that the implementation was not considering unsaved changes.

### TESTING INSTRUCTIONS
CI should be sufficient.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Show unsaved query edits in SQL editor tabs

### What Changed
- When retrieving a SQL editor tab, the returned editor now includes any unsaved edits so the UI reflects the current in-memory content instead of the last saved state
- No-op for tabs without unsaved changes; behavior only changes when there is an unsaved editor for the requested tab

### Impact
`✅ Visible unsaved changes in editor tabs`
`✅ Fewer stale-query displays when switching tabs`
`✅ Reduced confusion about lost edits`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
