### PR TITLE
feat(sqllab): Improved query status indicator bar

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Timer/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Timer/index.tsx
@@ -35,7 +35,9 @@ export function Timer({
   status = 'success',
 }: TimerProps) {
   const theme = useTheme();
-  const [clockStr, setClockStr] = useState('00:00:00.00');
+  const [clockStr, setClockStr] = useState(
+    startTime && endTime ? fDuration(startTime, endTime) : '00:00:00.00',
+  );
   const timer = useRef<ReturnType<typeof setInterval>>();
 
   useEffect(() => {

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -92,9 +92,7 @@ export type ResidualQueryObjectData = {
  * and `transformProps`.
  */
 export interface QueryObject
-  extends QueryFields,
-    TimeRange,
-    ResidualQueryObjectData {
+  extends QueryFields, TimeRange, ResidualQueryObjectData {
   /**
    * Definition for annotation layers.
    */
@@ -325,7 +323,6 @@ export type Query = {
   isDataPreview: boolean;
   link?: string;
   progress: number;
-  progressText?: string;
   resultsKey: string | null;
   catalog?: string | null;
   schema?: string;

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -92,7 +92,9 @@ export type ResidualQueryObjectData = {
  * and `transformProps`.
  */
 export interface QueryObject
-  extends QueryFields, TimeRange, ResidualQueryObjectData {
+  extends QueryFields,
+    TimeRange,
+    ResidualQueryObjectData {
   /**
    * Definition for annotation layers.
    */
@@ -316,12 +318,14 @@ export type Query = {
   errorMessage: string | null;
   extra: {
     progress: string | null;
+    progress_text?: string;
     errors?: SupersetError[];
   };
   id: string;
   isDataPreview: boolean;
   link?: string;
   progress: number;
+  progressText?: string;
   resultsKey: string | null;
   catalog?: string | null;
   schema?: string;

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -92,6 +92,7 @@ export interface SqlExecuteQueryResult {
   limitingFactor?: string;
   tempTable?: string | null;
   progress?: number;
+  progressText?: string | null;
   state?: string;
   [key: string]: unknown;
 }
@@ -392,7 +393,7 @@ export function startQuery(query: Query, runPreviewOnly?: boolean) {
     id: query.id ? query.id : nanoid(11),
     progress: 0,
     startDttm: now(),
-    state: query.runAsync ? 'pending' : 'running',
+    state: 'pending',
     cached: false,
   });
   return { type: START_QUERY, query, runPreviewOnly } as const;

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -92,7 +92,6 @@ export interface SqlExecuteQueryResult {
   limitingFactor?: string;
   tempTable?: string | null;
   progress?: number;
-  progressText?: string | null;
   state?: string;
   [key: string]: unknown;
 }

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/QueryStatusBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/QueryStatusBar.test.tsx
@@ -104,7 +104,7 @@ test('returns null when query is successful with results', () => {
     },
   });
   const { container } = render(<QueryStatusBar query={query} />);
-  expect(container.firstChild).toBeEmptyDOMElement();
+  expect(container).toBeEmptyDOMElement();
 });
 
 test('displays progress percentage when available', () => {

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/QueryStatusBar.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/QueryStatusBar.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isValidElement } from 'react';
+import { render, screen } from 'spec/helpers/testing-library';
+import { QueryState, type QueryResponse } from '@superset-ui/core';
+import QueryStatusBar from '.';
+
+jest.mock('../QueryStateLabel', () => ({
+  __esModule: true,
+  default: ({ query }: { query: { state: QueryState } }) => (
+    <div data-test="query-state-label">{query.state}</div>
+  ),
+}));
+
+const createMockQuery = (
+  overrides: Partial<QueryResponse> = {},
+): QueryResponse =>
+  ({
+    id: 'test-query-id',
+    dbId: 1,
+    sql: 'SELECT * FROM test',
+    sqlEditorId: 'test-editor',
+    tab: 'Test Tab',
+    ctas: false,
+    cached: false,
+    progress: 0,
+    startDttm: Date.now() - 1000,
+    endDttm: undefined,
+    state: QueryState.Running,
+    tempSchema: null,
+    tempTable: null,
+    userId: 1,
+    executedSql: null,
+    rows: 0,
+    queryLimit: 100,
+    catalog: null,
+    schema: 'test_schema',
+    errorMessage: null,
+    extra: {},
+    results: undefined,
+    ...overrides,
+  }) as QueryResponse;
+
+test('is valid element', () => {
+  const query = createMockQuery();
+  expect(isValidElement(<QueryStatusBar query={query} />)).toBe(true);
+});
+
+test('renders query state label', () => {
+  const query = createMockQuery({ state: QueryState.Running });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByTestId('query-state-label')).toBeInTheDocument();
+  expect(screen.getByText('Query State:')).toBeInTheDocument();
+});
+
+test('renders elapsed time section', () => {
+  const query = createMockQuery({ state: QueryState.Running });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('Elapsed:')).toBeInTheDocument();
+});
+
+test('renders steps for running query', () => {
+  const query = createMockQuery({ state: QueryState.Running, progress: 50 });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('Validate query')).toBeInTheDocument();
+  expect(screen.getByText('Connect to engine')).toBeInTheDocument();
+  expect(screen.getByText('Running')).toBeInTheDocument();
+  expect(screen.getByText('Download to client')).toBeInTheDocument();
+  expect(screen.getByText('Finish')).toBeInTheDocument();
+});
+
+test('renders steps for pending query', () => {
+  const query = createMockQuery({ state: QueryState.Pending });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('Validate query')).toBeInTheDocument();
+});
+
+test('returns null when query is successful with results', () => {
+  const query = createMockQuery({
+    state: QueryState.Success,
+    results: {
+      displayLimitReached: false,
+      columns: [],
+      selected_columns: [],
+      expanded_columns: [],
+      data: [],
+      query: { limit: 100 },
+    },
+  });
+  const { container } = render(<QueryStatusBar query={query} />);
+  expect(container.firstChild).toBeEmptyDOMElement();
+});
+
+test('displays progress percentage when available', () => {
+  const query = createMockQuery({
+    state: QueryState.Running,
+    progress: 75,
+  });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('(75%)')).toBeInTheDocument();
+});
+
+test('displays progress text when available', () => {
+  const query = createMockQuery({
+    state: QueryState.Running,
+    progress: 50,
+    extra: { progress: null, progress_text: 'Processing rows' },
+  });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('(50%, Processing rows)')).toBeInTheDocument();
+});
+
+test('displays only progress text when no percentage', () => {
+  const query = createMockQuery({
+    state: QueryState.Running,
+    progress: 0,
+    extra: { progress: null, progress_text: 'Initializing' },
+  });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('(Initializing)')).toBeInTheDocument();
+});
+
+test('renders for failed query state', () => {
+  const query = createMockQuery({
+    state: QueryState.Failed,
+    errorMessage: 'Query failed',
+  });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByTestId('query-state-label')).toBeInTheDocument();
+});
+
+test('renders for stopped query state', () => {
+  const query = createMockQuery({ state: QueryState.Stopped });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByTestId('query-state-label')).toBeInTheDocument();
+});
+
+test('renders for fetching state', () => {
+  const query = createMockQuery({
+    state: QueryState.Fetching,
+    progress: 100,
+  });
+  render(<QueryStatusBar query={query} />);
+  expect(screen.getByText('Download to client')).toBeInTheDocument();
+});

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
@@ -155,12 +155,12 @@ const QueryStatusBar: FC<QueryStatusBarProps> = ({ query }) => {
   const prevStepRef = useRef<number>(0);
   const progress =
     query.progress > 0 ? parseInt(query.progress.toFixed(0), 10) : undefined;
-  const { progress_text: progressText } = query.extra;
+  const { progress_text: progressText } = query.extra ?? {};
   const state =
     query.state === QueryState.Success &&
     prevStepRef.current === STATE_TO_STEP[QueryState.Running] &&
     !query.results
-      ? 'fetching'
+      ? QueryState.Fetching
       : query.state;
 
   const currentIndex = STATE_TO_STEP[state] || 0;

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
@@ -1,0 +1,216 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { FC, useMemo, createContext, useContext, useRef } from 'react';
+import { styled } from '@apache-superset/core';
+import {
+  Flex,
+  Steps,
+  type StepsProps,
+  StyledSpin,
+  Timer,
+} from '@superset-ui/core/components';
+import { QueryResponse, QueryState, t, usePrevious } from '@superset-ui/core';
+import QueryStateLabel from '../QueryStateLabel';
+
+type QueryStatusBarProps = {
+  query: QueryResponse;
+};
+
+const STATE_TO_STEP: Record<string, number> = {
+  offline: 4,
+  failed: 4,
+  pending: 0,
+  fetching: 3,
+  running: 2,
+  stopped: 4,
+  success: 4,
+};
+
+const ERROR_STATE = [QueryState.Failed, QueryState.Stopped];
+
+const StyledSteps = styled.div`
+  & .ant-steps {
+    margin: ${({ theme }) => theme.sizeUnit * 2}px 0;
+  }
+`;
+
+const ActiveDot = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.colorPrimary};
+    top: -1px;
+    opacity: 0;
+    animation: pulse 2s ease-out infinite;
+  }
+
+  &::after {
+    animation-delay: 1s;
+  }
+
+  @keyframes pulse {
+    0% {
+      transform: scale(0.5);
+      opacity: 0.8;
+    }
+    100% {
+      transform: scale(3);
+      opacity: 0;
+    }
+  }
+`;
+
+const progressContext = createContext<[number, string]>([0, '']);
+
+const ProgressStatus = () => {
+  const [percent, progressText] = useContext(progressContext);
+
+  return (
+    <>
+      {percent > 0 ? (
+        <span>
+          ({percent}%{progressText && `, ${progressText}`})
+        </span>
+      ) : (
+        <>{progressText && <span>({progressText})</span>}</>
+      )}
+    </>
+  );
+};
+
+const ProgressSpin = () => {
+  const [percent] = useContext(progressContext);
+  return (
+    <>
+      {typeof percent === 'number' && percent > 0 && (
+        <StyledSpin size="small" percent={percent} />
+      )}
+    </>
+  );
+};
+
+const customDot: StepsProps['progressDot'] = (dot, { status }) => {
+  return status === 'process' ? (
+    <ActiveDot>
+      <ProgressSpin />
+    </ActiveDot>
+  ) : (
+    <>{dot}</>
+  );
+};
+
+const QueryStatusBar: FC<QueryStatusBarProps> = ({ query }) => {
+  const steps = [
+    {
+      title: t('Validate query'),
+    },
+    {
+      title: t('Connect to engine'),
+    },
+    {
+      title: (
+        <Flex align="center" gap="small">
+          {t('Running')}
+          <ProgressStatus />
+        </Flex>
+      ),
+    },
+    {
+      title: t('Download to client'),
+    },
+    {
+      title: t('Finish'),
+    },
+  ];
+
+  const hasError = useMemo(
+    () => ERROR_STATE.includes(query.state),
+    [query.state],
+  );
+  const prevStepRef = useRef<number>(0);
+  const progress =
+    query.progress > 0 ? parseInt(query.progress.toFixed(0), 10) : undefined;
+  const { progress_text: progressText } = query.extra;
+  const state =
+    query.state === QueryState.Success &&
+    prevStepRef.current === STATE_TO_STEP[QueryState.Running] &&
+    !query.results
+      ? 'fetching'
+      : query.state;
+
+  const currentIndex = STATE_TO_STEP[state] || 0;
+  const prevStep = usePrevious(currentIndex);
+  prevStepRef.current = prevStep ?? prevStepRef.current;
+
+  if (query.state === QueryState.Success && query.results) {
+    return null;
+  }
+
+  if (
+    query.state === QueryState.Failed &&
+    prevStep === STATE_TO_STEP[QueryState.Failed]
+  ) {
+    return null;
+  }
+
+  return (
+    <StyledSteps>
+      <Flex justify="space-between">
+        <Flex gap="small" align="center">
+          <span>{t('Query State')}:</span>
+          <QueryStateLabel query={query} />
+        </Flex>
+        <Flex gap="small" align="center">
+          <span>{t('Elapsed')}:</span>
+          <Timer
+            startTime={query.startDttm}
+            endTime={query.endDttm}
+            status="default"
+            isRunning={currentIndex < steps.length - 2}
+          />
+        </Flex>
+      </Flex>
+      <progressContext.Provider value={[progress ?? 0, progressText ?? '']}>
+        <Steps
+          size="small"
+          current={hasError ? prevStep : currentIndex}
+          items={steps}
+          status={
+            hasError
+              ? 'error'
+              : currentIndex < steps.length - 1
+                ? 'process'
+                : 'finish'
+          }
+          {...(!hasError && { progressDot: customDot })}
+        />
+      </progressContext.Provider>
+    </StyledSteps>
+  );
+};
+export default QueryStatusBar;

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { FC, useMemo, createContext, useContext, useRef } from 'react';
-import { styled } from '@apache-superset/core';
+import { t, styled } from '@apache-superset/core';
 import {
   Flex,
   Steps,
@@ -25,7 +25,7 @@ import {
   StyledSpin,
   Timer,
 } from '@superset-ui/core/components';
-import { QueryResponse, QueryState, t, usePrevious } from '@superset-ui/core';
+import { QueryResponse, QueryState, usePrevious } from '@superset-ui/core';
 import QueryStateLabel from '../QueryStateLabel';
 
 type QueryStatusBarProps = {

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
@@ -114,15 +114,14 @@ const ProgressSpin = () => {
   );
 };
 
-const customDot: StepsProps['progressDot'] = (dot, { status }) => {
-  return status === 'process' ? (
+const customDot: StepsProps['progressDot'] = (dot, { status }) =>
+  status === 'process' ? (
     <ActiveDot>
       <ProgressSpin />
     </ActiveDot>
   ) : (
     <>{dot}</>
   );
-};
 
 const QueryStatusBar: FC<QueryStatusBarProps> = ({ query }) => {
   const steps = [

--- a/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryStatusBar/index.tsx
@@ -153,8 +153,7 @@ const QueryStatusBar: FC<QueryStatusBarProps> = ({ query }) => {
     [query.state],
   );
   const prevStepRef = useRef<number>(0);
-  const progress =
-    query.progress > 0 ? parseInt(query.progress.toFixed(0), 10) : undefined;
+  const progress = query.progress > 0 ? query.progress : undefined;
   const { progress_text: progressText } = query.extra ?? {};
   const state =
     query.state === QueryState.Success &&

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -332,25 +332,6 @@ describe('ResultSet', () => {
     expect(alert).toBeInTheDocument();
   });
 
-  test('should render running/pending/fetching query', async () => {
-    const { getByTestId } = setup(
-      { ...mockedProps, queryId: runningQuery.id },
-      mockStore(runningQueryState),
-    );
-    const progressBar = getByTestId('progress-bar');
-    expect(progressBar).toBeInTheDocument();
-  });
-
-  test('should render fetching w/ 100 progress query', async () => {
-    const { getByRole, getByText } = setup(
-      mockedProps,
-      mockStore(fetchingQueryState),
-    );
-    const loading = getByRole('status');
-    expect(loading).toBeInTheDocument();
-    expect(getByText('fetching')).toBeInTheDocument();
-  });
-
   test('should render a failed query with an errors object', async () => {
     const { errors } = failedQueryWithErrors;
 

--- a/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/ResultSet.test.tsx
@@ -35,7 +35,6 @@ import {
   cachedQuery,
   failedQueryWithErrors,
   queries,
-  runningQuery,
   stoppedQuery,
   initialState,
   user,
@@ -82,32 +81,6 @@ const stoppedQueryState = {
     ...initialState.sqlLab,
     queries: {
       [stoppedQuery.id]: stoppedQuery,
-    },
-  },
-};
-const runningQueryState = {
-  ...initialState,
-  sqlLab: {
-    ...initialState.sqlLab,
-    queries: {
-      [runningQuery.id]: runningQuery,
-    },
-  },
-};
-const fetchingQueryState = {
-  ...initialState,
-  sqlLab: {
-    ...initialState.sqlLab,
-    queries: {
-      [mockedProps.queryId]: {
-        dbId: 1,
-        cached: false,
-        ctas: false,
-        id: 'ryhHUZCGb',
-        progress: 100,
-        state: 'fetching',
-        startDttm: Date.now() - 500,
-      },
     },
   },
 };

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -61,7 +61,6 @@ import {
 import { EXPLORE_CHART_DEFAULT, SqlLabRootState } from 'src/SqlLab/types';
 import { mountExploreUrl } from 'src/explore/exploreUtils';
 import { postFormData } from 'src/explore/exploreUtils/formData';
-import ProgressBar from '@superset-ui/core/components/ProgressBar';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { prepareCopyToClipboardTabularData } from 'src/utils/common';
 import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -36,7 +36,6 @@ import {
   Tooltip,
   Input,
   Label,
-  Loading,
 } from '@superset-ui/core/components';
 import {
   CopyToClipboard,
@@ -90,7 +89,6 @@ import { makeUrl } from 'src/utils/pathUtils';
 import ExploreCtasResultsButton from '../ExploreCtasResultsButton';
 import ExploreResultsButton from '../ExploreResultsButton';
 import HighlightedSql from '../HighlightedSql';
-import QueryStateLabel from '../QueryStateLabel';
 import PanelToolbar from 'src/components/PanelToolbar';
 import { ViewContribution } from 'src/SqlLab/contributions';
 
@@ -816,34 +814,20 @@ const ResultSet = ({
     }
   }
 
-  let progressBar;
-  if (query.progress > 0) {
-    progressBar = (
-      <ProgressBar percent={parseInt(query.progress.toFixed(0), 10)} striped />
-    );
-  }
-
   const progressMsg = query?.extra?.progress ?? null;
 
   return (
-    <>
-      <ResultlessStyles>
-        <div>{!progressBar && <Loading position="normal" />}</div>
-        {/* show loading bar whenever progress bar is completed but needs time to render */}
-        <div>{query.progress === 100 && <Loading position="normal" />}</div>
-        <QueryStateLabel query={query} />
-        <div>
-          {progressMsg && <Alert type="success" message={progressMsg} />}
-        </div>
-        <div>{query.progress !== 100 && progressBar}</div>
-        {trackingUrl && <div>{trackingUrl}</div>}
-      </ResultlessStyles>
+    <ResultlessStyles>
+      {progressMsg && (
+        <Alert type="success" message={progressMsg} closable={false} />
+      )}
+      {trackingUrl && <div>{trackingUrl}</div>}
       <StreamingExportModal
         visible={showStreamingModal}
         onCancel={handleCloseStreamingModal}
         progress={progress}
       />
-    </>
+    </ResultlessStyles>
   );
 };
 

--- a/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
+++ b/superset-frontend/src/SqlLab/components/SouthPane/Results.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import { EmptyState } from '@superset-ui/core/components';
 import { t } from '@apache-superset/core';
@@ -26,6 +26,7 @@ import { styled, Alert } from '@apache-superset/core/ui';
 import { SqlLabRootState } from 'src/SqlLab/types';
 import ResultSet from '../ResultSet';
 import { LOCALSTORAGE_MAX_QUERY_AGE_MS } from '../../constants';
+import QueryStatusBar from '../QueryStatusBar';
 
 type Props = {
   latestQueryId?: string;
@@ -53,9 +54,13 @@ const Results: FC<Props> = ({
     ({ sqlLab: { databases } }: SqlLabRootState) => databases,
     shallowEqual,
   );
-  const latestQuery = useSelector(
-    ({ sqlLab: { queries } }: SqlLabRootState) => queries[latestQueryId || ''],
+  const queries = useSelector(
+    ({ sqlLab: { queries } }: SqlLabRootState) => queries,
     shallowEqual,
+  );
+  const latestQuery = useMemo(
+    () => queries[latestQueryId ?? ''],
+    [queries, latestQueryId],
   );
 
   if (
@@ -72,30 +77,32 @@ const Results: FC<Props> = ({
     );
   }
 
-  if (
+  const hasNoStoredResults =
     isFeatureEnabled(FeatureFlag.SqllabBackendPersistence) &&
     latestQuery.state === 'success' &&
     !latestQuery.resultsKey &&
-    !latestQuery.results
-  ) {
-    return (
-      <Alert
-        type="info"
-        message={t('No stored results found, you need to re-run your query')}
-      />
-    );
-  }
+    !latestQuery.results;
 
   return (
-    <ResultSet
-      search
-      queryId={latestQuery.id}
-      database={databases[latestQuery.dbId]}
-      displayLimit={displayLimit}
-      defaultQueryLimit={defaultQueryLimit}
-      showSql
-      showSqlInline
-    />
+    <>
+      <QueryStatusBar key={latestQueryId} query={latestQuery} />
+      {hasNoStoredResults ? (
+        <Alert
+          type="info"
+          message={t('No stored results found, you need to re-run your query')}
+        />
+      ) : (
+        <ResultSet
+          search
+          queryId={latestQuery.id}
+          database={databases[latestQuery.dbId]}
+          displayLimit={displayLimit}
+          defaultQueryLimit={defaultQueryLimit}
+          showSql
+          showSqlInline
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
### SUMMARY

The existing query status indicator makes it difficult to predict the progress, so this commit introduces a new progress status that shows which stage is currently in progress. This change will allow users to more accurately anticipate the query execution process and wait accordingly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

https://github.com/user-attachments/assets/d78f4480-64ff-46bb-999f-2449ea5e074f

After:

https://github.com/user-attachments/assets/d7e49950-87c0-4c73-8278-c46487bc614e

- percent progress

https://github.com/user-attachments/assets/2267c3c8-2d22-4b61-916f-40958062a701

- failed in running

https://github.com/user-attachments/assets/3a7b0507-646b-42ee-a341-7531b3de2522


### TESTING INSTRUCTIONS

specs are added

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
