### PR TITLE
fix(redshift): normalize table names to lowercase for CSV uploads

### DIFF
--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -159,6 +159,12 @@ class UploadCommand(BaseCommand):
         if not self._model:
             return
 
+        self._table_name, self._schema = (
+            self._model.db_engine_spec.normalize_table_name_for_upload(
+                self._table_name, self._schema
+            )
+        )
+
         self._reader.read(self._file, self._model, self._table_name, self._schema)
 
         sqla_table = (

--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -1154,6 +1154,26 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
         return None
 
     @classmethod
+    def normalize_table_name_for_upload(
+        cls,
+        table_name: str,
+        schema_name: str | None = None,
+    ) -> tuple[str, str | None]:
+        """
+        Normalize table and schema names for file upload.
+
+        Some databases (e.g., Redshift) fold unquoted identifiers to lowercase,
+        which can cause issues when the upload creates a table with one case
+        but metadata operations use a different case. Override this method
+        to normalize names according to database-specific rules.
+
+        :param table_name: The table name to normalize
+        :param schema_name: The schema name to normalize (optional)
+        :return: Tuple of (normalized_table_name, normalized_schema_name)
+        """
+        return table_name, schema_name
+
+    @classmethod
     def df_to_sql(
         cls,
         database: Database,

--- a/superset/db_engine_specs/redshift.py
+++ b/superset/db_engine_specs/redshift.py
@@ -104,6 +104,24 @@ class RedshiftEngineSpec(BasicParametersMixin, PostgresBaseEngineSpec):
     }
 
     @classmethod
+    def normalize_table_name_for_upload(
+        cls,
+        table_name: str,
+        schema_name: str | None = None,
+    ) -> tuple[str, str | None]:
+        """
+        Redshift folds unquoted identifiers to lowercase.
+
+        :param table_name: The table name to normalize
+        :param schema_name: The schema name to normalize (optional)
+        :return: Tuple of (normalized_table_name, normalized_schema_name)
+        """
+        return (
+            table_name.lower(),
+            schema_name.lower() if schema_name else None,
+        )
+
+    @classmethod
     def df_to_sql(
         cls,
         database: Database,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes an issue where uploading CSV files to Redshift with uppercase table names would report a failure in the UI, even though the table was actually created. The "replace" option also failed completely.

For this solution was added a normalize_table_name_for_upload() method to the base engine spec (no-op default) with a Redshift override that lowercases table and schema names before upload. This ensures consistency between table creation and metadata lookup.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - Backend fix, no UI changes.


### TESTING INSTRUCTIONS

1. Connect to a Redshift database in Superset
2. Go to Data → Upload CSV to Database
3. Select a CSV file and set the table name to something with uppercase characters (e.g., BPO_mytest_2)
4. Click Upload
5. Expected: Upload succeeds without errors
6. Try the "replace" option with the same uppercase table name
7. Expected: Replace succeeds without errors


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
