### PR TITLE
fix(filters): fix filter / customization name not updating in sidebar in real time

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -77,6 +77,7 @@ export interface ConfigModalSidebarProps {
     sourceType: 'filter' | 'customization',
     targetType: 'filter' | 'customization',
   ) => void;
+  formValuesVersion?: number;
 }
 
 const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
@@ -99,6 +100,7 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
   restoreItem,
   onCollapseChange,
   onCrossListDrop,
+  formValuesVersion,
 }) => {
   const handleFilterCrossListDrop = (
     sourceId: string,
@@ -140,6 +142,7 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
         />
       </StyledHeaderFlex>
       <StyledCollapse
+        key={formValuesVersion}
         activeKey={activeCollapseKeys}
         onChange={keys => onCollapseChange(keys as string[])}
         ghost

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useCallback } from 'react';
 import { t } from '@apache-superset/core';
 import { NativeFilterType, ChartCustomizationType } from '@superset-ui/core';
 import { styled } from '@apache-superset/core/ui';
@@ -77,7 +77,7 @@ export interface ConfigModalSidebarProps {
     sourceType: 'filter' | 'customization',
     targetType: 'filter' | 'customization',
   ) => void;
-  formValuesVersion?: number;
+  itemTitles?: Record<string, string>;
 }
 
 const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
@@ -100,8 +100,13 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
   restoreItem,
   onCollapseChange,
   onCrossListDrop,
-  formValuesVersion,
+  itemTitles,
 }) => {
+  const getTitle = useCallback(
+    (id: string) => itemTitles?.[id] ?? getItemTitle(id),
+    [itemTitles, getItemTitle],
+  );
+
   const handleFilterCrossListDrop = (
     sourceId: string,
     targetIndex: number,
@@ -142,7 +147,6 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
         />
       </StyledHeaderFlex>
       <StyledCollapse
-        key={formValuesVersion}
         activeKey={activeCollapseKeys}
         onChange={keys => onCollapseChange(keys as string[])}
         ghost
@@ -153,7 +157,7 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
             items={filterOrderedIds}
             removedItems={filterRemovedItems}
             erroredItems={filterErroredItems}
-            getItemTitle={getItemTitle}
+            getItemTitle={getTitle}
             onChange={onChange}
             onRearrange={onRearrange}
             onRemove={onRemove}
@@ -175,7 +179,7 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
             items={customizationOrderedIds}
             removedItems={customizationRemovedItems}
             erroredItems={customizationErroredItems}
-            getItemTitle={getItemTitle}
+            getItemTitle={getTitle}
             onChange={onChange}
             onRearrange={onRearrange}
             onRemove={onRemove}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.test.tsx
@@ -617,6 +617,45 @@ test('rearranges three filters and deletes one of them', async () => {
   );
 });
 
+test('updates sidebar title when filter name changes', async () => {
+  const nativeFilterConfig = [
+    buildNativeFilter('NATIVE_FILTER-1', 'state', []),
+    buildNativeFilter('NATIVE_FILTER-2', 'country', []),
+  ];
+
+  const state = {
+    ...defaultState(),
+    dashboardInfo: {
+      metadata: {
+        native_filter_configuration: nativeFilterConfig,
+      },
+    },
+    dashboardLayout,
+  };
+
+  defaultRender(state, {
+    ...props,
+    createNewOnOpen: false,
+  });
+
+  const filterNameInput = screen.getByRole('textbox', {
+    name: FILTER_NAME_REGEX,
+  });
+
+  const filterContainer = screen.getByTestId('filter-title-container');
+  const tabsBeforeChange = within(filterContainer).getAllByRole('tab');
+
+  expect(tabsBeforeChange[0]).not.toHaveTextContent('New Filter Name');
+
+  await userEvent.clear(filterNameInput);
+  await userEvent.type(filterNameInput, 'New Filter Name');
+
+  await waitFor(() => {
+    const tabsAfterChange = within(filterContainer).getAllByRole('tab');
+    expect(tabsAfterChange[0]).toHaveTextContent('New Filter Name');
+  });
+});
+
 test('modifies the name of a filter', async () => {
   jest.useFakeTimers();
   try {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -450,7 +450,9 @@ function FiltersConfigModal({
     ? Icons.FullscreenExitOutlined
     : Icons.FullscreenOutlined;
 
-  const handleValuesChange = useMemo(
+  const [formValuesVersion, setFormValuesVersion] = useState(0);
+
+  const debouncedErrorHandling = useMemo(
     () =>
       debounce(() => {
         setSaveAlertVisible(false);
@@ -458,6 +460,11 @@ function FiltersConfigModal({
       }, Constants.SLOW_DEBOUNCE),
     [modalSaveLogic],
   );
+
+  const handleValuesChange = useCallback(() => {
+    setFormValuesVersion(prev => prev + 1);
+    debouncedErrorHandling();
+  }, [debouncedErrorHandling]);
 
   const handleActiveFilterPanelChange = useCallback(
     (key: string | string[]) => setActiveFilterPanelKey(key),
@@ -567,6 +574,7 @@ function FiltersConfigModal({
                 restoreItem={restoreItem}
                 onCollapseChange={setActiveCollapseKeys}
                 onCrossListDrop={handleCrossListMove}
+                formValuesVersion={formValuesVersion}
               />
 
               <ConfigModalContent

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -452,6 +452,14 @@ function FiltersConfigModal({
 
   const [formValuesVersion, setFormValuesVersion] = useState(0);
 
+  const itemTitles = useMemo(() => {
+    const titles: Record<string, string> = {};
+    [...filterIds, ...chartCustomizationIds].forEach(id => {
+      titles[id] = modalSaveLogic.getItemTitle(id);
+    });
+    return titles;
+  }, [filterIds, chartCustomizationIds, modalSaveLogic, formValuesVersion]);
+
   const debouncedErrorHandling = useMemo(
     () =>
       debounce(() => {
@@ -564,6 +572,7 @@ function FiltersConfigModal({
                 customizationErroredItems={customizationState.erroredIds}
                 activeCollapseKeys={activeCollapseKeys}
                 getItemTitle={modalSaveLogic.getItemTitle}
+                itemTitles={itemTitles}
                 onAddFilter={filterOperations.addFilter}
                 onAddCustomization={
                   customizationOperations.addChartCustomization
@@ -574,7 +583,6 @@ function FiltersConfigModal({
                 restoreItem={restoreItem}
                 onCollapseChange={setActiveCollapseKeys}
                 onCrossListDrop={handleCrossListMove}
-                formValuesVersion={formValuesVersion}
               />
 
               <ConfigModalContent


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
fixes an issue where the filter and customization name in the sidebar did not update in real time as user typed the name of the filter/customization.Previously, when a user updated the name of a filter or customization control, the sidebar display would not reflect the new name immediately and one would have to click on the untitled section.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
AFTER:

https://github.com/user-attachments/assets/9290d44a-c67b-4978-961e-41150b16888a



### TESTING INSTRUCTIONS
1)  Navigate to a dashboard
2) Open the filters and customiation controls.
3) Add a filter and edit the name of a filter or customization control.
4) Verify that the sidebar immediately displays the new name after editing, without requiring a refresh/clicking on the untitled section.
5) Confirm that other filters or UI elements continue to function normally after the update.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x ] Has associated issue: Fixes #37356
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
