### PR TITLE
fix(mcp): tools not listed when JWT auth is enabled

### DIFF
--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -180,21 +180,21 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
         return None
 
     try:
-        from fastmcp.server.auth.providers.bearer import BearerAuthProvider
+        from fastmcp.server.auth.providers.jwt import JWTVerifier
 
         # For HS256 (symmetric), use the secret as the public_key parameter
         if app.config.get("MCP_JWT_ALGORITHM") == "HS256" and secret:
-            auth_provider = BearerAuthProvider(
+            auth_provider = JWTVerifier(
                 public_key=secret,  # HS256 uses secret as key
                 issuer=app.config.get("MCP_JWT_ISSUER"),
                 audience=app.config.get("MCP_JWT_AUDIENCE"),
                 algorithm="HS256",
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
             )
-            logger.info("Created BearerAuthProvider with HS256 secret")
+            logger.info("Created JWTVerifier with HS256 secret")
         else:
             # For RS256 (asymmetric), use public key or JWKS
-            auth_provider = BearerAuthProvider(
+            auth_provider = JWTVerifier(
                 jwks_uri=jwks_uri,
                 public_key=public_key,
                 issuer=app.config.get("MCP_JWT_ISSUER"),
@@ -203,7 +203,7 @@ def create_default_mcp_auth_factory(app: Flask) -> Optional[Any]:
                 required_scopes=app.config.get("MCP_REQUIRED_SCOPES", []),
             )
             logger.info(
-                "Created BearerAuthProvider with jwks_uri=%s, public_key=%s",
+                "Created JWTVerifier with jwks_uri=%s, public_key=%s",
                 jwks_uri,
                 "***" if public_key else None,
             )


### PR DESCRIPTION
### SUMMARY

When `MCP_AUTH_ENABLED=True` with a custom `MCP_AUTH_FACTORY`, the MCP server would authenticate clients successfully but return zero tools. This is because `init_fastmcp_server()` was creating a **new** FastMCP instance (with auth but no tools) instead of configuring the existing global instance that has all tools registered via `@tool` decorators.

**Root cause:** In `app.py`, when any "custom parameter" (like `auth`) was provided, the code created a brand new `FastMCP` instance via `create_mcp_app()`. But all tools are registered on the module-level `mcp` instance during import — the new instance had none.

**Fix (3 parts):**
1. `init_fastmcp_server()` now applies auth/middleware/config directly to the global `mcp` instance instead of creating a new one
2. Uses `mcp._mcp_server.name` / `.instructions` since these are read-only properties in FastMCP 2.14.x
3. Replaces references to non-existent `BearerAuthProvider` with `JWTVerifier` (the actual class in fastmcp 2.14.x)

### TESTING INSTRUCTIONS

1. Configure JWT auth in `superset_config.py`:
   ```python
   MCP_AUTH_ENABLED = True

   def custom_mcp_auth_factory(app):
       from fastmcp.server.auth.providers.jwt import JWTVerifier
       return JWTVerifier(
           public_key="dev_secret_for_mcp_tokens_change_in_production",
           issuer="superset-mcp-dev",
           audience="superset-mcp-api",
           algorithm="HS256",
           required_scopes=[],
       )

   MCP_AUTH_FACTORY = custom_mcp_auth_factory
   MCP_DEV_USERNAME = "admin"
   ```

2. Start the MCP server: `superset mcp run --port 5008`

3. Generate a test token and call `tools/list`:
   ```bash
   TOKEN=$(python -c "
   import jwt
   from datetime import datetime, timezone, timedelta
   print(jwt.encode(
       {'sub': 'admin', 'iss': 'superset-mcp-dev', 'aud': 'superset-mcp-api',
        'exp': datetime.now(timezone.utc) + timedelta(hours=1)},
       'dev_secret_for_mcp_tokens_change_in_production', algorithm='HS256'))
   ")
   curl -s -X POST http://localhost:5008/mcp \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Authorization: Bearer $TOKEN" \
     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
   ```

4. Verify tools are returned (should see `generate_chart`, `list_dashboards`, etc.)
5. Verify request without token is rejected with `invalid_token`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API