### PR TITLE
fix(dashboard): update chart customization UI text to "Display controls" 

### DIFF
--- a/superset-frontend/src/dashboard/components/CustomizationsBadge/index.tsx
+++ b/superset-frontend/src/dashboard/components/CustomizationsBadge/index.tsx
@@ -243,7 +243,7 @@ export const CustomizationsBadge = ({ chartId }: CustomizationsBadgeProps) => {
     <TooltipContent>
       <div>
         <SectionName>
-          {t('Chart Customization (%d)', effectiveCustomizations.length)}
+          {t('Display controls (%d)', effectiveCustomizations.length)}
         </SectionName>
         <GroupByInfo>
           {effectiveCustomizations.map(customization => {
@@ -291,7 +291,7 @@ export const CustomizationsBadge = ({ chartId }: CustomizationsBadgeProps) => {
     >
       <StyledTag
         ref={triggerRef}
-        aria-label={t('Chart customizations (%s)', customizationsCount)}
+        aria-label={t('Display controls (%s)', customizationsCount)}
         role="button"
         tabIndex={0}
       >

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -187,9 +187,9 @@ describe('FilterBar', () => {
     expect(container).toBeInTheDocument();
   });
 
-  test('should render the "Actions" heading', () => {
+  test('should render the "Filters and controls" heading', () => {
     renderWrapper();
-    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.getByText('Filters and controls')).toBeInTheDocument();
   });
 
   test('should render the "Clear all" option', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -80,7 +80,7 @@ const addFilterFlow = async () => {
   // open filter config modals
   userEvent.click(screen.getByTestId(getTestId('collapsable')));
   userEvent.click(screen.getByLabelText('setting'));
-  userEvent.click(screen.getByText('Filters and customizations'));
+  userEvent.click(screen.getByText('Add or edit filters and controls'));
   // select filter
   userEvent.click(screen.getByText('Value'));
   userEvent.click(screen.getByText('Time range'));

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBarSettings/index.tsx
@@ -171,7 +171,7 @@ const FilterBarSettings = () => {
         key: ADD_EDIT_FILTERS_MENU_KEY,
         label: (
           <FilterConfigurationLink>
-            {t('Filters and customizations')}
+            {t('Add or edit filters and controls')}
           </FilterConfigurationLink>
         ),
       });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -366,7 +366,7 @@ const FilterControls: FC<FilterControlsProps> = ({
                     lineHeight: 1.3,
                   }}
                 >
-                  {t('Chart Customization')}
+                  {t('Display controls')}
                 </Title>
                 <StyledIcon
                   iconSize="m"

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/Header.test.tsx
@@ -29,10 +29,10 @@ test('should render', () => {
   expect(container).toBeInTheDocument();
 });
 
-test('should render the "Actions" heading', () => {
+test('should render the "Filters and controls" heading', () => {
   const mockedProps = createProps();
   render(<Header {...mockedProps} />, { useRedux: true });
-  expect(screen.getByText('Actions')).toBeInTheDocument();
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
 });
 
 test('should render the expand button', () => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Header/index.tsx
@@ -69,7 +69,7 @@ type HeaderProps = {
 const Header: FC<HeaderProps> = ({ toggleFiltersBar }) => (
   <Wrapper>
     <TitleArea>
-      <span>{t('Actions')}</span>
+      <span>{t('Filters and controls')}</span>
       <FilterBarSettings />
       <HeaderButton
         {...getFilterBarTestId('collapse-button')}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -238,7 +238,7 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
           description={
             canEdit &&
             t(
-              'Click on "Filters and customizations" option in Settings to create new dashboard filters',
+              'Click on "Add or edit filters and controls" option in Settings to create new dashboard filters',
             )
           }
         />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterCard/FilterCard.test.tsx
@@ -327,13 +327,13 @@ test('open modal on edit filter button click', async () => {
 
   expect(
     screen.queryByRole('dialog', {
-      name: /filters and customization settings/i,
+      name: /add or edit display controls/i,
     }),
   ).not.toBeInTheDocument();
   userEvent.click(editButton);
   expect(
     await screen.findByRole('dialog', {
-      name: /filters and customization settings/i,
+      name: /add or edit display controls/i,
     }),
   ).toBeInTheDocument();
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -127,7 +127,7 @@ const ConfigModalSidebar: FC<ConfigModalSidebarProps> = ({
 
   const customizationsHeader: ReactNode = (
     <div>
-      {t('Chart customizations')} ({chartCustomizationIds.length})
+      {t('Display controls')} ({chartCustomizationIds.length})
     </div>
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -225,7 +225,7 @@ export const CustomizationPanels = {
   },
   settings: {
     key: 'settings',
-    name: t('Customization Settings'),
+    name: t('Display control settings'),
   },
 };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -221,7 +221,7 @@ export const FilterPanels = {
 export const CustomizationPanels = {
   configuration: {
     key: 'configuration',
-    name: t('Customization Configuration'),
+    name: t('Display control configuration'),
   },
   settings: {
     key: 'settings',
@@ -843,7 +843,7 @@ const FiltersConfigForm = (
                     label={
                       <StyledLabel>
                         {isChartCustomization
-                          ? t('Customization name')
+                          ? t('Display control name')
                           : t('Filter name')}
                       </StyledLabel>
                     }
@@ -873,7 +873,7 @@ const FiltersConfigForm = (
                       ]}
                       initialValue={customizationToEdit?.filterType}
                       label={
-                        <StyledLabel>{t('Customization Type')}</StyledLabel>
+                        <StyledLabel>{t('Display control type')}</StyledLabel>
                       }
                     >
                       <Select
@@ -1215,7 +1215,7 @@ const FiltersConfigForm = (
                                       initialValue={hasSorting}
                                       title={
                                         isChartCustomization
-                                          ? t('Sort customization values')
+                                          ? t('Sort display control values')
                                           : t('Sort filter values')
                                       }
                                       onChange={checked => {
@@ -1510,7 +1510,7 @@ const FiltersConfigForm = (
                               initialValue={hasDefaultValue}
                               title={
                                 isChartCustomization
-                                  ? t('Customization has default value')
+                                  ? t('Display control has default value')
                                   : t('Filter has default value')
                               }
                               tooltip={defaultValueTooltip}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -503,7 +503,7 @@ function FiltersConfigModal({
     <BaseModalWrapper
       open={isOpen}
       maskClosable={false}
-      title={t('Filters and customization settings')}
+      title={t('Add or edit display controls')}
       expanded={expanded}
       destroyOnHidden
       onCancel={handleCancel}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NewItemDropdown.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NewItemDropdown.tsx
@@ -52,7 +52,7 @@ const NewItemDropdown: FC<Props> = ({ onAddFilter, onAddCustomization }) => {
         },
         {
           key: 'customization',
-          label: t('Add customization'),
+          label: t('Add display control'),
           icon: (
             <Icons.SettingOutlined
               iconColor={theme.colorPrimary}


### PR DESCRIPTION

Change user-facing text from "chart customization" terminology to "display controls" for better clarity:

- Filter bar header: "Actions" → "Filters and controls"
- Modal title: "Filters and customization settings" → "Add or edit display controls"
- Settings panel: "Customization Settings" → "Display control settings"
- Sidebar header: "Chart customizations" → "Display controls"
- Section subheader: "Chart Customization" → "Display controls"
- Badge tooltip: "Chart Customization/customizations" → "Display controls"

Updated corresponding test files to reflect the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
