### PR TITLE
feat(dev): add make ports and make open commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Python version installed; we need 3.10-3.11
 PYTHON=`command -v python3.11 || command -v python3.10`
 
-.PHONY: install superset venv pre-commit up down logs ps nuke
+.PHONY: install superset venv pre-commit up down logs ps nuke ports open
 
 install: superset pre-commit
 
@@ -131,3 +131,9 @@ ps:
 
 nuke:
 	./scripts/docker-compose-up.sh nuke
+
+ports:
+	./scripts/docker-compose-up.sh ports
+
+open:
+	./scripts/docker-compose-up.sh open

--- a/docs/developer_portal/contributing/development-setup.md
+++ b/docs/developer_portal/contributing/development-setup.md
@@ -164,6 +164,8 @@ Available commands (run from repo root):
 | `make down` | Stop all services |
 | `make ps` | Show running containers |
 | `make logs` | Follow container logs |
+| `make ports` | Show assigned URLs and ports |
+| `make open` | Open browser to dev server |
 | `make nuke` | Stop, remove volumes & local images |
 
 From a subdirectory, use: `make -C $(git rev-parse --show-toplevel) up`


### PR DESCRIPTION
## **User description**
### SUMMARY

Adds two new commands to improve developer experience when running Superset via Docker:

- `make ports` - Shows the assigned URLs and ports for running services
- `make open` - Opens the browser directly to the dev server (port 9000)

**Problem:** When running `make up`, the port information is displayed at the start but quickly scrolls away as Docker logs flood the terminal. Developers often need to scroll back or guess the ports.

**Solution:** 
- `make ports` lets you check the URLs anytime
- `make open` opens your browser directly to the right URL
- Connection info is now also printed when you Ctrl+C out of `make up`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

```bash
$ make ports
🔍 Finding available ports...

🐳 Superset (superset-testbed2):
   Dev Server: http://localhost:9000  ← Use this for development
   Superset:   http://localhost:8088
   Nginx:      http://localhost:80
   WebSocket:  localhost:8080
   Database:   localhost:5432
   Redis:      localhost:6379

$ make open
🌐 Opening browser...
```

### TESTING INSTRUCTIONS

1. Run `make up` to start Superset
2. Press Ctrl+C - connection info should be printed again
3. Run `make ports` - should show assigned URLs
4. Run `make open` - should open browser to dev server

### ADDITIONAL INFORMATION

- [x] Changes UI
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show actual service ports, add make ports and make open commands**

### What Changed
- The dev tooling now detects and displays the actual ports used by running Docker containers, so reported URLs match what is currently bound.
- Added two developer commands: `make ports` to print assigned service URLs and `make open` to open the dev server in the browser.
- Connection information is printed when starting the compose stack and again after stopping (e.g., when you Ctrl+C), so ports are visible without scrolling through logs.

### Impact
`✅ Fewer terminal searches for ports`
`✅ Open dev server in browser with a single command`
`✅ Connection info remains visible after stopping services`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
