### PR TITLE
perf(date_parser): bound regex quantifiers for deterministic parsing performance

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -418,9 +418,9 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
     if time_range and separator in time_range:
         time_range_lookup = [
             (
-                r"^(start of|beginning of|end of)\s+"
-                r"(this|last|next|prior)\s+"
-                r"([0-9]+)?\s*"
+                r"^(start of|beginning of|end of)\s{1,5}"
+                r"(this|last|next|prior)\s{1,5}"
+                r"([0-9]+)?\s{0,5}"
                 r"(day|week|month|quarter|year)s?$",  # Matches phrases like "start of next month" # noqa: E501
                 lambda modifier, scope, delta, unit: handle_modifier_and_unit(
                     modifier,
@@ -431,8 +431,8 @@ def get_since_until(  # pylint: disable=too-many-arguments,too-many-locals,too-m
                 ),
             ),
             (
-                r"^(this|last|next|prior)\s+"
-                r"([0-9]+)?\s*"
+                r"^(this|last|next|prior)\s{1,5}"
+                r"([0-9]+)?\s{0,5}"
                 r"(second|minute|day|week|month|quarter|year)s?$",  # Matches "next 5 days" or "last 2 weeks" # noqa: E501
                 lambda scope, delta, unit: handle_scope_and_unit(
                     scope, delta, unit, get_relative_base(unit, relative_start)

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -611,3 +611,48 @@ def test_date_range_migration() -> None:
 
     field = "10 years ago"
     assert not re.search(DateRangeMigration.x_dateunit, field)
+
+
+# Tests for bounded whitespace regex patterns in time_range_lookup
+@pytest.mark.parametrize(
+    "time_range,should_parse",
+    [
+        ("last 7 days : ", True),
+        ("this week : ", True),
+        ("start of next month : ", True),
+        ("prior quarter : ", True),
+        ("last  7 days : ", True),
+        ("last   7 days : ", True),
+        ("last    7 days : ", True),
+        ("last     7 days : ", True),
+        ("last      7 days : ", False),  # 6 spaces - exceeds bound
+        ("start of     next     month : ", True),  # 5 spaces - valid
+        ("last week : ", True),
+        ("last  week : ", True),
+        ("last     week : ", True),
+        ("next 12 months : ", True),
+        ("next  12  months : ", True),
+        ("next     12     months : ", True),
+        ("last7days : ", False),  # no space after scope - invalid
+        ("last 7days : ", True),  # \s{0,5} allows 0 spaces after number - valid
+        ("lastweek : ", False),  # no space after scope - invalid
+        ("last" + " " * 100 + "7 days : ", False),
+        # === Negative Tests: Partial matches ===
+        ("last : ", False),
+        ("start of : ", False),
+        ("last 7 days extra : ", False),
+    ],
+)
+@patch("superset.utils.date_parser.parse_human_datetime", mock_parse_human_datetime)
+def test_time_range_bounded_whitespace_regex(
+    time_range: str, should_parse: bool
+) -> None:
+    """
+    1. Match expressions with 1-5 spaces between tokens
+    2. Reject expressions with 0 or 6+ spaces (fall back to DATETIME wrapping)
+    """
+    result = get_since_until(time_range)
+    if should_parse:
+        assert result[0] is not None, f"Expected '{time_range}' to parse successfully"
+    else:
+        assert result[0] is None, f"Expected '{time_range}' to NOT match bounded regex"

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -615,43 +615,46 @@ def test_date_range_migration() -> None:
 
 # Tests for bounded whitespace regex patterns in time_range_lookup
 @pytest.mark.parametrize(
-    "time_range,should_parse",
+    "time_range",
     [
-        ("last 7 days : ", True),
-        ("this week : ", True),
-        ("start of next month : ", True),
-        ("prior quarter : ", True),
-        ("last  7 days : ", True),
-        ("last   7 days : ", True),
-        ("last    7 days : ", True),
-        ("last     7 days : ", True),
-        ("last      7 days : ", False),  # 6 spaces - exceeds bound
-        ("start of     next     month : ", True),  # 5 spaces - valid
-        ("last week : ", True),
-        ("last  week : ", True),
-        ("last     week : ", True),
-        ("next 12 months : ", True),
-        ("next  12  months : ", True),
-        ("next     12     months : ", True),
-        ("last7days : ", False),  # no space after scope - invalid
-        ("last 7days : ", True),  # \s{0,5} allows 0 spaces after number - valid
-        ("lastweek : ", False),  # no space after scope - invalid
-        # === Negative Tests: Partial matches ===
-        ("last : ", False),
-        ("start of : ", False),
-        ("last 7 days extra : ", False),
+        "last 7 days : ",
+        "this week : ",
+        "start of next month : ",
+        "prior quarter : ",
+        "last  7 days : ",
+        "last   7 days : ",
+        "last    7 days : ",
+        "last     7 days : ",
+        "start of     next     month : ",  # 5 spaces - valid
+        "last week : ",
+        "last  week : ",
+        "last     week : ",
+        "next 12 months : ",
+        "next  12  months : ",
+        "next     12     months : ",
+        "last 7days : ",  # \s{0,5} allows 0 spaces after number - valid
     ],
 )
 @patch("superset.utils.date_parser.parse_human_datetime", mock_parse_human_datetime)
-def test_time_range_bounded_whitespace_regex(
-    time_range: str, should_parse: bool
-) -> None:
-    """
-    1. Match expressions with 1-5 spaces between tokens
-    2. Reject expressions with 0 or 6+ spaces (fall back to DATETIME wrapping)
-    """
+def test_time_range_bounded_whitespace_regex_valid(time_range: str) -> None:
+    """Match expressions with 1-5 spaces between tokens."""
     result = get_since_until(time_range)
-    if should_parse:
-        assert result[0] is not None, f"Expected '{time_range}' to parse successfully"
-    else:
-        assert result[0] is None, f"Expected '{time_range}' to NOT match bounded regex"
+    assert result[0] is not None, f"Expected '{time_range}' to parse successfully"
+
+
+@pytest.mark.parametrize(
+    "time_range",
+    [
+        "last      7 days : ",
+        "last7days : ",
+        "lastweek : ",
+        "last : ",
+        "start of : ",
+        "last 7 days extra : ",
+    ],
+)
+@patch("superset.utils.date_parser.parse_human_datetime", mock_parse_human_datetime)
+def test_time_range_bounded_whitespace_regex_invalid(time_range: str) -> None:
+    """Reject expressions with 0 or 6+ spaces (fall back to DATETIME wrapping)."""
+    result = get_since_until(time_range)
+    assert result[0] is None, f"Expected '{time_range}' to NOT match bounded regex"

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -636,7 +636,6 @@ def test_date_range_migration() -> None:
         ("last7days : ", False),  # no space after scope - invalid
         ("last 7days : ", True),  # \s{0,5} allows 0 spaces after number - valid
         ("lastweek : ", False),  # no space after scope - invalid
-        ("last" + " " * 100 + "7 days : ", False),
         # === Negative Tests: Partial matches ===
         ("last : ", False),
         ("start of : ", False),


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Harden date range parsing in get_since_until by bounding whitespace quantifiers in time_range_lookup regex patterns to prevent potential ReDoS (Regular Expression Denial of Service) attacks.

**Changes:**
- Replace unbounded `\s+` with `\s{1,5}` (1-5 whitespace characters)
- Replace unbounded `\s*` with `\s{0,5}` (0-5 whitespace characters)

This ensures the regex engine fails quickly on malformed inputs with excessive whitespace, rather than potentially hanging while trying many backtracking combinations. All existing valid date expressions continue to work as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend regex change with no UI impact.

### TESTING INSTRUCTIONS
1. Run the unit tests:
`   pytest tests/unit_tests/utils/date_parser_tests.py -v
`
2. Verify all tests pass, including the new `test_time_range_bounded_whitespace_regex` parametrized test.
3. Test in UI: Go to Chart Explorer → Time Range → Advanced → Enter expressions like last 7 days, start of next month.

OBS: Should work as before. This was a performance and security improvement.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
