### PR TITLE
fix: Druid ARRAY Expressions (#36926)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dependencies = [
     "slack_sdk>=3.19.0, <4",
     "sqlalchemy>=1.4, <2",
     "sqlalchemy-utils>=0.38.3, <0.39",
-    "sqlglot>=27.15.2, <28",
+    "sqlglot>=28.6.0, <29",
     # newer pandas needs 0.9+
     "tabulate>=0.9.0, <1.0",
     "typing-extensions>=4, <5",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -400,7 +400,7 @@ sqlalchemy-utils==0.38.3
     #   apache-superset (pyproject.toml)
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==27.15.2
+sqlglot==28.6.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -993,7 +993,7 @@ sqlalchemy-utils==0.38.3
     #   apache-superset
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==27.15.2
+sqlglot==28.6.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset-core/pyproject.toml
+++ b/superset-core/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pydantic>=2.8.0",
     "sqlalchemy>=1.4.0,<2.0",
     "sqlalchemy-utils>=0.38.0",
-    "sqlglot>=27.15.2, <28",
+    "sqlglot>=28.6.0, <29",
     "typing-extensions>=4.0.0",
 ]
 


### PR DESCRIPTION
### SUMMARY
Druid ARRAY Expressions were translated falsely to `ARRAY()` in `sqlglot` versions prior to `28.6.0`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/apache/superset/issues/36926
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API: upgrades sqlglot from `27` to `28`
- [x] Removes existing feature or API: upgrades sqlglot from `27` to `28`
