### PR TITLE
fix(api): nan is not properly handled for athena connections

### DIFF
--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -55,11 +55,8 @@ def df_to_records(dframe: pd.DataFrame) -> list[dict[str, Any]]:
 
     for record in records:
         for key in record:
-            val = record[key]
-            # Convert NaN/NA values to None for JSON compatibility
-            if pd.isna(val):
-                record[key] = None
-            else:
-                record[key] = _convert_big_integers(val)
+            record[key] = (
+                None if pd.isna(record[key]) else _convert_big_integers(record[key])
+            )
 
     return records

--- a/superset/dataframe.py
+++ b/superset/dataframe.py
@@ -41,6 +41,9 @@ def df_to_records(dframe: pd.DataFrame) -> list[dict[str, Any]]:
     """
     Convert a DataFrame to a set of records.
 
+    NaN values are converted to None for JSON compatibility.
+    This handles division by zero and other operations that produce NaN.
+
     :param dframe: the DataFrame to convert
     :returns: a list of dictionaries reflecting each single row of the DataFrame
     """
@@ -52,6 +55,11 @@ def df_to_records(dframe: pd.DataFrame) -> list[dict[str, Any]]:
 
     for record in records:
         for key in record:
-            record[key] = _convert_big_integers(record[key])
+            val = record[key]
+            # Convert NaN/NA values to None for JSON compatibility
+            if pd.isna(val):
+                record[key] = None
+            else:
+                record[key] = _convert_big_integers(val)
 
     return records

--- a/tests/unit_tests/dataframe_test.py
+++ b/tests/unit_tests/dataframe_test.py
@@ -17,18 +17,18 @@
 # pylint: disable=unused-argument, import-outside-toplevel
 from datetime import datetime
 
+import numpy as np
 import pytest
 from pandas import Timestamp
 from pandas._libs.tslibs import NaT
 
 from superset.dataframe import df_to_records
+from superset.db_engine_specs import BaseEngineSpec
+from superset.result_set import SupersetResultSet
 from superset.superset_typing import DbapiDescription
 
 
 def test_df_to_records() -> None:
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     data = [("a1", "b1", "c1"), ("a2", "b2", "c2")]
     cursor_descr: DbapiDescription = [
         (column, "string", None, None, None, None, False) for column in ("a", "b", "c")
@@ -43,9 +43,6 @@ def test_df_to_records() -> None:
 
 
 def test_df_to_records_NaT_type() -> None:  # noqa: N802
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     data = [(NaT,), (Timestamp("2023-01-06 20:50:31.749000+0000", tz="UTC"),)]
     cursor_descr: DbapiDescription = [
         ("date", "timestamp with time zone", None, None, None, None, False)
@@ -60,9 +57,6 @@ def test_df_to_records_NaT_type() -> None:  # noqa: N802
 
 
 def test_df_to_records_mixed_emoji_type() -> None:
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     data = [
         ("What's up?", "This is a string text", 1),
         ("What's up?", "This is a string with an 😍 added", 2),
@@ -100,9 +94,6 @@ def test_df_to_records_mixed_emoji_type() -> None:
 
 
 def test_df_to_records_mixed_accent_type() -> None:
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     data = [
         ("What's up?", "This is a string text", 1),
         ("What's up?", "This is a string with áccent", 2),
@@ -140,9 +131,6 @@ def test_df_to_records_mixed_accent_type() -> None:
 
 
 def test_js_max_int() -> None:
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     data = [(1, 1239162456494753670, "c1"), (2, 100, "c2")]
     cursor_descr: DbapiDescription = [
         ("a", "int", None, None, None, None, False),
@@ -192,9 +180,6 @@ def test_js_max_int() -> None:
     ],
 )
 def test_max_pandas_timestamp(input_, expected) -> None:
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     cursor_descr: DbapiDescription = [
         ("a", "datetime", None, None, None, None, False),
         ("b", "int", None, None, None, None, False),
@@ -207,11 +192,6 @@ def test_max_pandas_timestamp(input_, expected) -> None:
 
 def test_df_to_records_with_nan_from_division_by_zero() -> None:
     """Test that NaN values from division by zero are converted to None."""
-    import numpy as np
-
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     # Simulate Athena query: select 0.00 / 0.00 as test
     data = [(np.nan,), (5.0,), (np.nan,)]
     cursor_descr: DbapiDescription = [("test", "double", None, None, None, None, False)]
@@ -227,10 +207,6 @@ def test_df_to_records_with_nan_from_division_by_zero() -> None:
 
 def test_df_to_records_with_mixed_nan_and_valid_values() -> None:
     """Test that NaN values are properly handled alongside valid numeric data."""
-    import numpy as np
-
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
 
     # Simulate a query with multiple columns containing NaN values
     data = [
@@ -258,11 +234,6 @@ def test_df_to_records_with_mixed_nan_and_valid_values() -> None:
 
 def test_df_to_records_with_inf_and_nan() -> None:
     """Test that both NaN and infinity values are handled correctly."""
-    import numpy as np
-
-    from superset.db_engine_specs import BaseEngineSpec
-    from superset.result_set import SupersetResultSet
-
     # Test various edge cases: NaN, positive infinity, negative infinity
     data = [
         (np.nan, "division by zero"),


### PR DESCRIPTION
## Summary

Fix NaN Handling in DataFrame Conversion for All Database Connections

## Problem Description

When executing queries that produce NaN (Not a Number) values—such as division by zero operations—Superset would fail when attempting to save the results as a dataset or serialize the data to JSON. This issue affected all database connections, but was particularly noticeable with Amazon Athena, where queries like `SELECT 0.00 / 0.00` return IEEE 754 NaN values.

The root cause was that Python's `float('nan')` values cannot be serialized to valid JSON without special handling. When users attempted to save query results containing NaN values as datasets, the JSON serialization would fail, resulting in errors displayed in the UI.


### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
