### PR TITLE
fix: disable recaptcha for LDAP authentication

### DIFF
--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -35,7 +35,7 @@ from flask import (
 )
 from flask_appbuilder import BaseView, Model, ModelView
 from flask_appbuilder.actions import action
-from flask_appbuilder.const import AUTH_OAUTH, AUTH_SAML
+from flask_appbuilder.const import AUTH_LDAP, AUTH_OAUTH, AUTH_SAML
 from flask_appbuilder.forms import DynamicForm
 from flask_appbuilder.models.sqla.filters import BaseFilter
 from flask_appbuilder.security.sqla.models import User
@@ -547,7 +547,7 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]
     frontend_config["AUTH_USER_REGISTRATION"] = auth_user_registration
     should_show_recaptcha = auth_user_registration and (
-        auth_type not in (AUTH_OAUTH, AUTH_SAML)
+        auth_type not in (AUTH_LDAP, AUTH_OAUTH, AUTH_SAML)
     )
 
     if auth_user_registration:

--- a/tests/unit_tests/views/test_bootstrap_auth.py
+++ b/tests/unit_tests/views/test_bootstrap_auth.py
@@ -23,6 +23,7 @@ from flask_appbuilder.const import (
     AUTH_DB,
     AUTH_LDAP,
     AUTH_OAUTH,
+    AUTH_REMOTE_USER,
     AUTH_SAML,
 )
 
@@ -95,19 +96,19 @@ def test_bootstrap_oauth_providers(app_context: None) -> None:
 
 @pytest.mark.parametrize(
     "auth_type",
-    [AUTH_OAUTH, AUTH_SAML],
+    [AUTH_LDAP, AUTH_OAUTH, AUTH_SAML],
 )
-def test_recaptcha_not_shown_for_federated_auth(
+def test_recaptcha_not_shown_for_external_auth(
     app_context: None,
     auth_type: int,
 ) -> None:
-    """Recaptcha should not be shown for OAuth or SAML auth types."""
+    """Recaptcha should not be shown for LDAP, OAuth, or SAML auth types."""
     from flask import current_app
 
     current_app.config["AUTH_TYPE"] = auth_type
     current_app.config["AUTH_USER_REGISTRATION"] = True
     current_app.config["AUTH_USER_REGISTRATION_ROLE"] = "Public"
-    current_app.config.pop("RECAPTCHA_PUBLIC_KEY", None)
+    current_app.config["RECAPTCHA_PUBLIC_KEY"] = "test-key"
 
     payload = _get_bootstrap()
 
@@ -116,13 +117,13 @@ def test_recaptcha_not_shown_for_federated_auth(
 
 @pytest.mark.parametrize(
     "auth_type",
-    [AUTH_DB, AUTH_LDAP],
+    [AUTH_DB, AUTH_REMOTE_USER],
 )
-def test_recaptcha_shown_for_non_federated_auth(
+def test_recaptcha_shown_for_non_external_auth(
     app_context: None,
     auth_type: int,
 ) -> None:
-    """Recaptcha should be shown for DB and LDAP auth types when registration is on."""
+    """Recaptcha should be shown for DB and remote-user auth when registration is on."""
     from flask import current_app
 
     current_app.config["AUTH_TYPE"] = auth_type
@@ -133,6 +134,40 @@ def test_recaptcha_shown_for_non_federated_auth(
     payload = _get_bootstrap()
 
     assert payload["conf"]["RECAPTCHA_PUBLIC_KEY"] == "test-key"
+
+
+def test_recaptcha_not_shown_without_user_registration(
+    app_context: None,
+) -> None:
+    """Recaptcha should not be shown when user registration is disabled."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = AUTH_DB
+    current_app.config["AUTH_USER_REGISTRATION"] = False
+    current_app.config["RECAPTCHA_PUBLIC_KEY"] = "test-key"
+
+    payload = _get_bootstrap()
+
+    assert payload["conf"]["AUTH_USER_REGISTRATION"] is False
+    assert "RECAPTCHA_PUBLIC_KEY" not in payload["conf"]
+
+
+def test_ldap_auth_with_registration_role_still_set(
+    app_context: None,
+) -> None:
+    """AUTH_USER_REGISTRATION_ROLE is still set for LDAP even without recaptcha."""
+    from flask import current_app
+
+    current_app.config["AUTH_TYPE"] = AUTH_LDAP
+    current_app.config["AUTH_USER_REGISTRATION"] = True
+    current_app.config["AUTH_USER_REGISTRATION_ROLE"] = "Gamma"
+    current_app.config["RECAPTCHA_PUBLIC_KEY"] = "test-key"
+
+    payload = _get_bootstrap()
+
+    assert payload["conf"]["AUTH_USER_REGISTRATION"] is True
+    assert payload["conf"]["AUTH_USER_REGISTRATION_ROLE"] == "Gamma"
+    assert "RECAPTCHA_PUBLIC_KEY" not in payload["conf"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

When `AUTH_TYPE` is `AUTH_LDAP`, users are provisioned against the LDAP directory rather than through Superset's self-registration form, so showing a reCAPTCHA (and requiring `RECAPTCHA_PUBLIC_KEY`) makes no sense for LDAP deployments.

Originally this PR also fixed an init failure when `RECAPTCHA_PUBLIC_KEY` was unset with LDAP auth. That crash has since been fixed on master by #37009, and master now also excludes OAuth and SAML from the reCAPTCHA check. After rebasing, this PR's remaining scope is:

- Add `AUTH_LDAP` to the auth types excluded from `should_show_recaptcha` in `superset/views/base.py`. The exclusion list is now `(AUTH_LDAP, AUTH_OAUTH, AUTH_SAML)`, i.e. reCAPTCHA is only sent to the frontend for `AUTH_DB` and `AUTH_REMOTE_USER` when self-registration is enabled.
- Extend the existing `tests/unit_tests/views/test_bootstrap_auth.py` (instead of adding a separate test file) to cover the LDAP case, strengthen the "not shown" test to assert the key is excluded even when configured, and add coverage for registration-disabled and `AUTH_USER_REGISTRATION_ROLE` behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only change to the bootstrap config payload.

### TESTING INSTRUCTIONS

1. Configure `AUTH_TYPE = AUTH_LDAP`, `AUTH_USER_REGISTRATION = True`, and set a `RECAPTCHA_PUBLIC_KEY`.
2. Load any page and inspect the bootstrap data: `RECAPTCHA_PUBLIC_KEY` is no longer present in `conf`.
3. Unit tests: `pytest tests/unit_tests/views/test_bootstrap_auth.py`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
