### PR TITLE
fix(table charts v1 & v2): pagination, translation and search by

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -119,7 +119,7 @@ export default typedMemo(function DataTable<D extends object>({
   onServerPaginationChange,
   rowCount,
   selectPageSize,
-  noResults: noResultsText = 'No data found',
+  noResults: noResultsText = t('No data found'),
   hooks,
   serverPagination,
   wrapperRef: userWrapperRef,

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -952,6 +952,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       i: number,
     ): ColumnWithLooseAccessor<D> & {
       columnKey: string;
+      columnLabel: string;
     } => {
       const {
         key,
@@ -1040,6 +1041,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         // typing is incorrect in current version of `@types/react-table`
         // so we ask TS not to check.
         columnKey: key,
+        columnLabel: label,
         accessor: ((datum: D) => datum[key]) as never,
         Cell: ({ value, row }: { value: DataRecordValue; row: Row<D> }) => {
           const [isHtml, text] = formatColumnValue(column, value, row.original);
@@ -1441,13 +1443,14 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       columns as unknown as ColumnWithLooseAccessor &
         {
           columnKey: string;
+          columnLabel: string;
           sortType?: string;
         }[]
     )
       .filter(col => col?.sortType === 'alphanumeric')
       .map(column => ({
         value: column.columnKey,
-        label: column.columnKey,
+        label: column.columnLabel,
       }));
 
     if (!isEqual(options, searchOptions)) {


### PR DESCRIPTION
### SUMMARY

Fixing several issues with "Table" and "Table V2" plugins.

"**Table**":
When server-side pagination is used, a "Search by" selector is displayed: it lists columns by their name rather than by their label, unlike the "Table V2" chart. I therefore made the necessary changes so that labels are used.
<img width="903" height="292" alt="image" src="https://github.com/user-attachments/assets/ba1ad8ab-bd58-45a0-9477-3d89656750a3" />

When "Search box" is unchecked "Search by" selector remains displayed - this is no longer the case
<img width="1396" height="578" alt="image" src="https://github.com/user-attachments/assets/7ec8718d-7893-4092-be74-95a4845d9988" />

"**Table V2**":
When server-side pagination is used, the "Page Size" selector does not behave as expected: the value configured for the chart is not applied correctly and the default value is applied (it is fine on initial display but is lost afterwards, for example when resizing the window).
<img width="901" height="526" alt="image" src="https://github.com/user-attachments/assets/2b6d1683-9fa2-4035-a79a-78bc06f3b39b" />


"**Table**" and "**Table V2**":
Some strings could not be translated because the "t()" function intended for this purpose was not used.


___

## **CodeAnt-AI Description**
**Use column labels for "Search by", persist page size, and add translations for table charts**

### What Changed
- "Search by" dropdown now shows column labels (not column keys) in both Table and Table V2 when using server-side pagination
- Page size selector in Table V2 respects and keeps the configured page size instead of reverting to the default during interactions (e.g., resize)
- Several UI strings (for example "Search by", "No data found", "Clear Sort") are translated so they appear using the app's localization

### Impact
`✅ Clearer search labels in table filters`
`✅ Page size persists across interactions`
`✅ Localized table UI strings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
