### PR TITLE
feat(examples): Transpile virtual dataset SQL on import

### DIFF
--- a/superset/commands/dashboard/export_example.py
+++ b/superset/commands/dashboard/export_example.py
@@ -175,6 +175,10 @@ def export_dataset_yaml(
         "schema": None,  # Don't export - use target database's default schema
         # Preserve SQL for virtual datasets, None for physical (data is in parquet)
         "sql": dataset.sql if is_preserved_virtual else None,
+        # Track source database engine for SQL transpilation during import
+        "source_db_engine": (
+            dataset.database.db_engine_spec.engine if is_preserved_virtual else None
+        ),
         "params": None,  # Don't export - contains stale import metadata
         "template_params": dataset.template_params,
         "filter_select_enabled": dataset.filter_select_enabled,

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -75,6 +75,9 @@ def transpile_virtual_dataset_sql(config: dict[str, Any], database_id: int) -> N
 
     target_engine = database.db_engine_spec.engine
     source_engine = config.get("source_db_engine")
+    if target_engine == source_engine:
+        logger.info("Source and target dialects are identical, skipping transpilation")
+        return
 
     try:
         transpiled_sql = transpile_to_dialect(sql, target_engine, source_engine)

--- a/superset/commands/importers/v1/examples.py
+++ b/superset/commands/importers/v1/examples.py
@@ -74,20 +74,24 @@ def transpile_virtual_dataset_sql(config: dict[str, Any], database_id: int) -> N
         return
 
     target_engine = database.db_engine_spec.engine
+    source_engine = config.get("source_db_engine")
+
     try:
-        transpiled_sql = transpile_to_dialect(sql, target_engine)
+        transpiled_sql = transpile_to_dialect(sql, target_engine, source_engine)
         if transpiled_sql != sql:
             logger.info(
-                "Transpiled virtual dataset SQL for '%s' to %s dialect",
+                "Transpiled virtual dataset SQL for '%s' from %s to %s dialect",
                 config.get("table_name", "unknown"),
+                source_engine or "generic",
                 target_engine,
             )
             config["sql"] = transpiled_sql
     except QueryClauseValidationException as ex:
         logger.warning(
-            "Could not transpile SQL for dataset '%s' to %s: %s. "
+            "Could not transpile SQL for dataset '%s' from %s to %s: %s. "
             "Using original SQL which may not be compatible.",
             config.get("table_name", "unknown"),
+            source_engine or "generic",
             target_engine,
             ex,
         )

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -322,6 +322,8 @@ class ImportV1DatasetSchema(Schema):
     schema = fields.String(allow_none=True)
     catalog = fields.String(allow_none=True)
     sql = fields.String(allow_none=True)
+    # Source database engine for SQL transpilation (virtual datasets only)
+    source_db_engine = fields.String(allow_none=True, load_default=None)
     params = fields.Dict(allow_none=True)
     template_params = fields.Dict(allow_none=True)
     filter_select_enabled = fields.Boolean()

--- a/tests/unit_tests/commands/importers/v1/examples_test.py
+++ b/tests/unit_tests/commands/importers/v1/examples_test.py
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the examples importer, specifically SQL transpilation."""
+
+from unittest.mock import MagicMock, patch
+
+from superset.commands.importers.v1.examples import transpile_virtual_dataset_sql
+
+
+def test_transpile_virtual_dataset_sql_no_sql():
+    """Test that configs without SQL are unchanged."""
+    config = {"table_name": "my_table", "sql": None}
+    transpile_virtual_dataset_sql(config, 1)
+    assert config["sql"] is None
+
+
+def test_transpile_virtual_dataset_sql_empty_sql():
+    """Test that configs with empty SQL are unchanged."""
+    config = {"table_name": "my_table", "sql": ""}
+    transpile_virtual_dataset_sql(config, 1)
+    assert config["sql"] == ""
+
+
+@patch("superset.commands.importers.v1.examples.db")
+def test_transpile_virtual_dataset_sql_database_not_found(mock_db):
+    """Test graceful handling when database is not found."""
+    mock_db.session.query.return_value.get.return_value = None
+
+    config = {"table_name": "my_table", "sql": "SELECT * FROM foo"}
+    original_sql = config["sql"]
+
+    transpile_virtual_dataset_sql(config, 999)
+
+    # SQL should remain unchanged
+    assert config["sql"] == original_sql
+
+
+@patch("superset.commands.importers.v1.examples.db")
+@patch("superset.commands.importers.v1.examples.transpile_to_dialect")
+def test_transpile_virtual_dataset_sql_success(mock_transpile, mock_db):
+    """Test successful SQL transpilation."""
+    # Setup mock database
+    mock_database = MagicMock()
+    mock_database.db_engine_spec.engine = "mysql"
+    mock_db.session.query.return_value.get.return_value = mock_database
+
+    # Setup mock transpilation
+    mock_transpile.return_value = "SELECT * FROM `foo`"
+
+    config = {"table_name": "my_table", "sql": "SELECT * FROM foo"}
+    transpile_virtual_dataset_sql(config, 1)
+
+    # SQL should be transpiled
+    assert config["sql"] == "SELECT * FROM `foo`"
+    mock_transpile.assert_called_once_with("SELECT * FROM foo", "mysql")
+
+
+@patch("superset.commands.importers.v1.examples.db")
+@patch("superset.commands.importers.v1.examples.transpile_to_dialect")
+def test_transpile_virtual_dataset_sql_no_change(mock_transpile, mock_db):
+    """Test when transpilation returns same SQL (no dialect differences)."""
+    mock_database = MagicMock()
+    mock_database.db_engine_spec.engine = "postgresql"
+    mock_db.session.query.return_value.get.return_value = mock_database
+
+    original_sql = "SELECT * FROM foo"
+    mock_transpile.return_value = original_sql
+
+    config = {"table_name": "my_table", "sql": original_sql}
+    transpile_virtual_dataset_sql(config, 1)
+
+    assert config["sql"] == original_sql
+
+
+@patch("superset.commands.importers.v1.examples.db")
+@patch("superset.commands.importers.v1.examples.transpile_to_dialect")
+def test_transpile_virtual_dataset_sql_error_fallback(mock_transpile, mock_db):
+    """Test graceful fallback when transpilation fails."""
+    from superset.exceptions import QueryClauseValidationException
+
+    mock_database = MagicMock()
+    mock_database.db_engine_spec.engine = "mysql"
+    mock_db.session.query.return_value.get.return_value = mock_database
+
+    # Simulate transpilation failure
+    mock_transpile.side_effect = QueryClauseValidationException("Parse error")
+
+    original_sql = "SELECT SOME_POSTGRES_SPECIFIC_FUNCTION() FROM foo"
+    config = {"table_name": "my_table", "sql": original_sql}
+
+    # Should not raise, should keep original SQL
+    transpile_virtual_dataset_sql(config, 1)
+    assert config["sql"] == original_sql
+
+
+@patch("superset.commands.importers.v1.examples.db")
+@patch("superset.commands.importers.v1.examples.transpile_to_dialect")
+def test_transpile_virtual_dataset_sql_complex_query(mock_transpile, mock_db):
+    """Test transpilation of a more complex SQL query."""
+    mock_database = MagicMock()
+    mock_database.db_engine_spec.engine = "duckdb"
+    mock_db.session.query.return_value.get.return_value = mock_database
+
+    original_sql = """
+        SELECT
+            DATE_TRUNC('month', created_at) as month,
+            COUNT(*) as count
+        FROM orders
+        WHERE status = 'completed'
+        GROUP BY 1
+    """
+    transpiled_sql = """
+        SELECT
+            DATE_TRUNC('month', created_at) AS month,
+            COUNT(*) AS count
+        FROM orders
+        WHERE status = 'completed'
+        GROUP BY 1
+    """
+    mock_transpile.return_value = transpiled_sql
+
+    config = {"table_name": "monthly_orders", "sql": original_sql}
+    transpile_virtual_dataset_sql(config, 1)
+
+    assert config["sql"] == transpiled_sql
+    mock_transpile.assert_called_once_with(original_sql, "duckdb")

--- a/tests/unit_tests/sql/transpile_to_dialect_test.py
+++ b/tests/unit_tests/sql/transpile_to_dialect_test.py
@@ -349,7 +349,7 @@ def test_sqlglot_generation_error_raises_exception() -> None:
 
 # Tests for source_engine parameter
 @pytest.mark.parametrize(
-    "sql,source_engine,target_engine,expected",
+    ("sql", "source_engine", "target_engine", "expected"),
     [
         # PostgreSQL to MySQL - should convert :: casting to CAST()
         (


### PR DESCRIPTION
### SUMMARY

When importing example datasets, this PR automatically transpiles virtual dataset SQL to the target database dialect using SQLGlot. This ensures that virtual datasets exported from one database type (e.g., PostgreSQL) can be loaded into a different database type (e.g., MySQL, DuckDB, SQLite).

**Problem:** Virtual datasets contain raw SQL that is dialect-specific. If someone exports a dashboard with virtual datasets from PostgreSQL (using syntax like `DATE_TRUNC`, `::` casting, etc.) and someone else tries to load it with MySQL or SQLite, the SQL would fail.

**Solution:** Leverage Superset's existing `transpile_to_dialect()` function (which uses SQLGlot) to automatically convert the SQL to the target database's dialect during import.

**Changes:**
- Add `transpile_virtual_dataset_sql()` helper function in `superset/commands/importers/v1/examples.py`
- Integrate transpilation into `ImportExamplesCommand._import()` before dataset import
- Gracefully fall back to original SQL if transpilation fails (logs a warning)
- Add 7 comprehensive unit tests

This builds on the work from #36538 which modernized example data loading with Parquet and YAML configs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend change only

### TESTING INSTRUCTIONS

1. Export a dashboard with virtual datasets from a PostgreSQL-backed Superset instance
2. Configure a different database engine (e.g., DuckDB, MySQL) as the examples database
3. Run `superset load-examples`
4. Verify that virtual datasets are created with SQL transpiled to the target dialect

**Unit tests:**
```bash
pytest tests/unit_tests/commands/importers/v1/examples_test.py -v
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.ai/code)