### PR TITLE
fix: Move head_custom_extra above csrf token input

### DIFF
--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -65,15 +65,16 @@
 
     {{ js_bundle(assets_prefix, 'theme') }}
 
+    {% block head_js %}
+      {% include "head_custom_extra.html" %}
+    {% endblock %}
+
     <input
       type="hidden"
       name="csrf_token"
       id="csrf_token"
       value="{{ csrf_token() if csrf_token else '' }}"
     />
-    {% block head_js %}
-      {% include "head_custom_extra.html" %}
-    {% endblock %}
   </head>
 
   <body {% if standalone_mode %}class="standalone"{% endif %}>


### PR DESCRIPTION
### SUMMARY
In some browsers `<input>` is not a valid `<head>` element and browsers moves it, but also every other element in head below that input, to `<body>`. To prevent having the contents of head_custom_extra.html moved to body, we need to move it above the csrf_token input element

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
