### PR TITLE
fix: display correct icon for Multi Chart in quick switcher

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Icons/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Icons/index.tsx
@@ -42,6 +42,7 @@ const customIcons = [
   'Error',
   'Full',
   'Layers',
+  'Multiple',
   'Queued',
   'Redo',
   'Running',

--- a/superset-frontend/src/assets/images/icons/multiple.svg
+++ b/superset-frontend/src/assets/images/icons/multiple.svg
@@ -1,0 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<svg width="24" height="24" viewBox="5 4 15 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.8568 4.28897H4.14254C3.66843 4.28897 3.28540 4.67201 3.28540 5.14611V19.8604C3.28540 20.3345 3.66843 20.7175 4.14254 20.7175H19.8568C20.3309 20.7175 20.7139 20.3345 20.7139 19.8604V5.14611C20.7139 4.67201 20.3309 4.28897 19.8568 4.28897ZM5.21397 6.21754H7.85683V18.7889H5.21397V6.21754ZM18.7854 18.7889H8.85683V10.5746H18.7854V18.7889ZM8.85683 9.5746V6.21754H18.7854V9.5746H8.85683Z" fill="currentColor" />
+</svg>

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -54,9 +54,15 @@ export const FastVizSwitcher = memo(
       ) {
         vizTiles.unshift({
           name: currentSelection,
-          icon: (
-            <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
-          ),
+          icon:
+            currentSelection === 'deck_multi'
+              ? getMultiChartIcon()
+              : (
+                  <Icons.MonitorOutlined
+                    {...antdIconProps}
+                    aria-label="monitor"
+                  />
+                ),
         });
       }
       if (

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -24,7 +24,7 @@ import { getChartKey } from 'src/explore/exploreUtils';
 import { ExplorePageState } from 'src/explore/types';
 import { FastVizSwitcherProps } from './types';
 import { VizTile } from './VizTile';
-import { FEATURED_CHARTS } from './constants';
+import { FEATURED_CHARTS, getMultiChartIcon } from './constants';
 
 export const antdIconProps = {
   iconSize: 'l' as const,
@@ -67,12 +67,15 @@ export const FastVizSwitcher = memo(
       ) {
         vizTiles.unshift({
           name: currentViz,
-          icon: (
-            <Icons.CheckSquareOutlined
-              {...antdIconProps}
-              aria-label="check-square"
-            />
-          ),
+          icon:
+            currentViz === 'deck_multi'
+              ? getMultiChartIcon()
+              : (
+                  <Icons.CheckSquareOutlined
+                    {...antdIconProps}
+                    aria-label="check-square"
+                  />
+                ),
         });
       }
       return vizTiles;

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -24,7 +24,7 @@ import { getChartKey } from 'src/explore/exploreUtils';
 import { ExplorePageState } from 'src/explore/types';
 import { FastVizSwitcherProps } from './types';
 import { VizTile } from './VizTile';
-import { FEATURED_CHARTS, MULTI_CHART_ICON } from './constants';
+import { FEATURED_CHARTS, CUSTOM_CHART_ICONS } from './constants';
 
 export const antdIconProps = {
   iconSize: 'l' as const,
@@ -55,9 +55,7 @@ export const FastVizSwitcher = memo(
         vizTiles.unshift({
           name: currentSelection,
           icon:
-            currentSelection === 'deck_multi' ? (
-              MULTI_CHART_ICON
-            ) : (
+            CUSTOM_CHART_ICONS[currentSelection] || (
               <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
             ),
         });
@@ -71,9 +69,7 @@ export const FastVizSwitcher = memo(
         vizTiles.unshift({
           name: currentViz,
           icon:
-            currentViz === 'deck_multi' ? (
-              MULTI_CHART_ICON
-            ) : (
+            CUSTOM_CHART_ICONS[currentViz] || (
               <Icons.CheckSquareOutlined
                 {...antdIconProps}
                 aria-label="check-square"

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -54,10 +54,9 @@ export const FastVizSwitcher = memo(
       ) {
         vizTiles.unshift({
           name: currentSelection,
-          icon:
-            CUSTOM_CHART_ICONS[currentSelection] || (
-              <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
-            ),
+          icon: CUSTOM_CHART_ICONS[currentSelection] || (
+            <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
+          ),
         });
       }
       if (
@@ -68,13 +67,12 @@ export const FastVizSwitcher = memo(
       ) {
         vizTiles.unshift({
           name: currentViz,
-          icon:
-            CUSTOM_CHART_ICONS[currentViz] || (
-              <Icons.CheckSquareOutlined
-                {...antdIconProps}
-                aria-label="check-square"
-              />
-            ),
+          icon: CUSTOM_CHART_ICONS[currentViz] || (
+            <Icons.CheckSquareOutlined
+              {...antdIconProps}
+              aria-label="check-square"
+            />
+          ),
         });
       }
       return vizTiles;

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx
@@ -24,7 +24,7 @@ import { getChartKey } from 'src/explore/exploreUtils';
 import { ExplorePageState } from 'src/explore/types';
 import { FastVizSwitcherProps } from './types';
 import { VizTile } from './VizTile';
-import { FEATURED_CHARTS, getMultiChartIcon } from './constants';
+import { FEATURED_CHARTS, MULTI_CHART_ICON } from './constants';
 
 export const antdIconProps = {
   iconSize: 'l' as const,
@@ -55,14 +55,11 @@ export const FastVizSwitcher = memo(
         vizTiles.unshift({
           name: currentSelection,
           icon:
-            currentSelection === 'deck_multi'
-              ? getMultiChartIcon()
-              : (
-                  <Icons.MonitorOutlined
-                    {...antdIconProps}
-                    aria-label="monitor"
-                  />
-                ),
+            currentSelection === 'deck_multi' ? (
+              MULTI_CHART_ICON
+            ) : (
+              <Icons.MonitorOutlined {...antdIconProps} aria-label="monitor" />
+            ),
         });
       }
       if (
@@ -74,14 +71,14 @@ export const FastVizSwitcher = memo(
         vizTiles.unshift({
           name: currentViz,
           icon:
-            currentViz === 'deck_multi'
-              ? getMultiChartIcon()
-              : (
-                  <Icons.CheckSquareOutlined
-                    {...antdIconProps}
-                    aria-label="check-square"
-                  />
-                ),
+            currentViz === 'deck_multi' ? (
+              MULTI_CHART_ICON
+            ) : (
+              <Icons.CheckSquareOutlined
+                {...antdIconProps}
+                aria-label="check-square"
+              />
+            ),
         });
       }
       return vizTiles;

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -39,6 +39,7 @@ import {
   EchartsTimeseriesLineChartPlugin,
 } from '../../../../../plugins/plugin-chart-echarts/src';
 import TableChartPlugin from '../../../../../plugins/plugin-chart-table/src';
+import { MultiChartPlugin } from '../../../../../plugins/legacy-preset-chart-deckgl/src';
 import VizTypeControl, { VIZ_TYPE_CONTROL_TEST_ID } from './index';
 
 // Mock scrollIntoView to avoid errors in test environment
@@ -72,6 +73,7 @@ class MainPreset extends Preset {
         new EchartsMixedTimeseriesChartPlugin().configure({
           key: VizType.MixedTimeseries,
         }),
+        new MultiChartPlugin().configure({ key: 'deck_multi' }),
       ],
     });
   }
@@ -131,6 +133,8 @@ describe('VizTypeControl', () => {
     expect(screen.getByLabelText('area-chart')).toBeVisible();
     expect(screen.queryByLabelText('monitor')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('check-square')).not.toBeInTheDocument();
+    // Multi Chart should NOT appear when other charts are selected
+    expect(screen.queryByLabelText('multiple')).not.toBeInTheDocument();
 
     expect(
       within(screen.getByTestId('fast-viz-switcher')).getByText('Line Chart'),
@@ -150,6 +154,31 @@ describe('VizTypeControl', () => {
     expect(
       within(screen.getByTestId('fast-viz-switcher')).getByText('Area Chart'),
     ).toBeInTheDocument();
+    // Multi Chart text should NOT appear when Line Chart is selected
+    expect(
+      within(screen.getByTestId('fast-viz-switcher')).queryByText(
+        'deck.gl Multiple Layers',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test('Multi Chart appears with custom icon when selected', async () => {
+    const props = {
+      ...defaultProps,
+      value: 'deck_multi',
+      isModalOpenInit: false,
+    };
+    await waitForRenderWrapper(props);
+
+    // Multi Chart icon should be visible when deck_multi is selected
+    expect(screen.getByLabelText('multiple')).toBeVisible();
+    expect(
+      within(screen.getByTestId('fast-viz-switcher')).getByText(
+        'deck.gl Multiple Layers',
+      ),
+    ).toBeInTheDocument();
+    // Should not show the generic check-square icon
+    expect(screen.queryByLabelText('check-square')).not.toBeInTheDocument();
   });
 
   test('Render viz tiles when non-featured chart is selected', async () => {

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
@@ -16,15 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { ReactElement } from 'react';
 import { VizType } from '@superset-ui/core';
 import { css } from '@apache-superset/core/ui';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { VizMeta } from './types';
 
-// Multi Chart icon (only shown when selected)
-export const MULTI_CHART_ICON = (
-  <Icons.Multiple iconSize="l" viewBox="5 4 15 20" />
-);
+// Custom icons for non-featured charts
+export const CUSTOM_CHART_ICONS: Record<string, ReactElement> = {
+  deck_multi: <Icons.Multiple iconSize="l" viewBox="5 4 15 20" />,
+};
 
 export const FEATURED_CHARTS: VizMeta[] = [
   {

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
@@ -21,6 +21,9 @@ import { css } from '@apache-superset/core/ui';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { VizMeta } from './types';
 
+// Helper function for Multi Chart icon (only shown when selected)
+export const getMultiChartIcon = () => <Icons.Multiple iconSize="l" viewBox="5 4 15 20" />;
+
 export const FEATURED_CHARTS: VizMeta[] = [
   {
     name: VizType.Line,

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx
@@ -21,8 +21,10 @@ import { css } from '@apache-superset/core/ui';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { VizMeta } from './types';
 
-// Helper function for Multi Chart icon (only shown when selected)
-export const getMultiChartIcon = () => <Icons.Multiple iconSize="l" viewBox="5 4 15 20" />;
+// Multi Chart icon (only shown when selected)
+export const MULTI_CHART_ICON = (
+  <Icons.Multiple iconSize="l" viewBox="5 4 15 20" />
+);
 
 export const FEATURED_CHARTS: VizMeta[] = [
   {


### PR DESCRIPTION
### SUMMARY

Fixes the Multi Chart (deck.gl Multiple Layers) icon display in the fast viz switcher to match Figma design specifications. The Multi Chart now shows a custom icon with proper sizing and alignment, and only appears in the quick switcher when it's the selected chart type.

**Problem:**
1. Multi Chart was showing a generic fallback icon (CheckSquareOutlined/MonitorOutlined) instead of the custom icon from Figma
2. Multi Chart appeared in the quick switcher even when other charts were selected, cluttering the UI
3. Icon size and vertical alignment didn't match other featured charts
4. When selecting Multi Chart from "View all charts" modal, the generic MonitorOutlined icon appeared instead of the custom icon

**Root Cause:**
- `deck_multi` was not in the `FEATURED_CHARTS` array, so it fell back to generic icons
- No conditional logic existed in `FastVizSwitcher` to handle custom icons for non-featured charts in either selection state
- The `currentSelection` block (preview state) and `currentViz` block (active state) both needed custom icon handling
- The custom `multiple.svg` icon needed proper `viewBox` configuration for correct positioning

**Solution:**
- Added `multiple.svg` icon to the custom icons registry
- Created `getMultiChartIcon()` helper function that returns the properly configured Multi Chart icon
- Updated `FastVizSwitcher` to conditionally render the custom icon for `deck_multi` in **both** the `currentSelection` block (when selected from modal) and `currentViz` block (after clicking "Update chart")
- Configured `viewBox="5 4 15 20"` to ensure proper icon sizing and vertical alignment

**Changes Made:**
1. `superset-frontend/src/assets/images/icons/multiple.svg` - Added custom Multi Chart icon from Figma
2. `superset-frontend/packages/superset-ui-core/src/components/Icons/index.tsx` - Registered `Multiple` in custom icons array
3. `superset-frontend/src/explore/components/controls/VizTypeControl/constants.tsx` - Added `getMultiChartIcon()` helper function
4. `superset-frontend/src/explore/components/controls/VizTypeControl/FastVizSwitcher.tsx` - Added conditional logic to use custom icon for `deck_multi` in both `currentSelection` (lines 57-65) and `currentViz` (lines 76-84) states
5. `superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx` - Updated tests to verify Multi Chart only appears when selected

**Technical Details:**
The `viewBox="5 4 15 20"` adjustment is passed as a prop to override the default viewBox, similar to how `BigNumberChartTile` handles its custom viewBox. This crops and positions the icon to match the visual alignment of other featured chart icons in the quick switcher.

The fix handles two distinct UI states:
- **Selection state** (`currentSelection`): When user picks Multi Chart from modal but hasn't clicked "Update chart" yet
- **Active state** (`currentViz`): After clicking "Update chart" and Multi Chart is rendered

Both states now check `=== 'deck_multi'` and use `getMultiChartIcon()` instead of generic fallback icons.

### BEFORE/AFTER

**Before:** Multi Chart showed generic square icon and appeared even when not selected

https://github.com/user-attachments/assets/71473363-38e5-4093-b791-eb6764654ac1


**After:** Multi Chart shows custom icon matching Figma design, only appears when selected, with proper size and alignment

https://github.com/user-attachments/assets/eb272926-a2fc-43f6-84ef-1095706b4c8a


