### PR TITLE
fix(Tabs): prevent infinite rerenders with nested tabs

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -603,13 +603,21 @@ export function onRefresh(
   force = false,
   interval = 0,
   dashboardId,
+  isLazyLoad = false,
 ) {
   return dispatch => {
-    dispatch({ type: ON_REFRESH });
+    // Only dispatch ON_REFRESH for dashboard-level refreshes
+    // Skip it for lazy-loaded tabs to prevent infinite loops
+    if (!isLazyLoad) {
+      dispatch({ type: ON_REFRESH });
+    }
+    
     refreshCharts(chartList, force, interval, dashboardId, dispatch).then(
       () => {
         dispatch(onRefreshSuccess());
-        dispatch(onFiltersRefresh());
+        if (!isLazyLoad) {
+          dispatch(onFiltersRefresh());
+        }
       },
     );
   };

--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -611,7 +611,7 @@ export function onRefresh(
     if (!isLazyLoad) {
       dispatch({ type: ON_REFRESH });
     }
-    
+
     refreshCharts(chartList, force, interval, dashboardId, dispatch).then(
       () => {
         dispatch(onRefreshSuccess());

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -129,7 +129,7 @@ const Tab = props => {
     state => state.dashboardState.tabActivationTimes?.[props.id] || 0,
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
-  
+
   // Track which refresh we've already handled to prevent duplicates
   const handledRefreshRef = useRef(null);
 
@@ -142,11 +142,11 @@ const Tab = props => {
       ) {
         // Create a unique key for this specific refresh
         const refreshKey = `${props.id}-${lastRefreshTime}`;
-        
+
         // Only proceed if we haven't already handled this refresh
         if (handledRefreshRef.current !== refreshKey) {
           handledRefreshRef.current = refreshKey;
-          
+
           const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
           if (chartIds.length > 0) {
             // Use lazy load flag to avoid updating global refresh time

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Fragment, useCallback, memo, useEffect } from 'react';
+import { Fragment, useCallback, memo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
@@ -129,6 +129,9 @@ const Tab = props => {
     state => state.dashboardState.tabActivationTimes?.[props.id] || 0,
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
+  
+  // Track which refresh we've already handled to prevent duplicates
+  const handledRefreshRef = useRef(null);
 
   useEffect(() => {
     if (props.renderType === RENDER_TAB_CONTENT && props.isComponentVisible) {
@@ -137,13 +140,20 @@ const Tab = props => {
         tabActivationTime &&
         lastRefreshTime > tabActivationTime
       ) {
-        const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
-        if (chartIds.length > 0) {
-          requestAnimationFrame(() => {
+        // Create a unique key for this specific refresh
+        const refreshKey = `${props.id}-${lastRefreshTime}`;
+        
+        // Only proceed if we haven't already handled this refresh
+        if (handledRefreshRef.current !== refreshKey) {
+          handledRefreshRef.current = refreshKey;
+          
+          const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
+          if (chartIds.length > 0) {
+            // Use lazy load flag to avoid updating global refresh time
             setTimeout(() => {
-              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id));
+              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id, true));
             }, CHART_MOUNT_DELAY);
-          });
+          }
         }
       }
     }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -541,3 +541,105 @@ test('Should not refresh charts when tab becomes active if no dashboard refresh 
 
   expect(onRefresh).not.toHaveBeenCalled();
 });
+
+test('Should not cause infinite refresh loop with nested tabs - regression test', async () => {
+  jest.clearAllMocks();
+  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
+  getChartIdsFromComponent.mockReset();
+  getChartIdsFromComponent.mockReturnValue([201, 202]);
+
+  const props = createProps();
+  props.renderType = 'RENDER_TAB_CONTENT';
+  props.isComponentVisible = false;
+
+  const initialState = {
+    dashboardState: {
+      lastRefreshTime: Date.now() - 1000, // Dashboard was refreshed recently
+      tabActivationTimes: {
+        'TAB-YT6eNksV-': Date.now() - 5000, // Tab was activated before refresh
+      },
+    },
+    dashboardInfo: {
+      id: 23,
+      dash_edit_perm: true,
+    },
+  };
+
+  const { rerender } = render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState,
+  });
+
+  // Initial state - no refresh should happen
+  expect(onRefresh).not.toHaveBeenCalled();
+
+  // Make tab visible - should trigger ONE refresh
+  rerender(<Tab {...props} isComponentVisible />);
+
+  await waitFor(
+    () => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    },
+    { timeout: 500 },
+  );
+
+  // Clear the mock to track subsequent calls
+  jest.clearAllMocks();
+
+  // REGRESSION TEST: Multiple re-renders should NOT trigger additional refreshes
+  // This simulates the infinite loop scenario that was happening with nested tabs
+  for (let i = 0; i < 5; i++) {
+    rerender(<Tab {...props} isComponentVisible />);
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+
+  expect(onRefresh).not.toHaveBeenCalled();
+});
+
+test('Should use isLazyLoad flag for tab refreshes', async () => {
+  jest.clearAllMocks();
+  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
+  getChartIdsFromComponent.mockReset();
+  getChartIdsFromComponent.mockReturnValue([401, 402]);
+
+  const props = createProps();
+  props.renderType = 'RENDER_TAB_CONTENT';
+  props.isComponentVisible = true;
+
+  const initialState = {
+    dashboardState: {
+      lastRefreshTime: Date.now() - 1000, // Dashboard was refreshed recently
+      tabActivationTimes: {
+        'TAB-YT6eNksV-': Date.now() - 5000, // Tab was activated before refresh
+      },
+    },
+    dashboardInfo: {
+      id: 42,
+      dash_edit_perm: true,
+    },
+  };
+
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState,
+  });
+
+  // Tab should trigger refresh with isLazyLoad = true
+  await waitFor(
+    () => {
+      expect(onRefresh).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  // Verify that isLazyLoad flag is set to true for tab refreshes
+  expect(onRefresh).toHaveBeenCalledWith(
+    [401, 402],
+    true, // force
+    0, // interval
+    42, // dashboardId
+    true, // isLazyLoad should be true to prevent infinite loops
+  );
+});

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -500,6 +500,7 @@ test('Should refresh charts when tab becomes active after dashboard refresh', as
     true, // Force refresh
     0, // Interval
     23, // Dashboard ID
+    true, // isLazyLoad flag
   );
 });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/apache/superset/pull/35265 introduced a bug where refreshing a dashboard with nested tabs would cause infinite rerenders. This pr fixes that bug by introducing a lazy option to dashboard refresh action that doesn't update the global refresh time.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://github.com/user-attachments/assets/f9ccf624-11c2-436e-93e4-06b8d5749141

After:

https://github.com/user-attachments/assets/435f075d-0725-4ec2-8c7d-5ce51003affe



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create a dashboard with nested tabs.
2. Refresh it using Refresh dashboard button on three-dot menu.

This should not cause infinite rerenders.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
