### PR TITLE
fix(mcp): prevent MCP service from corrupting shared appbuilder singleton

### DIFF
--- a/superset/mcp_service/flask_singleton.py
+++ b/superset/mcp_service/flask_singleton.py
@@ -38,14 +38,14 @@ try:
 
     # Check if appbuilder is already initialized (main Superset app is running).
     # If so, reuse that app to avoid corrupting the shared appbuilder singleton.
-    # Calling create_app() again would re-initialize appbuilder and break view endpoints.
+    # Calling create_app() again would re-initialize appbuilder and break views.
     if appbuilder.app is not None:
         logger.info("Reusing existing Flask app from appbuilder for MCP service")
         app = appbuilder.app
     else:
         # Create a minimal Flask app for standalone MCP server.
         # We avoid calling create_app() which would run full FAB initialization
-        # and could corrupt the shared appbuilder singleton if the main app starts later.
+        # and could corrupt the shared appbuilder singleton if main app starts.
         from superset.app import SupersetApp
         from superset.mcp_service.mcp_config import get_mcp_config
 

--- a/superset/mcp_service/flask_singleton.py
+++ b/superset/mcp_service/flask_singleton.py
@@ -33,34 +33,47 @@ logger = logging.getLogger(__name__)
 logger.info("Creating Flask app instance for MCP service")
 
 try:
-    from superset.app import create_app
-    from superset.mcp_service.mcp_config import get_mcp_config
+    from superset.extensions import appbuilder
 
-    # Create a temporary context to avoid
-    # "Working outside of application context" errors.
-    _temp_app = create_app()
+    # Check if appbuilder is already initialized (main Superset app is running).
+    # If so, reuse that app to avoid corrupting the shared appbuilder singleton.
+    # Calling create_app() again would re-initialize appbuilder and break view endpoints.
+    if appbuilder.app is not None:
+        logger.info("Reusing existing Flask app from appbuilder for MCP service")
+        app = appbuilder.app
+    else:
+        from superset.app import create_app
+        from superset.mcp_service.mcp_config import get_mcp_config
 
-    # Push an application context and initialize core dependencies and extensions
-    with _temp_app.app_context():
-        # Apply MCP configuration - reads from app.config first, falls back to defaults
-        mcp_config = get_mcp_config(_temp_app.config)
-        _temp_app.config.update(mcp_config)
-        try:
-            from superset.initialization import SupersetAppInitializer
+        # Create a temporary context to avoid
+        # "Working outside of application context" errors.
+        _temp_app = create_app()
 
-            # Create initializer and run only dependency injection
-            # NOT the full init_app_in_ctx which includes web views
-            initializer = SupersetAppInitializer(_temp_app)
-            initializer.init_all_dependencies_and_extensions()
+        # Push an application context and initialize core dependencies and extensions
+        with _temp_app.app_context():
+            # Apply MCP configuration - reads from app.config first, falls back to defaults
+            mcp_config = get_mcp_config(_temp_app.config)
+            _temp_app.config.update(mcp_config)
+            try:
+                from superset.initialization import SupersetAppInitializer
 
-            logger.info("Core dependencies and extensions initialized for MCP service")
-        except Exception as e:
-            logger.warning("Failed to initialize dependencies for MCP service: %s", e)
+                # Create initializer and run only dependency injection
+                # NOT the full init_app_in_ctx which includes web views
+                initializer = SupersetAppInitializer(_temp_app)
+                initializer.init_all_dependencies_and_extensions()
 
-    # Store the app instance for later use
-    app = _temp_app
+                logger.info(
+                    "Core dependencies and extensions initialized for MCP service"
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to initialize dependencies for MCP service: %s", e
+                )
 
-    logger.info("Minimal Flask app instance created successfully for MCP service")
+        # Store the app instance for later use
+        app = _temp_app
+
+        logger.info("Minimal Flask app instance created successfully for MCP service")
 
 except Exception as e:
     logger.error("Failed to create Flask app: %s", e)

--- a/superset/mcp_service/flask_singleton.py
+++ b/superset/mcp_service/flask_singleton.py
@@ -25,6 +25,7 @@ Following the Stack Overflow recommendation:
 """
 
 import logging
+import os
 
 from flask import Flask
 
@@ -42,37 +43,49 @@ try:
         logger.info("Reusing existing Flask app from appbuilder for MCP service")
         app = appbuilder.app
     else:
-        from superset.app import create_app
+        # Create a minimal Flask app for standalone MCP server.
+        # We avoid calling create_app() which would run full FAB initialization
+        # and could corrupt the shared appbuilder singleton if the main app starts later.
+        from superset.app import SupersetApp
         from superset.mcp_service.mcp_config import get_mcp_config
 
-        # Create a temporary context to avoid
-        # "Working outside of application context" errors.
-        _temp_app = create_app()
+        # Disable debug mode to avoid side-effects like file watchers
+        _mcp_app = SupersetApp(__name__)
+        _mcp_app.debug = False
 
-        # Push an application context and initialize core dependencies and extensions
-        with _temp_app.app_context():
-            # Apply MCP configuration - reads from app.config first, falls back to defaults
-            mcp_config = get_mcp_config(_temp_app.config)
-            _temp_app.config.update(mcp_config)
+        # Load configuration
+        config_module = os.environ.get("SUPERSET_CONFIG", "superset.config")
+        _mcp_app.config.from_object(config_module)
+
+        # Apply MCP-specific configuration
+        mcp_config = get_mcp_config(_mcp_app.config)
+        _mcp_app.config.update(mcp_config)
+
+        # Initialize only the minimal dependencies needed for MCP service
+        with _mcp_app.app_context():
             try:
-                from superset.initialization import SupersetAppInitializer
+                from superset.extensions import db
 
-                # Create initializer and run only dependency injection
-                # NOT the full init_app_in_ctx which includes web views
-                initializer = SupersetAppInitializer(_temp_app)
-                initializer.init_all_dependencies_and_extensions()
+                db.init_app(_mcp_app)
+
+                # Initialize only MCP-specific dependencies
+                # MCP tools import directly from superset.daos/models, so we only need
+                # the MCP decorator injection, not the full superset_core abstraction
+                from superset.core.mcp.core_mcp_injection import (
+                    initialize_core_mcp_dependencies,
+                )
+
+                initialize_core_mcp_dependencies()
 
                 logger.info(
-                    "Core dependencies and extensions initialized for MCP service"
+                    "Minimal MCP dependencies initialized for standalone MCP service"
                 )
             except Exception as e:
                 logger.warning(
                     "Failed to initialize dependencies for MCP service: %s", e
                 )
 
-        # Store the app instance for later use
-        app = _temp_app
-
+        app = _mcp_app
         logger.info("Minimal Flask app instance created successfully for MCP service")
 
 except Exception as e:


### PR DESCRIPTION
### SUMMARY
Fixes a bug where the MCP service would corrupt Flask-AppBuilder's shared `appbuilder` singleton, causing `BuildError: Could not build url for endpoint 'None.login'` errors when accessing Superset.

**Root Cause:**

PR #37190 (`fix(mcp): push Flask app context in mcp_auth_hook for tool execution`) added `from superset.mcp_service.flask_singleton import get_flask_app` to `auth.py`. During main app initialization, when MCP tools are decorated with `@tool` (which uses `mcp_auth_hook`), this import triggers `flask_singleton.py` to be loaded. The `flask_singleton.py` module then calls `create_app()` creating a second Flask app that re-initializes the shared `appbuilder` singleton.

When `appbuilder.init_app()` is called a second time:
1. Flask-AppBuilder's `add_view_no_menu()` detects the view class is already registered
2. It returns a **new instance** without calling `create_blueprint()` (which sets the `endpoint` attribute)
3. The view's `endpoint` remains `None`
4. When the main app tries to build URLs (e.g., `get_url_for_login`), it fails with `BuildError`

**The Fix:**

Modified `superset/mcp_service/flask_singleton.py` to:

1. **Reuse existing app**: Check if `appbuilder.app` is already initialized (main Superset is running). If so, reuse that Flask app instead of creating a new one.

2. **Create minimal app for standalone**: When running as a standalone MCP server (appbuilder not initialized), create a minimal `SupersetApp` instance WITHOUT calling `create_app()`. This avoids the full FAB initialization that would corrupt the singleton if the main app starts later.

```python
# Before: Always created a new app via create_app()
_temp_app = create_app()

# After: Reuse existing app OR create minimal app without FAB
if appbuilder.app is not None:
    # Main Superset is running - reuse its app
    app = appbuilder.app
else:
    # Standalone MCP server - create minimal app without FAB initialization
    _mcp_app = SupersetApp(__name__)
    _mcp_app.config.from_object(config_module)
    # Initialize only the minimal dependencies:
    # 1. Database connection (MCP tools use DAOs which need db.session)
    # 2. MCP decorators (@tool, @prompt) - for tool registration
    # Note: MCP tools import directly from superset.daos/models, so we don't
    # need the full superset_core abstraction layer injection
    db.init_app(_mcp_app)
    initialize_core_mcp_dependencies()
    app = _mcp_app
```

**Why not just call `create_app()` in the else branch?**

Calling `create_app()` runs the full application bootstrap including `app_initializer.init_app()`, which initializes Flask-AppBuilder. If the main Superset app starts later, it would find the appbuilder already initialized with views that have `None` endpoints, causing the same corruption issue.

### TESTING INSTRUCTIONS
1. Enable MCP service in your Superset configuration
2. Start Superset in debug mode: `superset run -p 8088 --reload --debugger`
3. Navigate to `http://localhost:8088/superset/welcome/`
4. Verify the login page loads without errors
5. Verify you can log in successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
