### PR TITLE
fix(models): prevent SQLAlchemy and_() deprecation warning

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -3206,10 +3206,12 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             )
 
         if granularity:
-            qry = qry.where(and_(*(time_filters + where_clause_and)))
-        else:
+            if time_filters or where_clause_and:
+                qry = qry.where(and_(*(time_filters + where_clause_and)))
+        elif where_clause_and:
             qry = qry.where(and_(*where_clause_and))
-        qry = qry.having(and_(*having_clause_and))
+        if having_clause_and:
+            qry = qry.having(and_(*having_clause_and))
 
         self.make_orderby_compatible(select_exprs, orderby_exprs)
 


### PR DESCRIPTION
### SUMMARY
Fixes SQLAlchemy deprecation warning that occurs when `and_()` is called with no arguments in `get_sqla_query()`.

**Issue:** When `having_clause_and` or `where_clause_and` lists are empty, the code calls `and_()` without arguments, triggering:
```
SADeprecationWarning: Invoking and_() without arguments is deprecated, and will be disallowed in a future release. For an empty and_() construct, use and_(True, *args).
```

**Fix:** Check for non-empty lists before calling `and_()`, matching the pattern already used elsewhere in the same file (lines 2236-2244).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - No UI changes

### TESTING INSTRUCTIONS
1. Run the existing unit tests: `pytest tests/unit_tests/models/helpers_test.py -v`
2. All tests pass including `test_reapply_query_filters_with_empty_filters` which specifically covers this scenario

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API