### PR TITLE
fix(chart-creation): use exact match when loading dataset from URL parameter

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/Footer.test.tsx
@@ -37,6 +37,7 @@ const mockCreateResource = jest.fn();
 jest.mock('src/views/CRUD/hooks', () => ({
   useSingleViewResource: () => ({
     createResource: mockCreateResource,
+    state: { loading: false },
   }),
   getDatabaseDocumentationLinks: () => ({
     support:

--- a/superset-frontend/src/features/datasets/AddDataset/Footer/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/Footer/index.tsx
@@ -63,11 +63,10 @@ function Footer({
 }: FooterProps) {
   const history = useHistory();
   const theme = useTheme();
-  const { createResource } = useSingleViewResource<Partial<DatasetObject>>(
-    'dataset',
-    t('dataset'),
-    addDangerToast,
-  );
+  const { createResource, state } = useSingleViewResource<
+    Partial<DatasetObject>
+  >('dataset', t('dataset'), addDangerToast);
+  const { loading } = state;
 
   const createLogAction = (dataset: Partial<DatasetObject>) => {
     let totalCount = 0;
@@ -149,6 +148,7 @@ function Footer({
       <DropdownButton
         type="primary"
         disabled={disabledCheck}
+        loading={loading}
         tooltip={!datasetObject?.table_name ? tooltipText : undefined}
         onClick={() => onSave(true)}
         popupRender={() => dropdownMenu}

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import { createMemoryHistory } from 'history';
 import { ChartCreation } from 'src/pages/ChartCreation';

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -191,7 +191,7 @@ export class ChartCreation extends PureComponent<
   componentDidMount() {
     const params = new URLSearchParams(window.location.search).get('dataset');
     if (params) {
-      this.loadDatasources(params, 0, 1).then(r => {
+      this.loadDatasources(params, 0, 1, true).then(r => {
         const datasource = r.data[0];
         this.setState({ datasource });
       });
@@ -230,7 +230,12 @@ export class ChartCreation extends PureComponent<
     }
   }
 
-  loadDatasources(search: string, page: number, pageSize: number) {
+  loadDatasources(
+    search: string,
+    page: number,
+    pageSize: number,
+    exactMatch = false,
+  ) {
     const query = rison.encode({
       columns: [
         'id',
@@ -239,7 +244,9 @@ export class ChartCreation extends PureComponent<
         'database.database_name',
         'schema',
       ],
-      filters: [{ col: 'table_name', opr: 'ct', value: search }],
+      filters: [
+        { col: 'table_name', opr: exactMatch ? 'eq' : 'ct', value: search },
+      ],
       page,
       page_size: pageSize,
       order_column: 'table_name',

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -24,7 +24,12 @@ import { withTheme, Theme } from '@emotion/react';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { FilterPlugins, URL_PARAMS } from 'src/constants';
 import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
-import { AsyncSelect, Button, Steps } from '@superset-ui/core/components';
+import {
+  AsyncSelect,
+  Button,
+  Loading,
+  Steps,
+} from '@superset-ui/core/components';
 import withToasts from 'src/components/MessageToasts/withToasts';
 
 import VizTypeGallery, {
@@ -50,6 +55,7 @@ export type ChartCreationState = {
   datasetName?: string | string[] | null;
   vizType: string | null;
   canCreateDataset: boolean;
+  loading: boolean;
 };
 
 const ESTIMATED_NAV_HEIGHT = 56;
@@ -172,6 +178,9 @@ export class ChartCreation extends PureComponent<
 > {
   constructor(props: ChartCreationProps) {
     super(props);
+    const hasDatasetParam = new URLSearchParams(window.location.search).has(
+      'dataset',
+    );
     this.state = {
       vizType: null,
       canCreateDataset: findPermission(
@@ -179,6 +188,7 @@ export class ChartCreation extends PureComponent<
         'Dataset',
         props.user.roles,
       ),
+      loading: hasDatasetParam,
     };
 
     this.changeDatasource = this.changeDatasource.bind(this);
@@ -191,10 +201,14 @@ export class ChartCreation extends PureComponent<
   componentDidMount() {
     const params = new URLSearchParams(window.location.search).get('dataset');
     if (params) {
-      this.loadDatasources(params, 0, 1, true).then(r => {
-        const datasource = r.data[0];
-        this.setState({ datasource });
-      });
+      this.loadDatasources(params, 0, 1, true)
+        .then(r => {
+          const datasource = r.data[0];
+          this.setState({ datasource, loading: false });
+        })
+        .catch(() => {
+          this.setState({ loading: false });
+        });
       this.props.addSuccessToast(t('The dataset has been saved'));
     }
   }
@@ -307,6 +321,10 @@ export class ChartCreation extends PureComponent<
         .
       </span>
     );
+
+    if (this.state.loading) {
+      return <Loading />;
+    }
 
     return (
       <StyledContainer>


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When creating a dataset and being redirected to `/chart/add?dataset=flights`, the page was incorrectly selecting fake_flights instead of flights because the API used `ct (contains)` operator which matches any dataset containing "flights" and results are sorted alphabetically, so fake_flights comes before flights.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before

https://github.com/user-attachments/assets/63e6d049-41c7-4b81-9d67-ec790129cd37

- After

https://github.com/user-attachments/assets/70535643-32e9-4009-8f9c-4cef164bb6a6

- Spinner
<img width="1646" height="1241" alt="Screenshot 2025-12-30 120719" src="https://github.com/user-attachments/assets/0de72663-6dc5-420e-b838-11b2cd432fdd" />

https://github.com/user-attachments/assets/8f3220c8-a58f-4180-96fc-345498eac863



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- All tests should pass
- See the video above  for the reproduction steps

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
es new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Use exact dataset name when loading dataset from URL and keep contains for dropdown search

### What Changed
- When the page is opened with ?dataset=<name>, the dataset lookup uses an exact match so the correct dataset is selected instead of a partial alphabetic match
- Typing into the Dataset dropdown still uses a "contains" search so results match substrings during user search
- Added tests that verify the exact-match URL behavior, the contains behavior for dropdown search, and correct handling of URL-encoded special characters in dataset names

### Impact
`✅ Fewer incorrect dataset selections when opening chart creation via URL`
`✅ Clearer behavior for dataset lookup with special characters in URL`
`✅ Reduced chance of selecting the wrong dataset after redirect`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
h of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 of code health.

</details>
ry, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 of code health.

</details>
y maintains high standards of code health.

</details>
 of code health.

</details>
