### PR TITLE
fix: SqlLab error when collapsing the left panel preview

### DIFF
--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1098,13 +1098,14 @@ export function reFetchQueryResults(query) {
 
 export function expandTable(table) {
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
+    const sync =
+      isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
       table.initialized
-      ? SupersetClient.post({
-          endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
-          postPayload: { expanded: true },
-        })
-      : Promise.resolve();
+        ? SupersetClient.post({
+            endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
+            postPayload: { expanded: true },
+          })
+        : Promise.resolve();
 
     return sync
       .then(() => dispatch({ type: EXPAND_TABLE, table }))
@@ -1123,13 +1124,14 @@ export function expandTable(table) {
 
 export function collapseTable(table) {
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
+    const sync =
+      isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
       table.initialized
-      ? SupersetClient.post({
-          endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
-          postPayload: { expanded: false },
-        })
-      : Promise.resolve();
+        ? SupersetClient.post({
+            endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
+            postPayload: { expanded: false },
+          })
+        : Promise.resolve();
 
     return sync
       .then(() => dispatch({ type: COLLAPSE_TABLE, table }))

--- a/superset-frontend/src/SqlLab/actions/sqlLab.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.js
@@ -1098,7 +1098,8 @@ export function reFetchQueryResults(query) {
 
 export function expandTable(table) {
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence)
+    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
+      table.initialized
       ? SupersetClient.post({
           endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
           postPayload: { expanded: true },
@@ -1122,7 +1123,8 @@ export function expandTable(table) {
 
 export function collapseTable(table) {
   return function (dispatch) {
-    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence)
+    const sync = isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
+      table.initialized
       ? SupersetClient.post({
           endpoint: encodeURI(`/tableschemaview/${table.id}/expanded`),
           postPayload: { expanded: false },

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.js
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.js
@@ -934,6 +934,10 @@ describe('async actions', () => {
     fetchMock.delete(updateTableSchemaEndpoint, {});
     fetchMock.post(updateTableSchemaEndpoint, JSON.stringify({ id: 1 }));
 
+    const updateTableSchemaExpandedEndpoint =
+      'glob:**/tableschemaview/*/expanded';
+    fetchMock.post(updateTableSchemaExpandedEndpoint, {});
+
     const getTableMetadataEndpoint =
       'glob:**/api/v1/database/*/table_metadata/*';
     fetchMock.get(getTableMetadataEndpoint, {});
@@ -1411,10 +1415,10 @@ describe('async actions', () => {
 
     // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('expandTable', () => {
-      test('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend when initialized', () => {
         expect.assertions(2);
 
-        const table = { id: 1 };
+        const table = { id: 1, initialized: true };
         const store = mockStore({});
         const expectedActions = [
           {
@@ -1424,17 +1428,108 @@ describe('async actions', () => {
         ];
         return store.dispatch(actions.expandTable(table)).then(() => {
           expect(store.getActions()).toEqual(expectedActions);
-          expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(1);
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(1);
+        });
+      });
+
+      test('does not call backend when table is not initialized', () => {
+        expect.assertions(2);
+
+        const table = { id: 'yVJPtuSackF', initialized: false };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.EXPAND_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.expandTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          // Check all POST calls to find the expanded endpoint
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+        });
+      });
+
+      test('does not call backend when initialized is undefined', () => {
+        expect.assertions(2);
+
+        const table = { id: 'yVJPtuSackF' };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.EXPAND_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.expandTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          // Check all POST calls to find the expanded endpoint
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+        });
+      });
+
+      test('does not call backend when feature flag is off', () => {
+        expect.assertions(2);
+
+        isFeatureEnabled.mockImplementation(
+          feature => !(feature === 'SQLLAB_BACKEND_PERSISTENCE'),
+        );
+
+        const table = { id: 1, initialized: true };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.EXPAND_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.expandTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          // Check all POST calls to find the expanded endpoint
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+          isFeatureEnabled.mockRestore();
         });
       });
     });
 
     // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
     describe('collapseTable', () => {
-      test('updates the table schema state in the backend', () => {
+      test('updates the table schema state in the backend when initialized', () => {
         expect.assertions(2);
 
-        const table = { id: 1 };
+        const table = { id: 1, initialized: true };
         const store = mockStore({});
         const expectedActions = [
           {
@@ -1444,7 +1539,95 @@ describe('async actions', () => {
         ];
         return store.dispatch(actions.collapseTable(table)).then(() => {
           expect(store.getActions()).toEqual(expectedActions);
-          expect(fetchMock.calls(updateTableSchemaEndpoint)).toHaveLength(1);
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(1);
+        });
+      });
+
+      test('does not call backend when table is not initialized', () => {
+        expect.assertions(2);
+
+        const table = { id: 'yVJPtuSackF', initialized: false };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.COLLAPSE_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.collapseTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+        });
+      });
+
+      test('does not call backend when initialized is undefined', () => {
+        expect.assertions(2);
+
+        const table = { id: 'yVJPtuSackF' };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.COLLAPSE_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.collapseTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+        });
+      });
+
+      test('does not call backend when feature flag is off', () => {
+        expect.assertions(2);
+
+        isFeatureEnabled.mockImplementation(
+          feature => !(feature === 'SQLLAB_BACKEND_PERSISTENCE'),
+        );
+
+        const table = { id: 1, initialized: true };
+        const store = mockStore({});
+        const expectedActions = [
+          {
+            type: actions.COLLAPSE_TABLE,
+            table,
+          },
+        ];
+        return store.dispatch(actions.collapseTable(table)).then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+          const expandedCalls = fetchMock
+            .calls()
+            .filter(
+              call =>
+                call[0] &&
+                call[0].includes('/tableschemaview/') &&
+                call[0].includes('/expanded'),
+            );
+          expect(expandedCalls).toHaveLength(0);
+          isFeatureEnabled.mockRestore();
         });
       });
     });


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixed the 404 when collapsing/expanding the table schema preview in SQL Lab. Updated `expandTable` and `collapseTable` to check `table.initialized` before making backend calls, matching the pattern in `removeTables`. If not initialized, they skip the backend calls and only update local state. Once initialized, expand/collapse calls persist to the backend.

### BEFORE

https://github.com/user-attachments/assets/a5029c2d-6e82-42cc-9080-a4c576be7aea

### AFTER

https://github.com/user-attachments/assets/c5bf029b-6084-4dac-be3a-f076fe24204d


### TESTING INSTRUCTIONS
1) Open SQL Lab
2) Select a table
3) Try to collapse the table column preview
4) User should be able to collapse the table info without an error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
fix: avoid backend calls when expanding/collapsing uninitialized SQL Lab tables

### What Changed
- Expanding or collapsing a table in SQL Lab no longer sends a backend request if the table metadata hasn't finished initializing or if the backend-persistence feature is disabled; the UI state still updates locally.
- When a table is initialized and backend persistence is enabled, expand/collapse actions continue to persist to the backend as before.
- Tests added and updated to verify no backend requests occur for uninitialized tables or when the feature flag is off, and to verify backend requests occur when initialized.

### Impact
`✅ Fewer SQL Lab 404 errors when collapsing/expanding schema preview`
`✅ No unnecessary backend requests for tables without metadata`
`✅ Persisted expand/collapse state only after table metadata is loaded`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
