### PR TITLE
fix(table): preserve line breaks in cell content modal

### DIFF
--- a/superset-frontend/src/components/JsonModal/index.tsx
+++ b/superset-frontend/src/components/JsonModal/index.tsx
@@ -30,9 +30,8 @@ import type { JsonModalProps } from './types';
  * Preserve line breaks for multiline cell content (e.g. stack traces)
  * while keeping the change scoped to this component only.
  */
-const PreWrap = styled.pre`
+const PreWrap = styled.span`
   white-space: pre-wrap;
-  margin: 0;
 `;
 
 function renderBigIntStrToNumber(value: string | number) {

--- a/superset-frontend/src/components/JsonModal/index.tsx
+++ b/superset-frontend/src/components/JsonModal/index.tsx
@@ -17,31 +17,23 @@
  * under the License.
  */
 
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 import { FC, useMemo } from 'react';
 import { JSONTree } from 'react-json-tree';
+import { styled } from '@apache-superset/core/ui';
 import { useJsonTreeTheme } from 'src/hooks/useJsonTreeTheme';
 import { Button, ModalTrigger } from '@superset-ui/core/components';
 import { CopyToClipboard } from '../CopyToClipboard';
 import { convertBigIntStrToNumber } from './utils';
 import type { JsonModalProps } from './types';
+
+/**
+ * Preserve line breaks for multiline cell content (e.g. stack traces)
+ * while keeping the change scoped to this component only.
+ */
+const PreWrap = styled.pre`
+  white-space: pre-wrap;
+  margin: 0;
+`;
 
 function renderBigIntStrToNumber(value: string | number) {
   return <>{convertBigIntStrToNumber(value)}</>;
@@ -53,6 +45,7 @@ export const JsonModal: FC<JsonModalProps> = ({
   jsonValue,
 }) => {
   const jsonTreeTheme = useJsonTreeTheme();
+
   const content = useMemo(
     () =>
       typeof jsonValue === 'object' ? JSON.stringify(jsonValue) : jsonValue,
@@ -74,7 +67,7 @@ export const JsonModal: FC<JsonModalProps> = ({
         </Button>
       }
       modalTitle={modalTitle}
-      triggerNode={<>{content}</>}
+      triggerNode={<PreWrap>{content}</PreWrap>}
     />
   );
 };


### PR DESCRIPTION
### SUMMARY
Preserves line breaks when displaying multiline cell content (such as stack traces) in the Cell Content modal.

Previously, newline characters in cell values were collapsed, causing multiline text to render as a single line. This change wraps the modal trigger content in a styled component with `white-space: pre-wrap`, ensuring line breaks are rendered correctly while keeping the fix scoped to this specific use case.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
1. Open a table or results view in Explore.
2. Click on a cell containing multiline text (e.g. a stack trace with newlines).
3. Verify that line breaks are preserved in the Cell Content modal.
4. Confirm that other modals remain unaffected.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #36904
- [ ] Required feature flags
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
