### PR TITLE
fix(ag-grid-table): preserve time grain aggregation when temporal column casing changes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -252,7 +252,7 @@ const config: ControlPanelConfig = {
               visibility: ({ controls }) => {
                 const dttmLookup = Object.fromEntries(
                   ensureIsArray(controls?.groupby?.options).map(option => [
-                    option.column_name.toLowerCase(),
+                    (option.column_name || '').toLowerCase(),
                     option.is_dttm,
                   ]),
                 );
@@ -263,7 +263,7 @@ const config: ControlPanelConfig = {
                       return true;
                     }
                     if (isPhysicalColumn(selection)) {
-                      return !!dttmLookup[selection.toLowerCase()];
+                      return !!dttmLookup[(selection || '').toLowerCase()];
                     }
                     return false;
                   })

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -252,7 +252,7 @@ const config: ControlPanelConfig = {
               visibility: ({ controls }) => {
                 const dttmLookup = Object.fromEntries(
                   ensureIsArray(controls?.groupby?.options).map(option => [
-                    option.column_name,
+                    option.column_name.toLowerCase(),
                     option.is_dttm,
                   ]),
                 );
@@ -263,7 +263,7 @@ const config: ControlPanelConfig = {
                       return true;
                     }
                     if (isPhysicalColumn(selection)) {
-                      return !!dttmLookup[selection];
+                      return !!dttmLookup[selection.toLowerCase()];
                     }
                     return false;
                   })

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable camelcase */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import {
+  ControlPanelConfig,
+  ControlPanelsContainerProps,
+  ControlState,
+  CustomControlItem,
+} from '@superset-ui/chart-controls';
+import config from '../src/controlPanel';
+
+type VisibilityFn = (
+  props: ControlPanelsContainerProps,
+  control?: ControlState,
+) => boolean;
+
+function isControlWithVisibility(
+  controlItem: unknown,
+): controlItem is CustomControlItem & {
+  config: Required<CustomControlItem['config']> & { visibility: VisibilityFn };
+} {
+  return (
+    typeof controlItem === 'object' &&
+    controlItem !== null &&
+    'name' in controlItem &&
+    'config' in controlItem &&
+    typeof (controlItem as CustomControlItem).config?.visibility === 'function'
+  );
+}
+
+function getVisibility(
+  panel: ControlPanelConfig,
+  controlName: string,
+): VisibilityFn {
+  const item = (panel.controlPanelSections || [])
+    .flatMap(section => section?.controlSetRows || [])
+    .flat()
+    .find(c => isControlWithVisibility(c) && c.name === controlName);
+
+  if (!isControlWithVisibility(item)) {
+    throw new Error(`Control "${controlName}" with visibility not found`);
+  }
+  return item.config.visibility;
+}
+
+function mkProps(
+  groupbyValue: string[],
+  options = [
+    { column_name: 'ORDERDATE', is_dttm: true },
+    { column_name: 'some_other_col', is_dttm: false },
+  ],
+): ControlPanelsContainerProps {
+  return {
+    controls: {
+      groupby: { value: groupbyValue, options },
+    },
+  } as unknown as ControlPanelsContainerProps;
+}
+
+test('time_grain_sqla visibility should be case-insensitive', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+
+  expect(vis(mkProps(['orderdate']), controlState)).toBe(true);
+  expect(vis(mkProps(['ORDERDATE']), controlState)).toBe(true);
+  expect(vis(mkProps(['some_other_col']), controlState)).toBe(false);
+});


### PR DESCRIPTION
FEATURE_AG_GRID_TABLE_ENABLED=true

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a case-sensitivity issue causing table aggregation to break when a temporal column is renamed with different casing. The `time_grain_sqla` visibility check in the AG Grid Table control panel is made case-insensitive, ensuring time grain aggregation is applied even after renaming. Adds a unit test to prevent regressions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="1725" height="861" alt="Screenshot 2026-01-13 at 15 58 59" src="https://github.com/user-attachments/assets/b4e76bc8-b590-44e7-9bcd-9813ca0da151" />


#### After
<img width="1725" height="874" alt="Screenshot 2026-01-13 at 15 57 57" src="https://github.com/user-attachments/assets/37e29d1e-152d-4b6f-ac79-42cc6c929200" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. In Explore, create a Table chart with a dataset that has an uppercase temporal column (e.g., `ORDERDATE`).
2. Enable Aggregate, add the temporal column to Dimensions, set Month time grain, update chart. Verify aggregation works.
3. Rename the temporal column to lowercase (e.g., `orderdate`) and update chart.
4. Verify aggregation still follows the selected time grain.

Unit test:
- From superset-frontend, run:
  - `npm run test -- plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
