### PR TITLE
docs(exploring-data): add overview to tutorial

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -7,7 +7,6 @@ version: 1
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-## Exploring Data in Superset
 
 ## Exploring Data in Superset
 

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -7,7 +7,6 @@ version: 1
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-
 ## Exploring Data in Superset
 
 Apache Superset enables users to explore data interactively through SQL queries, visual query builders, and rich visualizations, making it easier to understand datasets before building charts and dashboards.

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -9,8 +9,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 ## Exploring Data in Superset
 
-In this tutorial, we will introduce key concepts in Apache Superset through the exploration of a
-real dataset which contains the flights made by employees of a UK-based organization in 2011. The
+Apache Superset enables users to explore data interactively through SQL queries, visual query builders, and rich visualizations, making it easier to understand datasets before building charts and dashboards.
+This contains the flights made by employees of a UK-based organization in 2011. The
 following information about each flight is given:
 
 - The traveler’s department. For the purposes of this tutorial the departments have been renamed

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -9,9 +9,13 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 ## Exploring Data in Superset
 
+## Exploring Data in Superset
+
 Apache Superset enables users to explore data interactively through SQL queries, visual query builders, and rich visualizations, making it easier to understand datasets before building charts and dashboards.
-This contains the flights made by employees of a UK-based organization in 2011. The
-following information about each flight is given:
+
+In this tutorial, we will introduce key concepts in Apache Superset through the exploration of a real dataset which contains the flights made by employees of a UK-based organization in 2011.
+
+The following information about each flight is given:
 
 - The traveler’s department. For the purposes of this tutorial the departments have been renamed
   Orange, Yellow and Purple.


### PR DESCRIPTION
### SUMMARY
Adds a brief high-level overview at the start of the “Exploring Data in Superset” tutorial while preserving the original introduction.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable (documentation-only change).

### TESTING INSTRUCTIONS
1. Open the “Exploring Data in Superset” documentation page.
2. Verify that a short overview appears before the tutorial steps.
3. Confirm the original tutorial introduction is still present.

### ADDITIONAL INFORMATION
- [x] This PR contains documentation changes only.