### PR TITLE
fix(dynamic-group-by): scope chart refreshes to affected charts only

### DIFF
--- a/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
+++ b/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
@@ -30,6 +30,7 @@ import {
 import { triggerQuery } from 'src/components/Chart/chartAction';
 import { removeDataMask, updateDataMask } from 'src/dataMask/actions';
 import { onSave } from './dashboardState';
+import { getRelatedChartsForChartCustomization } from 'src/dashboard/util/getRelatedCharts';
 
 const createUpdateDashboardApi = (id: number) =>
   makeApi<
@@ -204,10 +205,20 @@ export function saveChartCustomization(
         dispatch(onSave(lastModifiedTime));
       }
 
-      const { dashboardState } = getState();
-      const chartIds = dashboardState.sliceIds || [];
-      if (chartIds.length > 0) {
-        chartIds.forEach(chartId => {
+      const { sliceEntities } = getState();
+      const slices = sliceEntities.slices || {};
+      const affectedChartIds: number[] = [];
+      simpleItems.forEach(customization => {
+        const relatedCharts = getRelatedChartsForChartCustomization(
+          customization,
+          slices,
+        );
+        affectedChartIds.push(...relatedCharts);
+      });
+
+      const uniqueAffectedChartIds = [...new Set(affectedChartIds)];
+      if (uniqueAffectedChartIds.length > 0) {
+        uniqueAffectedChartIds.forEach(chartId => {
           dispatch(triggerQuery(true, chartId));
         });
       }

--- a/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
+++ b/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
@@ -237,12 +237,26 @@ export function saveChartCustomization(
         item => !item.removed && hasValidColumn(item.customization?.column),
       );
 
-      const uniqueAffectedChartIds = getAffectedChartIdsFromCustomizations(
+      const uniqueAffectedChartIds = new Set<number>();
+
+      const affectedFromRemaining = getAffectedChartIdsFromCustomizations(
         customizationsWithColumns,
         slices,
       );
-      if (uniqueAffectedChartIds.length > 0) {
-        uniqueAffectedChartIds.forEach(chartId => {
+      affectedFromRemaining.forEach(chartId =>
+        uniqueAffectedChartIds.add(chartId),
+      );
+
+      const affectedFromRemoved = getAffectedChartIdsFromCustomizations(
+        removedItems,
+        slices,
+      );
+      affectedFromRemoved.forEach(chartId =>
+        uniqueAffectedChartIds.add(chartId),
+      );
+
+      if (uniqueAffectedChartIds.size > 0) {
+        Array.from(uniqueAffectedChartIds).forEach(chartId => {
           dispatch(triggerQuery(true, chartId));
         });
       }

--- a/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
+++ b/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
@@ -237,6 +237,20 @@ export function saveChartCustomization(
         item => !item.removed && hasValidColumn(item.customization?.column),
       );
 
+      const itemsWithRemovedColumns = chartCustomizationItems
+        .filter(newItem => {
+          const existingItem = existingItemsMap.get(newItem.id);
+          if (!existingItem) return false;
+          const existingColumn = existingItem.customization?.column || null;
+          const newColumn = newItem.customization?.column || null;
+          return hasValidColumn(existingColumn) && !hasValidColumn(newColumn);
+        })
+        .map(newItem => {
+          const existingItem = existingItemsMap.get(newItem.id);
+          return existingItem as ChartCustomizationItem;
+        })
+        .filter(Boolean);
+
       const uniqueAffectedChartIds = new Set<number>();
 
       const affectedFromRemaining = getAffectedChartIdsFromCustomizations(
@@ -252,6 +266,14 @@ export function saveChartCustomization(
         slices,
       );
       affectedFromRemoved.forEach(chartId =>
+        uniqueAffectedChartIds.add(chartId),
+      );
+
+      const affectedFromColumnRemovals = getAffectedChartIdsFromCustomizations(
+        itemsWithRemovedColumns,
+        slices,
+      );
+      affectedFromColumnRemovals.forEach(chartId =>
         uniqueAffectedChartIds.add(chartId),
       );
 

--- a/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
+++ b/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
@@ -30,7 +30,7 @@ import {
 import { triggerQuery } from 'src/components/Chart/chartAction';
 import { removeDataMask, updateDataMask } from 'src/dataMask/actions';
 import { onSave } from './dashboardState';
-import { getRelatedChartsForChartCustomization } from 'src/dashboard/util/getRelatedCharts';
+import { getAffectedChartIdsFromCustomizations } from 'src/dashboard/util/getRelatedCharts';
 
 const createUpdateDashboardApi = (id: number) =>
   makeApi<
@@ -207,16 +207,10 @@ export function saveChartCustomization(
 
       const sliceEntities = getState().sliceEntities || {};
       const slices = sliceEntities.slices || {};
-      const affectedChartIds: number[] = [];
-      simpleItems.forEach(customization => {
-        const relatedCharts = getRelatedChartsForChartCustomization(
-          customization,
-          slices,
-        );
-        affectedChartIds.push(...relatedCharts);
-      });
-
-      const uniqueAffectedChartIds = [...new Set(affectedChartIds)];
+      const uniqueAffectedChartIds = getAffectedChartIdsFromCustomizations(
+        simpleItems,
+        slices,
+      );
       if (uniqueAffectedChartIds.length > 0) {
         uniqueAffectedChartIds.forEach(chartId => {
           dispatch(triggerQuery(true, chartId));

--- a/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
+++ b/superset-frontend/src/dashboard/actions/chartCustomizationActions.ts
@@ -205,7 +205,7 @@ export function saveChartCustomization(
         dispatch(onSave(lastModifiedTime));
       }
 
-      const { sliceEntities } = getState();
+      const sliceEntities = getState().sliceEntities || {};
       const slices = sliceEntities.slices || {};
       const affectedChartIds: number[] = [];
       simpleItems.forEach(customization => {

--- a/superset-frontend/src/dashboard/components/Dashboard.jsx
+++ b/superset-frontend/src/dashboard/components/Dashboard.jsx
@@ -224,6 +224,12 @@ class Dashboard extends PureComponent {
     );
 
     [...allKeys].forEach(filterKey => {
+      // Skip chart customization filters - they are handled separately by saveChartCustomization
+      // which triggers queries only for affected charts
+      if (filterKey.startsWith('chart_customization_')) {
+        return;
+      }
+
       if (
         !currFilterKeys.includes(filterKey) &&
         appliedFilterKeys.includes(filterKey)

--- a/superset-frontend/src/dashboard/components/nativeFilters/ChartCustomization/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ChartCustomization/GroupByFilterCard.tsx
@@ -441,10 +441,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
           return;
         }
 
-        if (
-          datasetId === lastFetchedDatasetIdRef.current ||
-          isFetchingRef.current
-        ) {
+        if (datasetId === lastFetchedDatasetIdRef.current) {
           return;
         }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/ChartCustomization/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ChartCustomization/utils.ts
@@ -61,3 +61,31 @@ export const ensureValidCustomization = (
   column: customization.column || null,
   ...customization,
 });
+
+/**
+ * Checks if a column value is valid (non-null, non-empty).
+ * A column is considered valid if:
+ * - It's a non-empty string (after trimming)
+ * - It's a non-empty array
+ * - Other truthy values are considered valid
+ *
+ * @param column - The column value to check (string, string[], or null)
+ * @returns true if the column has a valid value, false otherwise
+ */
+export function hasValidColumn(
+  column: string | string[] | null | undefined,
+): boolean {
+  if (column === null || column === undefined) {
+    return false;
+  }
+
+  if (typeof column === 'string') {
+    return column.trim() !== '';
+  }
+
+  if (Array.isArray(column)) {
+    return column.length > 0;
+  }
+
+  return true;
+}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -50,7 +50,7 @@ import {
   clearAllChartCustomizationsFromMetadata,
 } from 'src/dashboard/actions/chartCustomizationActions';
 import { ChartCustomizationItem } from 'src/dashboard/components/nativeFilters/ChartCustomization/types';
-import { getRelatedChartsForChartCustomization } from 'src/dashboard/util/getRelatedCharts';
+import { getAffectedChartIdsFromCustomizations } from 'src/dashboard/util/getRelatedCharts';
 import { Slice } from 'src/types/Chart';
 
 import { useImmer } from 'use-immer';
@@ -366,16 +366,10 @@ const FilterBar: FC<FiltersBarProps> = ({
 
         dispatch(setChartCustomization(mergedCustomizations));
 
-        const affectedChartIds: number[] = [];
-        mergedCustomizations.forEach(customization => {
-          const relatedCharts = getRelatedChartsForChartCustomization(
-            customization,
-            slices,
-          );
-          affectedChartIds.push(...relatedCharts);
-        });
-
-        const uniqueAffectedChartIds = [...new Set(affectedChartIds)];
+        const uniqueAffectedChartIds = getAffectedChartIdsFromCustomizations(
+          mergedCustomizations,
+          slices,
+        );
         if (uniqueAffectedChartIds.length > 0) {
           uniqueAffectedChartIds.forEach(chartId => {
             dispatch(triggerQuery(true, chartId));

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -164,7 +164,7 @@ const FilterBar: FC<FiltersBarProps> = ({
     state => state.dashboardInfo.metadata?.chart_customization_config || [],
   );
   const slices = useSelector<RootState, Record<string, Slice>>(
-    state => state.sliceEntities.slices || {},
+    state => state.sliceEntities?.slices || {},
   );
   const dispatch = useDispatch();
   const [updateKey, setUpdateKey] = useState(0);

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.test.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.test.ts
@@ -22,7 +22,11 @@ import {
   Filter,
   NativeFilterType,
 } from '@superset-ui/core';
-import { getRelatedCharts } from './getRelatedCharts';
+import { ChartCustomizationItem } from 'src/dashboard/components/nativeFilters/ChartCustomization/types';
+import {
+  getRelatedCharts,
+  getAffectedChartIdsFromCustomizations,
+} from './getRelatedCharts';
 
 const slices = {
   '1': { datasource: 'ds1', slice_id: 1 },
@@ -104,4 +108,243 @@ test('Return only chart ids in specific scope with cross filter', () => {
 
   const result = getRelatedCharts('1', filters['1'], slices);
   expect(result).toEqual([2]);
+});
+
+const slicesWithMultipleDatasets = {
+  '1': { datasource: '100__table', slice_id: 1 },
+  '2': { datasource: '100__table', slice_id: 2 },
+  '3': { datasource: '200__table', slice_id: 3 },
+  '4': { datasource: '200__table', slice_id: 4 },
+  '5': { datasource: '300__table', slice_id: 5 },
+} as any;
+
+test('Returns empty array for empty customizations', () => {
+  const customizations: ChartCustomizationItem[] = [];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([]);
+});
+
+test('Returns chart ID when customization has specific chartId', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      chartId: 1,
+      customization: {
+        name: 'Custom 1',
+        dataset: null,
+        column: null,
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1]);
+});
+
+test('Returns all charts matching dataset when customization has dataset', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2]);
+});
+
+test('Returns empty array when customization has no chartId and no dataset', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: null,
+        column: null,
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([]);
+});
+
+test('Returns unique chart IDs when multiple customizations affect same charts', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      chartId: 1,
+      customization: {
+        name: 'Custom 1',
+        dataset: null,
+        column: null,
+      },
+    },
+    {
+      id: 'custom2',
+      customization: {
+        name: 'Custom 2',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+    {
+      id: 'custom3',
+      chartId: 1,
+      customization: {
+        name: 'Custom 3',
+        dataset: null,
+        column: null,
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2]);
+});
+
+test('Returns charts from multiple different datasets', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+    {
+      id: 'custom2',
+      customization: {
+        name: 'Custom 2',
+        dataset: '200',
+        column: 'column2',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2, 3, 4]);
+});
+
+test('Handles mixed customizations with chartId and dataset', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      chartId: 5,
+      customization: {
+        name: 'Custom 1',
+        dataset: null,
+        column: null,
+      },
+    },
+    {
+      id: 'custom2',
+      customization: {
+        name: 'Custom 2',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([5, 1, 2]);
+});
+
+test('Handles dataset as number', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: 100,
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2]);
+});
+
+test('Handles dataset as DatasetReference object', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: { value: 100 },
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2]);
+});
+
+test('Filters out slices without datasource', () => {
+  const slicesWithMissingDatasource = {
+    '1': { datasource: '100__table', slice_id: 1 },
+    '2': { datasource: null, slice_id: 2 },
+    '3': { slice_id: 3 },
+  } as any;
+
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMissingDatasource,
+  );
+  expect(result).toEqual([1]);
+});
+
+test('Handles dataset with double underscore format correctly', () => {
+  const customizations: ChartCustomizationItem[] = [
+    {
+      id: 'custom1',
+      customization: {
+        name: 'Custom 1',
+        dataset: '100',
+        column: 'column1',
+      },
+    },
+  ];
+  const result = getAffectedChartIdsFromCustomizations(
+    customizations,
+    slicesWithMultipleDatasets,
+  );
+  expect(result).toEqual([1, 2]);
 });

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.ts
@@ -142,3 +142,28 @@ export function getRelatedChartsForChartCustomization(
     })
     .map(slice => slice.slice_id);
 }
+
+/**
+ * Get unique chart IDs affected by chart customizations.
+ * This function calculates which charts are affected by the given customizations
+ * and returns a deduplicated list of chart IDs.
+ *
+ * @param customizations - Array of chart customization items
+ * @param slices - Record of slice/chart entities keyed by chart ID
+ * @returns Array of unique chart IDs that are affected by the customizations
+ */
+export function getAffectedChartIdsFromCustomizations(
+  customizations: ChartCustomizationItem[],
+  slices: Record<string, Slice>,
+): number[] {
+  const affectedChartIds: number[] = [];
+  customizations.forEach(customization => {
+    const relatedCharts = getRelatedChartsForChartCustomization(
+      customization,
+      slices,
+    );
+    affectedChartIds.push(...relatedCharts);
+  });
+
+  return [...new Set(affectedChartIds)];
+}

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.ts
@@ -116,6 +116,7 @@ export function getRelatedCharts(
 export function getRelatedChartsForChartCustomization(
   customizationItem: ChartCustomizationItem,
   slices: Record<string, Slice>,
+  charts?: Record<string, { form_data?: { datasource?: string } }>,
 ): number[] {
   const { customization, chartId } = customizationItem;
   const { dataset } = customization;
@@ -135,10 +136,18 @@ export function getRelatedChartsForChartCustomization(
     targetDatasetId = String(dataset);
   }
 
-  return Object.values(slices)
+  const relatedCharts = Object.values(slices)
     .filter(slice => {
-      const sliceDataset = slice.datasource;
-      if (!sliceDataset) return false;
+      const chartFormData = charts?.[slice.slice_id]?.form_data;
+      const sliceDataset =
+        chartFormData?.datasource ||
+        slice.datasource ||
+        (slice.form_data?.datasource as string | undefined) ||
+        (slice.datasource_id ? String(slice.datasource_id) : undefined);
+
+      if (!sliceDataset) {
+        return false;
+      }
 
       const sliceDatasetParts = String(sliceDataset).split('__');
       const sliceDatasetId = sliceDatasetParts[0];
@@ -146,6 +155,8 @@ export function getRelatedChartsForChartCustomization(
       return sliceDatasetId === targetDatasetId;
     })
     .map(slice => slice.slice_id);
+
+  return relatedCharts;
 }
 
 /**

--- a/superset-frontend/src/dashboard/util/getRelatedCharts.ts
+++ b/superset-frontend/src/dashboard/util/getRelatedCharts.ts
@@ -128,7 +128,12 @@ export function getRelatedChartsForChartCustomization(
     return [];
   }
 
-  const targetDatasetId = String(dataset);
+  let targetDatasetId: string;
+  if (typeof dataset === 'object' && dataset !== null && 'value' in dataset) {
+    targetDatasetId = String(dataset.value);
+  } else {
+    targetDatasetId = String(dataset);
+  }
 
   return Object.values(slices)
     .filter(slice => {


### PR DESCRIPTION
<!---
fix(dynamic-group-by): scope chart refreshes to affected charts only
-->

### SUMMARY
This change prevents request storms caused by Dynamic Group By chart customizations by aligning chart refresh behavior with the existing native filters pattern.
Previously, applying or saving chart customizations triggered a forced re-query of all charts on the dashboard, regardless of whether they were affected. This caused unnecessary request fan-out and excessive /api/v1/chart/data traffic on dashboards with many charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1288" height="837" alt="Screenshot from 2026-01-07 20-47-03" src="https://github.com/user-attachments/assets/c03c786f-f290-4bc1-81e2-6a14e9b9b30f" />

AFTER;
<img width="1288" height="837" alt="Screenshot from 2026-01-07 21-02-31" src="https://github.com/user-attachments/assets/9d642c8e-d254-4969-9e73-170d02b40d23" />


### TESTING INSTRUCTIONS
1)Open a dashboard with multiple charts (ideally 10+).
2)Configure Dynamic Group By / Chart Customization for one or more charts.
3)Open the browser DevTools → Network tab (filter by /api/v1/chart/data).
4)Apply the chart customization.

Verify:

1)Only charts affected by the customization issue /api/v1/chart/data requests.
2)Unaffected charts do not re-query.
3)Each affected chart triggers only one request per apply action.
4)No repeated or cascading requests are observed.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
