### PR TITLE
fix(sqllab): show virtual dataset banner only when isDataset param is true

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -859,7 +859,7 @@ const SqlEditor: FC<Props> = ({
               `}
             >
               {' '}
-              {t(`You are edting a query from the virtual dataset `) +
+              {t(`You are editing a query from the virtual dataset `) +
                 queryEditor.name}
             </p>
             <p

--- a/superset-frontend/src/pages/SqlLab/LocationContext.tsx
+++ b/superset-frontend/src/pages/SqlLab/LocationContext.tsx
@@ -40,13 +40,14 @@ export const LocationProvider: FC = ({ children }: { children: ReactNode }) => {
   const permalink = location.pathname.match(/\/p\/\w+/)?.[0].slice(3);
   if (queryParams.size > 0 || permalink) {
     const autorun = queryParams.get('autorun') === 'true';
+    const isDataset = queryParams.get('isDataset') === 'true';
     const queryParamsState = {
       requestedQuery: {
         ...Object.fromEntries(queryParams),
         autorun,
         permalink,
       },
-      isDataset: true,
+      isDataset,
     } as LocationState;
     return <Provider value={queryParamsState}>{children}</Provider>;
   }


### PR DESCRIPTION
### SUMMARY

This PR fixes a bug where the "You are editing a query from the virtual dataset" banner was incorrectly shown in SQL Lab when opening URLs with query parameters.

**The Specific Scenario:**

When using MCP tools (or any external integration) to generate SQL Lab URLs with pre-populated context, the URL looks like:
```
/sqllab?dbid=1&schema=public&sql=SELECT...&title=My+Query
```

This URL is simply meant to open SQL Lab with a pre-filled query - it's NOT editing a virtual dataset. However, the banner was incorrectly appearing because `LocationContext.tsx` was hardcoding `isDataset: true` for **any** URL with query parameters.

**The Bug (in `LocationContext.tsx`):**
```tsx
// Any URL with query params would set isDataset to true
const queryParamsState = {
  requestedQuery: { ... },
  isDataset: true,  // BUG: Always true, regardless of actual intent
};
```

**The Fix:**
```tsx
// Only set isDataset=true when explicitly passed in the URL
const isDataset = queryParams.get('isDataset') === 'true';
const queryParamsState = {
  requestedQuery: { ... },
  isDataset,  // Now correctly reads from URL params
};
```

**When the banner SHOULD appear:**
Only when editing a virtual dataset from the Dataset Editor, which explicitly passes `isDataset=true`:
```
/sqllab?dbid=1&schema=public&sql=SELECT...&name=MyDataset&isDataset=true
```

Also fixes a typo in the banner text: "edting" → "editing"

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Virtual dataset banner incorrectly appears when opening SQL Lab via MCP-generated URL (or any URL with query params)

**After:** Banner only appears when `isDataset=true` is explicitly passed in the URL (i.e., when actually editing a virtual dataset)

### TESTING INSTRUCTIONS

1. **Test MCP/API-style URL (should NOT show banner):**
   - Navigate to `/sqllab?dbid=1&schema=public&sql=SELECT%201&title=Test%20Query`
   - Verify the virtual dataset banner does NOT appear
   - The SQL editor should be pre-populated with the query

2. **Test virtual dataset editing (SHOULD show banner):**
   - Navigate to `/sqllab?dbid=1&schema=public&sql=SELECT%201&name=Test&isDataset=true`
   - Verify the virtual dataset banner DOES appear

3. **Test from Dataset Editor:**
   - Go to a virtual dataset's settings
   - Click the "Edit in SQL Lab" link
   - Verify the banner appears correctly (since it passes `isDataset=true`)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API