### PR TITLE
fix(sqllab): invalid height in ResultTable

### DIFF
--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -28,7 +28,7 @@ import {
 } from '@superset-ui/core/components';
 import ProgressBar from '@superset-ui/core/components/ProgressBar';
 import { t } from '@apache-superset/core/translation';
-import { QueryResponse, QueryState } from '@superset-ui/core';
+import { QueryResponse } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { shallowEqual, useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';

--- a/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryTable/index.tsx
@@ -407,24 +407,12 @@ const QueryTable = ({
         modalBody={
           selectedQuery ? (
             <ModalResultSetWrapper>
-              {(() => {
-                const height =
-                  reduxQueries[selectedQuery.id]?.state ===
-                    QueryState.Success &&
-                  reduxQueries[selectedQuery.id]?.results
-                    ? Math.floor(window.innerHeight * 0.5)
-                    : undefined;
-                return (
-                  <ResultSet
-                    showSql
-                    queryId={selectedQuery.id}
-                    displayLimit={displayLimit}
-                    defaultQueryLimit={1000}
-                    useFixedHeight
-                    height={height}
-                  />
-                );
-              })()}
+              <ResultSet
+                showSql
+                queryId={selectedQuery.id}
+                displayLimit={displayLimit}
+                defaultQueryLimit={1000}
+              />
             </ModalResultSetWrapper>
           ) : null
         }

--- a/superset-frontend/src/SqlLab/components/QueryTable/styles.ts
+++ b/superset-frontend/src/SqlLab/components/QueryTable/styles.ts
@@ -44,4 +44,5 @@ export const ModalResultSetWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  height: 500px;
 `;

--- a/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
+++ b/superset-frontend/src/SqlLab/components/ResultSet/index.tsx
@@ -107,14 +107,12 @@ export interface ResultSetProps {
   csv?: boolean;
   database?: Record<string, any>;
   displayLimit: number;
-  height?: number;
   queryId: string;
   search?: boolean;
   showSql?: boolean;
   showSqlInline?: boolean;
   visualize?: boolean;
   defaultQueryLimit: number;
-  useFixedHeight?: boolean;
 }
 
 const ResultContainer = styled.div`
@@ -165,14 +163,12 @@ const ResultSet = ({
   csv = true,
   database = {},
   displayLimit,
-  height,
   queryId,
   search = true,
   showSql = false,
   showSqlInline = false,
   visualize = true,
   defaultQueryLimit,
-  useFixedHeight = false,
 }: ResultSetProps) => {
   const streamingThreshold = useSelector(
     (state: SqlLabRootState) =>
@@ -758,22 +754,18 @@ const ResultSet = ({
                 />
               )}
             </div>
-            {useFixedHeight && height !== undefined ? (
-              <ResultTable {...tableProps} height={height} />
-            ) : (
-              <div
-                css={css`
-                  flex: 1 1 auto;
-                  padding-bottom: ${theme.sizeUnit * 3}px;
-                `}
-              >
-                <AutoSizer disableWidth>
-                  {({ height: autoHeight }) => (
-                    <ResultTable {...tableProps} height={autoHeight} />
-                  )}
-                </AutoSizer>
-              </div>
-            )}
+            <div
+              css={css`
+                flex: 1 1 auto;
+                padding-bottom: ${theme.sizeUnit * 3}px;
+              `}
+            >
+              <AutoSizer disableWidth>
+                {({ height: autoHeight }) => (
+                  <ResultTable {...tableProps} height={autoHeight} />
+                )}
+              </AutoSizer>
+            </div>
           </ResultContainer>
           <StreamingExportModal
             visible={showStreamingModal}


### PR DESCRIPTION

### SUMMARY
During the process of fixing a bug in #36540, unnecessary logic for calculating the ResultSet table height was added. As a result, the table height does not match the actual content height, making it impossible to view the content at the bottom of the table. In the case of ResultTable, the height is automatically adjusted using AutoSizer, so if you provide the height via CSS, the table will be rendered correctly according to the desired height.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="894" height="488" alt="Screenshot_2026-01-23_at_2_45_48 PM" src="https://github.com/user-attachments/assets/3a11053d-024a-4ed7-b3d8-7c8680c002a1" />


After:
<img width="916" height="508" alt="Screenshot_2026-01-23_at_2_44_06 PM" src="https://github.com/user-attachments/assets/cda28674-1e56-4d3d-ae6b-a5ed86b6885d" />


### TESTING INSTRUCTIONS
locally tested

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
