### PR TITLE
fix(extensions): prevent duplicate initialization of LOCAL_EXTENSIONS watcher

### DIFF
--- a/superset/extensions/local_extensions_watcher.py
+++ b/superset/extensions/local_extensions_watcher.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Guard to prevent multiple initializations
+_watcher_initialized = False
+_watcher_lock = threading.Lock()
+
 
 def _get_file_handler_class() -> Any:
     """Get the file handler class, importing watchdog only when needed."""
@@ -68,6 +72,14 @@ def _get_file_handler_class() -> Any:
 
 def setup_local_extensions_watcher(app: Flask) -> None:  # noqa: C901
     """Set up file watcher for LOCAL_EXTENSIONS directories."""
+    global _watcher_initialized
+
+    # Prevent multiple initializations
+    with _watcher_lock:
+        if _watcher_initialized:
+            return
+        _watcher_initialized = True
+
     # Only set up watcher in debug mode or when Flask reloader is enabled
     if not (app.debug or app.config.get("FLASK_USE_RELOAD", False)):
         return


### PR DESCRIPTION
### SUMMARY
Fixes `RuntimeError: Cannot add watch - it is already scheduled` errors that occur when the `LOCAL_EXTENSIONS` file watcher is initialized multiple times.

**Root Cause:**
When running Superset in debug mode, `create_app()` can be called multiple times due to:
1. Flask's CLI (`FlaskGroup`) calling the app factory during initialization
2. Flask's reloader spawning separate parent/child processes

Each call to `create_app()` spawns a new daemon thread that attempts to schedule watchdog observers for the same directories. On macOS, the FSEvents backend throws `RuntimeError` when attempting to watch paths that are already scheduled.

**Solution:**
Added a module-level initialization guard (`_watcher_initialized`) with a thread-safe lock to ensure the watcher is only set up once per process. This prevents duplicate watch registrations regardless of how many times `create_app()` is invoked.

### TESTING INSTRUCTIONS
1. Configure `LOCAL_EXTENSIONS` in `superset_config.py` with one or more extension paths
2. Start Superset in debug mode: `superset run -p 8088 --with-threads --reload --debugger`
3. Verify no `RuntimeError: Cannot add watch - it is already scheduled` errors appear in the logs
4. Verify the watcher starts successfully with the expected number of directories

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
