### PR TITLE
feat(cache): use configurable hash algorithm for flask-caching

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -31,7 +31,7 @@ from superset import db
 from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.extensions import cache_manager
 from superset.models.cache import CacheKey
-from superset.utils.cache_manager import get_cache_hash_method
+from superset.utils.cache_manager import configurable_hash_method
 from superset.utils.hashing import hash_from_dict
 from superset.utils.json import json_int_dttm_ser
 
@@ -274,7 +274,7 @@ def etag_cache(  # noqa: C901
         wrapper.uncached = f  # type: ignore
         wrapper.cache_timeout = timeout  # type: ignore
         wrapper.make_cache_key = cache._memoize_make_cache_key(  # type: ignore # pylint: disable=protected-access
-            make_name=None, timeout=timeout, hash_method=get_cache_hash_method()
+            make_name=None, timeout=timeout, hash_method=configurable_hash_method
         )
 
         return wrapper

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -31,6 +31,7 @@ from superset import db
 from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.extensions import cache_manager
 from superset.models.cache import CacheKey
+from superset.utils.cache_manager import get_cache_hash_method
 from superset.utils.hashing import hash_from_dict
 from superset.utils.json import json_int_dttm_ser
 
@@ -273,7 +274,7 @@ def etag_cache(  # noqa: C901
         wrapper.uncached = f  # type: ignore
         wrapper.cache_timeout = timeout  # type: ignore
         wrapper.make_cache_key = cache._memoize_make_cache_key(  # type: ignore # pylint: disable=protected-access
-            make_name=None, timeout=timeout
+            make_name=None, timeout=timeout, hash_method=get_cache_hash_method()
         )
 
         return wrapper

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -56,9 +56,14 @@ class ConfigurableHashMethod:
 
         Returns:
             A hashlib hash object (e.g., sha256 or md5)
+
+        Raises:
+            ValueError: If HASH_ALGORITHM is set to an unsupported value
         """
         algorithm = current_app.config["HASH_ALGORITHM"]
-        hash_func = _HASH_METHODS[algorithm]
+        hash_func = _HASH_METHODS.get(algorithm)
+        if hash_func is None:
+            raise ValueError(f"Unsupported hash algorithm: {algorithm}")
         return hash_func(data)
 
 

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -14,10 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import hashlib
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
-from flask import Flask
+from flask import current_app, Flask
 from flask_caching import Cache
 from markupsafe import Markup
 
@@ -27,8 +28,114 @@ logger = logging.getLogger(__name__)
 
 CACHE_IMPORT_PATH = "superset.extensions.metastore_cache.SupersetMetastoreCache"
 
+# Hash function lookup table matching superset.utils.hashing
+_HASH_METHODS: dict[str, Callable[..., Any]] = {
+    "sha256": hashlib.sha256,
+    "md5": hashlib.md5,
+}
 
-class ExploreFormDataCache(Cache):
+
+def get_cache_hash_method() -> Callable[..., Any]:
+    """
+    Get the hash method based on the HASH_ALGORITHM config.
+
+    Returns the hashlib function corresponding to the configured algorithm.
+    """
+    algorithm = current_app.config["HASH_ALGORITHM"]
+    return _HASH_METHODS[algorithm]
+
+
+class SupersetCache(Cache):
+    """
+    Cache subclass that uses the configured HASH_ALGORITHM instead of MD5.
+
+    Flask-caching uses MD5 by default for cache key generation, which fails
+    in FIPS mode where MD5 is disabled. This class overrides the default
+    hash method to use the algorithm specified by HASH_ALGORITHM config.
+
+    Note: Switching hash algorithms will invalidate existing cache keys,
+    causing a one-time cache miss on upgrade.
+    """
+
+    def memoize(
+        self,
+        timeout: int | None = None,
+        make_name: Callable[..., Any] | None = None,
+        unless: Callable[..., bool] | None = None,
+        forced_update: Callable[..., bool] | None = None,
+        response_filter: Callable[..., Any] | None = None,
+        hash_method: Callable[..., Any] | None = None,
+        cache_none: bool = False,
+        source_check: bool | None = None,
+        args_to_ignore: Any | None = None,
+    ) -> Callable[..., Any]:
+        if hash_method is None:
+            hash_method = get_cache_hash_method()
+        return super().memoize(
+            timeout=timeout,
+            make_name=make_name,
+            unless=unless,
+            forced_update=forced_update,
+            response_filter=response_filter,
+            hash_method=hash_method,
+            cache_none=cache_none,
+            source_check=source_check,
+            args_to_ignore=args_to_ignore,
+        )
+
+    def cached(
+        self,
+        timeout: int | None = None,
+        key_prefix: str = "view/%s",
+        unless: Callable[..., bool] | None = None,
+        forced_update: Callable[..., bool] | None = None,
+        response_filter: Callable[..., Any] | None = None,
+        query_string: bool = False,
+        hash_method: Callable[..., Any] | None = None,
+        cache_none: bool = False,
+        make_cache_key: Callable[..., Any] | None = None,
+        source_check: bool | None = None,
+        response_hit_indication: bool | None = False,
+    ) -> Callable[..., Any]:
+        if hash_method is None:
+            hash_method = get_cache_hash_method()
+        return super().cached(
+            timeout=timeout,
+            key_prefix=key_prefix,
+            unless=unless,
+            forced_update=forced_update,
+            response_filter=response_filter,
+            query_string=query_string,
+            hash_method=hash_method,
+            cache_none=cache_none,
+            make_cache_key=make_cache_key,
+            source_check=source_check,
+            response_hit_indication=response_hit_indication,
+        )
+
+    # pylint: disable=protected-access
+    def _memoize_make_cache_key(
+        self,
+        make_name: Callable[..., Any] | None = None,
+        timeout: Callable[..., Any] | None = None,
+        forced_update: bool = False,
+        hash_method: Callable[..., Any] | None = None,
+        source_check: bool | None = False,
+        args_to_ignore: Any | None = None,
+    ) -> Callable[..., Any]:
+        if hash_method is None:
+            hash_method = get_cache_hash_method()
+        return super()._memoize_make_cache_key(
+            make_name=make_name,
+            timeout=timeout,
+            forced_update=forced_update,
+            hash_method=hash_method,
+            source_check=source_check,
+            args_to_ignore=args_to_ignore,
+        )
+
+
+class ExploreFormDataCache(SupersetCache):
     def get(self, *args: Any, **kwargs: Any) -> Optional[Union[str, Markup]]:
         cache = self.cache.get(*args, **kwargs)
 
@@ -53,10 +160,10 @@ class CacheManager:
     def __init__(self) -> None:
         super().__init__()
 
-        self._cache = Cache()
-        self._data_cache = Cache()
-        self._thumbnail_cache = Cache()
-        self._filter_state_cache = Cache()
+        self._cache = SupersetCache()
+        self._data_cache = SupersetCache()
+        self._thumbnail_cache = SupersetCache()
+        self._filter_state_cache = SupersetCache()
         self._explore_form_data_cache = ExploreFormDataCache()
 
     @staticmethod

--- a/tests/unit_tests/utils/test_cache_manager.py
+++ b/tests/unit_tests/utils/test_cache_manager.py
@@ -1,0 +1,228 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.utils.cache_manager import (
+    get_cache_hash_method,
+    SupersetCache,
+)
+
+
+def test_get_cache_hash_method_returns_sha256():
+    """Test that get_cache_hash_method returns sha256 when config is sha256."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    with patch("superset.utils.cache_manager.current_app", mock_app):
+        result = get_cache_hash_method()
+        assert result == hashlib.sha256
+
+
+def test_get_cache_hash_method_returns_md5():
+    """Test that get_cache_hash_method returns md5 when config is md5."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "md5"}
+
+    with patch("superset.utils.cache_manager.current_app", mock_app):
+        result = get_cache_hash_method()
+        assert result == hashlib.md5
+
+
+def test_superset_cache_memoize_uses_config_hash_method():
+    """Test that SupersetCache.memoize uses config-based hash method."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "memoize", return_value=lambda f: f
+        ) as mock_memoize,
+    ):
+        cache.memoize(timeout=300)
+
+        mock_memoize.assert_called_once()
+        call_kwargs = mock_memoize.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.sha256
+
+
+def test_superset_cache_memoize_with_md5_config():
+    """Test that SupersetCache.memoize uses md5 when configured."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "md5"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "memoize", return_value=lambda f: f
+        ) as mock_memoize,
+    ):
+        cache.memoize(timeout=300)
+
+        mock_memoize.assert_called_once()
+        call_kwargs = mock_memoize.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.md5
+
+
+def test_superset_cache_memoize_allows_explicit_hash_method():
+    """Test that SupersetCache.memoize allows explicit hash_method override."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "memoize", return_value=lambda f: f
+        ) as mock_memoize,
+    ):
+        cache.memoize(timeout=300, hash_method=hashlib.md5)
+
+        mock_memoize.assert_called_once()
+        call_kwargs = mock_memoize.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.md5
+
+
+def test_superset_cache_cached_uses_config_hash_method():
+    """Test that SupersetCache.cached uses config-based hash method."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "cached", return_value=lambda f: f
+        ) as mock_cached,
+    ):
+        cache.cached(timeout=300)
+
+        mock_cached.assert_called_once()
+        call_kwargs = mock_cached.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.sha256
+
+
+def test_superset_cache_cached_with_md5_config():
+    """Test that SupersetCache.cached uses md5 when configured."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "md5"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "cached", return_value=lambda f: f
+        ) as mock_cached,
+    ):
+        cache.cached(timeout=300)
+
+        mock_cached.assert_called_once()
+        call_kwargs = mock_cached.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.md5
+
+
+def test_superset_cache_cached_allows_explicit_hash_method():
+    """Test that SupersetCache.cached allows explicit hash_method override."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0], "cached", return_value=lambda f: f
+        ) as mock_cached,
+    ):
+        cache.cached(timeout=300, hash_method=hashlib.md5)
+
+        mock_cached.assert_called_once()
+        call_kwargs = mock_cached.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.md5
+
+
+def test_superset_cache_memoize_make_cache_key_uses_config():
+    """Test that SupersetCache._memoize_make_cache_key uses config hash method."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0],
+            "_memoize_make_cache_key",
+            return_value=lambda *args, **kwargs: "cache_key",
+        ) as mock_make_key,
+    ):
+        cache._memoize_make_cache_key(make_name=None, timeout=300)
+
+        mock_make_key.assert_called_once()
+        call_kwargs = mock_make_key.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.sha256
+
+
+def test_superset_cache_memoize_make_cache_key_allows_explicit_hash():
+    """Test _memoize_make_cache_key allows explicit hash_method override."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": "sha256"}
+
+    cache = SupersetCache()
+
+    with (
+        patch("superset.utils.cache_manager.current_app", mock_app),
+        patch.object(
+            cache.__class__.__bases__[0],
+            "_memoize_make_cache_key",
+            return_value=lambda *args, **kwargs: "cache_key",
+        ) as mock_make_key,
+    ):
+        cache._memoize_make_cache_key(
+            make_name=None, timeout=300, hash_method=hashlib.md5
+        )
+
+        mock_make_key.assert_called_once()
+        call_kwargs = mock_make_key.call_args[1]
+        assert call_kwargs["hash_method"] == hashlib.md5
+
+
+@pytest.mark.parametrize(
+    "algorithm,expected_hash_method",
+    [
+        ("sha256", hashlib.sha256),
+        ("md5", hashlib.md5),
+    ],
+)
+def test_get_cache_hash_method_parametrized(algorithm, expected_hash_method):
+    """Parametrized test for get_cache_hash_method with different algorithms."""
+    mock_app = MagicMock()
+    mock_app.config = {"HASH_ALGORITHM": algorithm}
+
+    with patch("superset.utils.cache_manager.current_app", mock_app):
+        result = get_cache_hash_method()
+        assert result == expected_hash_method


### PR DESCRIPTION
### SUMMARY

Flask-caching uses MD5 by default for cache key generation, which fails in FIPS mode where MD5 is disabled. This PR adds a `SupersetCache` class that uses the `HASH_ALGORITHM` config setting instead of hardcoded MD5.

**Changes:**
- Add `ConfigurableHashMethod` class that defers hash algorithm selection to runtime (reads from `HASH_ALGORITHM` config when the hash is computed, not at decorator time)
- Add `SupersetCache` class extending `Cache` with configurable hash method defaults
- Update `CacheManager` to use `SupersetCache` for all cache instances
- Update `etag_cache` decorator to use configurable hash method
- Add unit tests for new functionality

**Why a callable class?**

Flask-caching's `@memoize()` decorator is evaluated at module import time (class definition), before any Flask app context exists. The `ConfigurableHashMethod` class acts like a hashlib function but defers the config lookup to when the hash is actually computed (at function call time, when app context is available).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - no UI changes

### TESTING INSTRUCTIONS

1. Run unit tests: `pytest tests/unit_tests/utils/test_cache_manager.py -v`
2. Verify cache functionality works with both `HASH_ALGORITHM = "sha256"` (default) and `HASH_ALGORITHM = "md5"`

### ADDITIONAL INFORMATION

- ⚠️ Switching hash algorithms will invalidate existing cache keys (one-time cache miss on upgrade)
- This change is required for FIPS compliance where MD5 is disabled at the OS level

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback &amp; is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
