### PR TITLE
fix(timeseries): restore ECharts tooltip after closing drill menu

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -66,6 +66,7 @@ export default function EchartsTimeseries({
   const clickTimer = useRef<ReturnType<typeof setTimeout>>();
   const extraControlRef = useRef<HTMLDivElement>(null);
   const [extraControlHeight, setExtraControlHeight] = useState(0);
+
   useEffect(() => {
     const element = extraControlRef.current;
     if (!element) {
@@ -258,18 +259,6 @@ export default function EchartsTimeseries({
           crossFilter: hasDimensions
             ? getCrossFilterDataMask(seriesName)
             : undefined,
-        });
-
-        // Restore tooltip visibility after the drill menu closes
-        const restoreTooltip = () => {
-          const instance = echartRef.current?.getEchartInstance?.();
-          if (instance) {
-            instance.setOption({ tooltip: { show: true } }, false);
-          }
-        };
-        window.addEventListener('mousedown', restoreTooltip, {
-          once: true,
-          capture: true,
         });
       }
     },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -66,7 +66,6 @@ export default function EchartsTimeseries({
   const clickTimer = useRef<ReturnType<typeof setTimeout>>();
   const extraControlRef = useRef<HTMLDivElement>(null);
   const [extraControlHeight, setExtraControlHeight] = useState(0);
-
   useEffect(() => {
     const element = extraControlRef.current;
     if (!element) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -259,6 +259,18 @@ export default function EchartsTimeseries({
             ? getCrossFilterDataMask(seriesName)
             : undefined,
         });
+
+        // Restore tooltip visibility after the drill menu closes
+        const restoreTooltip = () => {
+          const instance = echartRef.current?.getEchartInstance?.();
+          if (instance) {
+            instance.setOption({ tooltip: { show: true } }, false);
+          }
+        };
+        window.addEventListener('mousedown', restoreTooltip, {
+          once: true,
+          capture: true,
+        });
       }
     },
   };

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
@@ -34,12 +34,6 @@ const mockCachedSupersetGet = cachedSupersetGet as jest.MockedFunction<
   typeof cachedSupersetGet
 >;
 
-// @ts-ignore
-global.featureFlags = {
-  [FeatureFlag.DrillToDetail]: true,
-  [FeatureFlag.DrillBy]: true,
-};
-
 const defaultFormData = {
   datasource: '1__table',
   viz_type: VizType.Pie,
@@ -97,6 +91,12 @@ const setup = () => {
 };
 
 beforeEach(() => {
+  // @ts-ignore
+  global.featureFlags = {
+    [FeatureFlag.DrillToDetail]: true,
+    [FeatureFlag.DrillBy]: true,
+  };
+
   mockCachedSupersetGet.mockClear();
   mockCachedSupersetGet.mockResolvedValue({
     response: {} as Response,
@@ -107,6 +107,11 @@ beforeEach(() => {
       },
     },
   });
+});
+
+afterEach(() => {
+  // @ts-ignore
+  delete global.featureFlags;
 });
 
 test('tooltip is restored when user clicks outside to close context menu', async () => {

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useRef } from 'react';
+import { FeatureFlag, VizType } from '@superset-ui/core';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import mockState from 'spec/fixtures/mockState';
+import { sliceId } from 'spec/fixtures/mockChartQueries';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
+import ChartContextMenu, {
+  ChartContextMenuRef,
+  ContextMenuItem,
+} from './ChartContextMenu';
+
+jest.mock('src/utils/cachedSupersetGet');
+
+const mockCachedSupersetGet = cachedSupersetGet as jest.MockedFunction<
+  typeof cachedSupersetGet
+>;
+
+// @ts-ignore
+global.featureFlags = {
+  [FeatureFlag.DrillToDetail]: true,
+  [FeatureFlag.DrillBy]: true,
+};
+
+const defaultFormData = {
+  datasource: '1__table',
+  viz_type: VizType.Pie,
+};
+
+const TestWrapper = ({ onClose = jest.fn() }: { onClose?: jest.Mock }) => {
+  const contextMenuRef = useRef<ChartContextMenuRef>(null);
+
+  return (
+    <>
+      <button
+        onClick={() => contextMenuRef.current?.open(100, 100, {})}
+        data-test="open-context-menu"
+      >
+        Open Context Menu
+      </button>
+      <ChartContextMenu
+        ref={contextMenuRef}
+        id={sliceId}
+        formData={defaultFormData}
+        onSelection={jest.fn()}
+        onClose={onClose}
+        displayedItems={ContextMenuItem.All}
+      />
+    </>
+  );
+};
+
+const setup = (props: Parameters<typeof TestWrapper>[0] = {}) => {
+  return render(<TestWrapper {...props} />, {
+    useRedux: true,
+    initialState: {
+      ...mockState,
+      user: {
+        ...mockState.user,
+        roles: {
+          Admin: [
+            ['can_explore', 'Superset'],
+            ['can_samples', 'Datasource'],
+            ['can_write', 'ExploreFormDataRestApi'],
+            ['can_get_drill_info', 'Dataset'],
+          ],
+        },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  mockCachedSupersetGet.mockClear();
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        columns: [],
+        metrics: [],
+      },
+    },
+  });
+});
+
+test('context menu calls onClose when user clicks outside to close it', async () => {
+  const onCloseMock = jest.fn();
+  setup({ onClose: onCloseMock });
+
+  const openButton = screen.getByTestId('open-context-menu');
+  userEvent.click(openButton);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('chart-context-menu')).toBeInTheDocument();
+  });
+
+  expect(onCloseMock).not.toHaveBeenCalled();
+
+  userEvent.click(document.body);
+
+  // Ensure onClose is called when dropdown closes
+  await waitFor(() => {
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});
+
+test('context menu calls onClose when user selects a menu item', async () => {
+  const onCloseMock = jest.fn();
+  setup({ onClose: onCloseMock });
+
+  const openButton = screen.getByTestId('open-context-menu');
+  userEvent.click(openButton);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('chart-context-menu')).toBeInTheDocument();
+  });
+
+  const menuItem = screen.getByText('Drill to detail');
+  userEvent.click(menuItem);
+
+  await waitFor(() => {
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -423,6 +423,9 @@ const ChartContextMenu = (
         trigger={['click']}
         onOpenChange={value => {
           setVisible(value);
+          if (!value) {
+            onClose();
+          }
         }}
         open={visible}
       >


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Right-clicking a Timeseries/Area chart to open the drill menu caused ECharts tooltips to stop appearing until page refresh. Tooltips are gated by an “in context menu” state, but visibility was not restored on close. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
![echart-tooltip-not-hidden](https://github.com/user-attachments/assets/afbacca8-bf7b-409f-bfa6-6252eff99c2f)

#### Before
https://github.com/user-attachments/assets/5196db2f-3ca7-429a-bb40-057c33b3c1b8


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create an Area chart with tooltips enabled and add it to a dashboard.
2. On the dashboard:
    - Right-click on the chart to open the drill menu.
    - Click anywhere to close the drill menu.
    - Hover the chart and confirm the tooltip appears again.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
