### PR TITLE
chore(Matrixify): disable matrixify for incompatible viz types

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -477,7 +477,7 @@ describe('ControlPanelsContainer', () => {
 
       // Also verify Data tab exists
       expect(screen.getByRole('tab', { name: /data/i })).toBeInTheDocument();
-      
+
       // Clean up this render before the next iteration
       unmount();
     }

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.test.tsx
@@ -297,9 +297,16 @@ describe('ControlPanelsContainer', () => {
       (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
     );
 
+    // Register control panel for line chart
+    getChartControlPanelRegistry().registerValue('line', {
+      controlPanelSections: [],
+    });
+
     const props = getDefaultProps();
+    // Use a chart type that supports matrixify (not a table)
     props.form_data = {
       ...props.form_data,
+      viz_type: 'line',
       matrixify_enable_vertical_layout: true,
     };
 
@@ -319,6 +326,7 @@ describe('ControlPanelsContainer', () => {
       ...props,
       form_data: {
         ...props.form_data,
+        viz_type: 'line',
         matrixify_enable_vertical_layout: true,
         matrixify_dimension_columns: {
           dimension: 'country',
@@ -336,6 +344,9 @@ describe('ControlPanelsContainer', () => {
       });
       expect(matrixifyTabAfterSave).toHaveAttribute('aria-selected', 'true');
     });
+
+    // Clean up
+    getChartControlPanelRegistry().remove('line');
   });
 
   test('should automatically switch to Matrixify tab when matrixify becomes enabled', async () => {
@@ -344,7 +355,17 @@ describe('ControlPanelsContainer', () => {
       (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
     );
 
+    // Register control panel for line chart
+    getChartControlPanelRegistry().registerValue('line', {
+      controlPanelSections: [],
+    });
+
     const props = getDefaultProps();
+    // Use a chart type that supports matrixify (not a table)
+    props.form_data = {
+      ...props.form_data,
+      viz_type: 'line',
+    };
 
     const { rerender } = render(<ControlPanelsContainer {...props} />, {
       useRedux: true,
@@ -359,6 +380,7 @@ describe('ControlPanelsContainer', () => {
       ...props,
       form_data: {
         ...props.form_data,
+        viz_type: 'line',
         matrixify_enable_horizontal_layout: true,
       },
     };
@@ -377,5 +399,92 @@ describe('ControlPanelsContainer', () => {
       'aria-selected',
       'false',
     );
+
+    // Clean up
+    getChartControlPanelRegistry().remove('line');
+  });
+
+  test('should not show Matrixify tab for table chart types', async () => {
+    // Enable Matrixify feature flag
+    mockIsFeatureEnabled.mockImplementation(
+      (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
+    );
+
+    // All table-type charts that don't support matrixify
+    const tableVizTypes = [
+      'table',
+      'ag-grid-table',
+      'pivot_table_v2',
+      'time_table',
+      'time_pivot',
+    ];
+
+    for (const vizType of tableVizTypes) {
+      const props = getDefaultProps();
+      props.form_data = {
+        ...props.form_data,
+        viz_type: vizType,
+      };
+
+      render(<ControlPanelsContainer {...props} />, {
+        useRedux: true,
+      });
+
+      // Wait for tabs to be rendered
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /data/i })).toBeInTheDocument();
+      });
+
+      // Check that Matrixify tab does not exist for table chart types
+      expect(
+        screen.queryByRole('tab', { name: /matrixify/i }),
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  test('should show Matrixify tab for supported chart types', async () => {
+    // Enable Matrixify feature flag
+    mockIsFeatureEnabled.mockImplementation(
+      (featureFlag: FeatureFlag) => featureFlag === FeatureFlag.Matrixify,
+    );
+
+    // Register control panels for non-table chart types
+    const simpleConfig = { controlPanelSections: [] };
+    getChartControlPanelRegistry().registerValue('line', simpleConfig);
+    getChartControlPanelRegistry().registerValue('bar', simpleConfig);
+    getChartControlPanelRegistry().registerValue('pie', simpleConfig);
+
+    // Non-table chart types that support matrixify
+    const supportedVizTypes = ['line', 'bar', 'pie'];
+
+    for (const vizType of supportedVizTypes) {
+      const props = getDefaultProps();
+      props.form_data = {
+        ...props.form_data,
+        viz_type: vizType,
+      };
+
+      const { unmount } = render(<ControlPanelsContainer {...props} />, {
+        useRedux: true,
+      });
+
+      // Wait for Matrixify tab to be rendered
+      await waitFor(() => {
+        expect(
+          screen.getByRole('tab', { name: /matrixify/i }),
+        ).toBeInTheDocument();
+      });
+
+      // Also verify Data tab exists
+      expect(screen.getByRole('tab', { name: /data/i })).toBeInTheDocument();
+      
+      // Clean up this render before the next iteration
+      unmount();
+    }
+
+    // Clean up registered chart types
+    getChartControlPanelRegistry().remove('line');
+    getChartControlPanelRegistry().remove('bar');
+    getChartControlPanelRegistry().remove('pie');
   });
 });

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -795,8 +795,14 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   ]);
 
   const showCustomizeTab = customizeSections.length > 0;
-  // Charts that don't support matrixify feature
-  const MATRIXIFY_INCOMPATIBLE_CHARTS = new Set([VizType.TableAgGrid]);
+  // Table charts don't support matrixify feature
+  const MATRIXIFY_INCOMPATIBLE_CHARTS = new Set([
+    VizType.Table,
+    VizType.TableAgGrid,
+    VizType.PivotTable,
+    VizType.TimeTable,
+    VizType.TimePivot,
+  ]);
   const showMatrixifyTab =
     isFeatureEnabled(FeatureFlag.Matrixify) &&
     !MATRIXIFY_INCOMPATIBLE_CHARTS.has(form_data.viz_type as VizType);

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -84,6 +84,15 @@ const TABS_KEYS = {
   MATRIXIFY: 'MATRIXIFY',
 };
 
+// Table charts don't support matrixify feature
+const MATRIXIFY_INCOMPATIBLE_CHARTS = new Set([
+  VizType.Table,
+  VizType.TableAgGrid,
+  VizType.PivotTable,
+  VizType.TimeTable,
+  VizType.TimePivot,
+]);
+
 export type ControlPanelsContainerProps = {
   exploreState: ExplorePageState['explore'];
   actions: ExploreActions;
@@ -795,14 +804,6 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   ]);
 
   const showCustomizeTab = customizeSections.length > 0;
-  // Table charts don't support matrixify feature
-  const MATRIXIFY_INCOMPATIBLE_CHARTS = new Set([
-    VizType.Table,
-    VizType.TableAgGrid,
-    VizType.PivotTable,
-    VizType.TimeTable,
-    VizType.TimePivot,
-  ]);
   const showMatrixifyTab =
     isFeatureEnabled(FeatureFlag.Matrixify) &&
     !MATRIXIFY_INCOMPATIBLE_CHARTS.has(form_data.viz_type as VizType);

--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -40,6 +40,7 @@ import {
   usePrevious,
   isFeatureEnabled,
   FeatureFlag,
+  VizType,
 } from '@superset-ui/core';
 import { styled, css, SupersetTheme, useTheme } from '@apache-superset/core/ui';
 import {
@@ -794,7 +795,11 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
   ]);
 
   const showCustomizeTab = customizeSections.length > 0;
-  const showMatrixifyTab = isFeatureEnabled(FeatureFlag.Matrixify);
+  // Charts that don't support matrixify feature
+  const MATRIXIFY_INCOMPATIBLE_CHARTS = new Set([VizType.TableAgGrid]);
+  const showMatrixifyTab =
+    isFeatureEnabled(FeatureFlag.Matrixify) &&
+    !MATRIXIFY_INCOMPATIBLE_CHARTS.has(form_data.viz_type as VizType);
 
   // Check if matrixify is enabled in form_data
   const matrixifyIsEnabled =


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Do not show matrixify tab for unsupported charts. These currently only consist of table charts we have.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

Before:
<img width="311" height="156" alt="image" src="https://github.com/user-attachments/assets/627b7283-93c8-4d45-8174-095a85c735cb" />


After:
<img width="315" height="138" alt="image" src="https://github.com/user-attachments/assets/37861e58-6dee-4567-9fcc-e2c4fa41544c" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
