### PR TITLE
fix(mcp): prevent DATE_TRUNC on non-temporal columns in chart generation

### DIFF
--- a/superset/mcp_service/chart/tool/generate_chart.py
+++ b/superset/mcp_service/chart/tool/generate_chart.py
@@ -159,7 +159,10 @@ async def generate_chart(  # noqa: C901
             )
 
         # Map the simplified config to Superset's form_data format
-        form_data = map_config_to_form_data(request.config)
+        # Pass dataset_id to enable column type checking for proper viz_type selection
+        form_data = map_config_to_form_data(
+            request.config, dataset_id=request.dataset_id
+        )
 
         chart = None
         chart_id = None

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -125,7 +125,9 @@ async def update_chart(
             )
 
         # Map the new config to form_data format
-        new_form_data = map_config_to_form_data(request.config)
+        # Get dataset_id from existing chart for column type checking
+        dataset_id = chart.datasource_id if chart.datasource_id else None
+        new_form_data = map_config_to_form_data(request.config, dataset_id=dataset_id)
 
         # Update chart using Superset's command
         from superset.commands.chart.update import UpdateChartCommand

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -66,7 +66,10 @@ def update_chart_preview(
 
     try:
         # Map the new config to form_data format
-        new_form_data = map_config_to_form_data(request.config)
+        # Pass dataset_id to enable column type checking for proper viz_type selection
+        new_form_data = map_config_to_form_data(
+            request.config, dataset_id=request.dataset_id
+        )
 
         # Generate new explore link with updated form_data
         explore_url = generate_explore_link(request.dataset_id, new_form_data)

--- a/superset/mcp_service/explore/tool/generate_explore_link.py
+++ b/superset/mcp_service/explore/tool/generate_explore_link.py
@@ -92,7 +92,10 @@ async def generate_explore_link(
     try:
         await ctx.report_progress(1, 3, "Converting configuration to form data")
         # Map config to form_data using shared utilities
-        form_data = map_config_to_form_data(request.config)
+        # Pass dataset_id to enable column type checking for proper viz_type selection
+        form_data = map_config_to_form_data(
+            request.config, dataset_id=request.dataset_id
+        )
 
         # Add datasource to form_data for consistency with generate_chart
         # Only set if not already present to avoid overwriting

--- a/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
+++ b/tests/unit_tests/mcp_service/explore/tool/test_generate_explore_link.py
@@ -68,9 +68,30 @@ def mock_webdriver_baseurl(app_context):
 
 
 def _mock_dataset(id: int = 1) -> Mock:
-    """Create a mock dataset object."""
+    """Create a mock dataset object with columns and db_engine_spec."""
+    from superset.utils.core import ColumnSpec, GenericDataType
+
+    # Create mock column that appears temporal
+    mock_column = Mock()
+    mock_column.column_name = "date"
+    mock_column.type = "TIMESTAMP"
+
+    # Create mock db_engine_spec
+    mock_db_engine_spec = Mock()
+    mock_column_spec = ColumnSpec(
+        sqla_type=Mock(), generic_type=GenericDataType.TEMPORAL, is_dttm=True
+    )
+    mock_db_engine_spec.get_column_spec.return_value = mock_column_spec
+
+    # Create mock database
+    mock_database = Mock()
+    mock_database.db_engine_spec = mock_db_engine_spec
+
+    # Create dataset with all required attributes
     dataset = Mock()
     dataset.id = id
+    dataset.columns = [mock_column]
+    dataset.database = mock_database
     return dataset
 
 


### PR DESCRIPTION
## Summary

When generating XY charts via MCP tools, columns like "year" stored as BIGINT were incorrectly treated as temporal columns, causing DATE_TRUNC SQL errors:

```
Error: function date_trunc(unknown, double precision) does not exist
LINE 2: DATE_TRUNC('DAY', year) AS year, ^
HINT: No function matches the given name and argument types.
```

This happens because Superset marks columns as `is_dttm=True` based on column name heuristics (e.g., columns named "year", "month"), but if the actual SQL type is BIGINT or INTEGER, DATE_TRUNC cannot be applied.

### Changes

- Add `is_column_truly_temporal()` helper to check actual SQL column type (not just `is_dttm` flag)
- Add `TEMPORAL_SQL_TYPES` and `NUMERIC_NON_TEMPORAL_TYPES` constants for type checking
- Add `configure_temporal_handling()` helper to reduce function complexity
- Update `map_xy_config()` to accept `dataset_id` and configure form_data based on actual column type:
  - **Temporal columns** (DATE, TIMESTAMP, etc.): Standard time series handling with optional time_grain
  - **Non-temporal columns** (BIGINT, INTEGER, etc.): Configure as categorical with `x_axis_sort_series_type="name"` and disable time_grain
- Update all MCP chart tools to pass `dataset_id` for column type checking

## Testing Instructions

1. Create a dataset with a BIGINT column named "year" (e.g., values like 2010, 2011, 2012)
2. Use MCP `generate_explore_link` tool to create a bar chart with year on x-axis
3. Verify the chart renders without DATE_TRUNC errors
4. Verify charts with proper TIMESTAMP columns still work with time_grain

## Additional Information

**Files changed:**
- `superset/mcp_service/chart/chart_utils.py` - Main logic changes
- `superset/mcp_service/chart/tool/generate_chart.py` - Pass dataset_id
- `superset/mcp_service/chart/tool/update_chart.py` - Pass dataset_id  
- `superset/mcp_service/chart/tool/update_chart_preview.py` - Pass dataset_id
- `superset/mcp_service/explore/tool/generate_explore_link.py` - Pass dataset_id