### PR TITLE
fix: HTML detection in tables

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -67,7 +67,6 @@ describe('isProbablyHTML', () => {
   });
 
   it('should return true for all known HTML tags', () => {
-    // Tags that were previously missing from hasHtmlTagPattern but are valid HTML
     expect(isProbablyHTML('<section>Content</section>')).toBe(true);
     expect(isProbablyHTML('<article>Content</article>')).toBe(true);
     expect(isProbablyHTML('<nav>Content</nav>')).toBe(true);

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.test.tsx
@@ -65,6 +65,25 @@ describe('isProbablyHTML', () => {
     expect(isProbablyHTML('if x < 5 and y > 10')).toBe(false);
     expect(isProbablyHTML('price < $100')).toBe(false);
   });
+
+  it('should return true for all known HTML tags', () => {
+    // Tags that were previously missing from hasHtmlTagPattern but are valid HTML
+    expect(isProbablyHTML('<section>Content</section>')).toBe(true);
+    expect(isProbablyHTML('<article>Content</article>')).toBe(true);
+    expect(isProbablyHTML('<nav>Content</nav>')).toBe(true);
+    expect(isProbablyHTML('<header>Content</header>')).toBe(true);
+    expect(isProbablyHTML('<footer>Content</footer>')).toBe(true);
+    expect(isProbablyHTML('<button>Click me</button>')).toBe(true);
+    expect(isProbablyHTML('<form>Content</form>')).toBe(true);
+    expect(isProbablyHTML('<input type="text">')).toBe(true);
+    expect(isProbablyHTML('<textarea>Content</textarea>')).toBe(true);
+    expect(isProbablyHTML('<select><option>1</option></select>')).toBe(true);
+    expect(isProbablyHTML('<blockquote>Quote</blockquote>')).toBe(true);
+    expect(isProbablyHTML('<video src="video.mp4"></video>')).toBe(true);
+    expect(isProbablyHTML('<audio src="audio.mp3"></audio>')).toBe(true);
+    expect(isProbablyHTML('<canvas></canvas>')).toBe(true);
+    expect(isProbablyHTML('<iframe src="page.html"></iframe>')).toBe(true);
+  });
 });
 
 describe('sanitizeHtmlIfNeeded', () => {

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -52,11 +52,75 @@ export function sanitizeHtml(htmlString: string) {
   return xssFilter.process(htmlString);
 }
 
-export function hasHtmlTagPattern(str: string): boolean {
-  const htmlTagPattern =
-    /<(html|head|body|div|span|a|p|h[1-6]|title|meta|link|script|style)/i;
+// Single source of truth for known HTML tags
+const KNOWN_HTML_TAGS = new Set([
+  'div',
+  'span',
+  'p',
+  'a',
+  'b',
+  'i',
+  'u',
+  'em',
+  'strong',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'table',
+  'tr',
+  'td',
+  'th',
+  'tbody',
+  'thead',
+  'tfoot',
+  'ul',
+  'ol',
+  'li',
+  'img',
+  'br',
+  'hr',
+  'pre',
+  'code',
+  'blockquote',
+  'section',
+  'article',
+  'nav',
+  'header',
+  'footer',
+  'form',
+  'input',
+  'button',
+  'select',
+  'option',
+  'textarea',
+  'label',
+  'fieldset',
+  'legend',
+  'video',
+  'audio',
+  'canvas',
+  'iframe',
+  'script',
+  'style',
+  'link',
+  'meta',
+  'title',
+  'html',
+  'head',
+  'body',
+]);
 
-  return htmlTagPattern.test(str);
+// Pre-compiled regex pattern using all known tags
+const HTML_TAG_PATTERN = new RegExp(
+  `<(${Array.from(KNOWN_HTML_TAGS).join('|')})\\b`,
+  'i',
+);
+
+export function hasHtmlTagPattern(str: string): boolean {
+  return HTML_TAG_PATTERN.test(str);
 }
 
 export function isProbablyHTML(text: string) {
@@ -91,64 +155,7 @@ export function isProbablyHTML(text: string) {
   // This prevents strings like "<abcdef:12345>" from being treated as HTML
   return elements.some(element => {
     const tagName = element.tagName.toLowerCase();
-    // List of common HTML tags we want to recognize
-    const knownHtmlTags = [
-      'div',
-      'span',
-      'p',
-      'a',
-      'b',
-      'i',
-      'u',
-      'em',
-      'strong',
-      'h1',
-      'h2',
-      'h3',
-      'h4',
-      'h5',
-      'h6',
-      'table',
-      'tr',
-      'td',
-      'th',
-      'tbody',
-      'thead',
-      'tfoot',
-      'ul',
-      'ol',
-      'li',
-      'img',
-      'br',
-      'hr',
-      'pre',
-      'code',
-      'blockquote',
-      'section',
-      'article',
-      'nav',
-      'header',
-      'footer',
-      'form',
-      'input',
-      'button',
-      'select',
-      'option',
-      'textarea',
-      'label',
-      'fieldset',
-      'legend',
-      'video',
-      'audio',
-      'canvas',
-      'iframe',
-      'script',
-      'style',
-      'link',
-      'meta',
-      'title',
-    ];
-    return knownHtmlTags.includes(tagName);
+    return KNOWN_HTML_TAGS.has(tagName);
   });
 }
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -52,7 +52,6 @@ export function sanitizeHtml(htmlString: string) {
   return xssFilter.process(htmlString);
 }
 
-// Single source of truth for known HTML tags
 const KNOWN_HTML_TAGS = new Set([
   'div',
   'span',
@@ -113,7 +112,6 @@ const KNOWN_HTML_TAGS = new Set([
   'body',
 ]);
 
-// Pre-compiled regex pattern using all known tags
 const HTML_TAG_PATTERN = new RegExp(
   `<(${Array.from(KNOWN_HTML_TAGS).join('|')})\\b`,
   'i',


### PR DESCRIPTION
### SUMMARY
Due to logical error in checking for common html tag patterns, we were often returning false negatives on many correct html tag, like "\<b\>\<\/b\>". Here's a small refactor of that logic

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1032" height="435" alt="image" src="https://github.com/user-attachments/assets/1c9f8d55-42c5-4378-8dc6-15ae7c4ca080" />

After:
<img width="900" height="389" alt="image" src="https://github.com/user-attachments/assets/5270f15e-d429-4fff-89d6-f932e1222cf0" />


### TESTING INSTRUCTIONS
1. Create a table chart
2. Switch to raw records
3. Add an adhoc column like '<b>Test</b>'
4. Verify that table displays a cell with text "Test" in bold

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
