### PR TITLE
feat(embedded-sdk): Add resolvePermalinkUrl callback for custom permalink URLs

### DIFF
--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -59,10 +59,14 @@ embedDashboard({
           // ...
       }
   },
-    // optional additional iframe sandbox attributes
+  // optional additional iframe sandbox attributes
   iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox'],
+  // optional Permissions Policy features
+  iframeAllowExtras: ['clipboard-write', 'fullscreen'],
   // optional config to enforce a particular referrerPolicy
-  referrerPolicy: "same-origin"
+  referrerPolicy: "same-origin",
+  // optional callback to customize permalink URLs
+  resolvePermalinkUrl: ({ key }) => `https://my-app.com/analytics/share/${key}`
 });
 ```
 
@@ -158,6 +162,20 @@ To pass additional sandbox attributes you can use `iframeSandboxExtras`:
   // optional additional iframe sandbox attributes
   iframeSandboxExtras: ['allow-top-navigation', 'allow-popups-to-escape-sandbox']
 ```
+
+### Permissions Policy
+
+To enable specific browser features within the embedded iframe, use `iframeAllowExtras` to set the iframe's [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) (the `allow` attribute):
+
+```js
+  // optional Permissions Policy features
+  iframeAllowExtras: ['clipboard-write', 'fullscreen']
+```
+
+Common permissions you might need:
+- `clipboard-write` - Required for "Copy permalink to clipboard" functionality
+- `fullscreen` - Required for fullscreen chart viewing
+- `camera`, `microphone` - If your dashboards include media capture features
 
 ### Enforcing a ReferrerPolicy on the request triggered by the iframe
 

--- a/superset-embedded-sdk/README.md
+++ b/superset-embedded-sdk/README.md
@@ -166,3 +166,42 @@ By default, the Embedded SDK creates an `iframe` element without a `referrerPoli
 This can be an issue as during the embedded enablement for a dashboard it's possible to specify which domain(s) are allowed to embed the dashboard, and this validation happens throuth the `Referrer` header. That said, in case the hosting app has a more restrictive policy that would omit this header, this validation would fail.
 
 Use the `referrerPolicy` parameter in the `embedDashboard` method to specify [a particular policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy) that works for your implementation.
+
+### Customizing Permalink URLs
+
+When users click share buttons inside an embedded dashboard, Superset generates permalinks using Superset's domain. If you want to use your own domain and URL format for these permalinks, you can provide a `resolvePermalinkUrl` callback:
+
+```js
+embedDashboard({
+  id: "abc123",
+  supersetDomain: "https://superset.example.com",
+  mountPoint: document.getElementById("my-superset-container"),
+  fetchGuestToken: () => fetchGuestTokenFromBackend(),
+
+  // Customize permalink URLs
+  resolvePermalinkUrl: ({ key }) => {
+    // key: the permalink key (e.g., "xyz789")
+    return `https://my-app.com/analytics/share/${key}`;
+  }
+});
+```
+
+To restore the dashboard state from a permalink in your app:
+
+```js
+// In your route handler for /analytics/share/:key
+const permalinkKey = routeParams.key;
+
+embedDashboard({
+  id: "abc123",
+  supersetDomain: "https://superset.example.com",
+  mountPoint: document.getElementById("my-superset-container"),
+  fetchGuestToken: () => fetchGuestTokenFromBackend(),
+  resolvePermalinkUrl: ({ key }) => `https://my-app.com/analytics/share/${key}`,
+  dashboardUiConfig: {
+    urlParams: {
+      permalink_key: permalinkKey,  // Restores filters, tabs, chart states, and scrolls to anchor
+    }
+  }
+});
+```

--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -252,14 +252,20 @@ export async function embedDashboard({
   setTimeout(refreshGuestToken, getGuestTokenRefreshTiming(guestToken));
 
   // Register the resolvePermalinkUrl method for the iframe to call
-  // Returns null if no callback provided, allowing iframe to use default URL
+  // Returns null if no callback provided or on error, allowing iframe to use default URL
   ourPort.defineMethod(
     'resolvePermalinkUrl',
-    async ({ key }: { key: string }) => {
+    async ({ key }: { key: string }): Promise<string | null> => {
       if (!resolvePermalinkUrl) {
         return null;
       }
-      return resolvePermalinkUrl({ key });
+      try {
+        const result = await resolvePermalinkUrl({ key });
+        return result;
+      } catch (error) {
+        log('Error in resolvePermalinkUrl callback:', error);
+        return null;
+      }
     },
   );
 

--- a/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
+++ b/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
@@ -69,7 +69,7 @@ export default function URLShortLinkButton({
         chartStates &&
         Object.keys(chartStates).length > 0;
 
-      const { url } = await getDashboardPermalink({
+      const result = await getDashboardPermalink({
         dashboardId,
         dataMask,
         activeTabs,
@@ -77,7 +77,9 @@ export default function URLShortLinkButton({
         chartStates: includeChartState ? chartStates : undefined,
         includeChartState,
       });
-      setShortUrl(url);
+      if (result?.url) {
+        setShortUrl(result.url);
+      }
     } catch (error) {
       if (error) {
         addDangerToast(

--- a/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
+++ b/superset-frontend/src/dashboard/components/URLShortLinkButton/index.tsx
@@ -69,7 +69,7 @@ export default function URLShortLinkButton({
         chartStates &&
         Object.keys(chartStates).length > 0;
 
-      const url = await getDashboardPermalink({
+      const { url } = await getDashboardPermalink({
         dashboardId,
         dataMask,
         activeTabs,

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -94,7 +94,7 @@ export const useShareMenuItems = (props: ShareMenuItemProps): MenuItem => {
       chartStates &&
       Object.keys(chartStates).length > 0;
 
-    const { url } = await getDashboardPermalink({
+    const result = await getDashboardPermalink({
       dashboardId,
       dataMask,
       activeTabs,
@@ -102,7 +102,10 @@ export const useShareMenuItems = (props: ShareMenuItemProps): MenuItem => {
       chartStates: includeChartState ? chartStates : undefined,
       includeChartState,
     });
-    return url;
+    if (!result?.url) {
+      throw new Error('Failed to generate permalink URL');
+    }
+    return result.url;
   }
 
   async function onCopyLink() {

--- a/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/ShareMenuItems/index.tsx
@@ -94,7 +94,7 @@ export const useShareMenuItems = (props: ShareMenuItemProps): MenuItem => {
       chartStates &&
       Object.keys(chartStates).length > 0;
 
-    return getDashboardPermalink({
+    const { url } = await getDashboardPermalink({
       dashboardId,
       dataMask,
       activeTabs,
@@ -102,6 +102,7 @@ export const useShareMenuItems = (props: ShareMenuItemProps): MenuItem => {
       chartStates: includeChartState ? chartStates : undefined,
       includeChartState,
     });
+    return url;
   }
 
   async function onCopyLink() {

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -180,7 +180,7 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       let anchor: string | undefined;
       if (permalinkKey) {
         const permalinkValue = await getPermalinkValue(permalinkKey);
-        if (permalinkValue) {
+        if (permalinkValue?.state) {
           ({ dataMask, activeTabs, chartStates, anchor } = permalinkValue.state);
         }
       } else if (nativeFilterKeyValue) {

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -177,10 +177,11 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       // the currently stored value when hydrating
       let activeTabs: string[] | undefined;
       let chartStates: DashboardChartStates | undefined;
+      let anchor: string | undefined;
       if (permalinkKey) {
         const permalinkValue = await getPermalinkValue(permalinkKey);
         if (permalinkValue) {
-          ({ dataMask, activeTabs, chartStates } = permalinkValue.state);
+          ({ dataMask, activeTabs, chartStates, anchor } = permalinkValue.state);
         }
       } else if (nativeFilterKeyValue) {
         dataMask = await getFilterValue(id, nativeFilterKeyValue);
@@ -203,6 +204,17 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
             chartStates,
           }),
         );
+
+        // Scroll to anchor element if specified in permalink state
+        if (anchor) {
+          // Use setTimeout to ensure the DOM has been updated after hydration
+          setTimeout(() => {
+            const element = document.getElementById(anchor);
+            if (element) {
+              element.scrollIntoView({ behavior: 'smooth' });
+            }
+          }, 0);
+        }
       }
       return null;
     }

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -181,7 +181,8 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
       if (permalinkKey) {
         const permalinkValue = await getPermalinkValue(permalinkKey);
         if (permalinkValue?.state) {
-          ({ dataMask, activeTabs, chartStates, anchor } = permalinkValue.state);
+          ({ dataMask, activeTabs, chartStates, anchor } =
+            permalinkValue.state);
         }
       } else if (nativeFilterKeyValue) {
         dataMask = await getFilterValue(id, nativeFilterKeyValue);

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { DataMaskStateWithId, JsonObject } from '@superset-ui/core';
-import Switchboard from '@superset-ui/switchboard';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { store } from '../views/store';
 import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
@@ -68,7 +67,7 @@ const getDashboardPermalink = async ({
     chartStates &&
     Object.keys(chartStates).length > 0;
 
-  const { key, url } = await getDashboardPermalinkUtil({
+  const { url } = await getDashboardPermalinkUtil({
     dashboardId,
     dataMask,
     activeTabs,
@@ -76,18 +75,6 @@ const getDashboardPermalink = async ({
     chartStates: includeChartState ? chartStates : undefined,
     includeChartState,
   });
-
-  // Ask the SDK to resolve the permalink URL
-  // Returns null if no callback was provided by the host
-  const resolvedUrl = await Switchboard.get<string | null>(
-    'resolvePermalinkUrl',
-    { key },
-  );
-
-  // If callback returned a valid URL string, use it; otherwise use Superset's default URL
-  if (typeof resolvedUrl === 'string' && resolvedUrl.length > 0) {
-    return resolvedUrl;
-  }
 
   return url;
 };

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { DataMaskStateWithId, JsonObject } from '@superset-ui/core';
+import Switchboard from '@superset-ui/switchboard';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { store } from '../views/store';
 import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
@@ -67,7 +68,7 @@ const getDashboardPermalink = async ({
     chartStates &&
     Object.keys(chartStates).length > 0;
 
-  return getDashboardPermalinkUtil({
+  const { key, url } = await getDashboardPermalinkUtil({
     dashboardId,
     dataMask,
     activeTabs,
@@ -75,6 +76,20 @@ const getDashboardPermalink = async ({
     chartStates: includeChartState ? chartStates : undefined,
     includeChartState,
   });
+
+  // Ask the SDK to resolve the permalink URL
+  // Returns null if no callback was provided by the host
+  const resolvedUrl = await Switchboard.get<string | null>(
+    'resolvePermalinkUrl',
+    { key },
+  );
+
+  // If callback returned a URL, use it; otherwise use Superset's default URL
+  if (resolvedUrl) {
+    return resolvedUrl;
+  }
+
+  return url;
 };
 
 const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -84,8 +84,8 @@ const getDashboardPermalink = async ({
     { key },
   );
 
-  // If callback returned a URL, use it; otherwise use Superset's default URL
-  if (resolvedUrl) {
+  // If callback returned a valid URL string, use it; otherwise use Superset's default URL
+  if (typeof resolvedUrl === 'string' && resolvedUrl.length > 0) {
     return resolvedUrl;
   }
 

--- a/superset-frontend/src/explore/components/EmbedCodeContent.jsx
+++ b/superset-frontend/src/explore/components/EmbedCodeContent.jsx
@@ -44,9 +44,11 @@ const EmbedCodeContent = ({ formData, addDangerToast }) => {
   const updateUrl = useCallback(() => {
     setUrl('');
     getChartPermalink(formData)
-      .then(url => {
-        setUrl(url);
-        setErrorMessage('');
+      .then(result => {
+        if (result?.url) {
+          setUrl(result.url);
+          setErrorMessage('');
+        }
       })
       .catch(() => {
         setErrorMessage(t('Error'));

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -204,8 +204,13 @@ export const useExploreAdditionalActionsMenu = (
   const shareByEmail = useCallback(async () => {
     try {
       const subject = t('Superset Chart');
-      const url = await getChartPermalink(latestQueryFormData);
-      const body = encodeURIComponent(t('%s%s', 'Check out this chart: ', url));
+      const result = await getChartPermalink(latestQueryFormData);
+      if (!result?.url) {
+        throw new Error('Failed to generate permalink');
+      }
+      const body = encodeURIComponent(
+        t('%s%s', 'Check out this chart: ', result.url),
+      );
       window.location.href = `mailto:?Subject=${subject}%20&Body=${body}`;
     } catch (error) {
       addDangerToast(t('Sorry, something went wrong. Try again later.'));
@@ -315,7 +320,13 @@ export const useExploreAdditionalActionsMenu = (
       if (!latestQueryFormData) {
         throw new Error();
       }
-      await copyTextToClipboard(() => getChartPermalink(latestQueryFormData));
+      await copyTextToClipboard(async () => {
+        const result = await getChartPermalink(latestQueryFormData);
+        if (!result?.url) {
+          throw new Error('Failed to generate permalink');
+        }
+        return result.url;
+      });
       addSuccessToast(t('Copied to clipboard!'));
     } catch (error) {
       addDangerToast(t('Sorry, something went wrong. Try again later.'));

--- a/superset-frontend/src/utils/urlUtils.ts
+++ b/superset-frontend/src/utils/urlUtils.ts
@@ -139,11 +139,22 @@ export function getDashboardUrlParams(
   return getUrlParamEntries(urlParams);
 }
 
-function getPermalink(endpoint: string, jsonPayload: JsonObject) {
+export type PermalinkResult = {
+  key: string;
+  url: string;
+};
+
+function getPermalink(
+  endpoint: string,
+  jsonPayload: JsonObject,
+): Promise<PermalinkResult> {
   return SupersetClient.post({
     endpoint,
     jsonPayload,
-  }).then(result => result.json.url as string);
+  }).then(result => ({
+    key: result.json.key as string,
+    url: result.json.url as string,
+  }));
 }
 
 export function getChartPermalink(
@@ -186,7 +197,7 @@ export function getDashboardPermalink({
    * Whether to include chart state in the permalink (default: false)
    */
   includeChartState?: boolean;
-}) {
+}): Promise<PermalinkResult> {
   const payload: JsonObject = {
     urlParams: getDashboardUrlParams(),
     dataMask,


### PR DESCRIPTION
### SUMMARY

This PR adds a `resolvePermalinkUrl` callback to the Embedded SDK that allows host applications to customize the permalink URLs generated when users click share buttons inside an embedded dashboard.

**Problem:**
When users click "Copy Link" on a chart or dashboard inside an embedded Superset dashboard, the generated permalink uses Superset's domain (e.g., `https://superset.example.com/superset/dashboard/p/xyz789/`). Host applications often need full control over the permalink URL to use their own domain, paths, and query parameters.

**Solution:**
- Added `resolvePermalinkUrl` callback to the SDK's `embedDashboard()` options
- When a permalink is generated, Superset calls this callback with the permalink key
- The host can return a custom URL (e.g., `https://my-app.com/analytics/share/xyz789`)
- If no callback is provided, Superset's default URL is used (backward compatible)

**Architecture:**
```
User clicks "Copy Link" in embedded Superset
            ↓
    POST /api/v1/dashboard/{id}/permalink
            ↓
    Backend returns { key: "xyz789", url: "..." }
            ↓
    Switchboard.get('resolvePermalinkUrl', { key })  ──→  SDK
            ↓                                              ↓
            ↓                                    host.resolvePermalinkUrl({ key })
            ↓                                              ↓
            ←──────────────────────────────────  "https://my-app.com/share/xyz789"
            ↓
    Copy resolved URL to clipboard
```

**Additional fix:**
- Fixed anchor scrolling for permalinks in embedded mode. The anchor (chart/tab ID to scroll to) was already stored in the permalink state but wasn't being applied when loading embedded dashboards. Now `DashboardPage.tsx` extracts the anchor from the permalink state and scrolls to the element after hydration.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - This is an SDK API change, not a UI change.

### TESTING INSTRUCTIONS

1. **Test custom permalink URLs in embedded mode:**
   ```javascript
   embedDashboard({
     id: "your-dashboard-uuid",
     supersetDomain: "https://superset.example.com",
     mountPoint: document.getElementById("dashboard"),
     fetchGuestToken: () => fetchGuestTokenFromBackend(),
     resolvePermalinkUrl: ({ key }) => {
       console.log("Permalink key:", key);
       return `https://my-app.com/share/${key}`;
     }
   });
   ```
   - Click the share/copy link button on a chart inside the embedded dashboard
   - Verify the clipboard contains your custom URL (e.g., `https://my-app.com/share/xyz789`)

2. **Test fallback behavior (no callback):**
   - Remove the `resolvePermalinkUrl` callback
   - Click share/copy link
   - Verify Superset's default URL is used

3. **Test permalink restoration with anchor:**
   ```javascript
   embedDashboard({
     // ...
     dashboardUiConfig: {
       urlParams: {
         permalink_key: "xyz789"  // A permalink that was created from a specific chart
       }
     }
   });
   ```
   - Verify the dashboard loads with the correct filter state
   - Verify the page scrolls to the specific chart that was shared

4. **Test non-embedded mode still works:**
   - Open a regular (non-embedded) dashboard
   - Click share/copy link on a chart
   - Verify the permalink URL is generated correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
