### PR TITLE
feat(sqllab): add getActivePanel API for panel visibility tracking

### DIFF
--- a/superset-frontend/packages/superset-core/src/api/sqlLab.ts
+++ b/superset-frontend/packages/superset-core/src/api/sqlLab.ts
@@ -239,6 +239,20 @@ export interface QueryResult {
  */
 
 /**
+ * Gets the currently active panel in the current tab.
+ * The active panel defaults to 'Results' when SQL Lab loads.
+ *
+ * @returns The current active panel object.
+ *
+ * @example
+ * ```typescript
+ * const panel = getActivePanel();
+ * console.log(`Active panel: ${panel.id}`);
+ * ```
+ */
+export declare const getActivePanel: () => Panel;
+
+/**
  * Gets the currently active tab in SQL Lab.
  *
  * @returns The current tab object, or undefined if no tab is active.

--- a/superset-frontend/src/core/sqlLab/index.ts
+++ b/superset-frontend/src/core/sqlLab/index.ts
@@ -215,6 +215,11 @@ function createQueryErrorContext(
 const getCurrentTab: typeof sqlLabApi.getCurrentTab = () =>
   getTab(activeEditorId());
 
+const getActivePanel: typeof sqlLabApi.getActivePanel = () => {
+  const { activeSouthPaneTab } = getSqlLabState();
+  return new Panel(String(activeSouthPaneTab));
+};
+
 const getTabs: typeof sqlLabApi.getTabs = () => {
   const { queryEditors } = getSqlLabState();
   return queryEditors
@@ -389,6 +394,7 @@ const onDidChangeTabTitle: typeof sqlLabApi.onDidChangeTabTitle = (
 
 export const sqlLab: typeof sqlLabApi = {
   CTASMethod,
+  getActivePanel,
   getCurrentTab,
   onDidChangeEditorDatabase,
   onDidChangeEditorSchema,


### PR DESCRIPTION
### SUMMARY
This PR adds a new `getActivePanel()` function to the SQL Lab extension API, enabling extensions to determine which panel is currently active in the South Pane.

**Motivation:**
Extensions that register panels in SQL Lab previously had no way to know if their panel was visible. This caused unnecessary API calls and processing when queries were executed, even when the extension's panel wasn't being viewed by the user.

**Changes:**

1. **API Type Declaration** (`superset-frontend/packages/superset-core/src/api/sqlLab.ts`):
   - Added `getActivePanel(): Panel` function declaration

2. **Implementation** (`superset-frontend/src/core/sqlLab/index.ts`):
   - Added `getActivePanel` function that reads `activeSouthPaneTab` from Redux state
   - Returns a `Panel` object with the active panel's ID (defaults to `'Results'`)

**Usage Example:**

```typescript
import { sqlLab } from "@apache-superset/core";

// Check if a specific panel is active
const activePanel = sqlLab.getActivePanel();
if (activePanel.id === "my_extension.panel") {
  // Panel is visible, perform operations
}

// Combined with existing onDidChangeActivePanel event
sqlLab.onDidChangeActivePanel((panel) => {
  if (panel.id === "my_extension.panel") {
    // Panel just became active
  }
});
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - This is an API addition with no UI changes.

### TESTING INSTRUCTIONS
1. Create or use an extension that registers a panel in SQL Lab
2. In the extension code, call `sqlLab.getActivePanel()` to verify it returns the correct panel
3. Switch between panels (Results, Query History, etc.) and verify:
   - `getActivePanel()` returns the correct panel ID
   - `onDidChangeActivePanel` event fires with the correct panel

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
