### PR TITLE
chore: add paths to backend extension stack traces

### DIFF
--- a/superset/extensions/types.py
+++ b/superset/extensions/types.py
@@ -34,3 +34,6 @@ class LoadedExtension:
     frontend: dict[str, bytes]
     backend: dict[str, bytes]
     version: str
+    source_base_path: (
+        str  # Base path for traceback filenames (absolute path or supx:// URL)
+    )

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -562,7 +562,10 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
         for extension in extensions.values():
             if backend_files := extension.backend:
-                install_in_memory_importer(backend_files)
+                install_in_memory_importer(
+                    backend_files,
+                    source_base_path=extension.source_base_path,
+                )
 
             backend = extension.manifest.backend
 


### PR DESCRIPTION
### SUMMARY
Currently when backend extensions raise exceptions, they don't contain a reference to the actual file (notice `File: "<string>"` at the top of the stack):

```python
Traceback (most recent call last):
  File "/Users/ville/projects/superset/superset/tasks/executor.py", line 108, in execute_task
    executor_fn(*args, **kwargs)
  File "<string>", line 36, in my_task
ZeroDivisionError: division by zero
```

This makes it difficult to track down where the error actually occurred.

In this PR, we propose stack traces will have a reference to the source file as follows:
- For bundled `supx` extensions, the reference will be `supx://<extension-id>/file.py`. This URL-like format is due to the fact that the python file doesn't exist physically on the system (it's inside the bundle).
- For local development extensions, the reference will be the pull path to the dist file: `.../dist/.../file.py`.

This will make stack traces more actionable, both when developing locally, and also when using bundles.

**Local extension after changes:**

```python
Traceback (most recent call last):
  File "/Users/ville/projects/superset/superset/tasks/executor.py", line 108, in execute_task
    executor_fn(*args, **kwargs)
  File "/Users/ville/projects/superset-extensions/helloworld/dist/backend/src/helloworld/api.py", line 36, in my_task
    x = 120/0
ZeroDivisionError: division by zero
```

Notice that for local extensions, it's now showing the actual code `x = 120/0` that raised the error to help narrow down the problematic code. This is thanks to the interpreter being able to read the file on the filesystem.

**supx bundle after changes:**

```python
Traceback (most recent call last):
  File "/Users/ville/projects/superset/superset/tasks/executor.py", line 108, in execute_task
    executor_fn(*args, **kwargs)
  File "supx://helloworld/backend/src/helloworld/api.py", line 36, in my_task
ZeroDivisionError: division by zero
```

Here we're intentionally **not** showing the offending code, as we don't want to expose more of the internals than necessary (line number and method should be fine). We _can_ add parity with local extensions for bundles, but IMO it's an unnecessary leak of extension internals, so I advise against it. It would also consume slightly more memory, as we'd have to load the supx code into [linecache](https://docs.python.org/3/library/linecache.html). While the memory overhead is arguably negligible, it's still unnecessary IMO. But I'm curious to hear how others feel about this.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
