### PR TITLE
fix: rename 'Truncate Axis' to 'Truncate Y Axis' in bar chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -243,10 +243,10 @@ function createAxisControl(axis: 'x' | 'y'): ControlSetRow[] {
         name: 'truncateYAxis',
         config: {
           type: 'CheckboxControl',
-          label: t('Truncate Axis'),
+          label: t('Truncate Y Axis'),
           default: truncateYAxis,
           renderTrigger: true,
-          description: t('It’s not recommended to truncate axis in Bar chart.'),
+          description: t('It’s not recommended to truncate Y axis in Bar chart.'),
           visibility: ({ controls }: ControlPanelsContainerProps) =>
             isXAxis ? isHorizontal(controls) : isVertical(controls),
           disableStash: true,


### PR DESCRIPTION
## Summary
- Renames the "Truncate Axis" label to "Truncate Y Axis" in bar chart controls
- Updates the description text to match

This clarifies which axis the control applies to, making it consistent with "Truncate X Axis".

## Test plan
- [x] Verified no tests reference the label text directly
- [x] Visual change only - no functional changes

Closes #37400

🤖 Generated with [Claude Code](https://claude.ai/code)