### PR TITLE
fix(transpile_query): Fix export_as_csv error: "transpile_to_dialect": ['Unknown field.']

### DIFF
--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1034,7 +1034,6 @@ class ChartDataExtrasSchema(Schema):
             "description": "If true, WHERE/HAVING clauses will be transpiled to the "
             "target database dialect using SQLGlot."
         },
-        load_default=False,
         allow_none=True,
     )
 

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1029,6 +1029,14 @@ class ChartDataExtrasSchema(Schema):
         },
         allow_none=True,
     )
+    transpile_to_dialect = fields.Boolean(
+        metadata={
+            "description": "If true, WHERE/HAVING clauses will be transpiled to the "
+            "target database dialect using SQLGlot."
+        },
+        load_default=False,
+        allow_none=True,
+    )
 
 
 class AnnotationLayerSchema(Schema):


### PR DESCRIPTION
### SUMMARY
When applying filters to Table-V2 and exporting as CSV an error would pop-up regarding `transpile_to_dialect` field not being recognized. This issue was introduced recently and this PR addresses this issue

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### BEFORE
https://github.com/user-attachments/assets/c4752e93-37ea-4a9a-a56a-dd3f3ff931df



#### AFTER
https://github.com/user-attachments/assets/c49af3ca-526a-4c31-8b2b-56371bde6e44



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
