### PR TITLE
fix(viz): display offset metrics as dashed lines regardless of compar…

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
@@ -17,22 +17,13 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import {
-  ensureIsArray,
-  JsonObject,
-  QueryFormData,
-  ComparisonType,
-} from '@superset-ui/core';
+import { ensureIsArray, JsonObject, QueryFormData } from '@superset-ui/core';
 import { hasTimeOffset } from './timeOffset';
 
 export const isDerivedSeries = (
   series: JsonObject,
   formData: QueryFormData,
 ): boolean => {
-  const comparisonType = formData.comparison_type;
-  if (comparisonType !== ComparisonType.Values) {
-    return false;
-  }
   const timeCompare: string[] = ensureIsArray(formData?.time_compare);
   return hasTimeOffset(series, timeCompare);
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
@@ -25,6 +25,6 @@ export const isDerivedSeries = (
   series: JsonObject,
   formData: QueryFormData,
 ): boolean => {
-  const timeCompare: string[] = ensureIsArray(formData?.time_compare);
+  const timeCompare = ensureIsArray(formData?.time_compare).filter((v): v is string => typeof v === 'string');
   return hasTimeOffset(series, timeCompare);
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
@@ -17,7 +17,8 @@
  * specific language governing permissions and limitationsxw
  * under the License.
  */
-import { ensureIsArray, JsonObject, QueryFormData } from '@superset-ui/core';
+import { ensureIsArray } from '@superset-ui/core';
+import type { JsonObject, QueryFormData } from '@superset-ui/core';
 import { hasTimeOffset } from './timeOffset';
 
 export const isDerivedSeries = (

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/timeOffset.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/timeOffset.ts
@@ -36,7 +36,7 @@ export const hasTimeOffset = (
   timeCompare: string[],
 ): boolean =>
   typeof series.name === 'string'
-    ? !!getTimeOffset(series, timeCompare)
+    ? !!getTimeOffset(series, timeCompare) || timeCompare.includes(series.name)
     : false;
 
 export const getOriginalSeries = (

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/isDerivedSeries.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/isDerivedSeries.test.ts
@@ -29,20 +29,19 @@ const series = {
   data: [100],
 };
 
-test('should be false if comparison type is not actual values', () => {
+test('should be false if time_compare is not set', () => {
   expect(isDerivedSeries(series, formData)).toEqual(false);
-  Object.keys(ComparisonType)
-    .filter(type => type === ComparisonType.Values)
-    .forEach(type => {
-      const formDataWithComparisonType = {
-        ...formData,
-        comparison_type: type,
-        time_compare: ['1 month ago'],
-      };
-      expect(isDerivedSeries(series, formDataWithComparisonType)).toEqual(
-        false,
-      );
-    });
+});
+
+test('should be true if series name matches time_compare regardless of comparison_type', () => {
+  Object.values(ComparisonType).forEach(type => {
+    const formDataWithComparisonType = {
+      ...formData,
+      comparison_type: type,
+      time_compare: ['1 month ago'],
+    };
+    expect(isDerivedSeries(series, formDataWithComparisonType)).toEqual(true);
+  });
 });
 
 test('should be true if comparison type is values', () => {


### PR DESCRIPTION
### SUMMARY
Fixes #36806 

This PR fixes a regression where offset metrics (time comparisons like "1 year ago") were not displayed as dashed lines when charts have no dimensions.

**Root Cause:**
The `isDerivedSeries` function only applied dashed styling when `comparison_type === "Values"`, and `hasTimeOffset` didn't detect series where the name exactly matched a time offset (which happens when there are no dimensions).

**Changes:**
- Removed the restrictive `comparison_type === "Values"` check in `isDerivedSeries.ts`
- Added exact match handling in `timeOffset.ts` for dimension-less charts
- Updated tests to reflect new behavior

### BEFORE/AFTER

**BEFORE**
<img width="848" height="493" alt="image" src="https://github.com/user-attachments/assets/ede17d65-3f65-4140-adf9-689351702c65" />


**AFTER **

<img width="830" height="693" alt="image" src="https://github.com/user-attachments/assets/05de1656-c8cf-47fc-8194-a25f81ea59b5" />


### TESTING INSTRUCTIONS
1. Create a new Line Chart
2. Select a dataset with a time column (e.g., `birth_names` with `ds`)
3. Add a metric (e.g., `COUNT(*)`)
4. Set Time Range to a valid range (e.g., `2005-01-01 to 2008-12-31`)
5. In Advanced Analytics, add Time Comparison: `1 year ago`
6. **Do NOT add any dimensions** (leave Dimensions empty)
7. Click "Update Chart"
8. Verify the offset metric line (`1 year ago`) appears **dashed**, not solid

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36806
- [ ] Required feature flags: None
- [x] Changes UI
- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API