### PR TITLE
fix(mcp): remove unused ctx parameter from health_check tool

### DIFF
--- a/superset/mcp_service/system/tool/health_check.py
+++ b/superset/mcp_service/system/tool/health_check.py
@@ -21,7 +21,6 @@ import datetime
 import logging
 import platform
 
-from fastmcp import Context
 from flask import current_app
 from superset_core.mcp import tool
 
@@ -32,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool(tags=["core"])
-async def health_check(ctx: Context) -> HealthCheckResponse:
+async def health_check() -> HealthCheckResponse:
     """
     Simple health check tool for testing the MCP service.
 


### PR DESCRIPTION
### SUMMARY
The `health_check` MCP tool had a `ctx: Context` parameter that was not being injected by FastMCP, causing "missing 1 required positional argument: 'ctx'" errors when calling the tool.

Since the function doesn't actually use the context, removing the parameter entirely fixes the issue.

### BEFORE/AFTER SCREENSHOTS OR COVERAGE DIFF
**Before:**
```
Error calling tool 'health_check': health_check() missing 1 required positional argument: 'ctx'
```

**After:**
```json
{"status":"healthy","timestamp":"2026-01-08T22:54:37.883286","service":"Superset OSS MCP Service","version":"0.0.0-dev","python_version":"3.11.9","platform":"Darwin","uptime_seconds":null}
```

### TESTING INSTRUCTIONS
1. Start the MCP service
2. Call the `health_check` tool without any parameters
3. Verify it returns a healthy status response

### ADDITIONAL INFORMATION
- [x] Has associated issue: N/A (bug discovered during testing)
- [x] Required CI checks pass
- [x] Changes are tested locally