### PR TITLE
fix(deckgl-contour): prevent WebGL freeze by clamping and auto-scaling cellSize

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
@@ -176,8 +176,7 @@ export const getLayer: GetLayerType<ContourLayer> = function ({
   const viewport = fd.viewport;
   if (viewport?.width && viewport?.height) {
     const estimatedCells =
-      (viewport.width / safeCellSize) *
-      (viewport.height / safeCellSize);
+      (viewport.width / safeCellSize) * (viewport.height / safeCellSize);
 
     if (estimatedCells > MAX_GRID_CELLS) {
       const scaleFactor = Math.sqrt(estimatedCells / MAX_GRID_CELLS);

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/Contour.tsx
@@ -174,21 +174,21 @@ export const getLayer: GetLayerType<ContourLayer> = function ({
   );
 
   const viewport = fd.viewport;
-  if (viewport?.width && viewport?.height) {
+  if (viewport && viewport.width > 0 && viewport.height > 0) {
     const estimatedCells =
       (viewport.width / safeCellSize) * (viewport.height / safeCellSize);
 
     if (estimatedCells > MAX_GRID_CELLS) {
       const scaleFactor = Math.sqrt(estimatedCells / MAX_GRID_CELLS);
-      const adjusted = Math.ceil(safeCellSize * scaleFactor);
+      const adjustedCellSize = Math.ceil(safeCellSize * scaleFactor);
 
       console.warn(
         `[DeckGL Contour] cellSize=${safeCellSize} would create ~${Math.round(
           estimatedCells,
-        )} cells. Auto-adjusted to ${adjusted} to prevent WebGL crash.`,
+        )} cells. Auto-adjusted to ${adjustedCellSize} to prevent WebGL crash.`,
       );
 
-      safeCellSize = adjusted;
+      safeCellSize = Math.min(MAX_CELL_SIZE, adjustedCellSize);
     }
   }
 

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.test.ts
@@ -1,0 +1,49 @@
+import {
+  getSafeCellSize,
+  MIN_CELL_SIZE,
+  MAX_CELL_SIZE,
+} from './getSafeCellSize';
+
+describe('getSafeCellSize', () => {
+  it('defaults to 200 when value is not finite', () => {
+    expect(getSafeCellSize({ cellSize: 'nope' })).toBe(200);
+  });
+
+  it('clamps below minimum', () => {
+    expect(getSafeCellSize({ cellSize: 1 })).toBe(MIN_CELL_SIZE);
+  });
+
+  it('clamps above maximum', () => {
+    expect(getSafeCellSize({ cellSize: 999999 })).toBe(MAX_CELL_SIZE);
+  });
+
+  it('auto-scales when estimated grid is too large', () => {
+    const size = getSafeCellSize({
+      cellSize: 1,
+      viewport: { width: 11000, height: 11000 },
+    });
+
+    expect(size).toBeGreaterThan(MIN_CELL_SIZE);
+  });
+
+  it('never exceeds MAX_CELL_SIZE', () => {
+    const size = getSafeCellSize({
+      cellSize: 1,
+      viewport: { width: 100000, height: 100000 },
+    });
+
+    expect(size).toBeLessThanOrEqual(MAX_CELL_SIZE);
+  });
+
+  it('calls onAutoAdjust when scaling happens', () => {
+    const spy = jest.fn();
+
+    getSafeCellSize({
+      cellSize: 1,
+      viewport: { width: 11000, height: 11000 },
+      onAutoAdjust: spy,
+    });
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.test.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.test.ts
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import {
   getSafeCellSize,
   MIN_CELL_SIZE,

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.ts
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 export const MIN_CELL_SIZE = 10;
 export const MAX_CELL_SIZE = 5000;
 export const MAX_GRID_CELLS = 1_000_000;

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/getSafeCellSize.ts
@@ -1,0 +1,55 @@
+export const MIN_CELL_SIZE = 10;
+export const MAX_CELL_SIZE = 5000;
+export const MAX_GRID_CELLS = 1_000_000;
+
+export function getSafeCellSize({
+  cellSize,
+  viewport,
+  onAutoAdjust,
+}: {
+  cellSize?: string | number;
+  viewport?: { width?: number; height?: number };
+  onAutoAdjust?: (info: {
+    original: number;
+    adjusted: number;
+    estimatedCells: number;
+  }) => void;
+}) {
+  let parsedCellSize = Number(cellSize ?? 200);
+  if (!Number.isFinite(parsedCellSize)) {
+    parsedCellSize = 200;
+  }
+
+  let safeCellSize = Math.min(
+    MAX_CELL_SIZE,
+    Math.max(MIN_CELL_SIZE, parsedCellSize),
+  );
+
+  if (
+    viewport &&
+    typeof viewport.width === 'number' &&
+    typeof viewport.height === 'number' &&
+    viewport.width > 0 &&
+    viewport.height > 0
+  ) {
+    const estimatedCells =
+      (viewport.width / safeCellSize) * (viewport.height / safeCellSize);
+
+    if (estimatedCells > MAX_GRID_CELLS) {
+      const scaleFactor = Math.sqrt(estimatedCells / MAX_GRID_CELLS);
+      const adjustedCellSize = Math.ceil(safeCellSize * scaleFactor);
+
+      const finalSize = Math.min(MAX_CELL_SIZE, adjustedCellSize);
+
+      onAutoAdjust?.({
+        original: safeCellSize,
+        adjusted: finalSize,
+        estimatedCells,
+      });
+
+      safeCellSize = finalSize;
+    }
+  }
+
+  return safeCellSize;
+}

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/index.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/index.ts
@@ -50,3 +50,5 @@ export default class ContourChartPlugin extends ChartPlugin {
     });
   }
 }
+
+export * from './getSafeCellSize';

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/index.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Contour/index.ts
@@ -51,4 +51,4 @@ export default class ContourChartPlugin extends ChartPlugin {
   }
 }
 
-export * from './getSafeCellSize';
+export { getSafeCellSize } from './getSafeCellSize';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -244,8 +244,10 @@ export default function transformProps(
     },
   );
 
-  const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
-  const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
+  const MetricDisplayNameA: string =
+    getMetricDisplayName(metrics[0], verboseMap) || '';
+  const MetricDisplayNameB: string =
+    getMetricDisplayName(metricsB[0], verboseMap) || '';
 
   const dataTypes = getColtypesMapping(queriesData[0]);
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
@@ -400,10 +402,12 @@ export default function transformProps(
 
     if (groupby.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = showQueryIdentifiers
+      const metricPart: string = showQueryIdentifiers
         ? `${MetricDisplayNameA} (Query A)`
         : MetricDisplayNameA;
-      displayName = `${metricPart}, ${entryName}`;
+      displayName = entryName.includes(metricPart)
+        ? entryName
+        : `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
@@ -471,10 +475,12 @@ export default function transformProps(
 
     if (groupbyB.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart = showQueryIdentifiers
+      const metricPart: string = showQueryIdentifiers
         ? `${MetricDisplayNameB} (Query B)`
         : MetricDisplayNameB;
-      displayName = `${metricPart}, ${entryName}`;
+      displayName = entryName.includes(metricPart)
+        ? entryName
+        : `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -244,10 +244,8 @@ export default function transformProps(
     },
   );
 
-  const MetricDisplayNameA: string =
-    getMetricDisplayName(metrics[0], verboseMap) || '';
-  const MetricDisplayNameB: string =
-    getMetricDisplayName(metricsB[0], verboseMap) || '';
+  const MetricDisplayNameA = getMetricDisplayName(metrics[0], verboseMap);
+  const MetricDisplayNameB = getMetricDisplayName(metricsB[0], verboseMap);
 
   const dataTypes = getColtypesMapping(queriesData[0]);
   const xAxisDataType = dataTypes?.[xAxisLabel] ?? dataTypes?.[xAxisOrig];
@@ -402,12 +400,10 @@ export default function transformProps(
 
     if (groupby.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart: string = showQueryIdentifiers
+      const metricPart = showQueryIdentifiers
         ? `${MetricDisplayNameA} (Query A)`
         : MetricDisplayNameA;
-      displayName = entryName.includes(metricPart)
-        ? entryName
-        : `${metricPart}, ${entryName}`;
+      displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query A)` : entryName;
@@ -475,12 +471,10 @@ export default function transformProps(
 
     if (groupbyB.length > 0) {
       // When we have groupby, format as "metric, dimension"
-      const metricPart: string = showQueryIdentifiers
+      const metricPart = showQueryIdentifiers
         ? `${MetricDisplayNameB} (Query B)`
         : MetricDisplayNameB;
-      displayName = entryName.includes(metricPart)
-        ? entryName
-        : `${metricPart}, ${entryName}`;
+      displayName = `${metricPart}, ${entryName}`;
     } else {
       // When no groupby, format as just the entry name with optional query identifier
       displayName = showQueryIdentifiers ? `${entryName} (Query B)` : entryName;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### Summary

Fixes #36838 

This PR prevents Deck.gl Contour charts from freezing or crashing the browser/WebGL when extremely small `cellSize` values are used.

It introduces safety guards that:

- Clamp `cellSize` to a safe min/max range
- Auto-scale `cellSize` when the estimated grid size becomes dangerously large
- Prevents GPU buffer overflows and UI freezes
- Keeps existing behavior for normal values

---

### Problem

Very small `cellSize` values can generate millions of grid cells, which causes:

- WebGL buffer allocation failures
- UI freezes
- Browser tab crashes
- Console errors like:

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/b4bcbb58-ed89-48ed-bdaf-2a7399e0d37f" />


---

### Solution

We now:

1. Clamp `cellSize` between safe min/max bounds
2. Estimate the total grid cell count
3. Auto-scale `cellSize` if the grid becomes too large
4. Log a warning when auto-adjustment occurs

This keeps the chart responsive and prevents GPU crashes.

---
### After 

https://github.com/user-attachments/assets/64bf9064-6a3c-49a4-ab6d-8082fae5a9e9

### Behavior Changes

- No change for valid `cellSize` values
- Extremely small values are safely adjusted instead of crashing the app

---

### Testing

- Reproduced freeze/crash with very small `cellSize`
- Verified UI no longer freezes
- Verified chart renders correctly
- Verified console errors are gone
