### PR TITLE
fix(sunburst): make Show Total text theme-aware

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -377,12 +377,12 @@ export default function transformProps(
           top: 'center',
           left: 'center',
           style: {
-          text: t('Total: %s', primaryValueFormatter(totalValue)),
-          fontSize: 16,
-          fontWeight: 'bold',
-          fill: theme.colorText,
-        },
-        z: 10,
+            text: t('Total: %s', primaryValueFormatter(totalValue)),
+            fontSize: 16,
+            fontWeight: 'bold',
+            fill: theme.colorText,
+          },
+          z: 10,
         }
       : null,
   };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -380,7 +380,7 @@ export default function transformProps(
             text: t('Total: %s', primaryValueFormatter(totalValue)),
             fontSize: 16,
             fontWeight: 'bold',
-            color: theme.colorText,
+            fill: theme.colorText,
 
           },
           z: 10,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -377,13 +377,12 @@ export default function transformProps(
           top: 'center',
           left: 'center',
           style: {
-            text: t('Total: %s', primaryValueFormatter(totalValue)),
-            fontSize: 16,
-            fontWeight: 'bold',
-            fill: theme.colorText,
-
-          },
-          z: 10,
+          text: t('Total: %s', primaryValueFormatter(totalValue)),
+          fontSize: 16,
+          fontWeight: 'bold',
+          fill: theme.colorText,
+        },
+        z: 10,
         }
       : null,
   };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Sunburst/transformProps.ts
@@ -380,6 +380,8 @@ export default function transformProps(
             text: t('Total: %s', primaryValueFormatter(totalValue)),
             fontSize: 16,
             fontWeight: 'bold',
+            color: theme.colorText,
+
           },
           z: 10,
         }


### PR DESCRIPTION
### SUMMARY

Fixes an issue where the “Show Total” text in the Sunburst chart is rendered in black and becomes invisible in dark mode.

The text color is now derived from Superset’s theme tokens so it adapts correctly to both light and dark themes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:  
- “Show Total” text rendered in black in dark mode, making it unreadable.

After:  
- “Show Total” text uses theme-aware color and is visible in both light and dark mode.

### TESTING INSTRUCTIONS

1. Open a dashboard with a Sunburst chart.
2. Enable the “Show Total” option in chart settings.
3. Switch Superset to Dark Mode.
4. Verify that the total value text is visible and readable.
5. Switch back to Light Mode and confirm text remains readable.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #37170
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
