### PR TITLE
fix(select): prevent bulk action buttons from being cut off in filters

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.test.tsx
@@ -86,7 +86,7 @@ const getSelect = () =>
   screen.getByRole('combobox', { name: new RegExp(ARIA_LABEL, 'i') });
 
 const selectAllButtonText = (length: number) => `Select all (${length})`;
-const deselectAllButtonText = (length: number) => `Deselect all (${length})`;
+const deselectAllButtonText = (length: number) => `Clear (${length})`;
 
 const findSelectOption = (text: string) =>
   waitFor(() =>

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.tsx
@@ -522,7 +522,7 @@ const Select = forwardRef(
               handleDeselectAll();
             }}
           >
-            {`${t('Deselect all')} (${bulkSelectCounts.deselectable})`}
+            {`${t('Clear')} (${bulkSelectCounts.deselectable})`}
           </Button>
         </StyledBulkActionsContainer>
       ),
@@ -776,6 +776,7 @@ const Select = forwardRef(
           options={visibleOptions}
           optionRender={option => <Space>{option.label || option.value}</Space>}
           oneLine={oneLine}
+          popupMatchSelectWidth={selectAllEnabled ? 168 : true}
           css={props.css}
           {...props}
           showSearch={shouldShowSearch}

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
@@ -142,5 +142,6 @@ export const StyledBulkActionsContainer = styled(Flex)`
   ${({ theme }) => `
     padding: ${theme.sizeUnit}px;
     border-top: 1px solid ${theme.colorSplit};
+    gap: ${theme.sizeUnit * 2}px;
   `}
 `;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Fixes the "Select all" and "Deselect all" buttons being cut off in multi-select filters, particularly when the filter bar is in horizontal orientation.

**Changes:**
- Renamed "Deselect all" button to "Clear" for brevity
- Set consistent 8px gap between the two bulk action buttons
- Added minimum dropdown width (168px) when bulk actions are enabled to ensure buttons are fully visible

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE:
<img width="312" height="431" alt="Screenshot 2026-01-26 at 17 24 50" src="https://github.com/user-attachments/assets/bb31e53d-c0bc-43fa-a1bc-3a8f9d2b2865" />

AFTER:
<img width="353" height="401" alt="Screenshot 2026-01-26 at 17 22 44" src="https://github.com/user-attachments/assets/ce7d19d9-6401-4389-bfaa-1295ada85ca8" />

### TESTING INSTRUCTIONS
1. Navigate to any dashboard with a multi-select filter
2. Set the filter bar orientation to **horizontal** (Settings → Filter bar orientation)
3. Click on the multi-select filter dropdown
4. Verify:
   - Both "Select all (X)" and "Clear (X)" buttons are fully visible
   - Buttons are on the same line with proper spacing
   - Dropdown aligns properly with the input field
5. Test with vertical filter bar orientation to ensure no regression


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
