### PR TITLE
fix(chart): Horizontal bar chart value labels cut off

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -56,6 +56,7 @@ import type { SeriesOption } from 'echarts';
 import {
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
+  EchartsTimeseriesSeriesType,
   OrientationType,
   TimeseriesChartTransformedProps,
 } from './types';
@@ -498,6 +499,39 @@ export default function transformProps(
     yAxisMin = calculateLowerLogTick(minPositiveValue);
   }
 
+  // For horizontal bar charts, calculate max from data to avoid cutting off labels
+  if (
+    isHorizontal &&
+    seriesType === EchartsTimeseriesSeriesType.Bar &&
+    truncateYAxis
+  ) {
+    let dataMax: number | undefined;
+    let dataMin: number | undefined;
+    rawSeries.forEach(s => {
+      if (s.data && Array.isArray(s.data)) {
+        (s.data as [number, any][]).forEach((datum: [number, any]) => {
+          const value = datum[0];
+          if (typeof value === 'number' && !Number.isNaN(value)) {
+            if (dataMax === undefined || value > dataMax) {
+              dataMax = value;
+            }
+            if (dataMin === undefined || value < dataMin) {
+              dataMin = value;
+            }
+          }
+        });
+      }
+    });
+    // Set max to actual data max to avoid gaps and ensure labels are visible
+    if (dataMax !== undefined && yAxisMax === undefined) {
+      yAxisMax = dataMax;
+    }
+    // Set min to actual data min for diverging bars
+    if (dataMin !== undefined && yAxisMin === undefined && dataMin < 0) {
+      yAxisMin = dataMin;
+    }
+  }
+
   const tooltipFormatter =
     xAxisDataType === GenericDataType.Temporal
       ? getTooltipTimeFormatter(tooltipTimeFormat)
@@ -603,6 +637,13 @@ export default function transformProps(
   if (isHorizontal) {
     [xAxis, yAxis] = [yAxis, xAxis];
     [padding.bottom, padding.left] = [padding.left, padding.bottom];
+    // Increase right padding for horizontal bar charts to ensure value labels are visible
+    if (seriesType === EchartsTimeseriesSeriesType.Bar && showValue) {
+      padding.right = Math.max(
+        padding.right || 0,
+        TIMESERIES_CONSTANTS.horizontalBarLabelRightPadding,
+      );
+    }
   }
 
   const echartOptions: EChartsCoreOption = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -46,7 +46,7 @@ export const TIMESERIES_CONSTANTS = {
   dataZoomEnd: 100,
   yAxisLabelTopOffset: 20,
   extraControlsOffset: 22,
-  // Minimum right padding for horizontal bar charts to ensure value labels are fully visible
+  // Min right padding (px) for horizontal bar charts to ensure value labels are fully visible
   horizontalBarLabelRightPadding: 70,
 };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/constants.ts
@@ -46,6 +46,8 @@ export const TIMESERIES_CONSTANTS = {
   dataZoomEnd: 100,
   yAxisLabelTopOffset: 20,
   extraControlsOffset: 22,
+  // Minimum right padding for horizontal bar charts to ensure value labels are fully visible
+  horizontalBarLabelRightPadding: 70,
 };
 
 export const LABEL_POSITION: [LabelPositionEnum, string][] = [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/helpers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Base timestamp used for test data generation.
+ * This provides a consistent starting point for all test timestamps.
+ */
+export const BASE_TIMESTAMP = 599616000000;
+
+/**
+ * Default interval between timestamps (300000000 ms ≈ 3.47 days).
+ * This matches the common pattern used in tests.
+ */
+export const DEFAULT_TIMESTAMP_INTERVAL = 300000000;
+
+/**
+ * Creates a timestamp with an offset from the base timestamp.
+ *
+ * @param offset - Offset in milliseconds from BASE_TIMESTAMP
+ * @returns Timestamp value
+ */
+export function createTimestamp(offset: number = 0): number {
+  return BASE_TIMESTAMP + offset;
+}
+
+/**
+ * Creates an array of timestamps starting from the base timestamp.
+ *
+ * @param count - Number of timestamps to generate
+ * @param intervalMs - Interval between timestamps in milliseconds (default: DEFAULT_TIMESTAMP_INTERVAL)
+ * @returns Array of timestamp values
+ */
+export function createTimestamps(
+  count: number,
+  intervalMs: number = DEFAULT_TIMESTAMP_INTERVAL,
+): number[] {
+  return Array.from({ length: count }, (_, index) =>
+    createTimestamp(index * intervalMs),
+  );
+}
+
+/**
+ * Creates a single test data row with a timestamp.
+ *
+ * @param values - Object containing series values (excluding __timestamp)
+ * @param timestamp - Timestamp value to include
+ * @returns Test data row with __timestamp property
+ */
+export function createTestDataRow(
+  values: Record<string, number>,
+  timestamp: number,
+): Record<string, number> & { __timestamp: number } {
+  return {
+    ...values,
+    __timestamp: timestamp,
+  };
+}
+
+/**
+ * Options for creating test data.
+ */
+export interface CreateTestDataOptions {
+  /** Base timestamp to start from (default: BASE_TIMESTAMP) */
+  baseTimestamp?: number;
+  /** Interval between timestamps in milliseconds (default: DEFAULT_TIMESTAMP_INTERVAL) */
+  intervalMs?: number;
+}
+
+/**
+ * Creates an array of test data rows with auto-generated timestamps.
+ *
+ * @param rows - Array of objects containing series values (without __timestamp)
+ * @param options - Options for timestamp generation
+ * @returns Array of test data rows with __timestamp properties
+ *
+ * @example
+ * ```typescript
+ * const data = createTestData(
+ *   [
+ *     { 'Series A': 15000 },
+ *     { 'Series A': 20000 },
+ *     { 'Series A': 18000 },
+ *   ],
+ *   { intervalMs: 300000000 }
+ * );
+ * // Returns:
+ * // [
+ * //   { 'Series A': 15000, __timestamp: 599616000000 },
+ * //   { 'Series A': 20000, __timestamp: 599916000000 },
+ * //   { 'Series A': 18000, __timestamp: 600216000000 },
+ * // ]
+ * ```
+ */
+export function createTestData(
+  rows: Array<Record<string, number>>,
+  options: CreateTestDataOptions = {},
+): Array<Record<string, number> & { __timestamp: number }> {
+  const {
+    baseTimestamp = BASE_TIMESTAMP,
+    intervalMs = DEFAULT_TIMESTAMP_INTERVAL,
+  } = options;
+
+  return rows.map((row, index) =>
+    createTestDataRow(row, baseTimestamp + index * intervalMs),
+  );
+}

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -898,8 +898,8 @@ describe('Horizontal bar chart axis bounds', () => {
     );
 
     // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    expect(xAxis.max).toBe(20000); // Should be the actual max value, not rounded
+    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+    expect(xAxisRaw.max).toBe(20000); // Should be the actual max value, not rounded
   });
 
   it('should set yAxis min and max for diverging horizontal bar charts', () => {
@@ -926,9 +926,9 @@ describe('Horizontal bar chart axis bounds', () => {
     );
 
     // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    expect(xAxis.max).toBe(20000); // Should be the actual max value
-    expect(xAxis.min).toBe(-21000); // Should be the actual min value for diverging bars
+    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+    expect(xAxisRaw.max).toBe(20000); // Should be the actual max value
+    expect(xAxisRaw.min).toBe(-21000); // Should be the actual min value for diverging bars
   });
 
   it('should not override explicit yAxisBounds', () => {
@@ -958,9 +958,9 @@ describe('Horizontal bar chart axis bounds', () => {
     );
 
     // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    expect(xAxis.max).toBe(25000); // Should respect explicit bound
-    expect(xAxis.min).toBe(0); // Should respect explicit bound
+    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+    expect(xAxisRaw.max).toBe(25000); // Should respect explicit bound
+    expect(xAxisRaw.min).toBe(0); // Should respect explicit bound
   });
 
   it('should not apply when truncateYAxis is false', () => {
@@ -1022,8 +1022,8 @@ describe('Horizontal bar chart axis bounds', () => {
     );
 
     // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxis = transformedProps.echartOptions.xAxis as any;
+    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
     // Should not have explicit max set when seriesType is not Bar
-    expect(xAxis.max).toBeUndefined();
+    expect(xAxisRaw.max).toBeUndefined();
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -34,6 +34,7 @@ import {
   EchartsTimeseriesSeriesType,
   OrientationType,
 } from '../../src/Timeseries/types';
+import { BASE_TIMESTAMP, createTestData } from './helpers';
 
 type YAxisFormatter = (value: number, index: number) => string;
 
@@ -59,10 +60,13 @@ const formData: SqlaFormData = {
 };
 const queriesData = [
   {
-    data: [
-      { 'San Francisco': 1, 'New York': 2, __timestamp: 599616000000 },
-      { 'San Francisco': 3, 'New York': 4, __timestamp: 599916000000 },
-    ],
+    data: createTestData(
+      [
+        { 'San Francisco': 1, 'New York': 2 },
+        { 'San Francisco': 3, 'New York': 4 },
+      ],
+      { intervalMs: 300000000 },
+    ),
   },
 ];
 const chartPropsConfig = {
@@ -87,15 +91,15 @@ describe('EchartsTimeseries transformProps', () => {
           series: expect.arrayContaining([
             expect.objectContaining({
               data: [
-                [599616000000, 1],
-                [599916000000, 3],
+                [BASE_TIMESTAMP, 1],
+                [BASE_TIMESTAMP + 300000000, 3],
               ],
               name: 'San Francisco',
             }),
             expect.objectContaining({
               data: [
-                [599616000000, 2],
-                [599916000000, 4],
+                [BASE_TIMESTAMP, 2],
+                [BASE_TIMESTAMP + 300000000, 4],
               ],
               name: 'New York',
             }),
@@ -124,15 +128,15 @@ describe('EchartsTimeseries transformProps', () => {
           series: expect.arrayContaining([
             expect.objectContaining({
               data: [
-                [1, 599616000000],
-                [3, 599916000000],
+                [1, BASE_TIMESTAMP],
+                [3, BASE_TIMESTAMP + 300000000],
               ],
               name: 'San Francisco',
             }),
             expect.objectContaining({
               data: [
-                [2, 599616000000],
-                [4, 599916000000],
+                [2, BASE_TIMESTAMP],
+                [4, BASE_TIMESTAMP + 300000000],
               ],
               name: 'New York',
             }),
@@ -169,22 +173,22 @@ describe('EchartsTimeseries transformProps', () => {
           series: expect.arrayContaining([
             expect.objectContaining({
               data: [
-                [599616000000, 1],
-                [599916000000, 3],
+                [BASE_TIMESTAMP, 1],
+                [BASE_TIMESTAMP + 300000000, 3],
               ],
               name: 'San Francisco',
             }),
             expect.objectContaining({
               data: [
-                [599616000000, 2],
-                [599916000000, 4],
+                [BASE_TIMESTAMP, 2],
+                [BASE_TIMESTAMP + 300000000, 4],
               ],
               name: 'New York',
             }),
             expect.objectContaining({
               data: [
-                [599616000000, 599616000001],
-                [599916000000, 599916000001],
+                [BASE_TIMESTAMP, BASE_TIMESTAMP + 1],
+                [BASE_TIMESTAMP + 300000000, BASE_TIMESTAMP + 300000000 + 1],
               ],
               name: 'My Formula',
             }),
@@ -307,64 +311,60 @@ describe('EchartsTimeseries transformProps', () => {
   it('Should add a baseline series for stream graph', () => {
     const streamQueriesData = [
       {
-        data: [
-          {
-            'San Francisco': 120,
-            'New York': 220,
-            Boston: 150,
-            Miami: 270,
-            Denver: 800,
-            __timestamp: 599616000000,
-          },
-          {
-            'San Francisco': 150,
-            'New York': 190,
-            Boston: 240,
-            Miami: 350,
-            Denver: 700,
-            __timestamp: 599616000001,
-          },
-          {
-            'San Francisco': 130,
-            'New York': 300,
-            Boston: 250,
-            Miami: 410,
-            Denver: 650,
-            __timestamp: 599616000002,
-          },
-          {
-            'San Francisco': 90,
-            'New York': 340,
-            Boston: 300,
-            Miami: 480,
-            Denver: 590,
-            __timestamp: 599616000003,
-          },
-          {
-            'San Francisco': 260,
-            'New York': 200,
-            Boston: 420,
-            Miami: 490,
-            Denver: 760,
-            __timestamp: 599616000004,
-          },
-          {
-            'San Francisco': 250,
-            'New York': 250,
-            Boston: 380,
-            Miami: 360,
-            Denver: 400,
-            __timestamp: 599616000005,
-          },
-          {
-            'San Francisco': 160,
-            'New York': 210,
-            Boston: 330,
-            Miami: 440,
-            Denver: 580,
-            __timestamp: 599616000006,
-          },
-        ],
+        data: createTestData(
+          [
+            {
+              'San Francisco': 120,
+              'New York': 220,
+              Boston: 150,
+              Miami: 270,
+              Denver: 800,
+            },
+            {
+              'San Francisco': 150,
+              'New York': 190,
+              Boston: 240,
+              Miami: 350,
+              Denver: 700,
+            },
+            {
+              'San Francisco': 130,
+              'New York': 300,
+              Boston: 250,
+              Miami: 410,
+              Denver: 650,
+            },
+            {
+              'San Francisco': 90,
+              'New York': 340,
+              Boston: 300,
+              Miami: 480,
+              Denver: 590,
+            },
+            {
+              'San Francisco': 260,
+              'New York': 200,
+              Boston: 420,
+              Miami: 490,
+              Denver: 760,
+            },
+            {
+              'San Francisco': 250,
+              'New York': 250,
+              Boston: 380,
+              Miami: 360,
+              Denver: 400,
+            },
+            {
+              'San Francisco': 160,
+              'New York': 210,
+              Boston: 330,
+              Miami: 440,
+              Denver: 580,
+            },
+          ],
+          { intervalMs: 1 },
+        ),
       },
     ];
     const streamFormData = { ...formData, stack: 'Stream' };
@@ -399,13 +399,13 @@ describe('EchartsTimeseries transformProps', () => {
       },
       type: 'line',
       data: [
-        [599616000000, -415.7692307692308],
-        [599616000001, -403.6219915054271],
-        [599616000002, -476.32314093071443],
-        [599616000003, -514.2120298196033],
-        [599616000004, -485.7378514158475],
-        [599616000005, -419.6402904402378],
-        [599616000006, -442.9833136960517],
+        [BASE_TIMESTAMP, -415.7692307692308],
+        [BASE_TIMESTAMP + 1, -403.6219915054271],
+        [BASE_TIMESTAMP + 2, -476.32314093071443],
+        [BASE_TIMESTAMP + 3, -514.2120298196033],
+        [BASE_TIMESTAMP + 4, -485.7378514158475],
+        [BASE_TIMESTAMP + 5, -419.6402904402378],
+        [BASE_TIMESTAMP + 6, -442.9833136960517],
       ],
     });
   });
@@ -438,32 +438,31 @@ describe('Does transformProps transform series correctly', () => {
   };
   const queriesData = [
     {
-      data: [
-        {
-          'San Francisco': 1,
-          'New York': 2,
-          Boston: 1,
-          __timestamp: 599616000000,
-        },
-        {
-          'San Francisco': 3,
-          'New York': 4,
-          Boston: 1,
-          __timestamp: 599916000000,
-        },
-        {
-          'San Francisco': 5,
-          'New York': 8,
-          Boston: 6,
-          __timestamp: 600216000000,
-        },
-        {
-          'San Francisco': 2,
-          'New York': 7,
-          Boston: 2,
-          __timestamp: 600516000000,
-        },
-      ],
+      data: createTestData(
+        [
+          {
+            'San Francisco': 1,
+            'New York': 2,
+            Boston: 1,
+          },
+          {
+            'San Francisco': 3,
+            'New York': 4,
+            Boston: 1,
+          },
+          {
+            'San Francisco': 5,
+            'New York': 8,
+            Boston: 6,
+          },
+          {
+            'San Francisco': 2,
+            'New York': 7,
+            Boston: 2,
+          },
+        ],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
   const chartPropsConfig = {
@@ -647,36 +646,35 @@ describe('Does transformProps transform series correctly', () => {
 describe('legend sorting', () => {
   const legendSortData = [
     {
-      data: [
-        {
-          Milton: 40,
-          'San Francisco': 1,
-          'New York': 2,
-          Boston: 1,
-          __timestamp: 599616000000,
-        },
-        {
-          Milton: 20,
-          'San Francisco': 3,
-          'New York': 4,
-          Boston: 1,
-          __timestamp: 599916000000,
-        },
-        {
-          Milton: 60,
-          'San Francisco': 5,
-          'New York': 8,
-          Boston: 6,
-          __timestamp: 600216000000,
-        },
-        {
-          Milton: 10,
-          'San Francisco': 2,
-          'New York': 7,
-          Boston: 2,
-          __timestamp: 600516000000,
-        },
-      ],
+      data: createTestData(
+        [
+          {
+            Milton: 40,
+            'San Francisco': 1,
+            'New York': 2,
+            Boston: 1,
+          },
+          {
+            Milton: 20,
+            'San Francisco': 3,
+            'New York': 4,
+            Boston: 1,
+          },
+          {
+            Milton: 60,
+            'San Francisco': 5,
+            'New York': 8,
+            Boston: 6,
+          },
+          {
+            Milton: 10,
+            'San Francisco': 2,
+            'New York': 7,
+            Boston: 2,
+          },
+        ],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 
@@ -876,11 +874,10 @@ const baseFormDataHorizontalBar: SqlaFormData = {
 test('should set yAxis max to actual data max for horizontal bar charts', () => {
   const queriesData = [
     {
-      data: [
-        { 'Series A': 15000, __timestamp: 599616000000 },
-        { 'Series A': 20000, __timestamp: 599916000000 },
-        { 'Series A': 18000, __timestamp: 600216000000 },
-      ],
+      data: createTestData(
+        [{ 'Series A': 15000 }, { 'Series A': 20000 }, { 'Series A': 18000 }],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 
@@ -904,11 +901,10 @@ test('should set yAxis max to actual data max for horizontal bar charts', () => 
 test('should set yAxis min and max for diverging horizontal bar charts', () => {
   const queriesData = [
     {
-      data: [
-        { 'Series A': -21000, __timestamp: 599616000000 },
-        { 'Series A': 20000, __timestamp: 599916000000 },
-        { 'Series A': 18000, __timestamp: 600216000000 },
-      ],
+      data: createTestData(
+        [{ 'Series A': -21000 }, { 'Series A': 20000 }, { 'Series A': 18000 }],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 
@@ -933,11 +929,10 @@ test('should set yAxis min and max for diverging horizontal bar charts', () => {
 test('should not override explicit yAxisBounds for horizontal bar charts', () => {
   const queriesData = [
     {
-      data: [
-        { 'Series A': 15000, __timestamp: 599616000000 },
-        { 'Series A': 20000, __timestamp: 599916000000 },
-        { 'Series A': 18000, __timestamp: 600216000000 },
-      ],
+      data: createTestData(
+        [{ 'Series A': 15000 }, { 'Series A': 20000 }, { 'Series A': 18000 }],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 
@@ -965,11 +960,10 @@ test('should not override explicit yAxisBounds for horizontal bar charts', () =>
 test('should not apply axis bounds calculation when truncateYAxis is false for horizontal bar charts', () => {
   const queriesData = [
     {
-      data: [
-        { 'Series A': 15000, __timestamp: 599616000000 },
-        { 'Series A': 20000, __timestamp: 599916000000 },
-        { 'Series A': 18000, __timestamp: 600216000000 },
-      ],
+      data: createTestData(
+        [{ 'Series A': 15000 }, { 'Series A': 20000 }, { 'Series A': 18000 }],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 
@@ -997,11 +991,10 @@ test('should not apply axis bounds calculation when truncateYAxis is false for h
 test('should not apply axis bounds calculation when seriesType is not Bar for horizontal charts', () => {
   const queriesData = [
     {
-      data: [
-        { 'Series A': 15000, __timestamp: 599616000000 },
-        { 'Series A': 20000, __timestamp: 599916000000 },
-        { 'Series A': 18000, __timestamp: 600216000000 },
-      ],
+      data: createTestData(
+        [{ 'Series A': 15000 }, { 'Series A': 20000 }, { 'Series A': 18000 }],
+        { intervalMs: 300000000 },
+      ),
     },
   ];
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -860,170 +860,168 @@ test('EchartsTimeseries should preserve static currency format with £ for GBP',
   expect(formatter(1000, 0)).toContain('£');
 });
 
-describe('Horizontal bar chart axis bounds', () => {
-  const baseFormData: SqlaFormData = {
-    colorScheme: 'bnbColors',
-    datasource: '3__table',
-    granularity_sqla: '__timestamp',
-    metric: 'sum__num',
-    groupby: [],
-    viz_type: 'echarts_timeseries',
-    seriesType: EchartsTimeseriesSeriesType.Bar,
-    orientation: OrientationType.Horizontal,
-    truncateYAxis: true,
-    yAxisBounds: [null, null],
-  };
+const baseFormDataHorizontalBar: SqlaFormData = {
+  colorScheme: 'bnbColors',
+  datasource: '3__table',
+  granularity_sqla: '__timestamp',
+  metric: 'sum__num',
+  groupby: [],
+  viz_type: 'echarts_timeseries',
+  seriesType: EchartsTimeseriesSeriesType.Bar,
+  orientation: OrientationType.Horizontal,
+  truncateYAxis: true,
+  yAxisBounds: [null, null],
+};
 
-  it('should set yAxis max to actual data max for horizontal bar charts', () => {
-    const queriesData = [
-      {
-        data: [
-          { 'Series A': 15000, __timestamp: 599616000000 },
-          { 'Series A': 20000, __timestamp: 599916000000 },
-          { 'Series A': 18000, __timestamp: 600216000000 },
-        ],
-      },
-    ];
+test('should set yAxis max to actual data max for horizontal bar charts', () => {
+  const queriesData = [
+    {
+      data: [
+        { 'Series A': 15000, __timestamp: 599616000000 },
+        { 'Series A': 20000, __timestamp: 599916000000 },
+        { 'Series A': 18000, __timestamp: 600216000000 },
+      ],
+    },
+  ];
 
-    const chartProps = new ChartProps({
-      formData: baseFormData,
-      width: 800,
-      height: 600,
-      queriesData,
-      theme: supersetTheme,
-    });
-
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
-
-    // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
-    expect(xAxisRaw.max).toBe(20000); // Should be the actual max value, not rounded
+  const chartProps = new ChartProps({
+    formData: baseFormDataHorizontalBar,
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
   });
 
-  it('should set yAxis min and max for diverging horizontal bar charts', () => {
-    const queriesData = [
-      {
-        data: [
-          { 'Series A': -21000, __timestamp: 599616000000 },
-          { 'Series A': 20000, __timestamp: 599916000000 },
-          { 'Series A': 18000, __timestamp: 600216000000 },
-        ],
-      },
-    ];
+  const transformedProps = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-    const chartProps = new ChartProps({
-      formData: baseFormData,
-      width: 800,
-      height: 600,
-      queriesData,
-      theme: supersetTheme,
-    });
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBe(20000); // Should be the actual max value, not rounded
+});
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+test('should set yAxis min and max for diverging horizontal bar charts', () => {
+  const queriesData = [
+    {
+      data: [
+        { 'Series A': -21000, __timestamp: 599616000000 },
+        { 'Series A': 20000, __timestamp: 599916000000 },
+        { 'Series A': 18000, __timestamp: 600216000000 },
+      ],
+    },
+  ];
 
-    // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
-    expect(xAxisRaw.max).toBe(20000); // Should be the actual max value
-    expect(xAxisRaw.min).toBe(-21000); // Should be the actual min value for diverging bars
+  const chartProps = new ChartProps({
+    formData: baseFormDataHorizontalBar,
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
   });
 
-  it('should not override explicit yAxisBounds', () => {
-    const queriesData = [
-      {
-        data: [
-          { 'Series A': 15000, __timestamp: 599616000000 },
-          { 'Series A': 20000, __timestamp: 599916000000 },
-          { 'Series A': 18000, __timestamp: 600216000000 },
-        ],
-      },
-    ];
+  const transformedProps = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-    const chartProps = new ChartProps({
-      formData: {
-        ...baseFormData,
-        yAxisBounds: [0, 25000], // Explicit bounds
-      },
-      width: 800,
-      height: 600,
-      queriesData,
-      theme: supersetTheme,
-    });
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBe(20000); // Should be the actual max value
+  expect(xAxisRaw.min).toBe(-21000); // Should be the actual min value for diverging bars
+});
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+test('should not override explicit yAxisBounds for horizontal bar charts', () => {
+  const queriesData = [
+    {
+      data: [
+        { 'Series A': 15000, __timestamp: 599616000000 },
+        { 'Series A': 20000, __timestamp: 599916000000 },
+        { 'Series A': 18000, __timestamp: 600216000000 },
+      ],
+    },
+  ];
 
-    // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
-    expect(xAxisRaw.max).toBe(25000); // Should respect explicit bound
-    expect(xAxisRaw.min).toBe(0); // Should respect explicit bound
+  const chartProps = new ChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      yAxisBounds: [0, 25000], // Explicit bounds
+    },
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
   });
 
-  it('should not apply when truncateYAxis is false', () => {
-    const queriesData = [
-      {
-        data: [
-          { 'Series A': 15000, __timestamp: 599616000000 },
-          { 'Series A': 20000, __timestamp: 599916000000 },
-          { 'Series A': 18000, __timestamp: 600216000000 },
-        ],
-      },
-    ];
+  const transformedProps = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-    const chartProps = new ChartProps({
-      formData: {
-        ...baseFormData,
-        truncateYAxis: false,
-      },
-      width: 800,
-      height: 600,
-      queriesData,
-      theme: supersetTheme,
-    });
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  expect(xAxisRaw.max).toBe(25000); // Should respect explicit bound
+  expect(xAxisRaw.min).toBe(0); // Should respect explicit bound
+});
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+test('should not apply axis bounds calculation when truncateYAxis is false for horizontal bar charts', () => {
+  const queriesData = [
+    {
+      data: [
+        { 'Series A': 15000, __timestamp: 599616000000 },
+        { 'Series A': 20000, __timestamp: 599916000000 },
+        { 'Series A': 18000, __timestamp: 600216000000 },
+      ],
+    },
+  ];
 
-    // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxis = transformedProps.echartOptions.xAxis as any;
-    // Should not have explicit max set when truncateYAxis is false
-    expect(xAxis.max).toBeUndefined();
+  const chartProps = new ChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      truncateYAxis: false,
+    },
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
   });
 
-  it('should not apply when seriesType is not Bar', () => {
-    const queriesData = [
-      {
-        data: [
-          { 'Series A': 15000, __timestamp: 599616000000 },
-          { 'Series A': 20000, __timestamp: 599916000000 },
-          { 'Series A': 18000, __timestamp: 600216000000 },
-        ],
-      },
-    ];
+  const transformedProps = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
 
-    const chartProps = new ChartProps({
-      formData: {
-        ...baseFormData,
-        seriesType: EchartsTimeseriesSeriesType.Line,
-      },
-      width: 800,
-      height: 600,
-      queriesData,
-      theme: supersetTheme,
-    });
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
+  const xAxis = transformedProps.echartOptions.xAxis as any;
+  // Should not have explicit max set when truncateYAxis is false
+  expect(xAxis.max).toBeUndefined();
+});
 
-    const transformedProps = transformProps(
-      chartProps as EchartsTimeseriesChartProps,
-    );
+test('should not apply axis bounds calculation when seriesType is not Bar for horizontal charts', () => {
+  const queriesData = [
+    {
+      data: [
+        { 'Series A': 15000, __timestamp: 599616000000 },
+        { 'Series A': 20000, __timestamp: 599916000000 },
+        { 'Series A': 18000, __timestamp: 600216000000 },
+      ],
+    },
+  ];
 
-    // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
-    const xAxisRaw = transformedProps.echartOptions.xAxis as any;
-    // Should not have explicit max set when seriesType is not Bar
-    expect(xAxisRaw.max).toBeUndefined();
+  const chartProps = new ChartProps({
+    formData: {
+      ...baseFormDataHorizontalBar,
+      seriesType: EchartsTimeseriesSeriesType.Line,
+    },
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
   });
+
+  const transformedProps = transformProps(
+    chartProps as EchartsTimeseriesChartProps,
+  );
+
+  // In horizontal orientation, axes are swapped, so yAxis becomes xAxis
+  const xAxisRaw = transformedProps.echartOptions.xAxis as any;
+  // Should not have explicit max set when seriesType is not Bar
+  expect(xAxisRaw.max).toBeUndefined();
 });


### PR DESCRIPTION
### SUMMARY

#### Problem
- Value labels (e.g., "20k") were cut off on the right
- X-axis max used rounded values, creating gaps and hiding labels

#### Solution
- Calculate axis max/min from actual data for horizontal bar charts
- Set axis bounds to data values (not rounded) to avoid gaps
- Handle diverging bars with negative values
- Increase right padding up to 70px (via constant) when value labels are shown
- Respect explicit user-defined yAxisBounds when set

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### BEFORE
<img width="1231" height="589" alt="image" src="https://github.com/user-attachments/assets/e4c9a9d7-72de-4bf2-bb84-5ee1189b446b" />

### AFTER
<img width="1230" height="601" alt="image" src="https://github.com/user-attachments/assets/c1ce881c-102b-4dc3-b145-8ca708c21dcc" />


### TESTING INSTRUCTIONS

1. Create a Bar chart using a metric with negative values
2. Select Horizontal view
3. Enable the Show value feature in the Customize tab.

Use a simple dataset like:
``` sql
SELECT * FROM (
    VALUES
        ('Category A', 20000),
        ('Category B', -21000),
        ('Category C', 18000),
) AS t(category, value1)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: [34401](https://github.com/apache/superset/issues/34401)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
