### PR TITLE
fix(mypy): add overrides for superset-core local dev consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,26 @@ module = "cryptography.*"
 ignore_errors = true
 follow_imports = "skip"
 
+# superset-core is installed as editable locally but CI may not expose types
+# This ensures consistent behavior between local dev and CI
+[[tool.mypy.overrides]]
+module = "superset_core.*"
+follow_imports = "skip"
+
+# Disable warn_unused_ignores for modules with dynamic type assignments
+# These type: ignore comments are needed in CI where superset-core types aren't visible
+[[tool.mypy.overrides]]
+module = [
+    "superset.core.api.core_api_injection",
+    "superset.security.manager",
+    "superset.daos.base",
+    "superset.connectors.sqla.models",
+    "superset.tags.filters",
+    "superset.commands.security.update",
+    "superset.commands.security.create",
+]
+warn_unused_ignores = false
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
## **User description**
## Summary

When `superset-core` is installed as an editable dependency locally (via `apache-superset-core = { path = "./superset-core", editable = true }`), mypy can see its type information and flags `# type: ignore` comments as unused. In CI, the types aren't exposed the same way, so those comments are still needed.

This adds mypy overrides to:
1. Skip following imports from `superset_core` module
2. Disable `warn_unused_ignores` for modules with dynamic type assignments that need `# type: ignore` in CI

**Affected modules:**
- `superset.core.api.core_api_injection`
- `superset.security.manager`
- `superset.daos.base`
- `superset.connectors.sqla.models`
- `superset.tags.filters`
- `superset.commands.security.update`
- `superset.commands.security.create`

## Before/After

**Before:** Local pre-commit mypy fails with 26 "Unused type: ignore comment" errors
**After:** Local pre-commit mypy passes, matching CI behavior

## Test Plan

- [x] Verified `pre-commit run mypy --files superset/core/api/core_api_injection.py` passes locally
- [x] Verified all previously failing files pass mypy locally
- [ ] CI should continue to pass (no behavioral change in CI)

## Additional Information

This issue started appearing for developers with local editable installs of superset-core after the superset-core package was introduced. The fix ensures consistent behavior between local development and CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add mypy overrides so local checks match CI when superset-core is editable

### What Changed
- Ignore following imports from the superset_core package during local mypy runs so editable local installs don't surface CI-only type differences
- Disable "warn_unused_ignores" for seven modules that rely on type: ignore comments in CI to avoid spurious local failures

### Impact
`✅ Fewer local mypy failures during pre-commit`
`✅ Consistent mypy results between local development and CI`
`✅ Shorter developer setup time when using an editable superset-core`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
