### PR TITLE
feat(ag-grid-table): Enable Time Shift feature for AG Grid Table

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -122,10 +122,7 @@ const buildQuery: BuildQuery<TableChartFormData> = (
 
     // Dashboard filter override - allows dashboard-level time shifts to OVERRIDE
     // chart-level time shift settings (from PRs #33947 and #34014)
-    if (
-      extra_form_data?.time_compare &&
-      !timeOffsets.includes(extra_form_data.time_compare)
-    ) {
+    if (extra_form_data?.time_compare) {
       timeOffsets = [extra_form_data.time_compare];
     }
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -120,6 +120,15 @@ const buildQuery: BuildQuery<TableChartFormData> = (
       }
     }
 
+    // Dashboard filter override - allows dashboard-level time shifts to OVERRIDE
+    // chart-level time shift settings (from PRs #33947 and #34014)
+    if (
+      extra_form_data?.time_compare &&
+      !timeOffsets.includes(extra_form_data.time_compare)
+    ) {
+      timeOffsets = [extra_form_data.time_compare];
+    }
+
     let temporalColumnAdded = false;
     let temporalColumn = null;
 

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -43,9 +43,7 @@ import {
 import { t } from '@apache-superset/core';
 import {
   ensureIsArray,
-  FeatureFlag,
   isAdhocColumn,
-  isFeatureEnabled,
   isPhysicalColumn,
   validateInteger,
   QueryFormColumn,
@@ -752,9 +750,7 @@ const config: ControlPanelConfig = {
         showCalculationType: false,
         showFullChoices: false,
       }),
-      visibility: ({ controls }) =>
-        isAggMode({ controls }) &&
-        isFeatureEnabled(FeatureFlag.TableV2TimeComparisonEnabled),
+      visibility: isAggMode,
     },
   ],
   formDataOverrides: formData => ({

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -25,12 +25,10 @@ import {
   DataRecord,
   ensureIsArray,
   extractTimegrain,
-  FeatureFlag,
   getMetricLabel,
   getNumberFormatter,
   getTimeFormatter,
   getTimeFormatterForGranularity,
-  isFeatureEnabled,
   NumberFormats,
   QueryMode,
   SMART_DATE_ID,
@@ -38,7 +36,7 @@ import {
   TimeFormatter,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/api/core';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, merge } from 'lodash';
 import {
   ConditionalFormattingConfig,
   getColorFormatters,
@@ -465,7 +463,7 @@ const transformProps = (
   const {
     height,
     width,
-    rawFormData: formData,
+    rawFormData: originalFormData,
     queriesData = [],
     ownState: serverPaginationData,
     filterState,
@@ -473,6 +471,15 @@ const transformProps = (
     emitCrossFilters,
     theme,
   } = chartProps;
+
+  // Merge extra_form_data (dashboard filter overrides) into formData
+  // This ensures dashboard-level settings (like time_compare) override chart-level settings
+  // From PRs #33947 and #34014
+  const formData = merge(
+    {},
+    originalFormData,
+    originalFormData.extra_form_data,
+  );
 
   const {
     include_search: includeSearch = false,
@@ -499,8 +506,7 @@ const transformProps = (
   const isUsingTimeComparison =
     !isEmpty(time_compare) &&
     queryMode === QueryMode.Aggregate &&
-    comparison_type === ComparisonType.Values &&
-    isFeatureEnabled(FeatureFlag.TableV2TimeComparisonEnabled);
+    comparison_type === ComparisonType.Values;
 
   const nonCustomNorInheritShifts = ensureIsArray(formData.time_compare).filter(
     (shift: string) => shift !== 'custom' && shift !== 'inherit',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -497,7 +497,7 @@ test('deletes a filter including dependencies', async () => {
       }),
     ),
   );
-});
+}, 30000);
 
 test('switches the order between two filters', async () => {
   const nativeFilterState = [


### PR DESCRIPTION
The Time Shift (time comparison) feature was already implemented in the AG Grid Table plugin but was gated behind the TableV2TimeComparisonEnabled feature flag. This commit enables the feature and adds dashboard override support to bring AG Grid Table to full parity with the normal Table plugin.

Changes:
- Removed feature flag checks from controlPanel.tsx and transformProps.ts
- Added extra_form_data.time_compare override logic in buildQuery.ts so dashboard-level time shifts can override chart-level settings
- Added merge() for extra_form_data in transformProps.ts to properly propagate dashboard filter overrides to the chart

This allows users to:
- Use Time Comparison controls in Aggregate mode (1 week ago, 1 month ago, etc.)
- See expanded columns (Main, #, △, %) for each metric
- Have dashboard filters override chart-level time shift settings

Related PRs: apache#33947, apache#34014

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
