### PR TITLE
feat(mcp): add stacked bar/area chart support

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -326,8 +326,8 @@ def map_xy_config(config: XYChartConfig) -> Dict[str, Any]:
         ]
 
     # Add stacking configuration
-    if config.stacked:
-        form_data["stack"] = "Stack"
+    if getattr(config, "stacked", False):
+        form_data["stack"] = True
 
     # Add configurations
     add_axis_config(form_data, config)

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -325,6 +325,10 @@ def map_xy_config(config: XYChartConfig) -> Dict[str, Any]:
             if filter_config is not None
         ]
 
+    # Add stacking configuration
+    if config.stacked:
+        form_data["stack"] = "Stack"
+
     # Add configurations
     add_axis_config(form_data, config)
     add_legend_config(form_data, config)

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -327,7 +327,7 @@ def map_xy_config(config: XYChartConfig) -> Dict[str, Any]:
 
     # Add stacking configuration
     if getattr(config, "stacked", False):
-        form_data["stack"] = True
+        form_data["stack"] = "Stack"
 
     # Add configurations
     add_axis_config(form_data, config)

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -688,6 +688,10 @@ class XYChartConfig(BaseModel):
             "If not specified, Superset will use its default behavior."
         ),
     )
+    stacked: bool = Field(
+        False,
+        description="Stack bars/areas on top of each other instead of side-by-side",
+    )
     group_by: ColumnRef | None = Field(None, description="Column to group by")
     x_axis: AxisConfig | None = Field(None, description="X-axis configuration")
     y_axis: AxisConfig | None = Field(None, description="Y-axis configuration")


### PR DESCRIPTION
### SUMMARY
Add `stacked` field to XYChartConfig schema in the MCP service that enables stacking bars/areas on top of each other instead of displaying them side-by-side.

**Changes:**
- Added `stacked: bool` field to `XYChartConfig` in `schemas.py` (default: `False`)
- Updated `map_xy_config()` in `chart_utils.py` to set `form_data["stack"] = "Stack"` when `stacked=True`

This allows LLM clients using the MCP service to create stacked bar and area charts by simply setting `stacked: true` in the chart configuration.

**Example usage:**
```json
{
    "dataset_id": 123,
    "config": {
        "chart_type": "xy",
        "x": {"name": "month"},
        "y": [{"name": "revenue", "aggregate": "SUM"}],
        "group_by": {"name": "product_line"},
        "kind": "bar",
        "stacked": true
    }
}
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is a schema/API enhancement, no UI changes.

### TESTING INSTRUCTIONS
1. Start the MCP service
2. Use `generate_chart` or `update_chart` tool with `stacked: true` in the XY chart config
3. Verify the resulting chart displays bars/areas stacked instead of side-by-side

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API