### PR TITLE
fix(controls): Only initialize categorical control on numeric x axis

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -218,8 +218,17 @@ export const xAxisForceCategoricalControl = {
     label: () => t('Force categorical'),
     default: false,
     description: t('Treat values as categorical.'),
-    initialValue: (control: ControlState, state: ControlPanelState | null) =>
-      state?.form_data?.x_axis_sort !== undefined || control.value,
+    initialValue: (control: ControlState, state: ControlPanelState | null) => {
+      const isNumericXAxis = checkColumnType(
+        getColumnLabel(state?.controls?.x_axis?.value as QueryFormColumn),
+        state?.controls?.datasource?.datasource,
+        [GenericDataType.Numeric],
+      );
+      if (!isNumericXAxis) {
+        return control.value;
+      }
+      return state?.form_data?.x_axis_sort !== undefined || control.value;
+    },
     renderTrigger: true,
     visibility: ({ controls }: { controls: ControlStateMapping }) =>
       checkColumnType(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -226,13 +226,13 @@ export const xAxisForceCategoricalControl = {
         state?.controls?.datasource?.datasource,
         [GenericDataType.Numeric],
       );
-      
+
       // Non-numeric columns (temporal, text) should not be forced categorical
       // based on x_axis_sort - just use the control's existing value
       if (!isNumericXAxis) {
         return control.value;
       }
-      
+
       // For numeric columns, force categorical if x_axis_sort is defined
       // (user wants to sort) or use the control's existing value
       return state?.form_data?.x_axis_sort !== undefined || control.value;

--- a/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/shared-controls/customControls.tsx
@@ -219,14 +219,22 @@ export const xAxisForceCategoricalControl = {
     default: false,
     description: t('Treat values as categorical.'),
     initialValue: (control: ControlState, state: ControlPanelState | null) => {
+      // Check if x-axis is numeric - only numeric columns should have
+      // their categorical behavior influenced by x_axis_sort setting
       const isNumericXAxis = checkColumnType(
         getColumnLabel(state?.controls?.x_axis?.value as QueryFormColumn),
         state?.controls?.datasource?.datasource,
         [GenericDataType.Numeric],
       );
+      
+      // Non-numeric columns (temporal, text) should not be forced categorical
+      // based on x_axis_sort - just use the control's existing value
       if (!isNumericXAxis) {
         return control.value;
       }
+      
+      // For numeric columns, force categorical if x_axis_sort is defined
+      // (user wants to sort) or use the control's existing value
       return state?.form_data?.x_axis_sort !== undefined || control.value;
     },
     renderTrigger: true,

--- a/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/shared-controls/customControls.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { GenericDataType } from '@apache-superset/core/api/core';
+import { xAxisForceCategoricalControl } from '../../src/shared-controls/customControls';
+import { checkColumnType } from '../../src/utils/checkColumnType';
+import type { ControlState } from '@superset-ui/chart-controls';
+
+jest.mock('../../src/utils/checkColumnType');
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  getColumnLabel: jest.fn((col: any) => col),
+}));
+
+test('xAxisForceCategoricalControl should not treat temporal columns as categorical when x_axis_sort exists', () => {
+  const mockCheckColumnType = jest.mocked(checkColumnType);
+
+  mockCheckColumnType.mockReturnValue(false); // temporal column (not numeric)
+
+  const control: ControlState = { value: false, type: 'CheckboxControl' };
+  const state = {
+    form_data: { x_axis_sort: 'asc' },
+    controls: {
+      x_axis: { value: 'date_column' },
+      datasource: { datasource: {} },
+    },
+  };
+
+  const result = xAxisForceCategoricalControl.config.initialValue!(
+    control,
+    state as any,
+  );
+
+  // Verify: should return control value (false) for non-numeric columns
+  expect(result).toBe(false);
+  expect(mockCheckColumnType).toHaveBeenCalledWith('date_column', {}, [
+    GenericDataType.Numeric,
+  ]);
+
+  mockCheckColumnType.mockClear();
+});


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Initializing the value of xAxisForceCategorical causes some charts to treat temporal axis as categorical. This is a defensive fix to adress that issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
