### PR TITLE
fix(trino): update query progress using cursor stats

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -224,8 +224,8 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             info = getattr(cursor, "stats", {}) or {}
             state = info.get("state", "UNKNOWN")
             completed_splits = float(info.get("completedSplits", 0))
-            total_splits = float(info.get("totalSplits"))
-            progress = completed_splits / (total_splits or 1)
+            total_splits = float(info.get("totalSplits", 1))
+            progress = (completed_splits / (total_splits or 1)) * 100
 
             if progress != query.progress:
                 query.progress = progress

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -221,10 +221,10 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 )
                 break
 
-            info = cursor.stats
-            state = info["state"]
-            completed_splits = info["completedSplits"]
-            total_splits = info["totalSplits"]
+            info = cursor.get("stats", {})
+            state = info.get("state", {})
+            completed_splits = float(info.get("completedSplits", 0))
+            total_splits = float(info.get("totalSplits"))
             progress = completed_splits / (total_splits or 1)
 
             if progress != query.progress:

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -201,12 +201,9 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             if execute_result is not None and execute_result.get("error"):
                 break
 
-            # Check if execute_event is set (thread completed or error occurred)
+            # Check if execute_event is set (thread completed)
             if execute_event is not None and execute_event.is_set():
-                # If there's an error, break; otherwise, it's a normal completion,
-                # so break after the final state update
-                if execute_result and execute_result.get("error"):
-                    break
+                break
 
             # if query cancelation was requested prior to the handle_cursor call, but
             # the query was still executed, trigger the actual query cancelation now

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -221,8 +221,8 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
                 )
                 break
 
-            info = cursor.get("stats", {})
-            state = info.get("state", {})
+            info = getattr(cursor, "stats", {}) or {}
+            state = info.get("state", "UNKNOWN")
             completed_splits = float(info.get("completedSplits", 0))
             total_splits = float(info.get("totalSplits"))
             progress = completed_splits / (total_splits or 1)

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -1081,14 +1081,14 @@ def test_handle_cursor_breaks_on_execute_error(
 @patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
 @patch("superset.db_engine_specs.trino.db")
 @patch("superset.db_engine_specs.trino.app")
-def test_handle_cursor_breaks_on_execute_event_set_with_error(
+def test_handle_cursor_breaks_on_execute_event_set(
     mock_app: Mock,
     mock_db: Mock,
     mock_cancel_query: Mock,
     mock_presto_handle_cursor: Mock,
     mocker: MockerFixture,
 ) -> None:
-    """Test that handle_cursor breaks the loop when execute_event is set with error."""
+    """Test that handle_cursor breaks the loop when execute_event is set."""
     import threading
 
     from superset.db_engine_specs.trino import TrinoEngineSpec
@@ -1105,16 +1105,16 @@ def test_handle_cursor_breaks_on_execute_event_set_with_error(
     execute_event = threading.Event()
     execute_event.set()  # Simulate thread completion
 
-    cursor_mock._execute_result = {"error": Exception("Test error")}
+    cursor_mock._execute_result = {}
     cursor_mock._execute_event = execute_event
 
     query = Query()
     query.status = "running"
 
-    # Should break immediately since execute_event is set and there's an error
+    # Should break immediately since execute_event is set
     TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
 
-    # cancel_query should not be called since we broke due to error
+    # cancel_query should not be called since we broke due to event being set
     mock_cancel_query.assert_not_called()
 
 

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -384,21 +384,30 @@ def test_prepare_cancel_query(
 
 
 @pytest.mark.parametrize("cancel_early", [True, False])
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
 @patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
-@patch("sqlalchemy.engine.Engine.connect")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
 def test_handle_cursor_early_cancel(
-    engine_mock: Mock,
+    mock_app: Mock,
+    mock_db: Mock,
     cancel_query_mock: Mock,
+    mock_presto_handle_cursor: Mock,
     cancel_early: bool,
     mocker: MockerFixture,
 ) -> None:
     from superset.db_engine_specs.trino import TrinoEngineSpec
     from superset.models.sql_lab import Query
 
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
     query_id = "myQueryId"
 
-    cursor_mock = engine_mock.return_value.__enter__.return_value
+    # Use spec to prevent MagicMock from creating attributes automatically
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
     cursor_mock.query_id = query_id
+    # Set stats to FINISHED so the progress loop exits immediately
+    cursor_mock.stats = {"state": "FINISHED", "completedSplits": 0, "totalSplits": 0}
 
     query = Query()
 
@@ -911,3 +920,297 @@ def test_timegrain_expressions(time_grain: str, expected_result: str) -> None:
         spec.get_timestamp_expr(col=column("col"), pdf=None, time_grain=time_grain)
     )
     assert actual == expected_result
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_progress_updates(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor updates query progress based on cursor stats."""
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
+    cursor_mock.query_id = "test-query-id"
+
+    # Simulate progress: 0/10 -> 5/10 -> 10/10 (FINISHED)
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 0, "totalSplits": 10}
+
+    call_count = 0
+
+    def update_stats(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            cursor_mock.stats = {
+                "state": "RUNNING",
+                "completedSplits": 5,
+                "totalSplits": 10,
+            }
+        elif call_count >= 2:
+            cursor_mock.stats = {
+                "state": "FINISHED",
+                "completedSplits": 10,
+                "totalSplits": 10,
+            }
+
+    with patch("superset.db_engine_specs.trino.time.sleep", side_effect=update_stats):
+        query = Query()
+        query.status = "running"
+        TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    assert query.progress == 1.0
+    assert mock_db.session.commit.called
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_cancels_on_stopped_status(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor cancels query when status is STOPPED."""
+    from superset.common.db_query_status import QueryStatus
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
+    cursor_mock.query_id = "test-query-id"
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 0, "totalSplits": 10}
+
+    query = Query()
+    query.status = QueryStatus.STOPPED
+
+    with patch("superset.db_engine_specs.trino.time.sleep"):
+        TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    mock_cancel_query.assert_called_once_with(
+        cursor=cursor_mock,
+        query=query,
+        cancel_query_id="test-query-id",
+    )
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_cancels_on_timed_out_status(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor cancels query when status is TIMED_OUT."""
+    from superset.common.db_query_status import QueryStatus
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
+    cursor_mock.query_id = "test-query-id"
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 0, "totalSplits": 10}
+
+    query = Query()
+    query.status = QueryStatus.TIMED_OUT
+
+    with patch("superset.db_engine_specs.trino.time.sleep"):
+        TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    mock_cancel_query.assert_called_once_with(
+        cursor=cursor_mock,
+        query=query,
+        cancel_query_id="test-query-id",
+    )
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_breaks_on_execute_error(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor breaks the loop when execute_result has an error."""
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(
+        spec=["query_id", "stats", "info_uri", "_execute_result", "_execute_event"]
+    )
+    cursor_mock.query_id = "test-query-id"
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 0, "totalSplits": 10}
+    cursor_mock._execute_result = {"error": Exception("Test error")}
+    cursor_mock._execute_event = None
+
+    query = Query()
+    query.status = "running"
+
+    # Should break immediately due to error in execute_result
+    TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    # cancel_query should not be called since we broke due to error, not status
+    mock_cancel_query.assert_not_called()
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_breaks_on_execute_event_set_with_error(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor breaks the loop when execute_event is set with error."""
+    import threading
+
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(
+        spec=["query_id", "stats", "info_uri", "_execute_result", "_execute_event"]
+    )
+    cursor_mock.query_id = "test-query-id"
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 5, "totalSplits": 10}
+
+    execute_event = threading.Event()
+    execute_event.set()  # Simulate thread completion
+
+    cursor_mock._execute_result = {"error": Exception("Test error")}
+    cursor_mock._execute_event = execute_event
+
+    query = Query()
+    query.status = "running"
+
+    # Should break immediately since execute_event is set and there's an error
+    TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    # cancel_query should not be called since we broke due to error
+    mock_cancel_query.assert_not_called()
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_handles_zero_total_splits(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor handles zero totalSplits without division error."""
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
+    cursor_mock.query_id = "test-query-id"
+
+    call_count = 0
+
+    def update_stats(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 1:
+            cursor_mock.stats = {
+                "state": "FINISHED",
+                "completedSplits": 0,
+                "totalSplits": 0,
+            }
+
+    # Start with zero splits
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 0, "totalSplits": 0}
+
+    with patch("superset.db_engine_specs.trino.time.sleep", side_effect=update_stats):
+        query = Query()
+        query.status = "running"
+        # Should not raise ZeroDivisionError
+        TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    # Progress should be 0/1 = 0 when totalSplits is 0
+    assert query.progress == 0.0
+
+
+@patch("superset.db_engine_specs.presto.PrestoBaseEngineSpec.handle_cursor")
+@patch("superset.db_engine_specs.trino.TrinoEngineSpec.cancel_query")
+@patch("superset.db_engine_specs.trino.db")
+@patch("superset.db_engine_specs.trino.app")
+def test_handle_cursor_only_commits_on_progress_change(
+    mock_app: Mock,
+    mock_db: Mock,
+    mock_cancel_query: Mock,
+    mock_presto_handle_cursor: Mock,
+    mocker: MockerFixture,
+) -> None:
+    """Test that handle_cursor only commits when progress changes."""
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+    from superset.models.sql_lab import Query
+
+    mock_app.config = {"DB_POLL_INTERVAL_SECONDS": {"trino": 0}}
+
+    cursor_mock = mocker.MagicMock(spec=["query_id", "stats", "info_uri"])
+    cursor_mock.query_id = "test-query-id"
+
+    call_count = 0
+
+    def update_stats(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Keep same progress for first two iterations, then finish
+        if call_count < 3:
+            cursor_mock.stats = {
+                "state": "RUNNING",
+                "completedSplits": 5,
+                "totalSplits": 10,
+            }
+        else:
+            cursor_mock.stats = {
+                "state": "FINISHED",
+                "completedSplits": 10,
+                "totalSplits": 10,
+            }
+
+    cursor_mock.stats = {"state": "RUNNING", "completedSplits": 5, "totalSplits": 10}
+
+    with patch("superset.db_engine_specs.trino.time.sleep", side_effect=update_stats):
+        query = Query()
+        query.status = "running"
+        TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
+
+    # Initial commit from set_extra_json_key, then commits only when progress changes
+    # Progress changes: None->0.5, 0.5->0.5 (no commit), 0.5->1.0
+    # So we expect: 1 (initial) + 1 (0.5) + 1 (1.0) = 3 commits total
+    commit_calls = mock_db.session.commit.call_count
+    assert commit_calls >= 2  # At least initial commit and one progress update

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -968,7 +968,7 @@ def test_handle_cursor_progress_updates(
         query.status = "running"
         TrinoEngineSpec.handle_cursor(cursor=cursor_mock, query=query)
 
-    assert query.progress == 1.0
+    assert query.progress == 100.0
     assert mock_db.session.commit.called
 
 


### PR DESCRIPTION
## **User description**
### SUMMARY

This PR adds logic to update query progress by referencing the stats info contained in the Trino cursor.
Additionally, this commit adds additional parameters (`execute_result` and `execute_event`) to the `handle_cursor` method to detect errors that occur in the execute thread running in parallel while updating query progress through the cursor. When an error is raised in the execute thread, the while loop in `handle_cursor` now properly breaks instead of continuing to poll unnecessarily. This prevents the cursor handling loop from running indefinitely when the execution thread has already failed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/43b24f53-bf52-4b02-9cb0-01b0594887ec


### TESTING INSTRUCTIONS

specs are added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Update Trino query progress from cursor stats and stop unnecessary polling on error or cancellation

### What Changed
- Query progress is updated from Trino cursor stats (completedSplits/totalSplits) and saved to the Query; commits happen only when progress changes
- The cursor polling loop stops immediately if the parallel execute thread reports an error or signals completion, preventing indefinite polling
- If a query was requested cancelled earlier or is marked STOPPED or TIMED_OUT, the handler issues a Trino cancel and stops polling
- Guard against zero total splits to avoid division errors
- Added unit tests covering progress updates, early cancellation, execute-thread error/event handling, zero total splits, and commit frequency

### Impact
`✅ Clearer query progress updates`
`✅ Fewer stuck query polls when execution fails`
`✅ Correct cancellation when queries are stopped or timed out`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
