### PR TITLE
fix(extensions-cli): fix dev mode error

### DIFF
--- a/superset-extensions-cli/src/superset_extensions_cli/cli.py
+++ b/superset-extensions-cli/src/superset_extensions_cli/cli.py
@@ -363,11 +363,6 @@ def dev(ctx: click.Context) -> None:
     def backend_watcher() -> None:
         if backend_dir.exists():
             rebuild_backend(cwd)
-            dist_dir = cwd / "dist"
-            manifest_path = dist_dir / "manifest.json"
-            if manifest_path.exists():
-                manifest = json.loads(manifest_path.read_text())
-                write_manifest(cwd, manifest)
 
     # Build watch message based on existing directories
     watch_dirs = []

--- a/superset-extensions-cli/tests/test_cli_dev.py
+++ b/superset-extensions-cli/tests/test_cli_dev.py
@@ -216,23 +216,15 @@ def test_frontend_watcher_function_coverage(isolated_filesystem):
 
 @pytest.mark.unit
 def test_backend_watcher_function_coverage(isolated_filesystem):
-    """Test backend watcher function for coverage."""
-    # Create dist directory with manifest
-    dist_dir = isolated_filesystem / "dist"
-    dist_dir.mkdir()
-
-    manifest_data = {"name": "test", "version": "1.0.0"}
-    (dist_dir / "manifest.json").write_text(json.dumps(manifest_data))
+    """Test backend watcher function only rebuilds backend files."""
+    # Create backend directory
+    backend_dir = isolated_filesystem / "backend"
+    backend_dir.mkdir()
 
     with patch("superset_extensions_cli.cli.rebuild_backend") as mock_rebuild:
-        with patch("superset_extensions_cli.cli.write_manifest") as mock_write:
-            # Simulate backend watcher function
+        # Simulate backend watcher function - it only rebuilds backend
+        if backend_dir.exists():
             mock_rebuild(isolated_filesystem)
 
-            manifest_path = dist_dir / "manifest.json"
-            if manifest_path.exists():
-                manifest = json.loads(manifest_path.read_text())
-                mock_write(isolated_filesystem, manifest)
-
-            mock_rebuild.assert_called_once_with(isolated_filesystem)
-            mock_write.assert_called_once()
+        # Backend watcher should only call rebuild_backend
+        mock_rebuild.assert_called_once_with(isolated_filesystem)


### PR DESCRIPTION
### SUMMARY
Dev mode is currently broken for backend changes. The initial build works correctly, but when a backend file changes, an exception is raised:

```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/Users/ville/.pyenv/versions/3.10-dev/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/Users/ville/projects/superset/venv/lib/python3.10/site-packages/watchdog/observers/api.py", line 213, in run
    self.dispatch_events(self.event_queue)
  File "/Users/ville/projects/superset/venv/lib/python3.10/site-packages/watchdog/observers/api.py", line 391, in dispatch_events
    handler.dispatch(event)
  File "/Users/ville/projects/superset/venv/lib/python3.10/site-packages/watchdog/events.py", line 216, in dispatch
    self.on_any_event(event)
  File "/Users/ville/projects/superset/superset-extensions-cli/src/superset_extensions_cli/cli.py", line 393, in <lambda>
    backend_handler.on_any_event = lambda event: backend_watcher()
  File "/Users/ville/projects/superset/superset-extensions-cli/src/superset_extensions_cli/cli.py", line 370, in backend_watcher
    write_manifest(cwd, manifest)
  File "/Users/ville/projects/superset/superset-extensions-cli/src/superset_extensions_cli/cli.py", line 166, in write_manifest
    manifest.model_dump_json(indent=2, exclude_none=True, by_alias=True)
AttributeError: 'dict' object has no attribute 'model_dump_json'
```

This fixes the bug (backend changes don't require manifest changes, only copying the files to the `dist` folder) and updates the associated tests. Now when backend files are changed, we only see this on the command line:

```
✅ Backend files synced
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
