### PR TITLE
fix: variable shadowing in test_connection command

### DIFF
--- a/superset/commands/database/test_connection.py
+++ b/superset/commands/database/test_connection.py
@@ -95,7 +95,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
         ex_str = ""
 
         url = make_url_safe(self._uri)
-        engine = url.get_backend_name()
+        engine_name = url.get_backend_name()
 
         serialized_encrypted_extra = self._properties.get(
             "masked_encrypted_extra",
@@ -136,7 +136,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     "test_connection_attempt",
                     ssh_tunnel_properties,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
 
             with database.get_sqla_engine() as engine:
@@ -174,7 +174,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     "test_connection_success",
                     ssh_tunnel_properties,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
 
         except (NoSuchModuleError, ModuleNotFoundError) as ex:
@@ -184,12 +184,12 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     ssh_tunnel_properties,
                     ex,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
             raise DatabaseTestConnectionDriverError(
                 message=_(
                     "Could not load database driver for: %(engine)s",
-                    engine=engine,
+                    engine=engine_name,
                 ),
             ) from ex
         except DBAPIError as ex:
@@ -199,7 +199,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     ssh_tunnel_properties,
                     ex,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
 
             if not database:
@@ -218,7 +218,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     ssh_tunnel_properties,
                     ex,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
             raise DatabaseSecurityUnsafeError(message=str(ex)) from ex
         except (SupersetTimeoutException, SSHTunnelingNotEnabledError) as ex:
@@ -228,7 +228,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     ssh_tunnel_properties,
                     ex,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
             # bubble up the exception to return proper status code
             raise
@@ -246,7 +246,7 @@ class TestConnectionDatabaseCommand(BaseCommand):
                     ssh_tunnel_properties,
                     ex,
                 ),
-                engine=engine,
+                engine=engine_name,
             )
             errors = database.db_engine_spec.extract_errors(ex, self._context)
             raise DatabaseTestConnectionUnexpectedError(errors) from ex


### PR DESCRIPTION
### SUMMARY

Fixes variable shadowing bug in `TestConnectionDatabaseCommand` where the `engine` variable (initially set to the backend name string) was being shadowed by the SQLAlchemy Engine object from the context manager. This caused the wrong value type to be passed to event logger calls.

The fix renames the initial variable to `engine_name` to avoid the shadowing issue.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - backend logging fix

### TESTING INSTRUCTIONS

1. Run existing unit tests: `pytest tests/unit_tests/commands/databases/test_connection_test.py`
2. Test database connection flow and verify event logging works correctly

### ADDITIONAL INFORMATION

- [x] Has associated issue: N/A
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
