### PR TITLE
chore(charts): echarts left padding too big and automation of title

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/chartTitle.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/chartTitle.tsx
@@ -23,7 +23,7 @@ import { ControlPanelSectionConfig } from '../types';
 import { formatSelectOptions } from '../utils';
 
 export const TITLE_MARGIN_OPTIONS: number[] = [
-  15, 30, 50, 75, 100, 125, 150, 200,
+  0, 15, 30, 50, 75, 100, 125, 150, 200,
 ];
 export const TITLE_POSITION_OPTIONS: [string, string][] = [
   ['Left', t('Left')],
@@ -82,7 +82,7 @@ export const titleControls: ControlPanelSectionConfig = {
           clearable: true,
           label: t('Y Axis Title Margin'),
           renderTrigger: true,
-          default: TITLE_MARGIN_OPTIONS[1],
+          default: TITLE_MARGIN_OPTIONS[0],
           choices: formatSelectOptions(TITLE_MARGIN_OPTIONS),
         },
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -242,8 +242,10 @@ export default function transformProps(
     // @ts-ignore
     ...outlierData,
   ];
-  const addYAxisTitleOffset = !!yAxisTitle;
-  const addXAxisTitleOffset = !!xAxisTitle;
+  const addYAxisTitleOffset =
+    !!yAxisTitle && convertInteger(yAxisTitleMargin) !== 0;
+  const addXAxisTitleOffset =
+    !!xAxisTitle && convertInteger(xAxisTitleMargin) !== 0;
   const chartPadding = getPadding(
     true,
     legendOrientation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -576,8 +576,11 @@ export default function transformProps(
       ? getXAxisFormatter(xAxisTimeFormat)
       : String;
 
-  const addYAxisTitleOffset = !!(yAxisTitle || yAxisTitleSecondary);
-  const addXAxisTitleOffset = !!xAxisTitle;
+  const addYAxisTitleOffset =
+    !!(yAxisTitle || yAxisTitleSecondary) &&
+    convertInteger(yAxisTitleMargin) !== 0;
+  const addXAxisTitleOffset =
+    !!xAxisTitle && convertInteger(xAxisTitleMargin) !== 0;
 
   const chartPadding = getPadding(
     showLegend,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -573,8 +573,10 @@ export default function transformProps(
     onLegendScroll,
   } = hooks;
 
-  const addYAxisLabelOffset = !!yAxisTitle;
-  const addXAxisLabelOffset = !!xAxisTitle;
+  const addYAxisLabelOffset =
+    !!yAxisTitle && convertInteger(yAxisTitleMargin) !== 0;
+  const addXAxisLabelOffset =
+    !!xAxisTitle && convertInteger(xAxisTitleMargin) !== 0;
   const padding = getPadding(
     showLegend,
     legendOrientation,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -656,7 +656,9 @@ export function getPadding(
       top:
         yAxisTitlePosition && yAxisTitlePosition === 'Top'
           ? TIMESERIES_CONSTANTS.gridOffsetTop + (Number(yAxisTitleMargin) || 0)
-          : TIMESERIES_CONSTANTS.gridOffsetTop + yAxisOffset,
+          : yAxisTitlePosition === 'Left'
+            ? TIMESERIES_CONSTANTS.gridOffsetTop
+            : TIMESERIES_CONSTANTS.gridOffsetTop + yAxisOffset,
       bottom:
         zoomable && !isHorizontal
           ? TIMESERIES_CONSTANTS.gridOffsetBottomZoomable + xAxisOffset

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -240,42 +240,39 @@ test('should configure time axis labels to show max label for last month visibil
       }),
     }),
   );
+});
 
-describe('getPadding', () => {
-  let getChartPaddingSpy: jest.SpyInstance;
+function setupGetChartPaddingMock(): jest.SpyInstance {
+  // Mock getChartPadding to return the padding object as-is for easier testing
+  const getChartPaddingSpy = jest.spyOn(seriesUtils, 'getChartPadding');
+  getChartPaddingSpy.mockImplementation(
+    (
+      show: boolean,
+      orientation: LegendOrientation,
+      margin: string | number | null | undefined,
+      padding:
+        | {
+            bottom?: number;
+            left?: number;
+            right?: number;
+            top?: number;
+          }
+        | undefined,
+    ) => {
+      return {
+        bottom: padding?.bottom ?? 0,
+        left: padding?.left ?? 0,
+        right: padding?.right ?? 0,
+        top: padding?.top ?? 0,
+      };
+    },
+  );
+  return getChartPaddingSpy;
+}
 
-  beforeEach(() => {
-    // Mock getChartPadding to return the padding object as-is for easier testing
-    getChartPaddingSpy = jest.spyOn(seriesUtils, 'getChartPadding');
-    getChartPaddingSpy.mockImplementation(
-      (
-        show: boolean,
-        orientation: LegendOrientation,
-        margin: string | number | null | undefined,
-        padding:
-          | {
-              bottom?: number;
-              left?: number;
-              right?: number;
-              top?: number;
-            }
-          | undefined,
-      ) => {
-        return {
-          bottom: padding?.bottom ?? 0,
-          left: padding?.left ?? 0,
-          right: padding?.right ?? 0,
-          top: padding?.top ?? 0,
-        };
-      },
-    );
-  });
-
-  afterEach(() => {
-    getChartPaddingSpy.mockRestore();
-  });
-
-  it('should only affect left margin when Y axis title position is Left', () => {
+test('getPadding should only affect left margin when Y axis title position is Left', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
     const result = getPadding(
       false, // showLegend
       LegendOrientation.Top, // legendOrientation
@@ -297,9 +294,14 @@ describe('getPadding', () => {
     expect(result.bottom).toBe(TIMESERIES_CONSTANTS.gridOffsetBottom);
     // Right should be base value
     expect(result.right).toBe(TIMESERIES_CONSTANTS.gridOffsetRight);
-  });
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
+});
 
-  it('should only affect top margin when Y axis title position is Top', () => {
+test('getPadding should only affect top margin when Y axis title position is Top', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
     const result = getPadding(
       false, // showLegend
       LegendOrientation.Top, // legendOrientation
@@ -321,9 +323,14 @@ describe('getPadding', () => {
     expect(result.bottom).toBe(TIMESERIES_CONSTANTS.gridOffsetBottom);
     // Right should be base value
     expect(result.right).toBe(TIMESERIES_CONSTANTS.gridOffsetRight);
-  });
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
+});
 
-  it('should use yAxisOffset for top when position is not specified and addYAxisTitleOffset is true', () => {
+test('getPadding should use yAxisOffset for top when position is not specified and addYAxisTitleOffset is true', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
     const result = getPadding(
       false, // showLegend
       LegendOrientation.Top, // legendOrientation
@@ -344,9 +351,14 @@ describe('getPadding', () => {
     );
     // Left should be base value
     expect(result.left).toBe(TIMESERIES_CONSTANTS.gridOffsetLeft);
-  });
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
+});
 
-  it('should not add yAxisOffset when addYAxisTitleOffset is false', () => {
+test('getPadding should not add yAxisOffset when addYAxisTitleOffset is false', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
     const result = getPadding(
       false, // showLegend
       LegendOrientation.Top, // legendOrientation
@@ -364,9 +376,14 @@ describe('getPadding', () => {
     expect(result.top).toBe(TIMESERIES_CONSTANTS.gridOffsetTop);
     // Left should be base value
     expect(result.left).toBe(TIMESERIES_CONSTANTS.gridOffsetLeft);
-  });
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
+});
 
-  it('should handle Left position with zero margin correctly', () => {
+test('getPadding should handle Left position with zero margin correctly', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
     const result = getPadding(
       false, // showLegend
       LegendOrientation.Top, // legendOrientation
@@ -384,5 +401,7 @@ describe('getPadding', () => {
     expect(result.top).toBe(TIMESERIES_CONSTANTS.gridOffsetTop);
     // Left should be base value only (margin is 0)
     expect(result.left).toBe(TIMESERIES_CONSTANTS.gridOffsetLeft);
-  });
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
 });

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -474,3 +474,181 @@ test('shows error indicator with function labels', async () => {
 
   expect(await screen.findByText(/Metric is required/)).toBeInTheDocument();
 });
+
+describe('Automatic axis title margin adjustment', () => {
+  beforeEach(() => {
+    getChartControlPanelRegistry().registerValue('table', {
+      controlPanelSections: [],
+    });
+  });
+
+  afterEach(() => {
+    getChartControlPanelRegistry().remove('table');
+  });
+
+  test('sets X axis margin to 30 when title is added and margin is 0', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          x_axis_title: { value: '' },
+          x_axis_title_margin: { value: 0 },
+        },
+      },
+    };
+
+    const { rerender } = renderWithRouter({ initialState: customState });
+
+    await waitFor(() => {
+      rerender(
+        <MemoryRouter initialEntries={[defaultPath]}>
+          <Route path={defaultPath}>
+            <ExploreViewContainer />
+          </Route>
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  test('sets Y axis margin to 30 when title is added and margin is 0', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          y_axis_title: { value: '' },
+          y_axis_title_margin: { value: 0 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Verify initial state renders without errors
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('resets X axis margin to 0 when title is removed', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          x_axis_title: { value: 'X Axis Label' },
+          x_axis_title_margin: { value: 30 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Component should handle title removal and reset margin
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('resets Y axis margin to 0 when title is removed', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          y_axis_title: { value: 'Y Axis Label' },
+          y_axis_title_margin: { value: 30 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Component should handle title removal and reset margin
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not change X axis margin when title is added but margin is already non-zero', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          x_axis_title: { value: '' },
+          x_axis_title_margin: { value: 50 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Component should not override user-set margin values
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not change Y axis margin when title is added but margin is already non-zero', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          y_axis_title: { value: '' },
+          y_axis_title_margin: { value: 50 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Component should not override user-set margin values
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('handles both X and Y axis titles being set simultaneously', async () => {
+    const customState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        controls: {
+          ...reduxState.explore.controls,
+          x_axis_title: { value: '' },
+          x_axis_title_margin: { value: 0 },
+          y_axis_title: { value: '' },
+          y_axis_title_margin: { value: 0 },
+        },
+      },
+    };
+
+    renderWithRouter({ initialState: customState });
+
+    // Component should handle both axes independently
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -516,7 +516,9 @@ test('automatic axis title margin adjustment sets X axis margin to 30 when title
     setControlValueSpy.mockClear();
 
     // Simulate title being added by dispatching action
-    store.dispatch(exploreActions.setControlValue('x_axis_title', 'X Axis Label'));
+    store.dispatch(
+      exploreActions.setControlValue('x_axis_title', 'X Axis Label'),
+    );
 
     await waitFor(() => {
       expect(setControlValueSpy).toHaveBeenCalledWith(
@@ -559,7 +561,9 @@ test('automatic axis title margin adjustment sets Y axis margin to 30 when title
     setControlValueSpy.mockClear();
 
     // Simulate title being added by dispatching action
-    store.dispatch(exploreActions.setControlValue('y_axis_title', 'Y Axis Label'));
+    store.dispatch(
+      exploreActions.setControlValue('y_axis_title', 'Y Axis Label'),
+    );
 
     await waitFor(() => {
       expect(setControlValueSpy).toHaveBeenCalledWith(
@@ -605,10 +609,7 @@ test('automatic axis title margin adjustment resets X axis margin to 0 when titl
     store.dispatch(exploreActions.setControlValue('x_axis_title', ''));
 
     await waitFor(() => {
-      expect(setControlValueSpy).toHaveBeenCalledWith(
-        'x_axis_title_margin',
-        0,
-      );
+      expect(setControlValueSpy).toHaveBeenCalledWith('x_axis_title_margin', 0);
     });
   } finally {
     getChartControlPanelRegistry().remove('table');
@@ -648,10 +649,7 @@ test('automatic axis title margin adjustment resets Y axis margin to 0 when titl
     store.dispatch(exploreActions.setControlValue('y_axis_title', ''));
 
     await waitFor(() => {
-      expect(setControlValueSpy).toHaveBeenCalledWith(
-        'y_axis_title_margin',
-        0,
-      );
+      expect(setControlValueSpy).toHaveBeenCalledWith('y_axis_title_margin', 0);
     });
   } finally {
     getChartControlPanelRegistry().remove('table');
@@ -688,7 +686,9 @@ test('automatic axis title margin adjustment does not change X axis margin when 
     setControlValueSpy.mockClear();
 
     // Simulate title being added by dispatching action
-    store.dispatch(exploreActions.setControlValue('x_axis_title', 'X Axis Label'));
+    store.dispatch(
+      exploreActions.setControlValue('x_axis_title', 'X Axis Label'),
+    );
 
     // Wait a bit to ensure useEffect has run
     await waitFor(() => {
@@ -737,7 +737,9 @@ test('automatic axis title margin adjustment does not change Y axis margin when 
     setControlValueSpy.mockClear();
 
     // Simulate title being added by dispatching action
-    store.dispatch(exploreActions.setControlValue('y_axis_title', 'Y Axis Label'));
+    store.dispatch(
+      exploreActions.setControlValue('y_axis_title', 'Y Axis Label'),
+    );
 
     // Wait a bit to ensure useEffect has run
     await waitFor(() => {
@@ -788,8 +790,12 @@ test('automatic axis title margin adjustment handles both X and Y axis titles be
     setControlValueSpy.mockClear();
 
     // Simulate both titles being added simultaneously
-    store.dispatch(exploreActions.setControlValue('x_axis_title', 'X Axis Label'));
-    store.dispatch(exploreActions.setControlValue('y_axis_title', 'Y Axis Label'));
+    store.dispatch(
+      exploreActions.setControlValue('x_axis_title', 'X Axis Label'),
+    );
+    store.dispatch(
+      exploreActions.setControlValue('y_axis_title', 'Y Axis Label'),
+    );
 
     await waitFor(() => {
       expect(setControlValueSpy).toHaveBeenCalledWith(

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -475,18 +475,15 @@ test('shows error indicator with function labels', async () => {
   expect(await screen.findByText(/Metric is required/)).toBeInTheDocument();
 });
 
-describe('Automatic axis title margin adjustment', () => {
-  beforeEach(() => {
-    getChartControlPanelRegistry().registerValue('table', {
-      controlPanelSections: [],
-    });
+function setupTableChartControlPanel() {
+  getChartControlPanelRegistry().registerValue('table', {
+    controlPanelSections: [],
   });
+}
 
-  afterEach(() => {
-    getChartControlPanelRegistry().remove('table');
-  });
-
-  test('sets X axis margin to 30 when title is added and margin is 0', async () => {
+test('automatic axis title margin adjustment sets X axis margin to 30 when title is added and margin is 0', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -510,9 +507,14 @@ describe('Automatic axis title margin adjustment', () => {
         </MemoryRouter>,
       );
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('sets Y axis margin to 30 when title is added and margin is 0', async () => {
+test('automatic axis title margin adjustment sets Y axis margin to 30 when title is added and margin is 0', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -533,9 +535,14 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('resets X axis margin to 0 when title is removed', async () => {
+test('automatic axis title margin adjustment resets X axis margin to 0 when title is removed', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -556,9 +563,14 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('resets Y axis margin to 0 when title is removed', async () => {
+test('automatic axis title margin adjustment resets Y axis margin to 0 when title is removed', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -579,9 +591,14 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('does not change X axis margin when title is added but margin is already non-zero', async () => {
+test('automatic axis title margin adjustment does not change X axis margin when title is added but margin is already non-zero', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -602,9 +619,14 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('does not change Y axis margin when title is added but margin is already non-zero', async () => {
+test('automatic axis title margin adjustment does not change Y axis margin when title is added but margin is already non-zero', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -625,9 +647,14 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
+});
 
-  test('handles both X and Y axis titles being set simultaneously', async () => {
+test('automatic axis title margin adjustment handles both X and Y axis titles being set simultaneously', async () => {
+  setupTableChartControlPanel();
+  try {
     const customState = {
       ...reduxState,
       explore: {
@@ -650,5 +677,7 @@ describe('Automatic axis title margin adjustment', () => {
         screen.queryByTestId('query-error-tooltip-trigger'),
       ).not.toBeInTheDocument();
     });
-  });
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+  }
 });

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -708,6 +708,54 @@ test('automatic axis title margin adjustment does not change X axis margin when 
   }
 });
 
+test('automatic axis title margin adjustment changes X axis margin when title is added and margin is less than 30', async () => {
+  setupTableChartControlPanel();
+  try {
+    const setControlValueSpy = jest.spyOn(exploreActions, 'setControlValue');
+
+    const initialState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        form_data: {
+          datasource: '1__table',
+          viz_type: VizType.Table,
+          metrics: [],
+        },
+        controls: {
+          ...reduxState.explore.controls,
+          x_axis_title: { value: '' },
+          x_axis_title_margin: { value: 20 },
+        },
+      },
+    };
+
+    const store = createStore(initialState, reducerIndex);
+    renderWithRouter({ initialState, store: store as Store });
+
+    // Clear any calls from initial render
+    setControlValueSpy.mockClear();
+
+    // Simulate title being added by dispatching action
+    store.dispatch(
+      exploreActions.setControlValue('x_axis_title', 'X Axis Label'),
+    );
+
+    // Wait a bit to ensure useEffect has run
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Should call setControlValue since margin is less than 30
+    expect(setControlValueSpy).toHaveBeenCalledWith('x_axis_title_margin', 30);
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+    jest.restoreAllMocks();
+  }
+});
+
 test('automatic axis title margin adjustment does not change Y axis margin when title is added but margin is already non-zero', async () => {
   setupTableChartControlPanel();
   try {
@@ -753,6 +801,54 @@ test('automatic axis title margin adjustment does not change Y axis margin when 
       'y_axis_title_margin',
       expect.any(Number),
     );
+  } finally {
+    getChartControlPanelRegistry().remove('table');
+    jest.restoreAllMocks();
+  }
+});
+
+test('automatic axis title margin adjustment changes Y axis margin when title is added and margin is less than 30', async () => {
+  setupTableChartControlPanel();
+  try {
+    const setControlValueSpy = jest.spyOn(exploreActions, 'setControlValue');
+
+    const initialState = {
+      ...reduxState,
+      explore: {
+        ...reduxState.explore,
+        form_data: {
+          datasource: '1__table',
+          viz_type: VizType.Table,
+          metrics: [],
+        },
+        controls: {
+          ...reduxState.explore.controls,
+          y_axis_title: { value: '' },
+          y_axis_title_margin: { value: 20 },
+        },
+      },
+    };
+
+    const store = createStore(initialState, reducerIndex);
+    renderWithRouter({ initialState, store: store as Store });
+
+    // Clear any calls from initial render
+    setControlValueSpy.mockClear();
+
+    // Simulate title being added by dispatching action
+    store.dispatch(
+      exploreActions.setControlValue('y_axis_title', 'Y Axis Label'),
+    );
+
+    // Wait a bit to ensure useEffect has run
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('query-error-tooltip-trigger'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Should call setControlValue since margin is less than 30
+    expect(setControlValueSpy).toHaveBeenCalledWith('y_axis_title_margin', 30);
   } finally {
     getChartControlPanelRegistry().remove('table');
     jest.restoreAllMocks();

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -571,6 +571,29 @@ function ExploreViewContainer(props) {
         }
       }
 
+      // Automatically set axis title margins when titles are added or removed
+      if (changedControlKeys.includes('x_axis_title')) {
+        const xAxisTitle = props.controls.x_axis_title?.value || '';
+        const currentMargin = props.controls.x_axis_title_margin?.value ?? 0;
+
+        if (xAxisTitle && currentMargin === 0) {
+          props.actions.setControlValue('x_axis_title_margin', 30);
+        } else if (!xAxisTitle && currentMargin !== 0) {
+          props.actions.setControlValue('x_axis_title_margin', 0);
+        }
+      }
+
+      if (changedControlKeys.includes('y_axis_title')) {
+        const yAxisTitle = props.controls.y_axis_title?.value || '';
+        const currentMargin = props.controls.y_axis_title_margin?.value ?? 0;
+
+        if (yAxisTitle && currentMargin === 0) {
+          props.actions.setControlValue('y_axis_title_margin', 30);
+        } else if (!yAxisTitle && currentMargin !== 0) {
+          props.actions.setControlValue('y_axis_title_margin', 0);
+        }
+      }
+
       // this should also be handled by the actions that are actually changing the controls
       const displayControlsChanged = changedControlKeys.filter(
         key => props.controls[key].renderTrigger,

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -576,7 +576,7 @@ function ExploreViewContainer(props) {
         const xAxisTitle = props.controls.x_axis_title?.value || '';
         const currentMargin = props.controls.x_axis_title_margin?.value ?? 0;
 
-        if (xAxisTitle && currentMargin === 0) {
+        if (xAxisTitle && currentMargin < 30) {
           props.actions.setControlValue('x_axis_title_margin', 30);
         } else if (!xAxisTitle && currentMargin !== 0) {
           props.actions.setControlValue('x_axis_title_margin', 0);
@@ -587,7 +587,7 @@ function ExploreViewContainer(props) {
         const yAxisTitle = props.controls.y_axis_title?.value || '';
         const currentMargin = props.controls.y_axis_title_margin?.value ?? 0;
 
-        if (yAxisTitle && currentMargin === 0) {
+        if (yAxisTitle && currentMargin < 30) {
           props.actions.setControlValue('y_axis_title_margin', 30);
         } else if (!yAxisTitle && currentMargin !== 0) {
           props.actions.setControlValue('y_axis_title_margin', 0);


### PR DESCRIPTION
### SUMMARY

#### Problem
Charts had too much left margin by default.

#### Solution
- Add 0 margin as an option (and default) on the X and Y axis
- Automatically set margin to 30 when an axis title is added and margin is 0
- Automatically reset margin to 0 when an axis title is removed
- Apply padding offsets only when both title exists and margin is non-zero

#### UPDATE:
- Also, automatically set margin to 30 when adding / updating a title if current margin is less than 30 (X and Y axis).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="1692" height="820" alt="image" src="https://github.com/user-attachments/assets/10ed4786-441f-4cc4-b046-ae00b250ae89" />

#### AFTER
https://github.com/user-attachments/assets/b6b7bb4c-8254-4424-87fb-9356ff77ebc1

### TESTING INSTRUCTIONS

1. Add a new chart.
2. Check the left margin that is too big, instead of 0.
3. Add a title on the Y axis and see how it grows automatically.
4. Add a title on the X axis and see how it grows automatically.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 96451
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
