### PR TITLE
fix(deckgl): change deck gl Path default line width unit to meters

### DIFF
--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.test.tsx
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/Path.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom';
+
+jest.mock('../../DeckGLContainer', () => ({
+  DeckGLContainerStyledWrapper: ({ children }: any) => (
+    <div data-testid="deckgl-container">{children}</div>
+  ),
+}));
+
+jest.mock('../../factory', () => ({
+  createDeckGLComponent: jest.fn(() => () => null),
+  GetLayerType: {},
+}));
+
+import { getLayer, getPoints, getHighlightLayer } from './Path';
+
+const mockFormData = {
+  datasource: 'test_datasource',
+  viz_type: 'deck_path',
+  color_picker: { r: 0, g: 122, b: 135, a: 1 },
+  line_width: 150,
+  line_width_unit: 'meters',
+  slice_id: 1,
+};
+
+const mockPayload = {
+  data: {
+    features: [
+      {
+        path: [
+          [-122.4, 37.8],
+          [-122.5, 37.9],
+        ],
+      },
+    ],
+  },
+};
+
+test('getLayer uses line_width_unit from formData', () => {
+  const layer = getLayer({
+    formData: mockFormData,
+    payload: mockPayload,
+    onContextMenu: jest.fn(),
+    filterState: undefined,
+    setDataMask: jest.fn(),
+    setTooltip: jest.fn(),
+    emitCrossFilters: false,
+  });
+
+  expect(layer.props.widthUnits).toBe('meters');
+});
+
+test('getLayer uses pixels when line_width_unit is pixels', () => {
+  const layer = getLayer({
+    formData: { ...mockFormData, line_width_unit: 'pixels' },
+    payload: mockPayload,
+    onContextMenu: jest.fn(),
+    filterState: undefined,
+    setDataMask: jest.fn(),
+    setTooltip: jest.fn(),
+    emitCrossFilters: false,
+  });
+
+  expect(layer.props.widthUnits).toBe('pixels');
+});
+
+test('getHighlightLayer uses line_width_unit from formData', () => {
+  const layer = getHighlightLayer({
+    formData: mockFormData,
+    payload: mockPayload,
+    filterState: { value: [] },
+    onContextMenu: jest.fn(),
+    setDataMask: jest.fn(),
+    setTooltip: jest.fn(),
+    emitCrossFilters: false,
+  });
+
+  expect(layer.props.widthUnits).toBe('meters');
+});
+
+test('getPoints extracts points from path data', () => {
+  const data = [
+    {
+      path: [
+        [0, 0],
+        [1, 1],
+      ],
+    },
+    {
+      path: [
+        [2, 2],
+        [3, 3],
+      ],
+    },
+  ];
+
+  const points = getPoints(data);
+
+  expect(points).toHaveLength(4);
+  expect(points[0]).toEqual([0, 0]);
+  expect(points[2]).toEqual([2, 2]);
+});

--- a/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/controlPanel.ts
+++ b/superset-frontend/plugins/legacy-preset-chart-deckgl/src/layers/Path/controlPanel.ts
@@ -75,7 +75,7 @@ const config: ControlPanelConfig = {
             config: {
               type: 'SelectControl',
               label: t('Line width unit'),
-              default: 'pixels',
+              default: 'meters',
               choices: [
                 ['meters', t('meters')],
                 ['pixels', t('pixels')],

--- a/superset/examples/deckgl_demo/charts/Deck.gl_Path.yaml
+++ b/superset/examples/deckgl_demo/charts/Deck.gl_Path.yaml
@@ -35,6 +35,7 @@ params:
   line_column: path_json
   line_type: json
   line_width: 150
+  line_width_unit: meters
   mapbox_style: https://tile.openstreetmap.org/{z}/{x}/{y}.png
   reverse_long_lat: false
   row_limit: 5000


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Changes the default `line_width_unit` for the deck.gl Path layer from `pixels` to `meters`. This provides a more practical default for geographic path visualizations where meter-based widths scale appropriately with map zoom levels.

Also updates the example deck.gl dashboard configuration to explicitly set `line_width_unit: "meters"` to align with the new default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="3136" height="1758" alt="image" src="https://github.com/user-attachments/assets/7a500186-1e8a-4573-bb2e-2829a766810a" />

AFTER:
<img width="1163" height="822" alt="Screenshot 2026-01-19 at 09 23 22" src="https://github.com/user-attachments/assets/abd8dc75-c050-42f8-8b64-f5b9386bbe11" />

### TESTING INSTRUCTIONS
1. Go to the Deck.gl Path on Charts
2. Will see now that the default line width unit is meters
3. (Extra) The witdh could me changed on the input field above - Line Width

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
