### PR TITLE
fix(table): align group headers correctly when filtering time compari…

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -710,9 +710,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     );
   };
 
+  // Compute visible columns before groupHeaderColumns to ensure index consistency.
+  // This filters out columns with config.visible === false.
+  const visibleColumnsMeta = useMemo(
+    () => filteredColumnsMeta.filter(col => col.config?.visible !== false),
+    [filteredColumnsMeta],
+  );
+
+  // Use visibleColumnsMeta for groupHeaderColumns to ensure indices match the actual
+  // table columns. This fixes header misalignment when columns are filtered.
   const groupHeaderColumns = useMemo(
-    () => getHeaderColumns(filteredColumnsMeta, isUsingTimeComparison),
-    [filteredColumnsMeta, getHeaderColumns, isUsingTimeComparison],
+    () => getHeaderColumns(visibleColumnsMeta, isUsingTimeComparison),
+    [visibleColumnsMeta, getHeaderColumns, isUsingTimeComparison],
   );
 
   const renderGroupingHeaders = (): JSX.Element => {
@@ -720,12 +729,20 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     const headers: any = [];
     let currentColumnIndex = 0;
 
-    Object.entries(groupHeaderColumns || {}).forEach(([key, value]) => {
+    // Sort entries by their first column index to ensure correct left-to-right order.
+    // Object.entries() maintains insertion order, but when columns are filtered,
+    // the first occurrence of each metric might not match the visual column order.
+    const sortedEntries = Object.entries(groupHeaderColumns || {}).sort(
+      (a, b) => a[1][0] - b[1][0],
+    );
+
+    sortedEntries.forEach(([key, value]) => {
       // Calculate the number of placeholder columns needed before the current header
       const startPosition = value[0];
       const colSpan = value.length;
-      // Retrieve the originalLabel from the first column in this group
-      const firstColumnInGroup = filteredColumnsMeta[startPosition];
+      // Retrieve the originalLabel from the first column in this group.
+      // Use visibleColumnsMeta to ensure consistent indexing with the actual table columns.
+      const firstColumnInGroup = visibleColumnsMeta[startPosition];
       const originalLabel = firstColumnInGroup
         ? columnsMeta.find(col => col.key === firstColumnInGroup.key)
             ?.originalLabel || key
@@ -1199,11 +1216,6 @@ export default function TableChart<D extends DataRecord = DataRecord>(
       handleContextMenu,
       allowRearrangeColumns,
     ],
-  );
-
-  const visibleColumnsMeta = useMemo(
-    () => filteredColumnsMeta.filter(col => col.config?.visible !== false),
-    [filteredColumnsMeta],
   );
 
   const columns = useMemo(

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -303,6 +303,81 @@ const comparisonWithConfig: TableChartProps = {
   emitCrossFilters: false,
 };
 
+/**
+ * Time comparison data with multiple metrics and some columns hidden.
+ * Used to test that group headers align correctly when filtering columns.
+ * Reproduces issue #37074.
+ */
+const comparisonWithHiddenColumns: TableChartProps = {
+  ...comparison,
+  height: 400,
+  width: 600,
+  rawFormData: {
+    ...comparison.rawFormData,
+    table_timestamp_format: 'smart_date',
+    metrics: ['metric_1', 'metric_2'],
+    percent_metrics: [],
+    column_config: {
+      // Hide Main and # columns for metric_1, only show △ and %
+      'Main metric_1': { visible: false },
+      '# metric_1': { visible: false },
+      '△ metric_1': { d3NumberFormat: '.0f' },
+      '% metric_1': { d3NumberFormat: '.2%' },
+      // Show all columns for metric_2
+      'Main metric_2': { d3NumberFormat: '.0f' },
+      '# metric_2': { d3NumberFormat: '.0f' },
+      '△ metric_2': { d3NumberFormat: '.0f' },
+      '% metric_2': { d3NumberFormat: '.2%' },
+    },
+    time_compare: ['1 year ago'],
+    comparison_color_enabled: true,
+    comparison_type: ComparisonType.Values,
+  },
+  datasource: {
+    ...comparison.datasource,
+    columnFormats: {},
+    currencyFormats: {},
+    verboseMap: { metric_1: 'Metric 1', metric_2: 'Metric 2' },
+  },
+  queriesData: [
+    {
+      ...basicQueryResult,
+      data: [
+        {
+          metric_1: 100,
+          'metric_1__1 year ago': 80,
+          metric_2: 200,
+          'metric_2__1 year ago': 150,
+        },
+      ],
+      colnames: [
+        'metric_1',
+        'metric_1__1 year ago',
+        'metric_2',
+        'metric_2__1 year ago',
+      ],
+      coltypes: [
+        GenericDataType.Numeric,
+        GenericDataType.Numeric,
+        GenericDataType.Numeric,
+        GenericDataType.Numeric,
+      ],
+    },
+    {
+      ...basicQueryResult,
+      data: [{ rowcount: 1 }],
+    },
+  ],
+  filterState: { filters: {} },
+  ownState: {},
+  hooks: {
+    onAddFilter: jest.fn(),
+    setDataMask: jest.fn(),
+    onContextMenu: jest.fn(),
+  },
+  emitCrossFilters: false,
+};
+
 const raw = {
   ...advanced,
   rawFormData: {
@@ -402,6 +477,7 @@ export default {
   advancedWithCurrency,
   comparison,
   comparisonWithConfig,
+  comparisonWithHiddenColumns,
   empty,
   raw,
   bigint,


### PR DESCRIPTION
### SUMMARY

  When using Table charts with Time Comparison and filtering columns (showing only % diff, collapsing groups, etc.), the group headers would become misaligned with the actual data columns.

  **Root cause:** Two issues in header rendering logic:
  1. `groupHeaderColumns` was computed from `filteredColumnsMeta` while `getColumnConfigs` used `visibleColumnsMeta` (which also filters out `config.visible === false`)
  2. `Object.entries` iteration didn't ensure correct visual column order

  **Fix:**
  - Move `visibleColumnsMeta` definition earlier and use it for `groupHeaderColumns`
  - Sort `Object.entries` by `startPosition` before rendering headers
  - Update `renderGroupingHeaders` lookup to use `visibleColumnsMeta` for consistency

  Added test case to verify header alignment when columns are hidden via config.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  N/A - This is a logic fix. The visual result is that group headers now correctly align with their respective data columns when filtering time comparison columns.

  ### TESTING INSTRUCTIONS

  1. Create a Table chart with 3+ metrics and Time Comparison enabled
  2. Filter to show only "%" columns - verify headers align correctly with data
  3. Collapse first metric group - verify remaining headers align correctly
  4. Try various combinations of filtering and collapsing groups

  ### ADDITIONAL INFORMATION

  - [x] Has associated issue: Fixes #37074
  - [ ] Required feature flags:
  - [ ] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API

 Fixes #37074