### PR TITLE
fix(treemap): restore sequential coloring + remove label box, 1px gap (fixes #36807)

### DIFF
--- a/superset-frontend/packages/superset-ui-switchboard/src/switchboard.ts
+++ b/superset-frontend/packages/superset-ui-switchboard/src/switchboard.ts
@@ -149,26 +149,26 @@ export class Switchboard {
   }: GetMessage): Promise<ReplyMessage | ErrorMessage> {
     const executor = this.methods[method];
     if (executor == null) {
-      return <ErrorMessage>{
+      return {
         switchboardAction: Actions.ERROR,
         messageId,
         error: `[${this.name}] Method "${method}" is not defined`,
-      };
+      } as ErrorMessage;
     }
     try {
       const result = await executor(args);
-      return <ReplyMessage>{
+      return {
         switchboardAction: Actions.REPLY,
         messageId,
         result,
-      };
+      } as ReplyMessage;
     } catch (err) {
       this.logError(err);
-      return <ErrorMessage>{
+      return {
         switchboardAction: Actions.ERROR,
         messageId,
         error: `[${this.name}] Method "${method}" threw an error`,
-      };
+      } as ErrorMessage;
     }
   }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/constants.ts
@@ -21,8 +21,10 @@ import { TreePathInfo } from '../types';
 
 export const COLOR_SATURATION = [0.7, 0.4];
 export const LABEL_FONTSIZE = 11;
-export const BORDER_WIDTH = 2;
-export const GAP_WIDTH = 2;
+// Reduce default border/gap to remove the thin visual gap around labels
+// These values can be exposed later as controls if needed
+export const BORDER_WIDTH = 0;
+export const GAP_WIDTH = 0;
 
 export const extractTreePathInfo = (
   treePathInfo: TreePathInfo[] | undefined,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -331,7 +331,7 @@ export default function transformProps(
     ).filter((c): c is string => !!c);
     if (inRangeColors.length === 0) {
       // Fall back to a safe theme color if no valid sequential colors are available
-      inRangeColors.push(theme?.colorPrimary ?? '#000000');
+      inRangeColors.push(theme.colorPrimary);
     }
     // assign visualMap in a type-safe way
     (echartOptions as any).visualMap = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Treemap/transformProps.ts
@@ -321,13 +321,18 @@ export default function transformProps(
     const startColor = colorFn('min', sliceId);
     const endColor = colorFn('max', sliceId);
     // try to pick a proper sequential palette from registry using the current colorScheme as a hint
-    const seqScheme = sequentialRegistry.get(
+    const seqScheme = sequentialRegistry?.get?.(
       (formData as any)?.linearColorScheme || (colorScheme as string),
     );
-    const inRangeColors: string[] =
+    const inRangeColors: string[] = (
       seqScheme?.colors && seqScheme.colors.length
         ? seqScheme.colors
-        : [startColor, endColor];
+        : [startColor, endColor]
+    ).filter((c): c is string => !!c);
+    if (inRangeColors.length === 0) {
+      // Fall back to a safe theme color if no valid sequential colors are available
+      inRangeColors.push(theme?.colorPrimary ?? '#000000');
+    }
     // assign visualMap in a type-safe way
     (echartOptions as any).visualMap = {
       show: false,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -85,7 +85,13 @@ describe('Treemap transformProps', () => {
   });
 
   it('auto mode: should NOT add visualMap for constant metric', () => {
-    const formDataConst = { ...formData } as any;
+    const formDataConst = {
+      colorScheme: 'bnbColors',
+      datasource: '3__table',
+      granularity_sqla: 'ds',
+      metric: 'sum__num',
+      groupby: ['foo', 'bar'],
+    } as any;
     const chartPropsConst = new ChartProps({
       formData: formDataConst,
       width: 800,
@@ -101,7 +107,6 @@ describe('Treemap transformProps', () => {
       theme: supersetTheme,
     });
     const result = transformProps(chartPropsConst as EchartsTreemapChartProps);
-    // @ts-ignore
-    expect(result.echartOptions.visualMap).toBeUndefined();
+    expect((result.echartOptions as any).visualMap).toBeUndefined();
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -74,4 +74,34 @@ describe('Treemap transformProps', () => {
       }),
     );
   });
+
+  it('auto mode: should add visualMap for numeric varying metric', () => {
+    const result = transformProps(chartProps as EchartsTreemapChartProps);
+    expect(result.echartOptions).toHaveProperty('visualMap');
+    // @ts-ignore
+    expect(result.echartOptions.visualMap.min).toBeCloseTo(2.5);
+    // @ts-ignore
+    expect(result.echartOptions.visualMap.max).toBeCloseTo(10);
+  });
+
+  it('auto mode: should NOT add visualMap for constant metric', () => {
+    const formDataConst = { ...formData } as any;
+    const chartPropsConst = new ChartProps({
+      formData: formDataConst,
+      width: 800,
+      height: 600,
+      queriesData: [
+        {
+          data: [
+            { foo: 'A', bar: 'b1', sum__num: 5 },
+            { foo: 'B', bar: 'b2', sum__num: 5 },
+          ],
+        },
+      ],
+      theme: supersetTheme,
+    });
+    const result = transformProps(chartPropsConst as EchartsTreemapChartProps);
+    // @ts-ignore
+    expect(result.echartOptions.visualMap).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## **User description**
### SUMMARY

- Restore sequential (continuous) coloring for Treemap when a numeric metric with varying values is present, while preserving categorical coloring for categorical/constant metrics.

- Remove boxed label appearance and eliminate the 1px gap by default.

- Ensure de-emphasized (filtered-out) nodes are muted via opacity rather than overriding their color so gradients remain visible.

- Add unit tests to prevent regressions.

### BEFORE/AFTER SCREENSHOTS 

-- BEFORE :
<img width="1197" height="472" alt="image" src="https://github.com/user-attachments/assets/5a4aa081-da11-46ee-9dcb-3a34b3086e48" />

-- AFTER :
<img width="1912" height="891" alt="image" src="https://github.com/user-attachments/assets/33126169-c337-495f-b120-d7a0786dbf50" />

<img width="1914" height="1023" alt="Screenshot 2025-12-27 204635" src="https://github.com/user-attachments/assets/ffd50512-53bf-4254-9edd-6f2b59d67b5f" />


### TESTING INSTRUCTIONS / FILES MODIFIED

- [`transformProps.ts`](plugins/plugin-chart-echarts/src/Treemap/transformProps.ts) — core logic and label/de-emphasis changes  
- [`constants.ts`](plugins/plugin-chart-echarts/src/Treemap/constants.ts) — adjusted defaults for `BORDER_WIDTH` / `GAP_WIDTH` to remove thin gap  
- [`transformProps.test.ts`](plugins/plugin-chart-echarts/test/transformProps.test.ts) — new/updated tests

###  What I Changed

- **Behavior**: Treemap now:
  - Automatically uses a sequential palette via the sequential scheme registry when metric values vary (`min !== max`).
  - Falls back to categorical palette behavior otherwise.
  - Uses opacity for de-emphasis instead of forcing a text color.

- **UI**: Labels no longer display a visible border/background by default, and that 1px gap.

- **Typing**: Replaced `@ts-ignore` with a typed assignment for `visualMap`.

- **Tests**: Added Jest tests validating `visualMap` existence for numeric-varying metric and absence for constant metrics.

### Fixes

- Closes: [#36807](https://github.com/apache/superset/issues/36807)


___

## **CodeAnt-AI Description**
Restore continuous coloring for numeric treemaps and remove boxed labels

### What Changed
- Treemap now shows a continuous/sequential color gradient when the metric column has varying numeric values; static/categorical metrics keep categorical colors.
- The visible label box and the thin 1px gap around labels are removed by default so labels render without a border or background.
- Filtered/de-emphasized nodes are muted using opacity so their color gradients remain visible instead of being overridden.
- Adds unit tests that verify sequential coloring is applied only for varying numeric metrics.

### Impact
`✅ Clearer sequential color gradients for numeric treemaps`
`✅ No boxed labels or thin gaps around treemap labels`
`✅ Filtered nodes retain underlying color gradients (better visual fidelity)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
