### PR TITLE
fix(prune_logs): improve performance by using id column only for ordering log records when max_rows_per_run is provided

### DIFF
--- a/superset/commands/logs/prune.py
+++ b/superset/commands/logs/prune.py
@@ -41,7 +41,7 @@ class LogPruneCommand(BaseCommand):
                                      Records older than this period will be deleted.
         max_rows_per_run (int | None): The maximum number of rows to delete in a single run.
                                        If provided and greater than zero, rows are selected
-                                       deterministically from the oldest first (by timestamp then id)
+                                       deterministically from the oldest first by id
                                        up to this limit in this execution.
     """  # noqa: E501
 
@@ -50,7 +50,7 @@ class LogPruneCommand(BaseCommand):
         :param retention_period_days: Number of days to keep in the logs table
         :param max_rows_per_run: The maximum number of rows to delete in a single run.
             If provided and greater than zero, rows are selected deterministically from the
-            oldest first (by timestamp then id) up to this limit in this execution.
+            oldest first by id up to this limit in this execution.
         """  # noqa: E501
         self.retention_period_days = retention_period_days
         self.max_rows_per_run = max_rows_per_run
@@ -71,7 +71,7 @@ class LogPruneCommand(BaseCommand):
         # Optionally limited by max_rows_per_run
         # order by oldest first for deterministic deletion
         if self.max_rows_per_run is not None and self.max_rows_per_run > 0:
-            select_stmt = select_stmt.order_by(Log.dttm.asc(), Log.id.asc()).limit(
+            select_stmt = select_stmt.order_by(Log.id.asc()).limit(
                 self.max_rows_per_run
             )
 


### PR DESCRIPTION
### SUMMARY
fix(prune_logs): improve performance by using id column only for log records when max_rows_per_run is provided

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### Before
```
EXPLAIN
SELECT id
FROM logs
WHERE dttm < NOW() - INTERVAL '30 days'
ORDER BY dttm ASC, id ASC
LIMIT 50000;
```

```
QUERY PLAN
Limit  (cost=5885728.47..5891562.21 rows=50000 width=12)
  ->  Gather Merge  (cost=5885728.47..9807290.72 rows=33611044 width=12)
        Workers Planned: 2
        ->  Sort  (cost=5884728.44..5926742.25 rows=16805522 width=12)
              Sort Key: dttm, id
              ->  Parallel Seq Scan on logs  (cost=0.00..4489060.05 rows=16805522 width=12)
                    Filter: (dttm < (now() - '30 days'::interval))
```

#### After
```
EXPLAIN
SELECT id
FROM logs
WHERE dttm < NOW() - INTERVAL '30 days'
ORDER BY id ASC
LIMIT 50000;
```

```
QUERY PLAN
Limit  (cost=0.56..17822.27 rows=50000 width=4)
  ->  Index Scan using logs_pkey on logs  (cost=0.56..14375279.10 rows=40330816 width=4)
        Filter: (dttm < (now() - '30 days'::interval))
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Run prune_logs Celery task

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
