### PR TITLE
feat(mcp): change save_chart default to False for preview-first workflow

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -835,7 +835,7 @@ class GenerateChartRequest(QueryCacheControl):
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")
     config: ChartConfig = Field(..., description="Chart configuration")
     save_chart: bool = Field(
-        default=True,
+        default=False,
         description="Whether to permanently save the chart in Superset",
     )
     generate_preview: bool = Field(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -862,6 +862,16 @@ class GenerateChartRequest(QueryCacheControl):
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_save_or_preview(self) -> "GenerateChartRequest":
+        """Ensure at least one of save_chart or generate_preview is enabled."""
+        if not self.save_chart and not self.generate_preview:
+            raise ValueError(
+                "At least one of 'save_chart' or 'generate_preview' must be True. "
+                "A request with both set to False would be a no-op."
+            )
+        return self
+
 
 class GenerateExploreLinkRequest(FormDataCacheControl):
     dataset_id: int | str = Field(..., description="Dataset identifier (ID, UUID)")

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -54,11 +54,11 @@ logger = logging.getLogger(__name__)
 async def generate_chart(  # noqa: C901
     request: GenerateChartRequest, ctx: Context
 ) -> GenerateChartResponse:
-    """Create and save a chart in Superset.
+    """Create a chart preview in Superset, optionally saving it permanently.
 
     IMPORTANT BEHAVIOR:
-    - Charts ARE saved by default (save_chart=True)
-    - Set save_chart=False for temporary preview only
+    - Charts are NOT saved by default (save_chart=False) - preview only
+    - Set save_chart=True to permanently save the chart
     - LLM clients MUST display returned chart URL to users
     - Embed preview_url as image: ![Chart Preview](preview_url)
     - Use numeric dataset ID or UUID (NOT schema.table_name format)

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -182,24 +182,24 @@ class TestGenerateChart:
     @pytest.mark.asyncio
     async def test_save_chart_flag(self):
         """Test save_chart flag behavior."""
-        # Default should be True (save chart)
+        # Default should be False (preview only, not saved)
         request1 = GenerateChartRequest(
             dataset_id="1",
             config=TableChartConfig(
                 chart_type="table", columns=[ColumnRef(name="col1")]
             ),
         )
-        assert request1.save_chart is True
+        assert request1.save_chart is False
 
-        # Explicit False (preview only)
+        # Explicit True (save chart permanently)
         request2 = GenerateChartRequest(
             dataset_id="1",
             config=TableChartConfig(
                 chart_type="table", columns=[ColumnRef(name="col1")]
             ),
-            save_chart=False,
+            save_chart=True,
         )
-        assert request2.save_chart is False
+        assert request2.save_chart is True
 
     @pytest.mark.asyncio
     async def test_preview_formats(self):

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -201,6 +201,17 @@ class TestGenerateChart:
         )
         assert request2.save_chart is True
 
+        # Both False should raise validation error (no-op request)
+        with pytest.raises(ValueError, match="At least one of"):
+            GenerateChartRequest(
+                dataset_id="1",
+                config=TableChartConfig(
+                    chart_type="table", columns=[ColumnRef(name="col1")]
+                ),
+                save_chart=False,
+                generate_preview=False,
+            )
+
     @pytest.mark.asyncio
     async def test_preview_formats(self):
         """Test preview format options."""


### PR DESCRIPTION
### SUMMARY
Change the default behavior of the MCP `generate_chart` tool to create preview-only charts by default (`save_chart=False`), requiring explicit `save_chart=True` to permanently save charts in Superset.

This enables a safer, more iterative workflow where LLM agents can preview charts before deciding to save them, reducing clutter from temporary or experimental visualizations.

**Changes:**
- Changed `save_chart` default from `True` to `False` in `GenerateChartRequest` schema
- Updated docstring in `generate_chart.py` to reflect the new default behavior
- Updated corresponding unit test to verify the new default

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a behavioral default change with no UI changes.

### TESTING INSTRUCTIONS
1. Call the MCP `generate_chart` tool without specifying `save_chart`
2. Verify that the chart is NOT saved to the database (preview-only mode)
3. Call with `save_chart=True` and verify the chart IS saved
4. Run MCP unit tests: `pytest tests/unit_tests/mcp_service/ -v`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)