### PR TITLE
fix(table): keep d3-format semantics when applying currency formatting

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
@@ -60,7 +60,11 @@ class CurrencyFormatter extends ExtensibleFunction {
   }
 
   getNormalizedD3Format() {
-    return this.d3Format.replace(/\$|%/g, '');
+    return this.d3Format.replaceAll('$', '');
+  }
+
+  normalizeForCurrency(value: string) {
+    return value.replaceAll('%', '');
   }
 
   format(value: number) {
@@ -71,10 +75,11 @@ class CurrencyFormatter extends ExtensibleFunction {
       return formattedValue as string;
     }
 
+    const normalizedValue = this.normalizeForCurrency(formattedValue);
     if (this.currency.symbolPosition === 'prefix') {
-      return `${getCurrencySymbol(this.currency)} ${formattedValue}`;
+      return `${getCurrencySymbol(this.currency)} ${normalizedValue}`;
     }
-    return `${formattedValue} ${getCurrencySymbol(this.currency)}`;
+    return `${normalizedValue} ${getCurrencySymbol(this.currency)}`;
   }
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/currency-format/CurrencyFormatter.ts
@@ -60,11 +60,11 @@ class CurrencyFormatter extends ExtensibleFunction {
   }
 
   getNormalizedD3Format() {
-    return this.d3Format.replaceAll('$', '');
+    return this.d3Format.replace(/\$/g, '');
   }
 
   normalizeForCurrency(value: string) {
-    return value.replaceAll('%', '');
+    return value.replace(/%/g, '');
   }
 
   format(value: number) {

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
@@ -109,7 +109,9 @@ test('CurrencyFormatter:getNormalizedD3Format', () => {
     currency: { symbol: 'USD', symbolPosition: 'prefix' },
     d3Format: ',.1%',
   });
-  expect(currencyFormatter4.getNormalizedD3Format()).toEqual(',.1');
+  expect(currencyFormatter4.getNormalizedD3Format()).toEqual(
+    currencyFormatter4.d3Format,
+  );
 });
 
 test('CurrencyFormatter:format', () => {
@@ -146,9 +148,9 @@ test('CurrencyFormatter:format', () => {
 
   const currencyFormatterWithPercentD3 = new CurrencyFormatter({
     currency: { symbol: 'USD', symbolPosition: 'prefix' },
-    d3Format: ',.1f%',
+    d3Format: ',.1%',
   });
-  expect(currencyFormatterWithPercentD3(VALUE)).toEqual('$ 56,100,057.0');
+  expect(currencyFormatterWithPercentD3(VALUE)).toEqual('$ 5,610,005,700.0');
 
   const currencyFormatterWithCurrencyD3 = new CurrencyFormatter({
     currency: { symbol: 'PLN', symbolPosition: 'suffix' },

--- a/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/currency-format/CurrencyFormatter.test.ts
@@ -109,9 +109,7 @@ test('CurrencyFormatter:getNormalizedD3Format', () => {
     currency: { symbol: 'USD', symbolPosition: 'prefix' },
     d3Format: ',.1%',
   });
-  expect(currencyFormatter4.getNormalizedD3Format()).toEqual(
-    currencyFormatter4.d3Format,
-  );
+  expect(currencyFormatter4.getNormalizedD3Format()).toEqual(',.1%');
 });
 
 test('CurrencyFormatter:format', () => {


### PR DESCRIPTION
### SUMMARY
This PR fixes an issue where applying a currency formatter breaks the underlying **d3-format** behavior.

Previously, the currency formatter took precedence by modifying the d3 format string itself—replacing symbols like `$` and `%` to later include the custom currency prefix or suffix. While removing `$` from the format string is generally safe, removing `%` alters the semantics of the formatter.

For example, given the value `123.21`:
- Using the d3 format `.2%`:
  → `12321.00%` (percentage formatting: value × 100)
- If `%` is removed and the format becomes `.2`
  → `1.2e+2` (significant-digits formatting, scientific notation)

The correct approach is therefore to preserve the original D3 format string for numeric semantics (especially `%`) and apply currency customization only to the formatted output. This PR keeps `%` in the D3 format to maintain correct behavior, while safely handling currency symbols without breaking D3’s formatting logic.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE:
<img width="1336" height="726" alt="image" src="https://github.com/user-attachments/assets/a8c9412f-2215-4224-8a82-dfccee25a30a" />

#### AFTER:
<img width="1333" height="727" alt="image" src="https://github.com/user-attachments/assets/964ab24b-e757-4cf0-bc4d-76a349bd5d64" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Create a table chart.
- Add a number column to the chart.
- Under the Customize tab, edit the number formatting of one of the number columns.
- Change the D3 format to a percentage format, for example `,.1%`.
- Under the currency format, select either a prefix or a suffix.
- Verify that the D3 format does not break.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
