### PR TITLE
fix(Matrixify): Do not clear values when saving

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -331,7 +331,9 @@ describe('ControlPanelsContainer', () => {
 
     // Matrixify tab should still be active after rerender
     await waitFor(() => {
-      const matrixifyTabAfterSave = screen.getByRole('tab', { name: /matrixify/i });
+      const matrixifyTabAfterSave = screen.getByRole('tab', {
+        name: /matrixify/i,
+      });
       expect(matrixifyTabAfterSave).toHaveAttribute('aria-selected', 'true');
     });
   });

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -27,6 +27,8 @@ import { t } from '@apache-superset/core';
 import {
   DatasourceType,
   getChartControlPanelRegistry,
+  isFeatureEnabled,
+  FeatureFlag,
 } from '@superset-ui/core';
 import { defaultControls, defaultState } from 'src/explore/store';
 import { ExplorePageState } from 'src/explore/types';
@@ -35,6 +37,13 @@ import {
   ControlPanelsContainer,
   ControlPanelsContainerProps,
 } from 'src/explore/components/ControlPanelsContainer';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 const FormDataMock = () => {
   const formData = useSelector(
@@ -90,10 +99,14 @@ describe('ControlPanelsContainer', () => {
 
   beforeEach(() => {
     getChartControlPanelRegistry().registerValue('table', defaultTableConfig);
+    jest.clearAllMocks();
+    // Default: feature disabled
+    mockIsFeatureEnabled.mockReturnValue(false);
   });
 
   afterEach(() => {
     getChartControlPanelRegistry().remove('table');
+    jest.clearAllMocks();
   });
 
   afterAll(() => {
@@ -276,5 +289,91 @@ describe('ControlPanelsContainer', () => {
     expect(screen.getByText('Calculation type')).toBeInTheDocument();
     expect(screen.getByText('Shift start date')).not.toBeVisible();
     expect(screen.getByText('Calculation type')).not.toBeVisible();
+  });
+
+  test('should stay on Matrixify tab when matrixify is enabled', async () => {
+    // Enable Matrixify feature flag
+    mockIsFeatureEnabled.mockImplementation(
+      (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
+    );
+
+    const props = getDefaultProps();
+    props.form_data = {
+      ...props.form_data,
+      matrixify_enable_vertical_layout: true,
+    };
+
+    const { rerender } = render(<ControlPanelsContainer {...props} />, {
+      useRedux: true,
+    });
+
+    // Check that Matrixify tab exists and is active
+    await waitFor(() => {
+      const matrixifyTab = screen.getByRole('tab', { name: /matrixify/i });
+      expect(matrixifyTab).toBeInTheDocument();
+      expect(matrixifyTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    // Simulate saving with updated dimension values
+    const updatedProps = {
+      ...props,
+      form_data: {
+        ...props.form_data,
+        matrixify_enable_vertical_layout: true,
+        matrixify_dimension_columns: {
+          dimension: 'country',
+          values: ['USA', 'Canada'],
+        },
+      },
+    };
+
+    rerender(<ControlPanelsContainer {...updatedProps} />);
+
+    // Matrixify tab should still be active after rerender
+    await waitFor(() => {
+      const matrixifyTabAfterSave = screen.getByRole('tab', { name: /matrixify/i });
+      expect(matrixifyTabAfterSave).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  test('should automatically switch to Matrixify tab when matrixify becomes enabled', async () => {
+    // Enable Matrixify feature flag
+    mockIsFeatureEnabled.mockImplementation(
+      (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
+    );
+
+    const props = getDefaultProps();
+
+    const { rerender } = render(<ControlPanelsContainer {...props} />, {
+      useRedux: true,
+    });
+
+    // Initially, Data tab should be active
+    const dataTab = screen.getByRole('tab', { name: /data/i });
+    expect(dataTab).toHaveAttribute('aria-selected', 'true');
+
+    // Enable matrixify
+    const updatedProps = {
+      ...props,
+      form_data: {
+        ...props.form_data,
+        matrixify_enable_horizontal_layout: true,
+      },
+    };
+
+    rerender(<ControlPanelsContainer {...updatedProps} />);
+
+    // Matrixify tab should now be active
+    await waitFor(() => {
+      const matrixifyTab = screen.getByRole('tab', { name: /matrixify/i });
+      expect(matrixifyTab).toBeInTheDocument();
+      expect(matrixifyTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    // Data tab should no longer be active
+    expect(screen.getByRole('tab', { name: /data/i })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
   });
 });

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -290,6 +290,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   const prevChartStatus = usePrevious(props.chart.chartStatus);
 
   const [showDatasourceAlert, setShowDatasourceAlert] = useState(false);
+  const [activeTabKey, setActiveTabKey] = useState<string>(TABS_KEYS.DATA);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -795,6 +796,18 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   const showCustomizeTab = customizeSections.length > 0;
   const showMatrixifyTab = isFeatureEnabled(FeatureFlag.Matrixify);
 
+  // Check if matrixify is enabled in form_data
+  const matrixifyIsEnabled =
+    form_data.matrixify_enable_vertical_layout ||
+    form_data.matrixify_enable_horizontal_layout;
+
+  // Auto-switch to Matrixify tab when it's enabled
+  useEffect(() => {
+    if (showMatrixifyTab && matrixifyIsEnabled) {
+      setActiveTabKey(TABS_KEYS.MATRIXIFY);
+    }
+  }, [showMatrixifyTab, matrixifyIsEnabled]);
+
   // Check if matrixify sections have validation errors
   const matrixifyHasErrors = useMemo(() => {
     if (!showMatrixifyTab) return false;
@@ -882,6 +895,8 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
           id="controlSections"
           data-test="control-tabs"
           allowOverflow={false}
+          activeKey={activeTabKey}
+          onChange={(key: string) => setActiveTabKey(key)}
           items={[
             {
               key: TABS_KEYS.DATA,

--- a/superset-frontend/src/explore/components/controls/MatrixifyDimensionControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MatrixifyDimensionControl.tsx
@@ -82,17 +82,21 @@ export default function MatrixifyDimensionControl(
 
   // Reset values when selection mode changes
   useEffect(() => {
-    if (prevSelectionMode.current !== selectionMode) {
-      prevSelectionMode.current = selectionMode;
-      if (value?.values && value.values.length > 0) {
-        onChange({
-          dimension: value.dimension,
-          values: [],
-          topNValues: [],
-        });
-      }
+    // Only clear values when actually switching between modes, not on initial load or re-render
+    if (
+      prevSelectionMode.current !== selectionMode && 
+      prevSelectionMode.current !== undefined &&
+      value?.dimension
+    ) {
+      // Clear values when switching between members and topn modes
+      onChange({
+        dimension: value.dimension,
+        values: [],
+        topNValues: [],
+      });
     }
-  }, [selectionMode, value]);
+    prevSelectionMode.current = selectionMode;
+  }, [selectionMode]);
 
   // Initialize dimension options from datasource
   useEffect(() => {
@@ -175,18 +179,6 @@ export default function MatrixifyDimensionControl(
   // Load TopN values when in TopN mode
   useEffect(() => {
     if (!value?.dimension || !datasource || selectionMode !== 'topn') {
-      // Clear values when switching away from topn mode
-      if (
-        selectionMode !== 'topn' &&
-        value?.values &&
-        value.values.length > 0
-      ) {
-        onChange({
-          dimension: value.dimension,
-          values: [],
-          topNValues: [],
-        });
-      }
       return undefined;
     }
 

--- a/superset-frontend/src/explore/components/controls/MatrixifyDimensionControl.tsx
+++ b/superset-frontend/src/explore/components/controls/MatrixifyDimensionControl.tsx
@@ -84,7 +84,7 @@ export default function MatrixifyDimensionControl(
   useEffect(() => {
     // Only clear values when actually switching between modes, not on initial load or re-render
     if (
-      prevSelectionMode.current !== selectionMode && 
+      prevSelectionMode.current !== selectionMode &&
       prevSelectionMode.current !== undefined &&
       value?.dimension
     ) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed a critical bug in the MatrixifyDimensionControl component where dimension values would unexpectedly disappear when saving a chart. The issue was caused by overly aggressive value
  clearing logic that triggered during component rerenders, not just when users actually switched between selection modes.

  Root Cause:
  The useEffect hook responsible for clearing values when switching between "members" and "topN" selection modes was triggering on every rerender, including during save operations. This
  happened because:
  1. The effect had unnecessary dependencies (value in the dependency array)
  2. The logic didn't differentiate between initial renders, rerenders, and actual mode changes
  3. There was duplicate clearing logic in multiple useEffect hooks

  Solution:
  - Improved the selection mode change detection to only clear values when actually switching between modes
  - Added checks to prevent clearing on initial render (prevSelectionMode.current !== undefined)
  - Removed duplicate value clearing logic from the TopN effect
  - Cleaned up effect dependencies to prevent unnecessary rerenders
  
  
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

  1. Create a new chart using a visualization type that supports matrixify controls
  2. In the matrixify dimension control:
    - Select a dimension (e.g., "country")
    - Add some dimension values (e.g., "USA", "Canada", "Australia")
  3. Save the chart
  4. Verify: The selected dimension values remain visible and selected in the control
  5. Switch between "members" and "topN" selection modes
  6. Verify: Values are cleared only when switching modes, not during normal saves
  7. Refresh the page and load the saved chart
  8. Verify: Previously saved dimension values load correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
