### PR TITLE
Fix(Table Chart): show correct cache time moment for Query2

### DIFF
--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -325,16 +325,18 @@ const SliceHeaderControls = (
   const updatedWhen = updatedDttm
     ? (extendedDayjs.utc(updatedDttm) as any).fromNow()
     : '';
-  const getCachedTitle = (itemCached: boolean) => {
+  const getCachedTitle = (itemCached: boolean, index: number) => {
     if (itemCached) {
-      return t('Cached %s', cachedWhen);
+      return t('Cached %s', cachedWhen[index]);
     }
     if (updatedWhen) {
       return t('Fetched %s', updatedWhen);
     }
     return '';
   };
-  const refreshTooltipData = [...new Set(isCached.map(getCachedTitle) || '')];
+  const refreshTooltipData = [
+    ...new Set(isCached.map((itemCached, index) => getCachedTitle(itemCached, index)) || ''),
+  ];
   // If all queries have same cache time we can unit them to one
   const refreshTooltip = refreshTooltipData.map((item, index) => (
     <div key={`tooltip-${index}`}>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes incorrect cache time moment(Cached a month ago) of Server pagination enabled Table chart of Query2.

Showing incorrect time moment even after force refresh.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE
<img width="724" height="198" alt="{FC109A89-509F-46FF-9BB8-DB4E9A7CFC2B}" src="https://github.com/user-attachments/assets/2a9b4b5f-a93f-4456-b44d-1c2d370a77eb" />

AFTER
<img width="954" height="293" alt="{45FB9A5B-3704-4B41-965E-19E9C18E0DCE}" src="https://github.com/user-attachments/assets/e10a684c-6eb2-40a8-a8ed-027c80f1aba2" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Create dashboard with sever pagination enable Table chart.
- Change the per page size
- Click on the three-dot menu.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
