### PR TITLE
chore(chart): rollback legend top alignment to the right

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -495,9 +495,6 @@ export function getLegendProps(
     case LegendOrientation.Top:
       legend.top = 0;
       legend.right = zoomable ? TIMESERIES_CONSTANTS.legendTopRightOffset : 0;
-      if (padding?.left) {
-        legend.left = padding.left;
-      }
       break;
     default:
       legend.top = 0;


### PR DESCRIPTION
### SUMMARY

In 6.0, legends were previously right aligned by default and now are left aligned. 
Talked to Sophie and we should change this back to right aligned to avoid customers seeing unexpected changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
<img width="1692" height="820" alt="image" src="https://github.com/user-attachments/assets/57b073d0-bd1b-43b5-b797-f839ad4bde64" />

#### AFTER
<img width="1030" height="626" alt="image" src="https://github.com/user-attachments/assets/123ecb19-9516-44f8-90b4-2828a261f241" />

### TESTING INSTRUCTIONS
1. Add a chart.
2. On the customize tab, set the "Show Legend"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: 96675
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
