### PR TITLE
feat(dashboard): show dataset column labels in View as table

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -457,6 +457,7 @@ const SliceHeaderControls = (
               isRequest
               isVisible
               canDownload={!!props.supersetCanCSV}
+              columnDisplayNames={datasetWithVerboseMap?.verbose_map}
             />
           }
         />

--- a/superset-frontend/src/explore/components/DataTableControl/index.tsx
+++ b/superset-frontend/src/explore/components/DataTableControl/index.tsx
@@ -164,6 +164,7 @@ const DataTableTemporalHeaderCell = ({
   onTimeColumnChange,
   datasourceId,
   isOriginalTimeColumn,
+  displayLabel,
 }: {
   columnName: string;
   onTimeColumnChange: (
@@ -172,6 +173,7 @@ const DataTableTemporalHeaderCell = ({
   ) => void;
   datasourceId?: string;
   isOriginalTimeColumn: boolean;
+  displayLabel?: string;
 }) => {
   const theme = useTheme();
 
@@ -215,10 +217,10 @@ const DataTableTemporalHeaderCell = ({
           onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
         />
       </Popover>
-      {columnName}
+      {displayLabel ?? columnName}
     </span>
   ) : (
-    <span>{columnName}</span>
+    <span>{displayLabel ?? columnName}</span>
   );
 };
 
@@ -258,6 +260,7 @@ export const useTableColumns = (
   isVisible?: boolean,
   moreConfigs?: { [key: string]: Partial<Column> },
   allowHTML?: boolean,
+  columnDisplayNames?: Record<string, string>,
 ) => {
   const [originalFormattedTimeColumns, setOriginalFormattedTimeColumns] =
     useState<string[]>(getTimeColumns(datasourceId));
@@ -302,6 +305,7 @@ export const useTableColumns = (
             .map((key, index) => {
               const colType = coltypes?.[index];
               const firstValue = data[0][key];
+              const headerLabel = columnDisplayNames?.[key] ?? key;
               const originalFormattedTimeColumnIndex =
                 colType === GenericDataType.Temporal
                   ? originalFormattedTimeColumns.indexOf(key)
@@ -320,9 +324,10 @@ export const useTableColumns = (
                       datasourceId={datasourceId}
                       onTimeColumnChange={onTimeColumnChange}
                       isOriginalTimeColumn={isOriginalTimeColumn}
+                      displayLabel={headerLabel}
                     />
                   ) : (
-                    key
+                    headerLabel
                   ),
                 Cell: ({ value }) => {
                   if (value === true) {
@@ -357,6 +362,7 @@ export const useTableColumns = (
       datasourceId,
       moreConfigs,
       originalFormattedTimeColumns,
+      columnDisplayNames,
     ],
   );
 };

--- a/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
+++ b/superset-frontend/src/explore/components/DataTableControl/useTableColumns.test.ts
@@ -105,6 +105,7 @@ test('useTableColumns with no options', () => {
         "Cell": [Function],
         "Header": <DataTableTemporalHeaderCell
           columnName="numtime"
+          displayLabel="numtime"
           isOriginalTimeColumn={false}
           onTimeColumnChange={[Function]}
         />,
@@ -168,6 +169,7 @@ test('useTableColumns with options', () => {
         "Cell": [Function],
         "Header": <DataTableTemporalHeaderCell
           columnName="numtime"
+          displayLabel="numtime"
           isOriginalTimeColumn={false}
           onTimeColumnChange={[Function]}
         />,
@@ -193,4 +195,30 @@ test('useTableColumns with options', () => {
       );
     });
   });
+});
+
+test('useTableColumns applies columnDisplayNames to headers', () => {
+  const columnDisplayNames = {
+    col01: 'Column One',
+    [NUMTIME_KEY]: 'Verbose Numtime',
+  } as Record<string, string>;
+  const hook = renderHook(() =>
+    useTableColumns(
+      colnames,
+      coltypes,
+      data,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      columnDisplayNames,
+    ),
+  );
+  const cols = hook.result.current as JsonObject[];
+  const col01 = cols.find(c => c.id === 'col01');
+  const numtime = cols.find(c => c.id === NUMTIME_KEY);
+  expect(col01?.Header).toBe('Column One');
+  // Temporal header is a component; ensure it received the displayLabel prop
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  expect(numtime?.Header.props.displayLabel).toBe('Verbose Numtime');
 });

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -55,6 +55,7 @@ export const ResultsPaneOnDashboard = ({
   isVisible,
   dataSize = 50,
   canDownload,
+  columnDisplayNames,
 }: ResultsPaneProps) => {
   const resultsPanes = useResultsPane({
     errorMessage,
@@ -66,6 +67,7 @@ export const ResultsPaneOnDashboard = ({
     dataSize,
     isVisible,
     canDownload,
+    columnDisplayNames,
   });
 
   if (resultsPanes.length === 1) {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -39,6 +39,7 @@ export const SingleQueryResultPane = ({
   dataSize = 50,
   isVisible,
   canDownload,
+  columnDisplayNames,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
 
@@ -52,6 +53,7 @@ export const SingleQueryResultPane = ({
     isVisible,
     {}, // moreConfig
     true, // allowHTML
+    columnDisplayNames,
   );
   const filteredData = useFilteredTableData(filterText, data);
 

--- a/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/useResultsPane.tsx
@@ -55,6 +55,7 @@ export const useResultsPane = ({
   isVisible,
   dataSize = 50,
   canDownload,
+  columnDisplayNames,
 }: ResultsPaneProps): ReactElement[] => {
   const metadata = getChartMetadataRegistry().get(
     queryFormData?.viz_type || queryFormData?.vizType,
@@ -164,6 +165,7 @@ export const useResultsPane = ({
         datasourceId={queryFormData.datasource}
         isVisible={isVisible}
         canDownload={canDownload}
+        columnDisplayNames={columnDisplayNames}
       />
     </StyledDiv>
   ));

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -49,6 +49,8 @@ export interface ResultsPaneProps {
   // reload OriginalFormattedTimeColumns from localStorage when isVisible is true
   isVisible: boolean;
   canDownload: boolean;
+  // Optional map of column/metric name -> verbose label
+  columnDisplayNames?: Record<string, string>;
 }
 
 export interface SamplesPaneProps {
@@ -88,4 +90,6 @@ export interface SingleQueryResultPaneProp extends QueryResultInterface {
   // reload OriginalFormattedTimeColumns from localStorage when isVisible is true
   isVisible: boolean;
   canDownload: boolean;
+  // Optional map of column/metric name -> verbose label
+  columnDisplayNames?: Record<string, string>;
 }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This feature updates the “View as table” option in dashboard chart overflow menus to display dataset column labels (verbose names) when available, instead of raw column names.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

#### BEFORE
<img width="879" height="417" alt="Screenshot 2026-01-15 at 13 43 50" src="https://github.com/user-attachments/assets/d133de87-09ca-4809-8b9d-8176115237b7" />


#### AFTER
<img width="880" height="321" alt="Screenshot 2026-01-15 at 13 50 00" src="https://github.com/user-attachments/assets/42aa88c0-2576-44d0-94f4-8d4fc55983f5" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Open your browser and log in to Superset.
2. Go to a dashboard with a chart that uses a dataset with column labels (verbose names).
     a. You can check/edit column labels in Data > Datasets > [Your Dataset] > Edit columns.
3. On the dashboard, open the chart’s overflow menu (three dots).
4. Click “View as table”.
5. Check the table headers:
**Expected:** Headers should show the dataset’s column labels (verbose names) if defined, otherwise the raw column name.
**Temporal columns:** Should also show the label and still allow formatting.
6. Run frontend tests to ensure coverage:
```bash
npm run test -- src/explore/components/DataTableControl/useTableColumns.test.ts
```



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
