### PR TITLE
refactor(db-engine-specs): use standard OAuth 2.0 params in base class

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -551,17 +551,17 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     ) -> str:
         """
         Return URI for initial OAuth2 request.
+
+        Uses standard OAuth 2.0 parameters only. Subclasses can override
+        to add provider-specific parameters (e.g., Google's prompt=consent).
         """
         uri = config["authorization_request_uri"]
         params = {
             "scope": config["scope"],
-            "access_type": "offline",
-            "include_granted_scopes": "false",
             "response_type": "code",
             "state": encode_oauth2_state(state),
             "redirect_uri": config["redirect_uri"],
             "client_id": config["id"],
-            "prompt": "consent",
         }
         return urljoin(uri, "?" + urlencode(params))
 

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -638,6 +638,11 @@ def test_get_oauth2_authorization_uri(
     encoded_state = query["state"][0].replace("%2E", ".")
     assert decode_oauth2_state(encoded_state) == state
 
+    # Verify Google-specific OAuth parameters are included
+    assert query["access_type"][0] == "offline"
+    assert query["include_granted_scopes"][0] == "false"
+    assert query["prompt"][0] == "consent"
+
 
 def test_get_oauth2_token(
     mocker: MockerFixture,

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -231,7 +231,7 @@ def test_get_sql_results_oauth2(mocker: MockerFixture, app) -> None:
                 "error_type": SupersetErrorType.OAUTH2_REDIRECT,
                 "level": ErrorLevel.WARNING,
                 "extra": {
-                    "url": "https://abcd1234.snowflakecomputing.com/oauth/authorize?scope=refresh_token+session%3Arole%3AUSERADMIN&access_type=offline&include_granted_scopes=false&response_type=code&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9%252EeyJleHAiOjE2MTcyMzU1MDAsImRhdGFiYXNlX2lkIjoxLCJ1c2VyX2lkIjo0MiwiZGVmYXVsdF9yZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0L2FwaS92MS9kYXRhYmFzZS9vYXV0aDIvIiwidGFiX2lkIjoiZmIxMWY1MjgtNmViYS00YThhLTgzN2UtNmIwZDM5ZWU5MTg3In0%252E7nLkei6-V8sVk_Pgm8cFhk0tnKRKayRE1Vc7RxuM9mw&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv1%2Fdatabase%2Foauth2%2F&client_id=my_client_id&prompt=consent",
+                    "url": "https://abcd1234.snowflakecomputing.com/oauth/authorize?scope=refresh_token+session%3Arole%3AUSERADMIN&response_type=code&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9%252EeyJleHAiOjE2MTcyMzU1MDAsImRhdGFiYXNlX2lkIjoxLCJ1c2VyX2lkIjo0MiwiZGVmYXVsdF9yZWRpcmVjdF91cmkiOiJodHRwOi8vbG9jYWxob3N0L2FwaS92MS9kYXRhYmFzZS9vYXV0aDIvIiwidGFiX2lkIjoiZmIxMWY1MjgtNmViYS00YThhLTgzN2UtNmIwZDM5ZWU5MTg3In0%252E7nLkei6-V8sVk_Pgm8cFhk0tnKRKayRE1Vc7RxuM9mw&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv1%2Fdatabase%2Foauth2%2F&client_id=my_client_id",
                     "tab_id": "fb11f528-6eba-4a8a-837e-6b0d39ee9187",
                     "redirect_uri": "http://localhost/api/v1/database/oauth2/",
                 },


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR refactors the OAuth 2.0 authorization flow to follow a cleaner architectural pattern.

Previously, `BaseEngineSpec.get_oauth2_authorization_uri()` included `Google-specific OAuth parameters (`prompt=consent, access_type=offline, include_granted_scopes=false`) directly in the base class. While this worked for Google Sheets, it's not the right design since these are provider-specific parameters rather than standard OAuth 2.0.

The refactor moves to a cleaner separation of concerns:

Base class: Uses only standard OAuth 2.0 parameters (`scope, response_type, state, redirect_uri, client_id`)
Google Sheets: Overrides the method to add Google-specific parameters needed for proper token refresh
This makes the codebase more maintainable and allows future OAuth-enabled database connections to work without needing to handle Google-specific quirks.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Verify Google Sheets OAuth still works correctly
2. Run the unit tests: pytest tests/unit_tests/db_engine_specs/test_base.py::test_get_oauth2_authorization_uri_standard_params tests/unit_tests/db_engine_specs/test_gsheets.py::test_get_oauth2_authorization_uri

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
