### PR TITLE
fix(docker): add C++ toolchain for python-geohash

### DIFF
--- a/docker/apt-install.sh
+++ b/docker/apt-install.sh
@@ -38,8 +38,15 @@ RESET='\033[0m'
 echo -e "${GREEN}Updating package lists...${RESET}"
 apt-get update -qq
 
+# Ensure native Python extensions can compile (python-geohash, psycopg2, mysqlclient)
+echo -e "${GREEN}Installing build toolchain...${RESET}"
+apt-get install -yqq --no-install-recommends \
+    build-essential \
+    g++
+
 echo -e "${GREEN}Installing packages: $@${RESET}"
 apt-get install -yqq --no-install-recommends "$@"
+
 
 echo -e "${GREEN}Autoremoving unnecessary packages...${RESET}"
 apt-get autoremove -yqq --purge

--- a/docker/apt-install.sh
+++ b/docker/apt-install.sh
@@ -38,15 +38,8 @@ RESET='\033[0m'
 echo -e "${GREEN}Updating package lists...${RESET}"
 apt-get update -qq
 
-# Ensure native Python extensions can compile (python-geohash, psycopg2, mysqlclient)
-echo -e "${GREEN}Installing build toolchain...${RESET}"
-apt-get install -yqq --no-install-recommends \
-    build-essential \
-    g++
-
 echo -e "${GREEN}Installing packages: $@${RESET}"
 apt-get install -yqq --no-install-recommends "$@"
-
 
 echo -e "${GREEN}Autoremoving unnecessary packages...${RESET}"
 apt-get autoremove -yqq --purge
@@ -55,4 +48,4 @@ echo -e "${GREEN}Cleaning up package cache and metadata...${RESET}"
 apt-get clean
 rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* /var/tmp/*
 
-echo -e "${GREEN}Installation and cleanup complete.${RESET}"
+echo -e "${GREEN}Installation and cleanup complete.${RESET}"   is this ok


### PR DESCRIPTION
### SUMMARY

The official Superset Docker image installs python-geohash==0.8.5, which requires
a C++ compiler to build from source. However, the image does not include g++ or
build-essential, causing pip install to fail inside the container.

This change ensures native Python extensions can compile correctly by installing
the minimal C++ toolchain in the apt layer.

---

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A – infrastructure change (Docker image build)

---

### TESTING INSTRUCTIONS

1. Build the Superset Docker image.
2. Run a container from the built image.
3. Run: `pip install python-geohash`
4. Verify that the package builds and installs successfully without errors.

Previously this failed with:
