### PR TITLE
fix: add sans-serif font fallback to fontFamily (Fixes #37096)

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -794,7 +794,7 @@ THEME_DEFAULT: Theme = {
         "colorInfo": "#66bcfe",
         # Fonts
         "fontUrls": [],
-        "fontFamily": "Inter, Helvetica, Arial",
+        "fontFamily": "Inter, Helvetica, Arial, sans-serif",
         "fontFamilyCode": "'Fira Code', 'Courier New', monospace",
         # Extra tokens
         "transitionTiming": 0.3,


### PR DESCRIPTION
This fix adds `sans-serif` as a generic font fallback to ensure consistent 
sans-serif rendering when preferred fonts (Inter, Helvetica, Arial) are not available.

Previously, when none of the specified fonts were available, browsers would default 
to serif fonts, causing inconsistent visuals in dashboard reports and screenshots.

Changes:
- Updated fontFamily in superset/config.py from "Inter, Helvetica, Arial" to "Inter, Helvetica, Arial, sans-serif"

Fixes #37096
