### PR TITLE
fix(datasets): respect application root in database management link

### DIFF
--- a/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/LeftPanel/index.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/features/datasets/AddDataset/types';
 import { Table } from 'src/hooks/apiResources';
 import { Typography } from '@superset-ui/core/components/Typography';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 
 interface LeftPanelProps {
   setDataset: Dispatch<SetStateAction<object>>;
@@ -191,7 +192,7 @@ export default function LeftPanel({
       description={
         <span>
           {t('Manage your databases')}{' '}
-          <Typography.Link href="/databaseview/list">
+          <Typography.Link href={ensureAppRoot('/databaseview/list')}>
             {t('here')}
           </Typography.Link>
         </span>


### PR DESCRIPTION
### SUMMARY
The 'Manage your databases here' link in the AddDataset LeftPanel was hardcoded as `/databaseview/list`, which didn't respect the configured HTTP prefix in subdirectory deployments (e.g., when
APPLICATION_ROOT` is set to a path like `/superset`).

This fix uses `ensureAppRoot()` to properly prefix the URL with the application root, ensuring the link works correctly in all deployment configurations.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Link behavior fix only

### TESTING INSTRUCTIONS
1. Configure Superset with a subdirectory deployment by setting `APPLICATION_ROOT = "/superset"` in your config
2. Navigate to the Datasets page and click "Add Dataset"
3. In the LeftPanel, click the "Manage your databases here" link
4. Verify the link navigates to `/superset/databaseview/list` instead of just `/databaseview/list`
5. Verify the link works correctly in default deployments (without `APPLICATION_ROOT` configured)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
