### PR TITLE
fix(extensions): gracefully handle dist directory rebuilding

### DIFF
--- a/superset/extensions/local_extensions_watcher.py
+++ b/superset/extensions/local_extensions_watcher.py
@@ -46,6 +46,10 @@ def _get_file_handler_class() -> Any:
                 if event.is_directory:
                     return
 
+                # Only trigger on changes to files in dist/ directory
+                if "/dist/" not in event.src_path:
+                    return
+
                 logger.info(
                     "File change detected in LOCAL_EXTENSIONS: %s", event.src_path
                 )
@@ -80,7 +84,9 @@ def setup_local_extensions_watcher(app: Flask) -> None:  # noqa: C901
     if not handler_class:
         return
 
-    # Collect dist directories to watch
+    # Collect extension directories to watch
+    # We watch the parent extension directory instead of just dist/
+    # to avoid the observer stopping when dist/ is deleted/recreated
     watch_dirs = []
     for ext_path in local_extensions:
         if not ext_path:
@@ -91,9 +97,8 @@ def setup_local_extensions_watcher(app: Flask) -> None:  # noqa: C901
             logger.warning("LOCAL_EXTENSIONS path does not exist: %s", ext_path)
             continue
 
-        dist_path = ext_path / "dist"
-        watch_dirs.append(str(dist_path))
-        logger.info("Watching LOCAL_EXTENSIONS dist directory: %s", dist_path)
+        watch_dirs.append(str(ext_path))
+        logger.info("Watching LOCAL_EXTENSIONS directory: %s", ext_path)
 
     if not watch_dirs:
         return

--- a/superset/extensions/local_extensions_watcher.py
+++ b/superset/extensions/local_extensions_watcher.py
@@ -46,8 +46,9 @@ def _get_file_handler_class() -> Any:
                 if event.is_directory:
                     return
 
-                # Only trigger on changes to files in dist/ directory
-                if "/dist/" not in event.src_path:
+                # Only trigger on changes to files in `dist` directory
+                src = getattr(event, "src_path", None)
+                if not isinstance(src, str) or "dist" not in Path(src).parts:
                     return
 
                 logger.info(


### PR DESCRIPTION
### SUMMARY
Currently the `LOCAL_EXTENSIONS` reloader stops working correctly if the `dist` folder is deleted with the following log:
```
2026-01-09 16:10:51,747:DEBUG:fsevents:Stopping because root path was changed
```

The proposed fix here does the following:
1. Watches the root of the extension folder
2. Ignores changes other than those affecting files in the `dist` folder

With these changes, the reloader works correctly with `build` and `dev` mode:

```
2026-01-09 16:47:30,552:INFO:superset.extensions.local_extensions_watcher:File change detected in LOCAL_EXTENSIONS: /Users/ville/projects/superset-extensions/helloworld/dist/backend/src/helloworld/mcp.py
2026-01-09 16:47:30,552:INFO:superset.extensions.local_extensions_watcher:Triggering restart by touching superset/__init__.py
```

We also implement an improvement suggested by AI to both validate that a local extension reference is indeed a directory, and deduplicate it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
