### PR TITLE
fix(dashboard): revert cell hover and active colors to grayscale

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/styles/index.tsx
@@ -287,14 +287,14 @@ export const StyledChartContainer = styled.div<{
     .dt-is-filter {
       cursor: pointer;
       :hover {
-        background-color: ${theme.colorPrimaryBgHover};
+        background-color: ${theme.colorFillContentHover};
       }
     }
 
     .dt-is-active-filter {
       background: ${theme.colorPrimaryBg};
       :hover {
-        background-color: ${theme.colorPrimaryBgHover};
+        background-color: ${theme.colorFillContentHover};
       }
     }
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -145,7 +145,7 @@ export const Styles = styled.div`
     }
 
     .hoverable:hover {
-      background-color: ${theme.colorPrimaryBgHover};
+      background-color: ${theme.colorFillContentHover};
       cursor: pointer;
     }
   `}

--- a/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
@@ -120,12 +120,12 @@ export default styled.div`
     }
 
     td.dt-is-filter:hover {
-      background-color: ${theme.colorPrimaryBgHover};
+      background-color: ${theme.colorFillContentHover};
     }
 
     td.dt-is-active-filter,
     td.dt-is-active-filter:hover {
-      background-color: ${theme.colorPrimaryBgHover};
+      background-color: ${theme.colorFillContentHover};
     }
 
     .dt-global-filter {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

We are reverting the cell hover's and active's color to grayscale instead of blue for AG and non AG grids.

The cell hover color is green/blue (turquoise), which is confusing because + and - cell bars colors can be green as well

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

BEFORE

<img width="341" height="519" alt="green_blue_cell" src="https://github.com/user-attachments/assets/de021bec-dfb1-4e5f-98a8-6aeebd6c0ee5" />

AFTER

https://github.com/user-attachments/assets/d66a3553-fdbf-418d-93d6-72439a929bc6

https://github.com/user-attachments/assets/d5443e1a-3d92-44e0-82b6-79670d18c4ed

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

You can check any of this AG and / or non AG grids. For example you can check in the Dashboard page.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
