### PR TITLE
fix(charts): properly parse error responses in StatefulChart

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -25,6 +25,7 @@ import {
   SupersetClientInterface,
   buildQueryContext,
   RequestConfig,
+  getClientErrorObject,
 } from '../..';
 import { Loading } from '../../components/Loading';
 import ChartClient from '../clients/ChartClient';
@@ -279,11 +280,17 @@ export default function StatefulChart(props: StatefulChartProps) {
       }
     } catch (err) {
       // Ignore abort errors
-      if (err.name === 'AbortError') {
+      if ((err as Error).name === 'AbortError') {
         return;
       }
 
-      const errorObj = err as Error;
+      const parsedError = await getClientErrorObject(
+        err as Parameters<typeof getClientErrorObject>[0],
+      );
+      const errorMessage =
+        parsedError.error || parsedError.message || 'An error occurred';
+
+      const errorObj = new Error(errorMessage);
       setStatus('error');
       setError(errorObj);
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using matrix charts, error messages from individual cells weren't displaying properly to users. 
For example, if one of the matrix cells had a divide-by-zero error in its calculation, users would see a blank or generic error instead of the actual database error message, making it difficult to diagnose and fix the issue.

This PR fixes the error handling in StatefulChart (the component used by matrix chart cells) so that error messages from the backend are properly extracted and displayed to users.

## Root Cause
When SupersetClient encounters an HTTP error (400, 422, etc.), it rejects with a raw `Response` object, not an `Error` object. The previous code assumed `err` was an `Error` and tried to access `err.message`, which was undefined for `Response` objects.

## Changes
The fix uses getClientErrorObject(), the same utility that the main Chart component uses for error handling. This utility knows how to properly parse different types of error responses:

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
- Before

<img width="1667" height="1256" alt="Screenshot 2026-01-13 160538" src="https://github.com/user-attachments/assets/fdcc51a6-420c-469f-935f-bd5649c5286b" />

- After

<img width="1657" height="1022" alt="Screenshot 2026-01-13 155830" src="https://github.com/user-attachments/assets/f4b5ecb1-f423-447a-9899-86b6ca7db9f3" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
-  Unit tests pass (`npm run test -- packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx`)
-  Pre-commit hooks pass
- Manual testing: 
     Create a chart with a divide by 0 calculation, enable matrixify, verify error message displays in the affected cell(s)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
