### PR TITLE
fix(mixed-timeseries): prevent duplicate legend entries

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -244,8 +244,10 @@ export default function transformProps(
     },
   );
 
-  const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
-  const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
+  const MetricDisplayNameA: string =
+    getMetricDisplayName(metrics[0], verboseMap) || '';
+  const MetricDisplayNameB: string =
+    getMetricDisplayName(metricsB[0], verboseMap) || '';
 
   const dataTypes = getColtypesMapping(queriesData[0]);
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
@@ -400,10 +402,12 @@ export default function transformProps(
 
     if (groupby.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = showQueryIdentifiers
+      const metricPart: string = showQueryIdentifiers
         ? `${MetricDisplayNameA} (Query A)`
         : MetricDisplayNameA;
-      displayName = `${metricPart}, ${entryName}`;
+      displayName = entryName.includes(metricPart)
+        ? entryName
+        : `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
@@ -471,10 +475,12 @@ export default function transformProps(
 
     if (groupbyB.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = showQueryIdentifiers
+      const metricPart: string = showQueryIdentifiers
         ? `${MetricDisplayNameB} (Query B)`
         : MetricDisplayNameB;
-      displayName = `${metricPart}, ${entryName}`;
+      displayName = entryName.includes(metricPart)
+        ? entryName
+        : `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
## Summary
Fixes an issue in the Mixed Timeseries chart where legend entries were duplicated due to incorrect series labeling.
Closes #37055 

## Changes
- Ensures unique series names are generated in `transformProps`
- Prevents duplicate legend items from appearing

## Reproduction

Before:
- Duplicate legend entries appeared for the same metric
- 
<img width="1920" height="1020" alt="pr issue" src="https://github.com/user-attachments/assets/b4878313-e315-4bac-902c-ed7103aea4de" />

After:
- Each metric appears exactly once in the legend

## Screenshots / Video

https://github.com/user-attachments/assets/913900ea-2976-47f2-8683-6154e24824ae


## Checklist
- [x] Tested locally
- [x] pre-commit hooks pass
- [x] No unrelated changes


