### PR TITLE
refactor(mcp): simplify single metric chart type check

### DIFF
--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -168,8 +168,7 @@ async def get_chart_data(  # noqa: C901
                 # - pop_kpi (BigNumberPeriodOverPeriod)
                 # These charts also don't have groupby columns
                 viz_type = chart.viz_type or ""
-                single_metric_types = ("big_number", "pop_kpi")
-                if viz_type.startswith("big_number") or viz_type in single_metric_types:
+                if viz_type in ("big_number", "big_number_total", "pop_kpi"):
                     # These chart types use "metric" (singular)
                     metric = form_data.get("metric")
                     metrics = [metric] if metric else []


### PR DESCRIPTION
## Summary

- Replaces mixed conditional (`startswith` + `in`) with explicit tuple membership check
- Makes single-metric chart type detection cleaner and more explicit
- Lists all chart types explicitly: `big_number`, `big_number_total`, `pop_kpi`

## Test plan

- [ ] Verify big_number charts still work correctly in get_chart_data
- [ ] Verify big_number_total charts still work correctly
- [ ] Verify pop_kpi charts still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)