### PR TITLE
fix(plugin-chart-table): remove column misalignment when no scrollbars are present

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -344,7 +344,7 @@ function StickyWrap({
         style={{
           height: bodyHeight,
           overflow: 'auto',
-          scrollbarGutter: 'stable',
+          scrollbarGutter: hasVerticalScroll ? 'stable' : undefined,
           width: maxWidth,
           boxSizing: 'border-box',
         }}


### PR DESCRIPTION
## **User description**
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a column misalignment issue in the Table chart when no scrollbars are present. The fix ensures consistent width calculation between header and body containers across all scrollbar scenarios.

**Background**

The Table chart's sticky header implementation has gone through several iterations to handle scrollbar-related alignment issues:

- **PR #26964** introduced `scrollbarGutter: 'stable'` to all containers (header, body, footer, sizer) to fix misalignment on macOS when users have "Always show scrollbars" enabled. This CSS property reserves space for scrollbars even when they're not visible.

- **PR #36190** refined this approach by removing `scrollbarGutter: 'stable'` from the header/footer and instead dynamically calculating `headerContainerWidth = maxWidth - scrollBarSize` when vertical scroll exists. This fixed cases where headers were offset from columns.

### The Problem

After PR #36190, a new edge case emerged: when **no scrollbars are present** (table fits entirely within its container), the columns become misaligned. This happens because:

- **Header**: Uses `maxWidth` (since `hasVerticalScroll` is false, no subtraction occurs)
- **Body**: Uses `maxWidth` + `scrollbarGutter: 'stable'` (always reserves ~8px for scrollbar)

The body reserves space for a scrollbar that doesn't exist, making its content area narrower than the header's, causing visible column misalignment.

### The Solution

Conditionally apply `scrollbarGutter: 'stable'` only when `hasVerticalScroll` is true:

Fixes #36370 #36185

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before: with vertical scrollbar, no horizontal scroll and no vertical scroll

https://github.com/user-attachments/assets/11481e2f-d6a9-42e5-a308-d6352b577483


<img width="1712" height="1267" alt="Screenshot 2026-01-03 132059" src="https://github.com/user-attachments/assets/8978fea8-6d5a-4a5b-88a8-6ced2abe798d" />
<img width="1712" height="1266" alt="Screenshot 2026-01-03 132051" src="https://github.com/user-attachments/assets/de56d46b-d3aa-4028-aeca-3483896c3d88" />
<img width="1716" height="1265" alt="Screenshot 2026-01-03 132003" src="https://github.com/user-attachments/assets/cff65ec0-95d2-42cc-a0fa-f131ec5c14e5" />


- After: with vertical scrollbar, no horizontal scroll and no vertical scroll.

https://github.com/user-attachments/assets/e02d28e8-733b-4b26-a6ab-b693aab4ba1b

<img width="1709" height="1268" alt="Screenshot 2026-01-03 131904" src="https://github.com/user-attachments/assets/ad000104-fdb9-43f7-96b1-87f09f7cce22" />
<img width="1715" height="1266" alt="Screenshot 2026-01-03 131856" src="https://github.com/user-attachments/assets/a3e45d50-d094-4675-8d42-8012ad4e1671" />
<img width="1714" height="1266" alt="Screenshot 2026-01-03 131851" src="https://github.com/user-attachments/assets/6d627f4d-37fe-433c-aa50-741404750405" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


___

## **CodeAnt-AI Description**
Fix column misalignment in Table when no vertical scrollbar

### What Changed
- The table body no longer reserves invisible scrollbar space when there is no vertical scrollbar, so header and body column widths match.
- Tables that fit entirely within their container no longer show a subtle right-side gap or shifted columns.
- Behavior remains unchanged when a vertical scrollbar is present (scrollbar space is still accounted for to keep alignment).

### Impact
`✅ Fewer misaligned table columns`
`✅ Consistent table layout when no scrollbar is visible`
`✅ No unexpected blank gap on the right of tables`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
