### PR TITLE
refactor(charts): filter saved metrics by key and label

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -145,7 +145,9 @@ test('Should filter simple columns by column_name and verbose_name', async () =>
 
   let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
   expect(within(dropdown).getByText('Total Sales')).toBeInTheDocument();
-  expect(within(dropdown).queryByText('User Identifier')).not.toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('User Identifier'),
+  ).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Creation Date')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Status')).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Last Update')).not.toBeInTheDocument();
@@ -165,18 +167,40 @@ test('Should filter simple columns by column_name and verbose_name', async () =>
   expect(within(dropdown).getByText('Creation Date')).toBeInTheDocument();
   expect(within(dropdown).getByText('Last Update')).toBeInTheDocument();
   expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
-  expect(within(dropdown).queryByText('User Identifier')).not.toBeInTheDocument();
+  expect(
+    within(dropdown).queryByText('User Identifier'),
+  ).not.toBeInTheDocument();
   expect(within(dropdown).queryByText('Status')).not.toBeInTheDocument();
 });
 
 test('Should filter saved expressions by column_name and verbose_name', async () => {
   const { container } = renderPopover({
     columns: [
-      { column_name: 'calc_revenue', verbose_name: 'Total Sales', expression: 'price * quantity' },
-      { column_name: 'calc_tax', verbose_name: 'Tax Amount', expression: 'price * 0.1' },
-      { column_name: 'calc_profit', verbose_name: 'Net Profit', expression: 'revenue - cost' },
-      { column_name: 'calc_margin', verbose_name: 'Profit Margin', expression: 'profit / revenue' },
-      { column_name: 'calc_discount', verbose_name: 'Discount Rate', expression: 'discount / price' },
+      {
+        column_name: 'calc_revenue',
+        verbose_name: 'Total Sales',
+        expression: 'price * quantity',
+      },
+      {
+        column_name: 'calc_tax',
+        verbose_name: 'Tax Amount',
+        expression: 'price * 0.1',
+      },
+      {
+        column_name: 'calc_profit',
+        verbose_name: 'Net Profit',
+        expression: 'revenue - cost',
+      },
+      {
+        column_name: 'calc_margin',
+        verbose_name: 'Profit Margin',
+        expression: 'profit / revenue',
+      },
+      {
+        column_name: 'calc_discount',
+        verbose_name: 'Discount Rate',
+        expression: 'discount / price',
+      },
     ],
     editedColumn: undefined,
     getCurrentTab: jest.fn(),

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.test.tsx
@@ -22,7 +22,7 @@ import {
   fireEvent,
   screen,
   userEvent,
-  selectOption,
+  within,
 } from 'spec/helpers/testing-library';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -123,74 +123,64 @@ test('open with Custom SQL tab selected when there is a custom SQL selected', ()
   expect(getByText('Custom SQL')).toHaveAttribute('aria-selected', 'true');
 });
 
-test('Should filter simple columns by column_name and select', async () => {
-  const mockOnChange = jest.fn();
+test('Should filter simple columns by column_name and verbose_name', async () => {
   renderPopover({
     columns: [
       { column_name: 'revenue_amount', verbose_name: 'Total Sales' },
       { column_name: 'user_id', verbose_name: 'User Identifier' },
+      { column_name: 'created_at', verbose_name: 'Creation Date' },
+      { column_name: 'order_status', verbose_name: 'Status' },
+      { column_name: 'updated_at', verbose_name: 'Last Update' },
     ],
     editedColumn: undefined,
     getCurrentTab: jest.fn(),
-    onChange: mockOnChange,
+    onChange: jest.fn(),
   });
 
   const combobox = screen.getByRole('combobox', {
     name: 'Columns and metrics',
   });
-  // Search by column_name - 'revenue' is only in column_name, not in verbose_name
+
   await userEvent.type(combobox, 'revenue');
-  await selectOption('Total Sales');
 
-  fireEvent.click(screen.getByText('Save'));
-  expect(mockOnChange).toHaveBeenCalledWith(
-    expect.objectContaining({ column_name: 'revenue_amount' }),
-  );
-});
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Total Sales')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('User Identifier')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Creation Date')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Status')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Last Update')).not.toBeInTheDocument();
 
-test('Should filter simple columns by verbose_name and select', async () => {
-  const mockOnChange = jest.fn();
-  renderPopover({
-    columns: [
-      { column_name: 'revenue_amount', verbose_name: 'Total Sales' },
-      { column_name: 'user_id', verbose_name: 'User Identifier' },
-    ],
-    editedColumn: undefined,
-    getCurrentTab: jest.fn(),
-    onChange: mockOnChange,
-  });
-
-  const combobox = screen.getByRole('combobox', {
-    name: 'Columns and metrics',
-  });
-  // Search by verbose_name - 'Identifier' is only in verbose_name, not in column_name
+  await userEvent.clear(combobox);
   await userEvent.type(combobox, 'Identifier');
-  await selectOption('User Identifier');
 
-  fireEvent.click(screen.getByText('Save'));
-  expect(mockOnChange).toHaveBeenCalledWith(
-    expect.objectContaining({ column_name: 'user_id' }),
-  );
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('User Identifier')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Creation Date')).not.toBeInTheDocument();
+
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, '_at');
+
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Creation Date')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Last Update')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('User Identifier')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Status')).not.toBeInTheDocument();
 });
 
-test('Should filter saved expressions by column_name and select', async () => {
-  const mockOnChange = jest.fn();
+test('Should filter saved expressions by column_name and verbose_name', async () => {
   const { container } = renderPopover({
     columns: [
-      {
-        column_name: 'calculated_revenue',
-        verbose_name: 'Total Sales Calculation',
-        expression: 'price * quantity',
-      },
-      {
-        column_name: 'calculated_tax',
-        verbose_name: 'Tax Amount',
-        expression: 'price * 0.1',
-      },
+      { column_name: 'calc_revenue', verbose_name: 'Total Sales', expression: 'price * quantity' },
+      { column_name: 'calc_tax', verbose_name: 'Tax Amount', expression: 'price * 0.1' },
+      { column_name: 'calc_profit', verbose_name: 'Net Profit', expression: 'revenue - cost' },
+      { column_name: 'calc_margin', verbose_name: 'Profit Margin', expression: 'profit / revenue' },
+      { column_name: 'calc_discount', verbose_name: 'Discount Rate', expression: 'discount / price' },
     ],
     editedColumn: undefined,
     getCurrentTab: jest.fn(),
-    onChange: mockOnChange,
+    onChange: jest.fn(),
   });
 
   const savedTab = container.querySelector('#adhoc-metric-edit-tabs-tab-saved');
@@ -200,49 +190,31 @@ test('Should filter saved expressions by column_name and select', async () => {
   const combobox = screen.getByRole('combobox', {
     name: 'Saved expressions',
   });
-  // Search by column_name - 'revenue' is only in column_name, not in verbose_name
+
   await userEvent.type(combobox, 'revenue');
-  await selectOption('Total Sales Calculation');
 
-  fireEvent.click(screen.getByText('Save'));
-  expect(mockOnChange).toHaveBeenCalledWith(
-    expect.objectContaining({ column_name: 'calculated_revenue' }),
-  );
-});
+  let dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Total Sales')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Tax Amount')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Net Profit')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Profit Margin')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Discount Rate')).not.toBeInTheDocument();
 
-test('Should filter saved expressions by verbose_name and select', async () => {
-  const mockOnChange = jest.fn();
-  const { container } = renderPopover({
-    columns: [
-      {
-        column_name: 'calculated_revenue',
-        verbose_name: 'Total Sales Calculation',
-        expression: 'price * quantity',
-      },
-      {
-        column_name: 'calculated_tax',
-        verbose_name: 'Tax Amount',
-        expression: 'price * 0.1',
-      },
-    ],
-    editedColumn: undefined,
-    getCurrentTab: jest.fn(),
-    onChange: mockOnChange,
-  });
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, 'Rate');
 
-  const savedTab = container.querySelector('#adhoc-metric-edit-tabs-tab-saved');
-  expect(savedTab).not.toBeNull();
-  fireEvent.click(savedTab!);
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Discount Rate')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Tax Amount')).not.toBeInTheDocument();
 
-  const combobox = screen.getByRole('combobox', {
-    name: 'Saved expressions',
-  });
-  // Search by verbose_name - 'Amount' is only in verbose_name, not in column_name
-  await userEvent.type(combobox, 'Amount');
-  await selectOption('Tax Amount');
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, 'profit');
 
-  fireEvent.click(screen.getByText('Save'));
-  expect(mockOnChange).toHaveBeenCalledWith(
-    expect.objectContaining({ column_name: 'calculated_tax' }),
-  );
+  dropdown = document.querySelector('.rc-virtual-list') as HTMLElement;
+  expect(within(dropdown).getByText('Net Profit')).toBeInTheDocument();
+  expect(within(dropdown).getByText('Profit Margin')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Total Sales')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Tax Amount')).not.toBeInTheDocument();
+  expect(within(dropdown).queryByText('Discount Rate')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/ColumnSelectPopover.tsx
@@ -428,8 +428,12 @@ const ColumnSelectPopover = ({
                                   />
                                 ),
                                 key: calculatedColumn.column_name,
+                                column_name: calculatedColumn.column_name,
+                                verbose_name:
+                                  calculatedColumn.verbose_name ?? '',
                               }),
                             )}
+                            optionFilterProps={['column_name', 'verbose_name']}
                           />
                         </FormItem>
                       ) : datasourceType === DatasourceType.Table ? (
@@ -545,6 +549,8 @@ const ColumnSelectPopover = ({
                             />
                           ),
                           key: `column-${simpleColumn.column_name}`,
+                          column_name: simpleColumn.column_name,
+                          verbose_name: simpleColumn.verbose_name ?? '',
                         })),
                         ...availableMetrics.map(metric => ({
                           value: metric.metric_name,
@@ -557,7 +563,14 @@ const ColumnSelectPopover = ({
                             </MetricOptionContainer>
                           ),
                           key: `metric-${metric.metric_name}`,
+                          metric_name: metric.metric_name,
+                          verbose_name: metric.verbose_name ?? '',
                         })),
+                      ]}
+                      optionFilterProps={[
+                        'column_name',
+                        'verbose_name',
+                        'metric_name',
                       ]}
                     />
                   </FormItem>

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/AdhocMetricEditPopover.test.tsx
@@ -248,3 +248,155 @@ test('Should render "Custom SQL" tab correctly', async () => {
 
   expect(await screen.findByRole('textbox')).toBeInTheDocument();
 });
+
+test('Should filter saved metrics by metric_name', async () => {
+  const props = {
+    ...createProps(),
+    savedMetricsOptions: [
+      {
+        id: 64,
+        metric_name: 'count',
+        expression: 'COUNT(*)',
+        verbose_name: 'Total Count',
+      },
+      {
+        id: 65,
+        metric_name: 'revenue_sum',
+        expression: 'sum(revenue)',
+        verbose_name: 'Total Sales Amount',
+      },
+    ],
+  };
+  render(<AdhocMetricEditPopover {...props} />);
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Select saved metrics',
+  });
+  userEvent.click(combobox);
+
+  // Search by metric_name - 'revenue' is only in metric_name, not in verbose_name
+  await userEvent.type(combobox, 'revenue');
+
+  await selectOption('Total Sales Amount', 'Select saved metrics');
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(props.onChange).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ metric_name: 'revenue_sum' }),
+    expect.anything(),
+  );
+});
+
+test('Should filter saved metrics by verbose_name', async () => {
+  const props = {
+    ...createProps(),
+    savedMetricsOptions: [
+      {
+        id: 64,
+        metric_name: 'count',
+        expression: 'COUNT(*)',
+        verbose_name: 'Total Count',
+      },
+      {
+        id: 65,
+        metric_name: 'revenue_sum',
+        expression: 'sum(revenue)',
+        verbose_name: 'Total Sales Amount',
+      },
+    ],
+  };
+  render(<AdhocMetricEditPopover {...props} />);
+
+  const combobox = screen.getByRole('combobox', {
+    name: 'Select saved metrics',
+  });
+  userEvent.click(combobox);
+
+  // Search by verbose_name - 'Sales' is only in verbose_name, not in metric_name
+  await userEvent.type(combobox, 'Sales');
+
+  await selectOption('Total Sales Amount', 'Select saved metrics');
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(props.onChange).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ metric_name: 'revenue_sum' }),
+    expect.anything(),
+  );
+});
+
+test('Should filter columns by column_name in Simple tab', async () => {
+  const props = {
+    ...createProps(),
+    columns: [
+      {
+        id: 1,
+        column_name: 'user_id',
+        verbose_name: 'User Identifier',
+        type: 'INTEGER',
+      },
+      {
+        id: 2,
+        column_name: 'created_at',
+        verbose_name: 'Creation Timestamp',
+        type: 'DATETIME',
+      },
+    ],
+  };
+  props.getCurrentTab.mockImplementation(tab => {
+    props.adhocMetric.expressionType = tab;
+  });
+  render(<AdhocMetricEditPopover {...props} />);
+
+  const tab = screen.getByRole('tab', { name: 'Simple' }).parentElement!;
+  userEvent.click(tab);
+
+  const columnCombobox = screen.getByRole('combobox', {
+    name: 'Select column',
+  });
+
+  // Search by column_name - 'created' is only in column_name, not in verbose_name
+  await userEvent.type(columnCombobox, 'created');
+
+  await selectOption('Creation Timestamp', 'Select column');
+
+  expect(props.onChange).toHaveBeenCalledTimes(0);
+});
+
+test('Should filter columns by verbose_name in Simple tab', async () => {
+  const props = {
+    ...createProps(),
+    columns: [
+      {
+        id: 1,
+        column_name: 'user_id',
+        verbose_name: 'User Identifier',
+        type: 'INTEGER',
+      },
+      {
+        id: 2,
+        column_name: 'created_at',
+        verbose_name: 'Creation Timestamp',
+        type: 'DATETIME',
+      },
+    ],
+  };
+  props.getCurrentTab.mockImplementation(tab => {
+    props.adhocMetric.expressionType = tab;
+  });
+  render(<AdhocMetricEditPopover {...props} />);
+
+  const tab = screen.getByRole('tab', { name: 'Simple' }).parentElement!;
+  userEvent.click(tab);
+
+  const columnCombobox = screen.getByRole('combobox', {
+    name: 'Select column',
+  });
+
+  // Search by verbose_name - 'Timestamp' is only in verbose_name, not in column_name
+  await userEvent.type(columnCombobox, 'Timestamp');
+
+  await selectOption('Creation Timestamp', 'Select column');
+
+  expect(props.onChange).toHaveBeenCalledTimes(0);
+});

--- a/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/MetricControl/AdhocMetricEditPopover/index.tsx
@@ -467,8 +467,11 @@ export default class AdhocMetricEditPopover extends PureComponent<
                           value: savedMetric.metric_name,
                           label: this.renderMetricOption(savedMetric),
                           key: savedMetric.id,
+                          metric_name: savedMetric.metric_name,
+                          verbose_name: savedMetric.verbose_name ?? '',
                         }),
                       )}
+                      optionFilterProps={['metric_name', 'verbose_name']}
                       {...savedSelectProps}
                     />
                   </FormItem>
@@ -526,7 +529,10 @@ export default class AdhocMetricEditPopover extends PureComponent<
                         value: column.column_name,
                         key: (column as { id?: unknown }).id,
                         label: this.renderColumnOption(column),
+                        column_name: column.column_name,
+                        verbose_name: column.verbose_name ?? '',
                       }))}
+                      optionFilterProps={['column_name', 'verbose_name']}
                       {...columnSelectProps}
                     />
                   </FormItem>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Saved metrics can be searched through a filterable select/combobox. However, labels (which are used as the display name for the combobox items) are not searchable. Currently, the filter/search only works for metric keys.
The behaviour is the same for Columns and Metrics under the Dimensions > Simple tab, so this PR also addresses it.

### PROBLEM
Ant Design's Select only searches through the value field by default, which Superset's core select component is based upon.
Source: search for `optionFilterProp`[here](https://ant.design/components/select).
And see `/superset-frontend/packages/superset-ui-core/src/components/Select/types.ts`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
<img width="401" height="347" alt="Screenshot 2026-01-14 at 15 55 10" src="https://github.com/user-attachments/assets/80297f8e-f626-4c8a-a98a-7b78705db70c" />
<img width="364" height="340" alt="Screenshot 2026-01-14 at 15 55 34" src="https://github.com/user-attachments/assets/7920d4ab-be6d-4c3e-aa82-b99fc74db68a" />
<img width="357" height="340" alt="Screenshot 2026-01-14 at 15 55 52" src="https://github.com/user-attachments/assets/dba3b16f-86b5-4191-a962-529c5bc2e0a9" />

#### After

https://github.com/user-attachments/assets/8bd4d618-f263-4d98-91f4-2c306ce5b9b6

<img width="676" height="362" alt="Screenshot 2026-01-14 at 16 29 29" src="https://github.com/user-attachments/assets/8d348d0d-841b-466a-b39e-9a8c080f2025" />
<img width="341" height="322" alt="Screenshot 2026-01-14 at 16 31 23" src="https://github.com/user-attachments/assets/05411e00-744b-4611-8574-26889a5282ce" />
<img width="356" height="339" alt="Screenshot 2026-01-14 at 16 31 46" src="https://github.com/user-attachments/assets/c98fde20-17da-407f-a102-60b799d3f155" />


### TESTING INSTRUCTIONS
1. Find a dataset that has metrics/columns or create metrics for a dataset.
1.1 To create metrics, go to the dataset, go to the top left corner under Chart Source, edit the dataset through the dots icon, and go to the Metrics tab. 
2. Add different values for the same metric for it's key and label (to verify different keywords yield the same metric.
3. Under the Data tab, Query > Metrics section, click the edit field to open the popover, go to the Saved metric drop-down selection and start typing the metric key and then label.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
