### PR TITLE
fix(dashboard): prevent PublishedLabel overlap in non-English languages

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ListViewCard/index.tsx
@@ -103,7 +103,8 @@ const TitleRight = styled.span`
 `;
 const CoverFooter = styled.div`
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  row-gap: ${({ theme }) => theme.sizeUnit}px;
   position: relative;
   top: -${({ theme }) => theme.sizeUnit * 9}px;
   padding: 0 8px;
@@ -111,6 +112,7 @@ const CoverFooter = styled.div`
 
 const CoverFooterLeft = styled.div`
   flex: 1;
+  min-width: 0;
   overflow: hidden;
 `;
 


### PR DESCRIPTION
### SUMMARY

Fixes the layout issue where the "Published"/"Draft" status label overlaps with the "Modified X ago" timestamp on dashboard cards when using non-English languages (German, Spanish, Russian, etc.).

**Root Cause:**
The `CoverFooter` component used `flex-wrap: nowrap`, which prevented the status label from wrapping to a new line when translated text was longer than English.

**Solution:**
1. Changed `flex-wrap` from `nowrap` to `wrap` in `CoverFooter`
2. Added `row-gap` for proper vertical spacing when content wraps
3. Added `min-width: 0` to `CoverFooterLeft` to override the default `min-width: auto`, allowing proper shrinking with `overflow: hidden` (standard flex ellipsis pattern used elsewhere in codebase)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before (German - text overlapping):**
![before](https://github.com/user-attachments/assets/da3f63fd-2c27-4307-8591-b35ee0322205)

**After (expected behavior):**
The status label will wrap to a new line when there's insufficient horizontal space, preventing overlap.

### TESTING INSTRUCTIONS

1. Change browser language to German, Spanish, or Russian
2. Navigate to the Welcome/Home page with dashboard cards
3. Verify that "Veröffentlicht" (German) or equivalent translated status labels no longer overlap with the timestamp
4. Resize browser window to verify responsive wrapping behavior

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #36357
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.