### PR TITLE
fix(i18n): ensure language pack loads before React renders

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
@@ -42,12 +42,15 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 beforeEach(() => {
+  jest.useRealTimers();
+  fetchMock.removeRoutes();
   fetchMock.get(DATASOURCE_ENDPOINT, [], { name: DATASOURCE_ENDPOINT });
   setupDatasourceEditorMocks();
   jest.clearAllMocks();
 });
 
 afterEach(async () => {
+  jest.useRealTimers();
   await cleanupAsyncOperations();
   fetchMock.clearHistory().removeRoutes();
   // Reset module mock since jest.fn() doesn't support mockRestore()

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -506,7 +506,7 @@ test('deletes a filter including dependencies', async () => {
   const filterTabs = within(filterContainer).getAllByRole('tab');
   const deleteIcon = filterTabs[1].querySelector('[data-icon="delete"]');
   fireEvent.click(deleteIcon!);
-  userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
+  await userEvent.click(screen.getByRole('button', { name: SAVE_REGEX }));
   await waitFor(() =>
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.permissions.test.tsx
@@ -35,6 +35,7 @@ import {
 jest.setTimeout(30000);
 
 beforeEach(() => {
+  jest.useRealTimers();
   setupMocks();
   jest.clearAllMocks();
 });

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -110,6 +110,6 @@ export default function initPreamble(): Promise<void> {
 // This module is prepended to multiple webpack entrypoints (see `webpack.config.js`).
 // Kick off initialization eagerly, while still allowing entrypoints to `await` it
 // before rendering when needed (e.g. the login page).
-void initPreamble().catch(err => {
+initPreamble().catch(err => {
   console.warn('Preamble initialization failed.', err);
 });

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -106,3 +106,10 @@ export default function initPreamble(): Promise<void> {
 
   return initPromise;
 }
+
+// This module is prepended to multiple webpack entrypoints (see `webpack.config.js`).
+// Kick off initialization eagerly, while still allowing entrypoints to `await` it
+// before rendering when needed (e.g. the login page).
+void initPreamble().catch(err => {
+  console.warn('Preamble initialization failed.', err);
+});

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { configure, LanguagePack } from '@apache-superset/core/ui';
+import { logging } from '@apache-superset/core';
 import { makeApi, initFeatureFlags } from '@superset-ui/core';
 import { extendedDayjs as dayjs } from '@superset-ui/core/utils/dates';
 import setupClient from './setup/setupClient';
@@ -82,7 +83,7 @@ export default function initPreamble(): Promise<void> {
         configure({ languagePack: json as LanguagePack });
         dayjs.locale(lang);
       } catch (err) {
-        console.warn(
+        logging.warn(
           'Failed to fetch language pack, falling back to default.',
           err,
         );
@@ -130,5 +131,5 @@ export default function initPreamble(): Promise<void> {
 // Kick off initialization eagerly, while still allowing entrypoints to `await` it
 // before rendering when needed (e.g. the login page).
 initPreamble().catch(err => {
-  console.warn('Preamble initialization failed.', err);
+  logging.warn('Preamble initialization failed.', err);
 });

--- a/superset-frontend/src/preamble.ts
+++ b/superset-frontend/src/preamble.ts
@@ -37,62 +37,72 @@ import 'dayjs/plugin/duration';
 import 'dayjs/plugin/updateLocale';
 import 'dayjs/plugin/localizedFormat';
 
-configure();
+let initPromise: Promise<void> | null = null;
 
-// Grab initial bootstrap data
-const bootstrapData = getBootstrapData();
-
-setupFormatters(
-  bootstrapData.common.d3_format,
-  bootstrapData.common.d3_time_format,
-);
-
-// Setup SupersetClient early so we can fetch language pack
-setupClient({ appRoot: applicationRoot() });
-
-// Load language pack before anything else
-(async () => {
-  const lang = bootstrapData.common.locale || 'en';
-  if (lang !== 'en') {
-    try {
-      // Second call to configure to set the language pack
-      const { json } = await SupersetClient.get({
-        endpoint: `/superset/language_pack/${lang}/`,
-      });
-      configure({ languagePack: json as LanguagePack });
-      dayjs.locale(lang);
-    } catch (err) {
-      console.warn(
-        'Failed to fetch language pack, falling back to default.',
-        err,
-      );
-      configure();
-      dayjs.locale('en');
-    }
+export default function initPreamble(): Promise<void> {
+  if (initPromise) {
+    return initPromise;
   }
 
-  // Continue with rest of setup
-  initFeatureFlags(bootstrapData.common.feature_flags);
+  initPromise = (async () => {
+    configure();
 
-  setupColors(
-    bootstrapData.common.extra_categorical_color_schemes,
-    bootstrapData.common.extra_sequential_color_schemes,
-  );
+    // Grab initial bootstrap data
+    const bootstrapData = getBootstrapData();
 
-  setupDashboardComponents();
+    setupFormatters(
+      bootstrapData.common.d3_format,
+      bootstrapData.common.d3_time_format,
+    );
 
-  const getMe = makeApi<void, User>({
-    method: 'GET',
-    endpoint: '/api/v1/me/',
-  });
+    // Setup SupersetClient early so we can fetch language pack
+    setupClient({ appRoot: applicationRoot() });
 
-  if (bootstrapData.user?.isActive) {
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') {
-        getMe().catch(() => {
-          // SupersetClient will redirect to login on 401
+    // Load language pack before rendering
+    const lang = bootstrapData.common.locale || 'en';
+    if (lang !== 'en') {
+      try {
+        // Second call to configure to set the language pack
+        const { json } = await SupersetClient.get({
+          endpoint: `/superset/language_pack/${lang}/`,
         });
+        configure({ languagePack: json as LanguagePack });
+        dayjs.locale(lang);
+      } catch (err) {
+        console.warn(
+          'Failed to fetch language pack, falling back to default.',
+          err,
+        );
+        configure();
+        dayjs.locale('en');
       }
+    }
+
+    // Continue with rest of setup
+    initFeatureFlags(bootstrapData.common.feature_flags);
+
+    setupColors(
+      bootstrapData.common.extra_categorical_color_schemes,
+      bootstrapData.common.extra_sequential_color_schemes,
+    );
+
+    setupDashboardComponents();
+
+    const getMe = makeApi<void, User>({
+      method: 'GET',
+      endpoint: '/api/v1/me/',
     });
-  }
-})();
+
+    if (bootstrapData.user?.isActive) {
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+          getMe().catch(() => {
+            // SupersetClient will redirect to login on 401
+          });
+        }
+      });
+    }
+  })();
+
+  return initPromise;
+}

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -28,7 +28,9 @@ if (appMountPoint) {
     try {
       await initPreamble();
     } finally {
-      const { default: App } = await import('./App');
+      const { default: App } = await import(
+        /* webpackMode: "eager" */ './App'
+      );
       ReactDOM.render(<App />, appMountPoint);
     }
   })();

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -19,6 +19,17 @@
 import 'src/public-path';
 
 import ReactDOM from 'react-dom';
-import App from './App';
+import initPreamble from 'src/preamble';
 
-ReactDOM.render(<App />, document.getElementById('app'));
+const appMountPoint = document.getElementById('app');
+
+if (appMountPoint) {
+  (async () => {
+    try {
+      await initPreamble();
+    } finally {
+      const { default: App } = await import('./App');
+      ReactDOM.render(<App />, appMountPoint);
+    }
+  })();
+}

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -19,6 +19,7 @@
 import 'src/public-path';
 
 import ReactDOM from 'react-dom';
+import { logging } from '@apache-superset/core';
 import initPreamble from 'src/preamble';
 
 const appMountPoint = document.getElementById('app');
@@ -32,7 +33,6 @@ if (appMountPoint) {
       ReactDOM.render(<App />, appMountPoint);
     }
   })().catch(err => {
-    // eslint-disable-next-line no-console
-    console.error('Unhandled error during app initialization', err);
+    logging.error('Unhandled error during app initialization', err);
   });
 }

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -33,5 +33,8 @@ if (appMountPoint) {
       );
       ReactDOM.render(<App />, appMountPoint);
     }
-  })();
+  })().catch(err => {
+    // eslint-disable-next-line no-console
+    console.error('Unhandled error during app initialization', err);
+  });
 }

--- a/superset-frontend/src/views/index.tsx
+++ b/superset-frontend/src/views/index.tsx
@@ -28,9 +28,7 @@ if (appMountPoint) {
     try {
       await initPreamble();
     } finally {
-      const { default: App } = await import(
-        /* webpackMode: "eager" */ './App'
-      );
+      const { default: App } = await import(/* webpackMode: "eager" */ './App');
       ReactDOM.render(<App />, appMountPoint);
     }
   })().catch(err => {

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -476,9 +476,12 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
         and bool(available_specs[GSheetsEngineSpec])
     )
 
-    language = (
-        locale.language if locale else app.config.get("BABEL_DEFAULT_LOCALE", "en")
-    )
+    if isinstance(locale, Locale):
+        language = locale.language
+    elif isinstance(locale, str):
+        language = locale
+    else:
+        language = app.config.get("BABEL_DEFAULT_LOCALE", "en")
     auth_type = app.config["AUTH_TYPE"]
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]
     frontend_config["AUTH_USER_REGISTRATION"] = auth_user_registration

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -476,7 +476,11 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
         and bool(available_specs[GSheetsEngineSpec])
     )
 
-    language = locale.language if locale else app.config.get("BABEL_DEFAULT_LOCALE", "en")
+    language = (
+        locale.language
+        if locale
+        else app.config.get("BABEL_DEFAULT_LOCALE", "en")
+    )
     auth_type = app.config["AUTH_TYPE"]
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]
     frontend_config["AUTH_USER_REGISTRATION"] = auth_user_registration

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -476,7 +476,7 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
         and bool(available_specs[GSheetsEngineSpec])
     )
 
-    language = locale.language if locale else "en"
+    language = locale.language if locale else app.config.get("BABEL_DEFAULT_LOCALE", "en")
     auth_type = app.config["AUTH_TYPE"]
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]
     frontend_config["AUTH_USER_REGISTRATION"] = auth_user_registration

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -477,9 +477,7 @@ def cached_common_bootstrap_data(  # pylint: disable=unused-argument
     )
 
     language = (
-        locale.language
-        if locale
-        else app.config.get("BABEL_DEFAULT_LOCALE", "en")
+        locale.language if locale else app.config.get("BABEL_DEFAULT_LOCALE", "en")
     )
     auth_type = app.config["AUTH_TYPE"]
     auth_user_registration = app.config["AUTH_USER_REGISTRATION"]


### PR DESCRIPTION
## **User description**
## Summary

Fixes the partial translation issue where UI elements display in English even when a non-English default language is configured.

**Root cause:** The language pack loads asynchronously in an IIFE, but React renders immediately without waiting. This creates a race condition where `t()` is called before translations are available.

## Changes

### Backend (`superset/views/base.py`)
- Use `BABEL_DEFAULT_LOCALE` config as fallback instead of hardcoded `"en"`
- Ensures unauthenticated users get the correct locale in bootstrap data

### Frontend (`superset-frontend/src/preamble.ts`)
- Fetch language pack via app root URL and apply a timeout to avoid indefinite blocking
- Refactor from IIFE to exported `initPreamble()` function returning `Promise<void>`
- Add singleton pattern to prevent duplicate initialization

### Frontend (`superset-frontend/src/views/index.tsx`)
- Await `initPreamble()` before rendering React app
- Use `try/finally` to ensure app renders even if language pack fails

## Before/After

**Before:**
```
1. preamble IIFE starts, requests language pack
2. ReactDOM.render() executes immediately
3. t('Sign in') → "Sign in" (English, pack not loaded yet)
4. Language pack loads (too late)
```

**After:**
```
1. await initPreamble() - waits for language pack
2. t() is configured with correct translations
3. ReactDOM.render() executes
4. t('Sign in') → "登录" (correct translation)
```

## Test Plan

1. Set `BABEL_DEFAULT_LOCALE = "zh"` (or any non-English locale)
2. Clear browser cache and cookies
3. Visit `/login/` in incognito mode
4. Verify login page displays in the configured language
5. Verify language switching still works after login

Fixes #35569
Fixes #36893


## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.


___

## **CodeAnt-AI Description**
Ensure the language pack is loaded before the app renders and use configured default locale

### What Changed
- The frontend now waits for the language pack to load before mounting the React app so UI text appears in the configured language at first render
- The preamble initialization runs safely for multiple entrypoints and still allows rendering if the language pack fetch fails (app falls back to default text but does not hang)
- The backend uses the configured BABEL_DEFAULT_LOCALE for bootstrap data when no user locale is present so unauthenticated pages receive the correct default language

### Impact
`✅ Fewer untranslated UI elements on first load`
`✅ Correct default language on public/unauthenticated pages`
`✅ App still renders when language pack fetch fails`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

