### PR TITLE
fix(chart): implement geohash decoding

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.test.ts
@@ -69,6 +69,37 @@ describe('Polygon transformProps', () => {
     emitCrossFilters: false,
   };
 
+  const mockedChartPropsWithGeoHash: Partial<ChartProps> = {
+    ...mockChartProps,
+    rawFormData: {
+      line_column: 'geohash',
+      line_type: 'geohash',
+      viewport: {},
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            geohash: '9q8yt',
+            'sum(population)': 9800,
+          },
+          {
+            geohash: '9q8yk',
+            'sum(population)': 13100,
+          },
+          {
+            geohash: '9q8yv',
+            'sum(population)': 15600,
+          },
+          {
+            geohash: '9q8yq',
+            'sum(population)': 7500,
+          },
+        ],
+      },
+    ],
+  };
+
   test('should use constant elevation value when point_radius_fixed type is "fix"', () => {
     const fixProps = {
       ...mockChartProps,
@@ -256,5 +287,24 @@ describe('Polygon transformProps', () => {
     const features = result.payload.data.features as PolygonFeature[];
     expect(features).toHaveLength(1);
     expect(features[0]?.elevation).toBeUndefined();
+  });
+
+  test('should handle geohash decoding successfully', () => {
+    const props = {
+      ...mockedChartPropsWithGeoHash,
+      rawFormData: {
+        ...mockedChartPropsWithGeoHash.rawFormData,
+        point_radius_fixed: {
+          type: 'fix',
+          value: '1000',
+        },
+      },
+    };
+
+    const result = transformProps(props as ChartProps);
+
+    const features = result.payload.data.features as PolygonFeature[];
+    expect(features.flatMap(p => p?.polygon || [])).toHaveLength(20); // 4 geohashes x 5 corners each
+    expect(features[0]?.elevation).toBe(1000);
   });
 });

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Polygon/transformProps.ts
@@ -26,6 +26,7 @@ import {
   addPropertiesToFeature,
 } from '../transformUtils';
 import { DeckPolygonFormData } from './buildQuery';
+import { decode_bbox } from 'ngeohash';
 
 function parseElevationValue(value: string): number | undefined {
   const parsed = parseFloat(value);
@@ -122,6 +123,16 @@ function processPolygonData(
             break;
           }
           case 'geohash':
+            polygonCoords = [];
+            const decoded = decode_bbox(String(rawPolygonData));
+            if (decoded) {
+              polygonCoords.push([decoded[1], decoded[0]]); // SW (minLon, minLat)
+              polygonCoords.push([decoded[1], decoded[2]]); // NW (minLon, maxLat)
+              polygonCoords.push([decoded[3], decoded[2]]); // NE (maxLon, maxLat)
+              polygonCoords.push([decoded[3], decoded[0]]); // SE (maxLon, minLat)
+              polygonCoords.push([decoded[1], decoded[0]]); // SW (close polygon)
+            }
+            break;
           case 'zipcode':
           default: {
             polygonCoords = Array.isArray(rawPolygonData) ? rawPolygonData : [];


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Implemented `geohash` decoding that was missing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

BEFORE

<img width="1909" height="857" alt="geohash_decoding" src="https://github.com/user-attachments/assets/1d0aa27d-59bf-4bb1-8810-cac627efb583" />

<img width="1641" height="774" alt="image" src="https://github.com/user-attachments/assets/2cae1678-4a4d-4ae0-aca6-c4c6a47a4711" />

AFTER

<img width="1419" height="840" alt="Screenshot 2026-01-10 at 1 01 30 AM" src="https://github.com/user-attachments/assets/b7affcf3-8fad-4490-968e-66fef99cb864" />

<img width="1433" height="813" alt="Screenshot 2026-01-10 at 1 01 15 AM" src="https://github.com/user-attachments/assets/ad55f727-433f-4f6f-bf1b-77b065b6d4b3" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Create a virtual dataset with below SQL query:
    ```
    SELECT '9q8yy' AS geohash, 150 AS value, 'residential' AS category, 12500 AS population UNION ALL
    SELECT '9q8yz', 230, 'commercial', 8200 UNION ALL
    SELECT '9q8yv', 180, 'residential', 15600 UNION ALL
    SELECT '9q8yw', 95, 'industrial', 3200 UNION ALL
    SELECT '9q8yt', 210, 'commercial', 9800 UNION ALL
    SELECT '9q8ys', 175, 'residential', 11200 UNION ALL
    SELECT '9q8yu', 88, 'park', 500 UNION ALL
    SELECT '9q8yn', 145, 'residential', 10800 UNION ALL
    SELECT '9q8yq', 260, 'commercial', 7500 UNION ALL
    SELECT '9q8yr', 120, 'mixed', 6300 UNION ALL
    SELECT '9q8yp', 200, 'residential', 14200 UNION ALL
    SELECT '9q8yj', 165, 'commercial', 8900 UNION ALL
    SELECT '9q8ym', 110, 'industrial', 4100 UNION ALL
    SELECT '9q8yk', 195, 'residential', 13100 UNION ALL
    SELECT '9q8yh', 140, 'mixed', 7200
    ```
2. Use this dataset to create a `deck.gl Polygon chart`. Set the encoding to `geohash (square)` and the metric as `sum(population)`.
3. Click on Create chart.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
