### PR TITLE
fix(config): Wire LOGO_TARGET_PATH and document custom spinner usage

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -355,19 +355,29 @@ AUTH_RATE_LIMIT = "5 per second"
 APP_NAME = "Superset"
 
 # Specify the App icon
+# NOTE: This variable is used to populate THEME_DEFAULT. If you override this in
+# superset_config.py, you must also override THEME_DEFAULT to see the change,
+# or set THEME_DEFAULT["token"]["brandLogoUrl"] directly.
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 
 # Specify where clicking the logo would take the user'
 # Default value of None will take you to '/superset/welcome'
 # You can also specify a relative URL e.g. '/superset/welcome' or '/dashboards/list'
 # or you can specify a full URL e.g. 'https://foo.bar'
+# NOTE: This variable is used to populate THEME_DEFAULT. If you override this in
+# superset_config.py, you must also override THEME_DEFAULT to see the change,
+# or set THEME_DEFAULT["token"]["brandLogoHref"] directly.
 LOGO_TARGET_PATH = None
 
 # Specify tooltip that should appear when hovering over the App Icon/Logo
+# NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_TOOLTIP = ""
 
 # Specify any text that should appear to the right of the logo
+# NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
+
+# APP_ICON_WIDTH is deprecated. Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1
@@ -780,9 +790,10 @@ THEME_DEFAULT: Theme = {
         "brandLogoAlt": "Apache Superset",
         "brandLogoUrl": APP_ICON,
         "brandLogoMargin": "18px 0",
-        "brandLogoHref": "/",
+        "brandLogoHref": LOGO_TARGET_PATH or "/",
         "brandLogoHeight": "24px",
         # Spinner
+        # "brandSpinnerUrl": "/static/assets/images/loading.gif",  # Set this to use a custom GIF/image loader
         "brandSpinnerUrl": None,
         "brandSpinnerSvg": None,
         # Default colors

--- a/superset/config.py
+++ b/superset/config.py
@@ -360,7 +360,7 @@ APP_NAME = "Superset"
 # or set THEME_DEFAULT["token"]["brandLogoUrl"] directly.
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 
-# Specify where clicking the logo would take the user'
+# Specify where clicking the logo would take the user
 # Default value of None will take you to '/superset/welcome'
 # You can also specify a relative URL e.g. '/superset/welcome' or '/dashboards/list'
 # or you can specify a full URL e.g. 'https://foo.bar'
@@ -377,7 +377,8 @@ LOGO_TOOLTIP = ""
 # NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
 
-# APP_ICON_WIDTH is deprecated. Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
+# APP_ICON_WIDTH is deprecated. 
+# Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1

--- a/superset/config.py
+++ b/superset/config.py
@@ -793,8 +793,8 @@ THEME_DEFAULT: Theme = {
         "brandLogoMargin": "18px 0",
         "brandLogoHref": LOGO_TARGET_PATH or "/",
         "brandLogoHeight": "24px",
-        # Spinner
-        # "brandSpinnerUrl": "/static/assets/images/loading.gif",  # Set this to use a custom GIF/image loader
+        # Spinner - Set this to use a custom GIF/image loader
+        # "brandSpinnerUrl": "/static/assets/images/loading.gif", 
         "brandSpinnerUrl": None,
         "brandSpinnerSvg": None,
         # Default colors

--- a/superset/config.py
+++ b/superset/config.py
@@ -413,7 +413,7 @@ APP_NAME = "Superset"
 # or set THEME_DEFAULT["token"]["brandLogoUrl"] directly.
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 
-# Specify where clicking the logo would take the user'
+# Specify where clicking the logo would take the user
 # Default value of None will take you to '/superset/welcome'
 # You can also specify a relative URL e.g. '/superset/welcome' or '/dashboards/list'
 # or you can specify a full URL e.g. 'https://foo.bar'
@@ -430,7 +430,8 @@ LOGO_TOOLTIP = ""
 # NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
 
-# APP_ICON_WIDTH is deprecated. Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
+# APP_ICON_WIDTH is deprecated. 
+# Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1

--- a/superset/config.py
+++ b/superset/config.py
@@ -408,19 +408,29 @@ AUTH_PASSWORD_COMMON_BLOCKLIST: list[str] = []
 APP_NAME = "Superset"
 
 # Specify the App icon
+# NOTE: This variable is used to populate THEME_DEFAULT. If you override this in
+# superset_config.py, you must also override THEME_DEFAULT to see the change,
+# or set THEME_DEFAULT["token"]["brandLogoUrl"] directly.
 APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 
 # Specify where clicking the logo would take the user'
 # Default value of None will take you to '/superset/welcome'
 # You can also specify a relative URL e.g. '/superset/welcome' or '/dashboards/list'
 # or you can specify a full URL e.g. 'https://foo.bar'
+# NOTE: This variable is used to populate THEME_DEFAULT. If you override this in
+# superset_config.py, you must also override THEME_DEFAULT to see the change,
+# or set THEME_DEFAULT["token"]["brandLogoHref"] directly.
 LOGO_TARGET_PATH = None
 
 # Specify tooltip that should appear when hovering over the App Icon/Logo
+# NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_TOOLTIP = ""
 
 # Specify any text that should appear to the right of the logo
+# NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
+
+# APP_ICON_WIDTH is deprecated. Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
 
 # Enables SWAGGER UI for superset openapi spec
 # ex: http://localhost:8080/swagger/v1
@@ -1008,9 +1018,10 @@ THEME_DEFAULT: Theme = {
         "brandLogoAlt": "Apache Superset",
         "brandLogoUrl": APP_ICON,
         "brandLogoMargin": "18px 0",
-        "brandLogoHref": "/",
+        "brandLogoHref": LOGO_TARGET_PATH or "/",
         "brandLogoHeight": "24px",
         # Spinner
+        # "brandSpinnerUrl": "/static/assets/images/loading.gif",  # Set this to use a custom GIF/image loader
         "brandSpinnerUrl": None,
         "brandSpinnerSvg": None,
         # Default colors

--- a/superset/config.py
+++ b/superset/config.py
@@ -1021,8 +1021,8 @@ THEME_DEFAULT: Theme = {
         "brandLogoMargin": "18px 0",
         "brandLogoHref": LOGO_TARGET_PATH or "/",
         "brandLogoHeight": "24px",
-        # Spinner
-        # "brandSpinnerUrl": "/static/assets/images/loading.gif",  # Set this to use a custom GIF/image loader
+        # Spinner - Set this to use a custom GIF/image loader
+        # "brandSpinnerUrl": "/static/assets/images/loading.gif", 
         "brandSpinnerUrl": None,
         "brandSpinnerSvg": None,
         # Default colors

--- a/superset/config.py
+++ b/superset/config.py
@@ -430,7 +430,7 @@ LOGO_TOOLTIP = ""
 # NOTE: This variable is deprecated and not used in the new theme system.
 LOGO_RIGHT_TEXT: Callable[[], str] | str = ""
 
-# APP_ICON_WIDTH is deprecated. 
+# APP_ICON_WIDTH is deprecated.
 # Use THEME_DEFAULT["token"]["brandLogoHeight"] instead (default: "24px").
 
 # Enables SWAGGER UI for superset openapi spec
@@ -1022,7 +1022,7 @@ THEME_DEFAULT: Theme = {
         "brandLogoHref": LOGO_TARGET_PATH or "/",
         "brandLogoHeight": "24px",
         # Spinner - Set this to use a custom GIF/image loader
-        # "brandSpinnerUrl": "/static/assets/images/loading.gif", 
+        # "brandSpinnerUrl": "/static/assets/images/loading.gif",
         "brandSpinnerUrl": None,
         "brandSpinnerSvg": None,
         # Default colors

--- a/superset/config.py
+++ b/superset/config.py
@@ -417,9 +417,8 @@ APP_ICON = "/static/assets/images/superset-logo-horiz.png"
 # Default value of None will take you to '/superset/welcome'
 # You can also specify a relative URL e.g. '/superset/welcome' or '/dashboards/list'
 # or you can specify a full URL e.g. 'https://foo.bar'
-# NOTE: This variable is used to populate THEME_DEFAULT. If you override this in
-# superset_config.py, you must also override THEME_DEFAULT to see the change,
-# or set THEME_DEFAULT["token"]["brandLogoHref"] directly.
+# NOTE: Overriding this in superset_config.py automatically updates the logo link
+# (THEME_DEFAULT["token"]["brandLogoHref"]); see sync_theme_logo_href below.
 LOGO_TARGET_PATH = None
 
 # Specify tooltip that should appear when hovering over the App Icon/Logo
@@ -1063,6 +1062,22 @@ THEME_DARK: Optional[Theme] = {
     },
     "algorithm": "dark",
 }
+
+
+def sync_theme_logo_href(
+    theme: Optional[Theme], logo_target_path: Optional[str]
+) -> None:
+    """
+    Apply ``LOGO_TARGET_PATH`` to a theme's ``brandLogoHref`` token.
+
+    ``THEME_DEFAULT`` / ``THEME_DARK`` are built above, before ``superset_config.py``
+    and environment overrides are applied at the bottom of this module. This is
+    re-run after those overrides so that setting only ``LOGO_TARGET_PATH`` updates
+    the logo link without also having to override the whole theme object.
+    """
+    if theme and logo_target_path and isinstance(theme.get("token"), dict):
+        theme["token"]["brandLogoHref"] = logo_target_path
+
 
 # Theme behavior and user preference settings
 # To force a single theme on all users, set THEME_DARK = None
@@ -2843,3 +2858,9 @@ for env_var in ENV_VAR_KEYS:
     if env_var in os.environ:
         config_var = env_var.replace("SUPERSET__", "")
         globals()[config_var] = os.environ[env_var]
+
+# THEME_DEFAULT / THEME_DARK are defined before the overrides above are applied,
+# so re-sync the logo link from the final LOGO_TARGET_PATH value here. This lets
+# users set just LOGO_TARGET_PATH without also overriding the whole theme.
+sync_theme_logo_href(THEME_DEFAULT, LOGO_TARGET_PATH)
+sync_theme_logo_href(THEME_DARK, LOGO_TARGET_PATH)

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -312,3 +312,24 @@ def test_full_setting(
     assert dttm_col.is_dttm
     assert dttm_col.python_date_format == "epoch_s"
     assert dttm_col.expression == "CAST(dttm as INTEGER)"
+
+
+def test_theme_default_logo_target_path() -> None:
+    """
+    Test that THEME_DEFAULT properly uses LOGO_TARGET_PATH for brandLogoHref.
+
+    When LOGO_TARGET_PATH is None (default), brandLogoHref should be "/".
+    When LOGO_TARGET_PATH is set, it should be used instead.
+    """
+    from superset import config
+
+    # Verify default behavior: LOGO_TARGET_PATH is None, so brandLogoHref is "/"
+    assert config.LOGO_TARGET_PATH is None
+    assert config.THEME_DEFAULT["token"]["brandLogoHref"] == "/"
+
+    # Verify the expression logic works correctly for custom values
+    custom_path = "https://example.com"
+    assert (custom_path or "/") == custom_path
+
+    # Verify APP_ICON is wired to brandLogoUrl
+    assert config.THEME_DEFAULT["token"]["brandLogoUrl"] == config.APP_ICON

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -314,22 +314,21 @@ def test_full_setting(
     assert dttm_col.expression == "CAST(dttm as INTEGER)"
 
 
-def test_theme_default_logo_target_path() -> None:
+def test_theme_default_logo_wiring() -> None:
     """
-    Test that THEME_DEFAULT properly uses LOGO_TARGET_PATH for brandLogoHref.
+    Verify THEME_DEFAULT is wired to the logo config variables at import time.
 
-    When LOGO_TARGET_PATH is None (default), brandLogoHref should be "/".
-    When LOGO_TARGET_PATH is set, it should be used instead.
+    THEME_DEFAULT is built from LOGO_TARGET_PATH and APP_ICON when the module is
+    imported. With the shipped defaults (LOGO_TARGET_PATH is None), brandLogoHref
+    falls back to "/", and brandLogoUrl mirrors APP_ICON. Overriding these in
+    superset_config.py requires also overriding THEME_DEFAULT, which is documented
+    alongside the variables.
     """
     from superset import config
 
-    # Verify default behavior: LOGO_TARGET_PATH is None, so brandLogoHref is "/"
+    # LOGO_TARGET_PATH defaults to None, so brandLogoHref falls back to "/"
     assert config.LOGO_TARGET_PATH is None
     assert config.THEME_DEFAULT["token"]["brandLogoHref"] == "/"
 
-    # Verify the expression logic works correctly for custom values
-    custom_path = "https://example.com"
-    assert (custom_path or "/") == custom_path
-
-    # Verify APP_ICON is wired to brandLogoUrl
+    # APP_ICON is wired to brandLogoUrl
     assert config.THEME_DEFAULT["token"]["brandLogoUrl"] == config.APP_ICON

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -314,21 +314,38 @@ def test_full_setting(
     assert dttm_col.expression == "CAST(dttm as INTEGER)"
 
 
-def test_theme_default_logo_wiring() -> None:
+def test_sync_theme_logo_href() -> None:
     """
-    Verify THEME_DEFAULT is wired to the logo config variables at import time.
+    Verify LOGO_TARGET_PATH is wired into a theme's brandLogoHref.
 
-    THEME_DEFAULT is built from LOGO_TARGET_PATH and APP_ICON when the module is
-    imported. With the shipped defaults (LOGO_TARGET_PATH is None), brandLogoHref
-    falls back to "/", and brandLogoUrl mirrors APP_ICON. Overriding these in
-    superset_config.py requires also overriding THEME_DEFAULT, which is documented
-    alongside the variables.
+    THEME_DEFAULT is built before superset_config.py overrides load, so the link
+    is re-synced afterwards via sync_theme_logo_href. A provided LOGO_TARGET_PATH
+    must update brandLogoHref; None must leave the existing value untouched.
     """
+    from copy import deepcopy
+
+    from superset.config import sync_theme_logo_href, THEME_DEFAULT
+
+    # A user-provided LOGO_TARGET_PATH propagates to the logo link.
+    theme = deepcopy(THEME_DEFAULT)
+    theme["token"]["brandLogoHref"] = "/"
+    sync_theme_logo_href(theme, "https://custom.url")
+    assert theme["token"]["brandLogoHref"] == "https://custom.url"
+
+    # The default (None) leaves the existing link untouched.
+    default_theme = deepcopy(THEME_DEFAULT)
+    default_theme["token"]["brandLogoHref"] = "/"
+    sync_theme_logo_href(default_theme, None)
+    assert default_theme["token"]["brandLogoHref"] == "/"
+
+    # A disabled theme (None) is a no-op rather than an error.
+    sync_theme_logo_href(None, "https://custom.url")
+
+
+def test_theme_default_logo_defaults() -> None:
+    """With the shipped defaults, brandLogoHref is "/" and brandLogoUrl is APP_ICON."""
     from superset import config
 
-    # LOGO_TARGET_PATH defaults to None, so brandLogoHref falls back to "/"
     assert config.LOGO_TARGET_PATH is None
     assert config.THEME_DEFAULT["token"]["brandLogoHref"] == "/"
-
-    # APP_ICON is wired to brandLogoUrl
     assert config.THEME_DEFAULT["token"]["brandLogoUrl"] == config.APP_ICON


### PR DESCRIPTION
SUMMARY
This PR addresses user confusion regarding customizing the loading icon and resolves a bug where `LOGO_TARGET_PATH` was being ignored by the default theme system in Superset 6.0.0.

Specifically, it:
1.  **Documents Custom Loading Icon**: Explicitly documents `brandSpinnerUrl` in `THEME_DEFAULT` within [config.py](cci:7://file:///c:/Users/ishwet/superset/superset/config.py:0:0-0:0). This clarifies that users can set a custom GIF/image loader via config without needing to replace source files or rebuild assets.
2.  **Fixes Logo Link**: Updates `THEME_DEFAULT` to correctly use `LOGO_TARGET_PATH` for `brandLogoHref`. Previously, `LOGO_TARGET_PATH` was ignored by the default theme, forcing users to override the entire theme object just to change the logo link.
3.  **Clarifies Configuration**: Added comments to `APP_ICON`, `LOGO_TOOLTIP`, `LOGO_RIGHT_TEXT`, and `APP_ICON_WIDTH` (deprecation note) to clarify their interaction with `THEME_DEFAULT` or their deprecated status.

BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (Configuration and Documentation changes only)

TESTING INSTRUCTIONS
To verify these changes locally:

1.  **Verify Logo Link Fix**:
    *   In `superset_config.py`, set `LOGO_TARGET_PATH = "https://custom.url"`.
    *   Restart Superset and click the top-left logo.
    *   **Result**: It should navigate to `https://custom.url` (previously it would stay on `/` unless the theme was overridden).

2.  **Verify Custom Spinner**:
    *   In `superset_config.py`, set:
        ```python
        THEME_DEFAULT = {
            "token": {
                "brandSpinnerUrl": "/static/assets/images/my-custom-spinner.gif"
            }
        }
        ```
    *   Restart Superset.
    *   **Result**: The custom GIF should appear during loading.

ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36940
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API