### PR TITLE
docs: add Netlify configuration for PR deploy previews

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Netlify configuration for Superset documentation
+# This enables automatic deploy previews for PRs that modify docs
+
+[build]
+  # Base directory is the docs folder
+  base = "docs"
+  # Build command for Docusaurus
+  command = "yarn install && yarn build"
+  # Output directory (relative to base)
+  publish = "build"
+
+[build.environment]
+  # Node version matching docs/.nvmrc
+  NODE_VERSION = "20"
+  # Yarn version
+  YARN_VERSION = "1.22.22"
+
+# Deploy preview settings
+[context.deploy-preview]
+  command = "yarn install && yarn build"
+
+# Branch deploy settings (for feature branches)
+[context.branch-deploy]
+  command = "yarn install && yarn build"
+
+# Redirect /docs to the main docs page
+[[redirects]]
+  from = "/docs"
+  to = "/docs/intro"
+  status = 301
+
+# Handle SPA routing for Docusaurus
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -25,6 +25,9 @@
   command = "yarn install && yarn build"
   # Output directory (relative to base)
   publish = "build"
+  # Skip builds when no docs changes (exit 0 = skip, exit 1 = build)
+  # Checks for changes in docs/ and README.md (which gets pulled into docs)
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- . ../README.md"
 
 [build.environment]
   # Node version matching docs/.nvmrc

--- a/superset-frontend/netlify.toml
+++ b/superset-frontend/netlify.toml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Netlify configuration for Superset Storybook
+# Deployed at: superset-storybook.netlify.app
+
+[build]
+  base = "superset-frontend"
+  command = "npm install && npm run build-storybook"
+  publish = "storybook-static"
+  # Skip builds when no relevant frontend changes
+  # Rebuilds on: component files, storybook config, dependencies
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- src/ packages/ plugins/ .storybook/ package.json yarn.lock"
+
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## **User description**
## Summary

Adds `netlify.toml` configuration to enable automatic deploy previews for documentation PRs. Once configured, PRs that modify `docs/**` will automatically get preview URLs.

## Setup Required

This PR adds the configuration file, but a Netlify site needs to be created/configured:

### Option A: Create a new Netlify site for docs
1. Create a new site on Netlify pointing to this repo
2. Set the base directory to `docs`
3. Enable "Deploy Previews" for all pull requests

### Option B: Repurpose existing superset-storybook site
1. Update the existing site's base directory from `superset-frontend` to `docs`
2. Enable "Deploy Previews" if not already enabled

### Expected Result
- PRs modifying docs will get comments with preview URLs like:
  `https://deploy-preview-123--superset-docs.netlify.app`
- Reviewers can view documentation changes without pulling/building locally

## Test plan
- [ ] Netlify site created/configured
- [ ] This PR should trigger a deploy preview once Netlify is connected
- [ ] Preview URL appears as a check/comment on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add Netlify deploy preview configuration for documentation PRs**

### What Changed
- Adds a Netlify configuration file that, when Netlify is connected, builds the site from the docs directory and creates deploy preview URLs for PRs that modify docs
- Ensures the docs build uses Node 20 and Yarn 1.22.22 and runs the standard install+build command for previews and branch deploys
- Adds redirects so /docs goes to /docs/intro and all SPA routes serve index.html, enabling preview navigation

### Impact
`✅ Deploy previews for docs PRs`
`✅ Preview URLs available for reviewers`
`✅ Viewable documentation changes without local builds`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
