### PR TITLE
docs(inthewild): Dark mode issues on InTheWild page

### DIFF
--- a/docs/src/pages/inTheWild.tsx
+++ b/docs/src/pages/inTheWild.tsx
@@ -102,7 +102,7 @@ export default function InTheWild() {
               return {
                 key: category,
                 label: (
-                  <Text strong style={{ fontSize: 16, lineHeight: '22px' }}>
+                  <Text strong style={{ fontSize: 16, lineHeight: '22px', color: 'var(--ifm-font-color-base)' }}>
                     {category} ({items.length})
                   </Text>
                 ),

--- a/docs/src/pages/inTheWild.tsx
+++ b/docs/src/pages/inTheWild.tsx
@@ -102,7 +102,7 @@ export default function InTheWild() {
               return {
                 key: category,
                 label: (
-                  <Text strong style={{ fontSize: 16, lineHeight: '22px', color: 'var(--ifm-font-color-base)' }}>
+                  <Text strong style={{ fontSize: 16, lineHeight: '22px', color: 'var(--ifm-font-base-color)' }}>
                     {category} ({items.length})
                   </Text>
                 ),

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -176,9 +176,9 @@ ul.dropdown__menu svg {
 
 /* Fix Ant Design Collapse arrow visibility in dark mode */
 [data-theme='dark'] .ant-collapse-expand-icon {
-  color: var(--ifm-font-color-base);
+  color: var(--ifm-font-base-color);
 }
 
 [data-theme='dark'] .ant-collapse-header {
-  color: var(--ifm-font-color-base);
+  color: var(--ifm-font-base-color);
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -173,3 +173,12 @@ ul.dropdown__menu svg {
 [data-theme='dark'] .alert--resources a {
   color: var(--ifm-color-primary-light);
 }
+
+/* Fix Ant Design Collapse arrow visibility in dark mode */
+[data-theme='dark'] .ant-collapse-expand-icon {
+  color: var(--ifm-font-color-base);
+}
+
+[data-theme='dark'] .ant-collapse-header {
+  color: var(--ifm-font-color-base);
+}


### PR DESCRIPTION
### SUMMARY
Section titles and arrows were using dark fonts/colors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**
<img width="1916" height="960" alt="Screenshot 2026-01-11 at 13 16 45" src="https://github.com/user-attachments/assets/3f982d91-aa5b-4363-958d-737a19b58d8e" />
**After:**
<img width="1919" height="1049" alt="Screenshot 2026-01-11 at 13 16 54" src="https://github.com/user-attachments/assets/72373b69-9aee-4414-b332-d061d55d5f66" />


### TESTING INSTRUCTIONS
Run docs app locally.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
