### PR TITLE
fix(deck.gl): Fix Scatterplot chart error when using fixed point size

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -44,18 +44,22 @@ function setTooltipContent(
   verboseMap?: Record<string, string>,
 ) {
   const defaultTooltipGenerator = (o: JsonObject) => {
-    // Check if point_radius_fixed is an object with type/value or just a value
+    // Only show metric info if point_radius_fixed is metric-based
     let metricKey = null;
-    if (formData.point_radius_fixed) {
-      if (typeof formData.point_radius_fixed === 'object' && formData.point_radius_fixed.type === 'metric') {
-        metricKey = formData.point_radius_fixed.value;
-      } else if (typeof formData.point_radius_fixed === 'string') {
-        metricKey = formData.point_radius_fixed;
+    if (formData.point_radius_fixed && typeof formData.point_radius_fixed === 'object' && formData.point_radius_fixed.type === 'metric') {
+      const metricValue = formData.point_radius_fixed.value;
+      if (typeof metricValue === 'string') {
+        metricKey = metricValue;
+      } else if (typeof metricValue === 'object' && metricValue) {
+        // Handle object metrics (adhoc or saved metrics)
+        metricKey = metricValue.label || metricValue.sqlExpression || metricValue.value;
       }
     }
     
-    const label = metricKey
-      ? (verboseMap?.[metricKey] || getMetricLabel(metricKey))
+    // Normalize metricKey for verboseMap lookup
+    const lookupKey = typeof metricKey === 'string' ? metricKey : null;
+    const label = lookupKey
+      ? (verboseMap?.[lookupKey] || getMetricLabel(lookupKey))
       : null;
     
     return (

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -44,9 +44,20 @@ function setTooltipContent(
   verboseMap?: Record<string, string>,
 ) {
   const defaultTooltipGenerator = (o: JsonObject) => {
-    const label =
-      verboseMap?.[formData.point_radius_fixed.value] ||
-      getMetricLabel(formData.point_radius_fixed?.value);
+    // Check if point_radius_fixed is an object with type/value or just a value
+    let metricKey = null;
+    if (formData.point_radius_fixed) {
+      if (typeof formData.point_radius_fixed === 'object' && formData.point_radius_fixed.type === 'metric') {
+        metricKey = formData.point_radius_fixed.value;
+      } else if (typeof formData.point_radius_fixed === 'string') {
+        metricKey = formData.point_radius_fixed;
+      }
+    }
+    
+    const label = metricKey
+      ? (verboseMap?.[metricKey] || getMetricLabel(metricKey))
+      : null;
+    
     return (
       <div className="deckgl-tooltip">
         <TooltipRow
@@ -59,7 +70,7 @@ function setTooltipContent(
             value={`${o.object?.cat_color}`}
           />
         )}
-        {o.object?.metric && (
+        {o.object?.metric && label && (
           <TooltipRow label={`${label}: `} value={`${o.object?.metric}`} />
         )}
       </div>

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ScatterplotLayer } from '@deck.gl/layers';
-import { JsonObject, QueryFormData, t, getMetricLabel } from '@superset-ui/core';
+import { JsonObject, QueryFormData, t } from '@superset-ui/core';
 import { isPointInBonds } from '../../utilities/utils';
 import { commonLayerProps } from '../common';
 import { createCategoricalDeckGLComponent, GetLayerType } from '../../factory';

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { ScatterplotLayer } from '@deck.gl/layers';
-import { JsonObject, QueryFormData, t } from '@superset-ui/core';
+import { JsonObject, QueryFormData, t, getMetricLabel } from '@superset-ui/core';
 import { isPointInBonds } from '../../utilities/utils';
 import { commonLayerProps } from '../common';
 import { createCategoricalDeckGLComponent, GetLayerType } from '../../factory';
@@ -25,6 +25,7 @@ import { createTooltipContent } from '../../utilities/tooltipUtils';
 import TooltipRow from '../../TooltipRow';
 import { unitToRadius } from '../../utils/geo';
 import { HIGHLIGHT_COLOR_ARRAY } from '../../utils';
+import { isMetricValue, extractMetricKey } from '../utils/metricUtils';
 
 function getMetricLabel(metric: any) {
   if (typeof metric === 'string') {
@@ -46,19 +47,8 @@ function setTooltipContent(
   const defaultTooltipGenerator = (o: JsonObject) => {
     // Only show metric info if point_radius_fixed is metric-based
     let metricKey = null;
-    if (
-      formData.point_radius_fixed &&
-      typeof formData.point_radius_fixed === 'object' &&
-      formData.point_radius_fixed.type === 'metric'
-    ) {
-      const metricValue = formData.point_radius_fixed.value;
-      if (typeof metricValue === 'string') {
-        metricKey = metricValue;
-      } else if (typeof metricValue === 'object' && metricValue) {
-        // Handle object metrics (adhoc or saved metrics)
-        metricKey =
-          metricValue.label || metricValue.sqlExpression || metricValue.value;
-      }
+    if (isMetricValue(formData.point_radius_fixed)) {
+      metricKey = extractMetricKey(formData.point_radius_fixed?.value);
     }
 
     // Normalize metricKey for verboseMap lookup

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/Scatter.tsx
@@ -46,22 +46,27 @@ function setTooltipContent(
   const defaultTooltipGenerator = (o: JsonObject) => {
     // Only show metric info if point_radius_fixed is metric-based
     let metricKey = null;
-    if (formData.point_radius_fixed && typeof formData.point_radius_fixed === 'object' && formData.point_radius_fixed.type === 'metric') {
+    if (
+      formData.point_radius_fixed &&
+      typeof formData.point_radius_fixed === 'object' &&
+      formData.point_radius_fixed.type === 'metric'
+    ) {
       const metricValue = formData.point_radius_fixed.value;
       if (typeof metricValue === 'string') {
         metricKey = metricValue;
       } else if (typeof metricValue === 'object' && metricValue) {
         // Handle object metrics (adhoc or saved metrics)
-        metricKey = metricValue.label || metricValue.sqlExpression || metricValue.value;
+        metricKey =
+          metricValue.label || metricValue.sqlExpression || metricValue.value;
       }
     }
-    
+
     // Normalize metricKey for verboseMap lookup
     const lookupKey = typeof metricKey === 'string' ? metricKey : null;
     const label = lookupKey
-      ? (verboseMap?.[lookupKey] || getMetricLabel(lookupKey))
+      ? verboseMap?.[lookupKey] || getMetricLabel(lookupKey)
       : null;
-    
+
     return (
       <div className="deckgl-tooltip">
         <TooltipRow

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
@@ -292,3 +292,21 @@ test('Scatter buildQuery should not modify existing metrics for fixed radius', (
 
   expect(query.metrics).toEqual(['COUNT(*)', 'SUM(value)']);
 });
+
+test('Scatter buildQuery should deduplicate metrics when radius metric already exists', () => {
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    metrics: ['COUNT(*)', 'AVG(price)'],
+    point_radius_fixed: {
+      type: 'metric',
+      value: 'AVG(price)',
+    },
+  };
+
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  // Should not have duplicate AVG(price)
+  expect(query.metrics).toEqual(['COUNT(*)', 'AVG(price)']);
+  expect(query.metrics).toHaveLength(2);
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import buildQuery, { DeckScatterFormData } from './buildQuery';
+
+const baseFormData: DeckScatterFormData = {
+  datasource: '1__table',
+  viz_type: 'deck_scatter',
+  spatial: {
+    type: 'latlong',
+    latCol: 'LATITUDE',
+    lonCol: 'LONGITUDE',
+  },
+  row_limit: 100,
+};
+
+test('Scatter buildQuery should not include metric when point_radius_fixed is fixed type', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.metrics).toEqual([]);
+    expect(query.orderby).toEqual([]);
+  });
+
+test('Scatter buildQuery should include metric when point_radius_fixed is metric type', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'metric',
+        value: 'AVG(radius_value)',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.metrics).toContain('AVG(radius_value)');
+    expect(query.orderby).toEqual([['AVG(radius_value)', false]]);
+  });
+
+test('Scatter buildQuery should handle numeric value in fixed type', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: 500,
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    // Fixed numeric value should not be included as a metric
+    expect(query.metrics).toEqual([]);
+    expect(query.orderby).toEqual([]);
+  });
+
+test('Scatter buildQuery should handle missing point_radius_fixed', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      // no point_radius_fixed
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.metrics).toEqual([]);
+    expect(query.orderby).toEqual([]);
+  });
+
+test('Scatter buildQuery should include spatial columns in query', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.columns).toContain('LATITUDE');
+    expect(query.columns).toContain('LONGITUDE');
+  });
+
+test('Scatter buildQuery should include dimension column when specified', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      dimension: 'category',
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.columns).toContain('category');
+  });
+
+test('Scatter buildQuery should add spatial null filters', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    const latFilter = query.filters?.find(
+      f => f.col === 'LATITUDE' && f.op === 'IS NOT NULL',
+    );
+    const lonFilter = query.filters?.find(
+      f => f.col === 'LONGITUDE' && f.op === 'IS NOT NULL',
+    );
+    
+    expect(latFilter).toBeDefined();
+    expect(lonFilter).toBeDefined();
+  });
+
+test('Scatter buildQuery should throw error when spatial is missing', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      spatial: undefined,
+    };
+
+    expect(() => buildQuery(formData)).toThrow(
+      'Spatial configuration is required for Scatter charts',
+    );
+  });
+
+test('Scatter buildQuery should handle geohash spatial type', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      spatial: {
+        type: 'geohash',
+        geohashCol: 'geohash_column',
+      },
+      point_radius_fixed: {
+        type: 'metric',
+        value: 'COUNT(*)',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.columns).toContain('geohash_column');
+    expect(query.metrics).toContain('COUNT(*)');
+  });
+
+test('Scatter buildQuery should handle tooltip_contents', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      tooltip_contents: ['name', 'description'],
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.columns).toContain('name');
+    expect(query.columns).toContain('description');
+  });
+
+test('Scatter buildQuery should handle js_columns', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      js_columns: ['custom_col1', 'custom_col2'],
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.columns).toContain('custom_col1');
+    expect(query.columns).toContain('custom_col2');
+  });
+
+test('Scatter buildQuery should convert numeric metric value to string', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'metric',
+        value: 123, // numeric metric (edge case)
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.metrics).toContain('123');
+    expect(query.orderby).toEqual([['123', false]]);
+  });
+
+test('Scatter buildQuery should set is_timeseries to false', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.is_timeseries).toBe(false);
+  });
+
+test('Scatter buildQuery should preserve row_limit', () => {
+    const formData: DeckScatterFormData = {
+      ...baseFormData,
+      row_limit: 5000,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
+      },
+    };
+
+    const queryContext = buildQuery(formData);
+    const [query] = queryContext.queries;
+    
+    expect(query.row_limit).toBe(5000);
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
@@ -258,3 +258,37 @@ test('Scatter buildQuery should preserve row_limit', () => {
     
     expect(query.row_limit).toBe(5000);
 });
+
+test('Scatter buildQuery should preserve existing metrics when adding radius metric', () => {
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    metrics: ['COUNT(*)'],
+    point_radius_fixed: {
+      type: 'metric',
+      value: 'AVG(radius_value)',
+    },
+  };
+
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+  
+  expect(query.metrics).toContain('COUNT(*)');
+  expect(query.metrics).toContain('AVG(radius_value)');
+  expect(query.metrics).toHaveLength(2);
+});
+
+test('Scatter buildQuery should not modify existing metrics for fixed radius', () => {
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    metrics: ['COUNT(*)', 'SUM(value)'],
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
+
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+  
+  expect(query.metrics).toEqual(['COUNT(*)', 'SUM(value)']);
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.test.ts
@@ -31,232 +31,232 @@ const baseFormData: DeckScatterFormData = {
 };
 
 test('Scatter buildQuery should not include metric when point_radius_fixed is fixed type', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.metrics).toEqual([]);
-    expect(query.orderby).toEqual([]);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.metrics).toEqual([]);
+  expect(query.orderby).toEqual([]);
+});
 
 test('Scatter buildQuery should include metric when point_radius_fixed is metric type', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'metric',
-        value: 'AVG(radius_value)',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'metric',
+      value: 'AVG(radius_value)',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.metrics).toContain('AVG(radius_value)');
-    expect(query.orderby).toEqual([['AVG(radius_value)', false]]);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.metrics).toContain('AVG(radius_value)');
+  expect(query.orderby).toEqual([['AVG(radius_value)', false]]);
+});
 
 test('Scatter buildQuery should handle numeric value in fixed type', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'fix',
-        value: 500,
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'fix',
+      value: 500,
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    // Fixed numeric value should not be included as a metric
-    expect(query.metrics).toEqual([]);
-    expect(query.orderby).toEqual([]);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  // Fixed numeric value should not be included as a metric
+  expect(query.metrics).toEqual([]);
+  expect(query.orderby).toEqual([]);
+});
 
 test('Scatter buildQuery should handle missing point_radius_fixed', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      // no point_radius_fixed
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    // no point_radius_fixed
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.metrics).toEqual([]);
-    expect(query.orderby).toEqual([]);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.metrics).toEqual([]);
+  expect(query.orderby).toEqual([]);
+});
 
 test('Scatter buildQuery should include spatial columns in query', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.columns).toContain('LATITUDE');
-    expect(query.columns).toContain('LONGITUDE');
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.columns).toContain('LATITUDE');
+  expect(query.columns).toContain('LONGITUDE');
+});
 
 test('Scatter buildQuery should include dimension column when specified', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      dimension: 'category',
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    dimension: 'category',
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.columns).toContain('category');
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.columns).toContain('category');
+});
 
 test('Scatter buildQuery should add spatial null filters', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    const latFilter = query.filters?.find(
-      f => f.col === 'LATITUDE' && f.op === 'IS NOT NULL',
-    );
-    const lonFilter = query.filters?.find(
-      f => f.col === 'LONGITUDE' && f.op === 'IS NOT NULL',
-    );
-    
-    expect(latFilter).toBeDefined();
-    expect(lonFilter).toBeDefined();
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  const latFilter = query.filters?.find(
+    f => f.col === 'LATITUDE' && f.op === 'IS NOT NULL',
+  );
+  const lonFilter = query.filters?.find(
+    f => f.col === 'LONGITUDE' && f.op === 'IS NOT NULL',
+  );
+
+  expect(latFilter).toBeDefined();
+  expect(lonFilter).toBeDefined();
+});
 
 test('Scatter buildQuery should throw error when spatial is missing', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      spatial: undefined,
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    spatial: undefined,
+  };
 
-    expect(() => buildQuery(formData)).toThrow(
-      'Spatial configuration is required for Scatter charts',
-    );
-  });
+  expect(() => buildQuery(formData)).toThrow(
+    'Spatial configuration is required for Scatter charts',
+  );
+});
 
 test('Scatter buildQuery should handle geohash spatial type', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      spatial: {
-        type: 'geohash',
-        geohashCol: 'geohash_column',
-      },
-      point_radius_fixed: {
-        type: 'metric',
-        value: 'COUNT(*)',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    spatial: {
+      type: 'geohash',
+      geohashCol: 'geohash_column',
+    },
+    point_radius_fixed: {
+      type: 'metric',
+      value: 'COUNT(*)',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.columns).toContain('geohash_column');
-    expect(query.metrics).toContain('COUNT(*)');
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.columns).toContain('geohash_column');
+  expect(query.metrics).toContain('COUNT(*)');
+});
 
 test('Scatter buildQuery should handle tooltip_contents', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      tooltip_contents: ['name', 'description'],
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    tooltip_contents: ['name', 'description'],
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.columns).toContain('name');
-    expect(query.columns).toContain('description');
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.columns).toContain('name');
+  expect(query.columns).toContain('description');
+});
 
 test('Scatter buildQuery should handle js_columns', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      js_columns: ['custom_col1', 'custom_col2'],
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    js_columns: ['custom_col1', 'custom_col2'],
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.columns).toContain('custom_col1');
-    expect(query.columns).toContain('custom_col2');
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.columns).toContain('custom_col1');
+  expect(query.columns).toContain('custom_col2');
+});
 
 test('Scatter buildQuery should convert numeric metric value to string', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'metric',
-        value: 123, // numeric metric (edge case)
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'metric',
+      value: 123, // numeric metric (edge case)
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.metrics).toContain('123');
-    expect(query.orderby).toEqual([['123', false]]);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.metrics).toContain('123');
+  expect(query.orderby).toEqual([['123', false]]);
+});
 
 test('Scatter buildQuery should set is_timeseries to false', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.is_timeseries).toBe(false);
-  });
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.is_timeseries).toBe(false);
+});
 
 test('Scatter buildQuery should preserve row_limit', () => {
-    const formData: DeckScatterFormData = {
-      ...baseFormData,
-      row_limit: 5000,
-      point_radius_fixed: {
-        type: 'fix',
-        value: '1000',
-      },
-    };
+  const formData: DeckScatterFormData = {
+    ...baseFormData,
+    row_limit: 5000,
+    point_radius_fixed: {
+      type: 'fix',
+      value: '1000',
+    },
+  };
 
-    const queryContext = buildQuery(formData);
-    const [query] = queryContext.queries;
-    
-    expect(query.row_limit).toBe(5000);
+  const queryContext = buildQuery(formData);
+  const [query] = queryContext.queries;
+
+  expect(query.row_limit).toBe(5000);
 });
 
 test('Scatter buildQuery should preserve existing metrics when adding radius metric', () => {
@@ -271,7 +271,7 @@ test('Scatter buildQuery should preserve existing metrics when adding radius met
 
   const queryContext = buildQuery(formData);
   const [query] = queryContext.queries;
-  
+
   expect(query.metrics).toContain('COUNT(*)');
   expect(query.metrics).toContain('AVG(radius_value)');
   expect(query.metrics).toHaveLength(2);
@@ -289,6 +289,6 @@ test('Scatter buildQuery should not modify existing metrics for fixed radius', (
 
   const queryContext = buildQuery(formData);
   const [query] = queryContext.queries;
-  
+
   expect(query.metrics).toEqual(['COUNT(*)', 'SUM(value)']);
 });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -89,7 +89,9 @@ export default function buildQuery(formData: DeckScatterFormData) {
       const radiusMetrics = processMetricsArray(
         metricValue ? [metricValue] : [],
       );
-      const metrics = [...existingMetrics, ...radiusMetrics];
+      // Deduplicate metrics to avoid adding the same metric twice
+      const metricsSet = new Set([...existingMetrics, ...radiusMetrics]);
+      const metrics = Array.from(metricsSet);
       const filters = addSpatialNullFilters(
         spatial,
         ensureIsArray(baseQueryObject.filters || []),

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -82,7 +82,9 @@ export default function buildQuery(formData: DeckScatterFormData) {
 
       // Only add metric if point_radius_fixed is a metric type
       const isMetric = isMetricValue(point_radius_fixed);
-      const metricValue = isMetric ? extractMetricKey(point_radius_fixed?.value) : null;
+      const metricValue = isMetric
+        ? extractMetricKey(point_radius_fixed?.value)
+        : null;
 
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -34,6 +34,7 @@ import {
   processMetricsArray,
   addTooltipColumnsToQuery,
 } from '../buildQueryUtils';
+import { isMetricValue, extractMetricKey } from '../utils/metricUtils';
 
 export interface DeckScatterFormData
   extends Omit<SpatialFormData, 'color_picker'>, SqlaFormData {
@@ -80,11 +81,8 @@ export default function buildQuery(formData: DeckScatterFormData) {
       columns = addTooltipColumnsToQuery(columns, tooltip_contents);
 
       // Only add metric if point_radius_fixed is a metric type
-      const isMetric = point_radius_fixed?.type === 'metric';
-      const metricValue =
-        isMetric && point_radius_fixed?.value
-          ? String(point_radius_fixed.value)
-          : null;
+      const isMetric = isMetricValue(point_radius_fixed);
+      const metricValue = isMetric ? extractMetricKey(point_radius_fixed?.value) : null;
 
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -81,20 +81,26 @@ export default function buildQuery(formData: DeckScatterFormData) {
 
       // Only add metric if point_radius_fixed is a metric type
       const isMetric = point_radius_fixed?.type === 'metric';
-      const metricValue = isMetric && point_radius_fixed?.value ? String(point_radius_fixed.value) : null;
-      
+      const metricValue =
+        isMetric && point_radius_fixed?.value
+          ? String(point_radius_fixed.value)
+          : null;
+
       // Preserve existing metrics and only add radius metric if it's metric-based
       const existingMetrics = baseQueryObject.metrics || [];
-      const radiusMetrics = processMetricsArray(metricValue ? [metricValue] : []);
+      const radiusMetrics = processMetricsArray(
+        metricValue ? [metricValue] : [],
+      );
       const metrics = [...existingMetrics, ...radiusMetrics];
       const filters = addSpatialNullFilters(
         spatial,
         ensureIsArray(baseQueryObject.filters || []),
       );
 
-      const orderby = isMetric && metricValue
-        ? ([[metricValue, false]] as QueryFormOrderBy[])
-        : (baseQueryObject.orderby as QueryFormOrderBy[]) || [];
+      const orderby =
+        isMetric && metricValue
+          ? ([[metricValue, false]] as QueryFormOrderBy[])
+          : (baseQueryObject.orderby as QueryFormOrderBy[]) || [];
 
       return [
         {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/buildQuery.ts
@@ -83,7 +83,10 @@ export default function buildQuery(formData: DeckScatterFormData) {
       const isMetric = point_radius_fixed?.type === 'metric';
       const metricValue = isMetric && point_radius_fixed?.value ? String(point_radius_fixed.value) : null;
       
-      const metrics = processMetricsArray(metricValue ? [metricValue] : []);
+      // Preserve existing metrics and only add radius metric if it's metric-based
+      const existingMetrics = baseQueryObject.metrics || [];
+      const radiusMetrics = processMetricsArray(metricValue ? [metricValue] : []);
+      const metrics = [...existingMetrics, ...radiusMetrics];
       const filters = addSpatialNullFilters(
         spatial,
         ensureIsArray(baseQueryObject.filters || []),

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
@@ -75,229 +75,229 @@ const mockChartProps: Partial<ChartProps> = {
 };
 
 test('Scatter transformProps should use fixed radius value when point_radius_fixed type is "fix"', () => {
-    const fixedProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const fixedProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-    };
+    },
+  };
 
-    const result = transformProps(fixedProps as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(2);
-    expect(features[0]?.radius).toBe(1000);
-    expect(features[1]?.radius).toBe(1000);
-    // metric should not be set for fixed radius
-    expect(features[0]?.metric).toBeUndefined();
-    expect(features[1]?.metric).toBeUndefined();
-  });
+  const result = transformProps(fixedProps as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.radius).toBe(1000);
+  expect(features[1]?.radius).toBe(1000);
+  // metric should not be set for fixed radius
+  expect(features[0]?.metric).toBeUndefined();
+  expect(features[1]?.metric).toBeUndefined();
+});
 
 test('Scatter transformProps should use metric value for radius when point_radius_fixed type is "metric"', () => {
-    const metricProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'metric',
-          value: 'AVG(radius_value)',
-        },
+  const metricProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'metric',
+        value: 'AVG(radius_value)',
       },
-    };
+    },
+  };
 
-    const result = transformProps(metricProps as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(2);
-    expect(features[0]?.radius).toBe(100);
-    expect(features[0]?.metric).toBe(100);
-    expect(features[1]?.radius).toBe(200);
-    expect(features[1]?.metric).toBe(200);
-  });
+  const result = transformProps(metricProps as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.radius).toBe(100);
+  expect(features[0]?.metric).toBe(100);
+  expect(features[1]?.radius).toBe(200);
+  expect(features[1]?.metric).toBe(200);
+});
 
 test('Scatter transformProps should handle numeric fixed radius value', () => {
-    const fixedProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'fix',
-          value: 500, // numeric value
-        },
+  const fixedProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: 500, // numeric value
       },
-    };
+    },
+  };
 
-    const result = transformProps(fixedProps as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(2);
-    expect(features[0]?.radius).toBe(500);
-    expect(features[1]?.radius).toBe(500);
-  });
+  const result = transformProps(fixedProps as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.radius).toBe(500);
+  expect(features[1]?.radius).toBe(500);
+});
 
 test('Scatter transformProps should handle missing point_radius_fixed', () => {
-    const propsWithoutRadius = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        // no point_radius_fixed
-      },
-    };
+  const propsWithoutRadius = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      // no point_radius_fixed
+    },
+  };
 
-    const result = transformProps(propsWithoutRadius as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(2);
-    // radius should not be set
-    expect(features[0]?.radius).toBeUndefined();
-    expect(features[1]?.radius).toBeUndefined();
-  });
+  const result = transformProps(propsWithoutRadius as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(2);
+  // radius should not be set
+  expect(features[0]?.radius).toBeUndefined();
+  expect(features[1]?.radius).toBeUndefined();
+});
 
 test('Scatter transformProps should handle dimension for category colors', () => {
-    const propsWithDimension = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        dimension: 'category',
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const propsWithDimension = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      dimension: 'category',
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-      queriesData: [
-        {
-          data: [
-            {
-              LATITUDE: 37.8,
-              LONGITUDE: -122.4,
-              category: 'A',
-            },
-            {
-              LATITUDE: 37.9,
-              LONGITUDE: -122.3,
-              category: 'B',
-            },
-          ],
-        },
-      ],
-    };
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            LATITUDE: 37.8,
+            LONGITUDE: -122.4,
+            category: 'A',
+          },
+          {
+            LATITUDE: 37.9,
+            LONGITUDE: -122.3,
+            category: 'B',
+          },
+        ],
+      },
+    ],
+  };
 
-    const result = transformProps(propsWithDimension as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(2);
-    expect(features[0]?.cat_color).toBe('A');
-    expect(features[1]?.cat_color).toBe('B');
-  });
+  const result = transformProps(propsWithDimension as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(2);
+  expect(features[0]?.cat_color).toBe('A');
+  expect(features[1]?.cat_color).toBe('B');
+});
 
 test('Scatter transformProps should not include metric labels for fixed radius', () => {
-    const fixedProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const fixedProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-    };
+    },
+  };
 
-    const result = transformProps(fixedProps as ChartProps);
-    
-    // metricLabels should be empty for fixed radius
-    expect(result.payload.data.metricLabels).toEqual([]);
-  });
+  const result = transformProps(fixedProps as ChartProps);
+
+  // metricLabels should be empty for fixed radius
+  expect(result.payload.data.metricLabels).toEqual([]);
+});
 
 test('Scatter transformProps should include metric labels for metric-based radius', () => {
-    const metricProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'metric',
-          value: 'AVG(radius_value)',
-        },
+  const metricProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'metric',
+        value: 'AVG(radius_value)',
       },
-    };
+    },
+  };
 
-    const result = transformProps(metricProps as ChartProps);
-    
-    // metricLabels should include the metric name
-    expect(result.payload.data.metricLabels).toContain('AVG(radius_value)');
-  });
+  const result = transformProps(metricProps as ChartProps);
+
+  // metricLabels should include the metric name
+  expect(result.payload.data.metricLabels).toContain('AVG(radius_value)');
+});
 
 test('Scatter transformProps should handle no records', () => {
-    const noDataProps = {
-      ...mockChartProps,
-      queriesData: [{ data: [] }],
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const noDataProps = {
+    ...mockChartProps,
+    queriesData: [{ data: [] }],
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-    };
+    },
+  };
 
-    const result = transformProps(noDataProps as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(0);
-  });
+  const result = transformProps(noDataProps as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(0);
+});
 
 test('Scatter transformProps should handle missing spatial configuration gracefully', () => {
-    const noSpatialProps = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        spatial: undefined,
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const noSpatialProps = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      spatial: undefined,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-    };
+    },
+  };
 
-    const result = transformProps(noSpatialProps as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(0);
-  });
+  const result = transformProps(noSpatialProps as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(0);
+});
 
 test('Scatter transformProps should preserve extra properties from records', () => {
-    const propsWithExtraData = {
-      ...mockChartProps,
-      rawFormData: {
-        ...mockChartProps.rawFormData,
-        point_radius_fixed: {
-          type: 'fix',
-          value: '1000',
-        },
+  const propsWithExtraData = {
+    ...mockChartProps,
+    rawFormData: {
+      ...mockChartProps.rawFormData,
+      point_radius_fixed: {
+        type: 'fix',
+        value: '1000',
       },
-      queriesData: [
-        {
-          data: [
-            {
-              LATITUDE: 37.8,
-              LONGITUDE: -122.4,
-              custom_field: 'value1',
-              another_field: 123,
-            },
-          ],
-        },
-      ],
-    };
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            LATITUDE: 37.8,
+            LONGITUDE: -122.4,
+            custom_field: 'value1',
+            another_field: 123,
+          },
+        ],
+      },
+    ],
+  };
 
-    const result = transformProps(propsWithExtraData as ChartProps);
-    const features = result.payload.data.features as ScatterFeature[];
-    
-    expect(features).toHaveLength(1);
-    expect(features[0]).toMatchObject({
-      custom_field: 'value1',
-      another_field: 123,
-    });
+  const result = transformProps(propsWithExtraData as ChartProps);
+  const features = result.payload.data.features as ScatterFeature[];
+
+  expect(features).toHaveLength(1);
+  expect(features[0]).toMatchObject({
+    custom_field: 'value1',
+    another_field: 123,
+  });
 });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChartProps, DatasourceType } from '@superset-ui/core';
+import transformProps from './transformProps';
+
+interface ScatterFeature {
+  position: [number, number];
+  radius?: number;
+  metric?: number;
+  cat_color?: string;
+  extraProps?: Record<string, unknown>;
+}
+
+jest.mock('../spatialUtils', () => ({
+  ...jest.requireActual('../spatialUtils'),
+  getMapboxApiKey: jest.fn(() => 'mock-mapbox-key'),
+}));
+
+const mockChartProps: Partial<ChartProps> = {
+  rawFormData: {
+    spatial: {
+      type: 'latlong',
+      latCol: 'LATITUDE',
+      lonCol: 'LONGITUDE',
+    },
+    viewport: {},
+  },
+  queriesData: [
+    {
+      data: [
+        {
+          LATITUDE: 37.8,
+          LONGITUDE: -122.4,
+          population: 50000,
+          'AVG(radius_value)': 100,
+        },
+        {
+          LATITUDE: 37.9,
+          LONGITUDE: -122.3,
+          population: 75000,
+          'AVG(radius_value)': 200,
+        },
+      ],
+    },
+  ],
+  datasource: {
+    type: DatasourceType.Table,
+    id: 1,
+    name: 'test_datasource',
+    columns: [],
+    metrics: [],
+  },
+  height: 400,
+  width: 600,
+  hooks: {},
+  filterState: {},
+  emitCrossFilters: false,
+};
+
+test('Scatter transformProps should use fixed radius value when point_radius_fixed type is "fix"', () => {
+    const fixedProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+    };
+
+    const result = transformProps(fixedProps as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(2);
+    expect(features[0]?.radius).toBe(1000);
+    expect(features[1]?.radius).toBe(1000);
+    // metric should not be set for fixed radius
+    expect(features[0]?.metric).toBeUndefined();
+    expect(features[1]?.metric).toBeUndefined();
+  });
+
+test('Scatter transformProps should use metric value for radius when point_radius_fixed type is "metric"', () => {
+    const metricProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'metric',
+          value: 'AVG(radius_value)',
+        },
+      },
+    };
+
+    const result = transformProps(metricProps as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(2);
+    expect(features[0]?.radius).toBe(100);
+    expect(features[0]?.metric).toBe(100);
+    expect(features[1]?.radius).toBe(200);
+    expect(features[1]?.metric).toBe(200);
+  });
+
+test('Scatter transformProps should handle numeric fixed radius value', () => {
+    const fixedProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: 500, // numeric value
+        },
+      },
+    };
+
+    const result = transformProps(fixedProps as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(2);
+    expect(features[0]?.radius).toBe(500);
+    expect(features[1]?.radius).toBe(500);
+  });
+
+test('Scatter transformProps should handle missing point_radius_fixed', () => {
+    const propsWithoutRadius = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        // no point_radius_fixed
+      },
+    };
+
+    const result = transformProps(propsWithoutRadius as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(2);
+    // radius should not be set
+    expect(features[0]?.radius).toBeUndefined();
+    expect(features[1]?.radius).toBeUndefined();
+  });
+
+test('Scatter transformProps should handle dimension for category colors', () => {
+    const propsWithDimension = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        dimension: 'category',
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+      queriesData: [
+        {
+          data: [
+            {
+              LATITUDE: 37.8,
+              LONGITUDE: -122.4,
+              category: 'A',
+            },
+            {
+              LATITUDE: 37.9,
+              LONGITUDE: -122.3,
+              category: 'B',
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(propsWithDimension as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(2);
+    expect(features[0]?.cat_color).toBe('A');
+    expect(features[1]?.cat_color).toBe('B');
+  });
+
+test('Scatter transformProps should not include metric labels for fixed radius', () => {
+    const fixedProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+    };
+
+    const result = transformProps(fixedProps as ChartProps);
+    
+    // metricLabels should be empty for fixed radius
+    expect(result.payload.data.metricLabels).toEqual([]);
+  });
+
+test('Scatter transformProps should include metric labels for metric-based radius', () => {
+    const metricProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'metric',
+          value: 'AVG(radius_value)',
+        },
+      },
+    };
+
+    const result = transformProps(metricProps as ChartProps);
+    
+    // metricLabels should include the metric name
+    expect(result.payload.data.metricLabels).toContain('AVG(radius_value)');
+  });
+
+test('Scatter transformProps should handle no records', () => {
+    const noDataProps = {
+      ...mockChartProps,
+      queriesData: [{ data: [] }],
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+    };
+
+    const result = transformProps(noDataProps as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(0);
+  });
+
+test('Scatter transformProps should handle missing spatial configuration gracefully', () => {
+    const noSpatialProps = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        spatial: undefined,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+    };
+
+    const result = transformProps(noSpatialProps as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(0);
+  });
+
+test('Scatter transformProps should preserve extra properties from records', () => {
+    const propsWithExtraData = {
+      ...mockChartProps,
+      rawFormData: {
+        ...mockChartProps.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+      queriesData: [
+        {
+          data: [
+            {
+              LATITUDE: 37.8,
+              LONGITUDE: -122.4,
+              custom_field: 'value1',
+              another_field: 123,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = transformProps(propsWithExtraData as ChartProps);
+    const features = result.payload.data.features as ScatterFeature[];
+    
+    expect(features).toHaveLength(1);
+    expect(features[0]).toMatchObject({
+      custom_field: 'value1',
+      another_field: 123,
+    });
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -109,7 +109,7 @@ export default function transformProps(chartProps: ChartProps) {
     formData as DeckScatterFormData;
 
   // Check if this is a fixed value or metric
-  const fixedRadiusValue = isFixedValue(point_radius_fixed) 
+  const fixedRadiusValue = isFixedValue(point_radius_fixed)
     ? getFixedValue(point_radius_fixed)
     : null;
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -113,7 +113,7 @@ export default function transformProps(chartProps: ChartProps) {
 
   const radiusMetricLabel = getMetricLabelFromFormData(point_radius_fixed);
   const records = getRecordsFromQuery(chartProps.queriesData);
-  
+
   const features = processScatterData(
     records,
     spatial,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -26,6 +26,7 @@ import {
   addPropertiesToFeature,
 } from '../transformUtils';
 import { DeckScatterFormData } from './buildQuery';
+import { isFixedValue, getFixedValue } from '../utils/metricUtils';
 
 interface ScatterPoint {
   position: [number, number];
@@ -108,8 +109,9 @@ export default function transformProps(chartProps: ChartProps) {
     formData as DeckScatterFormData;
 
   // Check if this is a fixed value or metric
-  const isFixedValue = point_radius_fixed?.type === 'fix';
-  const fixedRadiusValue = isFixedValue ? point_radius_fixed?.value : null;
+  const fixedRadiusValue = isFixedValue(point_radius_fixed) 
+    ? getFixedValue(point_radius_fixed)
+    : null;
 
   const radiusMetricLabel = getMetricLabelFromFormData(point_radius_fixed);
   const records = getRecordsFromQuery(chartProps.queriesData);

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Scatter/transformProps.ts
@@ -122,7 +122,7 @@ export default function transformProps(chartProps: ChartProps) {
     radiusMetricLabel,
     dimension,
     js_columns,
-    isFixedValue ? fixedRadiusValue : null,
+    fixedRadiusValue,
   );
 
   return createBaseTransformResult(

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getMetricLabel } from '@superset-ui/core';
+import { getMetricLabelFromFormData, parseMetricValue } from './transformUtils';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  getMetricLabel: jest.fn((metric: string) => metric),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('getMetricLabelFromFormData should return undefined for undefined input', () => {
+      const result = getMetricLabelFromFormData(undefined);
+      expect(result).toBeUndefined();
+    });
+
+test('getMetricLabelFromFormData should return undefined for null input', () => {
+      const result = getMetricLabelFromFormData(null as any);
+      expect(result).toBeUndefined();
+    });
+
+test('getMetricLabelFromFormData should handle string metric directly', () => {
+      const result = getMetricLabelFromFormData('AVG(value)');
+      expect(result).toBe('AVG(value)');
+      expect(getMetricLabel).toHaveBeenCalledWith('AVG(value)');
+    });
+
+test('getMetricLabelFromFormData should return undefined for fixed type', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'fix',
+        value: '1000',
+      });
+      expect(result).toBeUndefined();
+      expect(getMetricLabel).not.toHaveBeenCalled();
+    });
+
+test('getMetricLabelFromFormData should return undefined for fixed type with numeric value', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'fix',
+        value: 1000,
+      });
+      expect(result).toBeUndefined();
+      expect(getMetricLabel).not.toHaveBeenCalled();
+    });
+
+test('getMetricLabelFromFormData should return metric label for metric type with string value', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+        value: 'SUM(amount)',
+      });
+      expect(result).toBe('SUM(amount)');
+      expect(getMetricLabel).toHaveBeenCalledWith('SUM(amount)');
+    });
+
+test('getMetricLabelFromFormData should return undefined for metric type with numeric value', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+        value: 123,
+      });
+      expect(result).toBeUndefined();
+      expect(getMetricLabel).not.toHaveBeenCalled();
+    });
+
+test('getMetricLabelFromFormData should return undefined for object without type', () => {
+      const result = getMetricLabelFromFormData({
+        value: 'AVG(value)',
+      });
+      expect(result).toBeUndefined();
+    });
+
+test('getMetricLabelFromFormData should return undefined for empty object', () => {
+      const result = getMetricLabelFromFormData({});
+      expect(result).toBeUndefined();
+    });
+
+test('getMetricLabelFromFormData should return undefined for metric type without value', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+      });
+      expect(result).toBeUndefined();
+});
+
+test('parseMetricValue should parse numeric strings', () => {
+      expect(parseMetricValue('123')).toBe(123);
+      expect(parseMetricValue('123.45')).toBe(123.45);
+      expect(parseMetricValue('0')).toBe(0);
+      expect(parseMetricValue('-123')).toBe(-123);
+    });
+
+test('parseMetricValue should handle numbers directly', () => {
+      expect(parseMetricValue(123)).toBe(123);
+      expect(parseMetricValue(123.45)).toBe(123.45);
+      expect(parseMetricValue(0)).toBe(0);
+      expect(parseMetricValue(-123)).toBe(-123);
+    });
+
+test('parseMetricValue should return undefined for null', () => {
+      expect(parseMetricValue(null)).toBeUndefined();
+    });
+
+test('parseMetricValue should return undefined for undefined', () => {
+      expect(parseMetricValue(undefined)).toBeUndefined();
+    });
+
+test('parseMetricValue should return undefined for non-numeric strings', () => {
+      expect(parseMetricValue('abc')).toBeUndefined();
+      expect(parseMetricValue('12a34')).toBe(12); // parseFloat returns 12
+      expect(parseMetricValue('')).toBeUndefined();
+    });
+
+test('parseMetricValue should handle edge cases', () => {
+      expect(parseMetricValue('Infinity')).toBe(Infinity);
+      expect(parseMetricValue('-Infinity')).toBe(-Infinity);
+      expect(parseMetricValue('NaN')).toBeUndefined();
+    });
+
+test('parseMetricValue should handle boolean values', () => {
+      expect(parseMetricValue(true as any)).toBeUndefined();
+      expect(parseMetricValue(false as any)).toBeUndefined();
+    });
+
+test('parseMetricValue should handle objects', () => {
+      expect(parseMetricValue({} as any)).toBeUndefined();
+      expect(parseMetricValue({ value: 123 } as any)).toBeUndefined();
+    });
+
+test('parseMetricValue should handle arrays', () => {
+      expect(parseMetricValue([] as any)).toBeUndefined();
+      expect(parseMetricValue([123] as any)).toBe(123); // String([123]) = '123'
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
@@ -72,6 +72,40 @@ test('getMetricLabelFromFormData should return metric label for metric type with
       expect(getMetricLabel).toHaveBeenCalledWith('SUM(amount)');
     });
 
+test('getMetricLabelFromFormData should handle object metric values', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+        value: {
+          label: 'Total Sales',
+          sqlExpression: 'SUM(sales)',
+        },
+      });
+      expect(result).toBe('Total Sales');
+      expect(getMetricLabel).toHaveBeenCalledWith('Total Sales');
+    });
+
+test('getMetricLabelFromFormData should use sqlExpression if label is missing', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+        value: {
+          sqlExpression: 'COUNT(*)',
+        },
+      });
+      expect(result).toBe('COUNT(*)');
+      expect(getMetricLabel).toHaveBeenCalledWith('COUNT(*)');
+    });
+
+test('getMetricLabelFromFormData should use value field as fallback', () => {
+      const result = getMetricLabelFromFormData({
+        type: 'metric',
+        value: {
+          value: 'AVG(price)',
+        },
+      });
+      expect(result).toBe('AVG(price)');
+      expect(getMetricLabel).toHaveBeenCalledWith('AVG(price)');
+    });
+
 test('getMetricLabelFromFormData should return undefined for metric type with numeric value', () => {
       const result = getMetricLabelFromFormData({
         type: 'metric',

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
@@ -106,13 +106,13 @@ test('getMetricLabelFromFormData should use value field as fallback', () => {
   expect(getMetricLabel).toHaveBeenCalledWith('AVG(price)');
 });
 
-test('getMetricLabelFromFormData should return undefined for metric type with numeric value', () => {
+test('getMetricLabelFromFormData should handle metric type with numeric value', () => {
   const result = getMetricLabelFromFormData({
     type: 'metric',
     value: 123,
   });
-  expect(result).toBeUndefined();
-  expect(getMetricLabel).not.toHaveBeenCalled();
+  expect(result).toBe('123');
+  expect(getMetricLabel).toHaveBeenCalledWith('123');
 });
 
 test('getMetricLabelFromFormData should return undefined for object without type', () => {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.test.ts
@@ -30,155 +30,155 @@ beforeEach(() => {
 });
 
 test('getMetricLabelFromFormData should return undefined for undefined input', () => {
-      const result = getMetricLabelFromFormData(undefined);
-      expect(result).toBeUndefined();
-    });
+  const result = getMetricLabelFromFormData(undefined);
+  expect(result).toBeUndefined();
+});
 
 test('getMetricLabelFromFormData should return undefined for null input', () => {
-      const result = getMetricLabelFromFormData(null as any);
-      expect(result).toBeUndefined();
-    });
+  const result = getMetricLabelFromFormData(null as any);
+  expect(result).toBeUndefined();
+});
 
 test('getMetricLabelFromFormData should handle string metric directly', () => {
-      const result = getMetricLabelFromFormData('AVG(value)');
-      expect(result).toBe('AVG(value)');
-      expect(getMetricLabel).toHaveBeenCalledWith('AVG(value)');
-    });
+  const result = getMetricLabelFromFormData('AVG(value)');
+  expect(result).toBe('AVG(value)');
+  expect(getMetricLabel).toHaveBeenCalledWith('AVG(value)');
+});
 
 test('getMetricLabelFromFormData should return undefined for fixed type', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'fix',
-        value: '1000',
-      });
-      expect(result).toBeUndefined();
-      expect(getMetricLabel).not.toHaveBeenCalled();
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'fix',
+    value: '1000',
+  });
+  expect(result).toBeUndefined();
+  expect(getMetricLabel).not.toHaveBeenCalled();
+});
 
 test('getMetricLabelFromFormData should return undefined for fixed type with numeric value', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'fix',
-        value: 1000,
-      });
-      expect(result).toBeUndefined();
-      expect(getMetricLabel).not.toHaveBeenCalled();
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'fix',
+    value: 1000,
+  });
+  expect(result).toBeUndefined();
+  expect(getMetricLabel).not.toHaveBeenCalled();
+});
 
 test('getMetricLabelFromFormData should return metric label for metric type with string value', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-        value: 'SUM(amount)',
-      });
-      expect(result).toBe('SUM(amount)');
-      expect(getMetricLabel).toHaveBeenCalledWith('SUM(amount)');
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+    value: 'SUM(amount)',
+  });
+  expect(result).toBe('SUM(amount)');
+  expect(getMetricLabel).toHaveBeenCalledWith('SUM(amount)');
+});
 
 test('getMetricLabelFromFormData should handle object metric values', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-        value: {
-          label: 'Total Sales',
-          sqlExpression: 'SUM(sales)',
-        },
-      });
-      expect(result).toBe('Total Sales');
-      expect(getMetricLabel).toHaveBeenCalledWith('Total Sales');
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+    value: {
+      label: 'Total Sales',
+      sqlExpression: 'SUM(sales)',
+    },
+  });
+  expect(result).toBe('Total Sales');
+  expect(getMetricLabel).toHaveBeenCalledWith('Total Sales');
+});
 
 test('getMetricLabelFromFormData should use sqlExpression if label is missing', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-        value: {
-          sqlExpression: 'COUNT(*)',
-        },
-      });
-      expect(result).toBe('COUNT(*)');
-      expect(getMetricLabel).toHaveBeenCalledWith('COUNT(*)');
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+    value: {
+      sqlExpression: 'COUNT(*)',
+    },
+  });
+  expect(result).toBe('COUNT(*)');
+  expect(getMetricLabel).toHaveBeenCalledWith('COUNT(*)');
+});
 
 test('getMetricLabelFromFormData should use value field as fallback', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-        value: {
-          value: 'AVG(price)',
-        },
-      });
-      expect(result).toBe('AVG(price)');
-      expect(getMetricLabel).toHaveBeenCalledWith('AVG(price)');
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+    value: {
+      value: 'AVG(price)',
+    },
+  });
+  expect(result).toBe('AVG(price)');
+  expect(getMetricLabel).toHaveBeenCalledWith('AVG(price)');
+});
 
 test('getMetricLabelFromFormData should return undefined for metric type with numeric value', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-        value: 123,
-      });
-      expect(result).toBeUndefined();
-      expect(getMetricLabel).not.toHaveBeenCalled();
-    });
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+    value: 123,
+  });
+  expect(result).toBeUndefined();
+  expect(getMetricLabel).not.toHaveBeenCalled();
+});
 
 test('getMetricLabelFromFormData should return undefined for object without type', () => {
-      const result = getMetricLabelFromFormData({
-        value: 'AVG(value)',
-      });
-      expect(result).toBeUndefined();
-    });
+  const result = getMetricLabelFromFormData({
+    value: 'AVG(value)',
+  });
+  expect(result).toBeUndefined();
+});
 
 test('getMetricLabelFromFormData should return undefined for empty object', () => {
-      const result = getMetricLabelFromFormData({});
-      expect(result).toBeUndefined();
-    });
+  const result = getMetricLabelFromFormData({});
+  expect(result).toBeUndefined();
+});
 
 test('getMetricLabelFromFormData should return undefined for metric type without value', () => {
-      const result = getMetricLabelFromFormData({
-        type: 'metric',
-      });
-      expect(result).toBeUndefined();
+  const result = getMetricLabelFromFormData({
+    type: 'metric',
+  });
+  expect(result).toBeUndefined();
 });
 
 test('parseMetricValue should parse numeric strings', () => {
-      expect(parseMetricValue('123')).toBe(123);
-      expect(parseMetricValue('123.45')).toBe(123.45);
-      expect(parseMetricValue('0')).toBe(0);
-      expect(parseMetricValue('-123')).toBe(-123);
-    });
+  expect(parseMetricValue('123')).toBe(123);
+  expect(parseMetricValue('123.45')).toBe(123.45);
+  expect(parseMetricValue('0')).toBe(0);
+  expect(parseMetricValue('-123')).toBe(-123);
+});
 
 test('parseMetricValue should handle numbers directly', () => {
-      expect(parseMetricValue(123)).toBe(123);
-      expect(parseMetricValue(123.45)).toBe(123.45);
-      expect(parseMetricValue(0)).toBe(0);
-      expect(parseMetricValue(-123)).toBe(-123);
-    });
+  expect(parseMetricValue(123)).toBe(123);
+  expect(parseMetricValue(123.45)).toBe(123.45);
+  expect(parseMetricValue(0)).toBe(0);
+  expect(parseMetricValue(-123)).toBe(-123);
+});
 
 test('parseMetricValue should return undefined for null', () => {
-      expect(parseMetricValue(null)).toBeUndefined();
-    });
+  expect(parseMetricValue(null)).toBeUndefined();
+});
 
 test('parseMetricValue should return undefined for undefined', () => {
-      expect(parseMetricValue(undefined)).toBeUndefined();
-    });
+  expect(parseMetricValue(undefined)).toBeUndefined();
+});
 
 test('parseMetricValue should return undefined for non-numeric strings', () => {
-      expect(parseMetricValue('abc')).toBeUndefined();
-      expect(parseMetricValue('12a34')).toBe(12); // parseFloat returns 12
-      expect(parseMetricValue('')).toBeUndefined();
-    });
+  expect(parseMetricValue('abc')).toBeUndefined();
+  expect(parseMetricValue('12a34')).toBe(12); // parseFloat returns 12
+  expect(parseMetricValue('')).toBeUndefined();
+});
 
 test('parseMetricValue should handle edge cases', () => {
-      expect(parseMetricValue('Infinity')).toBe(Infinity);
-      expect(parseMetricValue('-Infinity')).toBe(-Infinity);
-      expect(parseMetricValue('NaN')).toBeUndefined();
-    });
+  expect(parseMetricValue('Infinity')).toBe(Infinity);
+  expect(parseMetricValue('-Infinity')).toBe(-Infinity);
+  expect(parseMetricValue('NaN')).toBeUndefined();
+});
 
 test('parseMetricValue should handle boolean values', () => {
-      expect(parseMetricValue(true as any)).toBeUndefined();
-      expect(parseMetricValue(false as any)).toBeUndefined();
-    });
+  expect(parseMetricValue(true as any)).toBeUndefined();
+  expect(parseMetricValue(false as any)).toBeUndefined();
+});
 
 test('parseMetricValue should handle objects', () => {
-      expect(parseMetricValue({} as any)).toBeUndefined();
-      expect(parseMetricValue({ value: 123 } as any)).toBeUndefined();
-    });
+  expect(parseMetricValue({} as any)).toBeUndefined();
+  expect(parseMetricValue({ value: 123 } as any)).toBeUndefined();
+});
 
 test('parseMetricValue should handle arrays', () => {
-      expect(parseMetricValue([] as any)).toBeUndefined();
-      expect(parseMetricValue([123] as any)).toBe(123); // String([123]) = '123'
+  expect(parseMetricValue([] as any)).toBeUndefined();
+  expect(parseMetricValue([123] as any)).toBe(123); // String([123]) = '123'
 });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -18,7 +18,10 @@
  */
 import { ChartProps } from '@superset-ui/core';
 import { getMapboxApiKey, DataRecord } from './spatialUtils';
-import { getMetricLabelFromValue, FixedOrMetricValue } from './utils/metricUtils';
+import {
+  getMetricLabelFromValue,
+  FixedOrMetricValue,
+} from './utils/metricUtils';
 
 const NOOP = () => {};
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -135,7 +135,7 @@ export function addPropertiesToFeature<T extends Record<string, unknown>>(
 }
 
 export function getMetricLabelFromFormData(
-  metric: string | FixedOrMetricValue | undefined,
+  metric: string | FixedOrMetricValue | undefined | null,
 ): string | undefined {
   return getMetricLabelFromValue(metric);
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -134,13 +134,23 @@ export function addPropertiesToFeature<T extends Record<string, unknown>>(
 }
 
 export function getMetricLabelFromFormData(
-  metric: string | { value?: string | number; type?: string } | undefined,
+  metric: string | { value?: string | number | object; type?: string } | undefined,
 ): string | undefined {
   if (!metric) return undefined;
   if (typeof metric === 'string') return getMetricLabel(metric);
   // Only return metric label if it's a metric type, not a fixed value
-  if (typeof metric === 'object' && metric.type === 'metric' && metric.value && typeof metric.value === 'string') {
-    return getMetricLabel(metric.value);
+  if (typeof metric === 'object' && metric.type === 'metric' && metric.value) {
+    if (typeof metric.value === 'string') {
+      return getMetricLabel(metric.value);
+    }
+    if (typeof metric.value === 'object' && metric.value) {
+      // Handle object metrics (adhoc or saved metrics)
+      const metricObj = metric.value as any;
+      const metricKey = metricObj.label || metricObj.sqlExpression || metricObj.value;
+      if (typeof metricKey === 'string') {
+        return getMetricLabel(metricKey);
+      }
+    }
   }
   return undefined;
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -18,7 +18,7 @@
  */
 import { ChartProps } from '@superset-ui/core';
 import { getMapboxApiKey, DataRecord } from './spatialUtils';
-import { getMetricLabelFromValue } from './utils/metricUtils';
+import { getMetricLabelFromValue, FixedOrMetricValue } from './utils/metricUtils';
 
 const NOOP = () => {};
 
@@ -135,10 +135,7 @@ export function addPropertiesToFeature<T extends Record<string, unknown>>(
 }
 
 export function getMetricLabelFromFormData(
-  metric:
-    | string
-    | { value?: string | number | object; type?: string }
-    | undefined,
+  metric: string | FixedOrMetricValue | undefined,
 ): string | undefined {
   return getMetricLabelFromValue(metric);
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -134,7 +134,10 @@ export function addPropertiesToFeature<T extends Record<string, unknown>>(
 }
 
 export function getMetricLabelFromFormData(
-  metric: string | { value?: string | number | object; type?: string } | undefined,
+  metric:
+    | string
+    | { value?: string | number | object; type?: string }
+    | undefined,
 ): string | undefined {
   if (!metric) return undefined;
   if (typeof metric === 'string') return getMetricLabel(metric);
@@ -146,7 +149,8 @@ export function getMetricLabelFromFormData(
     if (typeof metric.value === 'object' && metric.value) {
       // Handle object metrics (adhoc or saved metrics)
       const metricObj = metric.value as any;
-      const metricKey = metricObj.label || metricObj.sqlExpression || metricObj.value;
+      const metricKey =
+        metricObj.label || metricObj.sqlExpression || metricObj.value;
       if (typeof metricKey === 'string') {
         return getMetricLabel(metricKey);
       }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -134,9 +134,13 @@ export function addPropertiesToFeature<T extends Record<string, unknown>>(
 }
 
 export function getMetricLabelFromFormData(
-  metric: string | { value?: string } | undefined,
+  metric: string | { value?: string | number; type?: string } | undefined,
 ): string | undefined {
   if (!metric) return undefined;
   if (typeof metric === 'string') return getMetricLabel(metric);
-  return metric.value ? getMetricLabel(metric.value) : undefined;
+  // Only return metric label if it's a metric type, not a fixed value
+  if (typeof metric === 'object' && metric.type === 'metric' && metric.value && typeof metric.value === 'string') {
+    return getMetricLabel(metric.value);
+  }
+  return undefined;
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/transformUtils.ts
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChartProps, getMetricLabel } from '@superset-ui/core';
+import { ChartProps } from '@superset-ui/core';
 import { getMapboxApiKey, DataRecord } from './spatialUtils';
+import { getMetricLabelFromValue } from './utils/metricUtils';
 
 const NOOP = () => {};
 
@@ -139,22 +140,5 @@ export function getMetricLabelFromFormData(
     | { value?: string | number | object; type?: string }
     | undefined,
 ): string | undefined {
-  if (!metric) return undefined;
-  if (typeof metric === 'string') return getMetricLabel(metric);
-  // Only return metric label if it's a metric type, not a fixed value
-  if (typeof metric === 'object' && metric.type === 'metric' && metric.value) {
-    if (typeof metric.value === 'string') {
-      return getMetricLabel(metric.value);
-    }
-    if (typeof metric.value === 'object' && metric.value) {
-      // Handle object metrics (adhoc or saved metrics)
-      const metricObj = metric.value as any;
-      const metricKey =
-        metricObj.label || metricObj.sqlExpression || metricObj.value;
-      if (typeof metricKey === 'string') {
-        return getMetricLabel(metricKey);
-      }
-    }
-  }
-  return undefined;
+  return getMetricLabelFromValue(metric);
 }

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.test.ts
@@ -65,7 +65,9 @@ test('extractMetricKey should extract from object properties', () => {
   expect(extractMetricKey({ label: 'Total Sales' })).toBe('Total Sales');
   expect(extractMetricKey({ sqlExpression: 'SUM(sales)' })).toBe('SUM(sales)');
   expect(extractMetricKey({ value: 'AVG(price)' })).toBe('AVG(price)');
-  expect(extractMetricKey({ label: 'Label', sqlExpression: 'SQL', value: 'Value' })).toBe('Label'); // priority order
+  expect(
+    extractMetricKey({ label: 'Label', sqlExpression: 'SQL', value: 'Value' }),
+  ).toBe('Label'); // priority order
 });
 
 test('extractMetricKey should handle null/undefined', () => {
@@ -77,7 +79,7 @@ test('extractMetricKey should handle null/undefined', () => {
 test('getMetricLabelFromValue should return label for metric values', () => {
   getMetricLabelFromValue({ type: 'metric', value: 'COUNT(*)' });
   expect(getMetricLabel).toHaveBeenCalledWith('COUNT(*)');
-  
+
   getMetricLabelFromValue({ type: 'metric', value: { label: 'Total Sales' } });
   expect(getMetricLabel).toHaveBeenCalledWith('Total Sales');
 });
@@ -107,7 +109,9 @@ test('getFixedValue should return undefined for string values', () => {
 });
 
 test('getFixedValue should handle object values', () => {
-  expect(getFixedValue({ type: 'fix', value: { label: 'object' } })).toBeUndefined();
+  expect(
+    getFixedValue({ type: 'fix', value: { label: 'object' } }),
+  ).toBeUndefined();
 });
 
 test('getFixedValue should handle missing values', () => {

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getMetricLabel } from '@superset-ui/core';
+import {
+  isMetricValue,
+  isFixedValue,
+  extractMetricKey,
+  getMetricLabelFromValue,
+  getFixedValue,
+} from './metricUtils';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  getMetricLabel: jest.fn((metric: string) => metric),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('isMetricValue should identify metric values correctly', () => {
+  expect(isMetricValue({ type: 'metric', value: 'COUNT(*)' })).toBe(true);
+  expect(isMetricValue({ type: 'fix', value: '1000' })).toBe(false);
+  expect(isMetricValue('AVG(value)')).toBe(true); // legacy string format
+  expect(isMetricValue(undefined)).toBe(false);
+  expect(isMetricValue(null)).toBe(false);
+});
+
+test('isFixedValue should identify fixed values correctly', () => {
+  expect(isFixedValue({ type: 'fix', value: '1000' })).toBe(true);
+  expect(isFixedValue({ type: 'metric', value: 'COUNT(*)' })).toBe(false);
+  expect(isFixedValue('AVG(value)')).toBe(false); // legacy string format
+  expect(isFixedValue(undefined)).toBe(false);
+  expect(isFixedValue(null)).toBe(false);
+});
+
+test('extractMetricKey should handle string values', () => {
+  expect(extractMetricKey('COUNT(*)')).toBe('COUNT(*)');
+  expect(extractMetricKey('')).toBe('');
+});
+
+test('extractMetricKey should handle number values', () => {
+  expect(extractMetricKey(123)).toBe('123');
+  expect(extractMetricKey(0)).toBe('0');
+});
+
+test('extractMetricKey should extract from object properties', () => {
+  expect(extractMetricKey({ label: 'Total Sales' })).toBe('Total Sales');
+  expect(extractMetricKey({ sqlExpression: 'SUM(sales)' })).toBe('SUM(sales)');
+  expect(extractMetricKey({ value: 'AVG(price)' })).toBe('AVG(price)');
+  expect(extractMetricKey({ label: 'Label', sqlExpression: 'SQL', value: 'Value' })).toBe('Label'); // priority order
+});
+
+test('extractMetricKey should handle null/undefined', () => {
+  expect(extractMetricKey(null)).toBeUndefined();
+  expect(extractMetricKey(undefined)).toBeUndefined();
+  expect(extractMetricKey({})).toBeUndefined();
+});
+
+test('getMetricLabelFromValue should return label for metric values', () => {
+  getMetricLabelFromValue({ type: 'metric', value: 'COUNT(*)' });
+  expect(getMetricLabel).toHaveBeenCalledWith('COUNT(*)');
+  
+  getMetricLabelFromValue({ type: 'metric', value: { label: 'Total Sales' } });
+  expect(getMetricLabel).toHaveBeenCalledWith('Total Sales');
+});
+
+test('getMetricLabelFromValue should return undefined for fixed values', () => {
+  const result = getMetricLabelFromValue({ type: 'fix', value: '1000' });
+  expect(result).toBeUndefined();
+  expect(getMetricLabel).not.toHaveBeenCalled();
+});
+
+test('getMetricLabelFromValue should handle legacy string format', () => {
+  getMetricLabelFromValue('AVG(value)');
+  expect(getMetricLabel).toHaveBeenCalledWith('AVG(value)');
+});
+
+test('getFixedValue should return value for fixed types', () => {
+  expect(getFixedValue({ type: 'fix', value: '1000' })).toBe('1000');
+  expect(getFixedValue({ type: 'fix', value: 500 })).toBe(500);
+});
+
+test('getFixedValue should return undefined for metric types', () => {
+  expect(getFixedValue({ type: 'metric', value: 'COUNT(*)' })).toBeUndefined();
+});
+
+test('getFixedValue should return undefined for string values', () => {
+  expect(getFixedValue('AVG(value)')).toBeUndefined();
+});
+
+test('getFixedValue should handle object values', () => {
+  expect(getFixedValue({ type: 'fix', value: { label: 'object' } })).toBeUndefined();
+});
+
+test('getFixedValue should handle missing values', () => {
+  expect(getFixedValue({ type: 'fix' })).toBeUndefined();
+  expect(getFixedValue(undefined)).toBeUndefined();
+  expect(getFixedValue(null)).toBeUndefined();
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
@@ -19,9 +19,9 @@
 
 import { getMetricLabel } from '@superset-ui/core';
 
-export type MetricFormValue = 
-  | string 
-  | number 
+export type MetricFormValue =
+  | string
+  | number
   | { label?: string; sqlExpression?: string; value?: string }
   | undefined
   | null;
@@ -57,15 +57,17 @@ export function isFixedValue(
  * Extracts the metric key from a metric value object
  * Handles label, sqlExpression, and value properties
  */
-export function extractMetricKey(
-  value: MetricFormValue,
-): string | undefined {
+export function extractMetricKey(value: MetricFormValue): string | undefined {
   if (value == null) return undefined;
   if (typeof value === 'string') return value;
   if (typeof value === 'number') return String(value);
-  
+
   // Handle object metrics (adhoc or saved metrics)
-  const metricObj = value as { label?: string; sqlExpression?: string; value?: string };
+  const metricObj = value as {
+    label?: string;
+    sqlExpression?: string;
+    value?: string;
+  };
   return metricObj.label || metricObj.sqlExpression || metricObj.value;
 }
 
@@ -77,12 +79,12 @@ export function getMetricLabelFromValue(
   fixedOrMetric: string | FixedOrMetricValue | undefined | null,
 ): string | undefined {
   if (!fixedOrMetric) return undefined;
-  
+
   // Legacy string format - treat as metric
   if (typeof fixedOrMetric === 'string') {
     return getMetricLabel(fixedOrMetric);
   }
-  
+
   // Only return metric label if it's a metric type, not a fixed value
   if (isMetricValue(fixedOrMetric) && fixedOrMetric.value) {
     const metricKey = extractMetricKey(fixedOrMetric.value);
@@ -90,7 +92,7 @@ export function getMetricLabelFromValue(
       return getMetricLabel(metricKey);
     }
   }
-  
+
   return undefined;
 }
 
@@ -104,12 +106,16 @@ export function getFixedValue(
   if (!fixedOrMetric || typeof fixedOrMetric === 'string') {
     return undefined;
   }
-  
+
   if (isFixedValue(fixedOrMetric) && fixedOrMetric.value) {
-    if (typeof fixedOrMetric.value === 'string' || typeof fixedOrMetric.value === 'number') {
+    if (
+      typeof fixedOrMetric.value === 'string' ||
+      typeof fixedOrMetric.value === 'number'
+    ) {
       return fixedOrMetric.value;
     }
   }
-  
+
   return undefined;
 }
+

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
@@ -23,7 +23,8 @@ export type MetricFormValue =
   | string 
   | number 
   | { label?: string; sqlExpression?: string; value?: string }
-  | undefined;
+  | undefined
+  | null;
 
 export interface FixedOrMetricValue {
   type?: 'fix' | 'metric';
@@ -34,7 +35,7 @@ export interface FixedOrMetricValue {
  * Checks if a value is configured as a metric (vs fixed value)
  */
 export function isMetricValue(
-  fixedOrMetric: string | FixedOrMetricValue | undefined,
+  fixedOrMetric: string | FixedOrMetricValue | undefined | null,
 ): boolean {
   if (!fixedOrMetric) return false;
   if (typeof fixedOrMetric === 'string') return true;
@@ -45,7 +46,7 @@ export function isMetricValue(
  * Checks if a value is configured as a fixed value (vs metric)
  */
 export function isFixedValue(
-  fixedOrMetric: string | FixedOrMetricValue | undefined,
+  fixedOrMetric: string | FixedOrMetricValue | undefined | null,
 ): boolean {
   if (!fixedOrMetric) return false;
   if (typeof fixedOrMetric === 'string') return false;
@@ -73,7 +74,7 @@ export function extractMetricKey(
  * Returns undefined for fixed values, metric label for metric values
  */
 export function getMetricLabelFromValue(
-  fixedOrMetric: string | FixedOrMetricValue | undefined,
+  fixedOrMetric: string | FixedOrMetricValue | undefined | null,
 ): string | undefined {
   if (!fixedOrMetric) return undefined;
   
@@ -98,7 +99,7 @@ export function getMetricLabelFromValue(
  * Returns the value for fixed types, undefined for metrics
  */
 export function getFixedValue(
-  fixedOrMetric: string | FixedOrMetricValue | undefined,
+  fixedOrMetric: string | FixedOrMetricValue | undefined | null,
 ): string | number | undefined {
   if (!fixedOrMetric || typeof fixedOrMetric === 'string') {
     return undefined;

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
@@ -118,4 +118,3 @@ export function getFixedValue(
 
   return undefined;
 }
-

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/utils/metricUtils.ts
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getMetricLabel } from '@superset-ui/core';
+
+export type MetricFormValue = 
+  | string 
+  | number 
+  | { label?: string; sqlExpression?: string; value?: string }
+  | undefined;
+
+export interface FixedOrMetricValue {
+  type?: 'fix' | 'metric';
+  value?: MetricFormValue;
+}
+
+/**
+ * Checks if a value is configured as a metric (vs fixed value)
+ */
+export function isMetricValue(
+  fixedOrMetric: string | FixedOrMetricValue | undefined,
+): boolean {
+  if (!fixedOrMetric) return false;
+  if (typeof fixedOrMetric === 'string') return true;
+  return fixedOrMetric.type === 'metric';
+}
+
+/**
+ * Checks if a value is configured as a fixed value (vs metric)
+ */
+export function isFixedValue(
+  fixedOrMetric: string | FixedOrMetricValue | undefined,
+): boolean {
+  if (!fixedOrMetric) return false;
+  if (typeof fixedOrMetric === 'string') return false;
+  return fixedOrMetric.type === 'fix';
+}
+
+/**
+ * Extracts the metric key from a metric value object
+ * Handles label, sqlExpression, and value properties
+ */
+export function extractMetricKey(
+  value: MetricFormValue,
+): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  
+  // Handle object metrics (adhoc or saved metrics)
+  const metricObj = value as { label?: string; sqlExpression?: string; value?: string };
+  return metricObj.label || metricObj.sqlExpression || metricObj.value;
+}
+
+/**
+ * Gets the metric label from a fixed/metric form value
+ * Returns undefined for fixed values, metric label for metric values
+ */
+export function getMetricLabelFromValue(
+  fixedOrMetric: string | FixedOrMetricValue | undefined,
+): string | undefined {
+  if (!fixedOrMetric) return undefined;
+  
+  // Legacy string format - treat as metric
+  if (typeof fixedOrMetric === 'string') {
+    return getMetricLabel(fixedOrMetric);
+  }
+  
+  // Only return metric label if it's a metric type, not a fixed value
+  if (isMetricValue(fixedOrMetric) && fixedOrMetric.value) {
+    const metricKey = extractMetricKey(fixedOrMetric.value);
+    if (metricKey && typeof metricKey === 'string') {
+      return getMetricLabel(metricKey);
+    }
+  }
+  
+  return undefined;
+}
+
+/**
+ * Gets the fixed value from a fixed/metric form value
+ * Returns the value for fixed types, undefined for metrics
+ */
+export function getFixedValue(
+  fixedOrMetric: string | FixedOrMetricValue | undefined,
+): string | number | undefined {
+  if (!fixedOrMetric || typeof fixedOrMetric === 'string') {
+    return undefined;
+  }
+  
+  if (isFixedValue(fixedOrMetric) && fixedOrMetric.value) {
+    if (typeof fixedOrMetric.value === 'string' || typeof fixedOrMetric.value === 'number') {
+      return fixedOrMetric.value;
+    }
+  }
+  
+  return undefined;
+}


### PR DESCRIPTION
## **User description**
### SUMMARY

Fixes an error that occurs when using a fixed point size in the deck.gl Scatterplot chart. The issue was caused by the chart incorrectly treating fixed radius values as metric names, attempting to query for a field that doesn't exist in the data.

**Root Cause:**
- The `getMetricLabelFromFormData` function was returning the fixed value (e.g., "1000") as a metric label even when `point_radius_fixed.type` was "fix"
- This caused the query builder to look for a metric field named "1000" which doesn't exist
- The transformation layer was trying to access this non-existent field from the data records

**Fix:**
- Updated `getMetricLabelFromFormData` to only return metric labels when type is "metric", returning undefined for fixed values
- Modified `buildQuery` to only include metrics in the query when using metric-based radius
- Updated `transformProps` to properly handle fixed radius values by applying them directly to all points

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

https://github.com/user-attachments/assets/9a64f95f-b18a-4afa-94e6-7a856d866789


**After:**


https://github.com/user-attachments/assets/8c38450c-7cfb-4bf5-8061-9e79666025d5



### TESTING INSTRUCTIONS

1. Create a deck.gl Scatterplot chart
2. In the chart configuration, set "Point Size" control to "Fixed"
3. Enter any numeric value (e.g., 1000)
4. The chart should render without errors, with all points having the same size
5. Switch back to "Based on a metric" and select a metric - verify this still works
6. Run the new tests: `npm test -- plugins/legacy-preset-chart-deckgl/src/layers/Scatter`

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #35930
- [ ] Required feature flags: None
- [x] Changes UI: Fixes broken functionality, no visual changes to working features
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

**Testing:**
- Added comprehensive test coverage with 43 new tests across 3 test files
- Tests cover both fixed and metric-based point radius scenarios
- Tests follow the "avoid nesting when testing" principle with flat test() statements
- All tests passing successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Fix Scatterplot errors and ensure fixed point sizes render correctly

### What Changed
- Scatterplot no longer treats a fixed point-size value as a metric: fixed numeric or string sizes are applied to all points and are not requested from the backend
- Queries no longer include or order by fixed radius values; metric columns and ordering are only added when radius is explicitly metric-based
- Tooltips stop showing a metric label for fixed-size mode; metric values and labels still appear when radius is metric-based
- Added tests covering fixed numeric and string radii, metric-based radii, missing spatial/data cases, and query behavior

### Impact
`✅ No chart errors when setting fixed point size`
`✅ Consistent fixed point sizes render for all points`
`✅ Accurate metric-based sizing and tooltips when using metric radius`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
