### PR TITLE
feat(charts): improve negative stacked bar label positioning and accessibility

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -143,7 +143,7 @@ export const getBaselineSeriesForStream = (
   };
 };
 
-export function transformNegativeLabelsPosition(
+export function optimizeBarLabelPlacement(
   series: SeriesOption,
   isHorizontal: boolean,
 ): TimeseriesDataRecord[] {
@@ -351,7 +351,7 @@ export function transformSeries(
     ...series,
     ...(Array.isArray(data) && seriesType === 'bar'
       ? {
-          data: transformNegativeLabelsPosition(series, isHorizontal),
+          data: optimizeBarLabelPlacement(series, isHorizontal),
         }
       : null),
     connectNulls,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -22,14 +22,16 @@ import { supersetTheme } from '@apache-superset/core/ui';
 import type { SeriesOption } from 'echarts';
 import { EchartsTimeseriesSeriesType } from '../../src';
 import { TIMESERIES_CONSTANTS } from '../../src/constants';
-import { LegendOrientation } from '../../src/types';
+import {
+  LegendOrientation,
+  EchartsTimeseriesChartProps,
+} from '../../src/types';
 import {
   transformSeries,
   transformNegativeLabelsPosition,
   getPadding,
 } from '../../src/Timeseries/transformers';
 import transformProps from '../../src/Timeseries/transformProps';
-import { EchartsTimeseriesChartProps } from '../../src/types';
 import * as seriesUtils from '../../src/utils/series';
 
 // Mock the colorScale function
@@ -215,15 +217,34 @@ describe('transformNegativeLabelsPosition', () => {
       stack: 'obs',
     };
 
-    const result =
-      Array.isArray(series.data) && series.type === 'bar' && !series.stack
-        ? transformNegativeLabelsPosition(series, isHorizontal)
-        : series.data;
-    expect((result as any)[0].label).toBe(undefined);
-    expect((result as any)[1].label).toBe(undefined);
-    expect((result as any)[2].label).toBe(undefined);
-    expect((result as any)[3].label).toBe(undefined);
-    expect((result as any)[4].label).toBe(undefined);
+    const result = transformNegativeLabelsPosition(series, isHorizontal, true);
+    expect((result as any)[0].label.position).toBe('insideTop');
+    expect((result as any)[1].label.position).toBe('insideTop');
+    expect((result as any)[2].label.position).toBe('insideBottom');
+    expect((result as any)[3].label.position).toBe('insideBottom');
+    expect((result as any)[4].label.position).toBe('insideTop');
+  });
+
+  it('label position for horizontal stacked charts', () => {
+    const isHorizontal = true;
+    const series: SeriesOption = {
+      data: [
+        [1, 2020],
+        [-3, 2021],
+        [2, 2022],
+        [-4, 2023],
+        [-6, 2024],
+      ],
+      type: EchartsTimeseriesSeriesType.Bar,
+      stack: 'obs',
+    };
+
+    const result = transformNegativeLabelsPosition(series, isHorizontal, true);
+    expect((result as any)[0].label.position).toBe('insideRight');
+    expect((result as any)[1].label.position).toBe('insideLeft');
+    expect((result as any)[2].label.position).toBe('insideRight');
+    expect((result as any)[3].label.position).toBe('insideLeft');
+    expect((result as any)[4].label.position).toBe('insideLeft');
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -223,7 +223,7 @@ describe('optimizeBarLabelPlacement', () => {
     expect((result as any)[4].label.position).toBe('insideTop');
   });
 
-  it('label position for horizontal stacked charts', () => {
+  test('label position for horizontal stacked charts', () => {
     const isHorizontal = true;
     const series: SeriesOption = {
       data: [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -34,10 +34,12 @@ import {
 import transformProps from '../../src/Timeseries/transformProps';
 import * as seriesUtils from '../../src/utils/series';
 
-// Mock the colorScale function
-const mockColorScale = jest.fn(
-  () => '#1f77b4',
-) as Partial<CategoricalColorScale>;
+// Mock the colorScale function to return different colors based on key
+const mockColorScale = jest.fn((key: string) => {
+  if (key === 'test-key') return '#1f77b4'; // blue
+  if (key === 'series-key') return '#ff7f0e'; // orange
+  return '#2ca02c'; // green for any other key
+}) as unknown as CategoricalColorScale;
 
 describe('transformSeries', () => {
   const series = { name: 'test-series' };
@@ -51,7 +53,8 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect((result as any)?.itemStyle.color).toBeDefined();
+    expect(mockColorScale).toHaveBeenCalledWith('test-key', 1);
+    expect((result as any)?.itemStyle.color).toBe('#1f77b4');
   });
 
   test('should use seriesKey if timeShiftColor is not enabled', () => {
@@ -63,7 +66,8 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect((result as any)?.itemStyle.color).toBeDefined();
+    expect(mockColorScale).toHaveBeenCalledWith('series-key', 2);
+    expect((result as any)?.itemStyle.color).toBe('#ff7f0e');
   });
 
   test('should apply border styles for bar series with connectNulls', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../../src/types';
 import {
   transformSeries,
-  transformNegativeLabelsPosition,
+  optimizeBarLabelPlacement,
   getPadding,
 } from '../../src/Timeseries/transformers';
 import transformProps from '../../src/Timeseries/transformProps';
@@ -129,7 +129,7 @@ describe('transformSeries', () => {
   });
 });
 
-describe('transformNegativeLabelsPosition', () => {
+describe('optimizeBarLabelPlacement', () => {
   test('label position for non-stacked vertical charts', () => {
     const isHorizontal = false;
     const series: SeriesOption = {
@@ -143,7 +143,7 @@ describe('transformNegativeLabelsPosition', () => {
       type: EchartsTimeseriesSeriesType.Bar,
       stack: undefined,
     };
-    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    const result = optimizeBarLabelPlacement(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideTop');
     expect((result as any)[1].label.position).toBe('insideTop');
     expect((result as any)[2].label.position).toBe('insideBottom');
@@ -165,7 +165,7 @@ describe('transformNegativeLabelsPosition', () => {
       stack: undefined,
     };
 
-    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    const result = optimizeBarLabelPlacement(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideRight');
     expect((result as any)[1].label.position).toBe('insideLeft');
     expect((result as any)[2].label.position).toBe('insideRight');
@@ -192,7 +192,7 @@ describe('transformNegativeLabelsPosition', () => {
       !series.stack &&
       series.type !== 'line' &&
       series.type === 'bar'
-        ? transformNegativeLabelsPosition(series, isHorizontal)
+        ? optimizeBarLabelPlacement(series, isHorizontal)
         : series.data;
     expect((result as any)[0].label).toBe(undefined);
     expect((result as any)[1].label).toBe(undefined);
@@ -215,7 +215,7 @@ describe('transformNegativeLabelsPosition', () => {
       stack: 'obs',
     };
 
-    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    const result = optimizeBarLabelPlacement(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideTop');
     expect((result as any)[1].label.position).toBe('insideTop');
     expect((result as any)[2].label.position).toBe('insideBottom');
@@ -237,7 +237,7 @@ describe('transformNegativeLabelsPosition', () => {
       stack: 'obs',
     };
 
-    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    const result = optimizeBarLabelPlacement(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideRight');
     expect((result as any)[1].label.position).toBe('insideLeft');
     expect((result as any)[2].label.position).toBe('insideRight');

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -36,8 +36,8 @@ import * as seriesUtils from '../../src/utils/series';
 
 // Mock the colorScale function
 const mockColorScale = jest.fn(
-  (key: string, sliceId?: number) => `color-for-${key}-${sliceId}`,
-) as unknown as CategoricalColorScale;
+  () => '#1f77b4',
+) as Partial<CategoricalColorScale>;
 
 describe('transformSeries', () => {
   const series = { name: 'test-series' };
@@ -51,7 +51,7 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect((result as any)?.itemStyle.color).toBe('color-for-test-key-1');
+    expect((result as any)?.itemStyle.color).toBeDefined();
   });
 
   test('should use seriesKey if timeShiftColor is not enabled', () => {
@@ -63,7 +63,7 @@ describe('transformSeries', () => {
 
     const result = transformSeries(series, mockColorScale, 'test-key', opts);
 
-    expect((result as any)?.itemStyle.color).toBe('color-for-series-key-2');
+    expect((result as any)?.itemStyle.color).toBeDefined();
   });
 
   test('should apply border styles for bar series with connectNulls', () => {
@@ -126,7 +126,7 @@ describe('transformSeries', () => {
 });
 
 describe('transformNegativeLabelsPosition', () => {
-  test('label position bottom of negative value no Horizontal', () => {
+  test('label position for non-stacked vertical charts', () => {
     const isHorizontal = false;
     const series: SeriesOption = {
       data: [
@@ -139,15 +139,12 @@ describe('transformNegativeLabelsPosition', () => {
       type: EchartsTimeseriesSeriesType.Bar,
       stack: undefined,
     };
-    const result =
-      Array.isArray(series.data) && series.type === 'bar' && !series.stack
-        ? transformNegativeLabelsPosition(series, isHorizontal)
-        : series.data;
-    expect((result as any)[0].label).toBe(undefined);
-    expect((result as any)[1].label).toBe(undefined);
-    expect((result as any)[2].label.position).toBe('outside');
-    expect((result as any)[3].label.position).toBe('outside');
-    expect((result as any)[4].label).toBe(undefined);
+    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    expect((result as any)[0].label.position).toBe('insideTop');
+    expect((result as any)[1].label.position).toBe('insideTop');
+    expect((result as any)[2].label.position).toBe('insideBottom');
+    expect((result as any)[3].label.position).toBe('insideBottom');
+    expect((result as any)[4].label.position).toBe('insideTop');
   });
 
   test('label position left of negative value is Horizontal', () => {
@@ -164,15 +161,12 @@ describe('transformNegativeLabelsPosition', () => {
       stack: undefined,
     };
 
-    const result =
-      Array.isArray(series.data) && series.type === 'bar' && !series.stack
-        ? transformNegativeLabelsPosition(series, isHorizontal)
-        : series.data;
-    expect((result as any)[0].label).toBe(undefined);
-    expect((result as any)[1].label.position).toBe('outside');
-    expect((result as any)[2].label).toBe(undefined);
-    expect((result as any)[3].label.position).toBe('outside');
-    expect((result as any)[4].label.position).toBe('outside');
+    const result = transformNegativeLabelsPosition(series, isHorizontal);
+    expect((result as any)[0].label.position).toBe('insideRight');
+    expect((result as any)[1].label.position).toBe('insideLeft');
+    expect((result as any)[2].label.position).toBe('insideRight');
+    expect((result as any)[3].label.position).toBe('insideLeft');
+    expect((result as any)[4].label.position).toBe('insideLeft');
   });
 
   test('label position to line type', () => {
@@ -217,7 +211,7 @@ describe('transformNegativeLabelsPosition', () => {
       stack: 'obs',
     };
 
-    const result = transformNegativeLabelsPosition(series, isHorizontal, true);
+    const result = transformNegativeLabelsPosition(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideTop');
     expect((result as any)[1].label.position).toBe('insideTop');
     expect((result as any)[2].label.position).toBe('insideBottom');
@@ -239,7 +233,7 @@ describe('transformNegativeLabelsPosition', () => {
       stack: 'obs',
     };
 
-    const result = transformNegativeLabelsPosition(series, isHorizontal, true);
+    const result = transformNegativeLabelsPosition(series, isHorizontal);
     expect((result as any)[0].label.position).toBe('insideRight');
     expect((result as any)[1].label.position).toBe('insideLeft');
     expect((result as any)[2].label.position).toBe('insideRight');


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes label positioning and readability issues for negative values in stacked bar charts. Previously, labels on negative stacked bars were positioned outside the chart area making them hard to understand in relation to their data segments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### After
<img width="482" height="405" alt="image" src="https://github.com/user-attachments/assets/b014fbba-ccd4-445f-95d0-b64a2cbdedc9" />
<img width="469" height="412" alt="image" src="https://github.com/user-attachments/assets/6e2111fc-4faa-4795-b2db-4eee09389c83" />


#### Before
<img width="916" height="933" alt="image" src="https://github.com/user-attachments/assets/fe0889c6-26c1-4c04-8b53-32381597036b" />
<img width="401" height="644" alt="image" src="https://github.com/user-attachments/assets/c724941b-75c2-4e83-a869-67a57c0be951" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
#### Test only with NEGATIVE values
1. Create a stacked bar chart with mixed positive and negative values:
2. Go to http://localhost:8088/sqllab and paste this script for ALL negative values
```SQL
WITH chart_data AS (
SELECT *
FROM (VALUES
('Bar 1', 'Segment A', -10),
('Bar 1', 'Segment B', -5),
('Bar 2', 'Segment A', -7),
('Bar 2', 'Segment B', -3),
('Bar 3', 'Segment A', -12),
('Bar 3', 'Segment B', -6)
) AS t(bar, segment, value)
)
SELECT *
FROM chart_data;
```

Script for MIXED values
```SQL
-- True mixed positive/negative values
WITH chart_data AS (
SELECT *
FROM (VALUES
-- Bar 1: Mixed values
('Bar 1', 'Segment A', -10),
('Bar 1', 'Segment B', 8),

-- Bar 2: Mixed values
('Bar 2', 'Segment A', 5),
('Bar 2', 'Segment B', -7),

-- Bar 3: Mixed values  
('Bar 3', 'Segment A', -12),
('Bar 3', 'Segment B', 15)
) AS t(column1, column2, column3)
)
SELECT *
FROM chart_data;
```
 
3. Then press the "Create chart" button
<img width="190" height="103" alt="image" src="https://github.com/user-attachments/assets/8fbacf08-bc26-467a-833a-b2f81894854d" />

4. Configure:
    - Chart Type: Time-series Bar Chart
    - X-axis: column1
    - Metrics: SUM(column3)
    - Customize tab:
        - Show Value: ✓ Enable
        - Stacked Style: Stack
5. Check the labels are positioned inside the bar at the very edge
6. Change the color scheme and make sure the label changes its color to keep the color ratio according to AA standard 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
