### PR TITLE
fix(chart): enable cross-filter on bar charts without dimensions

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
@@ -309,3 +309,93 @@ test('falls back to window resize listener when ResizeObserver is unavailable', 
   addEventListenerSpy.mockRestore();
   removeEventListenerSpy.mockRestore();
 });
+
+// Test for issue #25334: Bar chart cross-filter without dimensions
+test('emits cross-filter on X-axis value when no dimensions and categorical X-axis', async () => {
+  const setDataMaskMock = jest.fn();
+
+  const propsWithCategoricalXAxis: TimeseriesChartTransformedProps = {
+    ...defaultProps,
+    emitCrossFilters: true,
+    setDataMask: setDataMaskMock,
+    groupby: [], // No dimensions
+    xAxis: {
+      label: 'category_column',
+      type: AxisType.Category, // Categorical X-axis
+    },
+  };
+
+  render(<EchartsTimeseries {...propsWithCategoricalXAxis} />);
+
+  // Get the click handler from the mock
+  const lastCall = mockEchart.mock.calls.at(-1);
+  expect(lastCall).toBeDefined();
+  const [props] = lastCall as [EchartsProps];
+  expect(props.eventHandlers).toBeDefined();
+  expect(props.eventHandlers?.click).toBeDefined();
+
+  // Simulate a click event with X-axis data
+  const clickHandler = props.eventHandlers?.click;
+  if (clickHandler) {
+    clickHandler({
+      seriesName: 'Sales', // This is the metric name
+      data: ['Product A', 100], // X-axis value is 'Product A'
+      name: 'Product A',
+      dataIndex: 0,
+    });
+
+    // Wait for the timer (TIMER_DURATION = 300ms)
+    await waitFor(
+      () => {
+        expect(setDataMaskMock).toHaveBeenCalled();
+      },
+      { timeout: 500 },
+    );
+
+    // Verify the cross-filter uses the X-axis column and value, not the metric
+    const dataMaskCall = setDataMaskMock.mock.calls[0][0];
+    expect(dataMaskCall.extraFormData.filters).toEqual([
+      {
+        col: 'category_column', // X-axis column
+        op: 'IN',
+        val: ['Product A'], // X-axis value, not 'Sales' (metric)
+      },
+    ]);
+  }
+});
+
+test('does not emit cross-filter when no dimensions and time-based X-axis', async () => {
+  const setDataMaskMock = jest.fn();
+
+  const propsWithTimeXAxis: TimeseriesChartTransformedProps = {
+    ...defaultProps,
+    emitCrossFilters: true,
+    setDataMask: setDataMaskMock,
+    groupby: [], // No dimensions
+    xAxis: {
+      label: '__timestamp',
+      type: AxisType.Time, // Time-based X-axis (not categorical)
+    },
+  };
+
+  render(<EchartsTimeseries {...propsWithTimeXAxis} />);
+
+  const lastCall = mockEchart.mock.calls.at(-1);
+  expect(lastCall).toBeDefined();
+  const [props] = lastCall as [EchartsProps];
+
+  // Simulate a click event
+  const clickHandler = props.eventHandlers?.click;
+  if (clickHandler) {
+    clickHandler({
+      seriesName: 'Sales',
+      data: [1609459200000, 100], // Timestamp
+      name: '2021-01-01',
+      dataIndex: 0,
+    });
+
+    // Wait a bit and verify setDataMask was NOT called
+    await new Promise(resolve => setTimeout(resolve, 400));
+    expect(setDataMaskMock).not.toHaveBeenCalled();
+  }
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -231,10 +231,9 @@ export default function EchartsTimeseries({
           // Cross-filter by dimension (original behavior)
           const { seriesName: name } = props;
           handleChange(name);
-        } else if (canCrossFilterByXAxis && props.data) {
+        } else if (canCrossFilterByXAxis && props.data?.[0] != null) {
           // Cross-filter by X-axis value when no dimensions (issue #25334)
-          const xAxisValue = props.data[0];
-          handleXAxisChange(xAxisValue);
+          handleXAxisChange(props.data[0]);
         }
       }, TIMER_DURATION);
     },
@@ -316,7 +315,7 @@ export default function EchartsTimeseries({
         let crossFilter;
         if (hasDimensions) {
           crossFilter = getCrossFilterDataMask(seriesName);
-        } else if (canCrossFilterByXAxis && data) {
+        } else if (canCrossFilterByXAxis && data?.[0] != null) {
           crossFilter = getXAxisCrossFilterDataMask(data[0]);
         }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -419,7 +419,7 @@ export default function transformProps(
         timeCompare: array,
         timeShiftColor,
         theme,
-        hasDimensions: groupBy.length > 0,
+        hasDimensions: (groupBy?.length ?? 0) > 0,
       },
     );
     if (transformedSeries) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -419,6 +419,7 @@ export default function transformProps(
         timeCompare: array,
         timeShiftColor,
         theme,
+        hasDimensions: groupBy.length > 0,
       },
     );
     if (transformedSeries) {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -196,6 +196,7 @@ export function transformSeries(
     timeCompare?: string[];
     timeShiftColor?: boolean;
     theme?: SupersetTheme;
+    hasDimensions?: boolean;
   },
 ): SeriesOption | undefined {
   const { name, data } = series;
@@ -237,8 +238,12 @@ export function transformSeries(
   const isConfidenceBand =
     forecastSeries.type === ForecastSeriesEnum.ForecastLower ||
     forecastSeries.type === ForecastSeriesEnum.ForecastUpper;
+  // When cross-filtering by X-axis (no dimensions), selectedValues contains
+  // X-axis values rather than series names, so skip series-level dimming.
   const isFiltered =
-    filterState?.selectedValues && !filterState?.selectedValues.includes(name);
+    opts.hasDimensions !== false &&
+    filterState?.selectedValues &&
+    !filterState?.selectedValues.includes(name);
   const opacity = isFiltered
     ? OpacityEnum.SemiTransparent
     : opts.lineStyle?.opacity || OpacityEnum.NonTransparent;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -89,6 +89,34 @@ describe('transformSeries', () => {
     expect((result as any).itemStyle.borderType).toBeUndefined();
     expect((result as any).itemStyle.borderColor).toBeUndefined();
   });
+
+  it('should dim series when selectedValues does not include series name (dimension-based filtering)', () => {
+    const opts = {
+      filterState: { selectedValues: ['other-series'] },
+      hasDimensions: true,
+      seriesType: EchartsTimeseriesSeriesType.Bar,
+      timeShiftColor: false,
+    };
+
+    const result = transformSeries(series, mockColorScale, 'test-key', opts);
+
+    // OpacityEnum.SemiTransparent = 0.3
+    expect((result as any).itemStyle.opacity).toBe(0.3);
+  });
+
+  it('should not dim series when hasDimensions is false (X-axis cross-filtering)', () => {
+    const opts = {
+      filterState: { selectedValues: ['Product A'] },
+      hasDimensions: false,
+      seriesType: EchartsTimeseriesSeriesType.Bar,
+      timeShiftColor: false,
+    };
+
+    const result = transformSeries(series, mockColorScale, 'test-key', opts);
+
+    // OpacityEnum.NonTransparent = 1 (not dimmed)
+    expect((result as any).itemStyle.opacity).toBe(1);
+  });
 });
 
 describe('transformNegativeLabelsPosition', () => {


### PR DESCRIPTION
## Summary

Fixes #25334 - Bar charts now emit cross-filters using the X-axis category value when no dimensions are configured.

**The Problem:**
When a bar chart has no "Dimensions" field set, clicking on a bar did nothing - cross-filtering was completely disabled. Users expected clicking on a bar (e.g., "Product A") to filter other charts by that X-axis value.

**The Fix:**
When no dimensions exist but the X-axis is categorical, use the X-axis column/value for cross-filtering:

- Added `getXAxisCrossFilterDataMask()` - creates cross-filter using X-axis column and clicked value
- Added `handleXAxisChange()` - emits the X-axis-based cross-filter
- Modified click handler to check `canCrossFilterByXAxis` (categorical X-axis without dimensions)
- Updated context menu to provide X-axis cross-filter option

**Before:** Clicking a bar with no dimensions → nothing happens
**After:** Clicking a bar with no dimensions → filters by X-axis category value

## Test plan

- [x] Added unit tests for new cross-filter behavior
- [x] Existing tests pass
- [ ] Manual testing: Create a bar chart without dimensions, click on bars to verify cross-filtering works

## Technical Details

The key insight was that the X-axis value is available in `props.data[0]` during click events, but was never used for cross-filtering. The contextmenu handler already had logic to extract this value for drill-to-detail, so the fix follows the same pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)