### PR TITLE
fix(reports): Use authenticated user as recipient for chart/dashboard reports

### DIFF
--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -60,16 +60,19 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
     def _populate_recipients(self, exceptions: list[ValidationError]) -> None:
         """
         Populate recipients based on creation method and current user.
-        
+
         For reports initiated from charts or dashboards, always use
         the current user's email as the recipient, ignoring any
         client-provided recipient values. Raises validation error if
         user has no email address.
         """
         creation_method = self._properties.get("creation_method")
-        
+
         # For reports from charts/dashboards, always use current user
-        if creation_method in (ReportCreationMethod.CHARTS, ReportCreationMethod.DASHBOARDS):
+        if creation_method in (
+            ReportCreationMethod.CHARTS,
+            ReportCreationMethod.DASHBOARDS,
+        ):
             if hasattr(g, "user") and g.user and g.user.email:
                 # Override any provided recipients with current user's email
                 self._properties["recipients"] = [
@@ -103,7 +106,7 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
         owner_ids: Optional[list[int]] = self._properties.get("owners")
 
         exceptions: list[ValidationError] = []
-        
+
         # Populate recipients if needed (may add validation errors)
         self._populate_recipients(exceptions)
 

--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -78,7 +78,7 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
                 self._properties["recipients"] = [
                     {
                         "type": ReportRecipientType.EMAIL,
-                        "recipient_config_json": json.dumps({"target": g.user.email}),
+                        "recipient_config_json": {"target": g.user.email},
                     }
                 ]
             else:

--- a/superset/commands/report/create.py
+++ b/superset/commands/report/create.py
@@ -18,6 +18,7 @@ import logging
 from functools import partial
 from typing import Any, Optional
 
+from flask import g
 from flask_babel import gettext as _
 from marshmallow import ValidationError
 
@@ -30,11 +31,13 @@ from superset.commands.report.exceptions import (
     ReportScheduleCreationMethodUniquenessValidationError,
     ReportScheduleInvalidError,
     ReportScheduleNameUniquenessValidationError,
+    ReportScheduleUserEmailNotFoundError,
 )
 from superset.daos.database import DatabaseDAO
 from superset.daos.report import ReportScheduleDAO
 from superset.reports.models import (
     ReportCreationMethod,
+    ReportRecipientType,
     ReportSchedule,
     ReportScheduleType,
 )
@@ -53,6 +56,32 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
     def run(self) -> ReportSchedule:
         self.validate()
         return ReportScheduleDAO.create(attributes=self._properties)
+
+    def _populate_recipients(self, exceptions: list[ValidationError]) -> None:
+        """
+        Populate recipients based on creation method and current user.
+        
+        For reports initiated from charts or dashboards, always use
+        the current user's email as the recipient, ignoring any
+        client-provided recipient values. Raises validation error if
+        user has no email address.
+        """
+        creation_method = self._properties.get("creation_method")
+        
+        # For reports from charts/dashboards, always use current user
+        if creation_method in (ReportCreationMethod.CHARTS, ReportCreationMethod.DASHBOARDS):
+            if hasattr(g, "user") and g.user and g.user.email:
+                # Override any provided recipients with current user's email
+                self._properties["recipients"] = [
+                    {
+                        "type": ReportRecipientType.EMAIL,
+                        "recipient_config_json": json.dumps({"target": g.user.email}),
+                    }
+                ]
+            else:
+                # User doesn't have an email address - can't create report
+                exceptions.append(ReportScheduleUserEmailNotFoundError())
+        # For creation from alerts_reports view, keep the recipients as provided
 
     def validate(self) -> None:
         """
@@ -74,6 +103,9 @@ class CreateReportScheduleCommand(CreateMixin, BaseReportScheduleCommand):
         owner_ids: Optional[list[int]] = self._properties.get("owners")
 
         exceptions: list[ValidationError] = []
+        
+        # Populate recipients if needed (may add validation errors)
+        self._populate_recipients(exceptions)
 
         # Validate name type uniqueness
         if not ReportScheduleDAO.validate_update_uniqueness(name, report_type):

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -309,3 +309,16 @@ class ReportScheduleForbiddenError(ForbiddenError):
 
 class ReportSchedulePruneLogError(CommandException):
     message = _("An error occurred while pruning logs ")
+
+
+class ReportScheduleUserEmailNotFoundError(ValidationError):
+    """
+    Validation error when user email is required but not found
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            _("Unable to create report: User email address is required but not found. "
+              "Please ensure your user profile has a valid email address."),
+            field_name="recipients",
+        )

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -318,7 +318,9 @@ class ReportScheduleUserEmailNotFoundError(ValidationError):
 
     def __init__(self) -> None:
         super().__init__(
-            _("Unable to create report: User email address is required but not found. "
-              "Please ensure your user profile has a valid email address."),
+            _(
+                "Unable to create report: User email address is required but not found. "
+                "Please ensure your user profile has a valid email address."
+            ),
             field_name="recipients",
         )

--- a/superset/commands/report/exceptions.py
+++ b/superset/commands/report/exceptions.py
@@ -319,8 +319,8 @@ class ReportScheduleUserEmailNotFoundError(ValidationError):
     def __init__(self) -> None:
         super().__init__(
             _(
-                "Unable to create report: User email address is required but not found. "
-                "Please ensure your user profile has a valid email address."
+                "Unable to create report: User email address is required but not "
+                "found. Please ensure your user profile has a valid email address."
             ),
             field_name="recipients",
         )

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -224,7 +224,7 @@ class ReportSchedulePostSchema(Schema):
         validate=[Range(min=1, error=_("Value must be greater than 0"))],
     )
 
-    recipients = fields.List(fields.Nested(ReportRecipientSchema))
+    recipients = fields.List(fields.Nested(ReportRecipientSchema), required=False)
     report_format = fields.String(
         dump_default=ReportDataFormat.PNG,
         validate=validate.OneOf(choices=tuple(key.value for key in ReportDataFormat)),

--- a/tests/unit_tests/commands/report/test_create_recipients.py
+++ b/tests/unit_tests/commands/report/test_create_recipients.py
@@ -45,7 +45,7 @@ def test_populate_recipients_chart_creation_with_user_email() -> None:
             ],
         }
 
-        exceptions = []
+        exceptions: list[Exception] = []
         command._populate_recipients(exceptions)
 
         # Check that recipients were overridden
@@ -73,7 +73,7 @@ def test_populate_recipients_dashboard_creation_with_user_email() -> None:
             # No recipients provided initially
         }
 
-        exceptions = []
+        exceptions: list[Exception] = []
         command._populate_recipients(exceptions)
 
         # Check that recipients were set
@@ -104,7 +104,7 @@ def test_populate_recipients_alerts_reports_keeps_original() -> None:
         "recipients": original_recipients,
     }
 
-    exceptions = []
+    exceptions: list[Exception] = []
     command._populate_recipients(exceptions)
 
     # Check that recipients were NOT changed
@@ -125,7 +125,7 @@ def test_populate_recipients_chart_creation_no_user_email() -> None:
             "creation_method": ReportCreationMethod.CHARTS,
         }
 
-        exceptions = []
+        exceptions: list[Exception] = []
         command._populate_recipients(exceptions)
 
         # Check that validation error was added
@@ -149,7 +149,7 @@ def test_populate_recipients_dashboard_creation_no_user() -> None:
             "creation_method": ReportCreationMethod.DASHBOARDS,
         }
 
-        exceptions = []
+        exceptions: list[Exception] = []
         command._populate_recipients(exceptions)
 
         # Check that validation error was added
@@ -171,7 +171,7 @@ def test_populate_recipients_no_creation_method() -> None:
         "recipients": original_recipients,
     }
 
-    exceptions = []
+    exceptions: list[Exception] = []
     command._populate_recipients(exceptions)
 
     # Check that recipients were NOT changed

--- a/tests/unit_tests/commands/report/test_create_recipients.py
+++ b/tests/unit_tests/commands/report/test_create_recipients.py
@@ -1,0 +1,179 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, patch
+
+from superset.commands.report.create import CreateReportScheduleCommand
+from superset.commands.report.exceptions import ReportScheduleUserEmailNotFoundError
+from superset.reports.models import (
+    ReportCreationMethod,
+    ReportRecipientType,
+)
+
+
+def test_populate_recipients_chart_creation_with_user_email() -> None:
+    """Test that chart/dashboard creation methods use current user's email."""
+    with patch("superset.commands.report.create.g") as mock_g:
+        # Setup user with email
+        mock_user = MagicMock()
+        mock_user.email = "user@example.com"
+        mock_g.user = mock_user
+
+        # Create command instance
+        command = CreateReportScheduleCommand({})
+        command._properties = {
+            "creation_method": ReportCreationMethod.CHARTS,
+            "recipients": [
+                {
+                    "type": ReportRecipientType.EMAIL,
+                    "recipient_config_json": {"target": "ignored@example.com"},
+                }
+            ],
+        }
+
+        exceptions = []
+        command._populate_recipients(exceptions)
+
+        # Check that recipients were overridden
+        assert len(command._properties["recipients"]) == 1
+        assert command._properties["recipients"][0]["type"] == ReportRecipientType.EMAIL
+        assert (
+            command._properties["recipients"][0]["recipient_config_json"]["target"]
+            == "user@example.com"
+        )
+        assert len(exceptions) == 0
+
+
+def test_populate_recipients_dashboard_creation_with_user_email() -> None:
+    """Test that dashboard creation uses current user's email."""
+    with patch("superset.commands.report.create.g") as mock_g:
+        # Setup user with email
+        mock_user = MagicMock()
+        mock_user.email = "dashboard_user@example.com"
+        mock_g.user = mock_user
+
+        # Create command instance
+        command = CreateReportScheduleCommand({})
+        command._properties = {
+            "creation_method": ReportCreationMethod.DASHBOARDS,
+            # No recipients provided initially
+        }
+
+        exceptions = []
+        command._populate_recipients(exceptions)
+
+        # Check that recipients were set
+        assert len(command._properties["recipients"]) == 1
+        assert command._properties["recipients"][0]["type"] == ReportRecipientType.EMAIL
+        assert (
+            command._properties["recipients"][0]["recipient_config_json"]["target"]
+            == "dashboard_user@example.com"
+        )
+        assert len(exceptions) == 0
+
+
+def test_populate_recipients_alerts_reports_keeps_original() -> None:
+    """Test that alerts_reports creation method preserves provided recipients."""
+    command = CreateReportScheduleCommand({})
+    original_recipients = [
+        {
+            "type": ReportRecipientType.EMAIL,
+            "recipient_config_json": {"target": "admin@example.com"},
+        },
+        {
+            "type": ReportRecipientType.SLACK,
+            "recipient_config_json": {"target": "#alerts"},
+        },
+    ]
+    command._properties = {
+        "creation_method": ReportCreationMethod.ALERTS_REPORTS,
+        "recipients": original_recipients,
+    }
+
+    exceptions = []
+    command._populate_recipients(exceptions)
+
+    # Check that recipients were NOT changed
+    assert command._properties["recipients"] == original_recipients
+    assert len(exceptions) == 0
+
+
+def test_populate_recipients_chart_creation_no_user_email() -> None:
+    """Test that chart creation fails when user has no email."""
+    with patch("superset.commands.report.create.g") as mock_g:
+        # Setup user without email
+        mock_user = MagicMock()
+        mock_user.email = None
+        mock_g.user = mock_user
+
+        command = CreateReportScheduleCommand({})
+        command._properties = {
+            "creation_method": ReportCreationMethod.CHARTS,
+        }
+
+        exceptions = []
+        command._populate_recipients(exceptions)
+
+        # Check that validation error was added
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0], ReportScheduleUserEmailNotFoundError)
+        # Recipients should not be set
+        assert (
+            "recipients" not in command._properties
+            or command._properties["recipients"] == []
+        )
+
+
+def test_populate_recipients_dashboard_creation_no_user() -> None:
+    """Test that dashboard creation fails when there's no user."""
+    with patch("superset.commands.report.create.g") as mock_g:
+        # No user in context
+        mock_g.user = None
+
+        command = CreateReportScheduleCommand({})
+        command._properties = {
+            "creation_method": ReportCreationMethod.DASHBOARDS,
+        }
+
+        exceptions = []
+        command._populate_recipients(exceptions)
+
+        # Check that validation error was added
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0], ReportScheduleUserEmailNotFoundError)
+
+
+def test_populate_recipients_no_creation_method() -> None:
+    """Test that recipients are unchanged when no creation_method is specified."""
+    command = CreateReportScheduleCommand({})
+    original_recipients = [
+        {
+            "type": ReportRecipientType.EMAIL,
+            "recipient_config_json": {"target": "user@example.com"},
+        }
+    ]
+    command._properties = {
+        # No creation_method specified
+        "recipients": original_recipients,
+    }
+
+    exceptions = []
+    command._populate_recipients(exceptions)
+
+    # Check that recipients were NOT changed
+    assert command._properties["recipients"] == original_recipients
+    assert len(exceptions) == 0


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When users create email reports from a chart or dashboard UI, they now automatically become the recipient without needing to manually enter their email address. This improves UX and prevents a common mistake where users forget to add themselves as recipients.

  The change only affects reports created via the chart/dashboard UI buttons (`creation_method` = CHARTS/DASHBOARDS). Reports created from the Alerts & Reports management page
  (`creation_method` = ALERTS_REPORTS) continue to work as before, allowing admins to specify custom recipients.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After this pr, reports work without recipient and default to current user's email when initiated from dashboards/charts

<img width="1407" height="983" alt="image" src="https://github.com/user-attachments/assets/fff37b02-b89d-4fee-a2be-018efe011af2" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Ensure `ALERT_REPORTS` feature flag is enabled in your config
2. Set up email configuration (e.g., use MailHog locally)
3. Navigate to any chart or dashboard
4. Click the email/report icon to create a new report
5. Configure the schedule and save
6. Verify that the report is sent to your email address (check MailHog)
7. Navigate to Settings → Alerts & Reports
8. Create a new report and specify custom recipients
9. Verify custom recipients are preserved (not overridden)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
