### PR TITLE
fix(dataset-editor): add missing Data type label in calculated columns tab

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -44,7 +44,6 @@ import TableSelector from 'src/components/TableSelector';
 import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import TextControl from 'src/explore/components/controls/TextControl';
 import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
-import SelectControl from 'src/explore/components/controls/SelectControl';
 import SpatialControl from 'src/explore/components/controls/SpatialControl';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
@@ -61,6 +60,7 @@ import {
   Icons,
   Loading,
   Row,
+  Select,
   Typography,
   Label,
 } from '@superset-ui/core/components';
@@ -314,12 +314,13 @@ function ColumnCollectionTable({
                 fieldKey="type"
                 label={t('Data type')}
                 control={
-                  <SelectControl
+                  <Select
                     ariaLabel={t('Data type')}
+                    header={<FormLabel>{t('Data type')}</FormLabel>}
                     options={DATA_TYPES}
                     name="type"
-                    freeForm
-                    clearable
+                    allowNewOptions
+                    allowClear
                   />
                 }
               />

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.jsx
@@ -44,6 +44,7 @@ import TableSelector from 'src/components/TableSelector';
 import CheckboxControl from 'src/explore/components/controls/CheckboxControl';
 import TextControl from 'src/explore/components/controls/TextControl';
 import TextAreaControl from 'src/explore/components/controls/TextAreaControl';
+import SelectControl from 'src/explore/components/controls/SelectControl';
 import SpatialControl from 'src/explore/components/controls/SpatialControl';
 import withToasts from 'src/components/MessageToasts/withToasts';
 import CurrencyControl from 'src/explore/components/controls/CurrencyControl';
@@ -60,7 +61,6 @@ import {
   Icons,
   Loading,
   Row,
-  Select,
   Typography,
   Label,
 } from '@superset-ui/core/components';
@@ -314,12 +314,12 @@ function ColumnCollectionTable({
                 fieldKey="type"
                 label={t('Data type')}
                 control={
-                  <Select
+                  <SelectControl
                     ariaLabel={t('Data type')}
                     options={DATA_TYPES}
                     name="type"
-                    allowNewOptions
-                    allowClear
+                    freeForm
+                    clearable
                   />
                 }
               />

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
@@ -221,6 +221,27 @@ test('can add new columns', async () => {
   });
 });
 
+test('renders Data type label in calculated columns tab', async () => {
+  const testProps = createProps();
+  await asyncRender({
+    ...testProps,
+    datasource: { ...testProps.datasource, table_name: 'Vehicle Sales +' },
+  });
+
+  const calcColsTab = screen.getByTestId('collection-tab-Calculated columns');
+  await userEvent.click(calcColsTab);
+
+  const calcColsPanel = within(
+    await screen.findByRole('tabpanel', { name: /calculated columns/i }),
+  );
+
+  const addBtn = calcColsPanel.getByRole('button', { name: /add item/i });
+  await userEvent.click(addBtn);
+
+  const dataTypeLabels = await calcColsPanel.findAllByText('Data type');
+  expect(dataTypeLabels.length).toBeGreaterThanOrEqual(2);
+});
+
 test('renders isSqla fields', async () => {
   const testProps = createProps();
   await asyncRender({


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
The "Data type" field in the calculated columns tab of the dataset editor was missing its label. This was caused by using the `Select` component which doesn't render form labels passed via props. Fixed by replacing `Select` with `SelectControl`, which includes `ControlHeader` for proper label rendering - matching the pattern used by other fields in the same form.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="1830" height="1364" alt="image" src="https://github.com/user-attachments/assets/61ef0ae9-de2d-4ba3-95a9-166889657967" />

AFTER:
<img width="950" height="469" alt="Screenshot 2026-01-15 at 07 33 08" src="https://github.com/user-attachments/assets/9d8c6fb7-1005-457d-a390-537cf617e82a" />

### TESTING INSTRUCTIONS

1. Go to the dataset list
2. Click edit on any dataset
3. Switch to the calculated columns tab
4. Add an item
5. You will see now the Data Type select field.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
