### PR TITLE
fix(datasets): ui bug fixes

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
@@ -99,6 +99,15 @@ const Description = styled.p<{ size: EmptyStateSize }>`
   `}
 `;
 
+const sizeOrder: Record<EmptyStateSize, number> = {
+  small: 0,
+  medium: 1,
+  large: 2,
+};
+
+const getLargerSize = (a: EmptyStateSize, b: EmptyStateSize): EmptyStateSize =>
+  sizeOrder[a] >= sizeOrder[b] ? a : b;
+
 const getImageHeight = (size: EmptyStateSize) => {
   switch (size) {
     case 'small':
@@ -148,41 +157,49 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   buttonIcon,
   buttonAction,
   size = 'medium',
+  textSize,
   children,
-}) => (
-  <EmptyStateContainer>
-    {image && <ImageContainer image={image} size={size} />}
-    <div
-      css={(theme: SupersetTheme) => css`
-        max-width: ${size === 'large'
-          ? theme.sizeUnit * 150
-          : theme.sizeUnit * 100}px;
-      `}
-    >
-      {title && <Title size={size}>{title}</Title>}
-      {description && (
-        <Description size={size} className="ant-empty-description">
-          {description}
-        </Description>
-      )}
-      {buttonText && buttonAction && (
-        <Button
-          icon={buttonIcon}
-          buttonStyle="primary"
-          onClick={buttonAction}
-          onMouseDown={handleMouseDown}
-          css={(theme: SupersetTheme) => css`
-            margin-top: ${theme.sizeUnit * 4}px;
-            z-index: 1;
-            box-shadow: none;
-          `}
-        >
-          {buttonText}
-        </Button>
-      )}
-      {children}
-    </div>
-  </EmptyStateContainer>
-);
+}) => {
+  const effectiveTextSize = textSize ?? size;
+  const containerSize = getLargerSize(size, effectiveTextSize);
+  return (
+    <EmptyStateContainer>
+      {image && <ImageContainer image={image} size={size} />}
+      <div
+        css={(theme: SupersetTheme) => css`
+          max-width: ${containerSize === 'large'
+            ? theme.sizeUnit * 150
+            : theme.sizeUnit * 100}px;
+        `}
+      >
+        {title && <Title size={effectiveTextSize}>{title}</Title>}
+        {description && (
+          <Description
+            size={effectiveTextSize}
+            className="ant-empty-description"
+          >
+            {description}
+          </Description>
+        )}
+        {buttonText && buttonAction && (
+          <Button
+            icon={buttonIcon}
+            buttonStyle="primary"
+            onClick={buttonAction}
+            onMouseDown={handleMouseDown}
+            css={(theme: SupersetTheme) => css`
+              margin-top: ${theme.sizeUnit * 4}px;
+              z-index: 1;
+              box-shadow: none;
+            `}
+          >
+            {buttonText}
+          </Button>
+        )}
+        {children}
+      </div>
+    </EmptyStateContainer>
+  );
+};
 
 export type { EmptyStateProps };

--- a/superset-frontend/packages/superset-ui-core/src/components/EmptyState/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/EmptyState/types.ts
@@ -28,6 +28,9 @@ export type EmptyStateProps = {
   buttonText?: ReactNode;
   buttonIcon?: IconType;
   buttonAction?: (event: SyntheticEvent) => void;
+  /** Controls image size. Defaults to 'medium'. */
   size?: EmptyStateSize;
+  /** Controls title and description text size. Defaults to the value of `size` if not provided. */
+  textSize?: EmptyStateSize;
   children?: ReactNode;
 };

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -49,15 +49,13 @@ interface StyledHeaderProps {
   position: EPosition;
 }
 
-const LOADER_WIDTH = 120;
-const SPINNER_WIDTH = 40;
-const TEXT_WIDTH = 150;
-const HALF = 0.5;
 const MARGIN_MULTIPLIER = 3;
 
 const StyledHeader = styled.div<StyledHeaderProps>`
   ${({ theme, position }) => `
   position: ${position};
+  display: flex;
+  align-items: center;
   margin: ${theme.sizeUnit * (MARGIN_MULTIPLIER + 1)}px
     ${theme.sizeUnit * MARGIN_MULTIPLIER}px
     ${theme.sizeUnit * MARGIN_MULTIPLIER}px
@@ -72,7 +70,6 @@ const StyledHeader = styled.div<StyledHeaderProps>`
 
   .anticon:first-of-type {
     margin-right: ${theme.sizeUnit * 2}px;
-    vertical-align: text-top;
   }
 
   `}
@@ -105,16 +102,11 @@ const LoaderContainer = styled.div`
 
 const StyledLoader = styled.div`
   ${({ theme }) => `
-  max-width: 50%;
-  width: ${LOADER_WIDTH}px;
-
-  .ant-image {
-    width: ${SPINNER_WIDTH}px;
-    margin-left: ${(LOADER_WIDTH - SPINNER_WIDTH) * HALF}px;
-  }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   div {
-    width: ${TEXT_WIDTH}px;
     margin-top: ${theme.sizeUnit * MARGIN_MULTIPLIER}px;
     text-align: center;
     font-weight: ${theme.fontWeightNormal};
@@ -269,7 +261,7 @@ const DatasetPanel = ({
     loader = (
       <LoaderContainer>
         <StyledLoader>
-          <Loading position="inline-centered" />
+          <Loading position="inline-centered" size="m" />
           <div>{REFRESHING}</div>
         </StyledLoader>
       </LoaderContainer>

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.tsx
@@ -49,8 +49,9 @@ interface StyledHeaderProps {
   position: EPosition;
 }
 
-const LOADER_WIDTH = 200;
-const SPINNER_WIDTH = 120;
+const LOADER_WIDTH = 120;
+const SPINNER_WIDTH = 40;
+const TEXT_WIDTH = 150;
 const HALF = 0.5;
 const MARGIN_MULTIPLIER = 3;
 
@@ -61,7 +62,7 @@ const StyledHeader = styled.div<StyledHeaderProps>`
     ${theme.sizeUnit * MARGIN_MULTIPLIER}px
     ${theme.sizeUnit * MARGIN_MULTIPLIER}px
     ${theme.sizeUnit * (MARGIN_MULTIPLIER + 3)}px;
-  font-size: ${theme.sizeUnit * 6}px;
+  font-size: ${theme.sizeUnit * 5}px;
   font-weight: ${theme.fontWeightStrong};
   padding-bottom: ${theme.sizeUnit * MARGIN_MULTIPLIER}px;
 
@@ -113,11 +114,11 @@ const StyledLoader = styled.div`
   }
 
   div {
-    width: 100%;
+    width: ${TEXT_WIDTH}px;
     margin-top: ${theme.sizeUnit * MARGIN_MULTIPLIER}px;
     text-align: center;
     font-weight: ${theme.fontWeightNormal};
-    font-size: ${theme.fontSizeLG}px;
+    font-size: ${theme.fontSize}px;
     color: ${theme.colorTextSecondary};
   }
   `}
@@ -331,7 +332,7 @@ const DatasetPanel = ({
             }
             title={tableName || ''}
           >
-            <Icons.InsertRowAboveOutlined iconSize="xxl" />
+            <Icons.InsertRowAboveOutlined iconSize="xl" />
             {tableName}
           </StyledHeader>
         </>

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/MessageContent.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/MessageContent.tsx
@@ -94,7 +94,8 @@ export const MessageContent = (props: MessageContentProps) => {
     <StyledContainer>
       <StyledEmptyState
         image={currentImage}
-        size="large"
+        size="medium"
+        textSize="large"
         title={currentTitle}
         description={currentDescription}
       />


### PR DESCRIPTION
### SUMMARY

This PR addresses the following issues: 
1.Blank state grid icon is too large
2.Spinner is huge
3.When there is an error/no columns, the icon is too large
4.The icon and table name are too large. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
<img width="1710" height="932" alt="image" src="https://github.com/user-attachments/assets/5c57d545-1d15-449b-a953-59e797190480" />

#### AFTER
<img width="1708" height="931" alt="image" src="https://github.com/user-attachments/assets/f9736736-3781-4faa-bd0c-24e485227c8a" />

#### BEFORE
<img width="1703" height="926" alt="image" src="https://github.com/user-attachments/assets/758363a0-29b2-405f-a960-15581d89d76f" />

#### AFTER
<img width="1708" height="925" alt="image" src="https://github.com/user-attachments/assets/96e180fd-deaf-444c-ac2a-221fe5104b4f" />

#### BEFORE
<img width="1710" height="932" alt="image" src="https://github.com/user-attachments/assets/c72a9945-8508-4812-a6bf-509f4c2654cf" />

#### AFTER
<img width="1710" height="930" alt="image" src="https://github.com/user-attachments/assets/70954861-3071-4322-b4a8-cc3ea8599ca1" />

#### BEFORE
<img width="1709" height="928" alt="image" src="https://github.com/user-attachments/assets/ecb175eb-e118-49a4-932a-34e890b55dc5" />

#### AFTER
<img width="1705" height="924" alt="image" src="https://github.com/user-attachments/assets/156ea1f6-d423-4731-a7b8-5f7cd0463ea4" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
