### PR TITLE
fix(dashboard): resolve dropdown popup positioning

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -64,6 +64,7 @@ import {
 } from './styles';
 import {
   DEFAULT_SORT_COMPARATOR,
+  DROPDOWN_ALIGN_BOTTOM,
   EMPTY_OPTIONS,
   MAX_TAG_COUNT,
   TOKEN_SEPARATORS,
@@ -777,6 +778,7 @@ const Select = forwardRef(
           optionRender={option => <Space>{option.label || option.value}</Space>}
           oneLine={oneLine}
           css={props.css}
+          dropdownAlign={DROPDOWN_ALIGN_BOTTOM}
           {...props}
           showSearch={shouldShowSearch}
           ref={ref}

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/constants.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/constants.ts
@@ -19,7 +19,7 @@
 import { LabeledValue as AntdLabeledValue } from 'antd/es/select';
 import { t } from '@apache-superset/core';
 import { rankedSearchCompare } from '../../utils/rankedSearchCompare';
-import { RawValue } from './types';
+import { RawValue, SelectProps } from './types';
 
 export const MAX_TAG_COUNT = 4;
 
@@ -32,6 +32,12 @@ export const DEFAULT_PAGE_SIZE = 100;
 export const SELECT_ALL_VALUE: RawValue = t('Select All');
 
 export const VIRTUAL_THRESHOLD = 20;
+
+export const DROPDOWN_ALIGN_BOTTOM: SelectProps['dropdownAlign'] = {
+  points: ['tl', 'bl'],
+  offset: [0, 4],
+  overflow: { adjustX: 0, adjustY: 1 },
+};
 
 export const SELECT_ALL_OPTION = {
   value: SELECT_ALL_VALUE,

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts
@@ -71,6 +71,7 @@ export type AntdExposedProps = Pick<
   | 'virtual'
   | 'getPopupContainer'
   | 'menuItemSelectedIcon'
+  | 'dropdownAlign'
 >;
 
 export type SelectOptionsType = Exclude<AntdProps['options'], undefined>;


### PR DESCRIPTION
### SUMMARY

When zooming in any page (150% to 200% zoom), the dropdown filter popup was positioning over the dropdown input creating a bad user experience when manipulating the dropdown component.

The fix simply aligns the dropdown popup always below the dropdown input.

This fix will affect all the places that are using this dropdown component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

BEFORE:

<img width="2047" height="1073" alt="89550_1" src="https://github.com/user-attachments/assets/35cc7807-3664-4405-a196-23d530d5ffd2" />

The dropdown covers the input box, preventing any filtering or selection via typing. This breaks basic usability on smaller screens.

<img width="2048" height="1061" alt="89550_2" src="https://github.com/user-attachments/assets/93970066-8254-4f18-b905-a0dcb2b17052" />

AFTER

https://github.com/user-attachments/assets/cc873446-2f35-4bb6-ab20-4216d48c9a0a

### TESTING INSTRUCTIONS

1. Create or open a dashboard with a filter of type Value that has 100+ options.
2. Open the filter dropdown on a screen smaller than 1080p resolution or simulate by increasing browser zoom (e.g., 150%).
3. Observe how the dropdown overlaps the input box and becomes unresponsive to typing.
4. Try to test the most important places where these dropdowns are used.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/34135
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
