### PR TITLE
fix(mcp): use chart.query_context for get_chart_data like the API does

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -975,6 +975,14 @@ class GetChartDataRequest(QueryCacheControl):
     format: Literal["json", "csv", "excel"] = Field(
         default="json", description="Data export format"
     )
+    include_raw_data: bool = Field(
+        default=False,
+        description=(
+            "If true, retrieves raw data from the underlying dataset instead of "
+            "the chart's aggregated view. Useful for charts like big_number that "
+            "normally return only a single aggregated value."
+        ),
+    )
 
 
 class DataColumn(BaseModel):

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -973,7 +973,7 @@ class GetChartDataRequest(QueryCacheControl):
         default=None,
         description=(
             "Maximum number of data rows to return. If not specified, uses the "
-            "chart's configured row limit. Capped at 10000 for safety."
+            "chart's configured row limit."
         ),
     )
     format: Literal["json", "csv", "excel"] = Field(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -970,18 +970,14 @@ class GetChartDataRequest(QueryCacheControl):
 
     identifier: int | str = Field(description="Chart identifier (ID, UUID)")
     limit: int | None = Field(
-        default=100, description="Maximum number of data rows to return"
+        default=None,
+        description=(
+            "Maximum number of data rows to return. If not specified, uses the "
+            "chart's configured row limit. Capped at 10000 for safety."
+        ),
     )
     format: Literal["json", "csv", "excel"] = Field(
         default="json", description="Data export format"
-    )
-    include_raw_data: bool = Field(
-        default=False,
-        description=(
-            "If true, retrieves raw data from the underlying dataset instead of "
-            "the chart's aggregated view. Useful for charts like big_number that "
-            "normally return only a single aggregated value."
-        ),
     )
 
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -49,8 +49,6 @@ async def get_chart_data(  # noqa: C901
     """Get chart data by ID or UUID.
 
     Returns the actual data behind a chart for LLM analysis without image rendering.
-    Uses the chart's saved query_context to retrieve data exactly as shown in the
-    visualization (same as /api/v1/chart/{id}/data endpoint).
 
     Supports:
     - Numeric ID or UUID lookup
@@ -126,7 +124,6 @@ async def get_chart_data(  # noqa: C901
 
         try:
             await ctx.report_progress(2, 4, "Preparing data query")
-            # Get chart data using the same approach as /api/v1/chart/{id}/data
             from superset.charts.schemas import ChartDataQueryContextSchema
             from superset.commands.chart.data.get_data_command import ChartDataCommand
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -161,7 +161,10 @@ async def get_chart_data(  # noqa: C901
                 from superset.common.query_context_factory import QueryContextFactory
 
                 factory = QueryContextFactory()
-                row_limit = min(request.limit or 100, MAX_ROW_LIMIT)
+                # Use request.limit if specified, otherwise use chart's configured
+                # row_limit, with MAX_ROW_LIMIT as safety cap
+                chart_row_limit = form_data.get("row_limit", 1000)
+                row_limit = min(request.limit or chart_row_limit, MAX_ROW_LIMIT)
                 query_context = factory.create(
                     datasource={
                         "id": chart.datasource_id,

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -23,6 +23,7 @@ import logging
 from typing import Any, Dict, List, TYPE_CHECKING
 
 from fastmcp import Context
+from flask import current_app
 from superset_core.mcp import tool
 
 if TYPE_CHECKING:
@@ -155,10 +156,11 @@ async def get_chart_data(  # noqa: C901
                 from superset.common.query_context_factory import QueryContextFactory
 
                 factory = QueryContextFactory()
-                # Use request.limit if specified, otherwise use chart's configured
-                # row_limit (respects global ROW_LIMIT config)
-                chart_row_limit = form_data.get("row_limit", 1000)
-                row_limit = request.limit or chart_row_limit
+                row_limit = (
+                    request.limit
+                    or form_data.get("row_limit")
+                    or current_app.config["ROW_LIMIT"]
+                )
                 query_context = factory.create(
                     datasource={
                         "id": chart.datasource_id,

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for the get_chart_data request schema and MAX_ROW_LIMIT
+"""
+
+import pytest
+
+from superset.mcp_service.chart.schemas import GetChartDataRequest
+from superset.mcp_service.chart.tool.get_chart_data import MAX_ROW_LIMIT
+
+
+class TestGetChartDataRequestSchema:
+    """Test the GetChartDataRequest schema validation."""
+
+    def test_default_request(self):
+        """Test creating request with all defaults."""
+        request = GetChartDataRequest(identifier=1)
+
+        assert request.identifier == 1
+        assert request.limit == 100
+        assert request.format == "json"
+        assert request.include_raw_data is False
+        assert request.use_cache is True
+        assert request.force_refresh is False
+        assert request.cache_timeout is None
+
+    def test_request_with_uuid_identifier(self):
+        """Test creating request with UUID identifier."""
+        uuid = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+        request = GetChartDataRequest(identifier=uuid)
+
+        assert request.identifier == uuid
+
+    def test_request_with_include_raw_data_true(self):
+        """Test creating request with include_raw_data enabled."""
+        request = GetChartDataRequest(identifier=1, include_raw_data=True)
+
+        assert request.include_raw_data is True
+
+    def test_request_with_include_raw_data_false(self):
+        """Test creating request with include_raw_data explicitly disabled."""
+        request = GetChartDataRequest(identifier=1, include_raw_data=False)
+
+        assert request.include_raw_data is False
+
+    def test_request_with_custom_limit(self):
+        """Test creating request with custom limit."""
+        request = GetChartDataRequest(identifier=1, limit=500)
+
+        assert request.limit == 500
+
+    def test_request_with_csv_format(self):
+        """Test creating request with CSV format."""
+        request = GetChartDataRequest(identifier=1, format="csv")
+
+        assert request.format == "csv"
+
+    def test_request_with_excel_format(self):
+        """Test creating request with Excel format."""
+        request = GetChartDataRequest(identifier=1, format="excel")
+
+        assert request.format == "excel"
+
+    def test_request_with_cache_control(self):
+        """Test creating request with cache control options."""
+        request = GetChartDataRequest(
+            identifier=1,
+            use_cache=False,
+            force_refresh=True,
+            cache_timeout=3600,
+        )
+
+        assert request.use_cache is False
+        assert request.force_refresh is True
+        assert request.cache_timeout == 3600
+
+    def test_invalid_format(self):
+        """Test that invalid format raises validation error."""
+        with pytest.raises(
+            ValueError, match="Input should be 'json', 'csv' or 'excel'"
+        ):
+            GetChartDataRequest(identifier=1, format="invalid")
+
+    def test_model_dump_serialization(self):
+        """Test that the request serializes correctly for JSON."""
+        request = GetChartDataRequest(
+            identifier=123,
+            limit=50,
+            format="json",
+            include_raw_data=True,
+        )
+
+        data = request.model_dump()
+
+        assert isinstance(data, dict)
+        assert data["identifier"] == 123
+        assert data["limit"] == 50
+        assert data["format"] == "json"
+        assert data["include_raw_data"] is True
+
+
+class TestMaxRowLimit:
+    """Test the MAX_ROW_LIMIT constant."""
+
+    def test_max_row_limit_is_defined(self):
+        """Test that MAX_ROW_LIMIT is defined and reasonable."""
+        assert MAX_ROW_LIMIT is not None
+        assert isinstance(MAX_ROW_LIMIT, int)
+        assert MAX_ROW_LIMIT > 0
+
+    def test_max_row_limit_value(self):
+        """Test that MAX_ROW_LIMIT has expected value."""
+        assert MAX_ROW_LIMIT == 10000
+
+    def test_row_limit_capping_logic(self):
+        """Test the row limit capping logic used in get_chart_data."""
+        # Test that the capping logic works correctly
+        test_cases = [
+            (None, 100),  # None defaults to 100
+            (50, 50),  # Within limit
+            (100, 100),  # Default
+            (5000, 5000),  # Within limit
+            (10000, 10000),  # At limit
+            (15000, 10000),  # Exceeds limit, capped
+            (100000, 10000),  # Far exceeds limit, capped
+        ]
+
+        for requested_limit, expected in test_cases:
+            result = min(requested_limit or 100, MAX_ROW_LIMIT)
+            assert result == expected, (
+                f"For requested_limit={requested_limit}, "
+                f"expected {expected} but got {result}"
+            )

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -16,13 +16,12 @@
 # under the License.
 
 """
-Tests for the get_chart_data request schema and MAX_ROW_LIMIT
+Tests for the get_chart_data request schema
 """
 
 import pytest
 
 from superset.mcp_service.chart.schemas import GetChartDataRequest
-from superset.mcp_service.chart.tool.get_chart_data import MAX_ROW_LIMIT
 
 
 class TestGetChartDataRequestSchema:
@@ -98,36 +97,3 @@ class TestGetChartDataRequestSchema:
         assert data["identifier"] == 123
         assert data["limit"] == 50
         assert data["format"] == "json"
-
-
-class TestMaxRowLimit:
-    """Test the MAX_ROW_LIMIT constant."""
-
-    def test_max_row_limit_is_defined(self):
-        """Test that MAX_ROW_LIMIT is defined and reasonable."""
-        assert MAX_ROW_LIMIT is not None
-        assert isinstance(MAX_ROW_LIMIT, int)
-        assert MAX_ROW_LIMIT > 0
-
-    def test_max_row_limit_value(self):
-        """Test that MAX_ROW_LIMIT has expected value."""
-        assert MAX_ROW_LIMIT == 10000
-
-    def test_row_limit_capping_logic(self):
-        """Test the row limit capping logic used in get_chart_data."""
-        # Test that the capping logic works correctly when limit is specified
-        test_cases = [
-            (50, 50),  # Within limit
-            (100, 100),  # Reasonable limit
-            (5000, 5000),  # Within limit
-            (10000, 10000),  # At limit
-            (15000, 10000),  # Exceeds limit, capped
-            (100000, 10000),  # Far exceeds limit, capped
-        ]
-
-        for requested_limit, expected in test_cases:
-            result = min(requested_limit, MAX_ROW_LIMIT)
-            assert result == expected, (
-                f"For requested_limit={requested_limit}, "
-                f"expected {expected} but got {result}"
-            )


### PR DESCRIPTION
## Summary

- **Fixed `ctx` error**: Added missing `@parse_request(GetChartDataRequest)` decorator to `get_chart_data` tool, which was causing the error: `missing 1 required positional argument: 'ctx'` when calling from MCP clients
- **Fixed single row data issue**: Changed implementation to use `chart.query_context` (same approach as `/api/v1/chart/{id}/data` endpoint) instead of manually constructing queries, which was causing temporal line charts to return a single aggregated value instead of all data points
- **Respects chart's configured limits**: Trusts chart's configured `row_limit` from form_data (which respects global `ROW_LIMIT` and `SQL_MAX_ROW` config). Removed `MAX_ROW_LIMIT` constant per review feedback - charts already have enforced row limits from global config.

## Test Plan

### Verified Fix with Temporal Line Chart

Created a temporal line chart (chart 135) with `order_date` vs `SUM(sales)` on `cleaned_sales_data` dataset and compared API vs MCP responses:

| Aspect | API `/api/v1/chart/135/data/` | MCP `get_chart_data` |
|--------|------------------------------|----------------------|
| **Row count** | **252** | **252** ✅ |
| **Columns** | `order_date`, `SUM(sales)` | `order_date`, `SUM(sales)` ✅ |
| **First data point** | `2003-01-06, $12,133.25` | `2003-01-06, $12,133.25` ✅ |
| **Last data point** | `2005-05-31, $78,918.03` | `2005-05-31, $78,918.03` ✅ |

**API Response (first 5 rows):**
```json
{"order_date": 1041811200000.0, "SUM(sales)": 12133.25}
{"order_date": 1042070400000.0, "SUM(sales)": 11432.34}
{"order_date": 1042156800000.0, "SUM(sales)": 6864.05}
{"order_date": 1043798400000.0, "SUM(sales)": 54702.0}
{"order_date": 1043971200000.0, "SUM(sales)": 44621.96}
```

**MCP Response (first 5 rows):**
```json
{"order_date": "2003-01-06T00:00:00", "SUM(sales)": 12133.25}
{"order_date": "2003-01-09T00:00:00", "SUM(sales)": 11432.34}
{"order_date": "2003-01-10T00:00:00", "SUM(sales)": 6864.05}
{"order_date": "2003-01-29T00:00:00", "SUM(sales)": 54702}
{"order_date": "2003-01-31T00:00:00", "SUM(sales)": 44621.96}
```

**Result:** Both return identical data - 252 temporal data points with matching values.

### Tested Fallback Path (charts without saved `query_context`)

| Chart | Type | Rows Returned | Status |
|-------|------|---------------|--------|
| Chart 2: "Most Populated Countries" | table | 214 rows | ✅ |
| Chart 3: "Growth Rate" | timeseries line | 214 rows | ✅ |
| Chart 7: "World's Pop Growth" | area | 7 rows | ✅ |
| Chart 12: "Genders" | pie | 2 rows | ✅ |
| Chart 13: "Trends" | timeseries line | 250 rows | ✅ |

All charts return the correct number of data points instead of a single aggregated value.

## Additional Information

### Reported Issues (by @villebro)
1. `get_chart_data` was returning: `missing 1 required positional argument: 'ctx'`
2. Temporal line charts returning single aggregated value (e.g., `7291`) instead of all data points

### Root Causes
1. The `@parse_request` decorator was missing - this decorator handles FastMCP's context injection
2. The original implementation manually constructed queries from `form_data` parts instead of using the chart's saved `query_context`

### Key Fix
Now uses `ChartDataQueryContextSchema().load(query_context_json)` - the same approach as the `/api/v1/chart/{id}/data` endpoint:

```python
if chart.query_context:
    query_context_json = utils_json.loads(chart.query_context)
    query_context = ChartDataQueryContextSchema().load(query_context_json)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)