### PR TITLE
fix(roles): allow Public role to read themes

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -433,8 +433,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         ("can_time_range", "Api"),
         ("can_query_form_data", "Api"),
         ("can_query", "Api"),
-        # CSS for dashboard styling
+        # CSS and themes for dashboard styling
         ("can_read", "CssTemplate"),
+        ("can_read", "Theme"),
         # Embedded dashboard support
         ("can_read", "EmbeddedDashboard"),
         # Datasource metadata for chart rendering


### PR DESCRIPTION
### SUMMARY
Fixes #37294

In #36548 a canned set of permissions for a Public role was added. This is great! We need to also add `can read Theme`, as without that, a dashboard becomes un-Public if it is assigned a theme.

### TESTING INSTRUCTIONS
Create a public dashboard and verify it's accessible to unauthenticated user
Assign it a theme
Verify it's accessible (after this fix is applied) and inaccessible in Superset 6.0.0.
