### PR TITLE
fix(native-filters): enable Apply button when selecting Boolean FALSE value

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -17,7 +17,12 @@
  * under the License.
  */
 import { AppSection } from '@superset-ui/core';
-import { render, screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import { NULL_STRING } from 'src/utils/common';
 import SelectFilterPlugin from './SelectFilterPlugin';
 import transformProps from './transformProps';

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -652,12 +652,14 @@ describe('SelectFilterPlugin', () => {
       },
     );
 
-    const filterSelect = screen.getAllByRole('combobox')[0];
-    userEvent.click(filterSelect);
+    const filterSelect = screen.getByRole('combobox');
+    await userEvent.click(filterSelect);
 
     const falseOption = await screen.findByRole('option', { name: /false/i });
     expect(falseOption).toBeInTheDocument();
-    userEvent.click(falseOption);
+    await userEvent.click(falseOption);
+
+    expect(await screen.findByTitle('false')).toBeInTheDocument();
 
     expect(setDataMaskMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -984,3 +984,145 @@ test('Select boolean filter with null values', async () => {
     );
   });
 });
+
+test('Clear boolean FALSE value', async () => {
+  jest.useRealTimers();
+  const setDataMaskMock = jest.fn();
+  const testProps = {
+    ...selectMultipleProps,
+    formData: {
+      ...selectMultipleProps.formData,
+      multiSelect: false,
+      enableEmptyFilter: false,
+      groupby: ['is_active'],
+    },
+    queriesData: [
+      {
+        ...selectMultipleProps.queriesData[0],
+        colnames: ['is_active'],
+        data: [{ is_active: true }, { is_active: false }],
+        applied_filters: [{ column: 'is_active' }],
+      },
+    ],
+    filterState: { value: [false] },
+  };
+
+  render(
+    // @ts-ignore
+    <SelectFilterPlugin
+      // @ts-ignore
+      {...transformProps(testProps)}
+      setDataMask={setDataMaskMock}
+      showOverflow={false}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        nativeFilters: {
+          filters: {
+            'test-filter': {
+              name: 'Test Filter',
+            },
+          },
+        },
+        dataMask: {
+          'test-filter': {
+            extraFormData: {},
+            filterState: {
+              value: [false],
+            },
+          },
+        },
+      },
+    },
+  );
+
+  userEvent.click(
+    screen.getByRole('img', {
+      name: /close-circle/i,
+      hidden: true,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith({
+      extraFormData: {},
+      filterState: {
+        label: undefined,
+        value: null,
+        excludeFilterValues: true,
+      },
+    });
+  });
+});
+
+test('Clear boolean TRUE value', async () => {
+  jest.useRealTimers();
+  const setDataMaskMock = jest.fn();
+  const testProps = {
+    ...selectMultipleProps,
+    formData: {
+      ...selectMultipleProps.formData,
+      multiSelect: false,
+      enableEmptyFilter: false,
+      groupby: ['is_active'],
+    },
+    queriesData: [
+      {
+        ...selectMultipleProps.queriesData[0],
+        colnames: ['is_active'],
+        data: [{ is_active: true }, { is_active: false }],
+        applied_filters: [{ column: 'is_active' }],
+      },
+    ],
+    filterState: { value: [true] },
+  };
+
+  render(
+    // @ts-ignore
+    <SelectFilterPlugin
+      // @ts-ignore
+      {...transformProps(testProps)}
+      setDataMask={setDataMaskMock}
+      showOverflow={false}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        nativeFilters: {
+          filters: {
+            'test-filter': {
+              name: 'Test Filter',
+            },
+          },
+        },
+        dataMask: {
+          'test-filter': {
+            extraFormData: {},
+            filterState: {
+              value: [true],
+            },
+          },
+        },
+      },
+    },
+  );
+
+  userEvent.click(
+    screen.getByRole('img', {
+      name: /close-circle/i,
+      hidden: true,
+    }),
+  );
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith({
+      extraFormData: {},
+      filterState: {
+        label: undefined,
+        value: null,
+        excludeFilterValues: true,
+      },
+    });
+  });
+});

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -602,6 +602,81 @@ describe('SelectFilterPlugin', () => {
     expect(options[2]).toHaveTextContent('alpha');
   });
 
+  test('Select boolean FALSE value in single-select mode', async () => {
+    const setDataMaskMock = jest.fn();
+    render(
+      // @ts-ignore
+      <SelectFilterPlugin
+        // @ts-ignore
+        {...transformProps({
+          ...selectMultipleProps,
+          formData: {
+            ...selectMultipleProps.formData,
+            multiSelect: false,
+            groupby: ['is_active'],
+          },
+          queriesData: [
+            {
+              rowcount: 2,
+              colnames: ['is_active'],
+              coltypes: [1],
+              data: [{ is_active: true }, { is_active: false }],
+              applied_filters: [{ column: 'is_active' }],
+              rejected_filters: [],
+            },
+          ],
+          filterState: { value: undefined },
+        })}
+        setDataMask={setDataMaskMock}
+        showOverflow={false}
+      />,
+      {
+        useRedux: true,
+        initialState: {
+          nativeFilters: {
+            filters: {
+              'test-filter': {
+                name: 'Test Filter',
+              },
+            },
+          },
+          dataMask: {
+            'test-filter': {
+              extraFormData: {},
+              filterState: {
+                value: undefined,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    const falseOption = await screen.findByRole('option', { name: /false/i });
+    expect(falseOption).toBeInTheDocument();
+    userEvent.click(falseOption);
+
+    expect(setDataMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'is_active',
+              op: 'IN',
+              val: [false],
+            },
+          ],
+        },
+        filterState: expect.objectContaining({
+          value: [false],
+        }),
+      }),
+    );
+  });
+
   test('preserves backend order even when sortAscending is false and sortMetric is specified', () => {
     const testData = [
       { gender: 'zebra' },

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -604,29 +604,29 @@ describe('SelectFilterPlugin', () => {
 
   test('Select boolean FALSE value in single-select mode', async () => {
     const setDataMaskMock = jest.fn();
+    const testProps = {
+      ...selectMultipleProps,
+      formData: {
+        ...selectMultipleProps.formData,
+        multiSelect: false,
+        groupby: ['is_active'],
+      },
+      queriesData: [
+        {
+          ...selectMultipleProps.queriesData[0],
+          colnames: ['is_active'],
+          data: [{ is_active: true }, { is_active: false }],
+          applied_filters: [{ column: 'is_active' }],
+        },
+      ],
+      filterState: { value: undefined },
+    };
+
     render(
       // @ts-ignore
       <SelectFilterPlugin
         // @ts-ignore
-        {...transformProps({
-          ...selectMultipleProps,
-          formData: {
-            ...selectMultipleProps.formData,
-            multiSelect: false,
-            groupby: ['is_active'],
-          },
-          queriesData: [
-            {
-              rowcount: 2,
-              colnames: ['is_active'],
-              coltypes: [1],
-              data: [{ is_active: true }, { is_active: false }],
-              applied_filters: [{ column: 'is_active' }],
-              rejected_filters: [],
-            },
-          ],
-          filterState: { value: undefined },
-        })}
+        {...transformProps(testProps)}
         setDataMask={setDataMaskMock}
         showOverflow={false}
       />,
@@ -659,7 +659,8 @@ describe('SelectFilterPlugin', () => {
     expect(falseOption).toBeInTheDocument();
     await userEvent.click(falseOption);
 
-    expect(await screen.findByTitle('false')).toBeInTheDocument();
+    const selectedElements = await screen.findAllByTitle('FALSE');
+    expect(selectedElements.length).toBeGreaterThan(0);
 
     expect(setDataMaskMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -729,11 +729,10 @@ test('Select boolean FALSE value in single-select mode', async () => {
   );
 
   const filterSelect = screen.getByRole('combobox');
-  await userEvent.click(filterSelect);
+  userEvent.click(filterSelect);
 
   const falseOption = await screen.findByRole('option', { name: /false/i });
-  expect(falseOption).toBeInTheDocument();
-  await userEvent.click(falseOption);
+  userEvent.click(falseOption);
 
   await waitFor(() => {
     expect(setDataMaskMock).toHaveBeenCalledWith(
@@ -749,6 +748,237 @@ test('Select boolean FALSE value in single-select mode', async () => {
         },
         filterState: expect.objectContaining({
           value: [false],
+        }),
+      }),
+    );
+  });
+});
+
+test('Select boolean TRUE value in single-select mode', async () => {
+  jest.useRealTimers();
+  const setDataMaskMock = jest.fn();
+  const testProps = {
+    ...selectMultipleProps,
+    formData: {
+      ...selectMultipleProps.formData,
+      multiSelect: false,
+      groupby: ['is_active'],
+    },
+    queriesData: [
+      {
+        ...selectMultipleProps.queriesData[0],
+        colnames: ['is_active'],
+        data: [{ is_active: true }, { is_active: false }],
+        applied_filters: [{ column: 'is_active' }],
+      },
+    ],
+    filterState: { value: undefined },
+  };
+
+  render(
+    // @ts-ignore
+    <SelectFilterPlugin
+      // @ts-ignore
+      {...transformProps(testProps)}
+      setDataMask={setDataMaskMock}
+      showOverflow={false}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        nativeFilters: {
+          filters: {
+            'test-filter': {
+              name: 'Test Filter',
+            },
+          },
+        },
+        dataMask: {
+          'test-filter': {
+            extraFormData: {},
+            filterState: {
+              value: undefined,
+            },
+          },
+        },
+      },
+    },
+  );
+
+  const filterSelect = screen.getByRole('combobox');
+  userEvent.click(filterSelect);
+
+  const trueOption = await screen.findByRole('option', { name: /true/i });
+  userEvent.click(trueOption);
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'is_active',
+              op: 'IN',
+              val: [true],
+            },
+          ],
+        },
+        filterState: expect.objectContaining({
+          value: [true],
+        }),
+      }),
+    );
+  });
+});
+
+test('Select both boolean values in multi-select mode', async () => {
+  jest.useRealTimers();
+  const setDataMaskMock = jest.fn();
+  const testProps = {
+    ...selectMultipleProps,
+    formData: {
+      ...selectMultipleProps.formData,
+      multiSelect: true,
+      groupby: ['is_active'],
+    },
+    queriesData: [
+      {
+        ...selectMultipleProps.queriesData[0],
+        colnames: ['is_active'],
+        data: [{ is_active: true }, { is_active: false }],
+        applied_filters: [{ column: 'is_active' }],
+      },
+    ],
+    filterState: { value: [true] },
+  };
+
+  render(
+    // @ts-ignore
+    <SelectFilterPlugin
+      // @ts-ignore
+      {...transformProps(testProps)}
+      setDataMask={setDataMaskMock}
+      showOverflow={false}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        nativeFilters: {
+          filters: {
+            'test-filter': {
+              name: 'Test Filter',
+            },
+          },
+        },
+        dataMask: {
+          'test-filter': {
+            extraFormData: {},
+            filterState: {
+              value: [true],
+            },
+          },
+        },
+      },
+    },
+  );
+
+  const filterSelect = screen.getByRole('combobox');
+  userEvent.click(filterSelect);
+
+  const falseOption = await screen.findByRole('option', { name: /false/i });
+  userEvent.click(falseOption);
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'is_active',
+              op: 'IN',
+              val: [true, false],
+            },
+          ],
+        },
+        filterState: expect.objectContaining({
+          value: [true, false],
+        }),
+      }),
+    );
+  });
+});
+
+test('Select boolean filter with null values', async () => {
+  jest.useRealTimers();
+  const setDataMaskMock = jest.fn();
+  const testProps = {
+    ...selectMultipleProps,
+    formData: {
+      ...selectMultipleProps.formData,
+      multiSelect: true,
+      groupby: ['is_active'],
+    },
+    queriesData: [
+      {
+        ...selectMultipleProps.queriesData[0],
+        colnames: ['is_active'],
+        data: [{ is_active: true }, { is_active: false }, { is_active: null }],
+        applied_filters: [{ column: 'is_active' }],
+      },
+    ],
+    filterState: { value: [false] },
+  };
+
+  render(
+    // @ts-ignore
+    <SelectFilterPlugin
+      // @ts-ignore
+      {...transformProps(testProps)}
+      setDataMask={setDataMaskMock}
+      showOverflow={false}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        nativeFilters: {
+          filters: {
+            'test-filter': {
+              name: 'Test Filter',
+            },
+          },
+        },
+        dataMask: {
+          'test-filter': {
+            extraFormData: {},
+            filterState: {
+              value: [false],
+            },
+          },
+        },
+      },
+    },
+  );
+
+  const filterSelect = screen.getByRole('combobox');
+  userEvent.click(filterSelect);
+
+  const nullOption = await screen.findByRole('option', { name: NULL_STRING });
+  userEvent.click(nullOption);
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'is_active',
+              op: 'IN',
+              val: [false, null],
+            },
+          ],
+        },
+        filterState: expect.objectContaining({
+          value: [false, null],
         }),
       }),
     );

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -514,7 +514,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
             allowClear
             allowNewOptions={!searchAllOptions && creatable !== false}
             allowSelectAll={!searchAllOptions}
-            value={filterState.value || []}
+            value={multiSelect ? filterState.value || [] : filterState.value}
             disabled={isDisabled}
             getPopupContainer={
               showOverflow


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Issue: When using a Boolean column as a filter in a dashboard, selecting FALSE does not activate the "Apply Filters" button. This prevents users from applying the FALSE value unless another value (e.g., TRUE) is selected first.

Cause: In single-select mode, the Select component compares the raw value directly (false vs [ ]), and JavaScript's loose equality false == [ ] evaluates to true (both coerce to 0), so selecting boolean false was incorrectly treated as "no change" and onChange was never fired.

Fix: Pass undefined instead of [ ] as the initial value for single-select mode, so false == undefined correctly evaluates to false and triggers the onChange event.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
![before-boolean-filter](https://github.com/user-attachments/assets/18bcaa44-5387-4e63-8314-4088930fdb30)

AFTER:
![boolean-filter-after](https://github.com/user-attachments/assets/9c87565b-6825-4c9a-b04f-199f73b3764b)


### TESTING INSTRUCTIONS

1. Open a dashboard in Edit mode
2. Add a filter of single selection using a Boolean column (e.g., a column with TRUE/FALSE values)
3. Save and publish the dashboard 
4. In View mode, open the filter dropdown
5. Select FALSE only
6. The "Apply Filters" button shouldn't be greyed out

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
