### PR TITLE
fix: Prevent table rows from overlapping pagination in table view

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.test.ts
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.test.ts
@@ -27,6 +27,24 @@ import {
 } from 'spec/helpers/testing-library';
 import { useResultsTableView } from './useResultsTableView';
 
+const capturedProps: any[] = [];
+
+jest.mock(
+  'src/explore/components/DataTablesPane/components/SingleQueryResultPane',
+  () => {
+    const actual = jest.requireActual(
+      'src/explore/components/DataTablesPane/components/SingleQueryResultPane',
+    );
+    return {
+      ...actual,
+      SingleQueryResultPane: (props: any) => {
+        capturedProps.push(props);
+        return actual.SingleQueryResultPane(props);
+      },
+    };
+  },
+);
+
 const MOCK_CHART_DATA_RESULT = [
   {
     colnames: ['name', 'sum__num'],
@@ -110,4 +128,34 @@ test('Displays results for 2 queries', async () => {
   expect(
     within(getActiveTabElement()).getAllByTestId('table-row'),
   ).toHaveLength(2);
+});
+
+test('passes isPaginationSticky={false} to SingleQueryResultPane for single query', () => {
+  capturedProps.length = 0;
+  const { result } = renderHook(() =>
+    useResultsTableView(MOCK_CHART_DATA_RESULT.slice(0, 1), '1__table', true),
+  );
+  render(result.current, { useRedux: true });
+
+  expect(capturedProps.length).toBeGreaterThan(0);
+  capturedProps.forEach(props => {
+    expect(props).toMatchObject({
+      isPaginationSticky: false,
+    });
+  });
+});
+
+test('passes isPaginationSticky={false} to SingleQueryResultPane for multiple queries', () => {
+  capturedProps.length = 0;
+  const { result } = renderHook(() =>
+    useResultsTableView(MOCK_CHART_DATA_RESULT, '1__table', true),
+  );
+  render(result.current, { useRedux: true });
+
+  expect(capturedProps.length).toBeGreaterThanOrEqual(2);
+  capturedProps.forEach(props => {
+    expect(props).toMatchObject({
+      isPaginationSticky: false,
+    });
+  });
 });

--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { isDefined, QueryData, t } from '@superset-ui/core';
-import { css, styled } from '@apache-superset/core/ui';
+import { isDefined, QueryData } from '@superset-ui/core';
+import { css, styled, t } from '@apache-superset/core/ui';
 import { SingleQueryResultPane } from 'src/explore/components/DataTablesPane/components/SingleQueryResultPane';
 import Tabs from '@superset-ui/core/components/Tabs';
 

--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t } from '@apache-superset/core';
-import { isDefined, QueryData } from '@superset-ui/core';
+import { isDefined, QueryData, t } from '@superset-ui/core';
 import { css, styled } from '@apache-superset/core/ui';
 import { SingleQueryResultPane } from 'src/explore/components/DataTablesPane/components/SingleQueryResultPane';
 import Tabs from '@superset-ui/core/components/Tabs';
@@ -52,6 +51,7 @@ export const useResultsTableView = (
           datasourceId={datasourceId}
           isVisible
           canDownload={canDownload}
+          isPaginationSticky={false}
         />
       </PaginationContainer>
     );
@@ -73,6 +73,7 @@ export const useResultsTableView = (
               datasourceId={datasourceId}
               isVisible
               canDownload={canDownload}
+              isPaginationSticky={false}
             />
           </PaginationContainer>
         ),

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useState, useCallback } from 'react';
-import { t } from '@superset-ui/core';
+import { t } from '@apache-superset/core/ui';
 import {
   TableView,
   TableSize,

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SingleQueryResultPane.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useState, useCallback } from 'react';
-import { t } from '@apache-superset/core';
+import { t } from '@superset-ui/core';
 import {
   TableView,
   TableSize,
@@ -40,6 +40,7 @@ export const SingleQueryResultPane = ({
   isVisible,
   canDownload,
   columnDisplayNames,
+  isPaginationSticky = true,
 }: SingleQueryResultPaneProp) => {
   const [filterText, setFilterText] = useState('');
 
@@ -82,7 +83,7 @@ export const SingleQueryResultPane = ({
         noDataText={t('No results')}
         emptyWrapperType={EmptyWrapperType.Small}
         className="table-condensed"
-        isPaginationSticky
+        isPaginationSticky={isPaginationSticky}
         showRowCount={false}
         small
       />

--- a/superset-frontend/src/explore/components/DataTablesPane/types.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/types.ts
@@ -92,4 +92,5 @@ export interface SingleQueryResultPaneProp extends QueryResultInterface {
   canDownload: boolean;
   // Optional map of column/metric name -> verbose label
   columnDisplayNames?: Record<string, string>;
+  isPaginationSticky?: boolean;
 }


### PR DESCRIPTION
### SUMMARY

Fixes an issue where table rows overlap with pagination controls in the DrillBy modal.

The `SingleQueryResultPane` component has `isPaginationSticky` set to `true` by default, which keeps the pagination controls fixed at the bottom. However, in modals with limited height (like the DrillBy modal), this sticky behavior causes table rows to overlap with the pagination controls.

This PR:
- Adds a configurable `isPaginationSticky` prop to `SingleQueryResultPane` (defaults to `true` for backward compatibility)
- Passes `isPaginationSticky={false}` in the DrillBy modal results table to prevent the overlap

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1076" height="925" alt="532375919-2c8e9719-3700-4969-bcae-722c74c4b15c" src="https://github.com/user-attachments/assets/7534f1ec-9b7e-4f92-95da-2d45b62ebe76" />

https://github.com/user-attachments/assets/fbcedb39-ed2b-443a-9f81-1d82986b7a53



### TESTING INSTRUCTIONS

1. Open any chart that supports drill-by functionality
2. Click on a data point and select "Drill by"
3. In the DrillBy modal, observe the results table
4. Scroll through the table if there are many results
5. Verify that table rows do not overlap with pagination controls

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
