### PR TITLE
fix(timeseries): x-axis last month was hidden

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -532,6 +532,10 @@ export default function transformProps(
       formatter: xAxisFormatter,
       rotate: xAxisLabelRotation,
       interval: xAxisLabelInterval,
+      ...(xAxisType === AxisType.Time && {
+        showMaxLabel: true,
+        alignMaxLabel: 'right',
+      }),
     },
     minorTick: { show: minorTicks },
     minInterval:

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -16,13 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { CategoricalColorScale } from '@superset-ui/core';
+import { CategoricalColorScale, ChartProps } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/api/core';
+import { supersetTheme } from '@apache-superset/core/ui';
 import type { SeriesOption } from 'echarts';
 import { EchartsTimeseriesSeriesType } from '../../src';
 import {
   transformSeries,
   transformNegativeLabelsPosition,
 } from '../../src/Timeseries/transformers';
+import transformProps from '../../src/Timeseries/transformProps';
+import { EchartsTimeseriesChartProps } from '../../src/types';
 
 // Mock the colorScale function
 const mockColorScale = jest.fn(
@@ -189,4 +193,47 @@ describe('transformNegativeLabelsPosition', () => {
     expect((result as any)[3].label).toBe(undefined);
     expect((result as any)[4].label).toBe(undefined);
   });
+});
+
+test('should configure time axis labels to show max label for last month visibility', () => {
+  const formData = {
+    colorScheme: 'bnbColors',
+    datasource: '3__table',
+    granularity_sqla: 'ds',
+    metric: 'sum__num',
+    viz_type: 'my_viz',
+  };
+  const queriesData = [
+    {
+      data: [
+        { sum__num: 100, __timestamp: new Date('2026-01-01').getTime() },
+        { sum__num: 200, __timestamp: new Date('2026-02-01').getTime() },
+        { sum__num: 300, __timestamp: new Date('2026-03-01').getTime() },
+        { sum__num: 400, __timestamp: new Date('2026-04-01').getTime() },
+        { sum__num: 500, __timestamp: new Date('2026-05-01').getTime() },
+      ],
+      colnames: ['sum__num', '__timestamp'],
+      coltypes: [GenericDataType.Numeric, GenericDataType.Temporal],
+    },
+  ];
+  const chartProps = new ChartProps({
+    formData,
+    width: 800,
+    height: 600,
+    queriesData,
+    theme: supersetTheme,
+  });
+
+  const result = transformProps(
+    chartProps as unknown as EchartsTimeseriesChartProps,
+  );
+
+  expect(result.echartOptions.xAxis).toEqual(
+    expect.objectContaining({
+      axisLabel: expect.objectContaining({
+        showMaxLabel: true,
+        alignMaxLabel: 'right',
+      }),
+    }),
+  );
 });


### PR DESCRIPTION
### SUMMARY
Last month on the right on x-axis timeseries was not appearing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
#### BEFORE
<img width="1250" height="649" alt="image" src="https://github.com/user-attachments/assets/1e1f9857-eedf-4704-8cfc-14269a58c199" />

#### AFTER
<img width="1279" height="433" alt="image" src="https://github.com/user-attachments/assets/876adfb0-9885-4d36-9fec-1417196c5e4c" />


### TESTING INSTRUCTIONS
1. Create a new chart timeline chart.
2. Use month granularity.
3. Check for last month.

For ease, you can use this data in SQLLab
```sql
SELECT
  *
FROM (VALUES
  (CAST('2026-01-01' AS DATE), 21000),
  (CAST('2026-02-01' AS DATE), 22000),
  (CAST('2026-03-01' AS DATE), 23000),
  (CAST('2026-04-01' AS DATE), 24000),
  (CAST('2026-05-01' AS DATE), 25000)) AS t(date, value1)
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: 89307 and [33905](https://github.com/apache/superset/issues/33905)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
