### PR TITLE
fix(explore): remove extra spacing when Advanced Analytics section is hidden

### DIFF
--- a/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
+++ b/superset-frontend/src/explore/components/ControlPanelsContainer.tsx
@@ -726,7 +726,7 @@ export const ControlPanelsContainer = (props: ControlPanelsContainerProps) => {
       label: <PanelHeader />,
       children: PanelChildren,
       className: section.label ? '' : 'hidden-collapse-header',
-      style: { visibility: isVisible ? 'visible' : 'hidden' },
+      style: { display: isVisible ? 'block' : 'none' },
     };
   };
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed incorrect spacing in the control panel when the Advanced Analytics section is hidden for non-temporal x-axis charts. 

Root cause: The `displayTimeRelatedControls` visibility function correctly determined when to hide Advanced Analytics for non-temporal x-axis, but the section rendering used `visibility: hidden` instead of `display: none`, leaving empty space in the UI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### AFTER
<img width="241" height="809" alt="Screenshot 2026-01-26 at 19 05 15" src="https://github.com/user-attachments/assets/b3f5cec7-0df9-4be9-947e-4b1ef1d200ac" />

#### BEFORE
<img width="247" height="812" alt="Screenshot 2026-01-26 at 19 12 04" src="https://github.com/user-attachments/assets/8ca42e60-7117-44c4-99e0-7b90649cc84f" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create or edit a chart with a non-temporal x-axis (e.g., categorical data)
2. Open the chart in Explore view
3. Verify the Advanced Analytics section is not visible in the control panel
4. Confirm there is no extra spacing gap where the section would normally appear
5. Switch to a chart with a temporal x-axis and verify Advanced Analytics section appears normally
6. Run the existing tests: ```npm run test -- --testPathPatterns="ControlPanelsContainer.test.tsx"```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
