### PR TITLE
fix(reports): ensure CSV attachments use UTF-8 BOM when encoding is utf-8-sig

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -506,6 +506,20 @@ class BaseReportState:
 
         return pdf
 
+    def _ensure_utf8_bom(self, csv_data: bytes, encoding: str) -> bytes:
+        """
+        Ensure CSV bytes contain UTF-8 BOM when encoding is utf-8-sig.
+        Avoid double BOM.
+        """
+        if not csv_data:
+            return csv_data
+
+        enc = (encoding or "").lower().replace("_", "-")
+        if enc in ("utf-8-sig", "utf8-sig"):
+            if not csv_data.startswith(b"\xef\xbb\xbf"):
+                return b"\xef\xbb\xbf" + csv_data
+        return csv_data
+
     def _get_csv_data(self) -> bytes:
         start_time = datetime.utcnow()
         url = self._get_url(result_format=ChartDataResultFormat.CSV)
@@ -550,6 +564,9 @@ class BaseReportState:
             ) from ex
         if not csv_data:
             raise ReportScheduleCsvFailedError()
+
+        encoding = app.config.get("CSV_EXPORT", {}).get("encoding", "utf-8")
+        csv_data = self._ensure_utf8_bom(csv_data, encoding)
         return csv_data
 
     def _get_embedded_data(self) -> pd.DataFrame:

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -105,6 +105,10 @@ pytestmark = pytest.mark.usefixtures(
     "load_world_bank_dashboard_with_slices_module_scope"
 )
 
+# The default CSV_EXPORT encoding is "utf-8-sig", so report CSV attachments are
+# prefixed with a UTF-8 BOM to ensure correct rendering in spreadsheet software.
+CSV_FILE_WITH_BOM = b"\xef\xbb\xbf" + CSV_FILE
+
 
 def get_target_from_report_schedule(report_schedule: ReportSchedule) -> list[str]:
     return [
@@ -968,9 +972,9 @@ def test_email_chart_report_schedule_with_csv(
         )
         # Assert the email smtp address
         assert email_mock.call_args[0][0] == notification_targets[0]
-        # Assert the email csv file
+        # Assert the email csv file (BOM-prefixed for utf-8-sig encoding)
         smtp_images = email_mock.call_args[1]["data"]
-        assert smtp_images[list(smtp_images.keys())[0]] == CSV_FILE
+        assert smtp_images[list(smtp_images.keys())[0]] == CSV_FILE_WITH_BOM
         # Assert logs are correct
         assert_log(ReportState.SUCCESS)
 
@@ -1634,7 +1638,7 @@ def test_slack_chart_report_schedule_with_csv(
         )
         assert (
             slack_client_mock_class.return_value.files_upload.call_args[1]["file"]
-            == CSV_FILE
+            == CSV_FILE_WITH_BOM
         )
 
         # Assert logs are correct


### PR DESCRIPTION
## Summary

This PR fixes an issue where CSV attachments generated by Reports are missing the UTF-8 BOM, even when `CSV_EXPORT.encoding` is set to `utf-8-sig`.

This causes non-ASCII characters (e.g. CJK) to appear garbled in Excel and some email clients.

## Problem

- SQL Lab CSV exports correctly include the BOM
- Report email CSV attachments do not include the BOM
- This leads to inconsistent behavior between export paths

## Solution

- Ensure that CSV bytes returned by the Reports execution pipeline contain a UTF-8 BOM when `CSV_EXPORT.encoding` is `utf-8-sig`
- Scope the fix only to Reports export path

## Screenshots / Logs

Before:
- CSV bytes start with: `e5 94 ae ...` (no BOM)

After:
- CSV bytes start with: `ef bb bf e5 94 ae ...` (correct UTF-8 BOM)

## ADDITIONAL INFORMATION
 - [ ] Has associated issue:
 - [ ] Required feature flags:
 - [ ] Changes UI
 - [ ] Includes DB Migration (follow approval process in https://github.com/apache/superset/issues/13351)
   - [ ] Migration is atomic, supports rollback & is backwards-compatible
   - [ ] Confirm DB migration upgrade and downgrade tested
   - [ ] Runtime estimates and downtime expectations provided
 - [ ] Introduces new feature or API
 - [ ] Removes existing feature or API
