### PR TITLE
fix(mcp): restore select_columns filtering in list tools

### DIFF
--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -137,17 +137,20 @@ async def list_charts(request: ListChartsRequest, ctx: Context) -> ChartList:
             % (count, total_pages)
         )
 
-        # Apply field filtering via serialization context
-        # Use columns_requested from result (already resolved by ModelListCore)
-        columns_to_filter = result.columns_requested
-        await ctx.debug(
-            "Applying field filtering via serialization context: select_columns=%s"
-            % (columns_to_filter,)
-        )
-        filtered = result.model_dump(
-            mode="json", context={"select_columns": columns_to_filter}
-        )
-        return ChartList.model_validate(filtered)
+        # Apply field filtering via serialization context if select_columns specified
+        # This triggers ChartInfo._filter_fields_by_context for each chart
+        if request.select_columns:
+            await ctx.debug(
+                "Applying field filtering via serialization context: select_columns=%s"
+                % (request.select_columns,)
+            )
+            # Return dict with context - FastMCP handles serialization
+            return result.model_dump(
+                mode="json", context={"select_columns": request.select_columns}
+            )
+
+        # No filtering - return full result as dict
+        return result.model_dump(mode="json")
     except Exception as e:
         await ctx.error("Failed to list charts: %s" % (str(e),))
         raise

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -148,17 +148,20 @@ async def list_datasets(request: ListDatasetsRequest, ctx: Context) -> DatasetLi
             )
         )
 
-        # Apply field filtering via serialization context
-        # Use columns_requested from result (already resolved by ModelListCore)
-        columns_to_filter = result.columns_requested
-        await ctx.debug(
-            "Applying field filtering via serialization context: select_columns=%s"
-            % (columns_to_filter,)
-        )
-        filtered = result.model_dump(
-            mode="json", context={"select_columns": columns_to_filter}
-        )
-        return DatasetList.model_validate(filtered)
+        # Apply field filtering via serialization context if select_columns specified
+        # This triggers DatasetInfo._filter_fields_by_context for each dataset
+        if request.select_columns:
+            await ctx.debug(
+                "Applying field filtering via serialization context: select_columns=%s"
+                % (request.select_columns,)
+            )
+            # Return dict with context - FastMCP handles serialization
+            return result.model_dump(
+                mode="json", context={"select_columns": request.select_columns}
+            )
+
+        # No filtering - return full result as dict
+        return result.model_dump(mode="json")
 
     except Exception as e:
         await ctx.error(


### PR DESCRIPTION
## Summary

Fixes the `select_columns` parameter in MCP list tools (`list_charts`, `list_datasets`, `list_dashboards`) which was broken and not filtering response fields.

**Root Cause:**
Commit 84279acd2f changed the list tools to call `model_validate()` after filtering:
```python
filtered = result.model_dump(mode="json", context={"select_columns": ...})
return ChartList.model_validate(filtered)  # ← Bug: recreates models with None defaults
```

This recreated the Pydantic models from the filtered dict, causing all optional fields to be re-added with `None` values, effectively undoing the filtering.

**Fix:**
Restore the original behavior from PR #36035 - return the dict directly from `model_dump()` and let FastMCP handle serialization:
```python
if request.select_columns:
    return result.model_dump(mode="json", context={"select_columns": request.select_columns})
return result.model_dump(mode="json")
```

## Before/After

**Request:**
```json
{"page_size": 3, "page": 1, "select_columns": ["uuid"]}
```

**Before (broken):** Each chart has all 20+ fields with `null` values
```json
{"charts":[
  {"id":null,"slice_name":null,"viz_type":null,"datasource_name":null,"datasource_type":null,"url":null,"description":null,"cache_timeout":null,"form_data":null,"query_context":null,"changed_by":null,"changed_by_name":null,"changed_on":null,"changed_on_humanized":null,"created_by":null,"created_on":null,"created_on_humanized":null,"uuid":"49e16284-ca23-48e6-a4a9-1eb8b6c05139","tags":[],"owners":[]},
  ...
]}
```

**After (fixed):** Only the requested `uuid` field is returned
```json
{"charts":[
  {"uuid":"49e16284-ca23-48e6-a4a9-1eb8b6c05139"},
  {"uuid":"f0066e66-156c-4292-bd50-5a1a9e3a8311"},
  {"uuid":"0091ff28-c62b-4515-9f11-1fb42eb77632"}
]}
```

## Test Plan

- [x] Test `list_charts` with `select_columns: ["uuid"]` - response only contains uuid field ✅
- [ ] Test `list_datasets` with `select_columns: ["id", "table_name"]` - response should only contain those fields
- [ ] Test `list_dashboards` with `select_columns: ["id", "dashboard_title"]` - response should only contain those fields
- [ ] Test without `select_columns` - full response should be returned

🤖 Generated with [Claude Code](https://claude.ai/code)