### PR TITLE
feat(native filters): add filter type icons in config modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FilterTitleContainer.tsx
@@ -51,6 +51,16 @@ export const FilterTitle = styled.div`
   `}
 `;
 
+const StyledFilterIcon = styled(Icons.FilterOutlined)`
+  color: ${({ theme }) => theme.colorIcon};
+  margin-right: ${({ theme }) => theme.sizeUnit * 2}px;
+`;
+
+const StyledDividerIcon = styled(Icons.PicCenterOutlined)`
+  color: ${({ theme }) => theme.colorIcon};
+  margin-right: ${({ theme }) => theme.sizeUnit * 2}px;
+`;
+
 const StyledWarning = styled(Icons.ExclamationCircleOutlined)`
   color: ${({ theme }) => theme.colorErrorText};
   &.anticon {
@@ -74,6 +84,8 @@ interface Props {
   filters: string[];
   erroredFilters: string[];
 }
+
+const isFilterDivider = (id: string) => id.startsWith('NATIVE_FILTER_DIVIDER');
 
 const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
   (
@@ -116,6 +128,11 @@ const FilterTitleContainer = forwardRef<HTMLDivElement, Props>(
                 wordBreak: 'break-all',
               }}
             >
+              {isFilterDivider(id) ? (
+                <StyledDividerIcon iconSize="m" />
+              ) : (
+                <StyledFilterIcon iconSize="m" />
+              )}
               {isRemoved ? t('(Removed)') : getFilterTitle(id)}
             </div>
             {!removedFilters[id] && isErrored && (


### PR DESCRIPTION
### SUMMARY
I tried this forever ago, but we're in a better place to do this now. This will give me fewer headaches when managing filters, I think. 

Adds visual icons to distinguish between filters and dividers in the filter configuration modal's left panel:
- Filters display a filter icon (funnel)
- Dividers display a layout icon (horizontal lines)

This makes it easier to identify what type of item each entry is at a glance.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**After:**
<!-- Screenshot showing filter and divider icons in the config modal -->
<img width="284" height="210" alt="image" src="https://github.com/user-attachments/assets/67bc5a2b-f40f-4e76-a2d4-c3123a8b6c81" />

### TESTING INSTRUCTIONS
1. Open a dashboard with native filters
2. Click the gear icon to open filter settings
3. Add a filter and a divider
4. Observe the different icons next to each item in the left panel

### ADDITIONAL INFORMATION
- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)