### PR TITLE
fix(roles): optimize user fetching and resolve N+1 query issue

### DIFF
--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -233,18 +233,16 @@ describe('RoleListEditModal', () => {
     expect(urlMatch).toBeTruthy();
 
     const decodedQuery = rison.decode(urlMatch[1]);
-    expect(decodedQuery).toEqual(
-      {
-        page_size: 100,
-        page: 0,
-        filters: [
-          {
-            col: 'roles',
-            opr: 'rel_m_m',
-            value: mockRole.id,
-          },
-        ],
-      }
-    );
+    expect(decodedQuery).toEqual({
+      page_size: 100,
+      page: 0,
+      filters: [
+        {
+          col: 'roles',
+          opr: 'rel_m_m',
+          value: mockRole.id,
+        },
+      ],
+    });
   });
 });

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -225,7 +225,7 @@ describe('RoleListEditModal', () => {
       expect(mockGet).toHaveBeenCalled();
     });
 
-    // Verify the API was called with the correct filter
+    // verify the endpoint and query parameters
     const callArgs = mockGet.mock.calls[0][0];
     expect(callArgs.endpoint).toContain('/api/v1/security/users/');
 

--- a/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.test.tsx
@@ -24,6 +24,7 @@ import {
   waitFor,
 } from 'spec/helpers/testing-library';
 import { SupersetClient } from '@superset-ui/core';
+import rison from 'rison';
 import RoleListEditModal from './RoleListEditModal';
 import {
   updateRoleName,
@@ -207,5 +208,43 @@ describe('RoleListEditModal', () => {
     expect(screen.getByTitle('Last Name')).toBeInTheDocument();
     expect(screen.getByTitle('User Name')).toBeInTheDocument();
     expect(screen.getByTitle('Email')).toBeInTheDocument();
+  });
+
+  test('fetches users with correct role relationship filter', async () => {
+    const mockGet = SupersetClient.get as jest.Mock;
+    mockGet.mockResolvedValue({
+      json: {
+        count: 0,
+        result: [],
+      },
+    });
+
+    render(<RoleListEditModal {...mockProps} />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled();
+    });
+
+    // Verify the API was called with the correct filter
+    const callArgs = mockGet.mock.calls[0][0];
+    expect(callArgs.endpoint).toContain('/api/v1/security/users/');
+
+    const urlMatch = callArgs.endpoint.match(/\?q=(.+)/);
+    expect(urlMatch).toBeTruthy();
+
+    const decodedQuery = rison.decode(urlMatch[1]);
+    expect(decodedQuery).toEqual(
+      {
+        page_size: 100,
+        page: 0,
+        filters: [
+          {
+            col: 'roles',
+            opr: 'rel_m_m',
+            value: mockRole.id,
+          },
+        ],
+      }
+    );
   });
 });

--- a/superset-frontend/src/features/roles/RoleListEditModal.tsx
+++ b/superset-frontend/src/features/roles/RoleListEditModal.tsx
@@ -104,7 +104,7 @@ function RoleListEditModal({
   permissions,
   groups,
 }: RoleListEditModalProps) {
-  const { id, name, permission_ids, user_ids, group_ids } = role;
+  const { id, name, permission_ids, group_ids } = role;
   const [activeTabKey, setActiveTabKey] = useState(roleTabs.edit.key);
   const { addDangerToast, addSuccessToast } = useToasts();
   const [roleUsers, setRoleUsers] = useState<UserObject[]>([]);
@@ -112,13 +112,7 @@ function RoleListEditModal({
   const formRef = useRef<FormInstance | null>(null);
 
   useEffect(() => {
-    if (!user_ids.length) {
-      setRoleUsers([]);
-      setLoadingRoleUsers(false);
-      return;
-    }
-
-    const filters = [{ col: 'id', opr: 'in', value: user_ids }];
+    const filters = [{ col: 'roles', opr: 'rel_m_m', value: id }];
 
     fetchPaginatedData({
       endpoint: `/api/v1/security/users/`,
@@ -137,7 +131,7 @@ function RoleListEditModal({
         email: user.email,
       }),
     });
-  }, [user_ids]);
+  }, [id]);
 
   useEffect(() => {
     if (!loadingRoleUsers && formRef.current && roleUsers.length >= 0) {

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -20,8 +20,9 @@
 import jwt
 import pytest
 
+from flask.ctx import AppContext
 from flask_wtf.csrf import generate_csrf
-from superset import db
+from superset import db, security_manager
 from superset.daos.dashboard import EmbeddedDashboardDAO
 from superset.models.dashboard import Dashboard
 from superset.utils.urls import get_url_host
@@ -33,6 +34,76 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
 )
+
+
+@pytest.fixture
+def create_test_roles_with_users(app_context: AppContext):
+    """
+    Fixture that creates two test roles with specific users, permissions, and groups.
+    """
+    user1, user2, user3 = [
+        security_manager.add_user(
+            username=f"test_user_{i}",
+            first_name="Test",
+            last_name=f"User{i}",
+            email=f"test_user_{i}@test.com",
+            role=[],
+            password="password",  # noqa: S106
+        )
+        for i in range(3)
+    ]
+
+    test_group = security_manager.add_group(
+        name="test_group_1",
+        label="Test Group 1",
+        description="Test group for role testing",
+        roles=[],
+    )
+
+    pvm1 = security_manager.add_permission_view_menu("can_read", "Dashboard")
+    pvm2 = security_manager.add_permission_view_menu("can_write", "Dashboard")
+    pvm3 = security_manager.add_permission_view_menu("can_read", "Chart")
+
+    test_role_1 = security_manager.add_role("test_role_1", [pvm1, pvm2])
+    test_role_1.user.append(user1)
+    test_role_1.user.append(user2)
+    test_role_1.groups.append(test_group)
+
+    test_role_2 = security_manager.add_role("test_role_2", [pvm3])
+    test_role_2.user.append(user3)
+
+    db.session.commit()
+
+    test_data = {
+        "test_role_1": {
+            "role": test_role_1,
+            "user_ids": sorted([user1.id, user2.id]),
+            "permission_ids": sorted([pvm1.id, pvm2.id]),
+            "group_ids": [test_group.id],
+        },
+        "test_role_2": {
+            "role": test_role_2,
+            "user_ids": [user3.id],
+            "permission_ids": [pvm3.id],
+            "group_ids": [],
+        },
+    }
+
+    yield test_data
+
+    # Cleanup
+    db.session.delete(test_role_1)
+    db.session.delete(test_role_2)
+    db.session.delete(user1)
+    db.session.delete(user2)
+    db.session.delete(user3)
+    db.session.delete(test_group)
+    db.session.commit()
+
+
+@pytest.fixture
+def inject_test_roles_data(request, create_test_roles_with_users):
+    request.instance.test_roles_data = create_test_roles_with_users
 
 
 class TestSecurityCsrfApi(SupersetTestCase):
@@ -293,3 +364,35 @@ class TestSecurityRolesApi(SupersetTestCase):
         self.login(GAMMA_USERNAME)
         response = self.client.get(self.show_uri)
         self.assert403(response)
+
+    @pytest.mark.usefixtures("inject_test_roles_data")
+    def test_get_roles_with_specific_test_data(self):
+        """
+        Security API: Test roles endpoint with specific test data
+        """
+        self.login(ADMIN_USERNAME)
+        response = self.client.get(self.show_uri)
+        self.assert200(response)
+
+        data = json.loads(response.data.decode("utf-8"))
+
+        # Create a mapping of role names to API response
+        api_roles_by_name = {role["name"]: role for role in data["result"]}
+
+        # Verify test_role_1
+        assert "test_role_1" in api_roles_by_name
+        role1_api = api_roles_by_name["test_role_1"]
+        role1_expected = self.test_roles_data["test_role_1"]
+
+        assert sorted(role1_api["user_ids"]) == role1_expected["user_ids"]
+        assert sorted(role1_api["permission_ids"]) == role1_expected["permission_ids"]
+        assert sorted(role1_api["group_ids"]) == role1_expected["group_ids"]
+
+        # Verify test_role_2
+        assert "test_role_2" in api_roles_by_name
+        role2_api = api_roles_by_name["test_role_2"]
+        role2_expected = self.test_roles_data["test_role_2"]
+
+        assert sorted(role2_api["user_ids"]) == role2_expected["user_ids"]
+        assert sorted(role2_api["permission_ids"]) == role2_expected["permission_ids"]
+        assert role2_api["group_ids"] == role2_expected["group_ids"]

--- a/tests/integration_tests/security/api_tests.py
+++ b/tests/integration_tests/security/api_tests.py
@@ -371,7 +371,7 @@ class TestSecurityRolesApi(SupersetTestCase):
         Security API: Test roles endpoint with specific test data
         """
         self.login(ADMIN_USERNAME)
-        response = self.client.get(self.show_uri)
+        response = self.client.get(f"{self.show_uri}?q=(page_size:100)")
         self.assert200(response)
 
         data = json.loads(response.data.decode("utf-8"))
@@ -380,7 +380,10 @@ class TestSecurityRolesApi(SupersetTestCase):
         api_roles_by_name = {role["name"]: role for role in data["result"]}
 
         # Verify test_role_1
-        assert "test_role_1" in api_roles_by_name
+        assert "test_role_1" in api_roles_by_name, (
+            f"test_role_1 not found in API response. "
+            f"Available roles: {list(api_roles_by_name.keys())}"
+        )
         role1_api = api_roles_by_name["test_role_1"]
         role1_expected = self.test_roles_data["test_role_1"]
 
@@ -389,7 +392,10 @@ class TestSecurityRolesApi(SupersetTestCase):
         assert sorted(role1_api["group_ids"]) == role1_expected["group_ids"]
 
         # Verify test_role_2
-        assert "test_role_2" in api_roles_by_name
+        assert "test_role_2" in api_roles_by_name, (
+            f"test_role_2 not found in API response. "
+            f"Available roles: {list(api_roles_by_name.keys())}"
+        )
         role2_api = api_roles_by_name["test_role_2"]
         role2_expected = self.test_roles_data["test_role_2"]
 


### PR DESCRIPTION
### SUMMARY
Fixes a critical bug where editing roles with many users fails due to URL length limits, plus a secondary N+1 query optimization.

#### 1. Fix "Request Line is too large" error when editing roles with many users (Primary)
**Problem:** When editing a role with hundreds/thousands of users, the request to `/api/v1/security/users/?q=(filters:!((col:id,opr:in,value:!($USER_IDs)))...)` would fail because the URL became too long. This caused the user list to fail loading, and saving changes would inadvertently remove all role memberships.

**Solution:** Changed from filtering by user IDs (`col: 'id', opr: 'in', value: user_ids`) to filtering by role relationship (`col: 'roles', opr: 'rel_m_m', value: role_id`). The URL length now remains constant regardless of the number of users.

#### 2. Fix N+1 query issue in `/api/v1/security/roles/` endpoint (Secondary)
Also I noticed that the Changed SQLAlchemy loading strategy from `joinedload` to `selectinload` for `Role.permissions`, `Role.user`, and `Role.groups`. This eliminates N+1 queries when accessing `[user.id for user in role.user]`, `[perm.id for perm in role.permissions]`, and `[group.id for group in role.groups]` for each role.

Added a test to verify the correct filter parameters are sent to the API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

https://github.com/user-attachments/assets/b598fc0b-4ef7-4829-ae43-319c16f7a29f



### TESTING INSTRUCTIONS
1. Create a role with 2000+ users assigned
2. Navigate to Settings > Security > List Roles and click edit on that role
3. Verify the modal opens and displays users (previously would fail with "Request Line is too large")
4. Make a change and save
5. Verify all users remain assigned (previously would remove all memberships)
6. Check network tab - `/api/v1/security/users/` should use `rel_m_m` filter with short URL

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API