### PR TITLE
fix(table chart): time comparison totals returning null

### DIFF
--- a/tests/unit_tests/common/test_time_shifts.py
+++ b/tests/unit_tests/common/test_time_shifts.py
@@ -209,3 +209,36 @@ def test_join_offset_dfs_with_month_granularity():
     )
 
     assert_frame_equal(expected, result)
+
+
+def test_join_offset_dfs_totals_query_no_dimensions():
+    """
+    Test time offset join for totals query with no dimension columns.
+
+    This simulates a table chart totals query where:
+    - columns=[] (no dimensions, only metrics)
+    - time_offsets=["1 month ago"]
+    - The dataframes only contain metric columns (no datetime column)
+
+    The join should use the __temp_join_key__ fallback mechanism
+    to properly join the offset data.
+    """
+    # Main totals query result - only has metric column, no datetime
+    df = DataFrame({"Total Cost": [54211.76]})
+
+    # Offset query result - renamed metric column
+    offset_df = DataFrame({"Total Cost__1 month ago": [48000.50]})
+
+    offset_dfs = {"1 month ago": offset_df}
+    time_grain = "P1D"  # Daily grain from extras
+    join_keys = []  # No dimension columns for totals query
+
+    expected = DataFrame(
+        {"Total Cost": [54211.76], "Total Cost__1 month ago": [48000.50]}
+    )
+
+    result = query_context_processor.join_offset_dfs(
+        df, offset_dfs, time_grain, join_keys
+    )
+
+    assert_frame_equal(expected, result)


### PR DESCRIPTION
### SUMMARY

When a table chart has `show_totals=true` and `time_offsets` enabled (time comparison), the totals row was showing `null` for the time comparison column while individual rows displayed correct values.

**Root Cause:**
The totals query has `columns=[]` (no dimension columns), and `_determine_join_keys` in `superset/models/helpers.py` was trying to create a join column from the first column of the DataFrame. For totals queries, this first column is a numeric metric value (e.g., `54211.76`), not a datetime. The `generate_join_column` function falls back to `str(value)` for non-datetime values, causing mismatched join keys between the main DataFrame and offset DataFrame, resulting in the join failing and returning `null`.

**Fix:**
Added a check in `_determine_join_keys` that detects when there are no join keys AND the first column is not a datetime. In this case, it returns empty join keys, which triggers the `__temp_join_key__` fallback mechanism in `_perform_join` that correctly joins single-row aggregate results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Summary row shows `0` for the "# Previous" (time comparison) column
**After:** Summary row correctly shows the summed time comparison value

### TESTING INSTRUCTIONS

1. Create a table chart with:
   - At least one metric (e.g., `SUM(cost)`)
   - `show_totals` enabled
   - Time comparison enabled (e.g., "1 month ago")
   - A temporal filter (e.g., `TEMPORAL_RANGE` on a date column)

2. Verify the totals/summary row shows the correct time comparison value instead of `null` or `0`

3. Run the unit tests:
   ```bash
   pytest tests/unit_tests/common/test_time_shifts.py -v
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)