### PR TITLE
feat(mcp): support unsaved state in Explore and Dashboard tools

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -111,6 +111,24 @@ class ChartInfo(BaseModel):
     uuid: str | None = Field(None, description="Chart UUID")
     tags: List[TagInfo] = Field(default_factory=list, description="Chart tags")
     owners: List[UserInfo] = Field(default_factory=list, description="Chart owners")
+
+    # Fields for unsaved state support
+    form_data_key: str | None = Field(
+        None,
+        description=(
+            "Cache key used to retrieve unsaved form_data. When present, indicates "
+            "the form_data came from cache (unsaved edits) rather than the saved chart."
+        ),
+    )
+    is_unsaved_state: bool = Field(
+        default=False,
+        description=(
+            "True if the form_data came from cache (unsaved edits) rather than the "
+            "saved chart configuration. When true, the data reflects what the user "
+            "sees in the Explore view, not the saved version."
+        ),
+    )
+
     model_config = ConfigDict(from_attributes=True, ser_json_timedelta="iso8601")
 
     @model_serializer(mode="wrap", when_used="json")
@@ -202,12 +220,26 @@ class VersionedResponse(BaseModel):
 
 
 class GetChartInfoRequest(BaseModel):
-    """Request schema for get_chart_info with support for ID or UUID."""
+    """Request schema for get_chart_info with support for ID or UUID.
+
+    When form_data_key is provided, the tool will retrieve the unsaved chart state
+    from cache, allowing you to explain what the user actually sees (not the saved
+    version). This is useful when a user edits a chart in Explore but hasn't saved yet.
+    """
 
     identifier: Annotated[
         int | str,
         Field(description="Chart identifier - can be numeric ID or UUID string"),
     ]
+    form_data_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional cache key for retrieving unsaved chart state. When a user "
+            "edits a chart in Explore but hasn't saved, the current state is stored "
+            "with this key. If provided, the tool returns the current unsaved "
+            "configuration instead of the saved version."
+        ),
+    )
 
 
 def serialize_chart_object(chart: ChartLike | None) -> ChartInfo | None:
@@ -749,9 +781,24 @@ class UpdateChartPreviewRequest(FormDataCacheControl):
 
 
 class GetChartDataRequest(QueryCacheControl):
-    """Request for chart data with cache control."""
+    """Request for chart data with cache control.
+
+    When form_data_key is provided, the tool will use the unsaved chart configuration
+    from cache to query data, allowing you to get data for what the user actually sees
+    (not the saved version). This is useful when a user edits a chart in Explore but
+    hasn't saved yet.
+    """
 
     identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    form_data_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional cache key for retrieving unsaved chart state. When a user "
+            "edits a chart in Explore but hasn't saved, the current state is stored "
+            "with this key. If provided, the tool uses this configuration to query "
+            "data instead of the saved chart configuration."
+        ),
+    )
     limit: int | None = Field(
         default=None,
         description=(
@@ -827,9 +874,24 @@ class ChartData(BaseModel):
 
 
 class GetChartPreviewRequest(QueryCacheControl):
-    """Request for chart preview with cache control."""
+    """Request for chart preview with cache control.
+
+    When form_data_key is provided, the tool will render a preview using the unsaved
+    chart configuration from cache, allowing you to preview what the user actually sees
+    (not the saved version). This is useful when a user edits a chart in Explore but
+    hasn't saved yet.
+    """
 
     identifier: int | str = Field(description="Chart identifier (ID, UUID)")
+    form_data_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional cache key for retrieving unsaved chart state. When a user "
+            "edits a chart in Explore but hasn't saved, the current state is stored "
+            "with this key. If provided, the tool renders a preview using this "
+            "configuration instead of the saved chart configuration."
+        ),
+    )
     format: Literal["url", "ascii", "table", "vega_lite"] = Field(
         default="url",
         description=(

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -30,8 +30,13 @@ from superset_core.mcp import tool
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
+from superset.commands.chart.exceptions import (
+    ChartDataCacheLoadError,
+    ChartDataQueryFailedError,
+)
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
+from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import (
     ChartData,
@@ -543,7 +548,11 @@ async def get_chart_data(  # noqa: C901
                 cache_status=cache_status,
             )
 
-        except Exception as data_error:
+        except (
+            ChartDataCacheLoadError,
+            ChartDataQueryFailedError,
+            SupersetException,
+        ) as data_error:
             await ctx.error(
                 "Data retrieval failed: chart_id=%s, error=%s, error_type=%s"
                 % (
@@ -558,7 +567,7 @@ async def get_chart_data(  # noqa: C901
                 error_type="DataError",
             )
 
-    except Exception as e:
+    except SupersetException as e:
         await ctx.error(
             "Chart data retrieval failed: identifier=%s, error=%s, error_type=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -30,10 +30,6 @@ from superset_core.mcp import tool
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
-from superset.commands.chart.exceptions import (
-    ChartDataCacheLoadError,
-    ChartDataQueryFailedError,
-)
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.exceptions import SupersetException
@@ -548,11 +544,7 @@ async def get_chart_data(  # noqa: C901
                 cache_status=cache_status,
             )
 
-        except (
-            ChartDataCacheLoadError,
-            ChartDataQueryFailedError,
-            SupersetException,
-        ) as data_error:
+        except (CommandException, SupersetException) as data_error:
             await ctx.error(
                 "Data retrieval failed: chart_id=%s, error=%s, error_type=%s"
                 % (

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -166,11 +166,20 @@ async def get_chart_data(  # noqa: C901
                 )
                 if cached_form_data := _get_cached_form_data(request.form_data_key):
                     try:
-                        cached_form_data_dict = utils_json.loads(cached_form_data)
-                        using_unsaved_state = True
-                        await ctx.info(
-                            "Using cached form_data from form_data_key for data query"
-                        )
+                        parsed_form_data = utils_json.loads(cached_form_data)
+                        # Only use if it's actually a dict (not null, list, etc.)
+                        if isinstance(parsed_form_data, dict):
+                            cached_form_data_dict = parsed_form_data
+                            using_unsaved_state = True
+                            await ctx.info(
+                                "Using cached form_data from form_data_key "
+                                "for data query"
+                            )
+                        else:
+                            await ctx.warning(
+                                "Cached form_data is not a JSON object. "
+                                "Falling back to saved chart configuration."
+                            )
                     except (TypeError, ValueError) as e:
                         await ctx.warning(
                             "Failed to parse cached form_data: %s. "

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -43,6 +43,22 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
+def _get_cached_form_data(form_data_key: str) -> str | None:
+    """Retrieve form_data from cache using form_data_key.
+
+    Returns the JSON string of form_data if found, None otherwise.
+    """
+    from superset.commands.explore.form_data.get import GetFormDataCommand
+    from superset.commands.explore.form_data.parameters import CommandParameters
+
+    try:
+        cmd_params = CommandParameters(key=form_data_key)
+        return GetFormDataCommand(cmd_params).run()
+    except Exception as e:
+        logger.warning("Failed to retrieve form_data from cache: %s", e)
+        return None
+
+
 @tool(tags=["data"])
 @parse_request(GetChartDataRequest)
 async def get_chart_data(  # noqa: C901
@@ -57,15 +73,22 @@ async def get_chart_data(  # noqa: C901
     - Multiple formats: json, csv, excel
     - Cache control: use_cache, force_refresh, cache_timeout
     - Optional row limit override (respects chart's configured limits)
+    - form_data_key: retrieves data using unsaved chart configuration from Explore
+
+    When form_data_key is provided, the tool uses the cached (unsaved) chart
+    configuration to query data, allowing you to get data for what the user
+    actually sees in the Explore view (not the saved version).
 
     Returns underlying data in requested format with cache status.
     """
     await ctx.info(
-        "Starting chart data retrieval: identifier=%s, format=%s, limit=%s"
+        "Starting chart data retrieval: identifier=%s, format=%s, limit=%s, "
+        "form_data_key=%s"
         % (
             request.identifier,
             request.format,
             request.limit,
+            request.form_data_key,
         )
     )
     await ctx.debug(
@@ -126,16 +149,87 @@ async def get_chart_data(  # noqa: C901
 
         start_time = time.time()
 
+        # Track whether we're using unsaved state
+        using_unsaved_state = False
+        cached_form_data_dict = None
+
         try:
             await ctx.report_progress(2, 4, "Preparing data query")
             from superset.charts.schemas import ChartDataQueryContextSchema
             from superset.commands.chart.data.get_data_command import ChartDataCommand
 
+            # Check if form_data_key is provided - use cached form_data instead
+            if request.form_data_key:
+                await ctx.info(
+                    "Retrieving unsaved chart state from cache: form_data_key=%s"
+                    % (request.form_data_key,)
+                )
+                cached_form_data = _get_cached_form_data(request.form_data_key)
+
+                if cached_form_data:
+                    try:
+                        cached_form_data_dict = utils_json.loads(cached_form_data)
+                        using_unsaved_state = True
+                        await ctx.info(
+                            "Using cached form_data from form_data_key for data query"
+                        )
+                    except (TypeError, ValueError) as e:
+                        await ctx.warning(
+                            "Failed to parse cached form_data: %s. "
+                            "Falling back to saved chart configuration." % str(e)
+                        )
+                else:
+                    await ctx.warning(
+                        "form_data_key provided but no cached data found. "
+                        "The cache may have expired. Using saved chart configuration."
+                    )
+
             # Use the chart's saved query_context - this is the key!
             # The query_context contains all the information needed to reproduce
             # the chart's data exactly as shown in the visualization
             query_context_json = None
-            if chart.query_context:
+
+            # If using cached form_data, we need to build query_context from it
+            if using_unsaved_state and cached_form_data_dict:
+                # Build query context from cached form_data (unsaved state)
+                from superset.common.query_context_factory import QueryContextFactory
+
+                factory = QueryContextFactory()
+                row_limit = (
+                    request.limit
+                    or cached_form_data_dict.get("row_limit")
+                    or current_app.config["ROW_LIMIT"]
+                )
+
+                # Get datasource info from cached form_data or fall back to chart
+                datasource_id = cached_form_data_dict.get(
+                    "datasource_id", chart.datasource_id
+                )
+                datasource_type = cached_form_data_dict.get(
+                    "datasource_type", chart.datasource_type
+                )
+
+                query_context = factory.create(
+                    datasource={
+                        "id": datasource_id,
+                        "type": datasource_type,
+                    },
+                    queries=[
+                        {
+                            "filters": cached_form_data_dict.get("filters", []),
+                            "columns": cached_form_data_dict.get("groupby", []),
+                            "metrics": cached_form_data_dict.get("metrics", []),
+                            "row_limit": row_limit,
+                            "order_desc": cached_form_data_dict.get("order_desc", True),
+                        }
+                    ],
+                    form_data=cached_form_data_dict,
+                    force=request.force_refresh,
+                )
+                await ctx.debug(
+                    "Built query_context from cached form_data (unsaved state)"
+                )
+            elif chart.query_context:
                 try:
                     query_context_json = utils_json.loads(chart.query_context)
                     await ctx.debug(
@@ -146,7 +240,7 @@ async def get_chart_data(  # noqa: C901
                         "Failed to parse chart query_context: %s" % str(e)
                     )
 
-            if query_context_json is None:
+            if query_context_json is None and not using_unsaved_state:
                 # Fallback: Chart has no saved query_context
                 # This can happen with older charts that haven't been re-saved
                 await ctx.warning(
@@ -209,7 +303,7 @@ async def get_chart_data(  # noqa: C901
                     form_data=form_data,
                     force=request.force_refresh,
                 )
-            else:
+            elif query_context_json is not None:
                 # Apply request overrides to the saved query_context
                 query_context_json["force"] = request.force_refresh
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -188,7 +188,7 @@ async def get_chart_data(  # noqa: C901
             query_context_json = None
 
             # If using cached form_data, we need to build query_context from it
-            if using_unsaved_state and cached_form_data_dict:
+            if using_unsaved_state and cached_form_data_dict is not None:
                 # Build query context from cached form_data (unsaved state)
                 from superset.common.query_context_factory import QueryContextFactory
 

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -37,6 +37,22 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
+def _get_cached_form_data(form_data_key: str) -> str | None:
+    """Retrieve form_data from cache using form_data_key.
+
+    Returns the JSON string of form_data if found, None otherwise.
+    """
+    from superset.commands.explore.form_data.get import GetFormDataCommand
+    from superset.commands.explore.form_data.parameters import CommandParameters
+
+    try:
+        cmd_params = CommandParameters(key=form_data_key)
+        return GetFormDataCommand(cmd_params).run()
+    except Exception as e:
+        logger.warning("Failed to retrieve form_data from cache: %s", e)
+        return None
+
+
 @tool(tags=["discovery"])
 @parse_request(GetChartInfoRequest)
 async def get_chart_info(
@@ -49,6 +65,8 @@ async def get_chart_info(
     - URL field contains chart's screenshot URL for preview
     - Use numeric ID or UUID string (NOT chart name)
     - To find a chart ID, use the list_charts tool first
+    - When form_data_key is provided, returns the unsaved chart configuration
+      (what the user sees in Explore) instead of the saved version
 
     Example usage:
     ```json
@@ -64,12 +82,22 @@ async def get_chart_info(
     }
     ```
 
+    With unsaved state (form_data_key from Explore URL):
+    ```json
+    {
+        "identifier": 123,
+        "form_data_key": "abc123def456"
+    }
+    ```
+
     Returns chart details including name, type, and URL.
     """
     from superset.daos.chart import ChartDAO
+    from superset.utils import json as utils_json
 
     await ctx.info(
-        "Retrieving chart information: identifier=%s" % (request.identifier,)
+        "Retrieving chart information: identifier=%s, form_data_key=%s"
+        % (request.identifier, request.form_data_key)
     )
 
     with event_logger.log_context(action="mcp.get_chart_info.lookup"):
@@ -85,9 +113,41 @@ async def get_chart_info(
         result = tool.run_tool(request.identifier)
 
     if isinstance(result, ChartInfo):
+        # If form_data_key is provided, override form_data with cached version
+        if request.form_data_key:
+            await ctx.info(
+                "Retrieving unsaved chart state from cache: form_data_key=%s"
+                % (request.form_data_key,)
+            )
+            cached_form_data = _get_cached_form_data(request.form_data_key)
+
+            if cached_form_data:
+                try:
+                    result.form_data = utils_json.loads(cached_form_data)
+                    result.form_data_key = request.form_data_key
+                    result.is_unsaved_state = True
+
+                    # Update viz_type from cached form_data if present
+                    if result.form_data and "viz_type" in result.form_data:
+                        result.viz_type = result.form_data["viz_type"]
+
+                    await ctx.info(
+                        "Chart form_data overridden with unsaved state from cache"
+                    )
+                except Exception as e:
+                    await ctx.warning(
+                        "Failed to parse cached form_data: %s. "
+                        "Using saved chart configuration." % (str(e),)
+                    )
+            else:
+                await ctx.warning(
+                    "form_data_key provided but no cached data found. "
+                    "The cache may have expired. Using saved chart configuration."
+                )
+
         await ctx.info(
-            "Chart information retrieved successfully: chart_name=%s"
-            % (result.slice_name,)
+            "Chart information retrieved successfully: chart_name=%s, "
+            "is_unsaved_state=%s" % (result.slice_name, result.is_unsaved_state)
         )
     else:
         await ctx.warning("Chart retrieval failed: error=%s" % (str(result),))

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -264,7 +264,13 @@ class ListDashboardsRequest(MetadataCacheControl):
 
 
 class GetDashboardInfoRequest(MetadataCacheControl):
-    """Request schema for get_dashboard_info with support for ID, UUID, or slug."""
+    """Request schema for get_dashboard_info with support for ID, UUID, or slug.
+
+    When permalink_key is provided, the tool will retrieve the dashboard's filter
+    state from the permalink, allowing you to see what filters the user has applied
+    (not just the default filter state). This is useful when a user applies filters
+    in a dashboard but the URL contains a permalink_key.
+    """
 
     identifier: Annotated[
         int | str,
@@ -272,6 +278,15 @@ class GetDashboardInfoRequest(MetadataCacheControl):
             description="Dashboard identifier - can be numeric ID, UUID string, or slug"
         ),
     ]
+    permalink_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional permalink key for retrieving dashboard filter state. When a "
+            "user applies filters in a dashboard, the state can be persisted in a "
+            "permalink. If provided, the tool returns the filter configuration "
+            "from that permalink."
+        ),
+    )
 
 
 class DashboardInfo(BaseModel):
@@ -315,6 +330,32 @@ class DashboardInfo(BaseModel):
     charts: List[ChartInfo] = Field(
         default_factory=list, description="Dashboard charts"
     )
+
+    # Fields for permalink/filter state support
+    permalink_key: str | None = Field(
+        None,
+        description=(
+            "Permalink key used to retrieve filter state. When present, indicates "
+            "the filter_state came from a permalink rather than the default dashboard."
+        ),
+    )
+    filter_state: Dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Filter state from permalink. Contains dataMask (native filter values), "
+            "activeTabs, anchor, and urlParams. When present, represents the actual "
+            "filters the user has applied to the dashboard."
+        ),
+    )
+    is_permalink_state: bool = Field(
+        default=False,
+        description=(
+            "True if the filter_state came from a permalink rather than the default "
+            "dashboard configuration. When true, the filter_state reflects what the "
+            "user sees in the dashboard, not the default filter state."
+        ),
+    )
+
     model_config = ConfigDict(from_attributes=True, ser_json_timedelta="iso8601")
 
     @model_serializer(mode="wrap", when_used="json")

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -24,11 +24,12 @@ about a specific dashboard.
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict
 
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
+from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.extensions import event_logger
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
@@ -42,7 +43,7 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
-def _get_permalink_state(permalink_key: str) -> Dict[str, Any] | None:
+def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
     """Retrieve dashboard filter state from permalink.
 
     Returns the permalink value containing dashboardId and state if found,
@@ -51,10 +52,8 @@ def _get_permalink_state(permalink_key: str) -> Dict[str, Any] | None:
     from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
 
     try:
-        result = GetDashboardPermalinkCommand(permalink_key).run()
-        # Convert TypedDict to regular dict for type compatibility
-        return dict(result) if result else None
-    except Exception as e:
+        return GetDashboardPermalinkCommand(permalink_key).run()
+    except DashboardPermalinkGetFailedError as e:
         logger.warning("Failed to retrieve permalink state: %s", e)
         return None
 

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -30,6 +30,7 @@ from superset_core.mcp import tool
 
 from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
+from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
@@ -160,7 +161,7 @@ async def get_dashboard_info(
 
         return result
 
-    except Exception as e:
+    except SupersetException as e:
         await ctx.error(
             "Dashboard information retrieval failed: identifier=%s, error=%s, "
             "error_type=%s" % (request.identifier, str(e), type(e).__name__)

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -144,8 +144,11 @@ async def get_dashboard_info(
                         )
                     else:
                         # Extract the state from permalink value
-                        # Cast to dict for Pydantic compatibility
-                        permalink_state = dict(permalink_value.get("state", {}))
+                        # Handle None or non-dict state gracefully
+                        raw_state = permalink_value.get("state")
+                        permalink_state = (
+                            dict(raw_state) if isinstance(raw_state, dict) else {}
+                        )
                         result.permalink_key = request.permalink_key
                         result.filter_state = permalink_state
                         result.is_permalink_state = True

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -24,6 +24,7 @@ about a specific dashboard.
 
 import logging
 from datetime import datetime, timezone
+from typing import Any, Dict
 
 from fastmcp import Context
 from superset_core.mcp import tool
@@ -41,6 +42,23 @@ from superset.mcp_service.utils.schema_utils import parse_request
 logger = logging.getLogger(__name__)
 
 
+def _get_permalink_state(permalink_key: str) -> Dict[str, Any] | None:
+    """Retrieve dashboard filter state from permalink.
+
+    Returns the permalink value containing dashboardId and state if found,
+    None otherwise.
+    """
+    from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
+
+    try:
+        result = GetDashboardPermalinkCommand(permalink_key).run()
+        # Convert TypedDict to regular dict for type compatibility
+        return dict(result) if result else None
+    except Exception as e:
+        logger.warning("Failed to retrieve permalink state: %s", e)
+        return None
+
+
 @tool(tags=["discovery"])
 @parse_request(GetDashboardInfoRequest)
 async def get_dashboard_info(
@@ -50,8 +68,30 @@ async def get_dashboard_info(
     Get dashboard metadata by ID, UUID, or slug.
 
     Returns title, charts, and layout details.
+
+    When permalink_key is provided, also returns the filter state from that
+    permalink, allowing you to see what filters the user has applied to the
+    dashboard (not just the default filter state).
+
+    Example usage:
+    ```json
+    {
+        "identifier": 123
+    }
+    ```
+
+    With permalink (filter state from URL):
+    ```json
+    {
+        "identifier": 123,
+        "permalink_key": "abc123def456"
+    }
+    ```
     """
-    await ctx.info("Retrieving dashboard information: %s" % (request.identifier,))
+    await ctx.info(
+        "Retrieving dashboard information: identifier=%s, permalink_key=%s"
+        % (request.identifier, request.permalink_key)
+    )
     await ctx.debug(
         "Metadata cache settings: use_cache=%s, refresh_metadata=%s, force_refresh=%s"
         % (request.use_cache, request.refresh_metadata, request.force_refresh)
@@ -73,14 +113,44 @@ async def get_dashboard_info(
             result = tool.run_tool(request.identifier)
 
         if isinstance(result, DashboardInfo):
+            # If permalink_key is provided, retrieve filter state
+            if request.permalink_key:
+                await ctx.info(
+                    "Retrieving filter state from permalink: permalink_key=%s"
+                    % (request.permalink_key,)
+                )
+                permalink_value = _get_permalink_state(request.permalink_key)
+
+                if permalink_value:
+                    # Extract the state from permalink value
+                    permalink_state = permalink_value.get("state", {})
+                    result.permalink_key = request.permalink_key
+                    result.filter_state = permalink_state
+                    result.is_permalink_state = True
+
+                    await ctx.info(
+                        "Filter state retrieved from permalink: has_dataMask=%s, "
+                        "has_activeTabs=%s"
+                        % (
+                            "dataMask" in permalink_state,
+                            "activeTabs" in permalink_state,
+                        )
+                    )
+                else:
+                    await ctx.warning(
+                        "permalink_key provided but no permalink found. "
+                        "The permalink may have expired or is invalid."
+                    )
+
             await ctx.info(
                 "Dashboard information retrieved successfully: id=%s, title=%s, "
-                "chart_count=%s, published=%s"
+                "chart_count=%s, published=%s, is_permalink_state=%s"
                 % (
                     result.id,
                     result.dashboard_title,
                     result.chart_count,
                     result.published,
+                    result.is_permalink_state,
                 )
             )
         else:

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -30,7 +30,6 @@ from superset_core.mcp import tool
 
 from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
-from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
@@ -162,7 +161,7 @@ async def get_dashboard_info(
 
         return result
 
-    except SupersetException as e:
+    except Exception as e:
         await ctx.error(
             "Dashboard information retrieval failed: identifier=%s, error=%s, "
             "error_type=%s" % (request.identifier, str(e), type(e).__name__)

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -123,7 +123,8 @@ async def get_dashboard_info(
 
                 if permalink_value:
                     # Extract the state from permalink value
-                    permalink_state = permalink_value.get("state", {})
+                    # Cast to dict for Pydantic compatibility
+                    permalink_state = dict(permalink_value.get("state", {}))
                     result.permalink_key = request.permalink_key
                     result.filter_state = permalink_state
                     result.is_permalink_state = True

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -122,10 +122,20 @@ async def get_dashboard_info(
 
                 if permalink_value:
                     # Verify the permalink belongs to the requested dashboard
+                    # dashboardId in permalink is stored as str, result.id is int
                     permalink_dashboard_id = permalink_value.get("dashboardId")
+                    try:
+                        permalink_dashboard_id_int = (
+                            int(permalink_dashboard_id)
+                            if permalink_dashboard_id
+                            else None
+                        )
+                    except (ValueError, TypeError):
+                        permalink_dashboard_id_int = None
+
                     if (
-                        isinstance(permalink_dashboard_id, int)
-                        and permalink_dashboard_id != result.id
+                        permalink_dashboard_id_int is not None
+                        and permalink_dashboard_id_int != result.id
                     ):
                         await ctx.warning(
                             "permalink_key dashboardId (%s) does not match "


### PR DESCRIPTION
### SUMMARY

Add support for `form_data_key` (Explore) and `permalink_key` (Dashboard) parameters in MCP tools to retrieve unsaved/temporary state.

**Problem:**
When a user edits a chart in Explore (changes type, metrics, etc.) but doesn't save, the current state is stored with a `form_data_key`. Similarly, when users apply filters in a dashboard, the state can be persisted in a `permalink_key`. The MCP tools were previously unaware of these keys and would only retrieve the saved version of charts/dashboards.

This meant when users asked the chatbot to explain a chart they were editing, it would describe the saved version rather than what the user actually sees.

**Solution:**
- Add `form_data_key` parameter to chart tools (`get_chart_info`, `get_chart_data`, `get_chart_preview`) to retrieve unsaved chart configuration from cache
- Add `permalink_key` parameter to `get_dashboard_info` to retrieve dashboard filter state from permalink
- Add `is_unsaved_state`/`is_permalink_state` flags to indicate when data came from cache vs saved version

**Changes:**
- `superset/mcp_service/chart/schemas.py`: Add `form_data_key` to request schemas, add `is_unsaved_state` and `form_data_key` to `ChartInfo`
- `superset/mcp_service/chart/tool/get_chart_info.py`: Retrieve cached form_data when `form_data_key` provided
- `superset/mcp_service/chart/tool/get_chart_data.py`: Build query context from cached form_data
- `superset/mcp_service/dashboard/schemas.py`: Add `permalink_key` to request schema, add `filter_state` and `is_permalink_state` to `DashboardInfo`
- `superset/mcp_service/dashboard/tool/get_dashboard_info.py`: Retrieve filter state from permalink

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - API changes only

### TESTING INSTRUCTIONS

1. Start Superset with MCP service enabled
2. Create or open an existing chart in Explore
3. Make changes to the chart (e.g., change viz type, metrics) without saving
4. Copy the `form_data_key` from the URL
5. Call `get_chart_info` with the chart ID and the `form_data_key`
6. Verify the response contains `is_unsaved_state: true` and the `form_data` reflects the unsaved changes

For dashboards:
1. Open a dashboard and apply filters
2. Copy the `permalink_key` from the URL (if using permalinks)
3. Call `get_dashboard_info` with the dashboard ID and the `permalink_key`
4. Verify the response contains `is_permalink_state: true` and `filter_state` with the applied filters

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)