### PR TITLE
fix(mcp): add dataset validation for chart tools

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -133,7 +133,7 @@ def validate_chart_dataset(
             error=None,
         )
 
-    except Exception as e:
+    except (AttributeError, ValueError, RuntimeError) as e:
         logger.warning("Error validating chart dataset %s: %s", datasource_id, e)
         return DatasetValidationResult(
             is_valid=False,

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -44,7 +44,7 @@ class DatasetValidationResult:
     """Result of dataset accessibility validation."""
 
     is_valid: bool
-    dataset_id: int | None
+    dataset_id: int | str | None
     dataset_name: str | None
     warnings: list[str]
     error: str | None = None
@@ -67,6 +67,8 @@ def validate_chart_dataset(
     Returns:
         DatasetValidationResult with validation status and any warnings
     """
+    from sqlalchemy.exc import SQLAlchemyError
+
     from superset.daos.dataset import DatasetDAO
     from superset.mcp_service.auth import has_dataset_access
 
@@ -133,8 +135,8 @@ def validate_chart_dataset(
             error=None,
         )
 
-    except (AttributeError, ValueError, RuntimeError) as e:
-        logger.warning("Error validating chart dataset %s: %s", datasource_id, e)
+    except (AttributeError, ValueError, RuntimeError, SQLAlchemyError) as e:
+        logger.exception("Error validating chart dataset %s: %s", datasource_id, e)
         return DatasetValidationResult(
             is_valid=False,
             dataset_id=datasource_id,
@@ -151,6 +153,7 @@ def generate_explore_link(dataset_id: int | str, form_data: Dict[str, Any]) -> s
     from superset.commands.exceptions import CommandException
     from superset.commands.explore.form_data.parameters import CommandParameters
     from superset.daos.dataset import DatasetDAO
+    from superset.exceptions import SupersetException
     from superset.mcp_service.commands.create_form_data import (
         MCPCreateFormDataCommand,
     )
@@ -201,7 +204,15 @@ def generate_explore_link(dataset_id: int | str, form_data: Dict[str, Any]) -> s
         # Return URL with just the form_data_key
         return f"{base_url}/explore/?form_data_key={form_data_key}"
 
-    except (CommandException, SQLAlchemyError, ValueError, AttributeError) as e:
+    except (
+        CommandException,
+        SupersetException,
+        SQLAlchemyError,
+        KeyError,
+        ValueError,
+        AttributeError,
+        TypeError,
+    ) as e:
         # Fallback to basic explore URL with numeric ID if available
         logger.debug("Explore link generation fallback due to: %s", e)
         if numeric_dataset_id is not None:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -23,6 +23,7 @@ generation that can be used by both generate_chart and generate_explore_link too
 """
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Dict
 
 from superset.mcp_service.chart.schemas import (
@@ -36,6 +37,111 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.utils import json
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DatasetValidationResult:
+    """Result of dataset accessibility validation."""
+
+    is_valid: bool
+    dataset_id: int | None
+    dataset_name: str | None
+    warnings: list[str]
+    error: str | None = None
+
+
+def validate_chart_dataset(
+    chart: Any,
+    check_access: bool = True,
+) -> DatasetValidationResult:
+    """
+    Validate that a chart's dataset exists and is accessible.
+
+    This shared utility should be called by MCP tools after creating or retrieving
+    charts to detect issues like missing or deleted datasets early.
+
+    Args:
+        chart: A chart-like object with datasource_id, datasource_type attributes
+        check_access: Whether to also check user permissions (default True)
+
+    Returns:
+        DatasetValidationResult with validation status and any warnings
+    """
+    from superset.daos.dataset import DatasetDAO
+    from superset.mcp_service.auth import has_dataset_access
+
+    warnings: list[str] = []
+    datasource_id = getattr(chart, "datasource_id", None)
+
+    # Check if chart has a datasource reference
+    if datasource_id is None:
+        return DatasetValidationResult(
+            is_valid=False,
+            dataset_id=None,
+            dataset_name=None,
+            warnings=[],
+            error="Chart has no dataset reference (datasource_id is None)",
+        )
+
+    # Try to look up the dataset
+    try:
+        dataset = DatasetDAO.find_by_id(datasource_id)
+
+        if dataset is None:
+            return DatasetValidationResult(
+                is_valid=False,
+                dataset_id=datasource_id,
+                dataset_name=None,
+                warnings=[],
+                error=(
+                    f"Dataset (ID: {datasource_id}) has been deleted or does not "
+                    f"exist. The chart will not render correctly. "
+                    f"Consider updating the chart to use a different dataset."
+                ),
+            )
+
+        dataset_name = getattr(dataset, "table_name", None) or getattr(
+            dataset, "name", None
+        )
+
+        # Check if it's a virtual dataset (SQL Lab query)
+        is_virtual = bool(getattr(dataset, "sql", None))
+        if is_virtual:
+            warnings.append(
+                f"This chart uses a virtual dataset (SQL-based). "
+                f"If the dataset '{dataset_name}' is deleted, this chart will break."
+            )
+
+        # Check access permissions if requested
+        if check_access and not has_dataset_access(dataset):
+            return DatasetValidationResult(
+                is_valid=False,
+                dataset_id=datasource_id,
+                dataset_name=dataset_name,
+                warnings=warnings,
+                error=(
+                    f"Access denied to dataset '{dataset_name}' (ID: {datasource_id}). "
+                    f"You do not have permission to view this dataset."
+                ),
+            )
+
+        return DatasetValidationResult(
+            is_valid=True,
+            dataset_id=datasource_id,
+            dataset_name=dataset_name,
+            warnings=warnings,
+            error=None,
+        )
+
+    except Exception as e:
+        logger.warning("Error validating chart dataset %s: %s", datasource_id, e)
+        return DatasetValidationResult(
+            is_valid=False,
+            dataset_id=datasource_id,
+            dataset_name=None,
+            warnings=[],
+            error=f"Error validating dataset (ID: {datasource_id}): {str(e)}",
+        )
 
 
 def generate_explore_link(dataset_id: int | str, form_data: Dict[str, Any]) -> str:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -26,6 +26,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from superset.commands.exceptions import CommandException
 from superset.mcp_service.chart.schemas import (
     ChartCapabilities,
     ChartSemantics,
@@ -201,8 +202,9 @@ def generate_explore_link(dataset_id: int | str, form_data: Dict[str, Any]) -> s
         # Return URL with just the form_data_key
         return f"{base_url}/explore/?form_data_key={form_data_key}"
 
-    except (CommandException, SQLAlchemyError, ValueError, AttributeError):
+    except (CommandException, SQLAlchemyError, ValueError, AttributeError) as e:
         # Fallback to basic explore URL with numeric ID if available
+        logger.debug("Explore link generation fallback due to: %s", e)
         if numeric_dataset_id is not None:
             return (
                 f"{base_url}/explore/?datasource_type=table"

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -26,7 +26,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict
 
-from superset.commands.exceptions import CommandException
 from superset.mcp_service.chart.schemas import (
     ChartCapabilities,
     ChartSemantics,

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -25,6 +25,8 @@ from urllib.parse import parse_qs, urlparse
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.commands.exceptions import CommandException
+from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.auth import has_dataset_access
 from superset.mcp_service.chart.chart_utils import (
@@ -320,7 +322,7 @@ async def generate_chart(  # noqa: C901
                 # Add any validation warnings (e.g., virtual dataset warnings)
                 response_warnings.extend(validation_result.warnings)
 
-            except Exception as e:
+            except CommandException as e:
                 logger.error("Chart creation failed: %s", e)
                 await ctx.error("Chart creation failed: error=%s" % (str(e),))
                 raise
@@ -358,7 +360,7 @@ async def generate_chart(  # noqa: C901
                         "Generated form_data_key for saved chart: "
                         "form_data_key=%s" % (form_data_key,)
                     )
-            except Exception as fdk_error:
+            except CommandException as fdk_error:
                 logger.warning(
                     "Failed to generate form_data_key for saved chart: %s",
                     fdk_error,
@@ -476,7 +478,7 @@ async def generate_chart(  # noqa: C901
                                 if not hasattr(preview_result, "error"):
                                     previews[format_type] = preview_result
 
-            except Exception as e:
+            except (CommandException, ValueError, KeyError) as e:
                 # Log warning but don't fail the entire request
                 await ctx.warning("Preview generation failed: error=%s" % (str(e),))
                 logger.warning("Preview generation failed: %s", e)
@@ -544,7 +546,7 @@ async def generate_chart(  # noqa: C901
         )
         return GenerateChartResponse.model_validate(result)
 
-    except Exception as e:
+    except (CommandException, SupersetException, ValueError, KeyError) as e:
         await ctx.error(
             "Chart generation failed: error=%s, execution_time_ms=%s"
             % (
@@ -561,7 +563,7 @@ async def generate_chart(  # noqa: C901
         try:
             if hasattr(request, "config") and hasattr(request.config, "chart_type"):
                 chart_type = request.config.chart_type
-        except Exception as extract_error:
+        except AttributeError as extract_error:
             # Ignore errors when extracting chart type for error context
             logger.debug("Could not extract chart type: %s", extract_error)
 

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -529,10 +529,9 @@ async def generate_chart(  # noqa: C901
             else {},
             "performance": performance.model_dump() if performance else None,
             "accessibility": accessibility.model_dump() if accessibility else None,
-            # Runtime warnings (informational suggestions, not errors)
-            "warnings": runtime_warnings,
+            # Combined runtime and response warnings
+            "warnings": runtime_warnings + response_warnings,
             "success": True,
-            "warnings": response_warnings,
             "schema_version": "2.0",
             "api_version": "v1",
         }

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -32,6 +32,7 @@ from superset.mcp_service.chart.chart_utils import (
     analyze_chart_semantics,
     generate_chart_name,
     map_config_to_form_data,
+    validate_chart_dataset,
 )
 from superset.mcp_service.chart.schemas import (
     AccessibilityMetadata,
@@ -185,6 +186,7 @@ async def generate_chart(  # noqa: C901
         chart_id = None
         explore_url = None
         form_data_key = None
+        response_warnings: list[str] = []
 
         # Save chart by default (unless save_chart=False)
         if request.save_chart:
@@ -299,6 +301,24 @@ async def generate_chart(  # noqa: C901
                         chart.slice_name,
                     )
                 )
+
+                # Post-creation validation: verify the chart's dataset is accessible
+                validation_result = validate_chart_dataset(chart, check_access=True)
+                if not validation_result.is_valid:
+                    # Dataset validation failed - warn but don't fail the operation
+                    await ctx.warning(
+                        "Chart created but dataset validation failed: %s"
+                        % (validation_result.error,)
+                    )
+                    logger.warning(
+                        "Chart %s created but dataset validation failed: %s",
+                        chart.id,
+                        validation_result.error,
+                    )
+                    if validation_result.error:
+                        response_warnings.append(validation_result.error)
+                # Add any validation warnings (e.g., virtual dataset warnings)
+                response_warnings.extend(validation_result.warnings)
 
             except Exception as e:
                 logger.error("Chart creation failed: %s", e)
@@ -510,6 +530,7 @@ async def generate_chart(  # noqa: C901
             # Runtime warnings (informational suggestions, not errors)
             "warnings": runtime_warnings,
             "success": True,
+            "warnings": response_warnings,
             "schema_version": "2.0",
             "api_version": "v1",
         }

--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -305,22 +305,22 @@ async def generate_chart(  # noqa: C901
                 )
 
                 # Post-creation validation: verify the chart's dataset is accessible
-                validation_result = validate_chart_dataset(chart, check_access=True)
-                if not validation_result.is_valid:
+                dataset_check = validate_chart_dataset(chart, check_access=True)
+                if not dataset_check.is_valid:
                     # Dataset validation failed - warn but don't fail the operation
                     await ctx.warning(
                         "Chart created but dataset validation failed: %s"
-                        % (validation_result.error,)
+                        % (dataset_check.error,)
                     )
                     logger.warning(
                         "Chart %s created but dataset validation failed: %s",
                         chart.id,
-                        validation_result.error,
+                        dataset_check.error,
                     )
-                    if validation_result.error:
-                        response_warnings.append(validation_result.error)
+                    if dataset_check.error:
+                        response_warnings.append(dataset_check.error)
                 # Add any validation warnings (e.g., virtual dataset warnings)
-                response_warnings.extend(validation_result.warnings)
+                response_warnings.extend(dataset_check.warnings)
 
             except CommandException as e:
                 logger.error("Chart creation failed: %s", e)

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.extensions import event_logger
+from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
     ChartData,
     ChartError,
@@ -146,6 +147,22 @@ async def get_chart_data(  # noqa: C901
             )
         )
         logger.info("Getting data for chart %s: %s", chart.id, chart.slice_name)
+
+        # Validate the chart's dataset is accessible before retrieving data
+        validation_result = validate_chart_dataset(chart, check_access=True)
+        if not validation_result.is_valid:
+            await ctx.warning(
+                "Chart found but dataset is not accessible: %s"
+                % (validation_result.error,)
+            )
+            return ChartError(
+                error=validation_result.error
+                or "Chart's dataset is not accessible. Dataset may have been deleted.",
+                error_type="DatasetNotAccessible",
+            )
+        # Log any warnings (e.g., virtual dataset warnings)
+        for warning in validation_result.warnings:
+            await ctx.warning("Dataset warning: %s" % (warning,))
 
         start_time = time.time()
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
+from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
@@ -675,7 +676,7 @@ async def get_chart_data(  # noqa: C901
                 cache_status=cache_status,
             )
 
-        except Exception as data_error:
+        except (CommandException, SupersetException, ValueError) as data_error:
             await ctx.error(
                 "Data retrieval failed: chart_id=%s, error=%s, error_type=%s"
                 % (
@@ -690,7 +691,7 @@ async def get_chart_data(  # noqa: C901
                 error_type="DataError",
             )
 
-    except Exception as e:
+    except (CommandException, SupersetException, ValueError, KeyError) as e:
         await ctx.error(
             "Chart data retrieval failed: identifier=%s, error=%s, error_type=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -27,6 +27,7 @@ from superset_core.mcp import tool
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.extensions import event_logger
+from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
     ChartError,
     ChartInfo,
@@ -149,6 +150,25 @@ async def get_chart_info(
             "Chart information retrieved successfully: chart_name=%s, "
             "is_unsaved_state=%s" % (result.slice_name, result.is_unsaved_state)
         )
+
+        # Validate the chart's dataset is accessible
+        if result.id:
+            chart = ChartDAO.find_by_id(result.id)
+            if chart:
+                validation_result = validate_chart_dataset(chart, check_access=True)
+                if not validation_result.is_valid:
+                    await ctx.warning(
+                        "Chart found but dataset is not accessible: %s"
+                        % (validation_result.error,)
+                    )
+                    return ChartError(
+                        error=validation_result.error
+                        or "Chart's dataset is not accessible",
+                        error_type="DatasetNotAccessible",
+                    )
+                # Log any warnings (e.g., virtual dataset warnings)
+                for warning in validation_result.warnings:
+                    await ctx.warning("Dataset warning: %s" % (warning,))
     else:
         await ctx.warning("Chart retrieval failed: error=%s" % (str(result),))
 

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -1869,7 +1869,13 @@ async def _get_chart_preview_internal(  # noqa: C901
                                     self.uuid = None
 
                             chart = TransientChart(form_data)
-                    except (CommandException, ValueError, KeyError, AttributeError, TypeError) as e:
+                    except (
+                        CommandException,
+                        ValueError,
+                        KeyError,
+                        AttributeError,
+                        TypeError,
+                    ) as e:
                         # Form data key not found or invalid
                         logger.debug(
                             "Failed to get form data for key %s: %s",

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -25,6 +25,8 @@ from typing import Any, Dict, List, Protocol
 from fastmcp import Context
 from superset_core.mcp import tool
 
+from superset.commands.exceptions import CommandException
+from superset.exceptions import SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
@@ -177,7 +179,7 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
                 height=self.request.ascii_height or 20,
             )
 
-        except Exception as e:
+        except (CommandException, SupersetException, ValueError, KeyError) as e:
             logger.error("ASCII preview generation failed: %s", e)
             return ChartError(
                 error=f"Failed to generate ASCII preview: {str(e)}",
@@ -238,7 +240,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
                 row_count=len(data),
             )
 
-        except Exception as e:
+        except (CommandException, SupersetException, ValueError, KeyError) as e:
             logger.error("Table preview generation failed: %s", e)
             return ChartError(
                 error=f"Failed to generate table preview: {str(e)}",
@@ -257,7 +259,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
 
                 return utils_json.loads(self.chart.params)
             return None
-        except Exception:
+        except (ValueError, TypeError):
             return None
 
     def generate(self) -> VegaLitePreview | ChartError:
@@ -346,7 +348,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                 supports_streaming=False,
             )
 
-        except Exception as e:
+        except (CommandException, SupersetException, ValueError, KeyError) as e:
             logger.exception(
                 "Error generating Vega-Lite preview for chart %s", self.chart.id
             )
@@ -456,11 +458,11 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                     field_type = self._determine_field_type(sample_values)
                     field_types[field] = field_type
 
-                except Exception as e:
+                except (TypeError, ValueError, KeyError, AttributeError) as e:
                     logger.warning("Error analyzing field '%s': %s", field, e)
                     field_types[field] = "nominal"  # Safe default
 
-        except Exception as e:
+        except (TypeError, ValueError, KeyError, AttributeError) as e:
             logger.warning("Error in field type analysis: %s", e)
             # Return nominal types for all fields as fallback
             return dict.fromkeys(fields, "nominal")
@@ -946,7 +948,7 @@ def generate_ascii_chart(
                 "Unsupported chart type '%s', falling back to table", chart_type
             )
             return _generate_ascii_table(data, width)
-    except Exception as e:
+    except (TypeError, ValueError, KeyError, IndexError) as e:
         logger.error("ASCII chart generation failed: %s", e)
         import traceback
 
@@ -1867,7 +1869,7 @@ async def _get_chart_preview_internal(  # noqa: C901
                                     self.uuid = None
 
                             chart = TransientChart(form_data)
-                    except (ValueError, KeyError, AttributeError, TypeError) as e:
+                    except (CommandException, ValueError, KeyError, AttributeError, TypeError) as e:
                         # Form data key not found or invalid
                         logger.debug(
                             "Failed to get form data for key %s: %s",
@@ -2009,7 +2011,7 @@ async def _get_chart_preview_internal(  # noqa: C901
 
         return result
 
-    except Exception as e:
+    except (CommandException, SupersetException, ValueError, KeyError) as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, format=%s, error=%s, "
             "error_type=%s"
@@ -2074,7 +2076,7 @@ async def get_chart_preview(
             )
 
         return result
-    except Exception as e:
+    except (CommandException, SupersetException, ValueError, KeyError) as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, error=%s, error_type=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -179,7 +179,14 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
                 height=self.request.ascii_height or 20,
             )
 
-        except (CommandException, SupersetException, ValueError, KeyError) as e:
+        except (
+            CommandException,
+            SupersetException,
+            ValueError,
+            KeyError,
+            AttributeError,
+            TypeError,
+        ) as e:
             logger.error("ASCII preview generation failed: %s", e)
             return ChartError(
                 error=f"Failed to generate ASCII preview: {str(e)}",
@@ -240,7 +247,14 @@ class TablePreviewStrategy(PreviewFormatStrategy):
                 row_count=len(data),
             )
 
-        except (CommandException, SupersetException, ValueError, KeyError) as e:
+        except (
+            CommandException,
+            SupersetException,
+            ValueError,
+            KeyError,
+            AttributeError,
+            TypeError,
+        ) as e:
             logger.error("Table preview generation failed: %s", e)
             return ChartError(
                 error=f"Failed to generate table preview: {str(e)}",
@@ -348,7 +362,14 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                 supports_streaming=False,
             )
 
-        except (CommandException, SupersetException, ValueError, KeyError) as e:
+        except (
+            CommandException,
+            SupersetException,
+            ValueError,
+            KeyError,
+            AttributeError,
+            TypeError,
+        ) as e:
             logger.exception(
                 "Error generating Vega-Lite preview for chart %s", self.chart.id
             )
@@ -2017,7 +2038,14 @@ async def _get_chart_preview_internal(  # noqa: C901
 
         return result
 
-    except (CommandException, SupersetException, ValueError, KeyError) as e:
+    except (
+        CommandException,
+        SupersetException,
+        ValueError,
+        KeyError,
+        AttributeError,
+        TypeError,
+    ) as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, format=%s, error=%s, "
             "error_type=%s"
@@ -2082,7 +2110,14 @@ async def get_chart_preview(
             )
 
         return result
-    except (CommandException, SupersetException, ValueError, KeyError) as e:
+    except (
+        CommandException,
+        SupersetException,
+        ValueError,
+        KeyError,
+        AttributeError,
+        TypeError,
+    ) as e:
         await ctx.error(
             "Chart preview generation failed: identifier=%s, error=%s, error_type=%s"
             % (

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -26,6 +26,7 @@ from fastmcp import Context
 from superset_core.mcp import tool
 
 from superset.extensions import event_logger
+from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
     AccessibilityMetadata,
     ASCIIPreview,
@@ -1899,6 +1900,24 @@ async def _get_chart_preview_internal(  # noqa: C901
         )
         logger.info("Generating preview for chart %s", getattr(chart, "id", "NO_ID"))
         logger.info("Chart datasource_id: %s", getattr(chart, "datasource_id", "NONE"))
+
+        # Validate the chart's dataset is accessible before generating preview
+        # Skip validation for transient charts (no ID) - different data sources
+        if getattr(chart, "id", None) is not None:
+            validation_result = validate_chart_dataset(chart, check_access=True)
+            if not validation_result.is_valid:
+                await ctx.warning(
+                    "Chart found but dataset is not accessible: %s"
+                    % (validation_result.error,)
+                )
+                return ChartError(
+                    error=validation_result.error
+                    or "Chart's dataset is not accessible. Dataset may be deleted.",
+                    error_type="DatasetNotAccessible",
+                )
+            # Log any warnings (e.g., virtual dataset warnings)
+            for warning in validation_result.warnings:
+                await ctx.warning("Dataset warning: %s" % (warning,))
 
         import time
 


### PR DESCRIPTION
### SUMMARY

Add shared validation utility to detect missing/deleted datasets in MCP chart tools. This prevents confusing errors when users try to preview or get data from charts whose datasets have been deleted.

**Problem**: When a chart's dataset is deleted, the MCP tools would return confusing errors or fail silently. Users would see "Missing dataset" errors in the UI without clear indication of what went wrong.

**Solution**: Added a shared `validate_chart_dataset()` utility that:
- Checks if a chart's dataset exists and is accessible
- Returns clear error messages when datasets are missing/deleted
- Warns about virtual (SQL Lab) datasets that could be deleted

**Changes**:
- Added `validate_chart_dataset()` utility in `chart_utils.py`
- Updated `generate_chart` to validate dataset after chart creation (adds warnings to response)
- Updated `get_chart_info` to return `ChartError` with type `DatasetNotAccessible` if dataset is missing
- Updated `get_chart_preview` to validate before generating preview
- Updated `get_chart_data` to validate before fetching data
- Added documentation in MCP `CLAUDE.md`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend changes only

### TESTING INSTRUCTIONS

1. Create a chart using the MCP `generate_chart` tool
2. Delete the dataset the chart uses (via UI or API)
3. Try to get chart info, preview, or data using the MCP tools:
   - `get_chart_info` - Should return `ChartError` with `error_type: "DatasetNotAccessible"`
   - `get_chart_preview` - Should return `ChartError` with clear message about missing dataset
   - `get_chart_data` - Should return `ChartError` with clear message about missing dataset

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)