### PR TITLE
feat: use dataset labels in drill by modal

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -50,7 +50,7 @@ export interface ChartDataResponseResult {
    * Name of each column, for retaining the order of the output columns.
    */
   colnames: string[];
-  label_map: Record<string, string[]>;
+  label_map?: Record<string, string[]>;
   /**
    * Generic data types, based on the final output pandas dataframe.
    */

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryResponse.ts
@@ -50,6 +50,7 @@ export interface ChartDataResponseResult {
    * Name of each column, for retaining the order of the output columns.
    */
   colnames: string[];
+  label_map: Record<string, string[]>;
   /**
    * Generic data types, based on the final output pandas dataframe.
    */

--- a/superset-frontend/plugins/plugin-chart-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/testData.ts
@@ -87,6 +87,7 @@ const basicQueryResult: ChartDataResponseResult = {
   status: 'success',
   from_dttm: null,
   to_dttm: null,
+  label_map: {},
 };
 
 /**

--- a/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/DrillByModal.test.tsx
@@ -230,6 +230,45 @@ test('should render radio buttons', async () => {
   expect(tableRadio).toBeChecked();
 });
 
+test('should use label_map for results table columns', async () => {
+  fetchMock.post(
+    CHART_DATA_ENDPOINT,
+    {
+      result: [
+        {
+          data: [{ name: 'Alice', sum__num: 10 }],
+          colnames: ['name', 'sum__num'],
+          coltypes: [1, 0],
+          label_map: {
+            'Person Name': ['name'],
+          },
+        },
+      ],
+    },
+    { overwriteRoutes: true },
+  );
+
+  await renderModal({
+    column: { column_name: 'name', verbose_name: null },
+    drillByConfig: {
+      filters: [{ col: 'gender', op: '==', val: 'boy' }],
+      groupbyFieldName: 'groupby',
+    },
+  });
+
+  const tableRadio = await screen.findByRole('radio', { name: /table/i });
+  userEvent.click(tableRadio);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
+  });
+
+  expect(
+    screen.getByRole('columnheader', { name: 'Person Name' }),
+  ).toBeInTheDocument();
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+});
+
 test('render breadcrumbs', async () => {
   await renderModal({
     column: { column_name: 'name', verbose_name: null },
@@ -371,6 +410,7 @@ describe('Table view with pagination', () => {
           })),
           colnames: ['state', 'sum__num'],
           coltypes: [1, 0],
+          label_map: {},
         },
       ],
     };
@@ -514,6 +554,7 @@ describe('Table view with pagination', () => {
             data: [],
             colnames: ['state', 'sum__num'],
             coltypes: [1, 0],
+            label_map: {},
           },
         ],
       },
@@ -554,6 +595,7 @@ describe('Table view with pagination', () => {
     userEvent.click(tableRadio);
 
     await waitFor(() => {
+      expect(screen.getByTestId('drill-by-display-toggle')).toBeInTheDocument();
       expect(screen.getByTestId('drill-by-results-table')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add Drill By modal test coverage to ensure label_map column labels are applied in results table rendering and data still displays correctly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

*Before:*
<img width="852" height="375" alt="image" src="https://github.com/user-attachments/assets/7fa65f6d-96f9-4fda-b827-f671d4e69b4e" />

*After:*
<img width="847" height="403" alt="image" src="https://github.com/user-attachments/assets/a8def674-a7cd-4666-8d98-d94527fd3db7" />


### TESTING INSTRUCTIONS

1. Create a new metric to your test dataset. Make sure this metric has a label.
2. Create a table chart (this is reproducible with both legacy and V2) and add this metric to the chart.
3. Add any dimension.
4. Save the chart and add it to a dashboard.
5. Access the dashboard.
6. Right click on a dimension value > Drill by and choose a column.
7. Check the metric in the Drill By menu.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
