### PR TITLE
fix(echarts): cap tooltip at 80vh with internal scroll

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/test/tooltip.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/test/tooltip.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @jest-environment jsdom */
+import { getDefaultTooltip } from '../tooltip';
+test('getDefaultTooltip returns correct default properties', () => {
+  const tooltip = getDefaultTooltip({} as any);
+
+  expect(tooltip.enterable).toBe(true);
+  expect(tooltip.confine).toBe(true);
+  expect(tooltip.extraCssText).toContain('max-height:80vh');
+  expect(tooltip.extraCssText).toContain('overflow:auto');
+  expect(tooltip.hideDelay).toBe(50);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/test/tooltip.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/test/tooltip.test.ts
@@ -18,13 +18,51 @@
  */
 
 /** @jest-environment jsdom */
+import '@testing-library/jest-dom';
 import { getDefaultTooltip } from '../tooltip';
-test('getDefaultTooltip returns correct default properties', () => {
-  const tooltip = getDefaultTooltip({} as any);
+import type { Refs } from '../../types';
 
+test('getDefaultTooltip computes height and sets scroll styles', () => {
+  const refs: Refs = {
+    divRef: {
+      current: {
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+      },
+    },
+  } as unknown as Refs;
+
+  // Set viewport dimensions
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    value: 1200,
+    configurable: true,
+  });
+  Object.defineProperty(document.documentElement, 'clientHeight', {
+    value: 1000,
+    configurable: true,
+  });
+
+  const tooltip = getDefaultTooltip(refs);
+
+  // Basic defaults remain
   expect(tooltip.enterable).toBe(true);
   expect(tooltip.confine).toBe(true);
-  expect(tooltip.extraCssText).toContain('max-height:80vh');
-  expect(tooltip.extraCssText).toContain('overflow:auto');
   expect(tooltip.hideDelay).toBe(50);
+
+  // Call position to trigger runtime style application
+  const tooltipDom = document.createElement('div');
+  const result = tooltip.position(
+    [200, 300],
+    {} as any,
+    tooltipDom,
+    {} as any,
+    { contentSize: [300, 600], viewSize: [1200, 1000] },
+  );
+
+  // Height cap: min(800px, 80vh of 1000 => 800) => 800
+  expect(tooltipDom).toHaveStyle('max-height: 800px');
+  expect(tooltipDom).toHaveStyle('overflow: auto');
+  expect(tooltipDom).toHaveStyle('pointer-events: auto');
+  // Position returns a tuple [x, y]
+  expect(Array.isArray(result)).toBe(true);
+  expect(result).toHaveLength(2);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.test.tsx
@@ -72,11 +72,11 @@ test('getDefaultTooltip computes height and sets scroll styles', () => {
     { contentSize: [300, 600], viewSize: [1200, 1000] },
   );
 
-  // Verify position returns coordinate tuple
-  expect(Array.isArray(result)).toBe(true);
-  expect(result).toHaveLength(2);
-  expect(typeof result[0]).toBe('number');
-  expect(typeof result[1]).toBe('number');
+  // Verify the actual computed position, not just its shape. The cursor sits
+  // in the right half of the chart, so the tooltip is placed to its left;
+  // that pushes it past the left edge, so it clamps to the overflow margin.
+  // Vertically it would overflow the top, so it flips to just below the cursor.
+  expect(result).toEqual([5, 310]);
 
   const computedMaxHeight = parseInt(tooltipDom.style.maxHeight, 10);
   const viewportHeight = 1000;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -27,7 +27,7 @@ import {
 import { TOOLTIP_OVERFLOW_MARGIN, TOOLTIP_POINTER_MARGIN } from '../constants';
 import { Refs } from '../types';
 
-const TOOLTIP_Z_INDEX = 2147483647;
+const TOOLTIP_Z_INDEX = 2000;
 
 export function getDefaultTooltip(refs: Refs) {
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -27,7 +27,7 @@ import {
 import { TOOLTIP_OVERFLOW_MARGIN, TOOLTIP_POINTER_MARGIN } from '../constants';
 import { Refs } from '../types';
 
-const TOOLTIP_Z_INDEX = 2000;
+const TOOLTIP_Z_INDEX = 3010;
 
 export function getDefaultTooltip(refs: Refs) {
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -71,8 +71,6 @@ export function getDefaultTooltip(refs: Refs) {
       if (tooltipDom) {
         tooltipDom.style.maxHeight = `${maxAllowedHeight}px`;
         tooltipDom.style.overflow = 'auto';
-        // mobile momentum scrolling
-        tooltipDom.style.setProperty('-webkit-overflow-scrolling', 'touch');
         // ensure interactions within tooltip don't get swallowed
         tooltipDom.style.pointerEvents = 'auto';
       }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -47,51 +47,68 @@ export function getDefaultTooltip(refs: Refs) {
       rect: any,
       sizes: { contentSize: [number, number]; viewSize: [number, number] },
     ) => {
-      // algorithm partially based on this snippet:
+      // Algorithm partially based on this snippet:
       // https://github.com/apache/echarts/issues/5004#issuecomment-559668309
 
-      // The chart canvas position
       const divRect = refs.divRef?.current?.getBoundingClientRect();
-
-      // The mouse coordinates relative to the whole window
       const mouseX = canvasMousePos[0] + (divRect?.x || 0);
       const mouseY = canvasMousePos[1] + (divRect?.y || 0);
-
-      // Available viewport dimensions
       const viewportWidth = document.documentElement.clientWidth;
       const viewportHeight = document.documentElement.clientHeight;
-
-      // The width and height of the tooltip dom element
       const tooltipWidth = sizes.contentSize[0];
       const tooltipHeight = sizes.contentSize[1];
 
-      // Cap tooltip height to the smaller of 800px or 80vh
+      // Cap tooltip height to reduce blocking adjacent elements
       const maxAllowedHeight = Math.min(800, Math.floor(viewportHeight * 0.8));
+      const needsScrolling = tooltipHeight > maxAllowedHeight;
 
       if (tooltipDom) {
         tooltipDom.style.maxHeight = `${maxAllowedHeight}px`;
         tooltipDom.style.overflow = 'auto';
-        // ensure interactions within tooltip don't get swallowed
-        tooltipDom.style.pointerEvents = 'auto';
+        // Only enable pointer events when tooltip is scrollable
+        // This prevents blocking adjacent chart elements when scrolling isn't needed
+        tooltipDom.style.pointerEvents = needsScrolling ? 'auto' : 'none';
       }
 
-      // Use effective height for positioning after applying the cap
       const effectiveTooltipHeight = Math.min(tooltipHeight, maxAllowedHeight);
+      let xPos: number;
+      let yPos: number;
 
-      // Start by placing the tooltip top and right relative to the mouse position
-      let xPos = mouseX + TOOLTIP_POINTER_MARGIN;
-      let yPos = mouseY - TOOLTIP_POINTER_MARGIN - effectiveTooltipHeight;
+      // For scrollable tooltips, position further away horizontally to avoid blocking chart navigation
+      const horizontalMargin = needsScrolling
+        ? TOOLTIP_POINTER_MARGIN * 3
+        : TOOLTIP_POINTER_MARGIN;
 
-      // The tooltip is overflowing past the right edge of the window
-      if (xPos + tooltipWidth >= viewportWidth) {
-        // Attempt to place the tooltip to the left of the mouse position
-        xPos = mouseX - TOOLTIP_POINTER_MARGIN - tooltipWidth;
+      // Determine if cursor is in the right half of the chart to intelligently position tooltip
+      const chartWidth = divRect?.width || viewportWidth;
+      const cursorXInChart = canvasMousePos[0];
+      const isInRightHalfOfChart = cursorXInChart > chartWidth / 2;
 
-        // The tooltip is overflowing past the left edge of the window
-        if (xPos <= 0)
-          // Place the tooltip a fixed distance from the left edge of the window
+      // Position tooltip on the left when in right half, right when in left half
+      // This prevents blocking chart navigation
+      if (isInRightHalfOfChart) {
+        xPos = mouseX - horizontalMargin - tooltipWidth;
+
+        // If tooltip would go off left edge of viewport, push it back in
+        if (xPos <= 0) {
           xPos = TOOLTIP_OVERFLOW_MARGIN;
+        }
+      } else {
+        xPos = mouseX + horizontalMargin;
+
+        // If tooltip would go off right edge of viewport, position on left instead
+        if (xPos + tooltipWidth >= viewportWidth) {
+          xPos = mouseX - horizontalMargin - tooltipWidth;
+
+          // If still overflowing left edge, clamp to margin
+          if (xPos <= 0) {
+            xPos = TOOLTIP_OVERFLOW_MARGIN;
+          }
+        }
       }
+
+      // Position tooltip above cursor, or below if no space
+      yPos = mouseY - TOOLTIP_POINTER_MARGIN - effectiveTooltipHeight;
 
       // The tooltip is overflowing past the top edge of the window
       if (yPos <= 0) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -27,8 +27,6 @@ import {
 import { TOOLTIP_OVERFLOW_MARGIN, TOOLTIP_POINTER_MARGIN } from '../constants';
 import { Refs } from '../types';
 
-const TOOLTIP_Z_INDEX = 3010;
-
 export function getDefaultTooltip(refs: Refs) {
   return {
     appendToBody:
@@ -40,7 +38,6 @@ export function getDefaultTooltip(refs: Refs) {
     enterable: true,
     // keep within viewport and above header; enable internal scroll
     confine: true,
-    extraCssText: `max-height:80vh; overflow:auto; -webkit-overflow-scrolling:touch; pointer-events:auto; z-index:${TOOLTIP_Z_INDEX};`,
     // optional: reduce flicker when moving in/out of tooltip
     hideDelay: 50,
     position: (
@@ -57,20 +54,38 @@ export function getDefaultTooltip(refs: Refs) {
       const divRect = refs.divRef?.current?.getBoundingClientRect();
 
       // The mouse coordinates relative to the whole window
-      // The first parameter to the position function is the mouse position relative to the canvas
       const mouseX = canvasMousePos[0] + (divRect?.x || 0);
       const mouseY = canvasMousePos[1] + (divRect?.y || 0);
+
+      // Available viewport dimensions
+      const viewportWidth = document.documentElement.clientWidth;
+      const viewportHeight = document.documentElement.clientHeight;
 
       // The width and height of the tooltip dom element
       const tooltipWidth = sizes.contentSize[0];
       const tooltipHeight = sizes.contentSize[1];
 
+      // Cap tooltip height to the smaller of 800px or 80vh
+      const maxAllowedHeight = Math.min(800, Math.floor(viewportHeight * 0.8));
+
+      if (tooltipDom) {
+        tooltipDom.style.maxHeight = `${maxAllowedHeight}px`;
+        tooltipDom.style.overflow = 'auto';
+        // mobile momentum scrolling
+        tooltipDom.style.setProperty('-webkit-overflow-scrolling', 'touch');
+        // ensure interactions within tooltip don't get swallowed
+        tooltipDom.style.pointerEvents = 'auto';
+      }
+
+      // Use effective height for positioning after applying the cap
+      const effectiveTooltipHeight = Math.min(tooltipHeight, maxAllowedHeight);
+
       // Start by placing the tooltip top and right relative to the mouse position
       let xPos = mouseX + TOOLTIP_POINTER_MARGIN;
-      let yPos = mouseY - TOOLTIP_POINTER_MARGIN - tooltipHeight;
+      let yPos = mouseY - TOOLTIP_POINTER_MARGIN - effectiveTooltipHeight;
 
       // The tooltip is overflowing past the right edge of the window
-      if (xPos + tooltipWidth >= document.documentElement.clientWidth) {
+      if (xPos + tooltipWidth >= viewportWidth) {
         // Attempt to place the tooltip to the left of the mouse position
         xPos = mouseX - TOOLTIP_POINTER_MARGIN - tooltipWidth;
 
@@ -86,7 +101,7 @@ export function getDefaultTooltip(refs: Refs) {
         yPos = mouseY + TOOLTIP_POINTER_MARGIN;
 
         // The tooltip is overflowing past the bottom edge of the window
-        if (yPos + tooltipHeight >= document.documentElement.clientHeight)
+        if (yPos + effectiveTooltipHeight >= viewportHeight)
           // Place the tooltip a fixed distance from the top edge of the window
           yPos = TOOLTIP_OVERFLOW_MARGIN;
       }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/tooltip.ts
@@ -27,6 +27,8 @@ import {
 import { TOOLTIP_OVERFLOW_MARGIN, TOOLTIP_POINTER_MARGIN } from '../constants';
 import { Refs } from '../types';
 
+const TOOLTIP_Z_INDEX = 2147483647;
+
 export function getDefaultTooltip(refs: Refs) {
   return {
     appendToBody:
@@ -34,6 +36,13 @@ export function getDefaultTooltip(refs: Refs) {
     borderColor: 'transparent',
     // CSS hack applied on this class to resolve https://github.com/apache/superset/issues/30058
     className: 'echarts-tooltip',
+    // allow scrolling inside tooltip without re-triggering the chart
+    enterable: true,
+    // keep within viewport and above header; enable internal scroll
+    confine: true,
+    extraCssText: `max-height:80vh; overflow:auto; -webkit-overflow-scrolling:touch; pointer-events:auto; z-index:${TOOLTIP_Z_INDEX};`,
+    // optional: reduce flicker when moving in/out of tooltip
+    hideDelay: 50,
     position: (
       canvasMousePos: [number, number],
       params: CallbackDataParams,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enforces a viewport-capped height (80vh) with internal scrolling.
Sets a high z-index on the tooltip element to keep it above the header.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![e-chart-tooltip](https://github.com/user-attachments/assets/d3c336f2-934a-4d70-827b-627ca8ea0f6b)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open a dashboard with dense ECharts tooltips.
2. Hover a chart series to show the tooltip with long content.
3. Verify:
    a. Tooltip height is at most 80% of the viewport (80vh).
    b. Internal scroll works inside the tooltip; the chart doesn’t re-trigger on pointer movement into the tooltip.
    c. Tooltip remains above the sticky header (not clipped or hidden).
4. Resize the browser window and re-check the 80vh cap behavior.
5. Test in Chrome, Firefox, and Safari; ensure smooth scrolling (webkit-overflow-scrolling is applied).
6. Run `npm run test -- plugins/plugin-chart-echarts/src/utils/test/tooltip.test.ts` to make sure the tests are passing


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
