### PR TITLE
chore: remove deprecated function

### DIFF
--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -76,7 +76,7 @@ def apply_column_types(
                 )
             except ValueError:
                 df[column] = df[column].astype(str)
-        elif pd.api.types.is_datetime64tz_dtype(df[column]):
+        elif isinstance(df[column].dtype, pd.DatetimeTZDtype):
             # timezones are not supported
             df[column] = df[column].astype(str)
     return df


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix this error/warning:

2026-01-07 20:06:29,125| WARNING | /home/superset/preset/superset-oss/superset/utils/excel.py:79: DeprecationWarning: is_datetime64tz_dtype is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.DatetimeTZDtype)` instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
