### PR TITLE
fix(security): Add table blocklist and fix MCP SQL validation bypass

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1811,6 +1811,34 @@ DISALLOWED_SQL_FUNCTIONS: dict[str, set[str]] = {
     },
 }
 
+# Per-engine blocklist of system catalog tables/views that should not be queried.
+# Prevents information disclosure through system catalog access.
+DISALLOWED_SQL_TABLES: dict[str, set[str]] = {
+    "postgresql": {
+        "pg_stat_activity",
+        "pg_roles",
+        "pg_shadow",
+        "pg_authid",
+        "pg_settings",
+        "pg_config",
+        "pg_hba_file_rules",
+        "pg_stat_ssl",
+        "pg_stat_replication",
+        "pg_stat_wal_receiver",
+        "pg_user",
+    },
+    "mysql": {
+        "mysql.user",
+        "performance_schema.threads",
+        "performance_schema.processlist",
+    },
+    "mssql": {
+        "sys.server_principals",
+        "sys.sql_logins",
+        "sys.configurations",
+    },
+}
+
 
 # A function that intercepts the SQL to be executed and can alter it.
 # A common use case for this is around adding some sort of comment header to the SQL

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -399,6 +399,21 @@ class SupersetDisallowedSQLFunctionException(SupersetErrorException):
         )
 
 
+class SupersetDisallowedSQLTableException(SupersetErrorException):
+    """
+    Disallowed table/view found in SQL statement
+    """
+
+    def __init__(self, tables: set[str]):
+        super().__init__(
+            SupersetError(
+                message=f"SQL statement references disallowed table(s): {tables}",
+                error_type=SupersetErrorType.SYNTAX_ERROR,
+                level=ErrorLevel.ERROR,
+            )
+        )
+
+
 class CreateKeyValueDistributedLockFailedException(Exception):  # noqa: N818
     """
     Exception to signalize failure to acquire lock.

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -720,7 +720,12 @@ class SQLExecutor:
                 for table in engine_disallowed:
                     if table.lower() in present:
                         found.add(table)
-            return found if found else None
+            if found:
+                return found
+            # Fallback: check_tables_present detected a match but we couldn't
+            # map it back via statement.tables. Return the full configured
+            # blocklist to ensure the query is still rejected.
+            return set(engine_disallowed)
 
         return None
 

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -711,18 +711,15 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        # Use AST-based table detection
-        if script.check_tables_present(engine_disallowed):
-            # Return the specific tables that were found
-            found = set()
-            for statement in script.statements:
-                present = {table.table.lower() for table in statement.tables}
-                for table in engine_disallowed:
-                    if table.lower() in present:
-                        found.add(table)
-            return found or set(engine_disallowed)
+        # Single-pass AST-based table detection
+        found: set[str] = set()
+        for statement in script.statements:
+            present = {table.table.lower() for table in statement.tables}
+            for table in engine_disallowed:
+                if table.lower() in present:
+                    found.add(table)
 
-        return None
+        return found or None
 
     def _apply_rls_to_script(
         self, script: SQLScript, catalog: str | None, schema: str | None

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -451,10 +451,12 @@ class SQLExecutor:
         :raises SupersetSecurityException: If security checks fail
         """
         # Check disallowed functions
-        if disallowed := self._check_disallowed_functions(script):
+        if disallowed_functions := self._check_disallowed_functions(script):
             raise SupersetSecurityException(
                 SupersetError(
-                    message=f"Disallowed SQL functions: {', '.join(disallowed)}",
+                    message=(
+                        f"Disallowed SQL functions: {', '.join(disallowed_functions)}"
+                    ),
                     error_type=SupersetErrorType.INVALID_SQL_ERROR,
                     level=ErrorLevel.ERROR,
                 )

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -720,12 +720,7 @@ class SQLExecutor:
                 for table in engine_disallowed:
                     if table.lower() in present:
                         found.add(table)
-            if found:
-                return found
-            # Fallback: check_tables_present detected a match but we couldn't
-            # map it back via statement.tables. Return the full configured
-            # blocklist to ensure the query is still rejected.
-            return set(engine_disallowed)
+            return found or set(engine_disallowed)
 
         return None
 

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -460,6 +460,16 @@ class SQLExecutor:
                 )
             )
 
+        # Check disallowed tables
+        if disallowed_tables := self._check_disallowed_tables(script):
+            raise SupersetSecurityException(
+                SupersetError(
+                    message=f"Disallowed SQL tables: {', '.join(disallowed_tables)}",
+                    error_type=SupersetErrorType.INVALID_SQL_ERROR,
+                    level=ErrorLevel.ERROR,
+                )
+            )
+
         # Check DML permission
         if script.has_mutation() and not self.database.allow_dml:
             raise SupersetSecurityException(
@@ -683,6 +693,34 @@ class SQLExecutor:
                     found.add(func)
 
         return found if found else None
+
+    def _check_disallowed_tables(self, script: SQLScript) -> set[str] | None:
+        """
+        Check for disallowed SQL tables/views.
+
+        :param script: Parsed SQL script
+        :returns: Set of disallowed tables found, or None if none found
+        """
+        disallowed_config = app.config.get("DISALLOWED_SQL_TABLES", {})
+        engine_name = self.database.db_engine_spec.engine
+
+        # Get disallowed tables for this engine
+        engine_disallowed = disallowed_config.get(engine_name, set())
+        if not engine_disallowed:
+            return None
+
+        # Use AST-based table detection
+        if script.check_tables_present(engine_disallowed):
+            # Return the specific tables that were found
+            found = set()
+            for statement in script.statements:
+                present = {table.table.lower() for table in statement.tables}
+                for table in engine_disallowed:
+                    if table.lower() in present:
+                        found.add(table)
+            return found if found else None
+
+        return None
 
     def _apply_rls_to_script(
         self, script: SQLScript, catalog: str | None, schema: str | None

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -452,6 +452,15 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         """
         raise NotImplementedError()
 
+    def check_tables_present(self, tables: set[str]) -> bool:
+        """
+        Check if any of the given tables are present in the statement.
+
+        :param tables: Set of table names to check for (case-insensitive)
+        :return: True if any of the tables are present
+        """
+        raise NotImplementedError()
+
     def get_limit_value(self) -> int | None:
         """
         Get the limit value of the statement.
@@ -1180,6 +1189,16 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         :return: True if any of the functions are present
         """
         logger.warning("Kusto KQL doesn't support checking for functions present.")
+        return False
+
+    def check_tables_present(self, tables: set[str]) -> bool:
+        """
+        Check if any of the given tables are present in the statement.
+
+        :param tables: Set of table names to check for (case-insensitive)
+        :return: True if any of the tables are present
+        """
+        logger.warning("Kusto KQL doesn't support checking for tables present.")
         return False
 
     def get_limit_value(self) -> int | None:

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -766,6 +766,16 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         }
         return any(function.upper() in present for function in functions)
 
+    def check_tables_present(self, tables: set[str]) -> bool:
+        """
+        Check if any of the given tables are present in the statement.
+
+        :param tables: Set of table names to check for (case-insensitive)
+        :return: True if any of the tables are present
+        """
+        present = {table.table.lower() for table in self.tables}
+        return any(table.lower() in present for table in tables)
+
     def get_limit_value(self) -> int | None:
         """
         Parse a SQL query and return the `LIMIT` or `TOP` value, if present.
@@ -1311,6 +1321,17 @@ class SQLScript:
         return any(
             statement.check_functions_present(functions)
             for statement in self.statements
+        )
+
+    def check_tables_present(self, tables: set[str]) -> bool:
+        """
+        Check if any of the given tables are present in the script.
+
+        :param tables: Set of table names to check for (case-insensitive)
+        :return: True if any of the tables are present
+        """
+        return any(
+            statement.check_tables_present(tables) for statement in self.statements
         )
 
     def is_valid_ctas(self) -> bool:

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -45,6 +45,7 @@ from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     OAuth2RedirectError,
     SupersetDisallowedSQLFunctionException,
+    SupersetDisallowedSQLTableException,
     SupersetDMLNotAllowedException,
     SupersetErrorException,
     SupersetErrorsException,
@@ -410,6 +411,13 @@ def execute_sql_statements(  # noqa: C901
         disallowed_functions
     ):
         raise SupersetDisallowedSQLFunctionException(disallowed_functions)
+
+    disallowed_tables = app.config["DISALLOWED_SQL_TABLES"].get(
+        db_engine_spec.engine,
+        set(),
+    )
+    if disallowed_tables and parsed_script.check_tables_present(disallowed_tables):
+        raise SupersetDisallowedSQLTableException(disallowed_tables)
 
     if parsed_script.has_mutation() and not database.allow_dml:
         raise SupersetDMLNotAllowedException()

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -368,7 +368,7 @@ def test_execute_disallowed_tables(
 
     assert result.status == QueryStatus.FAILED
     assert result.error_message is not None
-    assert "Disallowed SQL tables" in result.error_message
+    assert "Disallowed SQL tables: pg_stat_activity" == result.error_message
 
 
 def test_execute_allowed_tables(
@@ -1351,7 +1351,7 @@ def test_async_handle_get_result_query_not_found(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
-    assert "not found" in query_result.error_message.lower()  # type: ignore[union-attr]
+    assert "not found" in query_result.error_message.lower()
 
 
 def test_async_handle_get_result_pending(
@@ -1492,7 +1492,7 @@ def test_async_handle_get_result_backend_load_error(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
-    assert "Error loading results" in query_result.error_message  # type: ignore[operator]
+    assert "Error loading results" in query_result.error_message
 
 
 def test_async_handle_get_result_no_results_key(
@@ -1523,7 +1523,7 @@ def test_async_handle_get_result_no_results_key(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
-    assert "Results not available" in query_result.error_message  # type: ignore[operator]
+    assert "Results not available" in query_result.error_message
 
 
 def test_async_handle_get_status_query_not_found(
@@ -2028,7 +2028,7 @@ def test_async_handle_get_result_with_empty_blob(
 
     # Should return failure when blob not found
     assert query_result.status == QueryStatus.FAILED
-    assert "Results not available" in query_result.error_message  # type: ignore[operator]
+    assert "Results not available" in query_result.error_message
 
 
 def test_async_handle_get_result_no_results_backend(
@@ -2068,7 +2068,7 @@ def test_async_handle_get_result_no_results_backend(
 
     # Should return failure when no results backend
     assert query_result.status == QueryStatus.FAILED
-    assert "Results not available" in query_result.error_message  # type: ignore[operator]
+    assert "Results not available" in query_result.error_message
 
 
 def test_create_query_record_with_user(

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -1351,6 +1351,7 @@ def test_async_handle_get_result_query_not_found(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
+    assert query_result.error_message is not None
     assert "not found" in query_result.error_message.lower()
 
 
@@ -1492,6 +1493,7 @@ def test_async_handle_get_result_backend_load_error(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
+    assert query_result.error_message is not None
     assert "Error loading results" in query_result.error_message
 
 
@@ -1523,6 +1525,7 @@ def test_async_handle_get_result_no_results_key(
     query_result = result.get_result()
 
     assert query_result.status == QueryStatus.FAILED
+    assert query_result.error_message is not None
     assert "Results not available" in query_result.error_message
 
 
@@ -2028,6 +2031,7 @@ def test_async_handle_get_result_with_empty_blob(
 
     # Should return failure when blob not found
     assert query_result.status == QueryStatus.FAILED
+    assert query_result.error_message is not None
     assert "Results not available" in query_result.error_message
 
 
@@ -2068,6 +2072,7 @@ def test_async_handle_get_result_no_results_backend(
 
     # Should return failure when no results backend
     assert query_result.status == QueryStatus.FAILED
+    assert query_result.error_message is not None
     assert "Results not available" in query_result.error_message
 
 

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2943,6 +2943,39 @@ def test_check_functions_present(sql: str, engine: str, expected: bool) -> None:
 
 
 @pytest.mark.parametrize(
+    "sql, engine, expected",
+    [
+        ("SELECT * FROM my_table", "postgresql", False),
+        ("SELECT * FROM pg_stat_activity", "postgresql", True),
+        ("SELECT * FROM PG_STAT_ACTIVITY", "postgresql", True),
+        ("SELECT * FROM pg_roles", "postgresql", True),
+        (
+            "WITH cte AS (SELECT 1) SELECT * FROM cte",
+            "postgresql",
+            False,
+        ),
+        (
+            "SELECT * FROM my_table; SELECT * FROM pg_settings",
+            "postgresql",
+            True,
+        ),
+        (
+            "SELECT * FROM schema.pg_stat_activity",
+            "postgresql",
+            True,
+        ),
+        ("Table | limit 10", "kustokql", False),
+    ],
+)
+def test_check_tables_present(sql: str, engine: str, expected: bool) -> None:
+    """
+    Check the `check_tables_present` method.
+    """
+    tables = {"pg_stat_activity", "pg_roles", "pg_settings"}
+    assert SQLScript(sql, engine).check_tables_present(tables) == expected
+
+
+@pytest.mark.parametrize(
     "kql, expected",
     [
         (


### PR DESCRIPTION
### SUMMARY

Fixes critical security vulnerabilities in SQL validation that allowed bypassing function and table blocklists:

**Bug 1 - Engine mismatch in MCP SQL validation**: `validate_sql_query` hardcoded `"sqlite"` for blocklist lookup instead of using `database.backend`, so PostgreSQL/MySQL/MSSQL function blocklists were never applied.

**Bug 2 - No table blocklist**: Users could query system catalog tables (`pg_stat_activity`, `pg_roles`, `pg_settings`, etc.) exposing sensitive infrastructure data like active sessions, credentials, and server configuration.

**Bug 3 - Weak DML detection**: Used `startswith` string check instead of AST-based mutation detection, easily bypassed with whitespace or comments.

#### Changes

1. **`superset/config.py`**: Added `DISALLOWED_SQL_TABLES` config with per-engine table blocklists (PostgreSQL, MySQL, MSSQL system catalogs)
2. **`superset/exceptions.py`**: Added `SupersetDisallowedSQLTableException`
3. **`superset/sql/parse.py`**: Added `check_tables_present()` to `SQLStatement` and `SQLScript` classes using sqlglot AST (handles case-insensitivity, schema-qualified names, excludes CTE aliases)
4. **`superset/sql/execution/executor.py`**: Added `_check_disallowed_tables()` check in the executor's `_check_security` pipeline, using proper engine from `database.db_engine_spec.engine`
5. **`superset/sql_lab.py`**: Added table validation after existing function check in the legacy `execute_sql_statements` path

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - Backend security fix, no UI changes.

### TESTING INSTRUCTIONS

Run the new unit tests:
```bash
pytest tests/unit_tests/sql/parse_tests.py::test_check_tables_present tests/unit_tests/sql/execution/test_executor.py::test_execute_disallowed_tables tests/unit_tests/sql/execution/test_executor.py::test_execute_allowed_tables tests/unit_tests/sql/execution/test_executor.py::test_check_disallowed_tables_no_config -v
```

Manual verification:
1. Configure `DISALLOWED_SQL_TABLES` with PostgreSQL system tables in `superset_config.py`
2. Attempt `SELECT * FROM pg_stat_activity` via SQL Lab against a PostgreSQL database
3. Verify the query is blocked with a clear error message
4. Verify normal queries like `SELECT * FROM my_table` still work

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API