### PR TITLE
fix(native-filters): respect filter scope in nested tabs by prioritizing chartsInScope

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -47,8 +47,9 @@ test('useIsFilterInScope should return true for dividers (always in scope)', () 
     description: 'Divider description',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(divider)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(divider),
+  ).toBe(true);
 });
 
 test('useIsFilterInScope should return true for filters with charts in active tabs', () => {
@@ -66,8 +67,9 @@ test('useIsFilterInScope should return true for filters with charts in active ta
     description: 'Sample filter description',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
 });
 
 test('useIsFilterInScope should return false for filters with inactive rootPath', () => {
@@ -84,8 +86,9 @@ test('useIsFilterInScope should return false for filters with inactive rootPath'
     description: 'Sample filter description',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(false);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(false);
 });
 
 test('useSelectFiltersInScope should return all filters in scope when no tabs exist', () => {
@@ -145,8 +148,9 @@ test('filter without chartsInScope should fall back to rootPath check', () => {
     description: 'Filter with missing chartsInScope',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
 });
 
 test('filter with empty chartsInScope array should check rootPath', () => {
@@ -172,8 +176,9 @@ test('filter with empty chartsInScope array should check rootPath', () => {
     description: 'Filter with empty chartsInScope',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
 });
 
 test('filter without chartsInScope and inactive rootPath should be out of scope', () => {
@@ -198,8 +203,9 @@ test('filter without chartsInScope and inactive rootPath should be out of scope'
     description: 'Filter in inactive tab',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(false);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(false);
 });
 
 test('filter with ROOT_ID in rootPath should be in scope when chartsInScope is missing', () => {
@@ -224,8 +230,9 @@ test('filter with ROOT_ID in rootPath should be in scope when chartsInScope is m
     description: 'Global filter with missing chartsInScope',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
 });
 
 test('useSelectFiltersInScope correctly categorizes filters with missing chartsInScope', () => {
@@ -293,6 +300,223 @@ test('filter with chartsInScope takes precedence over rootPath', () => {
     description: 'Filter with chartsInScope should ignore rootPath',
   };
 
-  const { result } = renderHook(() => useIsFilterInScope());
-  expect(result.current(filter)).toBe(true);
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
+});
+
+test('filter should be hidden on excluded nested tab even when parent tab is active', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB-Parent1', 'TAB-P1_Child2'] },
+      dashboardLayout: {
+        present: {
+          'CHART-1': {
+            type: 'CHART',
+            meta: { chartId: 1 },
+            parents: ['ROOT_ID', 'TAB-Parent1', 'TAB-P1_Child1'],
+          },
+          'CHART-2': {
+            type: 'CHART',
+            meta: { chartId: 2 },
+            parents: ['ROOT_ID', 'TAB-Parent1', 'TAB-P1_Child1'],
+          },
+          'CHART-5': {
+            type: 'CHART',
+            meta: { chartId: 5 },
+            parents: ['ROOT_ID', 'TAB-Parent2'],
+          },
+          'CHART-6': {
+            type: 'CHART',
+            meta: { chartId: 6 },
+            parents: ['ROOT_ID', 'TAB-Parent2'],
+          },
+          'TAB-Parent1': { type: 'TAB', id: 'TAB-Parent1' },
+          'TAB-P1_Child1': { type: 'TAB', id: 'TAB-P1_Child1' },
+          'TAB-P1_Child2': { type: 'TAB', id: 'TAB-P1_Child2' },
+          'TAB-Parent2': { type: 'TAB', id: 'TAB-Parent2' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filter: Filter = {
+    id: 'filter_nested',
+    name: 'Nested Tab Filter',
+    filterType: 'filter_select',
+    type: NativeFilterType.NativeFilter,
+    chartsInScope: [1, 2, 5, 6],
+    scope: { rootPath: ['TAB-P1_Child1', 'TAB-Parent2'], excluded: [3, 4] },
+    controlValues: {},
+    defaultDataMask: {},
+    cascadeParentIds: [],
+    targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+    description: 'Filter excluding P1_Child2',
+  };
+
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(false);
+});
+
+test('filter should be visible on included nested tab', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB-Parent1', 'TAB-P1_Child1'] },
+      dashboardLayout: {
+        present: {
+          'CHART-1': {
+            type: 'CHART',
+            meta: { chartId: 1 },
+            parents: ['ROOT_ID', 'TAB-Parent1', 'TAB-P1_Child1'],
+          },
+          'CHART-2': {
+            type: 'CHART',
+            meta: { chartId: 2 },
+            parents: ['ROOT_ID', 'TAB-Parent1', 'TAB-P1_Child1'],
+          },
+          'TAB-Parent1': { type: 'TAB', id: 'TAB-Parent1' },
+          'TAB-P1_Child1': { type: 'TAB', id: 'TAB-P1_Child1' },
+          'TAB-P1_Child2': { type: 'TAB', id: 'TAB-P1_Child2' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filter: Filter = {
+    id: 'filter_nested_visible',
+    name: 'Nested Tab Filter Visible',
+    filterType: 'filter_select',
+    type: NativeFilterType.NativeFilter,
+    chartsInScope: [1, 2, 5, 6],
+    scope: { rootPath: ['TAB-P1_Child1', 'TAB-Parent2'], excluded: [3, 4] },
+    controlValues: {},
+    defaultDataMask: {},
+    cascadeParentIds: [],
+    targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+    description: 'Filter including P1_Child1',
+  };
+
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
+});
+
+test('filter should be visible on top-level tab when charts have no nested parents', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB-Parent2'] },
+      dashboardLayout: {
+        present: {
+          'CHART-5': {
+            type: 'CHART',
+            meta: { chartId: 5 },
+            parents: ['ROOT_ID', 'TAB-Parent2'],
+          },
+          'CHART-6': {
+            type: 'CHART',
+            meta: { chartId: 6 },
+            parents: ['ROOT_ID', 'TAB-Parent2'],
+          },
+          'TAB-Parent2': { type: 'TAB', id: 'TAB-Parent2' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filter: Filter = {
+    id: 'filter_top_level',
+    name: 'Top Level Tab Filter',
+    filterType: 'filter_select',
+    type: NativeFilterType.NativeFilter,
+    chartsInScope: [1, 2, 5, 6],
+    scope: { rootPath: ['TAB-P1_Child1', 'TAB-Parent2'], excluded: [3, 4] },
+    controlValues: {},
+    defaultDataMask: {},
+    cascadeParentIds: [],
+    targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+    description: 'Filter including Parent2',
+  };
+
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
+});
+
+test('filter with chartsInScope referencing non-existent chart should still work', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB-Parent1'] },
+      dashboardLayout: {
+        present: {
+          'CHART-1': {
+            type: 'CHART',
+            meta: { chartId: 1 },
+            parents: ['ROOT_ID', 'TAB-Parent1'],
+          },
+          'TAB-Parent1': { type: 'TAB', id: 'TAB-Parent1' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filter: Filter = {
+    id: 'filter_missing_chart',
+    name: 'Filter With Missing Chart',
+    filterType: 'filter_select',
+    type: NativeFilterType.NativeFilter,
+    chartsInScope: [999],
+    scope: { rootPath: ['TAB-Parent1'], excluded: [] },
+    controlValues: {},
+    defaultDataMask: {},
+    cascadeParentIds: [],
+    targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+    description: 'Filter referencing non-existent chart',
+  };
+
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
+});
+
+test('filter with mix of existing and non-existent charts in chartsInScope', () => {
+  (useSelector as jest.Mock).mockImplementation((selector: Function) => {
+    const mockState = {
+      dashboardState: { activeTabs: ['TAB-Parent2'] },
+      dashboardLayout: {
+        present: {
+          'CHART-1': {
+            type: 'CHART',
+            meta: { chartId: 1 },
+            parents: ['ROOT_ID', 'TAB-Parent1'],
+          },
+          'TAB-Parent1': { type: 'TAB', id: 'TAB-Parent1' },
+          'TAB-Parent2': { type: 'TAB', id: 'TAB-Parent2' },
+        },
+      },
+    };
+    return selector(mockState);
+  });
+
+  const filter: Filter = {
+    id: 'filter_mixed_charts',
+    name: 'Filter With Mixed Charts',
+    filterType: 'filter_select',
+    type: NativeFilterType.NativeFilter,
+    chartsInScope: [1, 999],
+    scope: { rootPath: ['TAB-Parent1'], excluded: [] },
+    controlValues: {},
+    defaultDataMask: {},
+    cascadeParentIds: [],
+    targets: [{ column: { name: 'column_name' }, datasetId: 1 }],
+    description: 'Filter with mix of existing and non-existent charts',
+  };
+
+  expect(
+    renderHook(() => useIsFilterInScope()).result.current(filter),
+  ).toBe(true);
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.test.ts
@@ -47,9 +47,8 @@ test('useIsFilterInScope should return true for dividers (always in scope)', () 
     description: 'Divider description',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(divider),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(divider)).toBe(true);
 });
 
 test('useIsFilterInScope should return true for filters with charts in active tabs', () => {
@@ -67,9 +66,8 @@ test('useIsFilterInScope should return true for filters with charts in active ta
     description: 'Sample filter description',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('useIsFilterInScope should return false for filters with inactive rootPath', () => {
@@ -86,9 +84,8 @@ test('useIsFilterInScope should return false for filters with inactive rootPath'
     description: 'Sample filter description',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(false);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(false);
 });
 
 test('useSelectFiltersInScope should return all filters in scope when no tabs exist', () => {
@@ -148,9 +145,8 @@ test('filter without chartsInScope should fall back to rootPath check', () => {
     description: 'Filter with missing chartsInScope',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter with empty chartsInScope array should check rootPath', () => {
@@ -176,9 +172,8 @@ test('filter with empty chartsInScope array should check rootPath', () => {
     description: 'Filter with empty chartsInScope',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter without chartsInScope and inactive rootPath should be out of scope', () => {
@@ -203,9 +198,8 @@ test('filter without chartsInScope and inactive rootPath should be out of scope'
     description: 'Filter in inactive tab',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(false);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(false);
 });
 
 test('filter with ROOT_ID in rootPath should be in scope when chartsInScope is missing', () => {
@@ -230,9 +224,8 @@ test('filter with ROOT_ID in rootPath should be in scope when chartsInScope is m
     description: 'Global filter with missing chartsInScope',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('useSelectFiltersInScope correctly categorizes filters with missing chartsInScope', () => {
@@ -300,9 +293,8 @@ test('filter with chartsInScope takes precedence over rootPath', () => {
     description: 'Filter with chartsInScope should ignore rootPath',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter should be hidden on excluded nested tab even when parent tab is active', () => {
@@ -355,9 +347,8 @@ test('filter should be hidden on excluded nested tab even when parent tab is act
     description: 'Filter excluding P1_Child2',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(false);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(false);
 });
 
 test('filter should be visible on included nested tab', () => {
@@ -399,9 +390,8 @@ test('filter should be visible on included nested tab', () => {
     description: 'Filter including P1_Child1',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter should be visible on top-level tab when charts have no nested parents', () => {
@@ -441,9 +431,8 @@ test('filter should be visible on top-level tab when charts have no nested paren
     description: 'Filter including Parent2',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter with chartsInScope referencing non-existent chart should still work', () => {
@@ -478,9 +467,8 @@ test('filter with chartsInScope referencing non-existent chart should still work
     description: 'Filter referencing non-existent chart',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });
 
 test('filter with mix of existing and non-existent charts in chartsInScope', () => {
@@ -516,7 +504,6 @@ test('filter with mix of existing and non-existent charts in chartsInScope', () 
     description: 'Filter with mix of existing and non-existent charts',
   };
 
-  expect(
-    renderHook(() => useIsFilterInScope()).result.current(filter),
-  ).toBe(true);
+  const { result } = renderHook(() => useIsFilterInScope());
+  expect(result.current(filter)).toBe(true);
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -229,11 +229,9 @@ export function useIsFilterInScope() {
         return isChartInScope;
       }
 
-      const isFilterInActiveTab =
-        filter.scope?.rootPath &&
-        filter.scope.rootPath.some(tab => activeTabs.includes(tab));
-
-      return isFilterInActiveTab;
+      return (
+        filter.scope?.rootPath?.some(tab => activeTabs.includes(tab)) ?? false
+      );
     },
     [selectChartTabParents, activeTabs],
   );

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -195,6 +195,10 @@ export function useIsFilterInScope() {
   const activeTabs = useActiveDashboardTabs();
   const selectChartTabParents = useSelectChartTabParents();
 
+  // Filter is in scope if any of its charts is visible.
+  // Chart is visible if it's placed in an active tab tree or if it's not attached to any tab.
+  // Chart is in an active tab tree if all of its ancestors of type TAB are active
+  // Dividers are always in scope
   return useCallback(
     (filter: FilterElement | Divider) => {
       if (filter.type === NativeFilterType.Divider) return true;

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
@@ -20,133 +20,68 @@ import { getChartIdsInFilterScope } from './getChartIdsInFilterScope';
 import { CHART_TYPE } from './componentTypes';
 import { LayoutItem } from '../types';
 
-interface TestLayoutItem {
-  id: string;
-  type: string;
-  children: string[];
-  parents: string[];
-  meta?: { chartId?: number; text?: string };
-}
+/**
+ * Creates a minimal valid LayoutItem for testing.
+ * Only includes fields required by the type and used by getChartIdsInFilterScope.
+ */
+const createChartLayoutItem = (
+  id: string,
+  chartId: number,
+  parents: string[],
+): LayoutItem => ({
+  id,
+  type: CHART_TYPE,
+  children: [],
+  parents,
+  meta: {
+    chartId,
+    height: 100,
+    width: 100,
+    uuid: `test-uuid-${id}`,
+  },
+});
 
 const createNestedTabsLayout = (): LayoutItem[] => {
-  const layout: Record<string, TestLayoutItem> = {
-    ROOT_ID: {
-      id: 'ROOT_ID',
-      type: 'ROOT',
-      children: ['TABS-1'],
-      parents: [],
-    },
-    'TABS-1': {
-      id: 'TABS-1',
-      type: 'TABS',
-      children: ['TAB-Parent1', 'TAB-Parent2'],
-      parents: ['ROOT_ID'],
-    },
-    'TAB-Parent1': {
-      id: 'TAB-Parent1',
-      type: 'TAB',
-      children: ['TABS-nested'],
-      parents: ['ROOT_ID', 'TABS-1'],
-      meta: { text: 'Parent1' },
-    },
-    'TABS-nested': {
-      id: 'TABS-nested',
-      type: 'TABS',
-      children: ['TAB-P1_Child1', 'TAB-P1_Child2'],
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1'],
-    },
-    'TAB-P1_Child1': {
-      id: 'TAB-P1_Child1',
-      type: 'TAB',
-      children: ['CHART-1', 'CHART-2'],
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1', 'TABS-nested'],
-      meta: { text: 'P1_Child1' },
-    },
-    'TAB-P1_Child2': {
-      id: 'TAB-P1_Child2',
-      type: 'TAB',
-      children: ['CHART-3', 'CHART-4'],
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1', 'TABS-nested'],
-      meta: { text: 'P1_Child2' },
-    },
-    'TAB-Parent2': {
-      id: 'TAB-Parent2',
-      type: 'TAB',
-      children: ['CHART-5', 'CHART-6'],
-      parents: ['ROOT_ID', 'TABS-1'],
-      meta: { text: 'Parent2' },
-    },
-    'CHART-1': {
-      id: 'CHART-1',
-      type: CHART_TYPE,
-      children: [],
-      parents: [
-        'ROOT_ID',
-        'TABS-1',
-        'TAB-Parent1',
-        'TABS-nested',
-        'TAB-P1_Child1',
-      ],
-      meta: { chartId: 1 },
-    },
-    'CHART-2': {
-      id: 'CHART-2',
-      type: CHART_TYPE,
-      children: [],
-      parents: [
-        'ROOT_ID',
-        'TABS-1',
-        'TAB-Parent1',
-        'TABS-nested',
-        'TAB-P1_Child1',
-      ],
-      meta: { chartId: 2 },
-    },
-    'CHART-3': {
-      id: 'CHART-3',
-      type: CHART_TYPE,
-      children: [],
-      parents: [
-        'ROOT_ID',
-        'TABS-1',
-        'TAB-Parent1',
-        'TABS-nested',
-        'TAB-P1_Child2',
-      ],
-      meta: { chartId: 3 },
-    },
-    'CHART-4': {
-      id: 'CHART-4',
-      type: CHART_TYPE,
-      children: [],
-      parents: [
-        'ROOT_ID',
-        'TABS-1',
-        'TAB-Parent1',
-        'TABS-nested',
-        'TAB-P1_Child2',
-      ],
-      meta: { chartId: 4 },
-    },
-    'CHART-5': {
-      id: 'CHART-5',
-      type: CHART_TYPE,
-      children: [],
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent2'],
-      meta: { chartId: 5 },
-    },
-    'CHART-6': {
-      id: 'CHART-6',
-      type: CHART_TYPE,
-      children: [],
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent2'],
-      meta: { chartId: 6 },
-    },
-  };
-
-  return Object.values(layout).filter(
-    item => item.type === CHART_TYPE,
-  ) as unknown as LayoutItem[];
+  return [
+    createChartLayoutItem('CHART-1', 1, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent1',
+      'TABS-nested',
+      'TAB-P1_Child1',
+    ]),
+    createChartLayoutItem('CHART-2', 2, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent1',
+      'TABS-nested',
+      'TAB-P1_Child1',
+    ]),
+    createChartLayoutItem('CHART-3', 3, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent1',
+      'TABS-nested',
+      'TAB-P1_Child2',
+    ]),
+    createChartLayoutItem('CHART-4', 4, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent1',
+      'TABS-nested',
+      'TAB-P1_Child2',
+    ]),
+    createChartLayoutItem('CHART-5', 5, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent2',
+    ]),
+    createChartLayoutItem('CHART-6', 6, [
+      'ROOT_ID',
+      'TABS-1',
+      'TAB-Parent2',
+    ]),
+  ];
 };
 
 const allChartIds = [1, 2, 3, 4, 5, 6];
@@ -406,4 +341,38 @@ test('filter with selectedLayers and rootPath should combine both correctly', ()
   );
 
   expect(chartsInScope.sort()).toEqual([1, 5, 6]);
+});
+
+test('filter with selectedLayers should include charts even if they are in excluded array', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [1, 2],
+    selectedLayers: ['chart-1-layer-0', 'chart-2-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter with selectedLayers and excluded should exclude regular charts but include layer-selected charts', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent2'],
+    excluded: [5],
+    selectedLayers: ['chart-1-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 6]);
 });

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getChartIdsInFilterScope } from './getChartIdsInFilterScope';
+import { CHART_TYPE } from './componentTypes';
+import { LayoutItem } from '../types';
+
+interface TestLayoutItem {
+  id: string;
+  type: string;
+  children: string[];
+  parents: string[];
+  meta?: { chartId?: number; text?: string };
+}
+
+const createNestedTabsLayout = (): LayoutItem[] => {
+  const layout: Record<string, TestLayoutItem> = {
+    ROOT_ID: {
+      id: 'ROOT_ID',
+      type: 'ROOT',
+      children: ['TABS-1'],
+      parents: [],
+    },
+    'TABS-1': {
+      id: 'TABS-1',
+      type: 'TABS',
+      children: ['TAB-Parent1', 'TAB-Parent2'],
+      parents: ['ROOT_ID'],
+    },
+    'TAB-Parent1': {
+      id: 'TAB-Parent1',
+      type: 'TAB',
+      children: ['TABS-nested'],
+      parents: ['ROOT_ID', 'TABS-1'],
+      meta: { text: 'Parent1' },
+    },
+    'TABS-nested': {
+      id: 'TABS-nested',
+      type: 'TABS',
+      children: ['TAB-P1_Child1', 'TAB-P1_Child2'],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1'],
+    },
+    'TAB-P1_Child1': {
+      id: 'TAB-P1_Child1',
+      type: 'TAB',
+      children: ['CHART-1', 'CHART-2'],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1', 'TABS-nested'],
+      meta: { text: 'P1_Child1' },
+    },
+    'TAB-P1_Child2': {
+      id: 'TAB-P1_Child2',
+      type: 'TAB',
+      children: ['CHART-3', 'CHART-4'],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent1', 'TABS-nested'],
+      meta: { text: 'P1_Child2' },
+    },
+    'TAB-Parent2': {
+      id: 'TAB-Parent2',
+      type: 'TAB',
+      children: ['CHART-5', 'CHART-6'],
+      parents: ['ROOT_ID', 'TABS-1'],
+      meta: { text: 'Parent2' },
+    },
+    'CHART-1': {
+      id: 'CHART-1',
+      type: CHART_TYPE,
+      children: [],
+      parents: [
+        'ROOT_ID',
+        'TABS-1',
+        'TAB-Parent1',
+        'TABS-nested',
+        'TAB-P1_Child1',
+      ],
+      meta: { chartId: 1 },
+    },
+    'CHART-2': {
+      id: 'CHART-2',
+      type: CHART_TYPE,
+      children: [],
+      parents: [
+        'ROOT_ID',
+        'TABS-1',
+        'TAB-Parent1',
+        'TABS-nested',
+        'TAB-P1_Child1',
+      ],
+      meta: { chartId: 2 },
+    },
+    'CHART-3': {
+      id: 'CHART-3',
+      type: CHART_TYPE,
+      children: [],
+      parents: [
+        'ROOT_ID',
+        'TABS-1',
+        'TAB-Parent1',
+        'TABS-nested',
+        'TAB-P1_Child2',
+      ],
+      meta: { chartId: 3 },
+    },
+    'CHART-4': {
+      id: 'CHART-4',
+      type: CHART_TYPE,
+      children: [],
+      parents: [
+        'ROOT_ID',
+        'TABS-1',
+        'TAB-Parent1',
+        'TABS-nested',
+        'TAB-P1_Child2',
+      ],
+      meta: { chartId: 4 },
+    },
+    'CHART-5': {
+      id: 'CHART-5',
+      type: CHART_TYPE,
+      children: [],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent2'],
+      meta: { chartId: 5 },
+    },
+    'CHART-6': {
+      id: 'CHART-6',
+      type: CHART_TYPE,
+      children: [],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-Parent2'],
+      meta: { chartId: 6 },
+    },
+  };
+
+  return Object.values(layout).filter(
+    item => item.type === CHART_TYPE,
+  ) as unknown as LayoutItem[];
+};
+
+const allChartIds = [1, 2, 3, 4, 5, 6];
+
+test('filter scoped to all panels should include all charts', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter scoped to Parent1 tab should include only charts in Parent1 (including nested tabs)', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent1'],
+    excluded: [],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4]);
+});
+
+test('filter scoped to Parent2 tab should include only charts in Parent2', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent2'],
+    excluded: [],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([5, 6]);
+});
+
+test('filter scoped to P1_Child1 nested tab should include only charts in that tab', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-P1_Child1'],
+    excluded: [],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2]);
+});
+
+test('filter excluding P1_Child2 tab should not include charts 3 and 4', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-P1_Child1', 'TAB-Parent2'],
+    excluded: [3, 4],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 5, 6]);
+});
+
+test('filter with ROOT_ID rootPath excluding charts 3 and 4 should work correctly', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [3, 4],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 5, 6]);
+});
+
+test('filter scoped to multiple top-level tabs should include charts from all specified tabs', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent1', 'TAB-Parent2'],
+    excluded: [],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter scoped to nested tab with exclusion should work', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-P1_Child1'],
+    excluded: [2],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope).toEqual([1]);
+});

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
@@ -278,3 +278,133 @@ test('filter scoped to nested tab with exclusion should work', () => {
 
   expect(chartsInScope).toEqual([1]);
 });
+
+test('filter with selectedLayers should include charts from layer selections', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+    selectedLayers: ['chart-1-layer-0', 'chart-2-layer-1'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter with selectedLayers should include both layer-selected charts and regular charts', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent2'],
+    excluded: [],
+    selectedLayers: ['chart-1-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 5, 6]);
+});
+
+test('filter with selectedLayers should exclude charts that have layer selections from regular filtering', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-P1_Child1'],
+    excluded: [],
+    selectedLayers: ['chart-1-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2]);
+});
+
+
+test('filter with selectedLayers should ignore invalid layer key formats', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+    selectedLayers: [
+      'chart-1-layer-0',
+      'invalid-format',
+      'chart-2-layer-1',
+      'chart-invalid-layer-0',
+    ],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter with selectedLayers should handle charts not in chartIds array', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+    selectedLayers: ['chart-1-layer-0', 'chart-999-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter with selectedLayers should deduplicate chart IDs', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+    selectedLayers: [
+      'chart-1-layer-0',
+      'chart-1-layer-1',
+      'chart-2-layer-0',
+      'chart-2-layer-2',
+    ],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 2, 3, 4, 5, 6]);
+});
+
+test('filter with selectedLayers and rootPath should combine both correctly', () => {
+  const chartLayoutItems = createNestedTabsLayout();
+  const filterScope = {
+    rootPath: ['TAB-Parent2'],
+    excluded: [],
+    selectedLayers: ['chart-1-layer-0'],
+  };
+
+  const chartsInScope = getChartIdsInFilterScope(
+    filterScope,
+    allChartIds,
+    chartLayoutItems,
+  );
+
+  expect(chartsInScope.sort()).toEqual([1, 5, 6]);
+});

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
@@ -330,7 +330,6 @@ test('filter with selectedLayers should exclude charts that have layer selection
   expect(chartsInScope.sort()).toEqual([1, 2]);
 });
 
-
 test('filter with selectedLayers should ignore invalid layer key formats', () => {
   const chartLayoutItems = createNestedTabsLayout();
   const filterScope = {

--- a/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
+++ b/superset-frontend/src/dashboard/util/getChartIdsInFilterScope.test.ts
@@ -71,16 +71,8 @@ const createNestedTabsLayout = (): LayoutItem[] => {
       'TABS-nested',
       'TAB-P1_Child2',
     ]),
-    createChartLayoutItem('CHART-5', 5, [
-      'ROOT_ID',
-      'TABS-1',
-      'TAB-Parent2',
-    ]),
-    createChartLayoutItem('CHART-6', 6, [
-      'ROOT_ID',
-      'TABS-1',
-      'TAB-Parent2',
-    ]),
+    createChartLayoutItem('CHART-5', 5, ['ROOT_ID', 'TABS-1', 'TAB-Parent2']),
+    createChartLayoutItem('CHART-6', 6, ['ROOT_ID', 'TABS-1', 'TAB-Parent2']),
   ];
 };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
**Issue:**
Dashboard filters appear in tabs that were explicitly excluded from the filter scope, particularly when dealing with nested tabs.

**Root cause:**
The original implementation used OR logic (`isChartInScope || isFilterInActiveTab`), which allowed the `rootPath` fallback to incorrectly show filters even when charts in `chartsInScope` were not visible. When a child tab was excluded, but its parent tab was active, the `rootPath` check would match the parent tab and incorrectly display the filter.

**Fix:**
Changed the logic to prioritize `chartsInScope` when it exists, using if/else instead of OR. When `chartsInScope` is present, only chart visibility is checked (requiring all tab ancestors to be active). 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**BEFORE:**
![filter-scoping-fix-before](https://github.com/user-attachments/assets/e0491362-1433-4bca-af78-3d0866e33ab2)
**AFTER:**
![filter-scoping-fix-after](https://github.com/user-attachments/assets/7e6e68e5-8323-4bfd-9ae5-facd3dab52bf)

### TESTING INSTRUCTIONS
1.  Create a dashboard with two tabs.

2. One tab needs to have two other tabs (Child1 and Child2)

3 .Each of them needs to have two charts nested (Child1, Child2, and Parent2). You need to do this before creating the dashboard filter. If any of the previous tabs don’t have the charts nested, then the bug is not produced.

4. Create a dashboard filter (e.g. Time grain) and change the scope not to consider the Child2 tab).

<img width="1440" height="707" alt="image" src="https://github.com/user-attachments/assets/81b61881-c646-4d00-8403-b8ed764380e0" />

5. Save the changes.

**EXPECTED RESULTS**
The scope you assign in your dashboard filter is respected.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
