### PR TITLE
fix: add droppable area to tab empty state

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -116,11 +116,8 @@ const TitleDropIndicator = styled.div`
   }
 `;
 
-const renderDraggableContent = dropProps => {
-  return (
-    dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />
-  );
-};
+const renderDraggableContent = dropProps =>
+  dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />;
 
 const Tab = props => {
   const dispatch = useDispatch();
@@ -279,13 +276,13 @@ const Tab = props => {
                     (editMode ? (
                       <span>
                         {t('You can')}{' '}
-                        <Link
-                          to={`/chart/add?dashboard_id=${dashboardId}`}
+                        <a
+                          href={`/chart/add?dashboard_id=${dashboardId}`}
                           rel="noopener noreferrer"
                           target="_blank"
                         >
                           {t('create a new chart')}
-                        </Link>{' '}
+                        </a>{' '}
                         {t('or use existing ones from the panel on the right')}
                       </span>
                     ) : (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -115,8 +115,11 @@ const TitleDropIndicator = styled.div`
   }
 `;
 
-const renderDraggableContent = dropProps =>
-  dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />;
+const renderDraggableContent = dropProps => {
+  return (
+    dropProps.dropIndicatorProps && <div {...dropProps.dropIndicatorProps} />
+  );
+};
 
 const Tab = props => {
   const dispatch = useDispatch();
@@ -213,6 +216,46 @@ const Tab = props => {
 
   const shouldDropToChild = useCallback(item => item.type !== TAB_TYPE, []);
 
+  const renderDropableEmptyState = dropProps => {
+    return (
+      <EmptyState
+        title={
+          props.editMode
+            ? t('Drag and drop components to this tab')
+            : t('There are no components added to this tab')
+        }
+        description={
+          canEdit &&
+          (props.editMode ? (
+            <span>
+              {t('You can')}{' '}
+              <a
+                href={`/chart/add?dashboard_id=${props.dashboardId}`}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {t('create a new chart')}
+              </a>{' '}
+              {t('or use existing ones from the panel on the right')}
+            </span>
+          ) : (
+            <span>
+              {t('You can add the components in the')}{' '}
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={() => dispatch(setEditMode(true))}
+              >
+                {t('edit mode')}
+              </span>
+            </span>
+          ))
+        }
+        image="chart.svg"
+      />
+    );
+  };
+
   const renderTabContent = useCallback(() => {
     const {
       component: tabComponent,
@@ -253,41 +296,55 @@ const Tab = props => {
           </Droppable>
         )}
         {shouldDisplayEmptyState && (
-          <EmptyState
-            title={
-              editMode
-                ? t('Drag and drop components to this tab')
-                : t('There are no components added to this tab')
-            }
-            description={
-              canEdit &&
-              (editMode ? (
-                <span>
-                  {t('You can')}{' '}
-                  <a
-                    href={`/chart/add?dashboard_id=${dashboardId}`}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {t('create a new chart')}
-                  </a>{' '}
-                  {t('or use existing ones from the panel on the right')}
-                </span>
-              ) : (
-                <span>
-                  {t('You can add the components in the')}{' '}
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => dispatch(setEditMode(true))}
-                  >
-                    {t('edit mode')}
-                  </span>
-                </span>
-              ))
-            }
-            image="chart.svg"
-          />
+          <Droppable
+            component={tabComponent}
+            orientation="column"
+            index={editMode ? 1 : 0}
+            depth={depth}
+            onDrop={handleTopDropTargetDrop}
+            editMode={editMode}
+            dropToChild
+          >
+            {() => (
+              <div data-test="emptystate-drop-indicator">
+                <EmptyState
+                  title={
+                    editMode
+                      ? t('Drag and drop components to this tab')
+                      : t('There are no components added to this tab')
+                  }
+                  description={
+                    canEdit &&
+                    (editMode ? (
+                      <span>
+                        {t('You can')}{' '}
+                        <a
+                          href={`/chart/add?dashboard_id=${dashboardId}`}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {t('create a new chart')}
+                        </a>{' '}
+                        {t('or use existing ones from the panel on the right')}
+                      </span>
+                    ) : (
+                      <span>
+                        {t('You can add the components in the')}{' '}
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => dispatch(setEditMode(true))}
+                        >
+                          {t('edit mode')}
+                        </span>
+                      </span>
+                    ))
+                  }
+                  image="chart.svg"
+                />
+              </div>
+            )}
+          </Droppable>
         )}
         {tabComponent.children.map((componentId, componentIndex) => (
           <Fragment key={componentId}>

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -34,6 +34,7 @@ import {
 } from 'src/dashboard/components/dnd/DragDroppable';
 import { componentShape } from 'src/dashboard/util/propShapes';
 import { TAB_TYPE } from 'src/dashboard/util/componentTypes';
+import { Link } from 'react-router-dom';
 
 export const RENDER_TAB = 'RENDER_TAB';
 export const RENDER_TAB_CONTENT = 'RENDER_TAB_CONTENT';
@@ -278,13 +279,13 @@ const Tab = props => {
                     (editMode ? (
                       <span>
                         {t('You can')}{' '}
-                        <a
-                          href={`/chart/add?dashboard_id=${dashboardId}`}
+                        <Link
+                          to={`/chart/add?dashboard_id=${dashboardId}`}
                           rel="noopener noreferrer"
                           target="_blank"
                         >
                           {t('create a new chart')}
-                        </a>{' '}
+                        </Link>{' '}
                         {t('or use existing ones from the panel on the right')}
                       </span>
                     ) : (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -216,46 +216,6 @@ const Tab = props => {
 
   const shouldDropToChild = useCallback(item => item.type !== TAB_TYPE, []);
 
-  const renderDropableEmptyState = dropProps => {
-    return (
-      <EmptyState
-        title={
-          props.editMode
-            ? t('Drag and drop components to this tab')
-            : t('There are no components added to this tab')
-        }
-        description={
-          canEdit &&
-          (props.editMode ? (
-            <span>
-              {t('You can')}{' '}
-              <a
-                href={`/chart/add?dashboard_id=${props.dashboardId}`}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {t('create a new chart')}
-              </a>{' '}
-              {t('or use existing ones from the panel on the right')}
-            </span>
-          ) : (
-            <span>
-              {t('You can add the components in the')}{' '}
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={() => dispatch(setEditMode(true))}
-              >
-                {t('edit mode')}
-              </span>
-            </span>
-          ))
-        }
-        image="chart.svg"
-      />
-    );
-  };
-
   const renderTabContent = useCallback(() => {
     const {
       component: tabComponent,

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -28,6 +28,7 @@ import { setEditMode, onRefresh } from 'src/dashboard/actions/dashboardState';
 import getChartIdsFromComponent from 'src/dashboard/util/getChartIdsFromComponent';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import AnchorLink from 'src/dashboard/components/AnchorLink';
+import { Typography } from '@superset-ui/core/components/Typography';
 import {
   DragDroppable,
   Droppable,
@@ -276,13 +277,13 @@ const Tab = props => {
                     (editMode ? (
                       <span>
                         {t('You can')}{' '}
-                        <a
+                        <Typography.Link
                           href={`/chart/add?dashboard_id=${dashboardId}`}
                           rel="noopener noreferrer"
                           target="_blank"
                         >
                           {t('create a new chart')}
-                        </a>{' '}
+                        </Typography.Link>{' '}
                         {t('or use existing ones from the panel on the right')}
                       </span>
                     ) : (

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -403,6 +403,7 @@ test('Render tab content with no children, editMode: true, canEdit: true', () =>
       },
     },
   });
+  expect(screen.queryByTestId('emptystate-drop-indicator')).toBeInTheDocument();
   expect(
     screen.getByText('Drag and drop components to this tab'),
   ).toBeVisible();

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -56,9 +56,32 @@ jest.mock('src/dashboard/components/dnd/DragDroppable', () => ({
           dropIndicatorProps: props.dropIndicatorProps,
         }
       : {};
+    const handleClick = () => {
+      if (props.onDrop) {
+        // Create a mock dropResult based on the component props
+        const dropResult = {
+          source: {
+            id: 'MARKDOWN-1',
+            type: 'MARKDOWN',
+            index: 0,
+          },
+          dragging: {
+            id: 'MARKDOWN-1',
+            type: 'MARKDOWN',
+            meta: {},
+          },
+          destination: {
+            id: props.component?.id || '',
+            type: props.component?.type || '',
+            index: props.index ?? 0,
+          },
+        };
+        props.onDrop(dropResult);
+      }
+    };
     return (
       <div>
-        <button type="button" data-test="MockDroppable" onClick={props.onDrop}>
+        <button type="button" data-test="MockDroppable" onClick={handleClick}>
           DragDroppable
         </button>
         {props.children(childProps)}
@@ -414,6 +437,49 @@ test('Render tab content with no children, editMode: true, canEdit: true', () =>
   expect(
     screen.getByRole('link', { name: 'create a new chart' }),
   ).toHaveAttribute('href', '/chart/add?dashboard_id=23');
+});
+
+test('Drag to empty state, editMode: true, canEdit: true', async () => {
+  const props = createProps();
+  props.editMode = true;
+  props.component.children = [];
+  const mockHandleComponentDrop = jest.fn();
+  props.handleComponentDrop = mockHandleComponentDrop;
+
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState: {
+      dashboardInfo: {
+        dash_edit_perm: true,
+      },
+    },
+  });
+
+  const emptyStateIndicator = screen.getByTestId('emptystate-drop-indicator');
+  expect(emptyStateIndicator).toBeInTheDocument();
+
+  const mockDroppableButtons = screen.getAllByTestId('MockDroppable');
+  expect(mockDroppableButtons).toHaveLength(2);
+
+  // Click the MockDroppable button that wraps the empty state indicator (index 1)
+  // This simulates dropping a component on the empty state
+  userEvent.click(mockDroppableButtons[1]);
+
+  // Verify that handleComponentDrop was called with correct destination
+  await waitFor(() => {
+    expect(mockHandleComponentDrop).toHaveBeenCalled();
+  });
+
+  expect(mockHandleComponentDrop).toHaveBeenCalledWith(
+    expect.objectContaining({
+      destination: {
+        id: props.component.id,
+        index: 0,
+        type: 'TAB',
+      },
+    }),
+  );
 });
 
 test('AnchorLink renders in view mode', () => {


### PR DESCRIPTION
### SUMMARY
Unable to drag a chart into a second level tab's body to add it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:**

https://github.com/user-attachments/assets/7e3388f5-673c-49dc-b1cf-3557ae5e056d

**After:**

https://github.com/user-attachments/assets/54b02cef-06e2-46bc-996d-a9dc88456e95

### TESTING INSTRUCTIONS

1. Create a dashboard with tabs that are not at the top level (see the video for the second set of tabs)
2. In edit dashboard, try to drag a chart into the body of the tab to add it to the EMPTY tab

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
