### PR TITLE
fix(TableChart): render cell bars for columns with NULL values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -67,8 +67,10 @@ function getValueRange(
   alignPositiveNegative: boolean,
   data: InputData[],
 ) {
-  if (typeof data?.[0]?.[key] === 'number') {
-    const nums = data.map(row => row[key]) as number[];
+  const nums = data
+    .map(row => row[key])
+    .filter(value => typeof value === 'number') as number[];
+  if (nums.length > 0) {
     return (
       alignPositiveNegative ? [0, d3Max(nums.map(Math.abs))] : d3Extent(nums)
     ) as ValueRange;

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -68,12 +68,21 @@ function getValueRange(
   data: InputData[],
 ) {
   const nums = data
-    .map(row => row[key])
-    .filter(value => typeof value === 'number') as number[];
+    .map(row => {
+      const raw = row[key];
+      return raw instanceof Number ? raw.valueOf() : raw;
+    })
+    .filter(
+      (value): value is number =>
+        typeof value === 'number' && Number.isFinite(value),
+    ) as number[];
   if (nums.length > 0) {
-    return (
-      alignPositiveNegative ? [0, d3Max(nums.map(Math.abs))] : d3Extent(nums)
-    ) as ValueRange;
+    const maxAbs = d3Max(nums.map(Math.abs));
+    if (alignPositiveNegative) {
+      return [0, maxAbs ?? 0] as ValueRange;
+    }
+    const extent = d3Extent(nums) as ValueRange | undefined;
+    return extent ?? [0, 0];
   }
   return null;
 }

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -385,7 +385,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       const nums = data
         ?.map(row => row?.[key])
         .filter(value => typeof value === 'number') as number[];
-      if (data && nums.length === data.length) {
+      if (nums.length > 0) {
         return (
           alignPositiveNegative
             ? [0, d3Max(nums.map(Math.abs))]
@@ -958,6 +958,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             display: block;
             top: 0;
             ${valueRange &&
+            typeof value === 'number' &&
             `
                 width: ${`${cellWidth({
                   value: value as number,


### PR DESCRIPTION
## **User description**
### SUMMARY
**Bug**: Table chart cell bars didn't render for columns containing NULL values, even when other rows had valid numeric data.

**Root Cause**: The `getValueRange` function required all values in a column to be numeric (`nums.length === data.length`). If any cell was NULL, the column returned `null` and no bars were rendered.

**Solution**:
1. Changed the condition to require at least one numeric value (`nums.length > 0`) instead of all values being numeric.
2. Added a type check (`typeof value === 'number'`) before rendering cell bars to prevent `BigInt` values from causing `Math.abs` errors.

**Result**: Columns with NULL values now render bars for non-NULL numeric cells, and `BigInt` values are safely excluded from bar rendering.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
### Before
<img width="2816" height="1502" alt="image" src="https://github.com/user-attachments/assets/a7468ad9-7521-45b7-b4bf-a8bd7e595581" />

### After
<img width="1433" height="434" alt="image" src="https://github.com/user-attachments/assets/ef3d91b1-da2b-4428-970f-a69bb766d57d" />


### TESTING INSTRUCTIONS
1. Create a table chart with a dataset containing columns with mixed NULL and numeric values
2. Enable "Show cell bars" in the chart configuration
4. Verify that numeric cells display bars even when other cells in the same column are NULL
5. Verify that BigInt values don't cause rendering errors

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Render cell bars for numeric cells even when the column contains NULLs

### What Changed
- Table columns now compute ranges using only numeric cells so columns with some NULL values still show bars for non-NULL numeric cells
- Cell bar rendering now verifies a value is a JavaScript number before calculating width/offset, preventing errors from non-number types like BigInt
- Added a unit test that checks a column with NULLs still renders bars for its numeric cells

### Impact
`✅ Cell bars appear in columns with mixed NULL and numeric values`
`✅ Fewer rendering errors caused by non-number values (e.g., BigInt)`
`✅ Reduced regression risk via automated test coverage`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
