### PR TITLE
fix(dashboard): hide out-of-scope native filters for sub-tabs

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -1095,3 +1095,43 @@ test('useIsFilterInScope: nested Tabs mounted under hideTab:true — outer ances
   // TAB-Outer2 is not in the active path → out of scope, scoping preserved.
   expect(result.current(otherOuterFilter)).toBe(false);
 });
+
+test('useSelectFiltersInScope should hide tab-scoped filters when a sibling tab is active', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB_PARENT', 'SUB_TAB_A'] },
+      dashboardLayout: {
+        present: {
+          TAB_PARENT: { type: 'TAB', id: 'TAB_PARENT' },
+          SUB_TAB_A: { type: 'TAB', id: 'SUB_TAB_A' },
+          SUB_TAB_B: { type: 'TAB', id: 'SUB_TAB_B' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filters: Filter[] = [
+    {
+      id: 'filter_sub_tab_b',
+      name: 'Sub-tab B Filter',
+      filterType: 'filter_select',
+      type: NativeFilterType.NativeFilter,
+      scope: { rootPath: ['SUB_TAB_B'], excluded: [] },
+      controlValues: {},
+      defaultDataMask: {},
+      cascadeParentIds: [],
+      targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+      description: 'Filter scoped to sub-tab B',
+    },
+  ];
+
+  const { result } = renderHook(() => useSelectFiltersInScope(filters));
+
+  // The filter should NOT be in scope
+  expect(result.current[0]).not.toContainEqual(
+    expect.objectContaining({ id: 'filter_sub_tab_b' }),
+  );
+  // The filter should NOT be in "out of scope" (it should be hidden)
+  expect(result.current[1]).toHaveLength(0);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -316,6 +316,7 @@ export function useIsFilterInScope() {
 
 export function useSelectFiltersInScope(filters: (Filter | Divider)[]) {
   const dashboardHasTabs = useDashboardHasTabs();
+  const dashboardLayout = useDashboardLayout();
   const isFilterInScope = useIsFilterInScope();
 
   return useMemo(() => {
@@ -332,12 +333,26 @@ export function useSelectFiltersInScope(filters: (Filter | Divider)[]) {
         if (filterInScope) {
           filtersInScope.push(filter);
         } else {
-          filtersOutOfScope.push(filter);
+          // Hide tab-scoped filters when their tab exists but is not active.
+          // Show in "Out of Scope" if it's a global filter or scoped to non-existent tabs.
+          const hasExplicitTabScope =
+            filter.type !== NativeFilterType.Divider &&
+            filter.scope?.rootPath &&
+            filter.scope.rootPath.length > 0 &&
+            filter.scope.rootPath.some(
+              id =>
+                id !== DASHBOARD_ROOT_ID &&
+                dashboardLayout[id]?.type === TAB_TYPE,
+            );
+
+          if (!hasExplicitTabScope) {
+            filtersOutOfScope.push(filter);
+          }
         }
       });
     }
     return [filtersInScope, filtersOutOfScope];
-  }, [filters, dashboardHasTabs, isFilterInScope]);
+  }, [filters, dashboardHasTabs, dashboardLayout, isFilterInScope]);
 }
 
 export function useIsCustomizationInScope() {


### PR DESCRIPTION
Fixes #37056

Native filters scoped to inactive tabs or sub-tabs are now completely hidden instead of being shown in the "Filters out of scope" section.

This ensures consistent UX between top-level tabs and nested sub-tabs:
- When a filter is out of scope for the active tab/sub-tab, it is fully hidden
- Behavior is now consistent for both top-level and nested tab structures

Changes:
- Modified `useSelectFiltersInScope` to skip adding out-of-scope tab-scoped filters to the `filtersOutOfScope` array
- Updated unit test expectations to verify filters are completely hidden when out of scope

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
This PR fixes inconsistent native filter scoping behavior when dashboards use tabs with sub-tabs.
Previously, filters scoped to inactive sub-tabs were still rendered under the "Filters out of scope"
section, while the same filters were fully hidden for top-level tabs. The updated logic ensures
filters that are out of scope for the active tab or sub-tab are completely hidden, providing a
consistent and predictable user experience across all tab levels.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
1. Create a dashboard with multiple tabs and nested sub-tabs
2. Add a native filter scoped only to one sub-tab
3. Switch to another sub-tab where the filter is out of scope
4. Verify the filter is completely hidden and does not appear under "Filters out of scope"
5. Confirm behavior is consistent for both top-level tabs and nested sub-tabs

### ADDITIONAL INFORMATION
- [x] Has associated issue: #37056
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
