### PR TITLE
[WIP] fix(native-filters): dynamic search not returning results beyond first 1k

### DIFF
--- a/superset-frontend/src/components/Select/utils.tsx
+++ b/superset-frontend/src/components/Select/utils.tsx
@@ -194,7 +194,7 @@ export const handleFilterOptionHelper = (
     }
   }
 
-  return false;
+  return true;
 };
 
 export const hasCustomLabels = (options: SelectOptionsType) =>


### PR DESCRIPTION
### SUMMARY

  When a dashboard filter column has more than 1000 distinct values and "Dynamically search all filter values" is
  enabled, searching for values not in the first 1000 results would return "No Data" instead of querying the server.

  **Root cause:** The `coltypeMap` was captured as an empty object on the component's first render via
  `useState(coltypeMap)`. When the debounced search fired, it used this stale empty value, preventing the ILIKE
  filter from being added to the server query.

  **Fix:**
  1. Use `coltypeMap` directly from props in `debouncedSearch` instead of the stale `initialColtypeMap`
  2. Add loading state (`isSearchPending`) to show feedback while waiting for server results
  3. Hide client-side filtered options while server search is pending to prevent flickering
  4. Prevent typed value from appearing as a selectable option when using server-side search
  5. Fix the same issue in the filter configuration modal's default value selector

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **Before:** Searching for values beyond the first 1000 shows "No Data"

  **After:** Searching triggers a server-side ILIKE query and returns matching results with a loading indicator

  ### TESTING INSTRUCTIONS

  1. Create or use a dataset with a column containing more than 1000 distinct values
  2. Create a dashboard with a filter on that column
  3. Enable "Dynamically search all filter values" in the filter settings
  4. On the dashboard, open the filter dropdown and search for a value that is NOT in the first 1000 results
  5. Verify the search returns results from the server (should see loading indicator, then results)
  6. Also test the default value selector in the filter configuration modal with the same setup

  ### ADDITIONAL INFORMATION

  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration
    - [ ] Migration is atomic, supports rollback & is backwards-compatible
    - [ ] Confirm DB migration upgrade and downgrade tested
    - [ ] Runtime estimates and downtime expectations provided
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API