### PR TITLE
fix(dashboard-import): dashboard import fails with keyerror when referencing deleted charts in expanded_slices metadata

### DIFF
--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -75,7 +75,9 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
     metadata = fixed.get("metadata", {})
     if "timed_refresh_immune_slices" in metadata:
         metadata["timed_refresh_immune_slices"] = [
-            id_map[old_id] for old_id in metadata["timed_refresh_immune_slices"]
+            id_map[old_id]
+            for old_id in metadata["timed_refresh_immune_slices"]
+            if old_id in id_map
         ]
 
     if "filter_scopes" in metadata:
@@ -100,6 +102,7 @@ def update_id_refs(  # pylint: disable=too-many-locals  # noqa: C901
         metadata["expanded_slices"] = {
             str(id_map[int(old_id)]): value
             for old_id, value in metadata["expanded_slices"].items()
+            if int(old_id) in id_map
         }
 
     if "default_filters" in metadata:


### PR DESCRIPTION
### SUMMARY

This PR fixes a critical bug where dashboard imports fail with a `KeyError` when the exported dashboard contains references to deleted charts in its metadata.

**Problem:**
When a chart is deleted from Superset, the dashboard metadata (specifically `expanded_slices`, `timed_refresh_immune_slices`, and other metadata fields) retains references to the deleted chart IDs. When these dashboards are exported and then imported into another workspace, the import process crashes with a `KeyError` and displays a generic error message: "Import dashboard failed for an unknown reason."

**Root Cause:**
The `update_id_refs()` function in `superset/commands/dashboard/importers/v1/utils.py` attempted to map all chart IDs from the metadata without checking if the charts exist in the import, causing a `KeyError` when encountering deleted chart references.

**Solution:**
1. Modified `update_id_refs()` to gracefully skip missing chart references in `expanded_slices` and `timed_refresh_immune_slices` metadata fields, consistent with how other metadata fields (`filter_scopes`, `default_filters`, `native_filter_configuration`) already handle missing charts.

2.  Added `_cleanup_dashboard_metadata()` method to `DeleteChartCommand` that automatically cleans up all dashboard metadata when a chart is deleted, preventing orphaned references from being created in the first place.

**Changes:**
- Modified `superset/commands/dashboard/importers/v1/utils.py`:
  - Added `if int(old_id) in id_map` check to `expanded_slices` processing (line 105)
  - Added `if old_id in id_map` check to `timed_refresh_immune_slices` processing (line 80)

- Modified `superset/commands/chart/delete.py`:
  - Added `_cleanup_dashboard_metadata()` method to remove chart references from dashboard metadata on deletion
  - Cleans up: `expanded_slices`, `timed_refresh_immune_slices`, `filter_scopes`, `default_filters`, `native_filter_configuration`, `chart_configuration`, and `global_chart_configuration`

- Added comprehensive unit tests in `tests/unit_tests/dashboards/commands/importers/v1/utils_test.py`:
  - `test_update_id_refs_expanded_slices_with_missing_chart()`
  - `test_update_id_refs_timed_refresh_immune_slices_with_missing_chart()`
  - `test_update_id_refs_multiple_missing_chart_references()`


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE: 

AFTER:


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
