### PR TITLE
fix: Rename Truncate Axis to Truncate Y Axis in bar chart controls

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -247,7 +247,7 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           default: truncateYAxis,
           renderTrigger: true,
           description: t(
-              'It’s not recommended to truncate Y axis in Bar chart.',
+            'It’s not recommended to truncate Y axis in Bar chart.',
           ),
           visibility: ({ controls }: ControlPanelsContainerProps) =>
             isXAxis ? isHorizontal(controls) : isVertical(controls),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -243,10 +243,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         name: 'truncateYAxis',
         config: {
           type: 'CheckboxControl',
-          label: t('Truncate Axis'),
+          label: t('Truncate Y Axis'),
           default: truncateYAxis,
           renderTrigger: true,
-          description: t('It’s not recommended to truncate axis in Bar chart.'),
+          description: t('It’s not recommended to truncate Y axis in Bar chart.'),
           visibility: ({ controls }: ControlPanelsContainerProps) =>
             isXAxis ? isHorizontal(controls) : isVertical(controls),
           disableStash: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -246,7 +246,9 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
           label: t('Truncate Y Axis'),
           default: truncateYAxis,
           renderTrigger: true,
-          description: t('It’s not recommended to truncate Y axis in Bar chart.'),
+          description: t(
+              'It’s not recommended to truncate Y axis in Bar chart.',
+          ),
           visibility: ({ controls }: ControlPanelsContainerProps) =>
             isXAxis ? isHorizontal(controls) : isVertical(controls),
           disableStash: true,


### PR DESCRIPTION
This PR renames the “Truncate Axis” control label to “Truncate Y Axis” to maintain consistency with the existing “Truncate X Axis” option in bar chart controls.

Fixes #37400 
