### PR TITLE
fix(dashboard-filters): prevent clearing all filters when editing a native filter

### DIFF
--- a/superset-frontend/src/dataMask/reducer.test.ts
+++ b/superset-frontend/src/dataMask/reducer.test.ts
@@ -24,6 +24,7 @@ import type {
   Filter,
   Filters,
   DataMask,
+  NativeFilterTarget,
 } from '@superset-ui/core';
 
 function makeFilter(
@@ -61,13 +62,13 @@ test('dataMask reducer: preserves other native filters when one is modified (tar
 
   const oldFilters: Filters = {
     'NATIVE_FILTER-1': makeFilter('NATIVE_FILTER-1', {
-      targets: [{ column: { name: 'col_a' } }],
+      targets: [{ column: { name: 'col_a' } }] as [Partial<NativeFilterTarget>],
       defaultDataMask: {
         filterState: { value: undefined },
       } as unknown as DataMask,
     }),
     'NATIVE_FILTER-2': makeFilter('NATIVE_FILTER-2', {
-      targets: [{ column: { name: 'col_b' } }],
+      targets: [{ column: { name: 'col_b' } }] as [Partial<NativeFilterTarget>],
       defaultDataMask: {
         filterState: { value: undefined },
       } as unknown as DataMask,
@@ -81,7 +82,9 @@ test('dataMask reducer: preserves other native filters when one is modified (tar
       deleted: [],
       modified: [
         makeFilter('NATIVE_FILTER-1', {
-          targets: [{ column: { name: 'col_changed' } }], // targets changed
+          targets: [{ column: { name: 'col_changed' } }] as [
+            Partial<NativeFilterTarget>,
+          ], // targets changed
           defaultDataMask: { filterState: { value: undefined } } as DataMask,
         }),
       ],
@@ -110,7 +113,7 @@ test('dataMask reducer: preserves modified filter state when targets unchanged a
 
   const oldFilters: Filters = {
     'NATIVE_FILTER-1': makeFilter('NATIVE_FILTER-1', {
-      targets: [{ column: { name: 'col_a' } }],
+      targets: [{ column: { name: 'col_a' } }] as [Partial<NativeFilterTarget>],
       controlValues: { enableEmptyFilter: true },
       defaultDataMask: { filterState: { value: undefined } } as DataMask,
     }),
@@ -123,7 +126,9 @@ test('dataMask reducer: preserves modified filter state when targets unchanged a
       deleted: [],
       modified: [
         makeFilter('NATIVE_FILTER-1', {
-          targets: [{ column: { name: 'col_a' } }], // targets unchanged
+          targets: [{ column: { name: 'col_a' } }] as [
+            Partial<NativeFilterTarget>,
+          ], // targets unchanged
           controlValues: { enableEmptyFilter: true },
           defaultDataMask: { filterState: { value: undefined } } as DataMask,
         }),

--- a/superset-frontend/src/dataMask/reducer.test.ts
+++ b/superset-frontend/src/dataMask/reducer.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import reducer, { getInitialDataMask } from './reducer';
+import { SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE } from './actions';
+import type {
+  DataMaskStateWithId,
+  Filter,
+  Filters,
+  DataMask,
+} from '@superset-ui/core';
+
+function makeFilter(
+  id: string,
+  opts: Partial<Filter> & { targets?: any } = {},
+): Filter {
+  return {
+    id,
+    name: id,
+    type: 'NATIVE_FILTER',
+    scope: [],
+    chartsInScope: [],
+    tabsInScope: [],
+    controlValues: {},
+    filterType: 'filter_select',
+    targets: opts.targets ?? [{ column: { name: 'col' } }],
+    defaultDataMask: { filterState: { value: undefined } } as DataMask,
+    ...opts,
+  } as unknown as Filter;
+}
+
+test('dataMask reducer: preserves other native filters when one is modified (targets changed)', () => {
+  const initialState: DataMaskStateWithId = {
+    'NATIVE_FILTER-1': {
+      id: 'NATIVE_FILTER-1',
+      ...getInitialDataMask('NATIVE_FILTER-1'),
+      filterState: { value: ['foo'] },
+    },
+    'NATIVE_FILTER-2': {
+      id: 'NATIVE_FILTER-2',
+      ...getInitialDataMask('NATIVE_FILTER-2'),
+      filterState: { value: ['bar'] },
+    },
+  } as unknown as DataMaskStateWithId;
+
+  const oldFilters: Filters = {
+    'NATIVE_FILTER-1': makeFilter('NATIVE_FILTER-1', {
+      targets: [{ column: { name: 'col_a' } }],
+      defaultDataMask: {
+        filterState: { value: undefined },
+      } as unknown as DataMask,
+    }),
+    'NATIVE_FILTER-2': makeFilter('NATIVE_FILTER-2', {
+      targets: [{ column: { name: 'col_b' } }],
+      defaultDataMask: {
+        filterState: { value: undefined },
+      } as unknown as DataMask,
+    }),
+  } as unknown as Filters;
+
+  const action = {
+    type: SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE,
+    filterChanges: {
+      added: [],
+      deleted: [],
+      modified: [
+        makeFilter('NATIVE_FILTER-1', {
+          targets: [{ column: { name: 'col_changed' } }], // targets changed
+          defaultDataMask: { filterState: { value: undefined } } as DataMask,
+        }),
+      ],
+    },
+    filters: oldFilters,
+  } as any;
+
+  const next = reducer(initialState, action);
+
+  // Filter 2 should be preserved entirely
+  expect(next['NATIVE_FILTER-2']?.filterState?.value).toEqual(['bar']);
+
+  // Filter 1 should be reset to default (undefined)
+  expect(next['NATIVE_FILTER-1']?.filterState?.value).toBeUndefined();
+});
+
+test('dataMask reducer: preserves modified filter state when targets unchanged and allow-empty', () => {
+  const initialState: DataMaskStateWithId = {
+    'NATIVE_FILTER-1': {
+      id: 'NATIVE_FILTER-1',
+      ...getInitialDataMask('NATIVE_FILTER-1'),
+      extraFormData: { append_form_data: { since: '1 year ago' } },
+      filterState: { value: ['foo'] },
+    },
+  } as unknown as DataMaskStateWithId;
+
+  const oldFilters: Filters = {
+    'NATIVE_FILTER-1': makeFilter('NATIVE_FILTER-1', {
+      targets: [{ column: { name: 'col_a' } }],
+      controlValues: { enableEmptyFilter: true },
+      defaultDataMask: { filterState: { value: undefined } } as DataMask,
+    }),
+  } as unknown as Filters;
+
+  const action = {
+    type: SET_DATA_MASK_FOR_FILTER_CHANGES_COMPLETE,
+    filterChanges: {
+      added: [],
+      deleted: [],
+      modified: [
+        makeFilter('NATIVE_FILTER-1', {
+          targets: [{ column: { name: 'col_a' } }], // targets unchanged
+          controlValues: { enableEmptyFilter: true },
+          defaultDataMask: { filterState: { value: undefined } } as DataMask,
+        }),
+      ],
+    },
+    filters: oldFilters,
+  } as any;
+
+  const next = reducer(initialState, action);
+
+  // Filter 1 keeps its state
+  expect(next['NATIVE_FILTER-1']?.filterState?.value).toEqual(['foo']);
+  expect(
+    (next['NATIVE_FILTER-1'] as any)?.extraFormData?.append_form_data?.since,
+  ).toEqual('1 year ago');
+});

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -104,21 +104,16 @@ function updateDataMaskForFilterChanges(
   draftDataMask: DataMaskStateWithId,
   initialDataMask?: Filters,
 ) {
-  const dataMask = initialDataMask || {};
-
-  Object.entries(dataMask).forEach(([key, value]) => {
-    mergedDataMask[key] = { ...value, ...value.defaultDataMask };
-  });
-
   filterChanges.deleted.forEach((filterId: string) => {
     delete mergedDataMask[filterId];
   });
 
   filterChanges.modified.forEach((filter: Filter) => {
     const existingFilter = draftDataMask[filter.id] as FilterWithExtaFromData;
+    const prevFilterDef = initialDataMask?.[filter.id] as Filter | undefined;
 
     // Check if targets are equal
-    const areTargetsEqual = isEqual(existingFilter?.targets, filter?.targets);
+    const areTargetsEqual = isEqual(prevFilterDef?.targets, filter?.targets);
 
     // Preserve state only if filter exists, has enableEmptyFilter=true and targets match
     const shouldPreserveState =
@@ -137,6 +132,17 @@ function updateDataMaskForFilterChanges(
         filterState: existingFilter.filterState,
       }),
     };
+  });
+
+  // Preserve state for native filters that were not modified or deleted
+  Object.entries(draftDataMask).forEach(([key, value]) => {
+    if (String(value?.id).startsWith(NATIVE_FILTER_PREFIX)) {
+      const wasDeleted = filterChanges.deleted.includes(key);
+      const wasModified = filterChanges.modified.some(f => f.id === key);
+      if (!wasDeleted && !wasModified) {
+        mergedDataMask[key] = value;
+      }
+    }
   });
 
   Object.values(draftDataMask).forEach(filter => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- Fixes a regression where saving edits to one native filter clears all applied filters on the dashboard.
- Adjusts reducer logic to only reset the edited filter(s) and preserve other filters’ data masks.
- Adds type-safe unit tests using top-level test() (no describe), aligning with current testing guidelines.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![dashboard-filters](https://github.com/user-attachments/assets/293c64ee-4d77-496c-b175-464eddecb303)

#### Before
![dashboard-filters-before](https://github.com/user-attachments/assets/c34bf04a-13a4-42f6-b105-8ab572746ce1)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
**Manual**
1. Open a dashboard with native filters.
2. Apply two filters (A and B) so both affect charts.
3. Edit filter A in the Native Filters modal, change its column/target, and save.
4. Verify:
    a. Filter A resets (cleared).
    b. Filter B remains applied.
5. Optional: Edit a filter without changing targets and with enableEmptyFilter or defaultToFirstItem set → state is preserved.

**Automated**
Frontend unit tests:
```bash
npm run test -- src/dataMask/reducer.test.ts -w=1
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
