### PR TITLE
feat(dashboard-filters): Enable "Select All" for dynamic search filters

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -680,6 +680,53 @@ describe('SelectFilterPlugin', () => {
     expect(options[1]).toHaveTextContent('alpha');
     expect(options[2]).toHaveTextContent('beta');
   });
+
+  test('allowSelectAll is enabled when searchAllOptions is enabled for multi-select', () => {
+    const { container } = getWrapper({
+      searchAllOptions: true,
+      multiSelect: true,
+    });
+    // Verify the Select component is rendered with multiSelect mode
+    const selectElement = container.querySelector('.ant-select-multiple');
+    expect(selectElement).toBeInTheDocument();
+  });
+
+  test('allowSelectAll is not enabled for single-select filters', () => {
+    const { container } = getWrapper({
+      searchAllOptions: true,
+      multiSelect: false,
+    });
+    // Verify the Select component is rendered in single mode (not multiple)
+    const selectElement = container.querySelector('.ant-select-multiple');
+    expect(selectElement).not.toBeInTheDocument();
+  });
+
+  test('Can select multiple values when searchAllOptions is enabled', async () => {
+    getWrapper({ searchAllOptions: true, multiSelect: true });
+    const filterSelect = screen.getAllByRole('combobox')[0];
+    userEvent.click(filterSelect);
+
+    // Select first option
+    userEvent.click(screen.getByTitle('girl'));
+    expect(
+      await screen.findByRole('option', { name: /girl/i }),
+    ).toBeInTheDocument();
+
+    // Verify multi-select works with searchAllOptions enabled
+    expect(setDataMask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraFormData: {
+          filters: [
+            {
+              col: 'gender',
+              op: 'IN',
+              val: expect.arrayContaining(['boy', 'girl']),
+            },
+          ],
+        },
+      }),
+    );
+  });
 });
 
 test('Select boolean FALSE value in single-select mode', async () => {

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -508,7 +508,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
             name={formData.nativeFilterId}
             allowClear
             allowNewOptions={!searchAllOptions && creatable !== false}
-            allowSelectAll={!searchAllOptions}
+            allowSelectAll={multiSelect}
             value={multiSelect ? filterState.value || [] : filterState.value}
             disabled={isDisabled}
             getPopupContainer={


### PR DESCRIPTION
## SUMMARY
Enables the "Select All" button for dashboard native filters when "Dynamically search all filter values" is enabled.

#### **The Change**
``` typescript
// Before
allowSelectAll={!searchAllOptions}  // Disabled when dynamic search was on

// After
allowSelectAll={multiSelect}  // Enabled for all multi-select filters
```

#### **Why This Works**

The Select component already handles "Select All" intelligently:
- When you search and click "Select All" → it selects only the visible/filtered results
- When you don't search and click "Select All" → it selects all available options

This works the same way whether the filter uses dynamic search (backend filtering) or static search (frontend filtering). The component already had this logic - we just needed to stop disabling the button.

### BEFORE/AFTER 

**BEFORE**: No "Select All"/"Deselect All" buttons when "Dynamically search all filter values" enabled

https://github.com/user-attachments/assets/63001590-fde4-4016-9de5-562f264dc872


**AFTER**: Buttons visible and functional for all multi-select filters

https://github.com/user-attachments/assets/dc63b67a-b3f4-40c1-9284-98521dfa20ec


### TESTING INSTRUCTIONS

1. Create a dashboard filter with "Dynamically search all filter values" enabled
2. Open the filter dropdown → Verify "Select All" button appears
3. Type a search term → Click "Select All" → Verify only matching values are selected
4. Deselect one value → Verify it's removed
5. Click "Deselect All" → Verify all cleared
6. Test non-dynamic filter → Verify "Select All" still works (regression check)

